### PR TITLE
perf: reduce lock contention in DDB and S3 hot paths

### DIFF
--- a/services/dynamodb/janitor.go
+++ b/services/dynamodb/janitor.go
@@ -37,52 +37,76 @@ func NewJanitor(backend *InMemoryDB, settings Settings) *Janitor {
 }
 
 // Run runs the janitor loop until ctx is cancelled.
+// Two tickers are used:
+//   - mainTicker (Interval, default 500ms): housekeeping tasks (table cleanup,
+//     txn-token sweeps, expression-cache evictions).
+//   - ttlTicker (defaultDDBTTLSweepInterval, 5s): per-table TTL and stream-record
+//     sweeps, which are O(tables × items) and too expensive to run every 500ms.
 func (j *Janitor) Run(ctx context.Context) {
 	mainTicker := time.NewTicker(j.Interval)
 	defer mainTicker.Stop()
+
+	ttlTicker := time.NewTicker(defaultDDBTTLSweepInterval)
+	defer ttlTicker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-ttlTicker.C:
+			j.sweepTTL(ctx)
+			j.sweepStreamRecords()
 		case <-mainTicker.C:
-			j.runOnce(ctx)
+			j.sweepTxnTokens()
+			j.sweepTxnPending()
+			j.Backend.exprCache.Sweep()
+			j.runTableCleaner(ctx)
 		}
 	}
 }
 
-// runOnce orchestrates the various janitor tasks.
+// runOnce orchestrates all janitor tasks in a single synchronous pass.
+// Called by tests; production code uses the two-ticker Run loop above.
 func (j *Janitor) runOnce(ctx context.Context) {
 	j.sweepTTL(ctx)
 	j.sweepTxnTokens()
 	j.sweepTxnPending()
 	j.sweepStreamRecords()
 	j.Backend.exprCache.Sweep()
-	j.runTableCleaner(ctx) // The original runOnce logic
+	j.runTableCleaner(ctx)
 }
 
 // runTableCleaner records the current queue depth and finalises all pending deletions.
 func (j *Janitor) runTableCleaner(ctx context.Context) {
 	db := j.Backend
 
-	// Snapshot pending tables under the lock across all regions, record depth before processing.
+	// Snapshot the tables to clean up and remove them from deletingTables under the
+	// global lock. The slow work (timer cancellation, mutex close) is done outside the
+	// lock so that concurrent DescribeTable / PutItem / Query calls are not stalled
+	// while thousands of per-table resources are being released.
 	db.mu.Lock("DDBJanitor")
 	depth := 0
 	names := make([]string, 0)
+	tablesToClose := make([]*Table, 0)
 
 	for region, regionTables := range db.deletingTables {
 		for name, table := range regionTables {
 			depth++
 			names = append(names, name)
+			tablesToClose = append(tablesToClose, table)
 			delete(db.deletingTables[region], name)
-			stopTableTimers(table)
-			if table.Tags != nil {
-				table.Tags.Close()
-			}
-			table.mu.Close()
 		}
 	}
 	db.mu.Unlock()
+
+	// Release per-table resources outside the global lock.
+	for _, table := range tablesToClose {
+		stopTableTimers(table)
+		if table.Tags != nil {
+			table.Tags.Close()
+		}
+		table.mu.Close()
+	}
 
 	telemetry.RecordWorkerQueueDepth("dynamodb", "TableCleaner", depth)
 	telemetry.RecordWorkerTask("dynamodb", "TableCleaner", "success")

--- a/services/dynamodb/table_ops.go
+++ b/services/dynamodb/table_ops.go
@@ -61,17 +61,10 @@ func (db *InMemoryDB) CreateTable(
 
 	region := getRegionFromContext(ctx, db)
 
-	db.mu.Lock("CreateTable")
-	defer db.mu.Unlock()
-
-	if _, exists := db.Tables[region]; !exists {
-		db.Tables[region] = make(map[string]*Table)
-	}
-
-	if _, exists := db.Tables[region][tableName]; exists {
-		return nil, NewResourceInUseException(fmt.Sprintf("table already exists: %s", tableName))
-	}
-
+	// Pre-lock: validate input and construct the table object. These operations
+	// touch no shared state and can run concurrently with other requests. Building
+	// the struct before the lock keeps the critical section to a handful of map ops,
+	// significantly reducing contention when thousands of tables are created together.
 	if err := validateAttributeDefinitions(input); err != nil {
 		return nil, err
 	}
@@ -100,12 +93,32 @@ func (db *InMemoryDB) CreateTable(
 		newTable.Status = string(types.TableStatusActive)
 	}
 
+	// Minimal critical section: check for duplicate, then insert into the shared maps.
+	db.mu.Lock("CreateTable")
+
+	if _, exists := db.Tables[region]; !exists {
+		db.Tables[region] = make(map[string]*Table)
+	}
+
+	if _, exists := db.Tables[region][tableName]; exists {
+		db.mu.Unlock()
+		// Release resources we allocated before discovering the duplicate.
+		stopTableTimers(newTable)
+		newTable.mu.Close()
+
+		return nil, NewResourceInUseException(fmt.Sprintf("table already exists: %s", tableName))
+	}
+
 	db.Tables[region][tableName] = newTable
 
 	if newTable.StreamARN != "" {
 		db.streamARNIndex[newTable.StreamARN] = newTable
 	}
 
+	db.mu.Unlock()
+
+	// Throttler has its own internal lock; call after releasing db.mu to keep the
+	// critical section above as short as possible.
 	rcu := int64(newTable.ProvisionedThroughput.ReadCapacityUnits)
 	wcu := int64(newTable.ProvisionedThroughput.WriteCapacityUnits)
 	db.throttler.SetTableCapacity(throttleKey(region, tableName), rcu, wcu)

--- a/services/s3/janitor.go
+++ b/services/s3/janitor.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -120,17 +122,20 @@ type lifecycleNoncurrentTransition struct {
 const (
 	defaultJanitorInterval = 500 * time.Millisecond
 
-	// janitorBatchSize is the maximum number of objects deleted from a pending
-	// bucket per janitor tick. This keeps each tick short while the queue is
-	// visibly draining on the live metrics dashboard.
-	janitorBatchSize = 100
+	// drainChunkSize is the maximum number of objects deleted per lock acquisition
+	// while draining a DeletePending bucket. Between chunks the bucket lock is
+	// released so that concurrent operations (PutObject, GetObject) are not
+	// starved. 10 000 is fast enough (sub-millisecond in practice) while keeping
+	// the critical section short.
+	drainChunkSize = 10_000
 )
 
 // Janitor is the S3 background worker that drains buckets queued for async
 // deletion and records queue-depth metrics for the live dashboard.
 type Janitor struct {
-	Backend  *InMemoryBackend
-	Interval time.Duration
+	Backend      *InMemoryBackend
+	activeDrains sync.Map
+	Interval     time.Duration
 }
 
 // NewJanitor creates a new S3 Janitor for the given backend.
@@ -149,6 +154,8 @@ func NewJanitor(backend *InMemoryBackend, settings Settings) *Janitor {
 }
 
 // Run runs the janitor loop until ctx is cancelled.
+// Each tick, sweepAndDrain spawns one goroutine per pending bucket so that
+// thousands of large buckets are drained in parallel rather than serially.
 func (j *Janitor) Run(ctx context.Context) {
 	ticker := time.NewTicker(j.Interval)
 	defer ticker.Stop()
@@ -158,9 +165,40 @@ func (j *Janitor) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			j.runOnce(ctx)
+			j.sweepAndDrain(ctx)
 			j.sweepLifecycle(ctx)
 			j.cleanupDefaultMultipart(ctx)
+		}
+	}
+}
+
+// sweepAndDrain records queue depth and spawns a dedicated goroutine per
+// pending bucket. A [sync.Map] (activeDrains) prevents duplicate goroutines for
+// buckets that are still being drained from a previous tick.
+func (j *Janitor) sweepAndDrain(ctx context.Context) {
+	b := j.Backend
+
+	b.mu.RLock("S3Janitor")
+	pending := make([]string, 0)
+
+	for _, regionBuckets := range b.buckets {
+		for name, bucket := range regionBuckets {
+			if bucket.DeletePending {
+				pending = append(pending, name)
+			}
+		}
+	}
+	b.mu.RUnlock()
+
+	telemetry.RecordWorkerQueueDepth("s3", "BucketCleaner", len(pending))
+	telemetry.RecordWorkerTask("s3", "BucketCleaner", "success")
+
+	for _, name := range pending {
+		if _, loaded := j.activeDrains.LoadOrStore(name, struct{}{}); !loaded {
+			go func(n string) {
+				defer j.activeDrains.Delete(n)
+				j.processBucket(ctx, n)
+			}(name)
 		}
 	}
 }
@@ -199,37 +237,18 @@ func (j *Janitor) cleanupDefaultMultipart(_ context.Context) {
 	}
 }
 
-// runOnce performs one pass: records queue depth, then processes pending buckets.
-func (j *Janitor) runOnce(ctx context.Context) {
-	b := j.Backend
-
-	// Snapshot pending bucket names under a short read-lock across all regions.
-	b.mu.RLock("S3Janitor")
-	pending := make([]string, 0)
-
-	for _, regionBuckets := range b.buckets {
-		for name, bucket := range regionBuckets {
-			if bucket.DeletePending {
-				pending = append(pending, name)
-			}
-		}
-	}
-	b.mu.RUnlock()
-
-	telemetry.RecordWorkerQueueDepth("s3", "BucketCleaner", len(pending))
-	telemetry.RecordWorkerTask("s3", "BucketCleaner", "success")
-
-	for _, name := range pending {
-		j.processBucket(ctx, name)
-	}
-}
-
-// processBucket deletes up to janitorBatchSize objects from a pending bucket, then
-// removes the bucket itself once it is empty.
+// processBucket fully drains a pending bucket by deleting all objects in repeated
+// chunks of drainChunkSize, releasing the bucket lock between chunks so that
+// concurrent operations are not starved. Once the bucket is empty it removes all
+// associated metadata (region index, uploads, tags) and closes the bucket mutex.
+//
+// Safe to call synchronously (directly for tests) or from a goroutine (production
+// via sweepAndDrain). When called from a goroutine the activeDrains sentinel in
+// sweepAndDrain prevents duplicate goroutines for the same bucket.
 func (j *Janitor) processBucket(ctx context.Context, name string) {
 	b := j.Backend
 
-	// Search for the bucket across all regions
+	// Locate the bucket once; it cannot move between regions.
 	b.mu.RLock("S3Janitor.processBucket")
 	bucket, foundRegion := findBucketAcrossRegions(b.buckets, name)
 	b.mu.RUnlock()
@@ -238,55 +257,62 @@ func (j *Janitor) processBucket(ctx context.Context, name string) {
 		return
 	}
 
-	// Delete a batch of objects under the bucket lock.
-	bucket.mu.Lock("S3Janitor.processBucket")
-	count := deleteBatch(bucket.Objects, janitorBatchSize)
+	// Drain all objects in chunks, yielding between each to avoid starving
+	// concurrent operations that are waiting on bucket.mu.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 
-	telemetry.RecordWorkerItems("s3", "BucketCleaner", count)
+		bucket.mu.Lock("S3Janitor.processBucket")
+		count := deleteBatch(bucket.Objects, drainChunkSize)
+		remaining := len(bucket.Objects)
+		bucket.mu.Unlock()
 
-	remaining := len(bucket.Objects)
-	bucket.mu.Unlock()
+		telemetry.RecordWorkerItems("s3", "BucketCleaner", count)
 
-	if remaining > 0 {
-		// More objects remain; they will be picked up on the next tick.
+		if remaining > 0 {
+			runtime.Gosched()
+
+			continue
+		}
+
+		// Bucket is empty — remove it from the region map and clean up the
+		// region entry if it has become empty to prevent unbounded map growth.
+		// Guard the index removal: only delete if it still points at foundRegion
+		// so a future bucket with the same name keeps its index entry.
+		// Also purge orphaned uploads and tags to prevent resource leaks.
+		b.mu.Lock("S3Janitor.removeBucket")
+		if regionBuckets, exists := b.buckets[foundRegion]; exists {
+			delete(regionBuckets, name)
+
+			if len(regionBuckets) == 0 {
+				delete(b.buckets, foundRegion)
+			}
+		}
+
+		if b.bucketIndex[name] == foundRegion {
+			delete(b.bucketIndex, name)
+		}
+
+		delete(b.uploads, name)
+
+		prefix := name + "/"
+		for tagKey := range b.tags {
+			if strings.HasPrefix(tagKey, prefix) {
+				delete(b.tags, tagKey)
+			}
+		}
+
+		b.mu.Unlock()
+		bucket.mu.Close()
+
+		logger.Load(ctx).InfoContext(ctx, "S3 janitor: bucket deleted", "bucket", name)
+
 		return
 	}
-
-	// Bucket is empty — remove it from the region map and clean up the region
-	// entry if it has become empty to prevent unbounded map accumulation.
-	// Guard the index removal: only delete the entry if it still points at
-	// foundRegion, so a future replacement of the bucket name does not
-	// accidentally lose its index entry.
-	// Also purge any orphaned uploads and tags that reference this bucket to
-	// prevent unbounded memory growth (resource leaks).
-	b.mu.Lock("S3Janitor.removeBucket")
-	if regionBuckets, exists := b.buckets[foundRegion]; exists {
-		delete(regionBuckets, name)
-
-		if len(regionBuckets) == 0 {
-			delete(b.buckets, foundRegion)
-		}
-	}
-
-	if b.bucketIndex[name] == foundRegion {
-		delete(b.bucketIndex, name)
-	}
-
-	// Purge in-progress multipart uploads that belong to this bucket.
-	delete(b.uploads, name)
-
-	// Purge per-object tags whose key is prefixed with "<bucketName>/".
-	prefix := name + "/"
-	for tagKey := range b.tags {
-		if strings.HasPrefix(tagKey, prefix) {
-			delete(b.tags, tagKey)
-		}
-	}
-
-	b.mu.Unlock()
-	bucket.mu.Close()
-
-	logger.Load(ctx).InfoContext(ctx, "S3 janitor: bucket deleted", "bucket", name)
 }
 
 // sweepLifecycle iterates over all active buckets, evaluates lifecycle rules,


### PR DESCRIPTION
DynamoDB janitor: two-ticker Run (500ms housekeeping, 5s TTL sweep); runTableCleaner releases db.mu before per-table cleanup; CreateTable pre-builds Table struct before acquiring db.mu.Lock.

S3 janitor: per-bucket drain goroutines (sync.Map dedup); full drain loop at drainChunkSize=10_000 objects per chunk.