### PR TITLE
feat(s3tables): implement 13 missing ops + shard locks per map

### DIFF
--- a/services/s3tables/backend.go
+++ b/services/s3tables/backend.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	statusEnabled = "enabled"
-	keySettings   = "settings"
+	statusEnabled        = "enabled"
+	keySettings          = "settings"
+	storageClassStandard = "STANDARD"
 )
 
 var (
@@ -40,10 +41,13 @@ var (
 type TableBucket struct {
 	CreatedAt                time.Time      `json:"createdAt"`
 	MaintenanceConfiguration map[string]any `json:"maintenanceConfiguration"`
+	Encryption               map[string]any `json:"encryption"`
 	ARN                      string         `json:"arn"`
 	Name                     string         `json:"name"`
 	OwnerAccountID           string         `json:"ownerAccountID"`
 	Policy                   string         `json:"policy"`
+	StorageClass             string         `json:"storageClass"`
+	MetricsEnabled           bool           `json:"metricsEnabled"`
 }
 
 // Namespace represents an S3 Tables namespace.
@@ -86,36 +90,48 @@ type Table struct {
 	OwnerAccountID           string         `json:"ownerAccountID"`
 	Policy                   string         `json:"policy"`
 	Name                     string         `json:"name"`
+	StorageClass             string         `json:"storageClass"`
 	Namespace                []string       `json:"namespace"`
 }
 
 // InMemoryBackend is an in-memory store for S3 Tables resources.
 type InMemoryBackend struct {
-	tableBuckets      map[string]*TableBucket             // keyed by ARN
-	namespaces        map[string]*Namespace               // keyed by tableBucketARN + "::" + namespace
-	tables            map[string]*Table                   // keyed by ARN
-	tableIndex        map[string]string                   // composite key (bucketARN::ns::name) → table ARN
-	bucketReplication map[string]*BucketReplicationConfig // keyed by bucket ARN
-	tableReplication  map[string]bool                     // keyed by table ARN
-	tableRecordExpiry map[string]*TableRecordExpiryConfig // keyed by table ARN
-	mu                *lockmetrics.RWMutex
-	accountID         string
-	region            string
+	tableBuckets            map[string]*TableBucket             // keyed by ARN
+	namespaces              map[string]*Namespace               // keyed by tableBucketARN + "::" + namespace
+	tables                  map[string]*Table                   // keyed by ARN
+	tableIndex              map[string]string                   // composite key (bucketARN::ns::name) → table ARN
+	bucketReplication       map[string]*BucketReplicationConfig // keyed by bucket ARN
+	tableReplication        map[string]bool                     // keyed by table ARN
+	tableRecordExpiry       map[string]*TableRecordExpiryConfig // keyed by table ARN
+	tags                    map[string]map[string]string        // keyed by ARN
+	tableReplicationConfigs map[string]map[string]any           // keyed by table ARN
+	// Lock ordering: muBuckets → muNamespaces → muTables → muState
+	muBuckets    *lockmetrics.RWMutex // covers tableBuckets
+	muNamespaces *lockmetrics.RWMutex // covers namespaces
+	muTables     *lockmetrics.RWMutex // covers tables + tableIndex
+	muState      *lockmetrics.RWMutex // covers replication, expiry, tags, tableReplicationConfigs
+	accountID    string
+	region       string
 }
 
 // NewInMemoryBackend creates a new in-memory S3 Tables backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		tableBuckets:      make(map[string]*TableBucket),
-		namespaces:        make(map[string]*Namespace),
-		tables:            make(map[string]*Table),
-		tableIndex:        make(map[string]string),
-		bucketReplication: make(map[string]*BucketReplicationConfig),
-		tableReplication:  make(map[string]bool),
-		tableRecordExpiry: make(map[string]*TableRecordExpiryConfig),
-		accountID:         accountID,
-		region:            region,
-		mu:                lockmetrics.New("s3tables"),
+		tableBuckets:            make(map[string]*TableBucket),
+		namespaces:              make(map[string]*Namespace),
+		tables:                  make(map[string]*Table),
+		tableIndex:              make(map[string]string),
+		bucketReplication:       make(map[string]*BucketReplicationConfig),
+		tableReplication:        make(map[string]bool),
+		tableRecordExpiry:       make(map[string]*TableRecordExpiryConfig),
+		tags:                    make(map[string]map[string]string),
+		tableReplicationConfigs: make(map[string]map[string]any),
+		accountID:               accountID,
+		region:                  region,
+		muBuckets:               lockmetrics.New("s3tables.buckets"),
+		muNamespaces:            lockmetrics.New("s3tables.namespaces"),
+		muTables:                lockmetrics.New("s3tables.tables"),
+		muState:                 lockmetrics.New("s3tables.state"),
 	}
 }
 
@@ -143,8 +159,14 @@ func (b *InMemoryBackend) AccountID() string { return b.accountID }
 
 // Reset clears all stored state.
 func (b *InMemoryBackend) Reset() {
-	b.mu.Lock("Reset")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("Reset")
+	b.muNamespaces.Lock("Reset")
+	b.muTables.Lock("Reset")
+	b.muState.Lock("Reset")
+	defer b.muBuckets.Unlock()
+	defer b.muNamespaces.Unlock()
+	defer b.muTables.Unlock()
+	defer b.muState.Unlock()
 
 	b.tableBuckets = make(map[string]*TableBucket)
 	b.namespaces = make(map[string]*Namespace)
@@ -153,12 +175,17 @@ func (b *InMemoryBackend) Reset() {
 	b.bucketReplication = make(map[string]*BucketReplicationConfig)
 	b.tableReplication = make(map[string]bool)
 	b.tableRecordExpiry = make(map[string]*TableRecordExpiryConfig)
+	b.tags = make(map[string]map[string]string)
+	b.tableReplicationConfigs = make(map[string]map[string]any)
 }
 
 // PutTableBucketReplication sets replication config for a table bucket.
 func (b *InMemoryBackend) PutTableBucketReplication(bucketARN string, cfg *BucketReplicationConfig) error {
-	b.mu.Lock("PutTableBucketReplication")
-	defer b.mu.Unlock()
+	b.muBuckets.RLock("PutTableBucketReplication")
+	defer b.muBuckets.RUnlock()
+
+	b.muState.Lock("PutTableBucketReplication")
+	defer b.muState.Unlock()
 
 	if _, ok := b.tableBuckets[bucketARN]; !ok {
 		return fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
@@ -171,8 +198,11 @@ func (b *InMemoryBackend) PutTableBucketReplication(bucketARN string, cfg *Bucke
 
 // GetTableBucketReplication returns the replication config for a table bucket.
 func (b *InMemoryBackend) GetTableBucketReplication(bucketARN string) (*BucketReplicationConfig, error) {
-	b.mu.RLock("GetTableBucketReplication")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("GetTableBucketReplication")
+	defer b.muBuckets.RUnlock()
+
+	b.muState.RLock("GetTableBucketReplication")
+	defer b.muState.RUnlock()
 
 	if _, ok := b.tableBuckets[bucketARN]; !ok {
 		return nil, fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
@@ -192,8 +222,11 @@ func (b *InMemoryBackend) GetTableBucketReplication(bucketARN string) (*BucketRe
 
 // DeleteTableBucketReplication removes the replication config for a table bucket.
 func (b *InMemoryBackend) DeleteTableBucketReplication(bucketARN string) error {
-	b.mu.Lock("DeleteTableBucketReplication")
-	defer b.mu.Unlock()
+	b.muBuckets.RLock("DeleteTableBucketReplication")
+	defer b.muBuckets.RUnlock()
+
+	b.muState.Lock("DeleteTableBucketReplication")
+	defer b.muState.Unlock()
 
 	if _, ok := b.tableBuckets[bucketARN]; !ok {
 		return fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
@@ -204,10 +237,13 @@ func (b *InMemoryBackend) DeleteTableBucketReplication(bucketARN string) error {
 	return nil
 }
 
-// PutTableReplication marks a table as having replication enabled.
+// PutTableReplication marks a table as having replication enabled (legacy boolean form).
 func (b *InMemoryBackend) PutTableReplication(tableArn string) error {
-	b.mu.Lock("PutTableReplication")
-	defer b.mu.Unlock()
+	b.muTables.RLock("PutTableReplication")
+	defer b.muTables.RUnlock()
+
+	b.muState.Lock("PutTableReplication")
+	defer b.muState.Unlock()
 
 	if _, ok := b.tables[tableArn]; !ok {
 		return fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
@@ -220,22 +256,29 @@ func (b *InMemoryBackend) PutTableReplication(tableArn string) error {
 
 // DeleteTableReplication removes replication for a table.
 func (b *InMemoryBackend) DeleteTableReplication(tableArn string) error {
-	b.mu.Lock("DeleteTableReplication")
-	defer b.mu.Unlock()
+	b.muTables.RLock("DeleteTableReplication")
+	defer b.muTables.RUnlock()
+
+	b.muState.Lock("DeleteTableReplication")
+	defer b.muState.Unlock()
 
 	if _, ok := b.tables[tableArn]; !ok {
 		return fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
 	}
 
 	delete(b.tableReplication, tableArn)
+	delete(b.tableReplicationConfigs, tableArn)
 
 	return nil
 }
 
 // PutTableRecordExpirationConfiguration sets record expiration config for a table.
 func (b *InMemoryBackend) PutTableRecordExpirationConfiguration(tableArn string, cfg *TableRecordExpiryConfig) error {
-	b.mu.Lock("PutTableRecordExpirationConfiguration")
-	defer b.mu.Unlock()
+	b.muTables.RLock("PutTableRecordExpirationConfiguration")
+	defer b.muTables.RUnlock()
+
+	b.muState.Lock("PutTableRecordExpirationConfiguration")
+	defer b.muState.Unlock()
 
 	if _, ok := b.tables[tableArn]; !ok {
 		return fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
@@ -248,8 +291,11 @@ func (b *InMemoryBackend) PutTableRecordExpirationConfiguration(tableArn string,
 
 // GetTableRecordExpirationConfiguration returns record expiry config for a table, defaulting to DISABLED.
 func (b *InMemoryBackend) GetTableRecordExpirationConfiguration(tableArn string) (*TableRecordExpiryConfig, error) {
-	b.mu.RLock("GetTableRecordExpirationConfiguration")
-	defer b.mu.RUnlock()
+	b.muTables.RLock("GetTableRecordExpirationConfiguration")
+	defer b.muTables.RUnlock()
+
+	b.muState.RLock("GetTableRecordExpirationConfiguration")
+	defer b.muState.RUnlock()
 
 	if _, ok := b.tables[tableArn]; !ok {
 		return nil, fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
@@ -269,8 +315,8 @@ func namespaceKey(tableBucketARN, namespace string) string {
 
 // CreateTableBucket creates a new TableBucket.
 func (b *InMemoryBackend) CreateTableBucket(name string) (*TableBucket, error) {
-	b.mu.Lock("CreateTableBucket")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("CreateTableBucket")
+	defer b.muBuckets.Unlock()
 
 	bucketARN := b.TableBucketARN(name)
 	if _, ok := b.tableBuckets[bucketARN]; ok {
@@ -282,6 +328,7 @@ func (b *InMemoryBackend) CreateTableBucket(name string) (*TableBucket, error) {
 		Name:           name,
 		OwnerAccountID: b.accountID,
 		CreatedAt:      time.Now().UTC(),
+		StorageClass:   storageClassStandard,
 		MaintenanceConfiguration: map[string]any{
 			"icebergUnreferencedFileRemoval": map[string]any{
 				keyStatusField: statusEnabled,
@@ -301,8 +348,8 @@ func (b *InMemoryBackend) CreateTableBucket(name string) (*TableBucket, error) {
 
 // GetTableBucket returns a TableBucket by ARN.
 func (b *InMemoryBackend) GetTableBucket(bucketARN string) (*TableBucket, error) {
-	b.mu.RLock("GetTableBucket")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("GetTableBucket")
+	defer b.muBuckets.RUnlock()
 
 	tb, ok := b.tableBuckets[bucketARN]
 	if !ok {
@@ -314,8 +361,14 @@ func (b *InMemoryBackend) GetTableBucket(bucketARN string) (*TableBucket, error)
 
 // DeleteTableBucket deletes a TableBucket by ARN, cascading to namespaces and tables.
 func (b *InMemoryBackend) DeleteTableBucket(bucketARN string) error {
-	b.mu.Lock("DeleteTableBucket")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("DeleteTableBucket")
+	b.muNamespaces.Lock("DeleteTableBucket")
+	b.muTables.Lock("DeleteTableBucket")
+	b.muState.Lock("DeleteTableBucket")
+	defer b.muBuckets.Unlock()
+	defer b.muNamespaces.Unlock()
+	defer b.muTables.Unlock()
+	defer b.muState.Unlock()
 
 	if _, ok := b.tableBuckets[bucketARN]; !ok {
 		return fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
@@ -326,6 +379,10 @@ func (b *InMemoryBackend) DeleteTableBucket(bucketARN string) error {
 		if t.TableBucketARN == bucketARN {
 			delete(b.tableIndex, tableCompositeKey(bucketARN, joinNamespace(t.Namespace), t.Name))
 			delete(b.tables, tableARN)
+			delete(b.tableReplication, tableARN)
+			delete(b.tableReplicationConfigs, tableARN)
+			delete(b.tableRecordExpiry, tableARN)
+			delete(b.tags, tableARN)
 		}
 	}
 
@@ -336,6 +393,8 @@ func (b *InMemoryBackend) DeleteTableBucket(bucketARN string) error {
 		}
 	}
 
+	delete(b.bucketReplication, bucketARN)
+	delete(b.tags, bucketARN)
 	delete(b.tableBuckets, bucketARN)
 
 	return nil
@@ -343,8 +402,8 @@ func (b *InMemoryBackend) DeleteTableBucket(bucketARN string) error {
 
 // ListTableBuckets returns all TableBuckets sorted by name.
 func (b *InMemoryBackend) ListTableBuckets() []*TableBucket {
-	b.mu.RLock("ListTableBuckets")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("ListTableBuckets")
+	defer b.muBuckets.RUnlock()
 
 	list := make([]*TableBucket, 0, len(b.tableBuckets))
 
@@ -361,8 +420,8 @@ func (b *InMemoryBackend) ListTableBuckets() []*TableBucket {
 
 // GetTableBucketMaintenanceConfiguration returns the maintenance config for a bucket.
 func (b *InMemoryBackend) GetTableBucketMaintenanceConfiguration(bucketARN string) (map[string]any, error) {
-	b.mu.RLock("GetTableBucketMaintenanceConfiguration")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("GetTableBucketMaintenanceConfiguration")
+	defer b.muBuckets.RUnlock()
 
 	tb, ok := b.tableBuckets[bucketARN]
 	if !ok {
@@ -379,8 +438,8 @@ func (b *InMemoryBackend) PutTableBucketMaintenanceConfiguration(
 	bucketARN, maintenanceType string,
 	value map[string]any,
 ) error {
-	b.mu.Lock("PutTableBucketMaintenanceConfiguration")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("PutTableBucketMaintenanceConfiguration")
+	defer b.muBuckets.Unlock()
 
 	tb, ok := b.tableBuckets[bucketARN]
 	if !ok {
@@ -398,8 +457,8 @@ func (b *InMemoryBackend) PutTableBucketMaintenanceConfiguration(
 
 // GetTableBucketPolicy returns the resource policy for a bucket.
 func (b *InMemoryBackend) GetTableBucketPolicy(bucketARN string) (string, error) {
-	b.mu.RLock("GetTableBucketPolicy")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("GetTableBucketPolicy")
+	defer b.muBuckets.RUnlock()
 
 	tb, ok := b.tableBuckets[bucketARN]
 	if !ok {
@@ -415,8 +474,8 @@ func (b *InMemoryBackend) GetTableBucketPolicy(bucketARN string) (string, error)
 
 // PutTableBucketPolicy sets the resource policy for a bucket.
 func (b *InMemoryBackend) PutTableBucketPolicy(bucketARN, policy string) error {
-	b.mu.Lock("PutTableBucketPolicy")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("PutTableBucketPolicy")
+	defer b.muBuckets.Unlock()
 
 	tb, ok := b.tableBuckets[bucketARN]
 	if !ok {
@@ -430,8 +489,8 @@ func (b *InMemoryBackend) PutTableBucketPolicy(bucketARN, policy string) error {
 
 // DeleteTableBucketPolicy removes the resource policy from a bucket.
 func (b *InMemoryBackend) DeleteTableBucketPolicy(bucketARN string) error {
-	b.mu.Lock("DeleteTableBucketPolicy")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("DeleteTableBucketPolicy")
+	defer b.muBuckets.Unlock()
 
 	tb, ok := b.tableBuckets[bucketARN]
 	if !ok {
@@ -443,10 +502,178 @@ func (b *InMemoryBackend) DeleteTableBucketPolicy(bucketARN string) error {
 	return nil
 }
 
+// PutTableBucketEncryption sets encryption config for a bucket.
+func (b *InMemoryBackend) PutTableBucketEncryption(bucketARN string, config map[string]any) error {
+	b.muBuckets.Lock("PutTableBucketEncryption")
+	defer b.muBuckets.Unlock()
+
+	tb, ok := b.tableBuckets[bucketARN]
+	if !ok {
+		return fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
+	}
+
+	tb.Encryption = cloneAnyMap(config)
+
+	return nil
+}
+
+// PutTableBucketMetricsConfiguration enables metrics for a bucket.
+func (b *InMemoryBackend) PutTableBucketMetricsConfiguration(bucketARN string) error {
+	b.muBuckets.Lock("PutTableBucketMetricsConfiguration")
+	defer b.muBuckets.Unlock()
+
+	tb, ok := b.tableBuckets[bucketARN]
+	if !ok {
+		return fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
+	}
+
+	tb.MetricsEnabled = true
+
+	return nil
+}
+
+// PutTableBucketStorageClass sets storage class for a bucket.
+func (b *InMemoryBackend) PutTableBucketStorageClass(bucketARN, storageClass string) error {
+	b.muBuckets.Lock("PutTableBucketStorageClass")
+	defer b.muBuckets.Unlock()
+
+	tb, ok := b.tableBuckets[bucketARN]
+	if !ok {
+		return fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, bucketARN)
+	}
+
+	tb.StorageClass = storageClass
+
+	return nil
+}
+
+// GetTableStorageClass returns the storage class for a table.
+func (b *InMemoryBackend) GetTableStorageClass(bucketARN string, namespace []string, name string) (string, error) {
+	b.muTables.RLock("GetTableStorageClass")
+	defer b.muTables.RUnlock()
+
+	nsStr := joinNamespace(namespace)
+	tableARN, ok := b.tableIndex[tableCompositeKey(bucketARN, nsStr, name)]
+	if !ok {
+		return "", fmt.Errorf("%w: table %q not found in namespace %s", ErrTableNotFound, name, nsStr)
+	}
+
+	t := b.tables[tableARN]
+	sc := t.StorageClass
+	if sc == "" {
+		sc = storageClassStandard
+	}
+
+	return sc, nil
+}
+
+// SetTableReplicationConfig sets the replication config (map form) for a table.
+func (b *InMemoryBackend) SetTableReplicationConfig(tableArn string, config map[string]any) error {
+	b.muTables.RLock("SetTableReplicationConfig")
+	defer b.muTables.RUnlock()
+
+	b.muState.Lock("SetTableReplicationConfig")
+	defer b.muState.Unlock()
+
+	if _, ok := b.tables[tableArn]; !ok {
+		return fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
+	}
+
+	b.tableReplication[tableArn] = true
+	b.tableReplicationConfigs[tableArn] = cloneAnyMap(config)
+
+	return nil
+}
+
+// GetTableReplicationConfig returns the replication config for a table.
+func (b *InMemoryBackend) GetTableReplicationConfig(tableArn string) (map[string]any, error) {
+	b.muTables.RLock("GetTableReplicationConfig")
+	defer b.muTables.RUnlock()
+
+	b.muState.RLock("GetTableReplicationConfig")
+	defer b.muState.RUnlock()
+
+	if _, ok := b.tables[tableArn]; !ok {
+		return nil, fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
+	}
+
+	cfg, ok := b.tableReplicationConfigs[tableArn]
+	if !ok {
+		return nil, fmt.Errorf("%w: no replication configuration for table %q", ErrTableNotFound, tableArn)
+	}
+
+	return cloneAnyMap(cfg), nil
+}
+
+// ValidateTableExists checks that a table ARN exists in the backend.
+func (b *InMemoryBackend) ValidateTableExists(tableArn string) error {
+	b.muTables.RLock("ValidateTableExists")
+	defer b.muTables.RUnlock()
+
+	if _, ok := b.tables[tableArn]; !ok {
+		return fmt.Errorf("%w: table %q not found", ErrTableNotFound, tableArn)
+	}
+
+	return nil
+}
+
+// TagResource adds or updates tags on a resource (bucket or table ARN).
+func (b *InMemoryBackend) TagResource(resourceArn string, newTags map[string]string) error {
+	b.muState.Lock("TagResource")
+	defer b.muState.Unlock()
+
+	existing := b.tags[resourceArn]
+	if existing == nil {
+		existing = make(map[string]string)
+	}
+
+	maps.Copy(existing, newTags)
+
+	b.tags[resourceArn] = existing
+
+	return nil
+}
+
+// UntagResource removes tags from a resource.
+func (b *InMemoryBackend) UntagResource(resourceArn string, tagKeys []string) error {
+	b.muState.Lock("UntagResource")
+	defer b.muState.Unlock()
+
+	existing := b.tags[resourceArn]
+	if existing == nil {
+		return nil
+	}
+
+	for _, k := range tagKeys {
+		delete(existing, k)
+	}
+
+	return nil
+}
+
+// ListTagsForResource returns all tags for a resource.
+func (b *InMemoryBackend) ListTagsForResource(resourceArn string) (map[string]string, error) {
+	b.muState.RLock("ListTagsForResource")
+	defer b.muState.RUnlock()
+
+	existing := b.tags[resourceArn]
+	if existing == nil {
+		return map[string]string{}, nil
+	}
+
+	result := make(map[string]string, len(existing))
+	maps.Copy(result, existing)
+
+	return result, nil
+}
+
 // CreateNamespace creates a new namespace within a table bucket.
 func (b *InMemoryBackend) CreateNamespace(tableBucketARN string, namespace []string) (*Namespace, error) {
-	b.mu.Lock("CreateNamespace")
-	defer b.mu.Unlock()
+	b.muBuckets.RLock("CreateNamespace")
+	defer b.muBuckets.RUnlock()
+
+	b.muNamespaces.Lock("CreateNamespace")
+	defer b.muNamespaces.Unlock()
 
 	if _, ok := b.tableBuckets[tableBucketARN]; !ok {
 		return nil, fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, tableBucketARN)
@@ -479,8 +706,8 @@ func (b *InMemoryBackend) CreateNamespace(tableBucketARN string, namespace []str
 
 // GetNamespace returns a namespace by bucket ARN and namespace name.
 func (b *InMemoryBackend) GetNamespace(tableBucketARN string, namespace []string) (*Namespace, error) {
-	b.mu.RLock("GetNamespace")
-	defer b.mu.RUnlock()
+	b.muNamespaces.RLock("GetNamespace")
+	defer b.muNamespaces.RUnlock()
 
 	nsStr := joinNamespace(namespace)
 	key := namespaceKey(tableBucketARN, nsStr)
@@ -495,8 +722,8 @@ func (b *InMemoryBackend) GetNamespace(tableBucketARN string, namespace []string
 
 // DeleteNamespace deletes a namespace from a table bucket.
 func (b *InMemoryBackend) DeleteNamespace(tableBucketARN string, namespace []string) error {
-	b.mu.Lock("DeleteNamespace")
-	defer b.mu.Unlock()
+	b.muNamespaces.Lock("DeleteNamespace")
+	defer b.muNamespaces.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	key := namespaceKey(tableBucketARN, nsStr)
@@ -512,8 +739,11 @@ func (b *InMemoryBackend) DeleteNamespace(tableBucketARN string, namespace []str
 
 // ListNamespaces returns all namespaces in a table bucket sorted by name.
 func (b *InMemoryBackend) ListNamespaces(tableBucketARN string) ([]*Namespace, error) {
-	b.mu.RLock("ListNamespaces")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("ListNamespaces")
+	defer b.muBuckets.RUnlock()
+
+	b.muNamespaces.RLock("ListNamespaces")
+	defer b.muNamespaces.RUnlock()
 
 	if _, ok := b.tableBuckets[tableBucketARN]; !ok {
 		return nil, fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, tableBucketARN)
@@ -536,8 +766,14 @@ func (b *InMemoryBackend) ListNamespaces(tableBucketARN string) ([]*Namespace, e
 
 // CreateTable creates a new table within a namespace.
 func (b *InMemoryBackend) CreateTable(tableBucketARN string, namespace []string, name, format string) (*Table, error) {
-	b.mu.Lock("CreateTable")
-	defer b.mu.Unlock()
+	b.muBuckets.RLock("CreateTable")
+	defer b.muBuckets.RUnlock()
+
+	b.muNamespaces.RLock("CreateTable")
+	defer b.muNamespaces.RUnlock()
+
+	b.muTables.Lock("CreateTable")
+	defer b.muTables.Unlock()
 
 	tb, ok := b.tableBuckets[tableBucketARN]
 	if !ok {
@@ -599,8 +835,8 @@ func (b *InMemoryBackend) CreateTable(tableBucketARN string, namespace []string,
 
 // GetTable returns a table by bucket ARN, namespace, and name.
 func (b *InMemoryBackend) GetTable(tableBucketARN string, namespace []string, name string) (*Table, error) {
-	b.mu.RLock("GetTable")
-	defer b.mu.RUnlock()
+	b.muTables.RLock("GetTable")
+	defer b.muTables.RUnlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -613,8 +849,8 @@ func (b *InMemoryBackend) GetTable(tableBucketARN string, namespace []string, na
 
 // DeleteTable deletes a table by bucket ARN, namespace, and name.
 func (b *InMemoryBackend) DeleteTable(tableBucketARN string, namespace []string, name string) error {
-	b.mu.Lock("DeleteTable")
-	defer b.mu.Unlock()
+	b.muTables.Lock("DeleteTable")
+	defer b.muTables.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	compositeKey := tableCompositeKey(tableBucketARN, nsStr, name)
@@ -632,8 +868,11 @@ func (b *InMemoryBackend) DeleteTable(tableBucketARN string, namespace []string,
 
 // ListTables returns all tables in a table bucket, optionally filtered by namespace.
 func (b *InMemoryBackend) ListTables(tableBucketARN, namespace string) ([]*Table, error) {
-	b.mu.RLock("ListTables")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("ListTables")
+	defer b.muBuckets.RUnlock()
+
+	b.muTables.RLock("ListTables")
+	defer b.muTables.RUnlock()
 
 	if _, ok := b.tableBuckets[tableBucketARN]; !ok {
 		return nil, fmt.Errorf("%w: table bucket %q not found", ErrTableBucketNotFound, tableBucketARN)
@@ -666,8 +905,11 @@ func (b *InMemoryBackend) RenameTable(
 	namespace []string,
 	name, newNamespace, newName string,
 ) error {
-	b.mu.Lock("RenameTable")
-	defer b.mu.Unlock()
+	b.muBuckets.RLock("RenameTable")
+	defer b.muBuckets.RUnlock()
+
+	b.muTables.Lock("RenameTable")
+	defer b.muTables.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	compositeKey := tableCompositeKey(tableBucketARN, nsStr, name)
@@ -715,8 +957,8 @@ func (b *InMemoryBackend) UpdateTableMetadataLocation(
 	namespace []string,
 	name, metadataLocation, _ string,
 ) (*Table, error) {
-	b.mu.Lock("UpdateTableMetadataLocation")
-	defer b.mu.Unlock()
+	b.muTables.Lock("UpdateTableMetadataLocation")
+	defer b.muTables.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -738,8 +980,8 @@ func (b *InMemoryBackend) GetTableMaintenanceConfiguration(
 	namespace []string,
 	name string,
 ) (map[string]any, string, error) {
-	b.mu.RLock("GetTableMaintenanceConfiguration")
-	defer b.mu.RUnlock()
+	b.muTables.RLock("GetTableMaintenanceConfiguration")
+	defer b.muTables.RUnlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -759,8 +1001,8 @@ func (b *InMemoryBackend) PutTableMaintenanceConfiguration(
 	name, maintenanceType string,
 	value map[string]any,
 ) error {
-	b.mu.Lock("PutTableMaintenanceConfiguration")
-	defer b.mu.Unlock()
+	b.muTables.Lock("PutTableMaintenanceConfiguration")
+	defer b.muTables.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -780,8 +1022,8 @@ func (b *InMemoryBackend) PutTableMaintenanceConfiguration(
 
 // GetTablePolicy returns the resource policy for a table.
 func (b *InMemoryBackend) GetTablePolicy(tableBucketARN string, namespace []string, name string) (string, error) {
-	b.mu.RLock("GetTablePolicy")
-	defer b.mu.RUnlock()
+	b.muTables.RLock("GetTablePolicy")
+	defer b.muTables.RUnlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -799,8 +1041,8 @@ func (b *InMemoryBackend) GetTablePolicy(tableBucketARN string, namespace []stri
 
 // PutTablePolicy sets the resource policy for a table.
 func (b *InMemoryBackend) PutTablePolicy(tableBucketARN string, namespace []string, name, policy string) error {
-	b.mu.Lock("PutTablePolicy")
-	defer b.mu.Unlock()
+	b.muTables.Lock("PutTablePolicy")
+	defer b.muTables.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -815,8 +1057,8 @@ func (b *InMemoryBackend) PutTablePolicy(tableBucketARN string, namespace []stri
 
 // DeleteTablePolicy removes the resource policy from a table.
 func (b *InMemoryBackend) DeleteTablePolicy(tableBucketARN string, namespace []string, name string) error {
-	b.mu.Lock("DeleteTablePolicy")
-	defer b.mu.Unlock()
+	b.muTables.Lock("DeleteTablePolicy")
+	defer b.muTables.Unlock()
 
 	nsStr := joinNamespace(namespace)
 	tableARN, ok := b.tableIndex[tableCompositeKey(tableBucketARN, nsStr, name)]
@@ -832,6 +1074,7 @@ func (b *InMemoryBackend) DeleteTablePolicy(tableBucketARN string, namespace []s
 func cloneTableBucket(tb *TableBucket) *TableBucket {
 	cp := *tb
 	cp.MaintenanceConfiguration = cloneAnyMap(tb.MaintenanceConfiguration)
+	cp.Encryption = cloneAnyMap(tb.Encryption)
 
 	return &cp
 }

--- a/services/s3tables/export_test.go
+++ b/services/s3tables/export_test.go
@@ -2,24 +2,24 @@ package s3tables
 
 // BucketCount returns the number of table buckets in the backend.
 func BucketCount(b *InMemoryBackend) int {
-	b.mu.RLock("BucketCount")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("BucketCount")
+	defer b.muBuckets.RUnlock()
 
 	return len(b.tableBuckets)
 }
 
 // NamespaceCount returns the number of namespaces in the backend.
 func NamespaceCount(b *InMemoryBackend) int {
-	b.mu.RLock("NamespaceCount")
-	defer b.mu.RUnlock()
+	b.muNamespaces.RLock("NamespaceCount")
+	defer b.muNamespaces.RUnlock()
 
 	return len(b.namespaces)
 }
 
 // TableCount returns the number of tables in the backend.
 func TableCount(b *InMemoryBackend) int {
-	b.mu.RLock("TableCount")
-	defer b.mu.RUnlock()
+	b.muTables.RLock("TableCount")
+	defer b.muTables.RUnlock()
 
 	return len(b.tables)
 }
@@ -29,32 +29,32 @@ func HandlerOpsLen(h *Handler) int { return len(h.GetSupportedOperations()) }
 
 // BucketReplicationCount returns the number of bucket replication configs in the backend.
 func BucketReplicationCount(b *InMemoryBackend) int {
-	b.mu.RLock("BucketReplicationCount")
-	defer b.mu.RUnlock()
+	b.muState.RLock("BucketReplicationCount")
+	defer b.muState.RUnlock()
 
 	return len(b.bucketReplication)
 }
 
 // TableReplicationCount returns the number of table replication entries in the backend.
 func TableReplicationCount(b *InMemoryBackend) int {
-	b.mu.RLock("TableReplicationCount")
-	defer b.mu.RUnlock()
+	b.muState.RLock("TableReplicationCount")
+	defer b.muState.RUnlock()
 
 	return len(b.tableReplication)
 }
 
 // TableRecordExpiryCount returns the number of table record expiry configs in the backend.
 func TableRecordExpiryCount(b *InMemoryBackend) int {
-	b.mu.RLock("TableRecordExpiryCount")
-	defer b.mu.RUnlock()
+	b.muState.RLock("TableRecordExpiryCount")
+	defer b.muState.RUnlock()
 
 	return len(b.tableRecordExpiry)
 }
 
 // AddBucketReplicationInternal directly inserts a replication config for tests.
 func AddBucketReplicationInternal(b *InMemoryBackend, bucketARN string, cfg *BucketReplicationConfig) {
-	b.mu.Lock("AddBucketReplicationInternal")
-	defer b.mu.Unlock()
+	b.muState.Lock("AddBucketReplicationInternal")
+	defer b.muState.Unlock()
 
 	b.bucketReplication[bucketARN] = cfg
 }

--- a/services/s3tables/handler.go
+++ b/services/s3tables/handler.go
@@ -97,14 +97,27 @@ func (h *Handler) GetSupportedOperations() []string {
 		"GetTableMetadataLocation",
 		"GetTablePolicy",
 		"GetTableRecordExpirationConfiguration",
+		"GetTableRecordExpirationJobStatus",
+		"GetTableReplication",
+		"GetTableReplicationStatus",
+		"GetTableStorageClass",
 		"ListNamespaces",
 		"ListTableBuckets",
 		"ListTables",
+		"ListTagsForResource",
+		"PutTableBucketEncryption",
 		"PutTableBucketMaintenanceConfiguration",
+		"PutTableBucketMetricsConfiguration",
 		"PutTableBucketPolicy",
+		"PutTableBucketReplication",
+		"PutTableBucketStorageClass",
 		"PutTableMaintenanceConfiguration",
 		"PutTablePolicy",
+		"PutTableRecordExpirationConfiguration",
+		"PutTableReplication",
 		"RenameTable",
+		"TagResource",
+		"UntagResource",
 		"UpdateTableMetadataLocation",
 	}
 }
@@ -132,7 +145,10 @@ func (h *Handler) RouteMatcher() service.Matcher {
 			strings.HasPrefix(path, "/get-table") ||
 			strings.HasPrefix(path, "/table-bucket-replication") ||
 			strings.HasPrefix(path, "/table-replication") ||
-			strings.HasPrefix(path, "/table-record-expiration")
+			strings.HasPrefix(path, "/table-record-expiration") ||
+			strings.HasPrefix(path, "/replication-status") ||
+			strings.HasPrefix(path, "/table-record-expiration-job-status") ||
+			strings.HasPrefix(path, "/tag/")
 	}
 }
 
@@ -155,13 +171,20 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 	}
 
 	switch segs[0] {
-	case "table-bucket-replication", "table-replication", "table-record-expiration":
+	case "table-bucket-replication", "table-replication", "table-record-expiration",
+		"replication-status", "table-record-expiration-job-status":
 		q := c.Request().URL.Query()
 		if arn := q.Get(keyTableBucketARN); arn != "" {
 			return arn
 		}
 
 		return q.Get("tableArn")
+	case "tag":
+		if len(segs) > 1 {
+			return segs[1]
+		}
+
+		return ""
 	}
 
 	if len(segs) > 1 {
@@ -234,12 +257,22 @@ func (h *Handler) routeRequest(r *http.Request) (string, dispatchFunc) {
 		return h.routeTableReplication(method, r)
 	case "table-record-expiration":
 		return h.routeTableRecordExpiration(method, r)
+	case "replication-status":
+		if method == http.MethodGet {
+			return "GetTableReplicationStatus", h.handleGetTableReplicationStatus
+		}
+	case "table-record-expiration-job-status":
+		if method == http.MethodGet {
+			return "GetTableRecordExpirationJobStatus", h.handleGetTableRecordExpirationJobStatus
+		}
+	case "tag":
+		return h.routeTag(segs, method)
 	}
 
 	return "", nil
 }
 
-//nolint:cyclop,gocognit // routing table is inherently switch-heavy
+//nolint:cyclop,gocognit,funlen // routing table is inherently switch-heavy
 func (h *Handler) routeBuckets(segs []string, method string, r *http.Request) (string, dispatchFunc) {
 	switch len(segs) {
 	case 1:
@@ -267,6 +300,8 @@ func (h *Handler) routeBuckets(segs []string, method string, r *http.Request) (s
 			switch method {
 			case http.MethodGet:
 				return "GetTableBucketEncryption", h.handleGetTableBucketEncryption
+			case http.MethodPut:
+				return "PutTableBucketEncryption", h.handlePutTableBucketEncryption
 			case http.MethodDelete:
 				return "DeleteTableBucketEncryption", h.handleDeleteTableBucketEncryption
 			}
@@ -274,12 +309,17 @@ func (h *Handler) routeBuckets(segs []string, method string, r *http.Request) (s
 			switch method {
 			case http.MethodGet:
 				return "GetTableBucketMetricsConfiguration", h.handleGetTableBucketMetricsConfiguration
+			case http.MethodPut:
+				return "PutTableBucketMetricsConfiguration", h.handlePutTableBucketMetricsConfiguration
 			case http.MethodDelete:
 				return "DeleteTableBucketMetricsConfiguration", h.handleDeleteTableBucketMetricsConfiguration
 			}
 		case segStorageClass:
-			if method == http.MethodGet {
+			switch method {
+			case http.MethodGet:
 				return "GetTableBucketStorageClass", h.handleGetTableBucketStorageClass
+			case http.MethodPut:
+				return "PutTableBucketStorageClass", h.handlePutTableBucketStorageClass
 			}
 		case "policy":
 			switch method {
@@ -373,6 +413,10 @@ func (h *Handler) routeTableSubResource(sub, method string, _ *http.Request) (st
 	case segEncryption:
 		if method == http.MethodGet {
 			return "GetTableEncryption", h.handleGetTableEncryption
+		}
+	case segStorageClass:
+		if method == http.MethodGet {
+			return "GetTableStorageClass", h.handleGetTableStorageClass
 		}
 	case "policy":
 		switch method {
@@ -596,14 +640,21 @@ func (h *Handler) handleGetTableBucketEncryption(ctx context.Context, r *http.Re
 
 	bucketARN := segs[1]
 
-	if _, err := h.Backend.GetTableBucket(bucketARN); err != nil {
+	tb, err := h.Backend.GetTableBucket(bucketARN)
+	if err != nil {
 		return nil, err
+	}
+
+	if tb.Encryption == nil {
+		return nil, awserr.ErrNotFound
 	}
 
 	log := logger.Load(ctx)
 	log.InfoContext(ctx, "s3tables: got table bucket encryption", keyArn, bucketARN)
 
-	return nil, awserr.ErrNotFound
+	return json.Marshal(map[string]any{
+		"encryptionConfiguration": tb.Encryption,
+	})
 }
 
 func (h *Handler) handleDeleteTableBucketEncryption(ctx context.Context, r *http.Request, _ []byte) ([]byte, error) {
@@ -679,8 +730,14 @@ func (h *Handler) handleGetTableBucketStorageClass(ctx context.Context, r *http.
 
 	bucketARN := segs[1]
 
-	if _, err := h.Backend.GetTableBucket(bucketARN); err != nil {
+	tb, err := h.Backend.GetTableBucket(bucketARN)
+	if err != nil {
 		return nil, err
+	}
+
+	sc := tb.StorageClass
+	if sc == "" {
+		sc = storageClassStandard
 	}
 
 	log := logger.Load(ctx)
@@ -688,7 +745,7 @@ func (h *Handler) handleGetTableBucketStorageClass(ctx context.Context, r *http.
 
 	return json.Marshal(map[string]any{
 		keyTableBucketARN: bucketARN,
-		"storageClass":    "STANDARD",
+		"storageClass":    sc,
 	})
 }
 
@@ -698,6 +755,8 @@ func (h *Handler) routeTableBucketReplication(method string, r *http.Request) (s
 	switch method {
 	case http.MethodGet:
 		return "GetTableBucketReplication", h.handleGetTableBucketReplication
+	case http.MethodPut:
+		return "PutTableBucketReplication", h.handlePutTableBucketReplication
 	case http.MethodDelete:
 		return "DeleteTableBucketReplication", h.handleDeleteTableBucketReplication
 	}
@@ -708,7 +767,12 @@ func (h *Handler) routeTableBucketReplication(method string, r *http.Request) (s
 }
 
 func (h *Handler) routeTableReplication(method string, r *http.Request) (string, dispatchFunc) {
-	if method == http.MethodDelete {
+	switch method {
+	case http.MethodGet:
+		return "GetTableReplication", h.handleGetTableReplication
+	case http.MethodPut:
+		return "PutTableReplication", h.handlePutTableReplication
+	case http.MethodDelete:
 		return "DeleteTableReplication", h.handleDeleteTableReplication
 	}
 
@@ -718,8 +782,11 @@ func (h *Handler) routeTableReplication(method string, r *http.Request) (string,
 }
 
 func (h *Handler) routeTableRecordExpiration(method string, r *http.Request) (string, dispatchFunc) {
-	if method == http.MethodGet {
+	switch method {
+	case http.MethodGet:
 		return "GetTableRecordExpirationConfiguration", h.handleGetTableRecordExpirationConfiguration
+	case http.MethodPut:
+		return "PutTableRecordExpirationConfiguration", h.handlePutTableRecordExpirationConfiguration
 	}
 
 	_ = r
@@ -1432,6 +1499,369 @@ func (h *Handler) handleDeleteTablePolicy(ctx context.Context, r *http.Request, 
 	return nil, nil
 }
 
+// === Tag operations ===
+
+// routeTag handles /tag/{resourceArn}.
+func (h *Handler) routeTag(segs []string, method string) (string, dispatchFunc) {
+	if len(segs) < 2 { //nolint:mnd // need at least tag + resourceArn
+		return "", nil
+	}
+
+	switch method {
+	case http.MethodGet:
+		return "ListTagsForResource", h.handleListTagsForResource
+	case http.MethodPost:
+		return "TagResource", h.handleTagResource
+	case http.MethodDelete:
+		return "UntagResource", h.handleUntagResource
+	}
+
+	return "", nil
+}
+
+func (h *Handler) handleListTagsForResource(ctx context.Context, r *http.Request, _ []byte) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 2 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing resourceArn", errInvalidRequest)
+	}
+
+	resourceArn := segs[1]
+
+	tags, err := h.Backend.ListTagsForResource(resourceArn)
+	if err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: listed tags for resource", "resourceArn", resourceArn)
+
+	return json.Marshal(map[string]any{
+		"tags": tags,
+	})
+}
+
+// tagResourceRequest is the request body for TagResource.
+type tagResourceRequest struct {
+	Tags map[string]string `json:"tags"`
+}
+
+func (h *Handler) handleTagResource(ctx context.Context, r *http.Request, body []byte) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 2 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing resourceArn", errInvalidRequest)
+	}
+
+	resourceArn := segs[1]
+
+	var req tagResourceRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if err := h.Backend.TagResource(resourceArn, req.Tags); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: tagged resource", "resourceArn", resourceArn)
+
+	return nil, nil
+}
+
+func (h *Handler) handleUntagResource(ctx context.Context, r *http.Request, _ []byte) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 2 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing resourceArn", errInvalidRequest)
+	}
+
+	resourceArn := segs[1]
+	tagKeys := r.URL.Query()["tagKeys"]
+
+	if err := h.Backend.UntagResource(resourceArn, tagKeys); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: untagged resource", "resourceArn", resourceArn)
+
+	return nil, nil
+}
+
+// === New bucket sub-resource handlers ===
+
+// putTableBucketEncryptionRequest is the request body for PutTableBucketEncryption.
+type putTableBucketEncryptionRequest struct {
+	EncryptionConfiguration map[string]any `json:"encryptionConfiguration"`
+}
+
+func (h *Handler) handlePutTableBucketEncryption(ctx context.Context, r *http.Request, body []byte) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 2 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing tableBucketARN", errInvalidRequest)
+	}
+
+	bucketARN := segs[1]
+
+	var req putTableBucketEncryptionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if err := h.Backend.PutTableBucketEncryption(bucketARN, req.EncryptionConfiguration); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: put table bucket encryption", keyArn, bucketARN)
+
+	return nil, nil
+}
+
+func (h *Handler) handlePutTableBucketMetricsConfiguration(
+	ctx context.Context,
+	r *http.Request,
+	_ []byte,
+) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 2 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing tableBucketARN", errInvalidRequest)
+	}
+
+	bucketARN := segs[1]
+
+	if err := h.Backend.PutTableBucketMetricsConfiguration(bucketARN); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: put table bucket metrics configuration", keyArn, bucketARN)
+
+	return nil, nil
+}
+
+// putTableBucketStorageClassRequest is the request body for PutTableBucketStorageClass.
+type putTableBucketStorageClassRequest struct {
+	StorageClassConfiguration map[string]any `json:"storageClassConfiguration"`
+}
+
+func (h *Handler) handlePutTableBucketStorageClass(ctx context.Context, r *http.Request, body []byte) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 2 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing tableBucketARN", errInvalidRequest)
+	}
+
+	bucketARN := segs[1]
+
+	var req putTableBucketStorageClassRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	storageClass := storageClassStandard
+	if scVal, found := req.StorageClassConfiguration["storageClass"]; found {
+		if scStr, isStr := scVal.(string); isStr && scStr != "" {
+			storageClass = scStr
+		}
+	}
+
+	if err := h.Backend.PutTableBucketStorageClass(bucketARN, storageClass); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: put table bucket storage class", keyArn, bucketARN)
+
+	return nil, nil
+}
+
+// === New table-bucket replication handler ===
+
+// putTableBucketReplicationRequest is the request body for PutTableBucketReplication.
+type putTableBucketReplicationRequest struct {
+	Configuration map[string]any `json:"configuration"`
+}
+
+func (h *Handler) handlePutTableBucketReplication(ctx context.Context, r *http.Request, body []byte) ([]byte, error) {
+	bucketARN := r.URL.Query().Get(keyTableBucketARN)
+	if bucketARN == "" {
+		return nil, fmt.Errorf("%w: tableBucketARN is required", errInvalidRequest)
+	}
+
+	var req putTableBucketReplicationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	cfg := &BucketReplicationConfig{
+		Destinations: parseBucketReplicationDestinations(req.Configuration),
+	}
+
+	if err := h.Backend.PutTableBucketReplication(bucketARN, cfg); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: put table bucket replication", keyArn, bucketARN)
+
+	return nil, nil
+}
+
+// === New table replication handlers ===
+
+func (h *Handler) handleGetTableReplication(ctx context.Context, r *http.Request, _ []byte) ([]byte, error) {
+	tableArn := r.URL.Query().Get("tableArn")
+	if tableArn == "" {
+		return nil, fmt.Errorf("%w: tableArn is required", errInvalidRequest)
+	}
+
+	cfg, err := h.Backend.GetTableReplicationConfig(tableArn)
+	if err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: got table replication", "tableArn", tableArn)
+
+	return json.Marshal(map[string]any{
+		keyConfiguration: cfg,
+		keyVersionToken:  "",
+	})
+}
+
+// putTableReplicationRequest is the request body for PutTableReplication.
+type putTableReplicationRequest struct {
+	Configuration map[string]any `json:"configuration"`
+}
+
+func (h *Handler) handlePutTableReplication(ctx context.Context, r *http.Request, body []byte) ([]byte, error) {
+	tableArn := r.URL.Query().Get("tableArn")
+	if tableArn == "" {
+		return nil, fmt.Errorf("%w: tableArn is required", errInvalidRequest)
+	}
+
+	var req putTableReplicationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if err := h.Backend.SetTableReplicationConfig(tableArn, req.Configuration); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: put table replication", "tableArn", tableArn)
+
+	return json.Marshal(map[string]any{
+		keyStatusField:  "ACTIVE",
+		keyVersionToken: "1",
+	})
+}
+
+func (h *Handler) handleGetTableReplicationStatus(ctx context.Context, r *http.Request, _ []byte) ([]byte, error) {
+	tableArn := r.URL.Query().Get("tableArn")
+	if tableArn == "" {
+		return nil, fmt.Errorf("%w: tableArn is required", errInvalidRequest)
+	}
+
+	if err := h.Backend.ValidateTableExists(tableArn); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: got table replication status", "tableArn", tableArn)
+
+	return json.Marshal(map[string]any{
+		"sourceTableArn": tableArn,
+		"destinations":   []any{},
+	})
+}
+
+// === New table record expiration handlers ===
+
+// putTableRecordExpirationRequest is the request body for PutTableRecordExpirationConfiguration.
+type putTableRecordExpirationRequest struct {
+	Value map[string]any `json:"value"`
+}
+
+func (h *Handler) handlePutTableRecordExpirationConfiguration(
+	ctx context.Context,
+	r *http.Request,
+	body []byte,
+) ([]byte, error) {
+	tableArn := r.URL.Query().Get("tableArn")
+	if tableArn == "" {
+		return nil, fmt.Errorf("%w: tableArn is required", errInvalidRequest)
+	}
+
+	var req putTableRecordExpirationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	cfg := &TableRecordExpiryConfig{Status: "DISABLED"}
+	if st, ok := req.Value[keyStatusField].(string); ok {
+		cfg.Status = st
+	}
+
+	if err := h.Backend.PutTableRecordExpirationConfiguration(tableArn, cfg); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: put table record expiration configuration", "tableArn", tableArn)
+
+	return nil, nil
+}
+
+func (h *Handler) handleGetTableRecordExpirationJobStatus(
+	ctx context.Context,
+	r *http.Request,
+	_ []byte,
+) ([]byte, error) {
+	tableArn := r.URL.Query().Get("tableArn")
+	if tableArn == "" {
+		return nil, fmt.Errorf("%w: tableArn is required", errInvalidRequest)
+	}
+
+	if err := h.Backend.ValidateTableExists(tableArn); err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: got table record expiration job status", "tableArn", tableArn)
+
+	return json.Marshal(map[string]any{
+		keyStatusField: "SUCCEEDED",
+	})
+}
+
+// === New table storage-class handler ===
+
+func (h *Handler) handleGetTableStorageClass(ctx context.Context, r *http.Request, _ []byte) ([]byte, error) {
+	segs := rawPathSegments(r)
+	if len(segs) < 4 { //nolint:mnd // minimum required segments
+		return nil, fmt.Errorf("%w: missing tableBucketARN, namespace or name", errInvalidRequest)
+	}
+
+	bucketARN := segs[1]
+	nsName := segs[2]
+	name := segs[3]
+
+	sc, err := h.Backend.GetTableStorageClass(bucketARN, splitNamespace(nsName), name)
+	if err != nil {
+		return nil, err
+	}
+
+	log := logger.Load(ctx)
+	log.InfoContext(ctx, "s3tables: got table storage class", keyName, name)
+
+	return json.Marshal(map[string]any{
+		"storageClassConfiguration": map[string]any{
+			"storageClass": sc,
+		},
+	})
+}
+
 // rawPathSegments splits the raw (or decoded) URL path into non-empty segments,
 // URL-decoding each segment individually so that encoded slashes in path params
 // (e.g. ARNs) are preserved as a single segment.
@@ -1460,4 +1890,35 @@ func rawPathSegments(r *http.Request) []string {
 	}
 
 	return segments
+}
+
+// parseBucketReplicationDestinations extracts replication destinations from a config map.
+func parseBucketReplicationDestinations(cfg map[string]any) []ReplicationDestination {
+	destsRaw, ok := cfg["destinations"]
+	if !ok {
+		return nil
+	}
+
+	destSlice, ok := destsRaw.([]any)
+	if !ok {
+		return nil
+	}
+
+	destinations := make([]ReplicationDestination, 0, len(destSlice))
+
+	for _, d := range destSlice {
+		dm, isMap := d.(map[string]any)
+		if !isMap {
+			continue
+		}
+
+		dest := ReplicationDestination{}
+		if arn, isStr := dm["destinationBucketARN"].(string); isStr {
+			dest.DestinationBucketARN = arn
+		}
+
+		destinations = append(destinations, dest)
+	}
+
+	return destinations
 }

--- a/services/s3tables/handler_test.go
+++ b/services/s3tables/handler_test.go
@@ -142,7 +142,7 @@ func TestHandler_RouteMatcher(t *testing.T) {
 		{name: "matches /namespaces/arn", path: "/namespaces/arn:aws:s3tables:us-east-1:123:bucket/test", want: true},
 		{name: "matches /tables/arn", path: "/tables/arn:aws:s3tables:us-east-1:123:bucket/test", want: true},
 		{name: "matches /get-table", path: "/get-table", want: true},
-		{name: "matches /tag/arn", path: "/tag/arn:aws:s3tables:us-east-1:123:bucket/test", want: false},
+		{name: "matches /tag/arn", path: "/tag/arn:aws:s3tables:us-east-1:123:bucket/test", want: true},
 		{name: "no match /s3", path: "/s3", want: false},
 		{name: "no match /", path: "/", want: false},
 	}

--- a/services/s3tables/persistence.go
+++ b/services/s3tables/persistence.go
@@ -6,32 +6,42 @@ import (
 )
 
 type backendSnapshot struct {
-	TableBuckets      map[string]*TableBucket             `json:"tableBuckets"`
-	Namespaces        map[string]*Namespace               `json:"namespaces"`
-	Tables            map[string]*Table                   `json:"tables"`
-	TableIndex        map[string]string                   `json:"tableIndex"`
-	BucketReplication map[string]*BucketReplicationConfig `json:"bucketReplication"`
-	TableReplication  map[string]bool                     `json:"tableReplication"`
-	TableRecordExpiry map[string]*TableRecordExpiryConfig `json:"tableRecordExpiry"`
-	AccountID         string                              `json:"accountID"`
-	Region            string                              `json:"region"`
+	TableBuckets            map[string]*TableBucket             `json:"tableBuckets"`
+	Namespaces              map[string]*Namespace               `json:"namespaces"`
+	Tables                  map[string]*Table                   `json:"tables"`
+	TableIndex              map[string]string                   `json:"tableIndex"`
+	BucketReplication       map[string]*BucketReplicationConfig `json:"bucketReplication"`
+	TableReplication        map[string]bool                     `json:"tableReplication"`
+	TableRecordExpiry       map[string]*TableRecordExpiryConfig `json:"tableRecordExpiry"`
+	Tags                    map[string]map[string]string        `json:"tags"`
+	TableReplicationConfigs map[string]map[string]any           `json:"tableReplicationConfigs"`
+	AccountID               string                              `json:"accountID"`
+	Region                  string                              `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
 func (b *InMemoryBackend) Snapshot() []byte {
-	b.mu.RLock("Snapshot")
-	defer b.mu.RUnlock()
+	b.muBuckets.RLock("Snapshot")
+	b.muNamespaces.RLock("Snapshot")
+	b.muTables.RLock("Snapshot")
+	b.muState.RLock("Snapshot")
+	defer b.muBuckets.RUnlock()
+	defer b.muNamespaces.RUnlock()
+	defer b.muTables.RUnlock()
+	defer b.muState.RUnlock()
 
 	snap := backendSnapshot{
-		TableBuckets:      b.tableBuckets,
-		Namespaces:        b.namespaces,
-		Tables:            b.tables,
-		TableIndex:        b.tableIndex,
-		BucketReplication: b.bucketReplication,
-		TableReplication:  b.tableReplication,
-		TableRecordExpiry: b.tableRecordExpiry,
-		AccountID:         b.accountID,
-		Region:            b.region,
+		TableBuckets:            b.tableBuckets,
+		Namespaces:              b.namespaces,
+		Tables:                  b.tables,
+		TableIndex:              b.tableIndex,
+		BucketReplication:       b.bucketReplication,
+		TableReplication:        b.tableReplication,
+		TableRecordExpiry:       b.tableRecordExpiry,
+		Tags:                    b.tags,
+		TableReplicationConfigs: b.tableReplicationConfigs,
+		AccountID:               b.accountID,
+		Region:                  b.region,
 	}
 
 	data, err := json.Marshal(snap)
@@ -54,8 +64,14 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 
 	ensureNonNilMaps(&snap)
 
-	b.mu.Lock("Restore")
-	defer b.mu.Unlock()
+	b.muBuckets.Lock("Restore")
+	b.muNamespaces.Lock("Restore")
+	b.muTables.Lock("Restore")
+	b.muState.Lock("Restore")
+	defer b.muBuckets.Unlock()
+	defer b.muNamespaces.Unlock()
+	defer b.muTables.Unlock()
+	defer b.muState.Unlock()
 
 	b.tableBuckets = snap.TableBuckets
 	b.namespaces = snap.Namespaces
@@ -64,6 +80,8 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.bucketReplication = snap.BucketReplication
 	b.tableReplication = snap.TableReplication
 	b.tableRecordExpiry = snap.TableRecordExpiry
+	b.tags = snap.Tags
+	b.tableReplicationConfigs = snap.TableReplicationConfigs
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 
@@ -97,5 +115,13 @@ func ensureNonNilMaps(snap *backendSnapshot) {
 
 	if snap.TableRecordExpiry == nil {
 		snap.TableRecordExpiry = make(map[string]*TableRecordExpiryConfig)
+	}
+
+	if snap.Tags == nil {
+		snap.Tags = make(map[string]map[string]string)
+	}
+
+	if snap.TableReplicationConfigs == nil {
+		snap.TableReplicationConfigs = make(map[string]map[string]any)
 	}
 }

--- a/services/s3tables/sdk_completeness_test.go
+++ b/services/s3tables/sdk_completeness_test.go
@@ -17,19 +17,5 @@ func TestSDKCompleteness(t *testing.T) {
 
 	backend := s3tables.NewInMemoryBackend("000000000000", "us-east-1")
 	h := s3tables.NewHandler(backend)
-	sdkcheck.CheckCompleteness(t, &s3tablessdk.Client{}, h.GetSupportedOperations(), []string{
-		"GetTableRecordExpirationJobStatus",
-		"GetTableReplication",
-		"GetTableReplicationStatus",
-		"GetTableStorageClass",
-		"ListTagsForResource",
-		"PutTableBucketEncryption",
-		"PutTableBucketMetricsConfiguration",
-		"PutTableBucketReplication",
-		"PutTableBucketStorageClass",
-		"PutTableRecordExpirationConfiguration",
-		"PutTableReplication",
-		"TagResource",
-		"UntagResource",
-	})
+	sdkcheck.CheckCompleteness(t, &s3tablessdk.Client{}, h.GetSupportedOperations(), []string{})
 }


### PR DESCRIPTION
## Summary
S3 Tables implementation with 13 missing SDK operations and significant performance improvements through fine-grained locking.

### New Operations
- TagResource, UntagResource, ListTagsForResource
- PutTableBucketEncryption, PutTableBucketMetricsConfiguration
- PutTableBucketStorageClass, PutTableBucketReplication
- PutTableReplication, GetTableReplication, GetTableReplicationStatus
- PutTableRecordExpirationConfiguration, GetTableRecordExpirationJobStatus
- GetTableStorageClass

### Performance Improvements
- Replace single global mutex with per-map RWMutex
- Dedicated locks for: muBuckets, muNamespaces, muTables, muState
- Consistent lock ordering to eliminate high-contention bottleneck on 9+ maps
- Addresses issue gh-1224

🤖 Merge request from refinery (queue: polecat/quartz-moqbotnr)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->