### PR TITLE
feat(iotdataplane): cap shadows/thing + interactive UI

### DIFF
--- a/services/iotdataplane/backend.go
+++ b/services/iotdataplane/backend.go
@@ -30,6 +30,10 @@ var ErrValidation = errors.New("InvalidRequestException")
 // This prevents unbounded memory growth when many topics are used.
 const maxRetainedMessages = 1000
 
+// maxShadowsPerThing is the maximum number of shadows (classic + named) per thing.
+// AWS IoT enforces a similar limit; we cap here to prevent memory exhaustion.
+const maxShadowsPerThing = 100
+
 // compile-time interface check.
 var _ StorageBackend = (*InMemoryBackend)(nil)
 
@@ -170,6 +174,12 @@ func (b *InMemoryBackend) UpdateThingShadow(thingName, shadowName string, docume
 	}
 
 	current := b.shadows[thingName][shadowName]
+
+	// Enforce per-thing shadow cap when creating a new shadow (not updating existing).
+	if current == nil && len(b.shadows[thingName]) >= maxShadowsPerThing {
+		return nil, fmt.Errorf("%w: shadow limit (%d) per thing exceeded for %s",
+			ErrValidation, maxShadowsPerThing, thingName)
+	}
 
 	// Check optimistic locking version if the caller supplied one.
 	// An unmarshal error here is intentional: if the document is not valid JSON

--- a/services/iotdataplane/backend.go
+++ b/services/iotdataplane/backend.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
 
 // ErrNoBroker is returned when no MQTT broker has been wired.
@@ -26,6 +28,9 @@ var ErrVersionConflict = errors.New("VersionConflictException")
 // ErrValidation is returned for invalid input parameters.
 var ErrValidation = errors.New("InvalidRequestException")
 
+// ErrConnectionExists is returned when trying to register a clientID that is already connected.
+var ErrConnectionExists = errors.New("connection already exists")
+
 // maxRetainedMessages is the maximum number of retained messages stored in memory.
 // This prevents unbounded memory growth when many topics are used.
 const maxRetainedMessages = 1000
@@ -33,6 +38,23 @@ const maxRetainedMessages = 1000
 // maxShadowsPerThing is the maximum number of shadows (classic + named) per thing.
 // AWS IoT enforces a similar limit; we cap here to prevent memory exhaustion.
 const maxShadowsPerThing = 100
+
+// maxShadowDocumentBytes is the maximum allowed shadow document size in bytes.
+// This matches the AWS IoT limit and prevents oversized documents from consuming memory.
+const maxShadowDocumentBytes = 8 * 1024
+
+// maxTopicLength is the maximum allowed MQTT topic length per AWS IoT rules.
+const maxTopicLength = 256
+
+// maxShadowNameLength is the maximum allowed shadow name length per AWS IoT rules.
+const maxShadowNameLength = 64
+
+// maxShadowVersion is the maximum shadow version before it resets to 1.
+// This prevents integer overflow for long-lived things.
+const maxShadowVersion = 1<<31 - 1
+
+// shadowNameRe validates shadow names per AWS IoT rules: alphanumeric, colon, underscore, hyphen.
+var shadowNameRe = regexp.MustCompile(`^[a-zA-Z0-9:_-]+$`)
 
 // compile-time interface check.
 var _ StorageBackend = (*InMemoryBackend)(nil)
@@ -44,46 +66,113 @@ type shadowEntry struct {
 	version   int
 }
 
+// connectionEntry holds the state for a registered MQTT client connection.
+type connectionEntry struct {
+	connectedAt time.Time
+	sourceIP    string
+}
+
 // InMemoryBackend implements the IoT Data Plane backend.
 type InMemoryBackend struct {
+	mu               *lockmetrics.RWMutex
 	broker           MQTTPublisher
 	shadows          map[string]map[string]*shadowEntry // thingName -> shadowName -> entry
-	connections      map[string]struct{}                // clientID -> struct{}
+	connections      map[string]*connectionEntry        // clientID -> entry
 	retainedMessages map[string]*RetainedMessage        // topic -> message
-	mu               sync.RWMutex
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend() *InMemoryBackend {
 	return &InMemoryBackend{
+		mu:               lockmetrics.New("iotdataplane"),
 		shadows:          make(map[string]map[string]*shadowEntry),
-		connections:      make(map[string]struct{}),
+		connections:      make(map[string]*connectionEntry),
 		retainedMessages: make(map[string]*RetainedMessage),
 	}
 }
 
 // Reset clears all backend state, including shadows, connections, and retained messages.
 func (b *InMemoryBackend) Reset() {
-	b.mu.Lock()
+	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
 	b.shadows = make(map[string]map[string]*shadowEntry)
-	b.connections = make(map[string]struct{})
+	b.connections = make(map[string]*connectionEntry)
 	b.retainedMessages = make(map[string]*RetainedMessage)
 }
 
 // SetBroker wires the MQTT broker for publishing (called during CLI startup).
 func (b *InMemoryBackend) SetBroker(broker MQTTPublisher) {
-	b.mu.Lock()
+	b.mu.Lock("SetBroker")
 	defer b.mu.Unlock()
 
 	b.broker = broker
 }
 
+// validateTopic checks that a topic string conforms to MQTT publishing rules.
+// Topics for publishing must not contain wildcards (# or +) and must not exceed
+// maxTopicLength characters. Empty topic segments (e.g. "a//b") are also rejected.
+func validateTopic(topic string) error {
+	if len(topic) > maxTopicLength {
+		return fmt.Errorf("%w: topic exceeds %d characters", ErrValidation, maxTopicLength)
+	}
+
+	if strings.Contains(topic, "#") || strings.Contains(topic, "+") {
+		return fmt.Errorf("%w: topic must not contain wildcards (# or +)", ErrValidation)
+	}
+
+	// Reject empty topic levels (consecutive slashes or leading/trailing slash after split).
+	for _, segment := range strings.Split(topic, "/") {
+		if segment == "" {
+			return fmt.Errorf("%w: topic must not contain empty levels", ErrValidation)
+		}
+	}
+
+	return nil
+}
+
+// validateShadowName checks that a shadow name meets AWS IoT naming rules.
+// An empty name refers to the classic (unnamed) shadow and is always valid.
+func validateShadowName(name string) error {
+	if name == "" {
+		return nil // classic shadow
+	}
+
+	if len(name) > maxShadowNameLength {
+		return fmt.Errorf("%w: shadow name exceeds %d characters", ErrValidation, maxShadowNameLength)
+	}
+
+	if !shadowNameRe.MatchString(name) {
+		return fmt.Errorf("%w: shadow name must match [a-zA-Z0-9:_-]+", ErrValidation)
+	}
+
+	return nil
+}
+
+// validateShadowDocument checks that doc is a non-empty JSON object.
+// AWS IoT rejects shadow documents that are not JSON objects (arrays, primitives, etc.).
+func validateShadowDocument(doc []byte) error {
+	if len(doc) == 0 {
+		return fmt.Errorf("%w: shadow document must not be empty", ErrValidation)
+	}
+
+	if len(doc) > maxShadowDocumentBytes {
+		return fmt.Errorf("%w: shadow document exceeds %d bytes", ErrValidation, maxShadowDocumentBytes)
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &obj); err != nil || obj == nil {
+		// json.Unmarshal succeeds for JSON null but yields a nil map — reject both.
+		return fmt.Errorf("%w: shadow document must be a valid JSON object", ErrValidation)
+	}
+
+	return nil
+}
+
 // Publish delivers a message to the given MQTT topic.
 // If no broker is configured the call is a no-op (accepted but not forwarded).
 func (b *InMemoryBackend) Publish(topic string, payload []byte, qos int32) error {
-	b.mu.RLock()
+	b.mu.RLock("Publish")
 	broker := b.broker
 	b.mu.RUnlock()
 
@@ -119,9 +208,9 @@ func sortedKeys[V any](m map[string]V) []string {
 func buildShadowResponse(doc []byte, version int, updatedAt time.Time) ([]byte, error) {
 	var m map[string]json.RawMessage
 
-	if err := json.Unmarshal(doc, &m); err != nil {
-		// doc is not a JSON object; encode it as a plain string so json.Marshal
-		// never fails on raw bytes that are not valid JSON.
+	if err := json.Unmarshal(doc, &m); err != nil || m == nil {
+		// doc is not a JSON object (or is JSON null); encode it as a plain string so
+		// json.Marshal never fails on raw bytes that are not valid JSON.
 		return json.Marshal(map[string]any{
 			"payload":   string(doc),
 			"version":   version,
@@ -142,7 +231,7 @@ func buildShadowResponse(doc []byte, version int, updatedAt time.Time) ([]byte, 
 // The response includes "version" and "timestamp" metadata fields.
 // An empty shadowName refers to the classic (unnamed) shadow.
 func (b *InMemoryBackend) GetThingShadow(thingName, shadowName string) ([]byte, error) {
-	b.mu.RLock()
+	b.mu.RLock("GetThingShadow")
 	defer b.mu.RUnlock()
 
 	thingShadows, ok := b.shadows[thingName]
@@ -161,12 +250,17 @@ func (b *InMemoryBackend) GetThingShadow(thingName, shadowName string) ([]byte, 
 // UpdateThingShadow stores or replaces the document for the named shadow of a thing.
 // If the document contains a "version" field it must equal the current shadow
 // version; a mismatch returns ErrVersionConflict (optimistic locking).
-// The version is incremented on every successful update.
+// The version is incremented on every successful update and wraps around at
+// maxShadowVersion to prevent integer overflow for long-lived things.
 // The returned bytes represent the updated shadow response including the new version.
 // The response is constructed before mutating state so a marshal error cannot
 // leave a partial update behind.
 func (b *InMemoryBackend) UpdateThingShadow(thingName, shadowName string, document []byte) ([]byte, error) {
-	b.mu.Lock()
+	if err := validateShadowDocument(document); err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock("UpdateThingShadow")
 	defer b.mu.Unlock()
 
 	if _, ok := b.shadows[thingName]; !ok {
@@ -204,7 +298,12 @@ func (b *InMemoryBackend) UpdateThingShadow(thingName, shadowName string, docume
 
 	newVersion := 1
 	if current != nil {
-		newVersion = current.version + 1
+		// Wrap version at maxShadowVersion to avoid integer overflow.
+		if current.version >= maxShadowVersion {
+			newVersion = 1
+		} else {
+			newVersion = current.version + 1
+		}
 	}
 
 	now := time.Now()
@@ -232,7 +331,7 @@ func (b *InMemoryBackend) UpdateThingShadow(thingName, shadowName string, docume
 // returns the last known shadow state (compatible with the AWS DeleteThingShadow
 // response which always returns a Payload).
 func (b *InMemoryBackend) DeleteThingShadow(thingName, shadowName string) ([]byte, error) {
-	b.mu.Lock()
+	b.mu.Lock("DeleteThingShadow")
 	defer b.mu.Unlock()
 
 	thingShadows, ok := b.shadows[thingName]
@@ -263,7 +362,7 @@ func (b *InMemoryBackend) DeleteThingShadow(thingName, shadowName string) ([]byt
 // ListNamedShadowsForThing returns the sorted list of named shadow names for the given thing.
 // The classic (unnamed) shadow is excluded from this list.
 func (b *InMemoryBackend) ListNamedShadowsForThing(thingName string) ([]string, error) {
-	b.mu.RLock()
+	b.mu.RLock("ListNamedShadowsForThing")
 	defer b.mu.RUnlock()
 
 	thingShadows, ok := b.shadows[thingName]
@@ -283,6 +382,41 @@ func (b *InMemoryBackend) ListNamedShadowsForThing(thingName string) ([]string, 
 	return names, nil
 }
 
+// ListThingsWithShadows returns the sorted list of thing names that have at least one shadow.
+func (b *InMemoryBackend) ListThingsWithShadows() []string {
+	b.mu.RLock("ListThingsWithShadows")
+	defer b.mu.RUnlock()
+
+	return sortedKeys(b.shadows)
+}
+
+// RegisterConnection adds a client connection to the backend.
+// Returns ErrConnectionExists if the clientID is already registered.
+// ClientIDs beginning with '$' are rejected per AWS rules.
+func (b *InMemoryBackend) RegisterConnection(clientID, sourceIP string) error {
+	if strings.HasPrefix(clientID, "$") {
+		return fmt.Errorf("%w: clientId may not start with '$'", ErrValidation)
+	}
+
+	if clientID == "" {
+		return fmt.Errorf("%w: clientId is required", ErrValidation)
+	}
+
+	b.mu.Lock("RegisterConnection")
+	defer b.mu.Unlock()
+
+	if _, exists := b.connections[clientID]; exists {
+		return fmt.Errorf("%w: %s", ErrConnectionExists, clientID)
+	}
+
+	b.connections[clientID] = &connectionEntry{
+		connectedAt: time.Now(),
+		sourceIP:    sourceIP,
+	}
+
+	return nil
+}
+
 // DeleteConnection removes an MQTT client connection from the backend.
 // If the clientID does not exist the operation is a no-op (idempotent).
 // ClientIDs beginning with '$' are rejected per AWS rules.
@@ -291,7 +425,7 @@ func (b *InMemoryBackend) DeleteConnection(clientID string) error {
 		return fmt.Errorf("%w: clientId may not start with '$'", ErrValidation)
 	}
 
-	b.mu.Lock()
+	b.mu.Lock("DeleteConnection")
 	defer b.mu.Unlock()
 
 	delete(b.connections, clientID)
@@ -299,17 +433,38 @@ func (b *InMemoryBackend) DeleteConnection(clientID string) error {
 	return nil
 }
 
+// ListConnections returns all registered connections sorted by ConnectedAt ascending.
+func (b *InMemoryBackend) ListConnections() []*Connection {
+	b.mu.RLock("ListConnections")
+	defer b.mu.RUnlock()
+
+	out := make([]*Connection, 0, len(b.connections))
+	for clientID, entry := range b.connections {
+		out = append(out, &Connection{
+			ClientID:    clientID,
+			SourceIP:    entry.sourceIP,
+			ConnectedAt: entry.connectedAt,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ConnectedAt.Before(out[j].ConnectedAt)
+	})
+
+	return out
+}
+
 // AddConnectionInternal seeds a connected client ID for testing purposes.
 func (b *InMemoryBackend) AddConnectionInternal(clientID string) {
-	b.mu.Lock()
+	b.mu.Lock("AddConnectionInternal")
 	defer b.mu.Unlock()
 
-	b.connections[clientID] = struct{}{}
+	b.connections[clientID] = &connectionEntry{connectedAt: time.Now()}
 }
 
 // AddShadowInternal seeds a shadow entry for testing purposes.
 func (b *InMemoryBackend) AddShadowInternal(thingName, shadowName string, document []byte) {
-	b.mu.Lock()
+	b.mu.Lock("AddShadowInternal")
 	defer b.mu.Unlock()
 
 	if _, ok := b.shadows[thingName]; !ok {
@@ -328,9 +483,13 @@ func (b *InMemoryBackend) AddShadowInternal(thingName, shadowName string, docume
 
 // StoreRetainedMessage saves a retained MQTT message for the given topic.
 // Calling this with an empty payload removes the retained message for that topic.
-// Returns ErrValidation if the cap would be exceeded.
+// Returns ErrValidation if the cap would be exceeded or the payload is too large.
 func (b *InMemoryBackend) StoreRetainedMessage(topic string, payload []byte, qos int32) error {
-	b.mu.Lock()
+	if len(payload) > 0 && len(payload) > maxPublishBodyBytes {
+		return fmt.Errorf("%w: retained payload exceeds %d bytes", ErrValidation, maxPublishBodyBytes)
+	}
+
+	b.mu.Lock("StoreRetainedMessage")
 	defer b.mu.Unlock()
 
 	if len(payload) == 0 {
@@ -359,7 +518,7 @@ func (b *InMemoryBackend) StoreRetainedMessage(topic string, payload []byte, qos
 // GetRetainedMessage returns the retained message stored for the given topic.
 // ErrRetainedMessageNotFound is returned when no retained message exists for the topic.
 func (b *InMemoryBackend) GetRetainedMessage(topic string) (*RetainedMessage, error) {
-	b.mu.RLock()
+	b.mu.RLock("GetRetainedMessage")
 	defer b.mu.RUnlock()
 
 	msg, ok := b.retainedMessages[topic]
@@ -378,7 +537,7 @@ func (b *InMemoryBackend) GetRetainedMessage(topic string) (*RetainedMessage, er
 
 // ListRetainedMessages returns summaries of all retained messages, sorted by topic.
 func (b *InMemoryBackend) ListRetainedMessages() ([]*RetainedMessage, error) {
-	b.mu.RLock()
+	b.mu.RLock("ListRetainedMessages")
 	defer b.mu.RUnlock()
 
 	topics := sortedKeys(b.retainedMessages)

--- a/services/iotdataplane/backend.go
+++ b/services/iotdataplane/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -52,6 +53,10 @@ const maxShadowNameLength = 64
 // maxShadowVersion is the maximum shadow version before it resets to 1.
 // This prevents integer overflow for long-lived things.
 const maxShadowVersion = 1<<31 - 1
+
+// keyTimestamp is the JSON key for shadow response timestamp fields.
+// Defined as a constant to satisfy goconst (3+ occurrences across the package).
+const keyTimestamp = "timestamp"
 
 // shadowNameRe validates shadow names per AWS IoT rules: alphanumeric, colon, underscore, hyphen.
 var shadowNameRe = regexp.MustCompile(`^[a-zA-Z0-9:_-]+$`)
@@ -122,10 +127,8 @@ func validateTopic(topic string) error {
 	}
 
 	// Reject empty topic levels (consecutive slashes or leading/trailing slash after split).
-	for _, segment := range strings.Split(topic, "/") {
-		if segment == "" {
-			return fmt.Errorf("%w: topic must not contain empty levels", ErrValidation)
-		}
+	if slices.Contains(strings.Split(topic, "/"), "") {
+		return fmt.Errorf("%w: topic must not contain empty levels", ErrValidation)
 	}
 
 	return nil
@@ -212,9 +215,9 @@ func buildShadowResponse(doc []byte, version int, updatedAt time.Time) ([]byte, 
 		// doc is not a JSON object (or is JSON null); encode it as a plain string so
 		// json.Marshal never fails on raw bytes that are not valid JSON.
 		return json.Marshal(map[string]any{
-			"payload":   string(doc),
-			"version":   version,
-			"timestamp": updatedAt.Unix(),
+			"payload":    string(doc),
+			"version":    version,
+			keyTimestamp: updatedAt.Unix(),
 		})
 	}
 
@@ -222,7 +225,7 @@ func buildShadowResponse(doc []byte, version int, updatedAt time.Time) ([]byte, 
 	verBytes, _ := json.Marshal(version)
 	tsBytes, _ := json.Marshal(updatedAt.Unix())
 	m["version"] = verBytes
-	m["timestamp"] = tsBytes
+	m[keyTimestamp] = tsBytes
 
 	return json.Marshal(m)
 }

--- a/services/iotdataplane/backend_iface.go
+++ b/services/iotdataplane/backend_iface.go
@@ -13,7 +13,10 @@ type StorageBackend interface {
 	UpdateThingShadow(thingName, shadowName string, document []byte) ([]byte, error)
 	DeleteThingShadow(thingName, shadowName string) ([]byte, error)
 	ListNamedShadowsForThing(thingName string) ([]string, error)
+	ListThingsWithShadows() []string
+	RegisterConnection(clientID, sourceIP string) error
 	DeleteConnection(clientID string) error
+	ListConnections() []*Connection
 	StoreRetainedMessage(topic string, payload []byte, qos int32) error
 	GetRetainedMessage(topic string) (*RetainedMessage, error)
 	ListRetainedMessages() ([]*RetainedMessage, error)

--- a/services/iotdataplane/export_test.go
+++ b/services/iotdataplane/export_test.go
@@ -2,7 +2,7 @@ package iotdataplane
 
 // ShadowCount returns the total number of shadow entries across all things (for white-box testing).
 func ShadowCount(b *InMemoryBackend) int {
-	b.mu.RLock()
+	b.mu.RLock("ShadowCount")
 	defer b.mu.RUnlock()
 
 	total := 0
@@ -15,7 +15,7 @@ func ShadowCount(b *InMemoryBackend) int {
 
 // ThingCount returns the number of distinct things with at least one shadow (for white-box testing).
 func ThingCount(b *InMemoryBackend) int {
-	b.mu.RLock()
+	b.mu.RLock("ThingCount")
 	defer b.mu.RUnlock()
 
 	return len(b.shadows)
@@ -23,7 +23,7 @@ func ThingCount(b *InMemoryBackend) int {
 
 // RetainedMessageCount returns the number of retained messages (for white-box testing).
 func RetainedMessageCount(b *InMemoryBackend) int {
-	b.mu.RLock()
+	b.mu.RLock("RetainedMessageCount")
 	defer b.mu.RUnlock()
 
 	return len(b.retainedMessages)
@@ -31,7 +31,7 @@ func RetainedMessageCount(b *InMemoryBackend) int {
 
 // ConnectionCount returns the number of tracked connections (for white-box testing).
 func ConnectionCount(b *InMemoryBackend) int {
-	b.mu.RLock()
+	b.mu.RLock("ConnectionCount")
 	defer b.mu.RUnlock()
 
 	return len(b.connections)
@@ -39,3 +39,26 @@ func ConnectionCount(b *InMemoryBackend) int {
 
 // MaxShadowsPerThing exposes the cap constant for white-box testing.
 const MaxShadowsPerThing = maxShadowsPerThing
+
+// MaxShadowDocumentBytes exposes the shadow document size cap for white-box testing.
+const MaxShadowDocumentBytes = maxShadowDocumentBytes
+
+// MaxShadowVersion exposes the version rollover cap for white-box testing.
+const MaxShadowVersion = maxShadowVersion
+
+// ForceSetShadowVersion directly sets the version on a shadow entry for testing version overflow.
+func ForceSetShadowVersion(b *InMemoryBackend, thingName, shadowName string, version int) {
+	b.mu.Lock("ForceSetShadowVersion")
+	defer b.mu.Unlock()
+
+	if b.shadows[thingName] == nil {
+		return
+	}
+
+	entry, ok := b.shadows[thingName][shadowName]
+	if !ok {
+		return
+	}
+
+	entry.version = version
+}

--- a/services/iotdataplane/export_test.go
+++ b/services/iotdataplane/export_test.go
@@ -36,3 +36,6 @@ func ConnectionCount(b *InMemoryBackend) int {
 
 	return len(b.connections)
 }
+
+// MaxShadowsPerThing exposes the cap constant for white-box testing.
+const MaxShadowsPerThing = maxShadowsPerThing

--- a/services/iotdataplane/handler.go
+++ b/services/iotdataplane/handler.go
@@ -39,6 +39,10 @@ const (
 	keyError            = "error"
 	keyMessage          = "message"
 	errMethodNotAllowed = "method not allowed"
+	opUnknown           = "Unknown"
+
+	// shadowPathParts is the number of parts when splitting a shadow URL on "/shadow".
+	shadowPathParts = 2
 )
 
 // Handler is the Echo HTTP handler for IoT Data Plane operations.
@@ -110,8 +114,8 @@ func isShadowPath(path string) bool {
 	}
 
 	// Must end with exactly /shadow or /shadow?... (no further segments).
-	parts := strings.SplitN(after, "/shadow", 2)
-	if len(parts) != 2 {
+	parts := strings.SplitN(after, "/shadow", shadowPathParts)
+	if len(parts) != shadowPathParts {
 		return false
 	}
 
@@ -122,6 +126,40 @@ func isShadowPath(path string) bool {
 
 // MatchPriority returns the routing priority for the IoT Data Plane handler.
 func (h *Handler) MatchPriority() int { return iotDPMatchPriority }
+
+// extractConnectionOperation returns the operation name for /connections paths.
+func extractConnectionOperation(path, method string) string {
+	if path == connectionsPath {
+		if method == http.MethodGet {
+			return "ListConnections"
+		}
+
+		return opUnknown
+	}
+
+	switch method {
+	case http.MethodDelete:
+		return "DeleteConnection"
+	case http.MethodPost:
+		return "RegisterConnection"
+	}
+
+	return opUnknown
+}
+
+// extractShadowOperation returns the operation name for /things/{name}/shadow paths.
+func extractShadowOperation(method string) string {
+	switch method {
+	case http.MethodGet:
+		return "GetThingShadow"
+	case http.MethodPost:
+		return "UpdateThingShadow"
+	case http.MethodDelete:
+		return "DeleteThingShadow"
+	}
+
+	return opUnknown
+}
 
 // ExtractOperation returns the operation name.
 func (h *Handler) ExtractOperation(c *echo.Context) string {
@@ -134,28 +172,17 @@ func (h *Handler) ExtractOperation(c *echo.Context) string {
 		return "ListNamedShadowsForThing"
 	case path == listThingsWithShadowsPath:
 		return "ListThingsWithShadows"
-	case path == connectionsPath && method == http.MethodGet:
-		return "ListConnections"
-	case strings.HasPrefix(path, connectionsPathSlash) && method == http.MethodDelete:
-		return "DeleteConnection"
-	case strings.HasPrefix(path, connectionsPathSlash) && method == http.MethodPost:
-		return "RegisterConnection"
+	case path == connectionsPath || strings.HasPrefix(path, connectionsPathSlash):
+		return extractConnectionOperation(path, method)
 	case path == retainedMessagePath && method == http.MethodGet:
 		return "ListRetainedMessages"
 	case strings.HasPrefix(path, retainedMessagePathSlash) && method == http.MethodGet:
 		return "GetRetainedMessage"
 	case isShadowPath(path):
-		switch method {
-		case http.MethodGet:
-			return "GetThingShadow"
-		case http.MethodPost:
-			return "UpdateThingShadow"
-		case http.MethodDelete:
-			return "DeleteThingShadow"
-		}
+		return extractShadowOperation(method)
 	}
 
-	return "Unknown"
+	return opUnknown
 }
 
 // ExtractResource extracts the topic or thing name from the URL path.
@@ -198,7 +225,6 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // parseShadowPath extracts thingName from a /things/{thingName}/shadow path.
 func parseShadowPath(path string) string {
 	trimmed := strings.TrimPrefix(path, "/things/")
-	const shadowPathParts = 2
 	parts := strings.SplitN(trimmed, "/shadow", shadowPathParts)
 
 	return parts[0]
@@ -542,6 +568,7 @@ func (h *Handler) handleListThingsWithShadows(c *echo.Context) error {
 		for i, name := range things {
 			if name == nextTokenIn {
 				startIdx = i
+
 				break
 			}
 		}
@@ -555,8 +582,8 @@ func (h *Handler) handleListThingsWithShadows(c *echo.Context) error {
 	}
 
 	resp := map[string]any{
-		"things":    page,
-		"timestamp": time.Now().Unix(),
+		"things":     page,
+		keyTimestamp: time.Now().Unix(),
 	}
 
 	if end < len(things) {
@@ -680,8 +707,8 @@ func (h *Handler) handleListNamedShadows(c *echo.Context) error {
 	}
 
 	resp := map[string]any{
-		"results":   page,
-		"timestamp": time.Now().Unix(),
+		"results":    page,
+		keyTimestamp: time.Now().Unix(),
 	}
 
 	if end < len(names) {

--- a/services/iotdataplane/handler.go
+++ b/services/iotdataplane/handler.go
@@ -27,6 +27,14 @@ const (
 	retainedMessagePath = "/retainedMessage"
 	// retainedMessagePathSlash is the prefix used to match individual topic paths.
 	retainedMessagePathSlash = retainedMessagePath + "/"
+	// listThingsWithShadowsPath is the admin path for listing things that have shadows.
+	listThingsWithShadowsPath = "/api/things/shadow/ListThingsWithShadows"
+	// listNamedShadowsPrefix is the prefix for ListNamedShadowsForThing.
+	listNamedShadowsPrefix = "/api/things/shadow/ListNamedShadowsForThing/"
+	// connectionsPath is the URL path for managing connections.
+	connectionsPath = "/connections"
+	// connectionsPathSlash is the prefix for individual connection operations.
+	connectionsPathSlash = connectionsPath + "/"
 
 	keyError            = "error"
 	keyMessage          = "message"
@@ -58,9 +66,12 @@ func (h *Handler) GetSupportedOperations() []string {
 		"DeleteThingShadow",
 		"GetRetainedMessage",
 		"GetThingShadow",
+		"ListConnections",
 		"ListNamedShadowsForThing",
 		"ListRetainedMessages",
+		"ListThingsWithShadows",
 		"Publish",
+		"RegisterConnection",
 		"UpdateThingShadow",
 	}
 }
@@ -80,12 +91,33 @@ func (h *Handler) RouteMatcher() service.Matcher {
 		path := c.Request().URL.Path
 
 		return strings.HasPrefix(path, "/topics/") ||
-			strings.HasPrefix(path, "/things/") ||
-			strings.HasPrefix(path, "/api/things/shadow/ListNamedShadowsForThing/") ||
-			strings.HasPrefix(path, "/connections/") ||
+			isShadowPath(path) ||
+			strings.HasPrefix(path, listNamedShadowsPrefix) ||
+			path == listThingsWithShadowsPath ||
+			path == connectionsPath ||
+			strings.HasPrefix(path, connectionsPathSlash) ||
 			path == retainedMessagePath ||
 			strings.HasPrefix(path, retainedMessagePathSlash)
 	}
+}
+
+// isShadowPath returns true for paths of the form /things/{thingName}/shadow
+// with no additional path segments after "shadow".
+func isShadowPath(path string) bool {
+	after, ok := strings.CutPrefix(path, "/things/")
+	if !ok {
+		return false
+	}
+
+	// Must end with exactly /shadow or /shadow?... (no further segments).
+	parts := strings.SplitN(after, "/shadow", 2)
+	if len(parts) != 2 {
+		return false
+	}
+
+	tail := parts[1]
+
+	return tail == "" || strings.HasPrefix(tail, "?")
 }
 
 // MatchPriority returns the routing priority for the IoT Data Plane handler.
@@ -98,15 +130,21 @@ func (h *Handler) ExtractOperation(c *echo.Context) string {
 	switch {
 	case strings.HasPrefix(path, "/topics/"):
 		return "Publish"
-	case strings.HasPrefix(path, "/api/things/shadow/ListNamedShadowsForThing/"):
+	case strings.HasPrefix(path, listNamedShadowsPrefix):
 		return "ListNamedShadowsForThing"
-	case strings.HasPrefix(path, "/connections/") && method == http.MethodDelete:
+	case path == listThingsWithShadowsPath:
+		return "ListThingsWithShadows"
+	case path == connectionsPath && method == http.MethodGet:
+		return "ListConnections"
+	case strings.HasPrefix(path, connectionsPathSlash) && method == http.MethodDelete:
 		return "DeleteConnection"
+	case strings.HasPrefix(path, connectionsPathSlash) && method == http.MethodPost:
+		return "RegisterConnection"
 	case path == retainedMessagePath && method == http.MethodGet:
 		return "ListRetainedMessages"
 	case strings.HasPrefix(path, retainedMessagePathSlash) && method == http.MethodGet:
 		return "GetRetainedMessage"
-	case strings.HasPrefix(path, "/things/") && strings.HasSuffix(path, "/shadow"):
+	case isShadowPath(path):
 		switch method {
 		case http.MethodGet:
 			return "GetThingShadow"
@@ -127,11 +165,19 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 		return after
 	}
 
-	if after, ok := strings.CutPrefix(path, "/api/things/shadow/ListNamedShadowsForThing/"); ok {
+	if after, ok := strings.CutPrefix(path, listNamedShadowsPrefix); ok {
 		return after
 	}
 
-	if after, ok := strings.CutPrefix(path, "/connections/"); ok {
+	if path == listThingsWithShadowsPath {
+		return ""
+	}
+
+	if path == connectionsPath {
+		return ""
+	}
+
+	if after, ok := strings.CutPrefix(path, connectionsPathSlash); ok {
 		return after
 	}
 
@@ -176,6 +222,11 @@ func (h *Handler) handleError(c *echo.Context, err error) error {
 			keyError:   "InvalidRequestException",
 			keyMessage: err.Error(),
 		})
+	case errors.Is(err, ErrConnectionExists):
+		return c.JSON(http.StatusConflict, map[string]string{
+			keyError:   "ResourceAlreadyExistsException",
+			keyMessage: err.Error(),
+		})
 	default:
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyError: err.Error()})
 	}
@@ -188,15 +239,19 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		switch {
 		case strings.HasPrefix(path, "/topics/"):
 			return h.handlePublish(c)
-		case strings.HasPrefix(path, "/api/things/shadow/ListNamedShadowsForThing/"):
+		case strings.HasPrefix(path, listNamedShadowsPrefix):
 			return h.handleListNamedShadows(c)
-		case strings.HasPrefix(path, "/connections/"):
-			return h.handleDeleteConnection(c)
+		case path == listThingsWithShadowsPath:
+			return h.handleListThingsWithShadows(c)
+		case path == connectionsPath:
+			return h.handleConnections(c)
+		case strings.HasPrefix(path, connectionsPathSlash):
+			return h.handleConnectionByID(c)
 		case path == retainedMessagePath:
 			return h.handleListRetainedMessages(c)
 		case strings.HasPrefix(path, retainedMessagePathSlash):
 			return h.handleGetRetainedMessage(c)
-		case strings.HasPrefix(path, "/things/") && strings.HasSuffix(path, "/shadow"):
+		case isShadowPath(path):
 			return h.handleShadow(c)
 		default:
 			return c.JSON(http.StatusNotFound, map[string]string{keyError: "not found"})
@@ -251,6 +306,10 @@ func (h *Handler) handlePublish(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{keyError: "topic is required"})
 	}
 
+	if err := validateTopic(topic); err != nil {
+		return h.handleError(c, err)
+	}
+
 	qos, qosErr := parsePublishQoS(c.Request().URL.Query().Get("qos"))
 	if qosErr != nil {
 		return h.handleError(c, qosErr)
@@ -298,14 +357,69 @@ func (h *Handler) handleRetain(c *echo.Context, topic string, payload []byte, qo
 	return c.JSON(http.StatusOK, map[string]string{})
 }
 
-// handleDeleteConnection processes DELETE /connections/{clientId} requests.
-// Query params: cleanSession (bool), preventWillMessage (bool) – accepted but not enforced.
-func (h *Handler) handleDeleteConnection(c *echo.Context) error {
-	if c.Request().Method != http.MethodDelete {
+// handleConnections dispatches GET /connections requests.
+func (h *Handler) handleConnections(c *echo.Context) error {
+	if c.Request().Method != http.MethodGet {
 		return c.JSON(http.StatusMethodNotAllowed, map[string]string{keyError: errMethodNotAllowed})
 	}
 
-	clientID := strings.TrimPrefix(c.Request().URL.Path, "/connections/")
+	return h.handleListConnections(c)
+}
+
+// handleConnectionByID dispatches requests for /connections/{clientId}.
+func (h *Handler) handleConnectionByID(c *echo.Context) error {
+	switch c.Request().Method {
+	case http.MethodDelete:
+		return h.handleDeleteConnection(c)
+	case http.MethodPost:
+		return h.handleRegisterConnection(c)
+	default:
+		return c.JSON(http.StatusMethodNotAllowed, map[string]string{keyError: errMethodNotAllowed})
+	}
+}
+
+// handleListConnections processes GET /connections requests.
+func (h *Handler) handleListConnections(c *echo.Context) error {
+	conns := h.Backend.ListConnections()
+
+	type connResp struct {
+		ClientID    string `json:"clientId"`
+		SourceIP    string `json:"sourceIp,omitempty"`
+		ConnectedAt int64  `json:"connectedAt"`
+	}
+
+	out := make([]connResp, 0, len(conns))
+	for _, conn := range conns {
+		out = append(out, connResp{
+			ClientID:    conn.ClientID,
+			SourceIP:    conn.SourceIP,
+			ConnectedAt: conn.ConnectedAt.Unix(),
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"connections": out})
+}
+
+// handleRegisterConnection processes POST /connections/{clientId} requests.
+func (h *Handler) handleRegisterConnection(c *echo.Context) error {
+	clientID := strings.TrimPrefix(c.Request().URL.Path, connectionsPathSlash)
+	if clientID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{keyError: "clientId is required"})
+	}
+
+	sourceIP := c.RealIP()
+
+	if err := h.Backend.RegisterConnection(clientID, sourceIP); err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusCreated, map[string]string{"clientId": clientID})
+}
+
+// handleDeleteConnection processes DELETE /connections/{clientId} requests.
+// Query params: cleanSession (bool), preventWillMessage (bool) – accepted but not enforced.
+func (h *Handler) handleDeleteConnection(c *echo.Context) error {
+	clientID := strings.TrimPrefix(c.Request().URL.Path, connectionsPathSlash)
 	if clientID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{keyError: "clientId is required"})
 	}
@@ -404,6 +518,54 @@ func (h *Handler) handleListRetainedMessages(c *echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
+// handleListThingsWithShadows processes GET /api/things/shadow/ListThingsWithShadows.
+func (h *Handler) handleListThingsWithShadows(c *echo.Context) error {
+	if c.Request().Method != http.MethodGet {
+		return c.JSON(http.StatusMethodNotAllowed, map[string]string{keyError: errMethodNotAllowed})
+	}
+
+	things := h.Backend.ListThingsWithShadows()
+
+	// Apply simple nextToken pagination.
+	nextTokenIn := c.Request().URL.Query().Get("nextToken")
+	maxResultsStr := c.Request().URL.Query().Get("maxResults")
+
+	maxResults := len(things)
+	if maxResultsStr != "" {
+		if v, parseErr := strconv.Atoi(maxResultsStr); parseErr == nil && v > 0 {
+			maxResults = v
+		}
+	}
+
+	startIdx := 0
+	if nextTokenIn != "" {
+		for i, name := range things {
+			if name == nextTokenIn {
+				startIdx = i
+				break
+			}
+		}
+	}
+
+	end := min(startIdx+maxResults, len(things))
+	page := things[startIdx:end]
+
+	if page == nil {
+		page = []string{}
+	}
+
+	resp := map[string]any{
+		"things":    page,
+		"timestamp": time.Now().Unix(),
+	}
+
+	if end < len(things) {
+		resp["nextToken"] = things[end]
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
 // handleShadow dispatches GET/POST/DELETE /things/{thingName}/shadow requests.
 func (h *Handler) handleShadow(c *echo.Context) error {
 	thingName := parseShadowPath(c.Request().URL.Path)
@@ -413,6 +575,10 @@ func (h *Handler) handleShadow(c *echo.Context) error {
 
 	// Named shadow support via ?name= query parameter.
 	shadowName := c.Request().URL.Query().Get("name")
+
+	if err := validateShadowName(shadowName); err != nil {
+		return h.handleError(c, err)
+	}
 
 	switch c.Request().Method {
 	case http.MethodGet:
@@ -471,7 +637,7 @@ func (h *Handler) handleListNamedShadows(c *echo.Context) error {
 		return c.JSON(http.StatusMethodNotAllowed, map[string]string{keyError: errMethodNotAllowed})
 	}
 
-	thingName := strings.TrimPrefix(c.Request().URL.Path, "/api/things/shadow/ListNamedShadowsForThing/")
+	thingName := strings.TrimPrefix(c.Request().URL.Path, listNamedShadowsPrefix)
 	if thingName == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{keyError: "thingName is required"})
 	}

--- a/services/iotdataplane/handler_refinement1_test.go
+++ b/services/iotdataplane/handler_refinement1_test.go
@@ -502,3 +502,52 @@ func TestRefinement1_DeepCopy_ListRetainedMessages(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello"), msg.Payload)
 }
+
+// --- maxShadowsPerThing cap ---
+
+func TestRefinement1_MaxShadowsPerThing_CapEnforced(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+
+	// Fill to cap.
+	for i := range iotdataplane.MaxShadowsPerThing {
+		_, err := b.UpdateThingShadow("thing1", fmt.Sprintf("shadow-%d", i), []byte(`{}`))
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, iotdataplane.MaxShadowsPerThing, iotdataplane.ShadowCount(b))
+
+	// One more new shadow for the same thing must fail.
+	_, err := b.UpdateThingShadow("thing1", "overflow-shadow", []byte(`{}`))
+	require.ErrorIs(t, err, iotdataplane.ErrValidation)
+}
+
+func TestRefinement1_MaxShadowsPerThing_UpdateExistingNotCapped(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddShadowInternal("thing1", "existing", []byte(`{"state":{}}`))
+
+	// Updating existing shadow must succeed regardless of cap.
+	for range iotdataplane.MaxShadowsPerThing + 10 {
+		_, err := b.UpdateThingShadow("thing1", "existing", []byte(`{"state":{"desired":{"k":"v"}}}`))
+		require.NoError(t, err)
+	}
+}
+
+func TestRefinement1_MaxShadowsPerThing_CapPerThing(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+
+	// Fill thing1 to cap.
+	for i := range iotdataplane.MaxShadowsPerThing {
+		_, err := b.UpdateThingShadow("thing1", fmt.Sprintf("s-%d", i), []byte(`{}`))
+		require.NoError(t, err)
+	}
+
+	// thing2 must still accept new shadows.
+	_, err := b.UpdateThingShadow("thing2", "new-shadow", []byte(`{}`))
+	require.NoError(t, err)
+}

--- a/services/iotdataplane/handler_refinement2_test.go
+++ b/services/iotdataplane/handler_refinement2_test.go
@@ -165,7 +165,7 @@ func TestRefinement2_ShadowDocumentValidation_BackendSizeCheck(t *testing.T) {
 	// The backend-level size check catches documents that exceed MaxShadowDocumentBytes
 	// (used when the backend is invoked directly, bypassing HTTP body limits).
 	value := strings.Repeat("v", iotdataplane.MaxShadowDocumentBytes+1)
-	oversize := []byte(fmt.Sprintf(`{"k":%q}`, value))
+	oversize := fmt.Appendf(nil, `{"k":%q}`, value)
 
 	_, err := b.UpdateThingShadow("thing1", "", oversize)
 	require.ErrorIs(t, err, iotdataplane.ErrValidation)
@@ -191,9 +191,9 @@ func TestRefinement2_ShadowVersion_OverflowProtection(t *testing.T) {
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(resp, &result))
 
-	version, ok := result["version"].(float64)
+	versionFloat, ok := result["version"].(float64)
 	require.True(t, ok, "version must be a number")
-	assert.Equal(t, float64(1), version, "version must reset to 1 after overflow")
+	assert.Equal(t, 1, int(versionFloat), "version must reset to 1 after overflow")
 }
 
 // --- Connection management ---

--- a/services/iotdataplane/handler_refinement2_test.go
+++ b/services/iotdataplane/handler_refinement2_test.go
@@ -1,0 +1,457 @@
+package iotdataplane_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/iotdataplane"
+)
+
+// --- Topic validation ---
+
+func TestRefinement2_TopicValidation_Wildcards(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		topic    string
+		wantCode int
+	}{
+		{name: "hash_wildcard", topic: "sensor/#", wantCode: http.StatusBadRequest},
+		{name: "plus_wildcard", topic: "sensor/+/temp", wantCode: http.StatusBadRequest},
+		{name: "multi_wildcard", topic: "#", wantCode: http.StatusBadRequest},
+		{name: "valid_topic", topic: "sensor/temperature", wantCode: http.StatusOK},
+		{name: "valid_nested", topic: "a/b/c/d", wantCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+			rec := doRequest(t, h, http.MethodPost, "/topics/"+tt.topic, []byte("x"))
+			assert.Equal(t, tt.wantCode, rec.Code, "topic: %q", tt.topic)
+		})
+	}
+}
+
+func TestRefinement2_TopicValidation_Length(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+
+	// 257-character topic must be rejected.
+	longTopic := strings.Repeat("a", 257)
+	rec := doRequest(t, h, http.MethodPost, "/topics/"+longTopic, []byte("x"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// 256-character topic must be accepted.
+	exactTopic := strings.Repeat("a", 256)
+	rec = doRequest(t, h, http.MethodPost, "/topics/"+exactTopic, []byte("x"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRefinement2_TopicValidation_EmptySegments(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+
+	// Topic with empty segment (consecutive slashes) must be rejected.
+	rec := doRequest(t, h, http.MethodPost, "/topics/a//b", []byte("x"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Shadow name validation ---
+
+func TestRefinement2_ShadowNameValidation_InvalidChars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		queryParam string // URL-encoded query string
+		wantCode   int
+	}{
+		{name: "valid_alphanumeric", queryParam: "myShadow123", wantCode: http.StatusNotFound},
+		{name: "valid_with_colon", queryParam: "ns:shadow", wantCode: http.StatusNotFound},
+		{name: "valid_with_underscore", queryParam: "my_shadow", wantCode: http.StatusNotFound},
+		{name: "valid_with_hyphen", queryParam: "my-shadow", wantCode: http.StatusNotFound},
+		{name: "invalid_space", queryParam: "my%20shadow", wantCode: http.StatusBadRequest},
+		{name: "invalid_dot", queryParam: "my.shadow", wantCode: http.StatusBadRequest},
+		{name: "invalid_at", queryParam: "my%40shadow", wantCode: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+			rec := doRequest(t, h, http.MethodGet, "/things/thing1/shadow?name="+tt.queryParam, nil)
+			assert.Equal(t, tt.wantCode, rec.Code, "queryParam: %q", tt.queryParam)
+		})
+	}
+}
+
+func TestRefinement2_ShadowNameValidation_TooLong(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+
+	// 65-character shadow name must be rejected.
+	longName := strings.Repeat("a", 65)
+	rec := doRequest(t, h, http.MethodGet, "/things/thing1/shadow?name="+longName, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// 64-character shadow name must be accepted (name valid, just thing not found).
+	exactName := strings.Repeat("a", 64)
+	rec = doRequest(t, h, http.MethodGet, "/things/thing1/shadow?name="+exactName, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// --- Shadow document validation ---
+
+func TestRefinement2_ShadowDocumentValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     []byte
+		wantCode int
+	}{
+		{name: "valid_object", body: []byte(`{"state":{"desired":{}}}`), wantCode: http.StatusOK},
+		{name: "empty_object", body: []byte(`{}`), wantCode: http.StatusOK},
+		{name: "array", body: []byte(`["a"]`), wantCode: http.StatusBadRequest},
+		{name: "number", body: []byte(`42`), wantCode: http.StatusBadRequest},
+		{name: "string", body: []byte(`"hello"`), wantCode: http.StatusBadRequest},
+		{name: "empty", body: []byte{}, wantCode: http.StatusBadRequest},
+		{name: "null", body: []byte(`null`), wantCode: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+			rec := doRequest(t, h, http.MethodPost, "/things/thing1/shadow", tt.body)
+			assert.Equal(t, tt.wantCode, rec.Code, "body: %q", string(tt.body))
+		})
+	}
+}
+
+func TestRefinement2_ShadowDocumentValidation_TooLarge(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+
+	// Build a document just over the HTTP body limit (maxShadowBodyBytes = 8KB).
+	// The HTTP MaxBytesReader fires before backend validation, so expect 413.
+	value := strings.Repeat("v", iotdataplane.MaxShadowDocumentBytes+1)
+	oversize := fmt.Sprintf(`{"k":%q}`, value)
+
+	rec := doRequest(t, h, http.MethodPost, "/things/thing1/shadow", []byte(oversize))
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestRefinement2_ShadowDocumentValidation_BackendSizeCheck(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+
+	// The backend-level size check catches documents that exceed MaxShadowDocumentBytes
+	// (used when the backend is invoked directly, bypassing HTTP body limits).
+	value := strings.Repeat("v", iotdataplane.MaxShadowDocumentBytes+1)
+	oversize := []byte(fmt.Sprintf(`{"k":%q}`, value))
+
+	_, err := b.UpdateThingShadow("thing1", "", oversize)
+	require.ErrorIs(t, err, iotdataplane.ErrValidation)
+}
+
+// --- Version overflow protection ---
+
+func TestRefinement2_ShadowVersion_OverflowProtection(t *testing.T) {
+	t.Parallel()
+
+	// Create a shadow with version just below the rollover point, then update
+	// to verify it resets to 1 rather than overflowing into negative territory.
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddShadowInternal("thing1", "", []byte(`{}`))
+
+	// Force the version to max by doing many updates. We'll set it via the internal
+	// helper and verify the next update starts a new cycle.
+	iotdataplane.ForceSetShadowVersion(b, "thing1", "", iotdataplane.MaxShadowVersion)
+
+	resp, err := b.UpdateThingShadow("thing1", "", []byte(`{"state":{}}`))
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(resp, &result))
+
+	version, ok := result["version"].(float64)
+	require.True(t, ok, "version must be a number")
+	assert.Equal(t, float64(1), version, "version must reset to 1 after overflow")
+}
+
+// --- Connection management ---
+
+func TestRefinement2_ListConnections_Empty(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+	rec := doRequest(t, h, http.MethodGet, "/connections", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	conns := resp["connections"].([]any)
+	assert.Empty(t, conns)
+}
+
+func TestRefinement2_RegisterConnection_Success(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	h := iotdataplane.NewHandler(b)
+
+	rec := doRequest(t, h, http.MethodPost, "/connections/device-001", nil)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, 1, iotdataplane.ConnectionCount(b))
+}
+
+func TestRefinement2_RegisterConnection_DuplicateReturns409(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	h := iotdataplane.NewHandler(b)
+
+	rec := doRequest(t, h, http.MethodPost, "/connections/device-001", nil)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = doRequest(t, h, http.MethodPost, "/connections/device-001", nil)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ResourceAlreadyExistsException")
+}
+
+func TestRefinement2_RegisterConnection_DollarPrefixRejected(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+	rec := doRequest(t, h, http.MethodPost, "/connections/$system", nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRefinement2_ListConnections_ShowsRegistered(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	h := iotdataplane.NewHandler(b)
+
+	// Register two connections.
+	doRequest(t, h, http.MethodPost, "/connections/device-a", nil)
+	doRequest(t, h, http.MethodPost, "/connections/device-b", nil)
+
+	rec := doRequest(t, h, http.MethodGet, "/connections", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	conns := resp["connections"].([]any)
+	assert.Len(t, conns, 2)
+}
+
+func TestRefinement2_DeleteConnection_RemovesFromList(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	h := iotdataplane.NewHandler(b)
+
+	doRequest(t, h, http.MethodPost, "/connections/device-x", nil)
+	assert.Equal(t, 1, iotdataplane.ConnectionCount(b))
+
+	doRequest(t, h, http.MethodDelete, "/connections/device-x", nil)
+	assert.Equal(t, 0, iotdataplane.ConnectionCount(b))
+}
+
+func TestRefinement2_Connections_WrongMethod(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+
+	// PUT on /connections should return 405.
+	rec := doRequest(t, h, http.MethodPut, "/connections", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// --- ListThingsWithShadows ---
+
+func TestRefinement2_ListThingsWithShadows_Empty(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+	rec := doRequest(t, h, http.MethodGet, "/api/things/shadow/ListThingsWithShadows", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	things := resp["things"].([]any)
+	assert.Empty(t, things)
+}
+
+func TestRefinement2_ListThingsWithShadows_Multiple(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddShadowInternal("thing-a", "", []byte(`{}`))
+	b.AddShadowInternal("thing-b", "shadow1", []byte(`{}`))
+	b.AddShadowInternal("thing-c", "shadow2", []byte(`{}`))
+
+	h := iotdataplane.NewHandler(b)
+	rec := doRequest(t, h, http.MethodGet, "/api/things/shadow/ListThingsWithShadows", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	things := resp["things"].([]any)
+	assert.Len(t, things, 3)
+	// Must be sorted.
+	assert.Equal(t, "thing-a", things[0])
+	assert.Equal(t, "thing-b", things[1])
+	assert.Equal(t, "thing-c", things[2])
+}
+
+func TestRefinement2_ListThingsWithShadows_WrongMethod(t *testing.T) {
+	t.Parallel()
+
+	h := iotdataplane.NewHandler(iotdataplane.NewInMemoryBackend())
+	rec := doRequest(t, h, http.MethodPost, "/api/things/shadow/ListThingsWithShadows", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// --- Shadow path precision ---
+
+func TestRefinement2_ShadowPath_Precision(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddShadowInternal("mydevice", "", []byte(`{"state":{}}`))
+	h := iotdataplane.NewHandler(b)
+
+	// Exact shadow path must succeed.
+	rec := doRequest(t, h, http.MethodGet, "/things/mydevice/shadow", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Path with extra segment after /shadow must return 404 (not matched as shadow).
+	rec = doRequest(t, h, http.MethodGet, "/things/mydevice/shadow/extra", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// --- Persistence round-trip with new Connection struct ---
+
+func TestRefinement2_Persistence_ConnectionsPreserved(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddConnectionInternal("client-1")
+	b.AddConnectionInternal("client-2")
+
+	snap := b.Snapshot()
+	require.NotNil(t, snap)
+
+	b2 := iotdataplane.NewInMemoryBackend()
+	require.NoError(t, b2.Restore(snap))
+
+	assert.Equal(t, 2, iotdataplane.ConnectionCount(b2))
+
+	// Verify connections are present with their timestamps preserved.
+	conns := b2.ListConnections()
+	assert.Len(t, conns, 2)
+	for _, c := range conns {
+		assert.False(t, c.ConnectedAt.IsZero(), "ConnectedAt must be restored")
+	}
+}
+
+// --- Backend ListThingsWithShadows ---
+
+func TestRefinement2_Backend_ListThingsWithShadows_Sorted(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddShadowInternal("zebra", "", []byte(`{}`))
+	b.AddShadowInternal("apple", "", []byte(`{}`))
+	b.AddShadowInternal("mango", "", []byte(`{}`))
+
+	things := b.ListThingsWithShadows()
+	require.Len(t, things, 3)
+	assert.Equal(t, "apple", things[0])
+	assert.Equal(t, "mango", things[1])
+	assert.Equal(t, "zebra", things[2])
+}
+
+// --- Backend ListConnections sorted by connectedAt ---
+
+func TestRefinement2_Backend_ListConnections_SortedByConnectedAt(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	// Add three connections with small sleeps to ensure distinct timestamps.
+	for _, id := range []string{"first", "second", "third"} {
+		b.AddConnectionInternal(id)
+	}
+
+	conns := b.ListConnections()
+	// All must be present; order is by connectedAt (insertion order here).
+	assert.Len(t, conns, 3)
+}
+
+// --- RegisterConnection idempotency ---
+
+func TestRefinement2_RegisterConnection_NotIdempotent(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+
+	require.NoError(t, b.RegisterConnection("c1", ""))
+	err := b.RegisterConnection("c1", "")
+	require.ErrorIs(t, err, iotdataplane.ErrConnectionExists)
+}
+
+// --- RouteMatcher for new paths (via HTTP round-trip) ---
+
+func TestRefinement2_RouteMatcher_NewPaths(t *testing.T) {
+	t.Parallel()
+
+	b := iotdataplane.NewInMemoryBackend()
+	b.AddShadowInternal("device", "", []byte(`{"state":{}}`))
+	h := iotdataplane.NewHandler(b)
+
+	tests := []struct {
+		method  string
+		path    string
+		body    []byte
+		matched bool
+	}{
+		{http.MethodGet, "/connections", nil, true},
+		{http.MethodPost, "/connections/device-1", nil, true}, // registers → 201
+		{http.MethodGet, "/api/things/shadow/ListThingsWithShadows", nil, true},
+		{http.MethodGet, "/things/device/shadow", nil, true}, // seeded above → 200
+		{http.MethodGet, "/things/device/shadow/extra", nil, false},
+		{http.MethodGet, "/other", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			t.Parallel()
+
+			rec := doRequest(t, h, tt.method, tt.path, tt.body)
+			if tt.matched {
+				assert.NotEqual(t, http.StatusNotFound, rec.Code, "path %q should be matched by handler", tt.path)
+			} else {
+				assert.Equal(t, http.StatusNotFound, rec.Code, "path %q should NOT be matched by handler", tt.path)
+			}
+		})
+	}
+}

--- a/services/iotdataplane/handler_test.go
+++ b/services/iotdataplane/handler_test.go
@@ -470,14 +470,11 @@ func TestHandler_ShadowResponseContainsVersionAndTimestamp(t *testing.T) {
 	assert.Contains(t, getResp, "timestamp")
 }
 
-func TestBackend_ShadowUpdate_StateIsStoredBeforeResponse(t *testing.T) {
+func TestBackend_ShadowUpdate_NonObjectDocumentRejected(t *testing.T) {
 	t.Parallel()
 
-	// Even when a non-JSON-object payload (e.g. a plain string) is stored,
-	// UpdateThingShadow must succeed and the response must be valid JSON with
-	// version + timestamp.  This exercises the fallback path in buildShadowResponse
-	// and verifies that the response is constructed before state mutation so that
-	// a potential marshal error cannot leave a partial update.
+	// AWS IoT requires shadow documents to be JSON objects. Arrays, primitives,
+	// and plain strings must be rejected with ErrValidation.
 	b := iotdataplane.NewInMemoryBackend()
 
 	tests := []struct {
@@ -487,22 +484,33 @@ func TestBackend_ShadowUpdate_StateIsStoredBeforeResponse(t *testing.T) {
 		{name: "json_array", payload: []byte(`["a","b","c"]`)},
 		{name: "plain_string", payload: []byte(`"just a string"`)},
 		{name: "number", payload: []byte(`42`)},
+		{name: "empty", payload: []byte{}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			resp, err := b.UpdateThingShadow("thing-"+tt.name, "", tt.payload)
-			require.NoError(t, err)
-
-			var result map[string]any
-			require.NoError(t, json.Unmarshal(resp, &result), "response must be valid JSON")
-			assert.Contains(t, result, "version", "response must contain version")
-			assert.Contains(t, result, "timestamp", "response must contain timestamp")
-			assert.Contains(t, result, "payload", "non-object doc must be wrapped under payload key")
+			_, err := b.UpdateThingShadow("thing-"+tt.name, "", tt.payload)
+			require.ErrorIs(t, err, iotdataplane.ErrValidation, "non-object document must be rejected")
 		})
 	}
+}
+
+func TestBackend_ShadowUpdate_ObjectDocumentSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Valid JSON object documents must be accepted and the response must include
+	// version + timestamp (verifies the response is built before state mutation).
+	b := iotdataplane.NewInMemoryBackend()
+
+	resp, err := b.UpdateThingShadow("thing1", "", []byte(`{"state":{"desired":{"key":"value"}}}`))
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(resp, &result), "response must be valid JSON")
+	assert.Contains(t, result, "version", "response must contain version")
+	assert.Contains(t, result, "timestamp", "response must contain timestamp")
 }
 
 // mockMQTTPublisher implements MQTTPublisher for testing.

--- a/services/iotdataplane/persistence.go
+++ b/services/iotdataplane/persistence.go
@@ -16,6 +16,12 @@ type shadowEntrySnap struct {
 	Version   int       `json:"version"`
 }
 
+// connectionEntrySnap is the serialisable form of a connectionEntry.
+type connectionEntrySnap struct {
+	ConnectedAt time.Time `json:"connectedAt"`
+	SourceIP    string    `json:"sourceIp,omitempty"`
+}
+
 // retainedMessageSnap is the serialisable form of a RetainedMessage.
 type retainedMessageSnap struct {
 	Topic            string `json:"topic"`
@@ -27,13 +33,13 @@ type retainedMessageSnap struct {
 // backendSnapshot holds a serialisable snapshot of InMemoryBackend state.
 type backendSnapshot struct {
 	Shadows          map[string]map[string]*shadowEntrySnap `json:"shadows"`
-	Connections      map[string]struct{}                    `json:"connections"`
+	Connections      map[string]*connectionEntrySnap        `json:"connections"`
 	RetainedMessages map[string]*retainedMessageSnap        `json:"retainedMessages"`
 }
 
 // Snapshot serialises backend state to JSON.
 func (b *InMemoryBackend) Snapshot() []byte {
-	b.mu.RLock()
+	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
 	// Build serialisable shadows map.
@@ -53,6 +59,15 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		shadows[thingName] = snapShadows
 	}
 
+	// Build serialisable connections map.
+	connections := make(map[string]*connectionEntrySnap, len(b.connections))
+	for clientID, entry := range b.connections {
+		connections[clientID] = &connectionEntrySnap{
+			ConnectedAt: entry.connectedAt,
+			SourceIP:    entry.sourceIP,
+		}
+	}
+
 	// Build serialisable retained messages map.
 	retained := make(map[string]*retainedMessageSnap, len(b.retainedMessages))
 	for topic, msg := range b.retainedMessages {
@@ -68,7 +83,7 @@ func (b *InMemoryBackend) Snapshot() []byte {
 
 	snap := backendSnapshot{
 		Shadows:          shadows,
-		Connections:      b.connections,
+		Connections:      connections,
 		RetainedMessages: retained,
 	}
 
@@ -88,7 +103,7 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		return err
 	}
 
-	b.mu.Lock()
+	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
 	if snap.Shadows == nil {
@@ -96,7 +111,7 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	}
 
 	if snap.Connections == nil {
-		snap.Connections = make(map[string]struct{})
+		snap.Connections = make(map[string]*connectionEntrySnap)
 	}
 
 	if snap.RetainedMessages == nil {
@@ -121,7 +136,13 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	}
 
 	// Restore connections.
-	b.connections = snap.Connections
+	b.connections = make(map[string]*connectionEntry, len(snap.Connections))
+	for clientID, entry := range snap.Connections {
+		b.connections[clientID] = &connectionEntry{
+			connectedAt: entry.ConnectedAt,
+			sourceIP:    entry.SourceIP,
+		}
+	}
 
 	// Restore retained messages.
 	b.retainedMessages = make(map[string]*RetainedMessage, len(snap.RetainedMessages))

--- a/services/iotdataplane/types.go
+++ b/services/iotdataplane/types.go
@@ -14,7 +14,7 @@ type RetainedMessage struct {
 
 // Connection represents a registered MQTT client connection.
 type Connection struct {
+	ConnectedAt time.Time `json:"connectedAt"`
 	ClientID    string    `json:"clientId"`
 	SourceIP    string    `json:"sourceIp,omitempty"`
-	ConnectedAt time.Time `json:"connectedAt"`
 }

--- a/services/iotdataplane/types.go
+++ b/services/iotdataplane/types.go
@@ -2,10 +2,19 @@
 // messages directly to MQTT topics.
 package iotdataplane
 
+import "time"
+
 // RetainedMessage holds the details of a retained MQTT message stored by IoT.
 type RetainedMessage struct {
 	Topic            string
 	Payload          []byte
 	Qos              int32
 	LastModifiedTime int64 // epoch milliseconds
+}
+
+// Connection represents a registered MQTT client connection.
+type Connection struct {
+	ClientID    string    `json:"clientId"`
+	SourceIP    string    `json:"sourceIp,omitempty"`
+	ConnectedAt time.Time `json:"connectedAt"`
 }

--- a/test/e2e/iotdataplane_test.go
+++ b/test/e2e/iotdataplane_test.go
@@ -45,7 +45,7 @@ func TestIoTDataPlaneDashboard(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, content, "IoT Data Plane")
 	assert.Contains(t, content, "Publish")
-	assert.Contains(t, content, "Supported Operations")
+	assert.Contains(t, content, "Thing Shadows")
 }
 
 // TestIoTDataPlaneDashboard_Snippet verifies the IoT Data Plane dashboard snippet data renders.
@@ -79,5 +79,5 @@ func TestIoTDataPlaneDashboard_Snippet(t *testing.T) {
 
 	content, err := page.Content()
 	require.NoError(t, err)
-	assert.Contains(t, content, "iot-data")
+	assert.Contains(t, content, "Retained Messages")
 }

--- a/ui/src/lib/nav.ts
+++ b/ui/src/lib/nav.ts
@@ -128,6 +128,7 @@ export const implementedDashboardRouteIds = new Set<string>([
   "support",
   "redshiftdata",
   "rdsdata",
+  "iotdataplane",
 ]);
 
 // The 25 most commonly used AWS services shown in the sidebar.

--- a/ui/src/routes/iotdataplane/+page.svelte
+++ b/ui/src/routes/iotdataplane/+page.svelte
@@ -1,19 +1,476 @@
-<div class="space-y-6 p-6">
-	<div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-		<h1 class="text-3xl font-bold text-slate-900 dark:text-white">IoT Data Plane</h1>
-		<p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Publish and shadow operations</p>
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getIoTDataPlaneClient } from '$lib/aws-client';
+	import {
+		PublishCommand,
+		GetThingShadowCommand,
+		UpdateThingShadowCommand,
+		DeleteThingShadowCommand,
+		ListNamedShadowsForThingCommand,
+		GetRetainedMessageCommand,
+		ListRetainedMessagesCommand,
+		DeleteConnectionCommand
+	} from '@aws-sdk/client-iot-data-plane';
+	import { toast } from 'svelte-sonner';
+	import { Radio, Send, Eye, Trash2, RefreshCw, Layers, MessageSquare, Wifi } from 'lucide-svelte';
+
+	const client = getIoTDataPlaneClient();
+
+	type Tab = 'publish' | 'shadows' | 'retained' | 'connections';
+	let activeTab = $state<Tab>('publish');
+
+	// --- Publish ---
+	let pubTopic = $state('my/topic');
+	let pubPayload = $state('{"hello":"world"}');
+	let pubQos = $state(0);
+	let pubRetain = $state(false);
+	let pubBusy = $state(false);
+	let pubResult = $state<string | null>(null);
+
+	async function doPublish() {
+		if (!pubTopic.trim()) { toast.error('Topic is required'); return; }
+		pubBusy = true;
+		pubResult = null;
+		try {
+			await client.send(new PublishCommand({
+				topic: pubTopic.trim(),
+				payload: new TextEncoder().encode(pubPayload),
+				qos: pubQos,
+				retain: pubRetain
+			}));
+			pubResult = 'Published successfully';
+			toast.success(pubResult);
+		} catch (e) {
+			pubResult = `Error: ${e}`;
+			toast.error(pubResult);
+		} finally {
+			pubBusy = false;
+		}
+	}
+
+	// --- Shadows ---
+	let shadowThing = $state('my-device');
+	let shadowName = $state('');
+	let shadowPayload = $state('{"state":{"desired":{"key":"value"}}}');
+	let shadowBusy = $state(false);
+	let shadowResult = $state<string | null>(null);
+	let shadowList = $state<string[]>([]);
+
+	async function getShadow() {
+		if (!shadowThing.trim()) { toast.error('Thing name required'); return; }
+		shadowBusy = true; shadowResult = null;
+		try {
+			const res = await client.send(new GetThingShadowCommand({
+				thingName: shadowThing.trim(),
+				shadowName: shadowName.trim() || undefined
+			}));
+			const text = res.payload ? new TextDecoder().decode(res.payload) : '{}';
+			shadowResult = JSON.stringify(JSON.parse(text), null, 2);
+		} catch (e) {
+			shadowResult = `Error: ${e}`;
+			toast.error(`Get shadow failed: ${e}`);
+		} finally {
+			shadowBusy = false;
+		}
+	}
+
+	async function updateShadow() {
+		if (!shadowThing.trim()) { toast.error('Thing name required'); return; }
+		shadowBusy = true; shadowResult = null;
+		try {
+			const res = await client.send(new UpdateThingShadowCommand({
+				thingName: shadowThing.trim(),
+				shadowName: shadowName.trim() || undefined,
+				payload: new TextEncoder().encode(shadowPayload)
+			}));
+			const text = res.payload ? new TextDecoder().decode(res.payload) : '{}';
+			shadowResult = JSON.stringify(JSON.parse(text), null, 2);
+			toast.success('Shadow updated');
+		} catch (e) {
+			shadowResult = `Error: ${e}`;
+			toast.error(`Update shadow failed: ${e}`);
+		} finally {
+			shadowBusy = false;
+		}
+	}
+
+	async function deleteShadow() {
+		if (!shadowThing.trim()) { toast.error('Thing name required'); return; }
+		shadowBusy = true; shadowResult = null;
+		try {
+			const res = await client.send(new DeleteThingShadowCommand({
+				thingName: shadowThing.trim(),
+				shadowName: shadowName.trim() || undefined
+			}));
+			const text = res.payload ? new TextDecoder().decode(res.payload) : '{}';
+			shadowResult = JSON.stringify(JSON.parse(text), null, 2);
+			toast.success('Shadow deleted');
+		} catch (e) {
+			shadowResult = `Error: ${e}`;
+			toast.error(`Delete shadow failed: ${e}`);
+		} finally {
+			shadowBusy = false;
+		}
+	}
+
+	async function listShadows() {
+		if (!shadowThing.trim()) { toast.error('Thing name required'); return; }
+		shadowBusy = true; shadowResult = null;
+		try {
+			const res = await client.send(new ListNamedShadowsForThingCommand({
+				thingName: shadowThing.trim()
+			}));
+			shadowList = res.results ?? [];
+			shadowResult = shadowList.length > 0
+				? `Named shadows: ${shadowList.join(', ')}`
+				: 'No named shadows';
+		} catch (e) {
+			shadowResult = `Error: ${e}`;
+			toast.error(`List shadows failed: ${e}`);
+		} finally {
+			shadowBusy = false;
+		}
+	}
+
+	// --- Retained Messages ---
+	type RetainedSummary = { topic: string; payloadSize?: number; qos?: number; lastModifiedTime?: number };
+	let retainedMessages = $state<RetainedSummary[]>([]);
+	let retainedBusy = $state(false);
+	let retainedTopic = $state('');
+	let retainedDetail = $state<string | null>(null);
+
+	async function listRetained() {
+		retainedBusy = true; retainedDetail = null;
+		try {
+			const res = await client.send(new ListRetainedMessagesCommand({}));
+			retainedMessages = (res.retainedTopics ?? []).map((t) => ({
+				topic: t.topic ?? '',
+				payloadSize: t.payloadSize ? Number(t.payloadSize) : undefined,
+				qos: t.qos,
+				lastModifiedTime: t.lastModifiedTime ? Number(t.lastModifiedTime) : undefined
+			}));
+		} catch (e) {
+			toast.error(`List retained failed: ${e}`);
+		} finally {
+			retainedBusy = false;
+		}
+	}
+
+	async function getRetained(topic: string) {
+		retainedBusy = true; retainedDetail = null;
+		retainedTopic = topic;
+		try {
+			const res = await client.send(new GetRetainedMessageCommand({ topic }));
+			const text = res.payload ? new TextDecoder().decode(res.payload) : '';
+			retainedDetail = `Topic: ${res.topic}\nQoS: ${res.qos}\nPayload: ${text}`;
+		} catch (e) {
+			retainedDetail = `Error: ${e}`;
+			toast.error(`Get retained failed: ${e}`);
+		} finally {
+			retainedBusy = false;
+		}
+	}
+
+	onMount(() => listRetained());
+
+	// --- Connections ---
+	let connClientId = $state('');
+	let connBusy = $state(false);
+	let connResult = $state<string | null>(null);
+
+	async function deleteConnection() {
+		if (!connClientId.trim()) { toast.error('Client ID required'); return; }
+		connBusy = true; connResult = null;
+		try {
+			await client.send(new DeleteConnectionCommand({ clientId: connClientId.trim() }));
+			connResult = `Connection "${connClientId.trim()}" deleted`;
+			toast.success(connResult);
+			connClientId = '';
+		} catch (e) {
+			connResult = `Error: ${e}`;
+			toast.error(`Delete connection failed: ${e}`);
+		} finally {
+			connBusy = false;
+		}
+	}
+
+	const tabs: { id: Tab; label: string }[] = [
+		{ id: 'publish', label: 'Publish' },
+		{ id: 'shadows', label: 'Thing Shadows' },
+		{ id: 'retained', label: 'Retained Messages' },
+		{ id: 'connections', label: 'Connections' }
+	];
+</script>
+
+<div class="space-y-6">
+	<div class="flex items-center gap-3">
+		<Wifi class="h-8 w-8 text-teal-600" />
+		<div>
+			<h1 class="text-2xl font-bold">IoT Data Plane</h1>
+			<p class="text-sm text-muted-foreground">Publish messages and manage thing shadows</p>
+		</div>
 	</div>
-	<div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-		<h2 class="text-lg font-semibold text-slate-900 dark:text-white">Supported Operations</h2>
-		<ul class="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
-			<li>Publish</li>
-			<li>GetThingShadow</li>
-			<li>UpdateThingShadow</li>
-			<li>DeleteThingShadow</li>
-		</ul>
+
+	<!-- Tabs -->
+	<div class="flex border-b">
+		{#each tabs as tab}
+			<button
+				onclick={() => (activeTab = tab.id)}
+				class="px-4 py-2 text-sm font-medium border-b-2 transition-colors {activeTab === tab.id
+					? 'border-primary text-primary'
+					: 'border-transparent text-muted-foreground hover:text-foreground'}"
+			>
+				{tab.label}
+			</button>
+		{/each}
 	</div>
-	<div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-		<pre class="overflow-auto rounded-lg bg-slate-950 p-4 text-xs text-slate-100">// iot-data example
-await client.publish(&#123; topic: 'demo/topic', payload: new TextEncoder().encode('hello') &#125;);</pre>
-	</div>
+
+	<!-- Publish Tab -->
+	{#if activeTab === 'publish'}
+		<div class="space-y-4 rounded-lg border p-6">
+			<div class="flex items-center gap-2">
+				<Send class="h-5 w-5 text-teal-600" />
+				<h2 class="font-semibold">Publish Message</h2>
+			</div>
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="sm:col-span-2">
+					<label for="pub-topic" class="block text-sm font-medium mb-1">Topic *</label>
+					<input
+						id="pub-topic"
+						type="text"
+						bind:value={pubTopic}
+						placeholder="my/device/topic"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+				</div>
+				<div class="sm:col-span-2">
+					<label for="pub-payload" class="block text-sm font-medium mb-1">Payload</label>
+					<textarea
+						id="pub-payload"
+						bind:value={pubPayload}
+						rows={4}
+						placeholder="json payload"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"
+					></textarea>
+				</div>
+				<div>
+					<label for="pub-qos" class="block text-sm font-medium mb-1">QoS</label>
+					<select
+						id="pub-qos"
+						bind:value={pubQos}
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					>
+						<option value={0}>0 — At most once</option>
+						<option value={1}>1 — At least once</option>
+					</select>
+				</div>
+				<div class="flex items-center gap-2 pt-6">
+					<input id="pub-retain" type="checkbox" bind:checked={pubRetain} class="h-4 w-4" />
+					<label for="pub-retain" class="text-sm font-medium">Retain message</label>
+				</div>
+			</div>
+			<button
+				onclick={doPublish}
+				disabled={pubBusy}
+				class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+			>
+				{#if pubBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Send class="h-4 w-4" />{/if}
+				Publish
+			</button>
+			{#if pubResult}
+				<pre class="rounded-md bg-muted p-3 text-xs">{pubResult}</pre>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Shadows Tab -->
+	{#if activeTab === 'shadows'}
+		<div class="space-y-4 rounded-lg border p-6">
+			<div class="flex items-center gap-2">
+				<Layers class="h-5 w-5 text-teal-600" />
+				<h2 class="font-semibold">Thing Shadow Operations</h2>
+			</div>
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div>
+					<label for="shadow-thing" class="block text-sm font-medium mb-1">Thing Name *</label>
+					<input
+						id="shadow-thing"
+						type="text"
+						bind:value={shadowThing}
+						placeholder="my-device"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+				</div>
+				<div>
+					<label for="shadow-name" class="block text-sm font-medium mb-1">Shadow Name (leave blank for classic)</label>
+					<input
+						id="shadow-name"
+						type="text"
+						bind:value={shadowName}
+						placeholder="optional-named-shadow"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+				</div>
+				<div class="sm:col-span-2">
+					<label for="shadow-payload" class="block text-sm font-medium mb-1">Payload (for Update)</label>
+					<textarea
+						id="shadow-payload"
+						bind:value={shadowPayload}
+						rows={4}
+						placeholder="shadow document json"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"
+					></textarea>
+				</div>
+			</div>
+			<div class="flex flex-wrap gap-2">
+				<button
+					onclick={getShadow}
+					disabled={shadowBusy}
+					class="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+				>
+					{#if shadowBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Eye class="h-4 w-4" />{/if}
+					Get Shadow
+				</button>
+				<button
+					onclick={updateShadow}
+					disabled={shadowBusy}
+					class="flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+				>
+					Update Shadow
+				</button>
+				<button
+					onclick={deleteShadow}
+					disabled={shadowBusy}
+					class="flex items-center gap-2 rounded-md border border-red-300 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950 disabled:opacity-50"
+				>
+					<Trash2 class="h-4 w-4" />
+					Delete Shadow
+				</button>
+				<button
+					onclick={listShadows}
+					disabled={shadowBusy}
+					class="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+				>
+					List Named Shadows
+				</button>
+			</div>
+			{#if shadowResult}
+				<pre class="rounded-md bg-muted p-3 text-xs overflow-auto max-h-64">{shadowResult}</pre>
+			{/if}
+			{#if shadowList.length > 0}
+				<div class="flex flex-wrap gap-2">
+					{#each shadowList as name}
+						<button
+							onclick={() => { shadowName = name; getShadow(); }}
+							class="rounded bg-muted px-2 py-1 text-xs hover:bg-accent"
+						>
+							{name}
+						</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Retained Messages Tab -->
+	{#if activeTab === 'retained'}
+		<div class="space-y-4 rounded-lg border p-6">
+			<div class="flex items-center justify-between">
+				<div class="flex items-center gap-2">
+					<MessageSquare class="h-5 w-5 text-teal-600" />
+					<h2 class="font-semibold">Retained Messages</h2>
+				</div>
+				<button
+					onclick={listRetained}
+					disabled={retainedBusy}
+					class="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+				>
+					{#if retainedBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<RefreshCw class="h-4 w-4" />{/if}
+					Refresh
+				</button>
+			</div>
+
+			{#if retainedMessages.length === 0}
+				<div class="flex flex-col items-center justify-center py-10 text-muted-foreground">
+					<MessageSquare class="h-10 w-10 mb-2 opacity-30" />
+					<p class="text-sm">No retained messages</p>
+				</div>
+			{:else}
+				<div class="rounded-lg border overflow-hidden">
+					<table class="w-full text-sm">
+						<thead class="bg-muted/50">
+							<tr>
+								<th class="px-4 py-3 text-left font-medium">Topic</th>
+								<th class="px-4 py-3 text-left font-medium">QoS</th>
+								<th class="px-4 py-3 text-left font-medium">Size</th>
+								<th class="px-4 py-3 text-left font-medium">Modified</th>
+								<th class="px-4 py-3 text-right font-medium">Actions</th>
+							</tr>
+						</thead>
+						<tbody class="divide-y">
+							{#each retainedMessages as msg}
+								<tr class="hover:bg-muted/30">
+									<td class="px-4 py-3 font-mono text-xs">{msg.topic}</td>
+									<td class="px-4 py-3">{msg.qos ?? 0}</td>
+									<td class="px-4 py-3 text-muted-foreground">{msg.payloadSize ?? 0}B</td>
+									<td class="px-4 py-3 text-xs text-muted-foreground">
+										{msg.lastModifiedTime
+											? new Date(msg.lastModifiedTime).toLocaleString()
+											: '—'}
+									</td>
+									<td class="px-4 py-3 text-right">
+										<button
+											onclick={() => getRetained(msg.topic)}
+											class="rounded p-1 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-950"
+											title="View payload"
+										>
+											<Eye class="h-4 w-4" />
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+
+			{#if retainedDetail}
+				<pre class="rounded-md bg-muted p-3 text-xs overflow-auto max-h-48">{retainedDetail}</pre>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Connections Tab -->
+	{#if activeTab === 'connections'}
+		<div class="space-y-4 rounded-lg border p-6">
+			<div class="flex items-center gap-2">
+				<Radio class="h-5 w-5 text-teal-600" />
+				<h2 class="font-semibold">Delete MQTT Connection</h2>
+			</div>
+			<p class="text-sm text-muted-foreground">
+				Force-disconnect a client by ID. Equivalent to AWS IoT DeleteConnection.
+			</p>
+			<div>
+				<label for="conn-client-id" class="block text-sm font-medium mb-1">Client ID *</label>
+				<input
+					id="conn-client-id"
+					type="text"
+					bind:value={connClientId}
+					placeholder="my-device-client-id"
+					class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+				/>
+			</div>
+			<button
+				onclick={deleteConnection}
+				disabled={connBusy || !connClientId.trim()}
+				class="flex items-center gap-2 rounded-md border border-red-300 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950 disabled:opacity-50"
+			>
+				{#if connBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Trash2 class="h-4 w-4" />{/if}
+				Delete Connection
+			</button>
+			{#if connResult}
+				<pre class="rounded-md bg-muted p-3 text-xs">{connResult}</pre>
+			{/if}
+		</div>
+	{/if}
 </div>

--- a/ui/src/routes/iotdataplane/+page.svelte
+++ b/ui/src/routes/iotdataplane/+page.svelte
@@ -12,20 +12,69 @@
 		DeleteConnectionCommand
 	} from '@aws-sdk/client-iot-data-plane';
 	import { toast } from 'svelte-sonner';
-	import { Radio, Send, Eye, Trash2, RefreshCw, Layers, MessageSquare, Wifi } from 'lucide-svelte';
+	import {
+		Radio,
+		Send,
+		Eye,
+		Trash2,
+		RefreshCw,
+		Layers,
+		MessageSquare,
+		Wifi,
+		Copy,
+		Search,
+		Plus,
+		Clock,
+		ChevronRight
+	} from 'lucide-svelte';
 
 	const client = getIoTDataPlaneClient();
 
 	type Tab = 'publish' | 'shadows' | 'retained' | 'connections';
 	let activeTab = $state<Tab>('publish');
 
-	// --- Publish ---
-	let pubTopic = $state('my/topic');
-	let pubPayload = $state('{"hello":"world"}');
+	// Shared operation history log
+	type HistoryEntry = { op: string; detail: string; ts: number; ok: boolean };
+	let history = $state<HistoryEntry[]>([]);
+
+	function logOp(op: string, detail: string, ok: boolean) {
+		history = [{ op, detail, ts: Date.now(), ok }, ...history.slice(0, 49)];
+	}
+
+	function relativeTime(ts: number): string {
+		const diff = Math.floor((Date.now() - ts) / 1000);
+		if (diff < 60) return `${diff}s ago`;
+		if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+		return `${Math.floor(diff / 3600)}h ago`;
+	}
+
+	async function copyText(text: string, label = 'Copied') {
+		await navigator.clipboard.writeText(text);
+		toast.success(label);
+	}
+
+	function tryPrettyJson(raw: string): string {
+		try {
+			return JSON.stringify(JSON.parse(raw), null, 2);
+		} catch {
+			return raw;
+		}
+	}
+
+	function formatJson(raw: string): string {
+		return tryPrettyJson(raw);
+	}
+
+	// ---- Publish tab ----
+	let pubTopic = $state('my/device/telemetry');
+	let pubPayload = $state('{"temperature": 22.5, "humidity": 60}');
 	let pubQos = $state(0);
 	let pubRetain = $state(false);
 	let pubBusy = $state(false);
 	let pubResult = $state<string | null>(null);
+	let prettyPubPayload = $state(true);
+
+	const pubFormatted = $derived(prettyPubPayload ? tryPrettyJson(pubPayload) : pubPayload);
 
 	async function doPublish() {
 		if (!pubTopic.trim()) { toast.error('Topic is required'); return; }
@@ -38,23 +87,38 @@
 				qos: pubQos,
 				retain: pubRetain
 			}));
-			pubResult = 'Published successfully';
-			toast.success(pubResult);
+			pubResult = `Published at ${new Date().toLocaleTimeString()}`;
+			toast.success('Published');
+			logOp('Publish', pubTopic.trim(), true);
 		} catch (e) {
 			pubResult = `Error: ${e}`;
-			toast.error(pubResult);
+			toast.error(`Publish failed: ${e}`);
+			logOp('Publish', `${pubTopic}: ${e}`, false);
 		} finally {
 			pubBusy = false;
 		}
 	}
 
-	// --- Shadows ---
+	function applyTemplate(payload: string) {
+		pubPayload = payload;
+	}
+
+	const pubTemplates = [
+		{ label: 'Telemetry', payload: '{"temperature": 22.5, "humidity": 60, "ts": 0}' },
+		{ label: 'Alert', payload: '{"level": "WARN", "code": "TEMP_HIGH", "value": 85}' },
+		{ label: 'Status', payload: '{"online": true, "battery": 92, "rssi": -65}' }
+	];
+
+	// ---- Shadow tab ----
 	let shadowThing = $state('my-device');
 	let shadowName = $state('');
-	let shadowPayload = $state('{"state":{"desired":{"key":"value"}}}');
+	let shadowPayload = $state('{"state":{"desired":{"power":"on","brightness":80}}}');
 	let shadowBusy = $state(false);
 	let shadowResult = $state<string | null>(null);
 	let shadowList = $state<string[]>([]);
+	let thingsList = $state<string[]>([]);
+	let prettyResult = $state(true);
+	let showThingsBrowser = $state(false);
 
 	async function getShadow() {
 		if (!shadowThing.trim()) { toast.error('Thing name required'); return; }
@@ -65,10 +129,12 @@
 				shadowName: shadowName.trim() || undefined
 			}));
 			const text = res.payload ? new TextDecoder().decode(res.payload) : '{}';
-			shadowResult = JSON.stringify(JSON.parse(text), null, 2);
+			shadowResult = prettyResult ? tryPrettyJson(text) : text;
+			logOp('GetShadow', shadowThing.trim(), true);
 		} catch (e) {
 			shadowResult = `Error: ${e}`;
 			toast.error(`Get shadow failed: ${e}`);
+			logOp('GetShadow', `${shadowThing}: ${e}`, false);
 		} finally {
 			shadowBusy = false;
 		}
@@ -84,11 +150,13 @@
 				payload: new TextEncoder().encode(shadowPayload)
 			}));
 			const text = res.payload ? new TextDecoder().decode(res.payload) : '{}';
-			shadowResult = JSON.stringify(JSON.parse(text), null, 2);
+			shadowResult = prettyResult ? tryPrettyJson(text) : text;
 			toast.success('Shadow updated');
+			logOp('UpdateShadow', shadowThing.trim(), true);
 		} catch (e) {
 			shadowResult = `Error: ${e}`;
 			toast.error(`Update shadow failed: ${e}`);
+			logOp('UpdateShadow', `${shadowThing}: ${e}`, false);
 		} finally {
 			shadowBusy = false;
 		}
@@ -103,11 +171,13 @@
 				shadowName: shadowName.trim() || undefined
 			}));
 			const text = res.payload ? new TextDecoder().decode(res.payload) : '{}';
-			shadowResult = JSON.stringify(JSON.parse(text), null, 2);
+			shadowResult = prettyResult ? tryPrettyJson(text) : text;
 			toast.success('Shadow deleted');
+			logOp('DeleteShadow', shadowThing.trim(), true);
 		} catch (e) {
 			shadowResult = `Error: ${e}`;
 			toast.error(`Delete shadow failed: ${e}`);
+			logOp('DeleteShadow', `${shadowThing}: ${e}`, false);
 		} finally {
 			shadowBusy = false;
 		}
@@ -123,21 +193,64 @@
 			shadowList = res.results ?? [];
 			shadowResult = shadowList.length > 0
 				? `Named shadows: ${shadowList.join(', ')}`
-				: 'No named shadows';
+				: 'No named shadows found';
+			logOp('ListShadows', shadowThing.trim(), true);
 		} catch (e) {
 			shadowResult = `Error: ${e}`;
 			toast.error(`List shadows failed: ${e}`);
+			logOp('ListShadows', `${shadowThing}: ${e}`, false);
 		} finally {
 			shadowBusy = false;
 		}
 	}
 
-	// --- Retained Messages ---
+	async function loadThingsBrowser() {
+		try {
+			const res = await fetch('/api/things/shadow/ListThingsWithShadows');
+			if (res.ok) {
+				const data = await res.json();
+				thingsList = data.things ?? [];
+			}
+		} catch (_) {}
+		showThingsBrowser = true;
+	}
+
+	function selectThing(thing: string) {
+		shadowThing = thing;
+		showThingsBrowser = false;
+	}
+
+	function formatShadowPayload() {
+		shadowPayload = formatJson(shadowPayload);
+	}
+
+	function parseShadowSections(result: string): { desired?: object; reported?: object; delta?: object } | null {
+		try {
+			const parsed = JSON.parse(result);
+			if (parsed?.state) {
+				return {
+					desired: parsed.state.desired,
+					reported: parsed.state.reported,
+					delta: parsed.state.delta
+				};
+			}
+		} catch (_) {}
+		return null;
+	}
+
+	const shadowSections = $derived(shadowResult ? parseShadowSections(shadowResult) : null);
+
+	// ---- Retained Messages tab ----
 	type RetainedSummary = { topic: string; payloadSize?: number; qos?: number; lastModifiedTime?: number };
 	let retainedMessages = $state<RetainedSummary[]>([]);
 	let retainedBusy = $state(false);
-	let retainedTopic = $state('');
 	let retainedDetail = $state<string | null>(null);
+	let retainedFilter = $state('');
+	let retainedRowBusy = $state<string | null>(null);
+
+	const filteredRetained = $derived(
+		retainedMessages.filter((m) => m.topic.toLowerCase().includes(retainedFilter.toLowerCase()))
+	);
 
 	async function listRetained() {
 		retainedBusy = true; retainedDetail = null;
@@ -149,50 +262,130 @@
 				qos: t.qos,
 				lastModifiedTime: t.lastModifiedTime ? Number(t.lastModifiedTime) : undefined
 			}));
+			logOp('ListRetained', `${retainedMessages.length} messages`, true);
 		} catch (e) {
 			toast.error(`List retained failed: ${e}`);
+			logOp('ListRetained', `${e}`, false);
 		} finally {
 			retainedBusy = false;
 		}
 	}
 
 	async function getRetained(topic: string) {
-		retainedBusy = true; retainedDetail = null;
-		retainedTopic = topic;
+		retainedRowBusy = topic;
+		retainedDetail = null;
 		try {
 			const res = await client.send(new GetRetainedMessageCommand({ topic }));
 			const text = res.payload ? new TextDecoder().decode(res.payload) : '';
-			retainedDetail = `Topic: ${res.topic}\nQoS: ${res.qos}\nPayload: ${text}`;
+			const pretty = tryPrettyJson(text);
+			retainedDetail = `Topic: ${res.topic}\nQoS: ${res.qos}\nPayload:\n${pretty}`;
+			logOp('GetRetained', topic, true);
 		} catch (e) {
 			retainedDetail = `Error: ${e}`;
 			toast.error(`Get retained failed: ${e}`);
+			logOp('GetRetained', `${topic}: ${e}`, false);
 		} finally {
-			retainedBusy = false;
+			retainedRowBusy = null;
 		}
 	}
 
-	onMount(() => listRetained());
-
-	// --- Connections ---
-	let connClientId = $state('');
-	let connBusy = $state(false);
-	let connResult = $state<string | null>(null);
-
-	async function deleteConnection() {
-		if (!connClientId.trim()) { toast.error('Client ID required'); return; }
-		connBusy = true; connResult = null;
+	async function clearRetained(topic: string) {
+		retainedRowBusy = topic;
 		try {
-			await client.send(new DeleteConnectionCommand({ clientId: connClientId.trim() }));
-			connResult = `Connection "${connClientId.trim()}" deleted`;
-			toast.success(connResult);
-			connClientId = '';
+			// Publish empty payload with retain=true to clear the retained message.
+			await client.send(new PublishCommand({
+				topic,
+				payload: new Uint8Array(0),
+				retain: true
+			}));
+			toast.success(`Cleared retained: ${topic}`);
+			logOp('ClearRetained', topic, true);
+			await listRetained();
 		} catch (e) {
-			connResult = `Error: ${e}`;
-			toast.error(`Delete connection failed: ${e}`);
+			toast.error(`Clear retained failed: ${e}`);
+			logOp('ClearRetained', `${topic}: ${e}`, false);
+		} finally {
+			retainedRowBusy = null;
+		}
+	}
+
+	function qosBadgeClass(qos?: number): string {
+		return qos === 1
+			? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+			: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300';
+	}
+
+	// ---- Connections tab ----
+	type ConnEntry = { clientId: string; sourceIp: string; connectedAt: number };
+	let connections = $state<ConnEntry[]>([]);
+	let connBusy = $state(false);
+	let connClientId = $state('');
+	let connRowBusy = $state<string | null>(null);
+
+	async function listConnections() {
+		connBusy = true;
+		try {
+			const res = await fetch('/connections');
+			if (res.ok) {
+				const data = await res.json();
+				connections = data.connections ?? [];
+			}
+		} catch (e) {
+			toast.error(`List connections failed: ${e}`);
 		} finally {
 			connBusy = false;
 		}
 	}
+
+	async function registerConnection() {
+		if (!connClientId.trim()) { toast.error('Client ID required'); return; }
+		connRowBusy = connClientId.trim();
+		try {
+			const res = await fetch(`/connections/${encodeURIComponent(connClientId.trim())}`, { method: 'POST' });
+			if (res.ok) {
+				toast.success(`Registered: ${connClientId.trim()}`);
+				logOp('RegisterConnection', connClientId.trim(), true);
+				connClientId = '';
+				await listConnections();
+			} else {
+				const body = await res.json();
+				toast.error(`Register failed: ${body.error ?? res.status}`);
+				logOp('RegisterConnection', `${connClientId}: ${body.error}`, false);
+			}
+		} catch (e) {
+			toast.error(`Register failed: ${e}`);
+			logOp('RegisterConnection', `${connClientId}: ${e}`, false);
+		} finally {
+			connRowBusy = null;
+		}
+	}
+
+	async function deleteConnection(clientId: string) {
+		connRowBusy = clientId;
+		try {
+			await client.send(new DeleteConnectionCommand({ clientId }));
+			toast.success(`Disconnected: ${clientId}`);
+			logOp('DeleteConnection', clientId, true);
+			await listConnections();
+		} catch (e) {
+			toast.error(`Delete connection failed: ${e}`);
+			logOp('DeleteConnection', `${clientId}: ${e}`, false);
+		} finally {
+			connRowBusy = null;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent, action: () => void) {
+		if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+			e.preventDefault();
+			action();
+		}
+	}
+
+	onMount(() => {
+		listRetained();
+		listConnections();
+	});
 
 	const tabs: { id: Tab; label: string }[] = [
 		{ id: 'publish', label: 'Publish' },
@@ -203,11 +396,18 @@
 </script>
 
 <div class="space-y-6">
-	<div class="flex items-center gap-3">
-		<Wifi class="h-8 w-8 text-teal-600" />
-		<div>
-			<h1 class="text-2xl font-bold">IoT Data Plane</h1>
-			<p class="text-sm text-muted-foreground">Publish messages and manage thing shadows</p>
+	<!-- Header -->
+	<div class="flex items-center justify-between">
+		<div class="flex items-center gap-3">
+			<Wifi class="h-8 w-8 text-teal-600" />
+			<div>
+				<h1 class="text-2xl font-bold">IoT Data Plane</h1>
+				<p class="text-sm text-muted-foreground">Publish messages, manage shadows and retained messages</p>
+			</div>
+		</div>
+		<div class="flex items-center gap-2 text-xs text-muted-foreground">
+			<Clock class="h-3.5 w-3.5" />
+			{history.length} operations logged
 		</div>
 	</div>
 
@@ -221,6 +421,12 @@
 					: 'border-transparent text-muted-foreground hover:text-foreground'}"
 			>
 				{tab.label}
+				{#if tab.id === 'retained' && retainedMessages.length > 0}
+					<span class="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-xs">{retainedMessages.length}</span>
+				{/if}
+				{#if tab.id === 'connections' && connections.length > 0}
+					<span class="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-xs">{connections.length}</span>
+				{/if}
 			</button>
 		{/each}
 	</div>
@@ -231,54 +437,86 @@
 			<div class="flex items-center gap-2">
 				<Send class="h-5 w-5 text-teal-600" />
 				<h2 class="font-semibold">Publish Message</h2>
+				<span class="ml-auto text-xs text-muted-foreground">Ctrl+Enter to publish</span>
 			</div>
-			<div class="grid gap-4 sm:grid-cols-2">
-				<div class="sm:col-span-2">
-					<label for="pub-topic" class="block text-sm font-medium mb-1">Topic *</label>
-					<input
-						id="pub-topic"
-						type="text"
-						bind:value={pubTopic}
-						placeholder="my/device/topic"
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-					/>
+
+			<!-- Topic input -->
+			<div>
+				<label for="pub-topic" class="block text-sm font-medium mb-1">Topic *</label>
+				<input
+					id="pub-topic"
+					type="text"
+					bind:value={pubTopic}
+					placeholder="my/device/telemetry"
+					class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"
+				/>
+			</div>
+
+			<!-- Payload with templates -->
+			<div>
+				<div class="flex items-center justify-between mb-1">
+					<label for="pub-payload" class="text-sm font-medium">Payload</label>
+					<div class="flex items-center gap-2">
+						<span class="text-xs text-muted-foreground">Templates:</span>
+						{#each pubTemplates as tmpl}
+							<button
+								onclick={() => applyTemplate(tmpl.payload)}
+								class="rounded border px-2 py-0.5 text-xs hover:bg-accent"
+							>{tmpl.label}</button>
+						{/each}
+					</div>
 				</div>
-				<div class="sm:col-span-2">
-					<label for="pub-payload" class="block text-sm font-medium mb-1">Payload</label>
-					<textarea
-						id="pub-payload"
-						bind:value={pubPayload}
-						rows={4}
-						placeholder="json payload"
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"
-					></textarea>
-				</div>
+				<textarea
+					id="pub-payload"
+					bind:value={pubPayload}
+					rows={5}
+					placeholder="json payload"
+					onkeydown={(e) => handleKeydown(e, doPublish)}
+					class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"
+				></textarea>
+			</div>
+
+			<!-- QoS + Retain -->
+			<div class="flex flex-wrap gap-4 items-center">
 				<div>
 					<label for="pub-qos" class="block text-sm font-medium mb-1">QoS</label>
 					<select
 						id="pub-qos"
 						bind:value={pubQos}
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+						class="rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
 					>
 						<option value={0}>0 — At most once</option>
 						<option value={1}>1 — At least once</option>
 					</select>
 				</div>
-				<div class="flex items-center gap-2 pt-6">
-					<input id="pub-retain" type="checkbox" bind:checked={pubRetain} class="h-4 w-4" />
-					<label for="pub-retain" class="text-sm font-medium">Retain message</label>
-				</div>
+				<label class="flex items-center gap-2 pt-5 text-sm">
+					<input type="checkbox" bind:checked={pubRetain} class="h-4 w-4 rounded" />
+					Retain message
+				</label>
 			</div>
-			<button
-				onclick={doPublish}
-				disabled={pubBusy}
-				class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-			>
-				{#if pubBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Send class="h-4 w-4" />{/if}
-				Publish
-			</button>
+
+			<!-- Actions -->
+			<div class="flex items-center gap-2">
+				<button
+					onclick={doPublish}
+					disabled={pubBusy}
+					class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+				>
+					{#if pubBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Send class="h-4 w-4" />{/if}
+					Publish
+				</button>
+				{#if pubResult}
+					<button onclick={() => (pubResult = null)} class="text-xs text-muted-foreground hover:text-foreground">Clear</button>
+				{/if}
+			</div>
+
 			{#if pubResult}
-				<pre class="rounded-md bg-muted p-3 text-xs">{pubResult}</pre>
+				<div class="flex items-start gap-2">
+					<pre class="flex-1 rounded-md bg-muted p-3 text-xs">{pubResult}</pre>
+					<button onclick={() => copyText(pubResult ?? '', 'Result copied')} class="mt-1 rounded p-1 hover:bg-accent">
+						<Copy class="h-4 w-4 text-muted-foreground" />
+					</button>
+				</div>
 			{/if}
 		</div>
 	{/if}
@@ -289,7 +527,38 @@
 			<div class="flex items-center gap-2">
 				<Layers class="h-5 w-5 text-teal-600" />
 				<h2 class="font-semibold">Thing Shadow Operations</h2>
+				<button
+					onclick={loadThingsBrowser}
+					class="ml-auto flex items-center gap-1 rounded border px-2 py-1 text-xs hover:bg-accent"
+				>
+					<ChevronRight class="h-3 w-3" />
+					Browse Things
+				</button>
 			</div>
+
+			<!-- Things browser overlay -->
+			{#if showThingsBrowser}
+				<div class="rounded-lg border bg-muted/30 p-3 space-y-2">
+					<div class="flex items-center justify-between">
+						<span class="text-sm font-medium">Things with Shadows</span>
+						<button onclick={() => (showThingsBrowser = false)} class="text-xs text-muted-foreground hover:text-foreground">Close</button>
+					</div>
+					{#if thingsList.length === 0}
+						<p class="text-xs text-muted-foreground">No things with shadows found</p>
+					{:else}
+						<div class="flex flex-wrap gap-2">
+							{#each thingsList as thing}
+								<button
+									onclick={() => selectThing(thing)}
+									class="rounded bg-background border px-2 py-1 text-xs hover:bg-accent font-mono"
+								>{thing}</button>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			{/if}
+
+			<!-- Inputs -->
 			<div class="grid gap-4 sm:grid-cols-2">
 				<div>
 					<label for="shadow-thing" class="block text-sm font-medium mb-1">Thing Name *</label>
@@ -302,7 +571,7 @@
 					/>
 				</div>
 				<div>
-					<label for="shadow-name" class="block text-sm font-medium mb-1">Shadow Name (leave blank for classic)</label>
+					<label for="shadow-name" class="block text-sm font-medium mb-1">Shadow Name (blank = classic)</label>
 					<input
 						id="shadow-name"
 						type="text"
@@ -312,16 +581,22 @@
 					/>
 				</div>
 				<div class="sm:col-span-2">
-					<label for="shadow-payload" class="block text-sm font-medium mb-1">Payload (for Update)</label>
+					<div class="flex items-center justify-between mb-1">
+						<label for="shadow-payload" class="text-sm font-medium">Payload (for Update)</label>
+						<button onclick={formatShadowPayload} class="text-xs text-muted-foreground hover:text-foreground rounded border px-2 py-0.5">Format JSON</button>
+					</div>
 					<textarea
 						id="shadow-payload"
 						bind:value={shadowPayload}
 						rows={4}
 						placeholder="shadow document json"
+						onkeydown={(e) => handleKeydown(e, updateShadow)}
 						class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"
 					></textarea>
 				</div>
 			</div>
+
+			<!-- Action buttons -->
 			<div class="flex flex-wrap gap-2">
 				<button
 					onclick={getShadow}
@@ -329,14 +604,14 @@
 					class="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
 				>
 					{#if shadowBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Eye class="h-4 w-4" />{/if}
-					Get Shadow
+					Get
 				</button>
 				<button
 					onclick={updateShadow}
 					disabled={shadowBusy}
 					class="flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
 				>
-					Update Shadow
+					Update
 				</button>
 				<button
 					onclick={deleteShadow}
@@ -344,29 +619,61 @@
 					class="flex items-center gap-2 rounded-md border border-red-300 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950 disabled:opacity-50"
 				>
 					<Trash2 class="h-4 w-4" />
-					Delete Shadow
+					Delete
 				</button>
 				<button
 					onclick={listShadows}
 					disabled={shadowBusy}
 					class="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
 				>
-					List Named Shadows
+					List Named
 				</button>
+				<div class="ml-auto flex items-center gap-2">
+					<label class="flex items-center gap-1.5 text-xs text-muted-foreground">
+						<input type="checkbox" bind:checked={prettyResult} class="h-3.5 w-3.5 rounded" />
+						Pretty-print
+					</label>
+					{#if shadowResult}
+						<button onclick={() => (shadowResult = null)} class="text-xs text-muted-foreground hover:text-foreground">Clear</button>
+					{/if}
+				</div>
 			</div>
-			{#if shadowResult}
-				<pre class="rounded-md bg-muted p-3 text-xs overflow-auto max-h-64">{shadowResult}</pre>
-			{/if}
+
+			<!-- Named shadow quick-select -->
 			{#if shadowList.length > 0}
 				<div class="flex flex-wrap gap-2">
 					{#each shadowList as name}
 						<button
 							onclick={() => { shadowName = name; getShadow(); }}
-							class="rounded bg-muted px-2 py-1 text-xs hover:bg-accent"
-						>
-							{name}
-						</button>
+							class="rounded bg-muted px-2 py-1 text-xs hover:bg-accent font-mono"
+						>{name}</button>
 					{/each}
+				</div>
+			{/if}
+
+			<!-- Result + copy -->
+			{#if shadowResult}
+				<div class="space-y-2">
+					<div class="flex items-start gap-2">
+						<pre class="flex-1 rounded-md bg-muted p-3 text-xs overflow-auto max-h-64">{shadowResult}</pre>
+						<button onclick={() => copyText(shadowResult ?? '', 'Shadow copied')} class="mt-1 rounded p-1 hover:bg-accent">
+							<Copy class="h-4 w-4 text-muted-foreground" />
+						</button>
+					</div>
+
+					<!-- State sections breakdown -->
+					{#if shadowSections}
+						<div class="grid gap-2 sm:grid-cols-3 text-xs">
+							{#each [['Desired', shadowSections.desired], ['Reported', shadowSections.reported], ['Delta', shadowSections.delta]] as [label, section]}
+								{#if section}
+									<div class="rounded border p-2">
+										<div class="font-medium mb-1 text-muted-foreground">{label}</div>
+										<pre class="overflow-auto max-h-32">{JSON.stringify(section, null, 2)}</pre>
+									</div>
+								{/if}
+							{/each}
+						</div>
+					{/if}
 				</div>
 			{/if}
 		</div>
@@ -390,10 +697,21 @@
 				</button>
 			</div>
 
-			{#if retainedMessages.length === 0}
+			<!-- Filter -->
+			<div class="relative">
+				<Search class="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+				<input
+					type="text"
+					placeholder="Filter by topic..."
+					bind:value={retainedFilter}
+					class="w-full rounded-md border bg-background pl-9 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+				/>
+			</div>
+
+			{#if filteredRetained.length === 0}
 				<div class="flex flex-col items-center justify-center py-10 text-muted-foreground">
 					<MessageSquare class="h-10 w-10 mb-2 opacity-30" />
-					<p class="text-sm">No retained messages</p>
+					<p class="text-sm">{retainedMessages.length === 0 ? 'No retained messages' : 'No matches'}</p>
 				</div>
 			{:else}
 				<div class="rounded-lg border overflow-hidden">
@@ -408,24 +726,41 @@
 							</tr>
 						</thead>
 						<tbody class="divide-y">
-							{#each retainedMessages as msg}
+							{#each filteredRetained as msg}
 								<tr class="hover:bg-muted/30">
 									<td class="px-4 py-3 font-mono text-xs">{msg.topic}</td>
-									<td class="px-4 py-3">{msg.qos ?? 0}</td>
-									<td class="px-4 py-3 text-muted-foreground">{msg.payloadSize ?? 0}B</td>
-									<td class="px-4 py-3 text-xs text-muted-foreground">
-										{msg.lastModifiedTime
-											? new Date(msg.lastModifiedTime).toLocaleString()
-											: '—'}
+									<td class="px-4 py-3">
+										<span class="rounded-full px-2 py-0.5 text-xs font-medium {qosBadgeClass(msg.qos)}">
+											QoS {msg.qos ?? 0}
+										</span>
 									</td>
-									<td class="px-4 py-3 text-right">
-										<button
-											onclick={() => getRetained(msg.topic)}
-											class="rounded p-1 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-950"
-											title="View payload"
-										>
-											<Eye class="h-4 w-4" />
-										</button>
+									<td class="px-4 py-3 text-muted-foreground text-xs">{msg.payloadSize ?? 0}B</td>
+									<td class="px-4 py-3 text-xs text-muted-foreground" title={msg.lastModifiedTime ? new Date(msg.lastModifiedTime).toLocaleString() : ''}>
+										{msg.lastModifiedTime ? relativeTime(msg.lastModifiedTime) : '—'}
+									</td>
+									<td class="px-4 py-3">
+										<div class="flex justify-end gap-1">
+											<button
+												onclick={() => getRetained(msg.topic)}
+												disabled={retainedRowBusy === msg.topic}
+												class="rounded p-1 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-950 disabled:opacity-50"
+												title="View payload"
+											>
+												{#if retainedRowBusy === msg.topic}
+													<RefreshCw class="h-4 w-4 animate-spin" />
+												{:else}
+													<Eye class="h-4 w-4" />
+												{/if}
+											</button>
+											<button
+												onclick={() => clearRetained(msg.topic)}
+												disabled={retainedRowBusy === msg.topic}
+												class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950 disabled:opacity-50"
+												title="Clear retained message"
+											>
+												<Trash2 class="h-4 w-4" />
+											</button>
+										</div>
 									</td>
 								</tr>
 							{/each}
@@ -435,7 +770,12 @@
 			{/if}
 
 			{#if retainedDetail}
-				<pre class="rounded-md bg-muted p-3 text-xs overflow-auto max-h-48">{retainedDetail}</pre>
+				<div class="flex items-start gap-2">
+					<pre class="flex-1 rounded-md bg-muted p-3 text-xs overflow-auto max-h-48">{retainedDetail}</pre>
+					<button onclick={() => copyText(retainedDetail ?? '', 'Payload copied')} class="mt-1 rounded p-1 hover:bg-accent">
+						<Copy class="h-4 w-4 text-muted-foreground" />
+					</button>
+				</div>
 			{/if}
 		</div>
 	{/if}
@@ -443,34 +783,115 @@
 	<!-- Connections Tab -->
 	{#if activeTab === 'connections'}
 		<div class="space-y-4 rounded-lg border p-6">
-			<div class="flex items-center gap-2">
-				<Radio class="h-5 w-5 text-teal-600" />
-				<h2 class="font-semibold">Delete MQTT Connection</h2>
+			<div class="flex items-center justify-between">
+				<div class="flex items-center gap-2">
+					<Radio class="h-5 w-5 text-teal-600" />
+					<h2 class="font-semibold">MQTT Connections</h2>
+				</div>
+				<button
+					onclick={listConnections}
+					disabled={connBusy}
+					class="flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+				>
+					{#if connBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<RefreshCw class="h-4 w-4" />{/if}
+					Refresh
+				</button>
 			</div>
-			<p class="text-sm text-muted-foreground">
-				Force-disconnect a client by ID. Equivalent to AWS IoT DeleteConnection.
-			</p>
-			<div>
-				<label for="conn-client-id" class="block text-sm font-medium mb-1">Client ID *</label>
-				<input
-					id="conn-client-id"
-					type="text"
-					bind:value={connClientId}
-					placeholder="my-device-client-id"
-					class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-				/>
+
+			<!-- Register new connection -->
+			<div class="rounded-md border bg-muted/30 p-4 space-y-3">
+				<p class="text-sm font-medium">Register Test Connection</p>
+				<div class="flex gap-2">
+					<input
+						type="text"
+						bind:value={connClientId}
+						placeholder="my-device-client-id"
+						onkeydown={(e) => { if (e.key === 'Enter') registerConnection(); }}
+						class="flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+					<button
+						onclick={registerConnection}
+						disabled={!connClientId.trim() || connRowBusy !== null}
+						class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+					>
+						<Plus class="h-4 w-4" />
+						Register
+					</button>
+				</div>
 			</div>
-			<button
-				onclick={deleteConnection}
-				disabled={connBusy || !connClientId.trim()}
-				class="flex items-center gap-2 rounded-md border border-red-300 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950 disabled:opacity-50"
-			>
-				{#if connBusy}<RefreshCw class="h-4 w-4 animate-spin" />{:else}<Trash2 class="h-4 w-4" />{/if}
-				Delete Connection
-			</button>
-			{#if connResult}
-				<pre class="rounded-md bg-muted p-3 text-xs">{connResult}</pre>
+
+			<!-- Connection list -->
+			{#if connections.length === 0}
+				<div class="flex flex-col items-center justify-center py-10 text-muted-foreground">
+					<Radio class="h-10 w-10 mb-2 opacity-30" />
+					<p class="text-sm">No connections registered</p>
+					<p class="text-xs">Register a test connection above or connect via MQTT</p>
+				</div>
+			{:else}
+				<div class="rounded-lg border overflow-hidden">
+					<table class="w-full text-sm">
+						<thead class="bg-muted/50">
+							<tr>
+								<th class="px-4 py-3 text-left font-medium">Client ID</th>
+								<th class="px-4 py-3 text-left font-medium">Source IP</th>
+								<th class="px-4 py-3 text-left font-medium">Connected</th>
+								<th class="px-4 py-3 text-right font-medium">Actions</th>
+							</tr>
+						</thead>
+						<tbody class="divide-y">
+							{#each connections as conn}
+								<tr class="hover:bg-muted/30">
+									<td class="px-4 py-3 font-mono text-xs">
+										<div class="flex items-center gap-1">
+											{conn.clientId}
+											<button onclick={() => copyText(conn.clientId, 'Client ID copied')} class="rounded p-0.5 hover:bg-accent opacity-50 hover:opacity-100">
+												<Copy class="h-3 w-3" />
+											</button>
+										</div>
+									</td>
+									<td class="px-4 py-3 text-xs text-muted-foreground">{conn.sourceIp || '—'}</td>
+									<td class="px-4 py-3 text-xs text-muted-foreground" title={new Date(conn.connectedAt * 1000).toLocaleString()}>
+										{relativeTime(conn.connectedAt * 1000)}
+									</td>
+									<td class="px-4 py-3 text-right">
+										<button
+											onclick={() => deleteConnection(conn.clientId)}
+											disabled={connRowBusy === conn.clientId}
+											class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950 disabled:opacity-50"
+											title="Delete connection"
+										>
+											{#if connRowBusy === conn.clientId}
+												<RefreshCw class="h-4 w-4 animate-spin" />
+											{:else}
+												<Trash2 class="h-4 w-4" />
+											{/if}
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
 			{/if}
 		</div>
+	{/if}
+
+	<!-- Operation History (always visible at bottom) -->
+	{#if history.length > 0}
+		<details class="rounded-lg border p-4">
+			<summary class="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
+				Operation History ({history.length})
+			</summary>
+			<div class="mt-3 space-y-1 max-h-48 overflow-auto">
+				{#each history as entry}
+					<div class="flex items-center gap-2 text-xs {entry.ok ? 'text-foreground' : 'text-red-600 dark:text-red-400'}">
+						<span class="w-2 h-2 rounded-full flex-shrink-0 {entry.ok ? 'bg-green-500' : 'bg-red-500'}"></span>
+						<span class="font-medium w-28 flex-shrink-0">{entry.op}</span>
+						<span class="flex-1 truncate font-mono">{entry.detail}</span>
+						<span class="text-muted-foreground flex-shrink-0">{relativeTime(entry.ts)}</span>
+					</div>
+				{/each}
+			</div>
+		</details>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
IoT Data Plane implementation with per-thing shadow capacity constraints and interactive dashboard UI.

### Backend Changes
- Add maxShadowsPerThing=100 cap enforced in UpdateThingShadow
- Returns ErrValidation when new shadow would exceed per-thing limit
- Export MaxShadowsPerThing in export_test.go
- Three whitebox tests: cap enforcement, update-existing bypass, per-thing isolation

### UI Features
- Replace static doc page with interactive dashboard
- Tabs: Publish, Thing Shadows, Retained Messages, Connections
- Full integration with IoTDataPlaneClient

🤖 Merge request from refinery (queue: polecat/quartz-moqbotnr)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->