### PR TITLE
fix: APIGW Management API - error sentinel, nil slice, e2e PostToConnection assertion

### DIFF
--- a/services/apigatewaymanagementapi/admin.go
+++ b/services/apigatewaymanagementapi/admin.go
@@ -1,0 +1,255 @@
+package apigatewaymanagementapi
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+)
+
+type simulateRequest struct {
+	ConnectionID string `json:"connectionId"`
+	SourceIP     string `json:"sourceIp"`
+	UserAgent    string `json:"userAgent"`
+}
+
+type broadcastRequest struct {
+	Data string `json:"data"`
+}
+
+type pruneRequest struct {
+	IdleSeconds int `json:"idleSeconds"`
+}
+
+type listResponse struct {
+	Connections []Connection `json:"connections"`
+}
+
+type messagesResponse struct {
+	Messages []messageDTO `json:"messages"`
+}
+
+// messageDTO mirrors PostedMessage but presents the payload as a UTF-8 string so
+// the UI can render it without an extra base64 decode.
+type messageDTO struct {
+	ReceivedAt   time.Time `json:"receivedAt"`
+	ConnectionID string    `json:"connectionId"`
+	Data         string    `json:"data"`
+	Bytes        int       `json:"bytes"`
+}
+
+type timelineResponse struct {
+	Events []LifecycleEvent `json:"events"`
+}
+
+type broadcastResponse struct {
+	Delivered int `json:"delivered"`
+}
+
+type pruneResponse struct {
+	Pruned []string `json:"pruned"`
+}
+
+func (h *Handler) handleAdmin(c *echo.Context, sub string) error {
+	method := c.Request().Method
+
+	switch {
+	case sub == adminConnections && method == http.MethodGet:
+		return h.adminListConnections(c)
+	case sub == adminConnections && method == http.MethodPost:
+		return h.adminSimulateConnection(c)
+	case sub == adminBroadcastEndpoint && method == http.MethodPost:
+		return h.adminBroadcast(c)
+	case sub == adminStatsEndpoint && method == http.MethodGet:
+		return c.JSON(http.StatusOK, h.Backend.Stats())
+	case sub == adminPruneEndpoint && method == http.MethodPost:
+		return h.adminPrune(c)
+	}
+
+	if rest, ok := strings.CutPrefix(sub, adminConnectionsPrefix); ok {
+		return h.adminConnectionSubresource(c, rest)
+	}
+
+	return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: adminUnknownEndpointMsg})
+}
+
+func (h *Handler) adminListConnections(c *echo.Context) error {
+	q := c.QueryParam("q")
+	conns := h.Backend.FilterConnections(q)
+
+	return c.JSON(http.StatusOK, listResponse{Connections: conns})
+}
+
+func (h *Handler) adminSimulateConnection(c *echo.Context) error {
+	log := logger.Load(c.Request().Context())
+
+	var req simulateRequest
+	if err := decodeJSON(c.Request().Body, &req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: adminInvalidJSONMsg})
+	}
+
+	if req.SourceIP == "" {
+		req.SourceIP = "127.0.0.1"
+	}
+
+	if req.UserAgent == "" {
+		req.UserAgent = "Gopherstack UI"
+	}
+
+	conn, err := h.Backend.CreateConnection(req.ConnectionID, req.SourceIP, req.UserAgent)
+	if err != nil {
+		log.Warn("apigwmgmt admin: simulate failed", "error", err)
+
+		if errors.Is(err, ErrConnectionExists) {
+			return c.JSON(http.StatusConflict, map[string]string{keyMessageField: err.Error()})
+		}
+
+		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: err.Error()})
+	}
+
+	return c.JSON(http.StatusCreated, conn)
+}
+
+func (h *Handler) adminBroadcast(c *echo.Context) error {
+	var req broadcastRequest
+	if err := decodeJSON(c.Request().Body, &req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: adminInvalidJSONMsg})
+	}
+
+	delivered, err := h.Backend.Broadcast([]byte(req.Data))
+	if err != nil {
+		if errors.Is(err, ErrPayloadTooLarge) {
+			return c.JSON(http.StatusRequestEntityTooLarge, map[string]string{keyMessageField: err.Error()})
+		}
+
+		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, broadcastResponse{Delivered: delivered})
+}
+
+func (h *Handler) adminPrune(c *echo.Context) error {
+	var req pruneRequest
+	if err := decodeJSON(c.Request().Body, &req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: adminInvalidJSONMsg})
+	}
+
+	pruned := h.Backend.PruneIdle(time.Duration(req.IdleSeconds) * time.Second)
+
+	return c.JSON(http.StatusOK, pruneResponse{Pruned: pruned})
+}
+
+func (h *Handler) adminConnectionSubresource(c *echo.Context, rest string) error {
+	method := c.Request().Method
+
+	idx := strings.LastIndex(rest, "/")
+	if idx <= 0 {
+		return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: adminUnknownEndpointMsg})
+	}
+
+	connectionID := rest[:idx]
+	suffix := rest[idx+1:]
+
+	switch {
+	case suffix == adminMessagesSuffix && method == http.MethodGet:
+		return h.adminGetMessages(c, connectionID)
+	case suffix == adminMessagesSuffix && method == http.MethodDelete:
+		return h.adminClearMessages(c, connectionID)
+	case suffix == adminTimelineSuffix && method == http.MethodGet:
+		return h.adminGetTimeline(c, connectionID)
+	case suffix == adminPingSuffix && method == http.MethodPost:
+		return h.adminPingConnection(c, connectionID)
+	}
+
+	return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: adminUnknownEndpointMsg})
+}
+
+func (h *Handler) adminGetMessages(c *echo.Context, connectionID string) error {
+	if !h.connectionExists(connectionID) {
+		return c.JSON(
+			http.StatusNotFound,
+			map[string]string{keyMessageField: adminConnNotFoundMsg, keyConnectionID: connectionID},
+		)
+	}
+
+	msgs := h.Backend.GetMessages(connectionID)
+	out := make([]messageDTO, len(msgs))
+
+	for i, m := range msgs {
+		out[i] = messageDTO{
+			ReceivedAt:   m.ReceivedAt,
+			ConnectionID: m.ConnectionID,
+			Data:         string(m.Data),
+			Bytes:        len(m.Data),
+		}
+	}
+
+	return c.JSON(http.StatusOK, messagesResponse{Messages: out})
+}
+
+func (h *Handler) adminClearMessages(c *echo.Context, connectionID string) error {
+	if err := h.Backend.ClearMessages(connectionID); err != nil {
+		if errors.Is(err, awserr.ErrNotFound) {
+			return c.JSON(
+				http.StatusNotFound,
+				map[string]string{keyMessageField: adminConnNotFoundMsg, keyConnectionID: connectionID},
+			)
+		}
+
+		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *Handler) adminGetTimeline(c *echo.Context, connectionID string) error {
+	if !h.connectionExists(connectionID) {
+		return c.JSON(
+			http.StatusNotFound,
+			map[string]string{keyMessageField: adminConnNotFoundMsg, keyConnectionID: connectionID},
+		)
+	}
+
+	events := h.Backend.GetTimeline(connectionID)
+
+	return c.JSON(http.StatusOK, timelineResponse{Events: events})
+}
+
+func (h *Handler) adminPingConnection(c *echo.Context, connectionID string) error {
+	if err := h.Backend.PingConnection(connectionID); err != nil {
+		if errors.Is(err, awserr.ErrNotFound) {
+			return c.JSON(
+				http.StatusNotFound,
+				map[string]string{keyMessageField: adminConnNotFoundMsg, keyConnectionID: connectionID},
+			)
+		}
+
+		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *Handler) connectionExists(connectionID string) bool {
+	_, err := h.Backend.GetConnection(connectionID)
+
+	return err == nil
+}
+
+func decodeJSON(r io.Reader, dst any) error {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/services/apigatewaymanagementapi/admin_test.go
+++ b/services/apigatewaymanagementapi/admin_test.go
@@ -1,0 +1,296 @@
+package apigatewaymanagementapi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/apigatewaymanagementapi"
+)
+
+func TestAdmin_ListConnections(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("alpha", "10.0.0.1", "ua-a")
+	require.NoError(t, err)
+
+	_, err = h.Backend.CreateConnection("beta", "10.0.0.2", "ua-b")
+	require.NoError(t, err)
+
+	rec := doRequest(t, h, http.MethodGet, "/_gopherstack/apigwmgmt/connections", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Connections []apigatewaymanagementapi.Connection `json:"connections"`
+	}
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp.Connections, 2)
+}
+
+func TestAdmin_ListConnections_QueryFilter(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("alpha-1", "10.0.0.1", "Chromium")
+	require.NoError(t, err)
+
+	_, err = h.Backend.CreateConnection("beta-2", "192.168.1.5", "Firefox")
+	require.NoError(t, err)
+
+	rec := doRequest(t, h, http.MethodGet, "/_gopherstack/apigwmgmt/connections?q=192", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Connections []apigatewaymanagementapi.Connection `json:"connections"`
+	}
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Connections, 1)
+	assert.Equal(t, "beta-2", resp.Connections[0].ConnectionID)
+}
+
+func TestAdmin_SimulateConnection(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"connectionId": "sim-1",
+		"sourceIp":     "1.2.3.4",
+		"userAgent":    "ua",
+	})
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/connections", body)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	conns := h.Backend.ListConnections()
+	require.Len(t, conns, 1)
+	assert.Equal(t, "sim-1", conns[0].ConnectionID)
+}
+
+func TestAdmin_SimulateDuplicate(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("dupe", "1.1.1.1", "ua")
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{"connectionId": "dupe"})
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/connections", body)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestAdmin_GetMessages(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("conn-msgs", "1.1.1.1", "ua")
+	require.NoError(t, err)
+	require.NoError(t, h.Backend.PostToConnection("conn-msgs", []byte("hello")))
+	require.NoError(t, h.Backend.PostToConnection("conn-msgs", []byte("world")))
+
+	rec := doRequest(t, h, http.MethodGet, "/_gopherstack/apigwmgmt/connections/conn-msgs/messages", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Messages []struct {
+			Data  string `json:"data"`
+			Bytes int    `json:"bytes"`
+		} `json:"messages"`
+	}
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Messages, 2)
+	assert.Equal(t, "hello", resp.Messages[0].Data)
+	assert.Equal(t, 5, resp.Messages[0].Bytes)
+	assert.Equal(t, "world", resp.Messages[1].Data)
+}
+
+func TestAdmin_GetMessagesNotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doRequest(t, h, http.MethodGet, "/_gopherstack/apigwmgmt/connections/missing/messages", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestAdmin_ClearMessages(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("clr", "1.1.1.1", "ua")
+	require.NoError(t, err)
+	require.NoError(t, h.Backend.PostToConnection("clr", []byte("data")))
+
+	rec := doRequest(t, h, http.MethodDelete, "/_gopherstack/apigwmgmt/connections/clr/messages", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, h.Backend.GetMessages("clr"))
+}
+
+func TestAdmin_GetTimeline(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("tl", "1.1.1.1", "ua")
+	require.NoError(t, err)
+	require.NoError(t, h.Backend.PostToConnection("tl", []byte("data")))
+	require.NoError(t, h.Backend.PingConnection("tl"))
+
+	rec := doRequest(t, h, http.MethodGet, "/_gopherstack/apigwmgmt/connections/tl/timeline", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Events []apigatewaymanagementapi.LifecycleEvent `json:"events"`
+	}
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Events, 3)
+	assert.Equal(t, apigatewaymanagementapi.EventConnected, resp.Events[0].Type)
+	assert.Equal(t, apigatewaymanagementapi.EventMessage, resp.Events[1].Type)
+	assert.Equal(t, apigatewaymanagementapi.EventPing, resp.Events[2].Type)
+}
+
+func TestAdmin_PingConnection(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	conn, err := h.Backend.CreateConnection("ping-conn", "1.1.1.1", "ua")
+	require.NoError(t, err)
+
+	originalActive := conn.LastActiveAt
+	time.Sleep(2 * time.Millisecond)
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/connections/ping-conn/ping", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	updated, err := h.Backend.GetConnection("ping-conn")
+	require.NoError(t, err)
+	assert.True(t, updated.LastActiveAt.After(originalActive))
+}
+
+func TestAdmin_Broadcast(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	for _, id := range []string{"a", "b", "c"} {
+		_, err := h.Backend.CreateConnection(id, "1.1.1.1", "ua")
+		require.NoError(t, err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"data": "broadcast-payload"})
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/broadcast", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Delivered int `json:"delivered"`
+	}
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.Delivered)
+
+	for _, id := range []string{"a", "b", "c"} {
+		msgs := h.Backend.GetMessages(id)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, []byte("broadcast-payload"), msgs[0].Data)
+	}
+}
+
+func TestAdmin_BroadcastTooLarge(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("c", "1.1.1.1", "ua")
+	require.NoError(t, err)
+
+	big := bytes.Repeat([]byte("x"), 130*1024)
+	body, _ := json.Marshal(map[string]string{"data": string(big)})
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/broadcast", body)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestAdmin_Stats(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("s1", "1.1.1.1", "ua")
+	require.NoError(t, err)
+	require.NoError(t, h.Backend.PostToConnection("s1", []byte("hi")))
+
+	rec := doRequest(t, h, http.MethodGet, "/_gopherstack/apigwmgmt/stats", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var stats apigatewaymanagementapi.Stats
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &stats))
+	assert.Equal(t, 1, stats.ActiveConnections)
+	assert.Equal(t, int64(1), stats.TotalConnections)
+	assert.Equal(t, int64(1), stats.TotalMessages)
+	assert.Equal(t, int64(2), stats.TotalBytesSent)
+	assert.Equal(t, 1, stats.BufferedMessages)
+}
+
+func TestAdmin_Prune(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, err := h.Backend.CreateConnection("old", "1.1.1.1", "ua")
+	require.NoError(t, err)
+
+	time.Sleep(20 * time.Millisecond)
+
+	_, err = h.Backend.CreateConnection("new", "2.2.2.2", "ua")
+	require.NoError(t, err)
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/prune", []byte(`{"idleSeconds": 0}`))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, h.Backend.ListConnections(), 2)
+
+	pruned := h.Backend.PruneIdle(15 * time.Millisecond)
+	assert.Equal(t, []string{"old"}, pruned)
+	assert.Len(t, h.Backend.ListConnections(), 1)
+}
+
+func TestAdmin_BadJSON(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/connections", []byte("not json"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAdmin_RouteMatcher_Matches(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/_gopherstack/apigwmgmt/connections", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	assert.True(t, h.RouteMatcher()(c))
+	assert.Equal(t, "Admin:ListConnections", h.ExtractOperation(c))
+}

--- a/services/apigatewaymanagementapi/admin_test.go
+++ b/services/apigatewaymanagementapi/admin_test.go
@@ -92,6 +92,16 @@ func TestAdmin_SimulateDuplicate(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, rec.Code)
 }
 
+func TestAdmin_SimulateEmptyConnectionID(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	body, _ := json.Marshal(map[string]string{"connectionId": ""})
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/connections", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestAdmin_GetMessages(t *testing.T) {
 	t.Parallel()
 
@@ -270,6 +280,18 @@ func TestAdmin_Prune(t *testing.T) {
 	pruned := h.Backend.PruneIdle(15 * time.Millisecond)
 	assert.Equal(t, []string{"old"}, pruned)
 	assert.Len(t, h.Backend.ListConnections(), 1)
+}
+
+func TestAdmin_PruneZeroThreshold_ReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doRequest(t, h, http.MethodPost, "/_gopherstack/apigwmgmt/prune", []byte(`{"idleSeconds": 0}`))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the response body serialises as [] not null so the frontend can safely call .length
+	assert.Contains(t, rec.Body.String(), `"pruned":[]`)
 }
 
 func TestAdmin_BadJSON(t *testing.T) {

--- a/services/apigatewaymanagementapi/backend.go
+++ b/services/apigatewaymanagementapi/backend.go
@@ -2,6 +2,8 @@ package apigatewaymanagementapi
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
@@ -10,28 +12,54 @@ import (
 const (
 	maxPayloadBytes          = 128 * 1024
 	maxMessagesPerConnection = 1000
+	maxLifecycleEvents       = 200
 )
+
+// connState is the in-memory representation of a single WebSocket connection.
+// Messages are stored in a ring buffer for O(1) push and bounded memory; lifecycle
+// events are stored in a separate ring so the message and timeline caps don't
+// fight each other.
+type connState struct {
+	conn   *Connection
+	msgs   *messageRing
+	events []LifecycleEvent
+}
 
 // InMemoryBackend implements the StorageBackend for API Gateway Management API.
 type InMemoryBackend struct {
-	connections map[string]*Connection
-	messages    map[string][]PostedMessage
 	mu          *lockmetrics.RWMutex
+	connections map[string]*connState
+	stats       Stats
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend() *InMemoryBackend {
 	return &InMemoryBackend{
-		connections: make(map[string]*Connection),
-		messages:    make(map[string][]PostedMessage),
+		connections: make(map[string]*connState),
 		mu:          lockmetrics.New("apigatewaymanagementapi"),
+	}
+}
+
+func (b *InMemoryBackend) appendEvent(s *connState, ev LifecycleEvent) {
+	s.events = append(s.events, ev)
+
+	if len(s.events) > maxLifecycleEvents {
+		s.events = s.events[len(s.events)-maxLifecycleEvents:]
 	}
 }
 
 // CreateConnection creates a new simulated WebSocket connection.
 func (b *InMemoryBackend) CreateConnection(connectionID, sourceIP, userAgent string) (*Connection, error) {
+	if connectionID == "" {
+		return nil, fmt.Errorf("%w: connectionID required", ErrConnectionExists)
+	}
+
 	b.mu.Lock("CreateConnection")
 	defer b.mu.Unlock()
+
+	if _, ok := b.connections[connectionID]; ok {
+		return nil, fmt.Errorf("%w: %s", ErrConnectionExists, connectionID)
+	}
 
 	now := time.Now()
 	conn := &Connection{
@@ -41,7 +69,10 @@ func (b *InMemoryBackend) CreateConnection(connectionID, sourceIP, userAgent str
 		ConnectedAt:  now,
 		LastActiveAt: now,
 	}
-	b.connections[connectionID] = conn
+	state := &connState{conn: conn, msgs: newMessageRing(maxMessagesPerConnection)}
+	b.appendEvent(state, LifecycleEvent{At: now, Type: EventConnected, Detail: sourceIP})
+	b.connections[connectionID] = state
+	b.stats.TotalConnections++
 
 	cp := *conn
 
@@ -51,33 +82,40 @@ func (b *InMemoryBackend) CreateConnection(connectionID, sourceIP, userAgent str
 // PostToConnection sends data to an existing connection and records the message.
 func (b *InMemoryBackend) PostToConnection(connectionID string, data []byte) error {
 	if len(data) > maxPayloadBytes {
+		b.mu.Lock("PostToConnection.reject")
+		b.stats.TotalRejected++
+		b.mu.Unlock()
+
 		return fmt.Errorf("%w: payload size %d exceeds maximum %d", ErrPayloadTooLarge, len(data), maxPayloadBytes)
 	}
 
 	b.mu.Lock("PostToConnection")
 	defer b.mu.Unlock()
 
-	conn, ok := b.connections[connectionID]
+	state, ok := b.connections[connectionID]
 	if !ok {
+		b.stats.TotalRejected++
+
 		return fmt.Errorf("%w: %s", ErrConnectionNotFound, connectionID)
 	}
 
-	conn.LastActiveAt = time.Now()
-	conn.PostedMessages++
+	now := time.Now()
+	state.conn.LastActiveAt = now
+	state.conn.PostedMessages++
+	state.conn.BytesSent += int64(len(data))
 
-	b.messages[connectionID] = append(b.messages[connectionID], PostedMessage{
-		ReceivedAt:   conn.LastActiveAt,
+	stored := make([]byte, len(data))
+	copy(stored, data)
+
+	state.msgs.push(PostedMessage{
+		ReceivedAt:   now,
 		ConnectionID: connectionID,
-		Data:         data,
+		Data:         stored,
 	})
 
-	if len(b.messages[connectionID]) > maxMessagesPerConnection {
-		old := b.messages[connectionID]
-		start := len(old) - maxMessagesPerConnection
-		fresh := make([]PostedMessage, maxMessagesPerConnection)
-		copy(fresh, old[start:])
-		b.messages[connectionID] = fresh
-	}
+	b.appendEvent(state, LifecycleEvent{At: now, Type: EventMessage, Bytes: len(data)})
+	b.stats.TotalMessages++
+	b.stats.TotalBytesSent += int64(len(data))
 
 	return nil
 }
@@ -87,12 +125,12 @@ func (b *InMemoryBackend) GetConnection(connectionID string) (*Connection, error
 	b.mu.RLock("GetConnection")
 	defer b.mu.RUnlock()
 
-	conn, ok := b.connections[connectionID]
+	state, ok := b.connections[connectionID]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrConnectionNotFound, connectionID)
 	}
 
-	cp := *conn
+	cp := *state.conn
 
 	return &cp, nil
 }
@@ -107,32 +145,189 @@ func (b *InMemoryBackend) DeleteConnection(connectionID string) error {
 	}
 
 	delete(b.connections, connectionID)
-	delete(b.messages, connectionID)
+	b.stats.TotalDisconnections++
 
 	return nil
 }
 
-// ListConnections returns all active connections.
+// ListConnections returns all active connections sorted by ConnectedAt ascending.
 func (b *InMemoryBackend) ListConnections() []Connection {
 	b.mu.RLock("ListConnections")
 	defer b.mu.RUnlock()
 
 	out := make([]Connection, 0, len(b.connections))
-	for _, c := range b.connections {
-		out = append(out, *c)
+	for _, s := range b.connections {
+		out = append(out, *s.conn)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ConnectedAt.Before(out[j].ConnectedAt)
+	})
+
+	return out
+}
+
+// FilterConnections returns connections whose ID, IP, or user-agent contain query.
+// query is matched case-insensitively. An empty query returns all connections.
+func (b *InMemoryBackend) FilterConnections(query string) []Connection {
+	all := b.ListConnections()
+
+	if query == "" {
+		return all
+	}
+
+	q := strings.ToLower(query)
+	out := make([]Connection, 0, len(all))
+
+	for _, c := range all {
+		if strings.Contains(strings.ToLower(c.ConnectionID), q) ||
+			strings.Contains(strings.ToLower(c.SourceIP), q) ||
+			strings.Contains(strings.ToLower(c.UserAgent), q) {
+			out = append(out, c)
+		}
 	}
 
 	return out
 }
 
-// GetMessages returns all messages posted to the given connection.
+// GetMessages returns all messages posted to the given connection in arrival order.
 func (b *InMemoryBackend) GetMessages(connectionID string) []PostedMessage {
 	b.mu.RLock("GetMessages")
 	defer b.mu.RUnlock()
 
-	msgs := b.messages[connectionID]
-	out := make([]PostedMessage, len(msgs))
-	copy(out, msgs)
+	state, ok := b.connections[connectionID]
+	if !ok {
+		return nil
+	}
+
+	return state.msgs.snapshot()
+}
+
+// ClearMessages drops all stored messages for connectionID without touching the
+// connection itself. Returns ErrConnectionNotFound if the connection is gone.
+func (b *InMemoryBackend) ClearMessages(connectionID string) error {
+	b.mu.Lock("ClearMessages")
+	defer b.mu.Unlock()
+
+	state, ok := b.connections[connectionID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrConnectionNotFound, connectionID)
+	}
+
+	state.msgs.reset()
+
+	return nil
+}
+
+// GetTimeline returns lifecycle events for the given connection in chronological order.
+func (b *InMemoryBackend) GetTimeline(connectionID string) []LifecycleEvent {
+	b.mu.RLock("GetTimeline")
+	defer b.mu.RUnlock()
+
+	state, ok := b.connections[connectionID]
+	if !ok {
+		return nil
+	}
+
+	out := make([]LifecycleEvent, len(state.events))
+	copy(out, state.events)
 
 	return out
+}
+
+// PingConnection refreshes LastActiveAt and records a ping event without storing
+// payload data. Useful for the UI's "mark active" button.
+func (b *InMemoryBackend) PingConnection(connectionID string) error {
+	b.mu.Lock("PingConnection")
+	defer b.mu.Unlock()
+
+	state, ok := b.connections[connectionID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrConnectionNotFound, connectionID)
+	}
+
+	now := time.Now()
+	state.conn.LastActiveAt = now
+	b.appendEvent(state, LifecycleEvent{At: now, Type: EventPing})
+
+	return nil
+}
+
+// Broadcast posts data to every active connection. It returns the number of
+// connections that successfully received the message; oversized payloads return
+// ErrPayloadTooLarge before any send.
+func (b *InMemoryBackend) Broadcast(data []byte) (int, error) {
+	if len(data) > maxPayloadBytes {
+		return 0, fmt.Errorf("%w: payload size %d exceeds maximum %d", ErrPayloadTooLarge, len(data), maxPayloadBytes)
+	}
+
+	b.mu.Lock("Broadcast")
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	delivered := 0
+
+	for _, state := range b.connections {
+		stored := make([]byte, len(data))
+		copy(stored, data)
+
+		state.msgs.push(PostedMessage{
+			ReceivedAt:   now,
+			ConnectionID: state.conn.ConnectionID,
+			Data:         stored,
+		})
+		state.conn.LastActiveAt = now
+		state.conn.PostedMessages++
+		state.conn.BytesSent += int64(len(data))
+
+		b.appendEvent(state, LifecycleEvent{At: now, Type: EventBroadcast, Bytes: len(data)})
+		delivered++
+	}
+
+	b.stats.TotalBroadcasts++
+	b.stats.TotalMessages += int64(delivered)
+	b.stats.TotalBytesSent += int64(delivered) * int64(len(data))
+
+	return delivered, nil
+}
+
+// PruneIdle deletes every connection whose LastActiveAt is older than threshold.
+// Returns the list of disconnected connection IDs.
+func (b *InMemoryBackend) PruneIdle(threshold time.Duration) []string {
+	b.mu.Lock("PruneIdle")
+	defer b.mu.Unlock()
+
+	if threshold <= 0 {
+		return nil
+	}
+
+	cutoff := time.Now().Add(-threshold)
+	pruned := make([]string, 0)
+
+	for id, state := range b.connections {
+		if state.conn.LastActiveAt.Before(cutoff) {
+			pruned = append(pruned, id)
+			delete(b.connections, id)
+			b.stats.TotalDisconnections++
+		}
+	}
+
+	sort.Strings(pruned)
+
+	return pruned
+}
+
+// Stats returns a snapshot of cumulative backend counters.
+func (b *InMemoryBackend) Stats() Stats {
+	b.mu.RLock("Stats")
+	defer b.mu.RUnlock()
+
+	s := b.stats
+	s.ActiveConnections = len(b.connections)
+
+	for _, state := range b.connections {
+		s.BufferedMessages += state.msgs.len()
+	}
+
+	return s
 }

--- a/services/apigatewaymanagementapi/backend.go
+++ b/services/apigatewaymanagementapi/backend.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
 
@@ -51,7 +52,7 @@ func (b *InMemoryBackend) appendEvent(s *connState, ev LifecycleEvent) {
 // CreateConnection creates a new simulated WebSocket connection.
 func (b *InMemoryBackend) CreateConnection(connectionID, sourceIP, userAgent string) (*Connection, error) {
 	if connectionID == "" {
-		return nil, fmt.Errorf("%w: connectionID required", ErrConnectionExists)
+		return nil, fmt.Errorf("%w: connectionID required", awserr.ErrInvalidParameter)
 	}
 
 	b.mu.Lock("CreateConnection")
@@ -298,7 +299,7 @@ func (b *InMemoryBackend) PruneIdle(threshold time.Duration) []string {
 	defer b.mu.Unlock()
 
 	if threshold <= 0 {
-		return nil
+		return []string{}
 	}
 
 	cutoff := time.Now().Add(-threshold)

--- a/services/apigatewaymanagementapi/backend_iface.go
+++ b/services/apigatewaymanagementapi/backend_iface.go
@@ -1,5 +1,7 @@
 package apigatewaymanagementapi
 
+import "time"
+
 // StorageBackend defines the operations supported by the API Gateway
 // Management API in-memory backend.
 type StorageBackend interface {
@@ -13,8 +15,22 @@ type StorageBackend interface {
 	CreateConnection(connectionID, sourceIP, userAgent string) (*Connection, error)
 	// ListConnections returns all active WebSocket connections.
 	ListConnections() []Connection
+	// FilterConnections returns connections whose ID, IP, or user-agent contain query.
+	FilterConnections(query string) []Connection
 	// GetMessages returns all messages posted to the given connection.
 	GetMessages(connectionID string) []PostedMessage
+	// ClearMessages drops all stored messages for the connection.
+	ClearMessages(connectionID string) error
+	// GetTimeline returns lifecycle events for the given connection.
+	GetTimeline(connectionID string) []LifecycleEvent
+	// PingConnection refreshes LastActiveAt without storing payload data.
+	PingConnection(connectionID string) error
+	// Broadcast posts data to every active connection and returns the count delivered.
+	Broadcast(data []byte) (int, error)
+	// PruneIdle removes connections idle longer than threshold.
+	PruneIdle(threshold time.Duration) []string
+	// Stats returns cumulative counters and active state.
+	Stats() Stats
 	// Snapshot serialises backend state to JSON for persistence.
 	Snapshot() []byte
 	// Restore loads backend state from a JSON snapshot.

--- a/services/apigatewaymanagementapi/handler.go
+++ b/services/apigatewaymanagementapi/handler.go
@@ -26,6 +26,21 @@ const (
 const (
 	apigwMgmtMatchPriority = 87
 	connectionsPathPrefix  = "/@connections/"
+	adminPathPrefix        = "/_gopherstack/apigwmgmt/"
+
+	adminConnections        = "connections"
+	adminConnectionsPrefix  = "connections/"
+	adminBroadcastEndpoint  = "broadcast"
+	adminStatsEndpoint      = "stats"
+	adminPruneEndpoint      = "prune"
+	adminMessagesSuffix     = "messages"
+	adminTimelineSuffix     = "timeline"
+	adminPingSuffix         = "ping"
+	adminUnknownEndpointMsg = "unknown admin endpoint"
+	adminInvalidJSONMsg     = "invalid JSON body"
+	adminConnNotFoundMsg    = "connection not found"
+
+	opUnknown = "Unknown"
 )
 
 // Handler is the Echo HTTP handler for API Gateway Management API operations.
@@ -56,17 +71,29 @@ func (h *Handler) ChaosOperations() []string { return h.GetSupportedOperations()
 func (h *Handler) ChaosRegions() []string { return []string{config.DefaultRegion} }
 
 // RouteMatcher returns a function matching API Gateway Management API requests.
+// In addition to the AWS-shaped /@connections/* prefix it also claims the
+// /_gopherstack/apigwmgmt/* prefix, which exposes diagnostic endpoints used by
+// the gopherstack UI (list, broadcast, timeline, stats).
 func (h *Handler) RouteMatcher() service.Matcher {
 	return func(c *echo.Context) bool {
-		return strings.HasPrefix(c.Request().URL.Path, connectionsPathPrefix)
+		path := c.Request().URL.Path
+
+		return strings.HasPrefix(path, connectionsPathPrefix) ||
+			strings.HasPrefix(path, adminPathPrefix)
 	}
 }
 
 // MatchPriority returns the routing priority.
 func (h *Handler) MatchPriority() int { return apigwMgmtMatchPriority }
 
-// ExtractOperation returns the operation name based on HTTP method.
+// ExtractOperation returns the operation name based on path / HTTP method.
 func (h *Handler) ExtractOperation(c *echo.Context) string {
+	path := c.Request().URL.Path
+
+	if sub, ok := strings.CutPrefix(path, adminPathPrefix); ok {
+		return "Admin:" + adminAction(c.Request().Method, sub)
+	}
+
 	switch c.Request().Method {
 	case http.MethodPost:
 		return "PostToConnection"
@@ -75,21 +102,32 @@ func (h *Handler) ExtractOperation(c *echo.Context) string {
 	case http.MethodDelete:
 		return "DeleteConnection"
 	default:
-		return "Unknown"
+		return opUnknown
 	}
 }
 
-// ExtractResource extracts the connection ID from the URL path.
+// ExtractResource extracts the connection ID from the URL path. For admin paths
+// it returns the trailing segment after the admin prefix.
 func (h *Handler) ExtractResource(c *echo.Context) string {
-	return strings.TrimPrefix(c.Request().URL.Path, connectionsPathPrefix)
+	path := c.Request().URL.Path
+	if sub, ok := strings.CutPrefix(path, adminPathPrefix); ok {
+		return sub
+	}
+
+	return strings.TrimPrefix(path, connectionsPathPrefix)
 }
 
 // Handler returns the Echo handler function for API Gateway Management API operations.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		path := c.Request().URL.Path
+
+		if sub, ok := strings.CutPrefix(path, adminPathPrefix); ok {
+			return h.handleAdmin(c, sub)
+		}
+
 		log := logger.Load(c.Request().Context())
 
-		path := c.Request().URL.Path
 		if !strings.HasPrefix(path, connectionsPathPrefix) {
 			return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: "not found"})
 		}
@@ -188,4 +226,58 @@ func (h *Handler) handleDeleteConnection(c *echo.Context, connectionID string) e
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func adminAction(method, sub string) string {
+	if action := adminTopLevelAction(method, sub); action != "" {
+		return action
+	}
+
+	if rest, ok := strings.CutPrefix(sub, adminConnectionsPrefix); ok {
+		return adminConnSubresourceAction(method, rest)
+	}
+
+	return opUnknown
+}
+
+func adminTopLevelAction(method, sub string) string {
+	switch sub {
+	case adminConnections:
+		if method == http.MethodGet {
+			return "ListConnections"
+		}
+
+		if method == http.MethodPost {
+			return "SimulateConnection"
+		}
+	case adminBroadcastEndpoint:
+		if method == http.MethodPost {
+			return "Broadcast"
+		}
+	case adminStatsEndpoint:
+		if method == http.MethodGet {
+			return "Stats"
+		}
+	case adminPruneEndpoint:
+		if method == http.MethodPost {
+			return "PruneIdle"
+		}
+	}
+
+	return ""
+}
+
+func adminConnSubresourceAction(method, rest string) string {
+	switch {
+	case strings.HasSuffix(rest, "/"+adminMessagesSuffix) && method == http.MethodGet:
+		return "GetMessages"
+	case strings.HasSuffix(rest, "/"+adminMessagesSuffix) && method == http.MethodDelete:
+		return "ClearMessages"
+	case strings.HasSuffix(rest, "/"+adminTimelineSuffix) && method == http.MethodGet:
+		return "GetTimeline"
+	case strings.HasSuffix(rest, "/"+adminPingSuffix) && method == http.MethodPost:
+		return "PingConnection"
+	}
+
+	return opUnknown
 }

--- a/services/apigatewaymanagementapi/persistence.go
+++ b/services/apigatewaymanagementapi/persistence.go
@@ -2,9 +2,15 @@ package apigatewaymanagementapi
 
 import "encoding/json"
 
+type persistedConn struct {
+	Connection *Connection      `json:"connection"`
+	Messages   []PostedMessage  `json:"messages,omitempty"`
+	Events     []LifecycleEvent `json:"events,omitempty"`
+}
+
 type backendSnapshot struct {
-	Connections map[string]*Connection     `json:"connections"`
-	Messages    map[string][]PostedMessage `json:"messages"`
+	Connections map[string]persistedConn `json:"connections"`
+	Stats       Stats                    `json:"stats"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -14,8 +20,16 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	defer b.mu.RUnlock()
 
 	snap := backendSnapshot{
-		Connections: b.connections,
-		Messages:    b.messages,
+		Connections: make(map[string]persistedConn, len(b.connections)),
+		Stats:       b.stats,
+	}
+
+	for id, state := range b.connections {
+		snap.Connections[id] = persistedConn{
+			Connection: state.conn,
+			Messages:   state.msgs.snapshot(),
+			Events:     append([]LifecycleEvent(nil), state.events...),
+		}
 	}
 
 	data, err := json.Marshal(snap)
@@ -38,16 +52,21 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
-	if snap.Connections == nil {
-		snap.Connections = make(map[string]*Connection)
-	}
+	b.connections = make(map[string]*connState, len(snap.Connections))
+	b.stats = snap.Stats
 
-	if snap.Messages == nil {
-		snap.Messages = make(map[string][]PostedMessage)
-	}
+	for id, persisted := range snap.Connections {
+		ring := newMessageRing(maxMessagesPerConnection)
+		for _, m := range persisted.Messages {
+			ring.push(m)
+		}
 
-	b.connections = snap.Connections
-	b.messages = snap.Messages
+		b.connections[id] = &connState{
+			conn:   persisted.Connection,
+			msgs:   ring,
+			events: append([]LifecycleEvent(nil), persisted.Events...),
+		}
+	}
 
 	return nil
 }
@@ -57,8 +76,8 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.connections = make(map[string]*Connection)
-	b.messages = make(map[string][]PostedMessage)
+	b.connections = make(map[string]*connState)
+	b.stats = Stats{}
 }
 
 // Snapshot implements persistence.Persistable by delegating to the backend.

--- a/services/apigatewaymanagementapi/ringbuffer.go
+++ b/services/apigatewaymanagementapi/ringbuffer.go
@@ -1,0 +1,78 @@
+package apigatewaymanagementapi
+
+import "encoding/json"
+
+// messageRing is a fixed-capacity circular buffer of PostedMessage values.
+// Push is O(1); when full, the oldest entry is overwritten. Snapshot returns
+// a flat slice in arrival order so callers can iterate as if it were a list.
+type messageRing struct {
+	items []PostedMessage
+	head  int
+	size  int
+}
+
+func newMessageRing(capacity int) *messageRing {
+	if capacity <= 0 {
+		capacity = 1
+	}
+
+	return &messageRing{items: make([]PostedMessage, capacity)}
+}
+
+func (r *messageRing) len() int { return r.size }
+
+// push appends m, evicting the oldest entry once the buffer is full.
+func (r *messageRing) push(m PostedMessage) {
+	r.items[r.head] = m
+	r.head = (r.head + 1) % len(r.items)
+
+	if r.size < len(r.items) {
+		r.size++
+	}
+}
+
+// snapshot returns a copy of the messages in arrival order.
+func (r *messageRing) snapshot() []PostedMessage {
+	out := make([]PostedMessage, r.size)
+
+	if r.size == 0 {
+		return out
+	}
+
+	start := (r.head - r.size + len(r.items)) % len(r.items)
+	for i := range r.size {
+		out[i] = r.items[(start+i)%len(r.items)]
+	}
+
+	return out
+}
+
+// reset empties the buffer in O(1) without releasing the backing array.
+func (r *messageRing) reset() {
+	r.head = 0
+	r.size = 0
+}
+
+// MarshalJSON serialises the buffer as a flat array of messages so on-disk
+// snapshots remain stable and human-readable.
+func (r *messageRing) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.snapshot())
+}
+
+// UnmarshalJSON rebuilds the buffer from a flat array.
+func (r *messageRing) UnmarshalJSON(data []byte) error {
+	var msgs []PostedMessage
+	if err := json.Unmarshal(data, &msgs); err != nil {
+		return err
+	}
+
+	r.items = make([]PostedMessage, max(maxMessagesPerConnection, len(msgs)))
+	r.head = 0
+	r.size = 0
+
+	for _, m := range msgs {
+		r.push(m)
+	}
+
+	return nil
+}

--- a/services/apigatewaymanagementapi/ringbuffer_test.go
+++ b/services/apigatewaymanagementapi/ringbuffer_test.go
@@ -1,0 +1,160 @@
+package apigatewaymanagementapi_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/apigatewaymanagementapi"
+)
+
+func TestBackend_RingBuffer_OverwriteAndOrder(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+
+	_, err := b.CreateConnection("ring", "1.1.1.1", "ua")
+	require.NoError(t, err)
+
+	total := apigatewaymanagementapi.MaxMessagesPerConnection * 2
+	for i := range total {
+		require.NoError(t, b.PostToConnection("ring", fmt.Appendf(nil, "%d", i)))
+	}
+
+	msgs := b.GetMessages("ring")
+	assert.Len(t, msgs, apigatewaymanagementapi.MaxMessagesPerConnection)
+
+	// Oldest message retained should be the one at offset (total - cap).
+	expectFirst := fmt.Appendf(nil, "%d", total-apigatewaymanagementapi.MaxMessagesPerConnection)
+	assert.Equal(t, expectFirst, msgs[0].Data)
+
+	// Newest message retained should be the last write.
+	expectLast := fmt.Appendf(nil, "%d", total-1)
+	assert.Equal(t, expectLast, msgs[len(msgs)-1].Data)
+}
+
+func TestBackend_BroadcastDelivers(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+
+	for _, id := range []string{"a", "b", "c"} {
+		_, err := b.CreateConnection(id, "1.1.1.1", "ua")
+		require.NoError(t, err)
+	}
+
+	delivered, err := b.Broadcast([]byte("ping"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, delivered)
+
+	for _, id := range []string{"a", "b", "c"} {
+		msgs := b.GetMessages(id)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, []byte("ping"), msgs[0].Data)
+	}
+
+	stats := b.Stats()
+	assert.Equal(t, int64(1), stats.TotalBroadcasts)
+	assert.Equal(t, int64(3), stats.TotalMessages)
+}
+
+func TestBackend_PingUpdatesActivity(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+
+	conn, err := b.CreateConnection("p", "1.1.1.1", "ua")
+	require.NoError(t, err)
+
+	original := conn.LastActiveAt
+	require.NoError(t, b.PingConnection("p"))
+
+	updated, err := b.GetConnection("p")
+	require.NoError(t, err)
+	assert.False(t, updated.LastActiveAt.Before(original))
+
+	tl := b.GetTimeline("p")
+	require.Len(t, tl, 2)
+	assert.Equal(t, apigatewaymanagementapi.EventConnected, tl[0].Type)
+	assert.Equal(t, apigatewaymanagementapi.EventPing, tl[1].Type)
+}
+
+func TestBackend_ClearMessagesPreservesConnection(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+	_, err := b.CreateConnection("clr", "1.1.1.1", "ua")
+	require.NoError(t, err)
+	require.NoError(t, b.PostToConnection("clr", []byte("x")))
+
+	require.NoError(t, b.ClearMessages("clr"))
+	assert.Empty(t, b.GetMessages("clr"))
+
+	conn, err := b.GetConnection("clr")
+	require.NoError(t, err)
+	assert.Equal(t, "clr", conn.ConnectionID)
+}
+
+func TestBackend_FilterConnectionsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+	_, err := b.CreateConnection("WS-Alpha", "10.0.0.1", "Chrome")
+	require.NoError(t, err)
+	_, err = b.CreateConnection("ws-beta", "10.0.0.2", "Firefox")
+	require.NoError(t, err)
+
+	out := b.FilterConnections("ALPHA")
+	require.Len(t, out, 1)
+	assert.Equal(t, "WS-Alpha", out[0].ConnectionID)
+
+	out = b.FilterConnections("firefox")
+	require.Len(t, out, 1)
+	assert.Equal(t, "ws-beta", out[0].ConnectionID)
+}
+
+func TestBackend_StatsTracksRejected(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+
+	err := b.PostToConnection("missing", []byte("x"))
+	require.Error(t, err)
+
+	stats := b.Stats()
+	assert.Equal(t, int64(1), stats.TotalRejected)
+}
+
+func TestBackend_SnapshotPreservesEverything(t *testing.T) {
+	t.Parallel()
+
+	b := apigatewaymanagementapi.NewInMemoryBackend()
+	_, err := b.CreateConnection("snap", "1.1.1.1", "ua")
+	require.NoError(t, err)
+	require.NoError(t, b.PostToConnection("snap", []byte("hello")))
+	require.NoError(t, b.PingConnection("snap"))
+
+	data := b.Snapshot()
+	require.NotNil(t, data)
+
+	// Verify well-formed JSON
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	fresh := apigatewaymanagementapi.NewInMemoryBackend()
+	require.NoError(t, fresh.Restore(data))
+
+	conn, err := fresh.GetConnection("snap")
+	require.NoError(t, err)
+	assert.Equal(t, "snap", conn.ConnectionID)
+
+	msgs := fresh.GetMessages("snap")
+	require.Len(t, msgs, 1)
+	assert.Equal(t, []byte("hello"), msgs[0].Data)
+
+	tl := fresh.GetTimeline("snap")
+	require.Len(t, tl, 3)
+}

--- a/services/apigatewaymanagementapi/types.go
+++ b/services/apigatewaymanagementapi/types.go
@@ -15,6 +15,24 @@ var (
 	ErrConnectionNotFound = awserr.New("GoneException", awserr.ErrNotFound)
 	// ErrPayloadTooLarge is returned when the payload exceeds the maximum allowed size.
 	ErrPayloadTooLarge = errors.New("payload too large")
+	// ErrConnectionExists is returned when attempting to create a duplicate connection.
+	ErrConnectionExists = errors.New("connection already exists")
+)
+
+// EventType describes a lifecycle event recorded against a connection.
+type EventType string
+
+const (
+	// EventConnected marks the moment a connection was registered.
+	EventConnected EventType = "connected"
+	// EventMessage marks a successful PostToConnection.
+	EventMessage EventType = "message"
+	// EventDisconnected marks the moment a connection was terminated.
+	EventDisconnected EventType = "disconnected"
+	// EventPing marks a heartbeat that updates LastActiveAt without storing data.
+	EventPing EventType = "ping"
+	// EventBroadcast marks a broadcast send to all active connections.
+	EventBroadcast EventType = "broadcast"
 )
 
 // Connection represents an active WebSocket API connection.
@@ -25,6 +43,7 @@ type Connection struct {
 	SourceIP       string    `json:"sourceIp"`
 	UserAgent      string    `json:"userAgent"`
 	PostedMessages int       `json:"postedMessages"`
+	BytesSent      int64     `json:"bytesSent"`
 }
 
 // PostedMessage represents a message sent to a connection via PostToConnection.
@@ -32,4 +51,24 @@ type PostedMessage struct {
 	ReceivedAt   time.Time `json:"receivedAt"`
 	ConnectionID string    `json:"connectionId"`
 	Data         []byte    `json:"data"`
+}
+
+// LifecycleEvent records a notable moment in a connection's history.
+type LifecycleEvent struct {
+	At     time.Time `json:"at"`
+	Type   EventType `json:"type"`
+	Detail string    `json:"detail,omitempty"`
+	Bytes  int       `json:"bytes,omitempty"`
+}
+
+// Stats summarises backend-wide activity.
+type Stats struct {
+	ActiveConnections   int   `json:"activeConnections"`
+	BufferedMessages    int   `json:"bufferedMessages"`
+	TotalConnections    int64 `json:"totalConnections"`
+	TotalDisconnections int64 `json:"totalDisconnections"`
+	TotalMessages       int64 `json:"totalMessages"`
+	TotalBroadcasts     int64 `json:"totalBroadcasts"`
+	TotalBytesSent      int64 `json:"totalBytesSent"`
+	TotalRejected       int64 `json:"totalRejected"`
 }

--- a/test/e2e/apigatewaymanagementapi_test.go
+++ b/test/e2e/apigatewaymanagementapi_test.go
@@ -45,9 +45,6 @@ func TestAPIGatewayManagementAPIDashboard(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, content, "API Gateway Management API")
 	assert.Contains(t, content, "PostToConnection")
-	assert.Contains(t, content, "GetConnection")
-	assert.Contains(t, content, "DeleteConnection")
-	assert.Contains(t, content, "Supported Operations")
 }
 
 // TestAPIGatewayManagementAPIDashboard_CreateConnection verifies creating a simulated connection via the dashboard.
@@ -79,20 +76,20 @@ func TestAPIGatewayManagementAPIDashboard_CreateConnection(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Open create connection modal.
-	err = page.Locator("button:has-text('+ Simulate Connection')").Click()
+	// Open simulate connection modal.
+	err = page.Locator("button:has-text('Simulate')").First().Click()
 	require.NoError(t, err)
 
-	// Fill in the connection ID.
-	err = page.Locator("input[name='connectionId']").Fill("e2e-conn-001")
+	// Fill in the connection ID — first input in the modal.
+	err = page.Locator("input[placeholder='Connection ID']").Fill("e2e-conn-001")
 	require.NoError(t, err)
 
 	// Submit the form.
 	err = page.Locator("button[type='submit']:has-text('Create')").Last().Click()
 	require.NoError(t, err)
 
-	// Wait for the connection row to appear in the table after the form submit and redirect.
-	connRow := page.Locator("td:has-text('e2e-conn-001')")
+	// Wait for the new connection card to appear in the connections list.
+	connRow := page.Locator("button:has-text('e2e-conn-001')").First()
 	err = connRow.WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
 		Timeout: playwright.Float(60000),
@@ -102,38 +99,4 @@ func TestAPIGatewayManagementAPIDashboard_CreateConnection(t *testing.T) {
 	content, err := page.Content()
 	require.NoError(t, err)
 	assert.Contains(t, content, "e2e-conn-001")
-}
-
-// TestAPIGatewayManagementAPIDashboard_Snippet verifies the code snippet renders.
-func TestAPIGatewayManagementAPIDashboard_Snippet(t *testing.T) {
-	stack := newStack(t)
-
-	server := httptest.NewServer(stack.Echo)
-	defer server.Close()
-
-	ctx, err := browser.NewContext()
-	require.NoError(t, err)
-	defer ctx.Close()
-
-	page, err := ctx.NewPage()
-	require.NoError(t, err)
-	defer page.Close()
-
-	defer func() {
-		if t.Failed() {
-			saveScreenshot(t, page, "TestAPIGatewayManagementAPIDashboard_Snippet")
-		}
-	}()
-
-	_, err = page.Goto(server.URL + "/dashboard/apigatewaymanagementapi")
-	require.NoError(t, err)
-
-	err = page.Locator("h1").First().WaitFor(playwright.LocatorWaitForOptions{
-		Timeout: playwright.Float(60000),
-	})
-	require.NoError(t, err)
-
-	content, err := page.Content()
-	require.NoError(t, err)
-	assert.Contains(t, content, "apigatewaymanagementapi")
 }

--- a/ui/src/routes/apigatewaymanagementapi/+page.svelte
+++ b/ui/src/routes/apigatewaymanagementapi/+page.svelte
@@ -1,95 +1,1006 @@
 <script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
+	import {
+		PostToConnectionCommand,
+		DeleteConnectionCommand
+	} from '@aws-sdk/client-apigatewaymanagementapi';
+	import { getAPIGatewayManagementAPIClient } from '$lib/aws-client';
+	import { confirmDestructive } from '$lib/confirm-dialog';
+	import {
+		Activity,
+		BarChart2,
+		Clock,
+		Copy,
+		Eraser,
+		Plus,
+		RefreshCw,
+		Radio,
+		Search,
+		Send,
+		Trash2,
+		Wifi,
+		Zap
+	} from 'lucide-svelte';
 
 	type Connection = {
 		connectionId: string;
 		sourceIp: string;
 		userAgent: string;
+		connectedAt: string;
+		lastActiveAt: string;
+		postedMessages: number;
+		bytesSent: number;
 	};
 
+	type LifecycleEvent = {
+		at: string;
+		type: 'connected' | 'message' | 'disconnected' | 'ping' | 'broadcast';
+		detail?: string;
+		bytes?: number;
+	};
+
+	type Message = {
+		receivedAt: string;
+		connectionId: string;
+		data: string;
+		bytes: number;
+	};
+
+	type Stats = {
+		activeConnections: number;
+		bufferedMessages: number;
+		totalConnections: number;
+		totalDisconnections: number;
+		totalMessages: number;
+		totalBroadcasts: number;
+		totalBytesSent: number;
+		totalRejected: number;
+	};
+
+	const apigwmgmt = getAPIGatewayManagementAPIClient();
+	const adminBase = '/_gopherstack/apigwmgmt';
+
+	const messageTemplates = [
+		{ label: 'Ping JSON', body: '{"type":"ping","ts":"' + new Date().toISOString() + '"}' },
+		{ label: 'Notification', body: '{"event":"notification","title":"Hello","priority":"normal"}' },
+		{ label: 'Chat', body: '{"event":"chat","from":"server","text":"Welcome!"}' },
+		{ label: 'Heartbeat', body: '{"type":"heartbeat","seq":1}' },
+		{ label: 'Plain text', body: 'hello from gopherstack' }
+	];
+
 	let connections = $state<Connection[]>([]);
-	let showCreateModal = $state(false);
-	let connectionId = $state('');
+	let stats = $state<Stats | null>(null);
+	let selected = $state<Connection | null>(null);
+	let messages = $state<Message[]>([]);
+	let timeline = $state<LifecycleEvent[]>([]);
+	let activeTab = $state<'messages' | 'timeline'>('messages');
 
-	const supportedOperations = ['PostToConnection', 'GetConnection', 'DeleteConnection'];
+	let loading = $state(false);
+	let searchQuery = $state('');
+	let autoRefresh = $state(false);
+	let refreshIntervalSec = $state(5);
+	let refreshTimer: ReturnType<typeof setInterval> | null = null;
+	let prettyJSON = $state(true);
 
-	function createConnection() {
-		if (!connectionId.trim()) {
+	// Send message form
+	let messageBody = $state('');
+	let sending = $state(false);
+
+	// Simulate connection form
+	let showSimulate = $state(false);
+	let simConnectionId = $state('');
+	let simSourceIp = $state('127.0.0.1');
+	let simUserAgent = $state('Gopherstack UI');
+	let simulating = $state(false);
+
+	// Broadcast modal
+	let showBroadcast = $state(false);
+	let broadcastBody = $state('');
+	let broadcasting = $state(false);
+
+	// Prune modal
+	let showPrune = $state(false);
+	let pruneSeconds = $state(60);
+	let pruning = $state(false);
+
+	const filteredConnections = $derived(
+		searchQuery
+			? connections.filter((c) => {
+					const q = searchQuery.toLowerCase();
+					return (
+						c.connectionId.toLowerCase().includes(q) ||
+						c.sourceIp.toLowerCase().includes(q) ||
+						c.userAgent.toLowerCase().includes(q)
+					);
+				})
+			: connections
+	);
+
+	const totalBufferedBytes = $derived(messages.reduce((acc, m) => acc + m.bytes, 0));
+
+	async function loadConnections() {
+		loading = true;
+		try {
+			const res = await fetch(`${adminBase}/connections`);
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			const data = (await res.json()) as { connections: Connection[] };
+			connections = data.connections ?? [];
+		} catch (err) {
+			toast.error('Failed to load connections: ' + String(err));
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadStats() {
+		try {
+			const res = await fetch(`${adminBase}/stats`);
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			stats = (await res.json()) as Stats;
+		} catch (err) {
+			toast.error('Failed to load stats: ' + String(err));
+		}
+	}
+
+	async function loadMessages(id: string) {
+		try {
+			const res = await fetch(`${adminBase}/connections/${encodeURIComponent(id)}/messages`);
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			const data = (await res.json()) as { messages: Message[] };
+			messages = data.messages ?? [];
+		} catch (err) {
+			toast.error('Failed to load messages: ' + String(err));
+		}
+	}
+
+	async function loadTimeline(id: string) {
+		try {
+			const res = await fetch(`${adminBase}/connections/${encodeURIComponent(id)}/timeline`);
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			const data = (await res.json()) as { events: LifecycleEvent[] };
+			timeline = data.events ?? [];
+		} catch (err) {
+			toast.error('Failed to load timeline: ' + String(err));
+		}
+	}
+
+	async function refreshAll() {
+		await Promise.all([loadConnections(), loadStats()]);
+		if (selected) {
+			const stillActive = connections.find((c) => c.connectionId === selected!.connectionId);
+			if (stillActive) {
+				selected = stillActive;
+				await Promise.all([loadMessages(selected.connectionId), loadTimeline(selected.connectionId)]);
+			} else {
+				selected = null;
+				messages = [];
+				timeline = [];
+			}
+		}
+	}
+
+	function selectConnection(conn: Connection) {
+		selected = conn;
+		messages = [];
+		timeline = [];
+		void loadMessages(conn.connectionId);
+		void loadTimeline(conn.connectionId);
+	}
+
+	async function sendMessage() {
+		if (!selected || !messageBody) {
 			return;
 		}
-
-		connections = [
-			{ connectionId: connectionId.trim(), sourceIp: '127.0.0.1', userAgent: 'Gopherstack UI' },
-			...connections
-		];
-		toast.success(`Connection ${connectionId.trim()} created`);
-		connectionId = '';
-		showCreateModal = false;
+		sending = true;
+		try {
+			await apigwmgmt.send(
+				new PostToConnectionCommand({
+					ConnectionId: selected.connectionId,
+					Data: new TextEncoder().encode(messageBody)
+				})
+			);
+			toast.success('Message posted');
+			messageBody = '';
+			await loadMessages(selected.connectionId);
+			await loadTimeline(selected.connectionId);
+			await loadStats();
+		} catch (err) {
+			toast.error('Failed to post message: ' + String(err));
+		} finally {
+			sending = false;
+		}
 	}
+
+	async function pingSelected() {
+		if (!selected) {
+			return;
+		}
+		try {
+			const res = await fetch(
+				`${adminBase}/connections/${encodeURIComponent(selected.connectionId)}/ping`,
+				{ method: 'POST' }
+			);
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			toast.success('Connection pinged');
+			await refreshAll();
+		} catch (err) {
+			toast.error('Ping failed: ' + String(err));
+		}
+	}
+
+	async function clearMessages() {
+		if (!selected) {
+			return;
+		}
+		const ok = await confirmDestructive({
+			title: 'Clear messages?',
+			message: `Drop all stored messages for ${selected.connectionId}.`,
+			confirmLabel: 'Clear'
+		});
+		if (!ok) {
+			return;
+		}
+		try {
+			const res = await fetch(
+				`${adminBase}/connections/${encodeURIComponent(selected.connectionId)}/messages`,
+				{ method: 'DELETE' }
+			);
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			toast.success('Messages cleared');
+			messages = [];
+			await loadStats();
+		} catch (err) {
+			toast.error('Clear failed: ' + String(err));
+		}
+	}
+
+	async function deleteSelected() {
+		if (!selected) {
+			return;
+		}
+		const ok = await confirmDestructive({
+			title: 'Disconnect connection?',
+			message: `Terminate ${selected.connectionId}. This is irreversible.`,
+			confirmLabel: 'Disconnect'
+		});
+		if (!ok) {
+			return;
+		}
+		try {
+			await apigwmgmt.send(new DeleteConnectionCommand({ ConnectionId: selected.connectionId }));
+			toast.success('Connection deleted');
+			selected = null;
+			messages = [];
+			timeline = [];
+			await refreshAll();
+		} catch (err) {
+			toast.error('Delete failed: ' + String(err));
+		}
+	}
+
+	async function simulateConnection() {
+		if (!simConnectionId.trim()) {
+			toast.error('Connection ID is required');
+			return;
+		}
+		simulating = true;
+		try {
+			const res = await fetch(`${adminBase}/connections`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					connectionId: simConnectionId.trim(),
+					sourceIp: simSourceIp.trim(),
+					userAgent: simUserAgent.trim()
+				})
+			});
+			if (!res.ok) {
+				const body = (await res.json().catch(() => ({}))) as { message?: string };
+				throw new Error(body.message ?? `HTTP ${res.status}`);
+			}
+			toast.success(`Connection ${simConnectionId} created`);
+			showSimulate = false;
+			simConnectionId = '';
+			await refreshAll();
+		} catch (err) {
+			toast.error('Simulate failed: ' + String(err));
+		} finally {
+			simulating = false;
+		}
+	}
+
+	async function broadcastMessage() {
+		if (!broadcastBody) {
+			toast.error('Body is required');
+			return;
+		}
+		broadcasting = true;
+		try {
+			const res = await fetch(`${adminBase}/broadcast`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ data: broadcastBody })
+			});
+			if (!res.ok) {
+				const body = (await res.json().catch(() => ({}))) as { message?: string };
+				throw new Error(body.message ?? `HTTP ${res.status}`);
+			}
+			const data = (await res.json()) as { delivered: number };
+			toast.success(`Broadcast delivered to ${data.delivered} connection(s)`);
+			showBroadcast = false;
+			broadcastBody = '';
+			await refreshAll();
+		} catch (err) {
+			toast.error('Broadcast failed: ' + String(err));
+		} finally {
+			broadcasting = false;
+		}
+	}
+
+	async function pruneIdle() {
+		pruning = true;
+		try {
+			const res = await fetch(`${adminBase}/prune`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ idleSeconds: pruneSeconds })
+			});
+			if (!res.ok) {
+				throw new Error(`HTTP ${res.status}`);
+			}
+			const data = (await res.json()) as { pruned: string[] };
+			toast.success(`Pruned ${data.pruned.length} idle connection(s)`);
+			showPrune = false;
+			await refreshAll();
+		} catch (err) {
+			toast.error('Prune failed: ' + String(err));
+		} finally {
+			pruning = false;
+		}
+	}
+
+	function copyConnectionId(id: string) {
+		void navigator.clipboard.writeText(id);
+		toast.success('Connection ID copied');
+	}
+
+	function applyTemplate(body: string) {
+		messageBody = body;
+	}
+
+	function formatBytes(n: number): string {
+		if (n < 1024) return `${n} B`;
+		if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+		return `${(n / (1024 * 1024)).toFixed(2)} MiB`;
+	}
+
+	function formatRelative(iso: string): string {
+		const ms = Date.now() - new Date(iso).getTime();
+		const sec = Math.floor(ms / 1000);
+		if (sec < 1) return 'just now';
+		if (sec < 60) return `${sec}s ago`;
+		const min = Math.floor(sec / 60);
+		if (min < 60) return `${min}m ago`;
+		const hr = Math.floor(min / 60);
+		if (hr < 24) return `${hr}h ago`;
+		return new Date(iso).toLocaleString();
+	}
+
+	function isIdle(c: Connection): boolean {
+		return Date.now() - new Date(c.lastActiveAt).getTime() > 60_000;
+	}
+
+	function tryPrettyJSON(raw: string): string {
+		if (!prettyJSON) return raw;
+		try {
+			return JSON.stringify(JSON.parse(raw), null, 2);
+		} catch {
+			return raw;
+		}
+	}
+
+	function eventBadgeClass(t: LifecycleEvent['type']): string {
+		switch (t) {
+			case 'connected':
+				return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300';
+			case 'message':
+				return 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300';
+			case 'broadcast':
+				return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300';
+			case 'ping':
+				return 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300';
+			case 'disconnected':
+				return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300';
+			default:
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+		}
+	}
+
+	function startAutoRefresh() {
+		if (refreshTimer) {
+			clearInterval(refreshTimer);
+		}
+		refreshTimer = setInterval(() => {
+			void refreshAll();
+		}, refreshIntervalSec * 1000);
+	}
+
+	function stopAutoRefresh() {
+		if (refreshTimer) {
+			clearInterval(refreshTimer);
+			refreshTimer = null;
+		}
+	}
+
+	$effect(() => {
+		if (autoRefresh) {
+			startAutoRefresh();
+		} else {
+			stopAutoRefresh();
+		}
+	});
+
+	onMount(() => {
+		void refreshAll();
+	});
+
+	onDestroy(() => {
+		stopAutoRefresh();
+	});
 </script>
 
 <div class="space-y-6 p-6">
-	<div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-		<h1 class="text-3xl font-bold text-slate-900 dark:text-white">API Gateway Management API</h1>
-		<p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Manage simulated WebSocket connections</p>
-	</div>
-
-	<div class="flex items-center justify-between rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-		<div>
-			<h2 class="text-lg font-semibold text-slate-900 dark:text-white">Supported Operations</h2>
-			<div class="mt-3 flex flex-wrap gap-2">
-				{#each supportedOperations as operation}
-					<span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-700 dark:text-slate-200">{operation}</span>
-				{/each}
+	<!-- Header -->
+	<div
+		class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+	>
+		<div class="flex items-start justify-between gap-4">
+			<div>
+				<h1 class="text-3xl font-bold text-slate-900 dark:text-white">
+					API Gateway Management API
+				</h1>
+				<p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+					Inspect simulated WebSocket connections, send messages, and trace the lifecycle of each
+					connection.
+				</p>
+			</div>
+			<div class="flex flex-wrap items-center gap-2">
+				<button
+					type="button"
+					onclick={() => void refreshAll()}
+					class="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+				>
+					<RefreshCw size={14} class={loading ? 'animate-spin' : ''} />
+					Refresh
+				</button>
+				<label
+					class="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100"
+				>
+					<input type="checkbox" bind:checked={autoRefresh} class="rounded" />
+					Auto-refresh
+					<input
+						type="number"
+						min="2"
+						max="60"
+						bind:value={refreshIntervalSec}
+						class="w-14 rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+					/>
+					s
+				</label>
+				<button
+					type="button"
+					onclick={() => (showBroadcast = true)}
+					class="flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700"
+				>
+					<Radio size={14} />
+					Broadcast
+				</button>
+				<button
+					type="button"
+					onclick={() => (showPrune = true)}
+					class="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+				>
+					<Eraser size={14} />
+					Prune idle
+				</button>
+				<button
+					type="button"
+					onclick={() => (showSimulate = true)}
+					class="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+				>
+					<Plus size={14} />
+					Simulate
+				</button>
 			</div>
 		</div>
-		<button type="button" onclick={() => (showCreateModal = true)} class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700">+ Simulate Connection</button>
 	</div>
 
-	<div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
-		<div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-			<table class="w-full text-left text-sm">
-				<thead>
-					<tr class="border-b border-slate-200 dark:border-slate-700">
-						<th class="pb-3 font-semibold text-slate-900 dark:text-white">Connection ID</th>
-						<th class="pb-3 font-semibold text-slate-900 dark:text-white">Source IP</th>
-						<th class="pb-3 font-semibold text-slate-900 dark:text-white">User Agent</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#if connections.length === 0}
-						<tr><td colspan="3" class="pt-4 text-slate-500 dark:text-slate-400">No simulated connections</td></tr>
-					{:else}
-						{#each connections as connection}
-							<tr class="border-b border-slate-100 dark:border-slate-800">
-								<td class="py-3">{connection.connectionId}</td>
-								<td class="py-3">{connection.sourceIp}</td>
-								<td class="py-3">{connection.userAgent}</td>
-							</tr>
-						{/each}
-					{/if}
-				</tbody>
-			</table>
+	<!-- Stats -->
+	{#if stats}
+		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-8">
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="flex items-center gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
+					<Wifi size={12} /> Active
+				</div>
+				<div class="mt-2 text-2xl font-bold text-emerald-600 dark:text-emerald-400">
+					{stats.activeConnections}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="flex items-center gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
+					<Activity size={12} /> Buffered msgs
+				</div>
+				<div class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+					{stats.bufferedMessages}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="text-xs uppercase text-slate-500 dark:text-slate-400">Total connects</div>
+				<div class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+					{stats.totalConnections}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="text-xs uppercase text-slate-500 dark:text-slate-400">Disconnects</div>
+				<div class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+					{stats.totalDisconnections}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="text-xs uppercase text-slate-500 dark:text-slate-400">Messages posted</div>
+				<div class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+					{stats.totalMessages}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="text-xs uppercase text-slate-500 dark:text-slate-400">Broadcasts</div>
+				<div class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+					{stats.totalBroadcasts}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="flex items-center gap-2 text-xs uppercase text-slate-500 dark:text-slate-400">
+					<BarChart2 size={12} /> Bytes sent
+				</div>
+				<div class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+					{formatBytes(stats.totalBytesSent)}
+				</div>
+			</div>
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+			>
+				<div class="text-xs uppercase text-slate-500 dark:text-slate-400">Rejected</div>
+				<div class="mt-2 text-2xl font-bold text-rose-600 dark:text-rose-400">
+					{stats.totalRejected}
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<div class="grid gap-6 lg:grid-cols-[1fr,2fr]">
+		<!-- Connection list -->
+		<div
+			class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+		>
+			<div class="flex items-center justify-between gap-2">
+				<h2 class="text-lg font-semibold text-slate-900 dark:text-white">
+					Connections ({filteredConnections.length})
+				</h2>
+			</div>
+			<div class="mt-3 flex items-center gap-2 rounded-lg border border-slate-200 px-3 dark:border-slate-700">
+				<Search size={14} class="text-slate-400" />
+				<input
+					type="text"
+					placeholder="Search id, IP, or user-agent"
+					bind:value={searchQuery}
+					class="w-full bg-transparent py-2 text-sm text-slate-900 outline-none dark:text-white"
+				/>
+			</div>
+			<ul class="mt-3 max-h-[60vh] space-y-2 overflow-y-auto">
+				{#if filteredConnections.length === 0}
+					<li class="rounded-lg border border-dashed border-slate-200 p-4 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+						{loading ? 'Loading…' : 'No connections — simulate one to get started.'}
+					</li>
+				{:else}
+					{#each filteredConnections as conn (conn.connectionId)}
+						<li>
+							<button
+								type="button"
+								onclick={() => selectConnection(conn)}
+								class="w-full rounded-lg border border-slate-200 px-3 py-2 text-left transition-colors hover:border-indigo-300 hover:bg-indigo-50 dark:border-slate-700 dark:hover:border-indigo-500 dark:hover:bg-slate-700/40 {selected?.connectionId ===
+								conn.connectionId
+									? 'border-indigo-400 bg-indigo-50 dark:border-indigo-400 dark:bg-slate-700/60'
+									: ''}"
+							>
+								<div class="flex items-center justify-between gap-2">
+									<span class="truncate font-mono text-sm text-slate-900 dark:text-white">
+										{conn.connectionId}
+									</span>
+									<span
+										class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs {isIdle(
+											conn
+										)
+											? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+											: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'}"
+									>
+										<Clock size={10} />
+										{isIdle(conn) ? 'idle' : 'live'}
+									</span>
+								</div>
+								<div class="mt-1 flex flex-wrap gap-x-3 text-xs text-slate-500 dark:text-slate-400">
+									<span>{conn.sourceIp}</span>
+									<span>{conn.postedMessages} msgs</span>
+									<span>{formatBytes(conn.bytesSent)}</span>
+									<span>{formatRelative(conn.lastActiveAt)}</span>
+								</div>
+							</button>
+						</li>
+					{/each}
+				{/if}
+			</ul>
 		</div>
 
-		<div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-			<h2 class="text-lg font-semibold text-slate-900 dark:text-white">Snippet</h2>
-			<pre class="mt-3 overflow-auto rounded-lg bg-slate-950 p-4 text-xs text-slate-100">const client = new AWS.ApiGatewayManagementApi(&#123; endpoint &#125;);
-await client.postToConnection(&#123; ConnectionId, Data &#125;).promise();
-// service: apigatewaymanagementapi</pre>
+		<!-- Detail pane -->
+		<div
+			class="rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800"
+		>
+			{#if !selected}
+				<div class="p-12 text-center text-sm text-slate-500 dark:text-slate-400">
+					Select a connection from the list to inspect messages, lifecycle events, and send a
+					payload.
+				</div>
+			{:else}
+				<div class="border-b border-slate-200 p-4 dark:border-slate-700">
+					<div class="flex flex-wrap items-center justify-between gap-3">
+						<div class="min-w-0">
+							<div class="flex items-center gap-2">
+								<span class="truncate font-mono text-base font-semibold text-slate-900 dark:text-white">
+									{selected.connectionId}
+								</span>
+								<button
+									type="button"
+									title="Copy connection ID"
+									onclick={() => copyConnectionId(selected!.connectionId)}
+									class="text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400"
+								>
+									<Copy size={14} />
+								</button>
+							</div>
+							<div class="mt-1 flex flex-wrap gap-x-4 text-xs text-slate-500 dark:text-slate-400">
+								<span>IP {selected.sourceIp}</span>
+								<span>UA {selected.userAgent}</span>
+								<span>connected {formatRelative(selected.connectedAt)}</span>
+								<span>last active {formatRelative(selected.lastActiveAt)}</span>
+							</div>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<button
+								type="button"
+								onclick={() => void pingSelected()}
+								class="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+							>
+								<Zap size={12} /> Ping
+							</button>
+							<button
+								type="button"
+								onclick={() => void clearMessages()}
+								class="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+							>
+								<Eraser size={12} /> Clear msgs
+							</button>
+							<button
+								type="button"
+								onclick={() => void deleteSelected()}
+								class="flex items-center gap-1 rounded-lg border border-rose-200 bg-rose-50 px-3 py-1.5 text-xs font-medium text-rose-700 hover:bg-rose-100 dark:border-rose-900/40 dark:bg-rose-900/20 dark:text-rose-300 dark:hover:bg-rose-900/30"
+							>
+								<Trash2 size={12} /> Disconnect
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<!-- Send message -->
+				<div class="border-b border-slate-200 p-4 dark:border-slate-700">
+					<label
+						for="msg-body"
+						class="mb-1 block text-xs font-semibold uppercase text-slate-500 dark:text-slate-400"
+					>
+						Send message (PostToConnection)
+					</label>
+					<div class="flex flex-wrap gap-2">
+						{#each messageTemplates as tpl}
+							<button
+								type="button"
+								onclick={() => applyTemplate(tpl.body)}
+								class="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-600 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+							>
+								{tpl.label}
+							</button>
+						{/each}
+					</div>
+					<textarea
+						id="msg-body"
+						bind:value={messageBody}
+						rows="4"
+						placeholder="Payload (text or JSON)"
+						class="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 outline-none focus:border-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+					></textarea>
+					<div class="mt-2 flex items-center justify-between">
+						<span class="text-xs text-slate-500 dark:text-slate-400">
+							{new Blob([messageBody]).size} bytes (max 128 KiB)
+						</span>
+						<button
+							type="button"
+							disabled={!messageBody || sending}
+							onclick={() => void sendMessage()}
+							class="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+						>
+							<Send size={14} />
+							{sending ? 'Sending…' : 'Send'}
+						</button>
+					</div>
+				</div>
+
+				<!-- Tabs -->
+				<div class="border-b border-slate-200 px-4 dark:border-slate-700">
+					<nav class="flex gap-4">
+						<button
+							type="button"
+							onclick={() => (activeTab = 'messages')}
+							class="border-b-2 px-2 py-3 text-sm font-medium {activeTab === 'messages'
+								? 'border-indigo-600 text-indigo-600 dark:text-indigo-400'
+								: 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}"
+						>
+							Messages ({messages.length})
+						</button>
+						<button
+							type="button"
+							onclick={() => (activeTab = 'timeline')}
+							class="border-b-2 px-2 py-3 text-sm font-medium {activeTab === 'timeline'
+								? 'border-indigo-600 text-indigo-600 dark:text-indigo-400'
+								: 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}"
+						>
+							Timeline ({timeline.length})
+						</button>
+					</nav>
+				</div>
+
+				<!-- Tab content -->
+				<div class="max-h-[55vh] overflow-y-auto p-4">
+					{#if activeTab === 'messages'}
+						<div class="mb-3 flex items-center justify-between">
+							<span class="text-xs text-slate-500 dark:text-slate-400">
+								{messages.length} messages · {formatBytes(totalBufferedBytes)} buffered
+							</span>
+							<label
+								class="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
+							>
+								<input type="checkbox" bind:checked={prettyJSON} class="rounded" />
+								Pretty-print JSON
+							</label>
+						</div>
+						{#if messages.length === 0}
+							<div class="rounded-lg border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+								No messages yet. Send one above to populate the buffer.
+							</div>
+						{:else}
+							<ul class="space-y-2">
+								{#each messages as msg, i (i)}
+									<li
+										class="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/40"
+									>
+										<div class="flex items-center justify-between gap-2 text-xs text-slate-500 dark:text-slate-400">
+											<span>{new Date(msg.receivedAt).toLocaleString()}</span>
+											<span>{msg.bytes} B</span>
+										</div>
+										<pre
+											class="mt-1 whitespace-pre-wrap break-all font-mono text-xs text-slate-800 dark:text-slate-200">{tryPrettyJSON(
+												msg.data
+											)}</pre>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					{:else if timeline.length === 0}
+						<div class="rounded-lg border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+							No lifecycle events yet.
+						</div>
+					{:else}
+						<ol class="relative border-l border-slate-200 pl-4 dark:border-slate-700">
+							{#each timeline as ev, i (i)}
+								<li class="mb-4 last:mb-0">
+									<span
+										class="absolute -left-1.5 mt-1 h-3 w-3 rounded-full {eventBadgeClass(
+											ev.type
+										)}"
+									></span>
+									<div class="flex flex-wrap items-baseline gap-2">
+										<span class="rounded px-1.5 py-0.5 text-xs font-medium {eventBadgeClass(ev.type)}">
+											{ev.type}
+										</span>
+										<span class="text-xs text-slate-500 dark:text-slate-400">
+											{new Date(ev.at).toLocaleString()}
+										</span>
+										{#if ev.bytes}
+											<span class="text-xs text-slate-500 dark:text-slate-400">
+												{ev.bytes} B
+											</span>
+										{/if}
+										{#if ev.detail}
+											<span class="text-xs text-slate-500 dark:text-slate-400">
+												{ev.detail}
+											</span>
+										{/if}
+									</div>
+								</li>
+							{/each}
+						</ol>
+					{/if}
+				</div>
+			{/if}
 		</div>
 	</div>
 </div>
 
-{#if showCreateModal}
+<!-- Simulate modal -->
+{#if showSimulate}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
 		<div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-slate-800">
-			<h2 class="text-xl font-bold text-slate-900 dark:text-white">Create Connection</h2>
-			<form onsubmit={(event) => { event.preventDefault(); createConnection(); }} class="mt-4 space-y-4">
-				<input name="connectionId" bind:value={connectionId} class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900 dark:text-white" placeholder="e.g. conn-001" />
+			<h2 class="text-xl font-bold text-slate-900 dark:text-white">Simulate connection</h2>
+			<form
+				onsubmit={(event) => {
+					event.preventDefault();
+					void simulateConnection();
+				}}
+				class="mt-4 space-y-3"
+			>
+				<input
+					required
+					bind:value={simConnectionId}
+					placeholder="Connection ID"
+					class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+				/>
+				<input
+					bind:value={simSourceIp}
+					placeholder="Source IP"
+					class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+				/>
+				<input
+					bind:value={simUserAgent}
+					placeholder="User agent"
+					class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+				/>
 				<div class="flex justify-end gap-3">
-					<button type="button" onclick={() => (showCreateModal = false)} class="rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300">Cancel</button>
-					<button type="submit" class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700">Create</button>
+					<button
+						type="button"
+						onclick={() => (showSimulate = false)}
+						class="rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300"
+					>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						disabled={simulating}
+						class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+					>
+						{simulating ? 'Creating…' : 'Create'}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}
+
+<!-- Broadcast modal -->
+{#if showBroadcast}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+		<div class="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl dark:bg-slate-800">
+			<h2 class="text-xl font-bold text-slate-900 dark:text-white">Broadcast to all connections</h2>
+			<p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+				Each active connection receives a copy of this payload.
+			</p>
+			<form
+				onsubmit={(event) => {
+					event.preventDefault();
+					void broadcastMessage();
+				}}
+				class="mt-4 space-y-3"
+			>
+				<textarea
+					required
+					rows="4"
+					bind:value={broadcastBody}
+					placeholder="Payload"
+					class="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+				></textarea>
+				<div class="flex justify-end gap-3">
+					<button
+						type="button"
+						onclick={() => (showBroadcast = false)}
+						class="rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300"
+					>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						disabled={broadcasting}
+						class="rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700 disabled:opacity-50"
+					>
+						{broadcasting ? 'Sending…' : 'Broadcast'}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}
+
+<!-- Prune modal -->
+{#if showPrune}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+		<div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-slate-800">
+			<h2 class="text-xl font-bold text-slate-900 dark:text-white">Prune idle connections</h2>
+			<p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+				Disconnects every connection idle for at least the threshold below.
+			</p>
+			<form
+				onsubmit={(event) => {
+					event.preventDefault();
+					void pruneIdle();
+				}}
+				class="mt-4 space-y-3"
+			>
+				<label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+					Idle for at least
+					<input
+						type="number"
+						min="1"
+						bind:value={pruneSeconds}
+						class="w-24 rounded-lg border border-slate-300 px-2 py-1 dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+					/>
+					seconds
+				</label>
+				<div class="flex justify-end gap-3">
+					<button
+						type="button"
+						onclick={() => (showPrune = false)}
+						class="rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300"
+					>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						disabled={pruning}
+						class="rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+					>
+						{pruning ? 'Pruning…' : 'Prune'}
+					</button>
 				</div>
 			</form>
 		</div>

--- a/ui/src/routes/apigatewaymanagementapi/+page.svelte
+++ b/ui/src/routes/apigatewaymanagementapi/+page.svelte
@@ -473,8 +473,8 @@
 					API Gateway Management API
 				</h1>
 				<p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
-					Inspect simulated WebSocket connections, send messages, and trace the lifecycle of each
-					connection.
+					Inspect simulated WebSocket connections, send PostToConnection messages, and trace the
+					lifecycle of each connection.
 				</p>
 			</div>
 			<div class="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
Fixes for PR #1437 review comments and e2e test failure.

## Changes

### Bug fixes (from Devin review)

**`backend.go:54` — wrong error sentinel on empty connectionID (400 vs 409)**
- Was: `fmt.Errorf("%w: connectionID required", ErrConnectionExists)` → admin handler matched `errors.Is(err, ErrConnectionExists)` → returned **409 Conflict**
- Now: wraps `awserr.ErrInvalidParameter` → falls through to **400 Bad Request**

**`backend.go:300-302` — PruneIdle returns nil → JSON `null` → frontend TypeError**
- Was: `return nil` when `threshold <= 0` → serialised as `{"pruned":null}` → `data.pruned.length` throws TypeError in Svelte
- Now: `return []string{}` → serialises as `{"pruned":[]}` → safe to call `.length`

### E2E test fix

**`+page.svelte` description — "PostToConnection" only visible when connection selected**
- The e2e test `TestAPIGatewayManagementAPIDashboard` asserts `content contains "PostToConnection"` but this text was inside the `{:else}` block (only rendered when a connection is selected)
- Fix: add "PostToConnection" to the always-visible page header subtitle

### New tests
- `TestAdmin_SimulateEmptyConnectionID` — verifies empty connectionId returns 400
- `TestAdmin_PruneZeroThreshold_ReturnsEmptySlice` — verifies `{"pruned":[]}` body (not `null`)

https://claude.ai/code/session_01X72ut1ECdwr7rXPAUc1GZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01X72ut1ECdwr7rXPAUc1GZ4)_