### PR TITLE
tests: use ephemeral TCP ports for server tests and add free port helper

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -198,8 +199,10 @@ func TestCLI_BuildLogger(t *testing.T) {
 
 //nolint:paralleltest // uses t.Setenv via parseCLI, which is incompatible with t.Parallel.
 func TestServerStartupAndShutdown(t *testing.T) {
+	port := freeTCPPort(t)
+
 	cli := parseCLI(t, map[string]string{
-		"PORT": "8123", // use an alternate port to avoid conflicts
+		"PORT": strconv.Itoa(port),
 	})
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -273,9 +276,10 @@ func TestCLI_InitScriptTimeout(t *testing.T) {
 func TestServerStartup_WithInitScript(t *testing.T) {
 	dir := t.TempDir()
 	marker := dir + "/marker.txt"
+	port := freeTCPPort(t)
 
 	cli := parseCLI(t, map[string]string{
-		"PORT": "8124",
+		"PORT": strconv.Itoa(port),
 	})
 	cli.InitScripts = []string{"echo ran > " + marker}
 	cli.InitScriptTimeout = 5 * time.Second
@@ -313,8 +317,9 @@ func TestServerStartup_WithDNS(t *testing.T) {
 	dnsPort := pc.LocalAddr().(*net.UDPAddr).Port
 	_ = pc.Close()
 
+	port := freeTCPPort(t)
 	cli := parseCLI(t, map[string]string{
-		"PORT": "8125",
+		"PORT": strconv.Itoa(port),
 	})
 	cli.DNSListenAddr = fmt.Sprintf("127.0.0.1:%d", dnsPort)
 	cli.DNSResolveIP = "127.0.0.1"
@@ -339,8 +344,9 @@ func TestServerStartup_WithDNS(t *testing.T) {
 
 //nolint:paralleltest // uses t.Setenv via parseCLI, which is incompatible with t.Parallel.
 func TestServerStartup_InvalidDNSConfig(t *testing.T) {
+	port := freeTCPPort(t)
 	cli := parseCLI(t, map[string]string{
-		"PORT": "8126",
+		"PORT": strconv.Itoa(port),
 	})
 	cli.DNSListenAddr = ":18553"
 	cli.DNSResolveIP = "not-an-ip" // invalid — server logs a warning and continues
@@ -365,8 +371,9 @@ func TestServerStartup_InvalidDNSConfig(t *testing.T) {
 
 //nolint:paralleltest // uses t.Setenv via parseCLI, which is incompatible with t.Parallel.
 func TestServerStartup_InvalidPortRange(t *testing.T) {
+	port := freeTCPPort(t)
 	cli := parseCLI(t, map[string]string{
-		"PORT": "8127",
+		"PORT": strconv.Itoa(port),
 	})
 	cli.PortRangeStart = 0 // invalid range — logs a warning and continues
 	cli.PortRangeEnd = 0
@@ -391,8 +398,11 @@ func TestServerStartup_InvalidPortRange(t *testing.T) {
 
 //nolint:paralleltest // uses t.Setenv via parseCLI, which is incompatible with t.Parallel.
 func TestHealthCmd_Success(t *testing.T) {
+	port := freeTCPPort(t)
+	portString := strconv.Itoa(port)
+
 	cli := parseCLI(t, map[string]string{
-		"PORT": "8130",
+		"PORT": portString,
 	})
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -405,7 +415,7 @@ func TestHealthCmd_Success(t *testing.T) {
 
 	// Wait for the server to be ready.
 	require.Eventually(t, func() bool {
-		resp, err := http.Get("http://localhost:8130/_gopherstack/health")
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/_gopherstack/health", port))
 		if err != nil {
 			return false
 		}
@@ -415,7 +425,7 @@ func TestHealthCmd_Success(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond, "server did not become ready")
 
 	// Run the health command against the running server.
-	cmd := &HealthCmd{Port: "8130"}
+	cmd := &HealthCmd{Port: portString}
 	require.NoError(t, cmd.Run())
 
 	cancel()
@@ -688,7 +698,8 @@ func TestPanicRecoveryMiddleware_RecoversPanic(t *testing.T) {
 //nolint:paralleltest // uses a fixed port that cannot be parallelised
 func TestHealthEndpoint_GoroutineAndMemStats(t *testing.T) {
 	// Uses t.Setenv-like machinery via parseCLI; no t.Parallel.
-	cli := parseCLI(t, map[string]string{"PORT": "8131"})
+	port := freeTCPPort(t)
+	cli := parseCLI(t, map[string]string{"PORT": strconv.Itoa(port)})
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -699,7 +710,7 @@ func TestHealthEndpoint_GoroutineAndMemStats(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		resp, err := http.Get("http://localhost:8131/_gopherstack/health")
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/_gopherstack/health", port))
 		if err != nil {
 			return false
 		}
@@ -708,7 +719,7 @@ func TestHealthEndpoint_GoroutineAndMemStats(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, 3*time.Second, 50*time.Millisecond, "server did not become ready")
 
-	resp, err := http.Get("http://localhost:8131/_gopherstack/health")
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/_gopherstack/health", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -14,17 +18,14 @@ func TestMultipleServersStartupAndShutdown(t *testing.T) {
 
 	tests := []struct {
 		name string
-		port string
 		demo bool
 	}{
 		{
 			name: "server startup without DEMO",
-			port: ":8001",
 			demo: false,
 		},
 		{
 			name: "server startup with DEMO",
-			port: ":8002",
 			demo: true,
 		},
 	}
@@ -32,10 +33,12 @@ func TestMultipleServersStartupAndShutdown(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			port := freeTCPPort(t)
 			stopChan := make(chan struct{})
+			errChan := make(chan error, 1)
 
 			go func() {
-				_ = startServerOnPort(t, tt.port, tt.demo, stopChan)
+				errChan <- startServerOnPort(t, port, tt.demo, stopChan)
 			}()
 
 			// Give the server time to start.
@@ -43,29 +46,38 @@ func TestMultipleServersStartupAndShutdown(t *testing.T) {
 
 			client := &http.Client{Timeout: 5 * time.Second}
 
-			resp, err := client.Get("http://localhost" + tt.port + "/dashboard")
-			require.NoError(t, err, "failed to reach server on %s", tt.port)
+			resp, err := client.Get(fmt.Sprintf("http://localhost:%d/dashboard", port))
+			require.NoError(t, err, "failed to reach server on :%d", port)
 			defer resp.Body.Close()
 
 			assert.True(t,
 				resp.StatusCode >= 200 && resp.StatusCode < 500,
 				"unexpected status code: %d", resp.StatusCode)
 
-			t.Logf("Server responding with status %d on port %s", resp.StatusCode, tt.port)
+			t.Logf("Server responding with status %d on port :%d", resp.StatusCode, port)
 
 			close(stopChan)
-			time.Sleep(100 * time.Millisecond)
+
+			select {
+			case runErr := <-errChan:
+				require.NoError(t, runErr)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "server did not shut down within timeout")
+			}
 		})
 	}
 }
 
 // startServerOnPort starts Gopherstack on the given port using the CLI run path.
 // It returns when the stopChan is closed.
-func startServerOnPort(t *testing.T, port string, demo bool, stopChan chan struct{}) error {
+func startServerOnPort(t *testing.T, port int, demo bool, stopChan chan struct{}) error {
 	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
 	cli := CLI{
 		LogLevel: "info",
-		Port:     port,
+		Port:     strconv.Itoa(port),
 		Region:   "us-east-1",
 		Demo:     demo,
 	}
@@ -73,13 +85,25 @@ func startServerOnPort(t *testing.T, port string, demo bool, stopChan chan struc
 	errChan := make(chan error, 1)
 
 	go func() {
-		errChan <- run(t.Context(), cli)
+		errChan <- run(ctx, cli)
 	}()
 
 	select {
 	case <-stopChan:
-		return nil
+		cancel()
+
+		return <-errChan
 	case err := <-errChan:
 		return err
 	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port
 }


### PR DESCRIPTION
### Motivation

- Reduce flakiness and port collisions in server tests by avoiding hard-coded ports and using ephemeral free ports.

### Description

- Replaced hard-coded port values in `cli_test.go` and `main_test.go` with dynamically allocated ports using a new `freeTCPPort` helper.
- Added `freeTCPPort` helper that binds to `127.0.0.1:0` to obtain an available port and updated tests to call `strconv.Itoa` and `fmt.Sprintf` where appropriate.
- Changed `startServerOnPort` signature to accept an `int` port and to use a cancellable `context` for shutdown, and updated callers to use an error channel to observe server shutdown results.
- Updated imports in the modified test files to include `net`, `context`, `fmt`, and `strconv` as needed.

### Testing

- Ran `go test ./...` which executed server startup/shutdown and health endpoint tests including `TestServerStartupAndShutdown`, `TestServerStartup_WithInitScript`, `TestHealthCmd_Success`, `TestMultipleServersStartupAndShutdown`, and `TestHealthEndpoint_GoroutineAndMemStats` and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2c4cc5dc8320acfb071772ff6d0a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
