### PR TITLE
feat(appconfig): HMAC pagination cursors + Extension/Association UI

### DIFF
--- a/services/appconfig/backend.go
+++ b/services/appconfig/backend.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"maps"
 	"sort"
-	"strconv"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
+	"github.com/blackbirdworks/gopherstack/pkgs/page"
 )
 
 const (
@@ -49,6 +51,7 @@ type InMemoryBackend struct {
 	versionCounters       map[string]map[string]int32
 	deploymentCounters    map[string]map[string]int32
 	mu                    *lockmetrics.RWMutex
+	paginationSecret      string
 	accountID             string
 	region                string
 }
@@ -68,10 +71,14 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		versionCounters:       make(map[string]map[string]int32),
 		deploymentCounters:    make(map[string]map[string]int32),
 		mu:                    lockmetrics.New("appconfig"),
+		paginationSecret:      uuid.NewString(),
 		accountID:             accountID,
 		region:                region,
 	}
 }
+
+// PaginationSecret returns the HMAC secret for pagination tokens.
+func (b *InMemoryBackend) PaginationSecret() string { return b.paginationSecret }
 
 // appconfigARN builds an AppConfig resource ARN for tag lookup/cleanup.
 func (b *InMemoryBackend) appconfigARN(resourcePath string) string {
@@ -128,7 +135,7 @@ func (b *InMemoryBackend) ListApplications(nextToken string, maxResults int) ([]
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token
 }
@@ -255,7 +262,7 @@ func (b *InMemoryBackend) ListEnvironments(
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token, nil
 }
@@ -378,7 +385,7 @@ func (b *InMemoryBackend) ListConfigurationProfiles(
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token, nil
 }
@@ -528,7 +535,7 @@ func (b *InMemoryBackend) ListHostedConfigurationVersions(
 
 	sort.Slice(out, func(i, j int) bool { return out[i].VersionNumber < out[j].VersionNumber })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token, nil
 }
@@ -613,7 +620,7 @@ func (b *InMemoryBackend) ListDeploymentStrategies(nextToken string, maxResults 
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token
 }
@@ -759,7 +766,7 @@ func (b *InMemoryBackend) ListDeployments(
 
 	sort.Slice(out, func(i, j int) bool { return out[i].DeploymentNumber < out[j].DeploymentNumber })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token, nil
 }
@@ -916,7 +923,7 @@ func (b *InMemoryBackend) ListExtensions(nextToken string, maxResults int, nameF
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token
 }
@@ -1036,7 +1043,7 @@ func (b *InMemoryBackend) ListExtensionAssociations(nextToken string, maxResults
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 
-	page, token := appConfigPaginate(out, nextToken, maxResults)
+	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
 	return page, token
 }
@@ -1206,34 +1213,11 @@ func (b *InMemoryBackend) latestConfigVersion(appID, profileID string) *HostedCo
 	return latest
 }
 
-// appConfigPaginate applies token-based pagination to a sorted slice.
-func appConfigPaginate[T any](all []T, nextToken string, maxResults int) ([]T, string) {
+// appConfigPaginate applies HMAC-signed token-based pagination to a sorted slice.
+func appConfigPaginate[T any](all []T, nextToken, secret string, maxResults int) ([]T, string) {
 	const defaultLimit = 50
 
-	startIdx := 0
-	if nextToken != "" {
-		if idx, err := strconv.Atoi(nextToken); err == nil && idx >= 0 {
-			startIdx = idx
-		}
-	}
+	p := page.NewHMAC(all, nextToken, secret, maxResults, defaultLimit)
 
-	if startIdx >= len(all) {
-		return []T{}, ""
-	}
-
-	limit := defaultLimit
-	if maxResults > 0 {
-		limit = maxResults
-	}
-
-	end := startIdx + limit
-
-	var outToken string
-	if end < len(all) {
-		outToken = strconv.Itoa(end)
-	} else {
-		end = len(all)
-	}
-
-	return all[startIdx:end], outToken
+	return p.Data, p.Next
 }

--- a/services/appconfig/backend.go
+++ b/services/appconfig/backend.go
@@ -94,6 +94,12 @@ func (b *InMemoryBackend) CreateApplication(name, description string) (*Applicat
 		return nil, fmt.Errorf("%w: Name is required", ErrBadRequest)
 	}
 
+	for _, a := range b.applications {
+		if a.Name == name {
+			return nil, fmt.Errorf("%w: application with name %q already exists", ErrConflict, name)
+		}
+	}
+
 	now := time.Now()
 	app := &Application{
 		ID:          newResourceID(),
@@ -193,9 +199,13 @@ func (b *InMemoryBackend) DeleteApplication(applicationID string) error {
 }
 
 // CreateEnvironment creates a new environment within an application.
-func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description string) (*Environment, error) {
+func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description string, monitors []Monitor) (*Environment, error) {
 	b.mu.Lock("CreateEnvironment")
 	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: Name is required", ErrBadRequest)
+	}
 
 	if _, ok := b.applications[applicationID]; !ok {
 		return nil, fmt.Errorf("%w: application %s", ErrApplicationNotFound, applicationID)
@@ -205,6 +215,12 @@ func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description str
 		b.environments[applicationID] = make(map[string]*Environment)
 	}
 
+	for _, e := range b.environments[applicationID] {
+		if e.Name == name {
+			return nil, fmt.Errorf("%w: environment with name %q already exists in application %s", ErrConflict, name, applicationID)
+		}
+	}
+
 	now := time.Now()
 	env := &Environment{
 		ID:            newResourceID(),
@@ -212,6 +228,7 @@ func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description str
 		Name:          name,
 		Description:   description,
 		State:         "ReadyForDeployment",
+		Monitors:      monitors,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
@@ -317,10 +334,19 @@ func (b *InMemoryBackend) DeleteEnvironment(applicationID, environmentID string)
 
 // CreateConfigurationProfile creates a new configuration profile.
 func (b *InMemoryBackend) CreateConfigurationProfile(
-	applicationID, name, description, locationURI, profileType string,
+	applicationID, name, description, locationURI, profileType, retrievalRoleArn string,
+	validators []Validator,
 ) (*ConfigurationProfile, error) {
 	b.mu.Lock("CreateConfigurationProfile")
 	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: Name is required", ErrBadRequest)
+	}
+
+	if locationURI == "" {
+		return nil, fmt.Errorf("%w: LocationUri is required", ErrBadRequest)
+	}
 
 	if _, ok := b.applications[applicationID]; !ok {
 		return nil, fmt.Errorf("%w: application %s", ErrApplicationNotFound, applicationID)
@@ -330,13 +356,21 @@ func (b *InMemoryBackend) CreateConfigurationProfile(
 		b.configProfiles[applicationID] = make(map[string]*ConfigurationProfile)
 	}
 
+	for _, p := range b.configProfiles[applicationID] {
+		if p.Name == name {
+			return nil, fmt.Errorf("%w: configuration profile with name %q already exists in application %s", ErrConflict, name, applicationID)
+		}
+	}
+
 	profile := &ConfigurationProfile{
-		ID:            newResourceID(),
-		ApplicationID: applicationID,
-		Name:          name,
-		Description:   description,
-		LocationURI:   locationURI,
-		Type:          profileType,
+		ID:               newResourceID(),
+		ApplicationID:    applicationID,
+		Name:             name,
+		Description:      description,
+		LocationURI:      locationURI,
+		Type:             profileType,
+		RetrievalRoleArn: retrievalRoleArn,
+		Validators:       validators,
 	}
 	b.configProfiles[applicationID][profile.ID] = profile
 	cp := *profile
@@ -437,13 +471,19 @@ func (b *InMemoryBackend) DeleteConfigurationProfile(applicationID, profileID st
 	return nil
 }
 
+const maxHostedConfigSizeBytes = 1024 * 1024 // 1 MiB, matching AWS limit
+
 // CreateHostedConfigurationVersion creates a hosted configuration version.
 func (b *InMemoryBackend) CreateHostedConfigurationVersion(
-	applicationID, profileID, contentType string,
+	applicationID, profileID, contentType, description, versionLabel string,
 	content []byte,
 ) (*HostedConfigurationVersion, error) {
 	b.mu.Lock("CreateHostedConfigurationVersion")
 	defer b.mu.Unlock()
+
+	if len(content) > maxHostedConfigSizeBytes {
+		return nil, fmt.Errorf("%w: content exceeds maximum size of %d bytes", ErrPayloadTooLarge, maxHostedConfigSizeBytes)
+	}
 
 	if _, ok := b.applications[applicationID]; !ok {
 		return nil, fmt.Errorf("%w: application %s", ErrApplicationNotFound, applicationID)
@@ -466,6 +506,15 @@ func (b *InMemoryBackend) CreateHostedConfigurationVersion(
 		b.versionCounters[applicationID] = make(map[string]int32)
 	}
 
+	// VersionLabel must be unique across versions for this profile.
+	if versionLabel != "" {
+		for _, v := range b.hostedConfigVersions[applicationID][profileID] {
+			if v.VersionLabel == versionLabel {
+				return nil, fmt.Errorf("%w: version label %q already exists for profile %s", ErrConflict, versionLabel, profileID)
+			}
+		}
+	}
+
 	b.versionCounters[applicationID][profileID]++
 	versionNumber := b.versionCounters[applicationID][profileID]
 
@@ -473,6 +522,8 @@ func (b *InMemoryBackend) CreateHostedConfigurationVersion(
 		ApplicationID:          applicationID,
 		ConfigurationProfileID: profileID,
 		ContentType:            contentType,
+		Description:            description,
+		VersionLabel:           versionLabel,
 		Content:                content,
 		VersionNumber:          versionNumber,
 		CreatedAt:              time.Now(),
@@ -511,9 +562,9 @@ func (b *InMemoryBackend) GetHostedConfigurationVersion(
 	return &cp, nil
 }
 
-// ListHostedConfigurationVersions returns paginated versions for a profile.
+// ListHostedConfigurationVersions returns paginated versions for a profile, optionally filtered by versionLabel.
 func (b *InMemoryBackend) ListHostedConfigurationVersions(
-	applicationID, profileID, nextToken string, maxResults int,
+	applicationID, profileID, nextToken, versionLabel string, maxResults int,
 ) ([]HostedConfigurationVersion, string, error) {
 	b.mu.RLock("ListHostedConfigurationVersions")
 	defer b.mu.RUnlock()
@@ -530,6 +581,10 @@ func (b *InMemoryBackend) ListHostedConfigurationVersions(
 
 	out := make([]HostedConfigurationVersion, 0, len(profileVersions))
 	for _, v := range profileVersions {
+		if versionLabel != "" && v.VersionLabel != versionLabel {
+			continue
+		}
+
 		out = append(out, *v)
 	}
 
@@ -573,6 +628,16 @@ func (b *InMemoryBackend) CreateDeploymentStrategy(
 ) (*DeploymentStrategy, error) {
 	b.mu.Lock("CreateDeploymentStrategy")
 	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: Name is required", ErrBadRequest)
+	}
+
+	for _, s := range b.deploymentStrategies {
+		if s.Name == name {
+			return nil, fmt.Errorf("%w: deployment strategy with name %q already exists", ErrConflict, name)
+		}
+	}
 
 	now := time.Now()
 	strategy := &DeploymentStrategy{
@@ -670,13 +735,25 @@ func (b *InMemoryBackend) DeleteDeploymentStrategy(strategyID string) error {
 
 // StartDeployment starts a deployment.
 func (b *InMemoryBackend) StartDeployment(
-	applicationID, environmentID, configProfileID, strategyID, configVersion string,
+	applicationID, environmentID, configProfileID, strategyID, configVersion, description string,
 ) (*Deployment, error) {
 	b.mu.Lock("StartDeployment")
 	defer b.mu.Unlock()
 
 	if _, ok := b.applications[applicationID]; !ok {
 		return nil, fmt.Errorf("%w: application %s", ErrApplicationNotFound, applicationID)
+	}
+
+	if _, ok := b.environments[applicationID][environmentID]; !ok {
+		return nil, fmt.Errorf("%w: environment %s", ErrEnvironmentNotFound, environmentID)
+	}
+
+	if profiles := b.configProfiles[applicationID]; profiles == nil || profiles[configProfileID] == nil {
+		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, configProfileID)
+	}
+
+	if _, ok := b.deploymentStrategies[strategyID]; !ok {
+		return nil, fmt.Errorf("%w: deployment strategy %s", ErrDeploymentStrategyNotFound, strategyID)
 	}
 
 	if b.deployments[applicationID] == nil {
@@ -701,7 +778,10 @@ func (b *InMemoryBackend) StartDeployment(
 		ConfigurationProfileID: configProfileID,
 		DeploymentStrategyID:   strategyID,
 		ConfigurationVersion:   configVersion,
+		Description:            description,
 		State:                  "COMPLETE",
+		TriggeredBy:            "USER",
+		PercentageComplete:     100.0,
 		DeploymentNumber:       deploymentNumber,
 		StartedAt:              now,
 		CompletedAt:            now,
@@ -771,6 +851,13 @@ func (b *InMemoryBackend) ListDeployments(
 	return page, token, nil
 }
 
+// stoppableDeploymentStates are the states from which a deployment can be stopped.
+var stoppableDeploymentStates = map[string]bool{
+	"BAKING":      true,
+	"DEPLOYING":   true,
+	"VALIDATING":  true,
+}
+
 // StopDeployment stops an in-progress deployment.
 func (b *InMemoryBackend) StopDeployment(applicationID, environmentID string, deploymentNumber int32) error {
 	b.mu.Lock("StopDeployment")
@@ -791,7 +878,13 @@ func (b *InMemoryBackend) StopDeployment(applicationID, environmentID string, de
 		return fmt.Errorf("%w: deployment %d", ErrDeploymentNotFound, deploymentNumber)
 	}
 
-	d.State = "ROLLEDBACK"
+	// Allow stopping from any non-terminal state to keep in-memory stub pragmatic.
+	// (Real deployments complete instantly here so we still accept the request.)
+	if d.State != "COMPLETE" && d.State != "ROLLED_BACK" && !stoppableDeploymentStates[d.State] {
+		return fmt.Errorf("%w: cannot stop deployment in state %s", ErrBadRequest, d.State)
+	}
+
+	d.State = "ROLLED_BACK"
 	d.CompletedAt = time.Now()
 
 	return nil
@@ -906,8 +999,8 @@ func (b *InMemoryBackend) GetExtension(extensionIdentifier string) (*Extension, 
 	return &cp, nil
 }
 
-// ListExtensions returns paginated extensions, optionally filtered by name.
-func (b *InMemoryBackend) ListExtensions(nextToken string, maxResults int, nameFilter string) ([]Extension, string) {
+// ListExtensions returns paginated extensions, optionally filtered by name and/or version number.
+func (b *InMemoryBackend) ListExtensions(nextToken string, maxResults int, nameFilter string, versionNumber int32) ([]Extension, string) {
 	b.mu.RLock("ListExtensions")
 	defer b.mu.RUnlock()
 
@@ -915,6 +1008,10 @@ func (b *InMemoryBackend) ListExtensions(nextToken string, maxResults int, nameF
 
 	for _, ext := range b.extensions {
 		if nameFilter != "" && ext.Name != nameFilter {
+			continue
+		}
+
+		if versionNumber > 0 && ext.VersionNumber != versionNumber {
 			continue
 		}
 
@@ -1031,13 +1128,22 @@ func (b *InMemoryBackend) GetExtensionAssociation(extensionAssociationID string)
 	return &cp, nil
 }
 
-// ListExtensionAssociations returns paginated extension associations.
-func (b *InMemoryBackend) ListExtensionAssociations(nextToken string, maxResults int) ([]ExtensionAssociation, string) {
+// ListExtensionAssociations returns paginated extension associations,
+// optionally filtered by extensionIdentifier (ARN prefix) and/or resourceIdentifier (ARN prefix).
+func (b *InMemoryBackend) ListExtensionAssociations(nextToken, extensionIdentifier, resourceIdentifier string, maxResults int) ([]ExtensionAssociation, string) {
 	b.mu.RLock("ListExtensionAssociations")
 	defer b.mu.RUnlock()
 
 	out := make([]ExtensionAssociation, 0, len(b.extensionAssociations))
 	for _, a := range b.extensionAssociations {
+		if extensionIdentifier != "" && a.ExtensionArn != extensionIdentifier {
+			continue
+		}
+
+		if resourceIdentifier != "" && a.ResourceArn != resourceIdentifier {
+			continue
+		}
+
 		out = append(out, *a)
 	}
 

--- a/services/appconfig/backend.go
+++ b/services/appconfig/backend.go
@@ -130,7 +130,10 @@ func (b *InMemoryBackend) GetApplication(applicationID string) (*Application, er
 }
 
 // ListApplications returns paginated applications.
-func (b *InMemoryBackend) ListApplications(nextToken string, maxResults int) ([]Application, string) {
+func (b *InMemoryBackend) ListApplications(
+	nextToken string,
+	maxResults int,
+) ([]Application, string) {
 	b.mu.RLock("ListApplications")
 	defer b.mu.RUnlock()
 
@@ -147,7 +150,9 @@ func (b *InMemoryBackend) ListApplications(nextToken string, maxResults int) ([]
 }
 
 // UpdateApplication updates an application's name and description.
-func (b *InMemoryBackend) UpdateApplication(applicationID, name, description string) (*Application, error) {
+func (b *InMemoryBackend) UpdateApplication(
+	applicationID, name, description string,
+) (*Application, error) {
 	b.mu.Lock("UpdateApplication")
 	defer b.mu.Unlock()
 
@@ -184,7 +189,10 @@ func (b *InMemoryBackend) DeleteApplication(applicationID string) error {
 	}
 
 	for profileID := range b.configProfiles[applicationID] {
-		delete(b.tags, b.appconfigARN("application/"+applicationID+"/configurationprofile/"+profileID))
+		delete(
+			b.tags,
+			b.appconfigARN("application/"+applicationID+"/configurationprofile/"+profileID),
+		)
 	}
 
 	delete(b.applications, applicationID)
@@ -199,7 +207,10 @@ func (b *InMemoryBackend) DeleteApplication(applicationID string) error {
 }
 
 // CreateEnvironment creates a new environment within an application.
-func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description string, monitors []Monitor) (*Environment, error) {
+func (b *InMemoryBackend) CreateEnvironment(
+	applicationID, name, description string,
+	monitors []Monitor,
+) (*Environment, error) {
 	b.mu.Lock("CreateEnvironment")
 	defer b.mu.Unlock()
 
@@ -217,7 +228,12 @@ func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description str
 
 	for _, e := range b.environments[applicationID] {
 		if e.Name == name {
-			return nil, fmt.Errorf("%w: environment with name %q already exists in application %s", ErrConflict, name, applicationID)
+			return nil, fmt.Errorf(
+				"%w: environment with name %q already exists in application %s",
+				ErrConflict,
+				name,
+				applicationID,
+			)
 		}
 	}
 
@@ -239,7 +255,9 @@ func (b *InMemoryBackend) CreateEnvironment(applicationID, name, description str
 }
 
 // GetEnvironment retrieves an environment by application and environment ID.
-func (b *InMemoryBackend) GetEnvironment(applicationID, environmentID string) (*Environment, error) {
+func (b *InMemoryBackend) GetEnvironment(
+	applicationID, environmentID string,
+) (*Environment, error) {
 	b.mu.RLock("GetEnvironment")
 	defer b.mu.RUnlock()
 
@@ -358,7 +376,12 @@ func (b *InMemoryBackend) CreateConfigurationProfile(
 
 	for _, p := range b.configProfiles[applicationID] {
 		if p.Name == name {
-			return nil, fmt.Errorf("%w: configuration profile with name %q already exists in application %s", ErrConflict, name, applicationID)
+			return nil, fmt.Errorf(
+				"%w: configuration profile with name %q already exists in application %s",
+				ErrConflict,
+				name,
+				applicationID,
+			)
 		}
 	}
 
@@ -379,18 +402,28 @@ func (b *InMemoryBackend) CreateConfigurationProfile(
 }
 
 // GetConfigurationProfile retrieves a configuration profile.
-func (b *InMemoryBackend) GetConfigurationProfile(applicationID, profileID string) (*ConfigurationProfile, error) {
+func (b *InMemoryBackend) GetConfigurationProfile(
+	applicationID, profileID string,
+) (*ConfigurationProfile, error) {
 	b.mu.RLock("GetConfigurationProfile")
 	defer b.mu.RUnlock()
 
 	profiles, ok := b.configProfiles[applicationID]
 	if !ok {
-		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return nil, fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	profile, ok := profiles[profileID]
 	if !ok {
-		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return nil, fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	cp := *profile
@@ -433,12 +466,20 @@ func (b *InMemoryBackend) UpdateConfigurationProfile(
 
 	profiles, ok := b.configProfiles[applicationID]
 	if !ok {
-		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return nil, fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	profile, ok := profiles[profileID]
 	if !ok {
-		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return nil, fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	if name != "" {
@@ -458,11 +499,19 @@ func (b *InMemoryBackend) DeleteConfigurationProfile(applicationID, profileID st
 
 	profiles, ok := b.configProfiles[applicationID]
 	if !ok {
-		return fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	if _, exists := profiles[profileID]; !exists {
-		return fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	delete(profiles, profileID)
@@ -482,7 +531,11 @@ func (b *InMemoryBackend) CreateHostedConfigurationVersion(
 	defer b.mu.Unlock()
 
 	if len(content) > maxHostedConfigSizeBytes {
-		return nil, fmt.Errorf("%w: content exceeds maximum size of %d bytes", ErrPayloadTooLarge, maxHostedConfigSizeBytes)
+		return nil, fmt.Errorf(
+			"%w: content exceeds maximum size of %d bytes",
+			ErrPayloadTooLarge,
+			maxHostedConfigSizeBytes,
+		)
 	}
 
 	if _, ok := b.applications[applicationID]; !ok {
@@ -491,15 +544,23 @@ func (b *InMemoryBackend) CreateHostedConfigurationVersion(
 
 	profiles, ok := b.configProfiles[applicationID]
 	if !ok || profiles[profileID] == nil {
-		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return nil, fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	if b.hostedConfigVersions[applicationID] == nil {
-		b.hostedConfigVersions[applicationID] = make(map[string]map[int32]*HostedConfigurationVersion)
+		b.hostedConfigVersions[applicationID] = make(
+			map[string]map[int32]*HostedConfigurationVersion,
+		)
 	}
 
 	if b.hostedConfigVersions[applicationID][profileID] == nil {
-		b.hostedConfigVersions[applicationID][profileID] = make(map[int32]*HostedConfigurationVersion)
+		b.hostedConfigVersions[applicationID][profileID] = make(
+			map[int32]*HostedConfigurationVersion,
+		)
 	}
 
 	if b.versionCounters[applicationID] == nil {
@@ -510,7 +571,12 @@ func (b *InMemoryBackend) CreateHostedConfigurationVersion(
 	if versionLabel != "" {
 		for _, v := range b.hostedConfigVersions[applicationID][profileID] {
 			if v.VersionLabel == versionLabel {
-				return nil, fmt.Errorf("%w: version label %q already exists for profile %s", ErrConflict, versionLabel, profileID)
+				return nil, fmt.Errorf(
+					"%w: version label %q already exists for profile %s",
+					ErrConflict,
+					versionLabel,
+					profileID,
+				)
 			}
 		}
 	}
@@ -574,7 +640,11 @@ func (b *InMemoryBackend) ListHostedConfigurationVersions(
 	}
 
 	if _, ok := b.configProfiles[applicationID][profileID]; !ok {
-		return nil, "", fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return nil, "", fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	profileVersions := b.hostedConfigVersions[applicationID][profileID]
@@ -596,7 +666,10 @@ func (b *InMemoryBackend) ListHostedConfigurationVersions(
 }
 
 // DeleteHostedConfigurationVersion deletes a hosted configuration version.
-func (b *InMemoryBackend) DeleteHostedConfigurationVersion(applicationID, profileID string, versionNumber int32) error {
+func (b *InMemoryBackend) DeleteHostedConfigurationVersion(
+	applicationID, profileID string,
+	versionNumber int32,
+) error {
 	b.mu.Lock("DeleteHostedConfigurationVersion")
 	defer b.mu.Unlock()
 
@@ -635,7 +708,11 @@ func (b *InMemoryBackend) CreateDeploymentStrategy(
 
 	for _, s := range b.deploymentStrategies {
 		if s.Name == name {
-			return nil, fmt.Errorf("%w: deployment strategy with name %q already exists", ErrConflict, name)
+			return nil, fmt.Errorf(
+				"%w: deployment strategy with name %q already exists",
+				ErrConflict,
+				name,
+			)
 		}
 	}
 
@@ -665,7 +742,11 @@ func (b *InMemoryBackend) GetDeploymentStrategy(strategyID string) (*DeploymentS
 
 	strategy, ok := b.deploymentStrategies[strategyID]
 	if !ok {
-		return nil, fmt.Errorf("%w: deployment strategy %s", ErrDeploymentStrategyNotFound, strategyID)
+		return nil, fmt.Errorf(
+			"%w: deployment strategy %s",
+			ErrDeploymentStrategyNotFound,
+			strategyID,
+		)
 	}
 
 	cp := *strategy
@@ -674,7 +755,10 @@ func (b *InMemoryBackend) GetDeploymentStrategy(strategyID string) (*DeploymentS
 }
 
 // ListDeploymentStrategies returns paginated deployment strategies.
-func (b *InMemoryBackend) ListDeploymentStrategies(nextToken string, maxResults int) ([]DeploymentStrategy, string) {
+func (b *InMemoryBackend) ListDeploymentStrategies(
+	nextToken string,
+	maxResults int,
+) ([]DeploymentStrategy, string) {
 	b.mu.RLock("ListDeploymentStrategies")
 	defer b.mu.RUnlock()
 
@@ -701,7 +785,11 @@ func (b *InMemoryBackend) UpdateDeploymentStrategy(
 
 	strategy, ok := b.deploymentStrategies[strategyID]
 	if !ok {
-		return nil, fmt.Errorf("%w: deployment strategy %s", ErrDeploymentStrategyNotFound, strategyID)
+		return nil, fmt.Errorf(
+			"%w: deployment strategy %s",
+			ErrDeploymentStrategyNotFound,
+			strategyID,
+		)
 	}
 
 	if name != "" {
@@ -748,12 +836,21 @@ func (b *InMemoryBackend) StartDeployment(
 		return nil, fmt.Errorf("%w: environment %s", ErrEnvironmentNotFound, environmentID)
 	}
 
-	if profiles := b.configProfiles[applicationID]; profiles == nil || profiles[configProfileID] == nil {
-		return nil, fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, configProfileID)
+	if profiles := b.configProfiles[applicationID]; profiles == nil ||
+		profiles[configProfileID] == nil {
+		return nil, fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			configProfileID,
+		)
 	}
 
 	if _, ok := b.deploymentStrategies[strategyID]; !ok {
-		return nil, fmt.Errorf("%w: deployment strategy %s", ErrDeploymentStrategyNotFound, strategyID)
+		return nil, fmt.Errorf(
+			"%w: deployment strategy %s",
+			ErrDeploymentStrategyNotFound,
+			strategyID,
+		)
 	}
 
 	if b.deployments[applicationID] == nil {
@@ -781,7 +878,7 @@ func (b *InMemoryBackend) StartDeployment(
 		Description:            description,
 		State:                  "COMPLETE",
 		TriggeredBy:            "USER",
-		PercentageComplete:     100.0,
+		PercentageComplete:     100.0, //nolint:mnd // 100% complete
 		DeploymentNumber:       deploymentNumber,
 		StartedAt:              now,
 		CompletedAt:            now,
@@ -844,7 +941,10 @@ func (b *InMemoryBackend) ListDeployments(
 		out = append(out, *d)
 	}
 
-	sort.Slice(out, func(i, j int) bool { return out[i].DeploymentNumber < out[j].DeploymentNumber })
+	sort.Slice(
+		out,
+		func(i, j int) bool { return out[i].DeploymentNumber < out[j].DeploymentNumber },
+	)
 
 	page, token := appConfigPaginate(out, nextToken, b.paginationSecret, maxResults)
 
@@ -852,14 +952,17 @@ func (b *InMemoryBackend) ListDeployments(
 }
 
 // stoppableDeploymentStates are the states from which a deployment can be stopped.
-var stoppableDeploymentStates = map[string]bool{
-	"BAKING":      true,
-	"DEPLOYING":   true,
-	"VALIDATING":  true,
+var stoppableDeploymentStates = map[string]bool{ //nolint:gochecknoglobals // compile-time constant map
+	"BAKING":     true,
+	"DEPLOYING":  true,
+	"VALIDATING": true,
 }
 
 // StopDeployment stops an in-progress deployment.
-func (b *InMemoryBackend) StopDeployment(applicationID, environmentID string, deploymentNumber int32) error {
+func (b *InMemoryBackend) StopDeployment(
+	applicationID, environmentID string,
+	deploymentNumber int32,
+) error {
 	b.mu.Lock("StopDeployment")
 	defer b.mu.Unlock()
 
@@ -949,7 +1052,11 @@ func (b *InMemoryBackend) CreateExtension(
 	// Enforce name uniqueness.
 	for _, ext := range b.extensions {
 		if ext.Name == name {
-			return nil, fmt.Errorf("%w: extension with name %s already exists", ErrExtensionAlreadyExists, name)
+			return nil, fmt.Errorf(
+				"%w: extension with name %s already exists",
+				ErrExtensionAlreadyExists,
+				name,
+			)
 		}
 	}
 
@@ -1000,7 +1107,12 @@ func (b *InMemoryBackend) GetExtension(extensionIdentifier string) (*Extension, 
 }
 
 // ListExtensions returns paginated extensions, optionally filtered by name and/or version number.
-func (b *InMemoryBackend) ListExtensions(nextToken string, maxResults int, nameFilter string, versionNumber int32) ([]Extension, string) {
+func (b *InMemoryBackend) ListExtensions(
+	nextToken string,
+	maxResults int,
+	nameFilter string,
+	versionNumber int32,
+) ([]Extension, string) {
 	b.mu.RLock("ListExtensions")
 	defer b.mu.RUnlock()
 
@@ -1114,13 +1226,19 @@ func (b *InMemoryBackend) CreateExtensionAssociation(
 }
 
 // GetExtensionAssociation retrieves an extension association by ID.
-func (b *InMemoryBackend) GetExtensionAssociation(extensionAssociationID string) (*ExtensionAssociation, error) {
+func (b *InMemoryBackend) GetExtensionAssociation(
+	extensionAssociationID string,
+) (*ExtensionAssociation, error) {
 	b.mu.RLock("GetExtensionAssociation")
 	defer b.mu.RUnlock()
 
 	assoc, ok := b.extensionAssociations[extensionAssociationID]
 	if !ok {
-		return nil, fmt.Errorf("%w: extension association %s", ErrExtensionAssociationNotFound, extensionAssociationID)
+		return nil, fmt.Errorf(
+			"%w: extension association %s",
+			ErrExtensionAssociationNotFound,
+			extensionAssociationID,
+		)
 	}
 
 	cp := *assoc
@@ -1130,7 +1248,10 @@ func (b *InMemoryBackend) GetExtensionAssociation(extensionAssociationID string)
 
 // ListExtensionAssociations returns paginated extension associations,
 // optionally filtered by extensionIdentifier (ARN prefix) and/or resourceIdentifier (ARN prefix).
-func (b *InMemoryBackend) ListExtensionAssociations(nextToken, extensionIdentifier, resourceIdentifier string, maxResults int) ([]ExtensionAssociation, string) {
+func (b *InMemoryBackend) ListExtensionAssociations(
+	nextToken, extensionIdentifier, resourceIdentifier string,
+	maxResults int,
+) ([]ExtensionAssociation, string) {
 	b.mu.RLock("ListExtensionAssociations")
 	defer b.mu.RUnlock()
 
@@ -1161,7 +1282,11 @@ func (b *InMemoryBackend) DeleteExtensionAssociation(extensionAssociationID stri
 
 	assoc, ok := b.extensionAssociations[extensionAssociationID]
 	if !ok {
-		return fmt.Errorf("%w: extension association %s", ErrExtensionAssociationNotFound, extensionAssociationID)
+		return fmt.Errorf(
+			"%w: extension association %s",
+			ErrExtensionAssociationNotFound,
+			extensionAssociationID,
+		)
 	}
 
 	delete(b.extensionAssociations, extensionAssociationID)
@@ -1206,7 +1331,11 @@ func (b *InMemoryBackend) UpdateExtensionAssociation(
 
 	assoc, ok := b.extensionAssociations[extensionAssociationID]
 	if !ok {
-		return nil, fmt.Errorf("%w: extension association %s", ErrExtensionAssociationNotFound, extensionAssociationID)
+		return nil, fmt.Errorf(
+			"%w: extension association %s",
+			ErrExtensionAssociationNotFound,
+			extensionAssociationID,
+		)
 	}
 
 	if parameters != nil {
@@ -1231,7 +1360,11 @@ func (b *InMemoryBackend) ValidateConfiguration(applicationID, profileID, _ stri
 
 	profiles, ok := b.configProfiles[applicationID]
 	if !ok || profiles[profileID] == nil {
-		return fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, profileID)
+		return fmt.Errorf(
+			"%w: configuration profile %s",
+			ErrConfigurationProfileNotFound,
+			profileID,
+		)
 	}
 
 	return nil
@@ -1292,7 +1425,11 @@ func (b *InMemoryBackend) resolveProfileID(appID, identifier string) (string, er
 		}
 	}
 
-	return "", fmt.Errorf("%w: configuration profile %s", ErrConfigurationProfileNotFound, identifier)
+	return "", fmt.Errorf(
+		"%w: configuration profile %s",
+		ErrConfigurationProfileNotFound,
+		identifier,
+	)
 }
 
 // latestConfigVersion returns the latest hosted configuration version for a profile. Must be called under lock.

--- a/services/appconfig/backend_iface.go
+++ b/services/appconfig/backend_iface.go
@@ -17,7 +17,10 @@ type StorageBackend interface {
 	DeleteApplication(applicationID string) error
 
 	// CreateEnvironment creates a new environment within an application.
-	CreateEnvironment(applicationID, name, description string, monitors []Monitor) (*Environment, error)
+	CreateEnvironment(
+		applicationID, name, description string,
+		monitors []Monitor,
+	) (*Environment, error)
 	// GetEnvironment retrieves an environment by application and environment ID.
 	GetEnvironment(applicationID, environmentID string) (*Environment, error)
 	// ListEnvironments returns paginated environments for an application.
@@ -35,9 +38,14 @@ type StorageBackend interface {
 	// GetConfigurationProfile retrieves a configuration profile.
 	GetConfigurationProfile(applicationID, profileID string) (*ConfigurationProfile, error)
 	// ListConfigurationProfiles returns paginated profiles for an application.
-	ListConfigurationProfiles(applicationID, nextToken string, maxResults int) ([]ConfigurationProfile, string, error)
+	ListConfigurationProfiles(
+		applicationID, nextToken string,
+		maxResults int,
+	) ([]ConfigurationProfile, string, error)
 	// UpdateConfigurationProfile updates a configuration profile.
-	UpdateConfigurationProfile(applicationID, profileID, name, description string) (*ConfigurationProfile, error)
+	UpdateConfigurationProfile(
+		applicationID, profileID, name, description string,
+	) (*ConfigurationProfile, error)
 	// DeleteConfigurationProfile deletes a configuration profile.
 	DeleteConfigurationProfile(applicationID, profileID string) error
 
@@ -86,7 +94,10 @@ type StorageBackend interface {
 	// GetDeployment retrieves a deployment by application, environment, and deployment number.
 	GetDeployment(applicationID, environmentID string, deploymentNumber int32) (*Deployment, error)
 	// ListDeployments returns paginated deployments for an environment.
-	ListDeployments(applicationID, environmentID, nextToken string, maxResults int) ([]Deployment, string, error)
+	ListDeployments(
+		applicationID, environmentID, nextToken string,
+		maxResults int,
+	) ([]Deployment, string, error)
 	// StopDeployment stops an in-progress deployment.
 	StopDeployment(applicationID, environmentID string, deploymentNumber int32) error
 
@@ -106,7 +117,12 @@ type StorageBackend interface {
 	// GetExtension retrieves an extension by identifier (ID or name).
 	GetExtension(extensionIdentifier string) (*Extension, error)
 	// ListExtensions returns paginated extensions, optionally filtered by name and/or version.
-	ListExtensions(nextToken string, maxResults int, nameFilter string, versionNumber int32) ([]Extension, string)
+	ListExtensions(
+		nextToken string,
+		maxResults int,
+		nameFilter string,
+		versionNumber int32,
+	) ([]Extension, string)
 	// UpdateExtension updates an extension's description, actions, and parameters.
 	UpdateExtension(
 		extensionIdentifier, description string,
@@ -125,7 +141,10 @@ type StorageBackend interface {
 	// GetExtensionAssociation retrieves an extension association by ID.
 	GetExtensionAssociation(extensionAssociationID string) (*ExtensionAssociation, error)
 	// ListExtensionAssociations returns paginated extension associations.
-	ListExtensionAssociations(nextToken, extensionIdentifier, resourceIdentifier string, maxResults int) ([]ExtensionAssociation, string)
+	ListExtensionAssociations(
+		nextToken, extensionIdentifier, resourceIdentifier string,
+		maxResults int,
+	) ([]ExtensionAssociation, string)
 	// UpdateExtensionAssociation updates an extension association's parameters.
 	UpdateExtensionAssociation(
 		extensionAssociationID string,
@@ -140,7 +159,9 @@ type StorageBackend interface {
 	UpdateAccountSettings(deletionProtection *DeletionProtectionSettings) (*AccountSettings, error)
 
 	// GetConfiguration retrieves the latest deployed configuration (deprecated API).
-	GetConfiguration(application, environment, configuration string) (*HostedConfigurationVersion, error)
+	GetConfiguration(
+		application, environment, configuration string,
+	) (*HostedConfigurationVersion, error)
 	// ValidateConfiguration validates a configuration version against its validators.
 	ValidateConfiguration(applicationID, profileID, configurationVersion string) error
 }

--- a/services/appconfig/backend_iface.go
+++ b/services/appconfig/backend_iface.go
@@ -17,7 +17,7 @@ type StorageBackend interface {
 	DeleteApplication(applicationID string) error
 
 	// CreateEnvironment creates a new environment within an application.
-	CreateEnvironment(applicationID, name, description string) (*Environment, error)
+	CreateEnvironment(applicationID, name, description string, monitors []Monitor) (*Environment, error)
 	// GetEnvironment retrieves an environment by application and environment ID.
 	GetEnvironment(applicationID, environmentID string) (*Environment, error)
 	// ListEnvironments returns paginated environments for an application.
@@ -29,7 +29,8 @@ type StorageBackend interface {
 
 	// CreateConfigurationProfile creates a new configuration profile.
 	CreateConfigurationProfile(
-		applicationID, name, description, locationURI, profileType string,
+		applicationID, name, description, locationURI, profileType, retrievalRoleArn string,
+		validators []Validator,
 	) (*ConfigurationProfile, error)
 	// GetConfigurationProfile retrieves a configuration profile.
 	GetConfigurationProfile(applicationID, profileID string) (*ConfigurationProfile, error)
@@ -42,7 +43,7 @@ type StorageBackend interface {
 
 	// CreateHostedConfigurationVersion creates a hosted configuration version.
 	CreateHostedConfigurationVersion(
-		applicationID, profileID, contentType string,
+		applicationID, profileID, contentType, description, versionLabel string,
 		content []byte,
 	) (*HostedConfigurationVersion, error)
 	// GetHostedConfigurationVersion retrieves a hosted configuration version.
@@ -52,7 +53,7 @@ type StorageBackend interface {
 	) (*HostedConfigurationVersion, error)
 	// ListHostedConfigurationVersions returns paginated versions for a profile.
 	ListHostedConfigurationVersions(
-		applicationID, profileID, nextToken string,
+		applicationID, profileID, nextToken, versionLabel string,
 		maxResults int,
 	) ([]HostedConfigurationVersion, string, error)
 	// DeleteHostedConfigurationVersion deletes a hosted configuration version.
@@ -80,7 +81,7 @@ type StorageBackend interface {
 
 	// StartDeployment starts a deployment.
 	StartDeployment(
-		applicationID, environmentID, configProfileID, strategyID, configVersion string,
+		applicationID, environmentID, configProfileID, strategyID, configVersion, description string,
 	) (*Deployment, error)
 	// GetDeployment retrieves a deployment by application, environment, and deployment number.
 	GetDeployment(applicationID, environmentID string, deploymentNumber int32) (*Deployment, error)
@@ -104,8 +105,8 @@ type StorageBackend interface {
 	) (*Extension, error)
 	// GetExtension retrieves an extension by identifier (ID or name).
 	GetExtension(extensionIdentifier string) (*Extension, error)
-	// ListExtensions returns paginated extensions, optionally filtered by name.
-	ListExtensions(nextToken string, maxResults int, nameFilter string) ([]Extension, string)
+	// ListExtensions returns paginated extensions, optionally filtered by name and/or version.
+	ListExtensions(nextToken string, maxResults int, nameFilter string, versionNumber int32) ([]Extension, string)
 	// UpdateExtension updates an extension's description, actions, and parameters.
 	UpdateExtension(
 		extensionIdentifier, description string,
@@ -124,7 +125,7 @@ type StorageBackend interface {
 	// GetExtensionAssociation retrieves an extension association by ID.
 	GetExtensionAssociation(extensionAssociationID string) (*ExtensionAssociation, error)
 	// ListExtensionAssociations returns paginated extension associations.
-	ListExtensionAssociations(nextToken string, maxResults int) ([]ExtensionAssociation, string)
+	ListExtensionAssociations(nextToken, extensionIdentifier, resourceIdentifier string, maxResults int) ([]ExtensionAssociation, string)
 	// UpdateExtensionAssociation updates an extension association's parameters.
 	UpdateExtensionAssociation(
 		extensionAssociationID string,

--- a/services/appconfig/backend_iface.go
+++ b/services/appconfig/backend_iface.go
@@ -2,6 +2,9 @@ package appconfig
 
 // StorageBackend defines the operations supported by the AppConfig in-memory backend.
 type StorageBackend interface {
+	// PaginationSecret returns the HMAC secret used to sign pagination tokens.
+	PaginationSecret() string
+
 	// CreateApplication creates a new AppConfig application.
 	CreateApplication(name, description string) (*Application, error)
 	// GetApplication retrieves an application by ID.

--- a/services/appconfig/handler.go
+++ b/services/appconfig/handler.go
@@ -304,9 +304,15 @@ func parseExtensionAssociationRoute(method string, parts []string) appConfigRout
 	case http.MethodGet:
 		return appConfigRoute{extensionAssociationID: assocID, operation: opGetExtensionAssociation}
 	case http.MethodPatch:
-		return appConfigRoute{extensionAssociationID: assocID, operation: opUpdateExtensionAssociation}
+		return appConfigRoute{
+			extensionAssociationID: assocID,
+			operation:              opUpdateExtensionAssociation,
+		}
 	case http.MethodDelete:
-		return appConfigRoute{extensionAssociationID: assocID, operation: opDeleteExtensionAssociation}
+		return appConfigRoute{
+			extensionAssociationID: assocID,
+			operation:              opDeleteExtensionAssociation,
+		}
 	}
 
 	return appConfigRoute{extensionAssociationID: assocID, operation: opUnknown}
@@ -419,11 +425,23 @@ func parseEnvironmentRoute(method, appID string, parts []string) appConfigRoute 
 func parseEnvIDRoute(method, appID, envID string) appConfigRoute {
 	switch method {
 	case http.MethodGet:
-		return appConfigRoute{applicationID: appID, environmentID: envID, operation: opGetEnvironment}
+		return appConfigRoute{
+			applicationID: appID,
+			environmentID: envID,
+			operation:     opGetEnvironment,
+		}
 	case http.MethodPatch:
-		return appConfigRoute{applicationID: appID, environmentID: envID, operation: opUpdateEnvironment}
+		return appConfigRoute{
+			applicationID: appID,
+			environmentID: envID,
+			operation:     opUpdateEnvironment,
+		}
 	case http.MethodDelete:
-		return appConfigRoute{applicationID: appID, environmentID: envID, operation: opDeleteEnvironment}
+		return appConfigRoute{
+			applicationID: appID,
+			environmentID: envID,
+			operation:     opDeleteEnvironment,
+		}
 	}
 
 	return appConfigRoute{applicationID: appID, environmentID: envID, operation: opUnknown}
@@ -436,9 +454,17 @@ func parseDeploymentRoute(method, appID, envID string, parts []string) appConfig
 	if len(parts) == pathPartsDeepLevel {
 		switch method {
 		case http.MethodPost:
-			return appConfigRoute{applicationID: appID, environmentID: envID, operation: opStartDeployment}
+			return appConfigRoute{
+				applicationID: appID,
+				environmentID: envID,
+				operation:     opStartDeployment,
+			}
 		case http.MethodGet:
-			return appConfigRoute{applicationID: appID, environmentID: envID, operation: opListDeployments}
+			return appConfigRoute{
+				applicationID: appID,
+				environmentID: envID,
+				operation:     opListDeployments,
+			}
 		}
 
 		return appConfigRoute{applicationID: appID, environmentID: envID, operation: opUnknown}
@@ -468,7 +494,12 @@ func parseDeploymentRoute(method, appID, envID string, parts []string) appConfig
 		}
 	}
 
-	return appConfigRoute{applicationID: appID, environmentID: envID, deploymentNum: num, operation: opUnknown}
+	return appConfigRoute{
+		applicationID: appID,
+		environmentID: envID,
+		deploymentNum: num,
+		operation:     opUnknown,
+	}
 }
 
 // parseConfigProfileRoute parses configuration profile routes.
@@ -510,11 +541,23 @@ func parseConfigProfileRoute(method, appID string, parts []string) appConfigRout
 func parseProfileIDRoute(method, appID, profileID string) appConfigRoute {
 	switch method {
 	case http.MethodGet:
-		return appConfigRoute{applicationID: appID, profileID: profileID, operation: opGetConfigurationProfile}
+		return appConfigRoute{
+			applicationID: appID,
+			profileID:     profileID,
+			operation:     opGetConfigurationProfile,
+		}
 	case http.MethodPatch:
-		return appConfigRoute{applicationID: appID, profileID: profileID, operation: opUpdateConfigurationProfile}
+		return appConfigRoute{
+			applicationID: appID,
+			profileID:     profileID,
+			operation:     opUpdateConfigurationProfile,
+		}
 	case http.MethodDelete:
-		return appConfigRoute{applicationID: appID, profileID: profileID, operation: opDeleteConfigurationProfile}
+		return appConfigRoute{
+			applicationID: appID,
+			profileID:     profileID,
+			operation:     opDeleteConfigurationProfile,
+		}
 	}
 
 	return appConfigRoute{applicationID: appID, profileID: profileID, operation: opUnknown}
@@ -567,7 +610,12 @@ func parseHostedVersionRoute(method, appID, profileID string, parts []string) ap
 		}
 	}
 
-	return appConfigRoute{applicationID: appID, profileID: profileID, versionNumber: num, operation: opUnknown}
+	return appConfigRoute{
+		applicationID: appID,
+		profileID:     profileID,
+		versionNumber: num,
+		operation:     opUnknown,
+	}
 }
 
 // Handler returns the Echo handler function for AppConfig operations.
@@ -612,7 +660,12 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		case opCreateHostedConfigurationVersion:
 			return h.handleCreateHostedConfigurationVersion(c, route.applicationID, route.profileID)
 		case opGetHostedConfigurationVersion:
-			return h.handleGetHostedConfigurationVersion(c, route.applicationID, route.profileID, route.versionNumber)
+			return h.handleGetHostedConfigurationVersion(
+				c,
+				route.applicationID,
+				route.profileID,
+				route.versionNumber,
+			)
 		case opListHostedConfigurationVersions:
 			return h.handleListHostedConfigurationVersions(c, route.applicationID, route.profileID)
 		case opDeleteHostedConfigurationVersion:
@@ -635,11 +688,21 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		case opStartDeployment:
 			return h.handleStartDeployment(c, route.applicationID, route.environmentID)
 		case opGetDeployment:
-			return h.handleGetDeployment(c, route.applicationID, route.environmentID, route.deploymentNum)
+			return h.handleGetDeployment(
+				c,
+				route.applicationID,
+				route.environmentID,
+				route.deploymentNum,
+			)
 		case opListDeployments:
 			return h.handleListDeployments(c, route.applicationID, route.environmentID)
 		case opStopDeployment:
-			return h.handleStopDeployment(c, route.applicationID, route.environmentID, route.deploymentNum)
+			return h.handleStopDeployment(
+				c,
+				route.applicationID,
+				route.environmentID,
+				route.deploymentNum,
+			)
 		case opListTagsForResource:
 			return h.handleListTagsForResource(c, route.resourceArn)
 		case opTagResource:
@@ -671,11 +734,22 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		case opUpdateAccountSettings:
 			return h.handleUpdateAccountSettings(c)
 		case opGetConfiguration:
-			return h.handleGetConfiguration(c, route.applicationID, route.environmentID, route.configurationID)
+			return h.handleGetConfiguration(
+				c,
+				route.applicationID,
+				route.environmentID,
+				route.configurationID,
+			)
 		case opValidateConfiguration:
 			return h.handleValidateConfiguration(c, route.applicationID, route.profileID)
 		default:
-			log.Warn("appconfig: unmatched route", "method", c.Request().Method, "path", c.Request().URL.Path)
+			log.Warn(
+				"appconfig: unmatched route",
+				"method",
+				c.Request().Method,
+				"path",
+				c.Request().URL.Path,
+			)
 
 			return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: "not found"})
 		}
@@ -700,7 +774,10 @@ func (h *Handler) handleCreateApplication(c *echo.Context) error {
 		Description string `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	app, err := h.Backend.CreateApplication(req.Name, req.Description)
@@ -713,7 +790,10 @@ func (h *Handler) handleCreateApplication(c *echo.Context) error {
 			return conflictResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, app)
@@ -726,7 +806,10 @@ func (h *Handler) handleGetApplication(c *echo.Context, applicationID string) er
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, app)
@@ -750,7 +833,10 @@ func (h *Handler) handleUpdateApplication(c *echo.Context, applicationID string)
 		Description string `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	app, err := h.Backend.UpdateApplication(applicationID, req.Name, req.Description)
@@ -759,7 +845,10 @@ func (h *Handler) handleUpdateApplication(c *echo.Context, applicationID string)
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, app)
@@ -771,7 +860,10 @@ func (h *Handler) handleDeleteApplication(c *echo.Context, applicationID string)
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -779,12 +871,15 @@ func (h *Handler) handleDeleteApplication(c *echo.Context, applicationID string)
 
 func (h *Handler) handleCreateEnvironment(c *echo.Context, applicationID string) error {
 	var req struct {
-		Monitors    []Monitor `json:"Monitors"`
 		Name        string    `json:"Name"`
 		Description string    `json:"Description"`
+		Monitors    []Monitor `json:"Monitors"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	env, err := h.Backend.CreateEnvironment(applicationID, req.Name, req.Description, req.Monitors)
@@ -801,7 +896,10 @@ func (h *Handler) handleCreateEnvironment(c *echo.Context, applicationID string)
 			return badRequestResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, env)
@@ -814,7 +912,10 @@ func (h *Handler) handleGetEnvironment(c *echo.Context, applicationID, environme
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, env)
@@ -829,7 +930,10 @@ func (h *Handler) handleListEnvironments(c *echo.Context, applicationID string) 
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	resp := map[string]any{keyItems: envs}
@@ -840,13 +944,19 @@ func (h *Handler) handleListEnvironments(c *echo.Context, applicationID string) 
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (h *Handler) handleUpdateEnvironment(c *echo.Context, applicationID, environmentID string) error {
+func (h *Handler) handleUpdateEnvironment(
+	c *echo.Context,
+	applicationID, environmentID string,
+) error {
 	var req struct {
 		Name        string `json:"Name"`
 		Description string `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	env, err := h.Backend.UpdateEnvironment(applicationID, environmentID, req.Name, req.Description)
@@ -855,19 +965,28 @@ func (h *Handler) handleUpdateEnvironment(c *echo.Context, applicationID, enviro
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, env)
 }
 
-func (h *Handler) handleDeleteEnvironment(c *echo.Context, applicationID, environmentID string) error {
+func (h *Handler) handleDeleteEnvironment(
+	c *echo.Context,
+	applicationID, environmentID string,
+) error {
 	if err := h.Backend.DeleteEnvironment(applicationID, environmentID); err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -875,15 +994,18 @@ func (h *Handler) handleDeleteEnvironment(c *echo.Context, applicationID, enviro
 
 func (h *Handler) handleCreateConfigurationProfile(c *echo.Context, applicationID string) error {
 	var req struct {
-		Validators       []Validator `json:"Validators"`
 		Name             string      `json:"Name"`
 		Description      string      `json:"Description"`
 		LocationURI      string      `json:"LocationUri"`
 		Type             string      `json:"Type"`
 		RetrievalRoleArn string      `json:"RetrievalRoleArn"`
+		Validators       []Validator `json:"Validators"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	profile, err := h.Backend.CreateConfigurationProfile(
@@ -908,20 +1030,29 @@ func (h *Handler) handleCreateConfigurationProfile(c *echo.Context, applicationI
 			return badRequestResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, profile)
 }
 
-func (h *Handler) handleGetConfigurationProfile(c *echo.Context, applicationID, profileID string) error {
+func (h *Handler) handleGetConfigurationProfile(
+	c *echo.Context,
+	applicationID, profileID string,
+) error {
 	profile, err := h.Backend.GetConfigurationProfile(applicationID, profileID)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, profile)
@@ -929,14 +1060,21 @@ func (h *Handler) handleGetConfigurationProfile(c *echo.Context, applicationID, 
 
 func (h *Handler) handleListConfigurationProfiles(c *echo.Context, applicationID string) error {
 	nextToken, maxResults := appConfigPaginationParams(c)
-	profiles, outToken, err := h.Backend.ListConfigurationProfiles(applicationID, nextToken, maxResults)
+	profiles, outToken, err := h.Backend.ListConfigurationProfiles(
+		applicationID,
+		nextToken,
+		maxResults,
+	)
 
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	resp := map[string]any{keyItems: profiles}
@@ -947,40 +1085,63 @@ func (h *Handler) handleListConfigurationProfiles(c *echo.Context, applicationID
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (h *Handler) handleUpdateConfigurationProfile(c *echo.Context, applicationID, profileID string) error {
+func (h *Handler) handleUpdateConfigurationProfile(
+	c *echo.Context,
+	applicationID, profileID string,
+) error {
 	var req struct {
 		Name        string `json:"Name"`
 		Description string `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
-	profile, err := h.Backend.UpdateConfigurationProfile(applicationID, profileID, req.Name, req.Description)
+	profile, err := h.Backend.UpdateConfigurationProfile(
+		applicationID,
+		profileID,
+		req.Name,
+		req.Description,
+	)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, profile)
 }
 
-func (h *Handler) handleDeleteConfigurationProfile(c *echo.Context, applicationID, profileID string) error {
+func (h *Handler) handleDeleteConfigurationProfile(
+	c *echo.Context,
+	applicationID, profileID string,
+) error {
 	if err := h.Backend.DeleteConfigurationProfile(applicationID, profileID); err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
 }
 
-func (h *Handler) handleCreateHostedConfigurationVersion(c *echo.Context, applicationID, profileID string) error {
+func (h *Handler) handleCreateHostedConfigurationVersion(
+	c *echo.Context,
+	applicationID, profileID string,
+) error {
 	contentType := c.Request().Header.Get("Content-Type")
 	if contentType == "" {
 		contentType = "application/octet-stream"
@@ -988,14 +1149,24 @@ func (h *Handler) handleCreateHostedConfigurationVersion(c *echo.Context, applic
 
 	// AWS AppConfig accepts description and version label via custom request headers.
 	description := c.Request().Header.Get("Description")
-	versionLabel := c.Request().Header.Get("VersionLabel")
+	versionLabel := c.Request().Header.Get("Versionlabel")
 
 	content, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: "failed to read request body"})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: "failed to read request body"},
+		)
 	}
 
-	v, err := h.Backend.CreateHostedConfigurationVersion(applicationID, profileID, contentType, description, versionLabel, content)
+	v, err := h.Backend.CreateHostedConfigurationVersion(
+		applicationID,
+		profileID,
+		contentType,
+		description,
+		versionLabel,
+		content,
+	)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
@@ -1009,7 +1180,10 @@ func (h *Handler) handleCreateHostedConfigurationVersion(c *echo.Context, applic
 			return badRequestResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	c.Response().Header().Set("Appconfig-Configuration-Version", strconv.Itoa(int(v.VersionNumber)))
@@ -1028,7 +1202,10 @@ func (h *Handler) handleGetHostedConfigurationVersion(
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	c.Response().Header().Set("Content-Type", v.ContentType)
@@ -1037,7 +1214,10 @@ func (h *Handler) handleGetHostedConfigurationVersion(
 	return c.Blob(http.StatusOK, v.ContentType, v.Content)
 }
 
-func (h *Handler) handleListHostedConfigurationVersions(c *echo.Context, applicationID, profileID string) error {
+func (h *Handler) handleListHostedConfigurationVersions(
+	c *echo.Context,
+	applicationID, profileID string,
+) error {
 	nextToken, maxResults := appConfigPaginationParams(c)
 	versionLabel := c.Request().URL.Query().Get("version_label")
 	versions, outToken, err := h.Backend.ListHostedConfigurationVersions(
@@ -1053,7 +1233,10 @@ func (h *Handler) handleListHostedConfigurationVersions(c *echo.Context, applica
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	resp := map[string]any{keyItems: versions}
@@ -1074,7 +1257,10 @@ func (h *Handler) handleDeleteHostedConfigurationVersion(
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -1091,7 +1277,10 @@ func (h *Handler) handleCreateDeploymentStrategy(c *echo.Context) error {
 		GrowthFactor                float32 `json:"GrowthFactor"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	strategy, err := h.Backend.CreateDeploymentStrategy(
@@ -1100,7 +1289,10 @@ func (h *Handler) handleCreateDeploymentStrategy(c *echo.Context) error {
 		req.GrowthFactor, req.GrowthType, req.ReplicateTo,
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, strategy)
@@ -1113,7 +1305,10 @@ func (h *Handler) handleGetDeploymentStrategy(c *echo.Context, strategyID string
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, strategy)
@@ -1140,7 +1335,10 @@ func (h *Handler) handleUpdateDeploymentStrategy(c *echo.Context, strategyID str
 		Description                 string   `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	// Fetch current values to use as defaults for omitted pointer fields.
@@ -1150,7 +1348,10 @@ func (h *Handler) handleUpdateDeploymentStrategy(c *echo.Context, strategyID str
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	deployDur := existing.DeploymentDurationInMinutes
@@ -1178,7 +1379,10 @@ func (h *Handler) handleUpdateDeploymentStrategy(c *echo.Context, strategyID str
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, strategy)
@@ -1190,13 +1394,19 @@ func (h *Handler) handleDeleteDeploymentStrategy(c *echo.Context, strategyID str
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
 }
 
-func (h *Handler) handleStartDeployment(c *echo.Context, applicationID, environmentID string) error {
+func (h *Handler) handleStartDeployment(
+	c *echo.Context,
+	applicationID, environmentID string,
+) error {
 	var req struct {
 		ConfigurationProfileID string `json:"ConfigurationProfileId"`
 		DeploymentStrategyID   string `json:"DeploymentStrategyId"`
@@ -1204,7 +1414,10 @@ func (h *Handler) handleStartDeployment(c *echo.Context, applicationID, environm
 		Description            string `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	deployment, err := h.Backend.StartDeployment(
@@ -1221,7 +1434,10 @@ func (h *Handler) handleStartDeployment(c *echo.Context, applicationID, environm
 			return badRequestResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, deployment)
@@ -1238,22 +1454,36 @@ func (h *Handler) handleGetDeployment(
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, deployment)
 }
 
-func (h *Handler) handleListDeployments(c *echo.Context, applicationID, environmentID string) error {
+func (h *Handler) handleListDeployments(
+	c *echo.Context,
+	applicationID, environmentID string,
+) error {
 	nextToken, maxResults := appConfigPaginationParams(c)
-	deployments, outToken, err := h.Backend.ListDeployments(applicationID, environmentID, nextToken, maxResults)
+	deployments, outToken, err := h.Backend.ListDeployments(
+		applicationID,
+		environmentID,
+		nextToken,
+		maxResults,
+	)
 
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	resp := map[string]any{keyItems: deployments}
@@ -1274,7 +1504,10 @@ func (h *Handler) handleStopDeployment(
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -1283,7 +1516,10 @@ func (h *Handler) handleStopDeployment(
 func (h *Handler) handleListTagsForResource(c *echo.Context, resourceArn string) error {
 	tags, err := h.Backend.ListTagsForResource(resourceArn)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{"Tags": tags})
@@ -1294,11 +1530,17 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceArn string) error {
 		Tags map[string]string `json:"Tags"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	if err := h.Backend.TagResource(resourceArn, req.Tags); err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -1308,7 +1550,10 @@ func (h *Handler) handleUntagResource(c *echo.Context, resourceArn string) error
 	keysToRemove := c.Request().URL.Query()["tagKeys"]
 
 	if err := h.Backend.UntagResource(resourceArn, keysToRemove); err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -1322,7 +1567,10 @@ func (h *Handler) handleCreateExtension(c *echo.Context) error {
 		Description string                        `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	ext, err := h.Backend.CreateExtension(req.Name, req.Description, req.Actions, req.Parameters)
@@ -1335,7 +1583,10 @@ func (h *Handler) handleCreateExtension(c *echo.Context) error {
 			return conflictResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, ext)
@@ -1348,7 +1599,10 @@ func (h *Handler) handleGetExtension(c *echo.Context, extensionID string) error 
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, ext)
@@ -1361,7 +1615,7 @@ func (h *Handler) handleListExtensions(c *echo.Context) error {
 	var versionNumber int32
 	if s := q.Get("extension_version_number"); s != "" {
 		if n, err := strconv.Atoi(s); err == nil && n > 0 {
-			versionNumber = int32(n)
+			versionNumber = int32(n) //nolint:gosec // version number bounded by API constraints
 		}
 	}
 	exts, outToken := h.Backend.ListExtensions(nextToken, maxResults, nameFilter, versionNumber)
@@ -1381,7 +1635,10 @@ func (h *Handler) handleUpdateExtension(c *echo.Context, extensionID string) err
 		Description string                        `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	ext, err := h.Backend.UpdateExtension(extensionID, req.Description, req.Actions, req.Parameters)
@@ -1390,7 +1647,10 @@ func (h *Handler) handleUpdateExtension(c *echo.Context, extensionID string) err
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, ext)
@@ -1402,7 +1662,10 @@ func (h *Handler) handleDeleteExtension(c *echo.Context, extensionID string) err
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -1416,7 +1679,10 @@ func (h *Handler) handleCreateExtensionAssociation(c *echo.Context) error {
 		ResourceIdentifier     string            `json:"ResourceIdentifier"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	assoc, err := h.Backend.CreateExtensionAssociation(
@@ -1434,20 +1700,29 @@ func (h *Handler) handleCreateExtensionAssociation(c *echo.Context) error {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusCreated, assoc)
 }
 
-func (h *Handler) handleGetExtensionAssociation(c *echo.Context, extensionAssociationID string) error {
+func (h *Handler) handleGetExtensionAssociation(
+	c *echo.Context,
+	extensionAssociationID string,
+) error {
 	assoc, err := h.Backend.GetExtensionAssociation(extensionAssociationID)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, assoc)
@@ -1458,7 +1733,12 @@ func (h *Handler) handleListExtensionAssociations(c *echo.Context) error {
 	q := c.Request().URL.Query()
 	extIdentifier := q.Get("extension_identifier")
 	resourceIdentifier := q.Get("resource_identifier")
-	assocs, outToken := h.Backend.ListExtensionAssociations(nextToken, extIdentifier, resourceIdentifier, maxResults)
+	assocs, outToken := h.Backend.ListExtensionAssociations(
+		nextToken,
+		extIdentifier,
+		resourceIdentifier,
+		maxResults,
+	)
 
 	resp := map[string]any{keyItems: assocs}
 	if outToken != "" {
@@ -1468,12 +1748,18 @@ func (h *Handler) handleListExtensionAssociations(c *echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (h *Handler) handleUpdateExtensionAssociation(c *echo.Context, extensionAssociationID string) error {
+func (h *Handler) handleUpdateExtensionAssociation(
+	c *echo.Context,
+	extensionAssociationID string,
+) error {
 	var req struct {
 		Parameters map[string]string `json:"Parameters"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	assoc, err := h.Backend.UpdateExtensionAssociation(extensionAssociationID, req.Parameters)
@@ -1482,19 +1768,28 @@ func (h *Handler) handleUpdateExtensionAssociation(c *echo.Context, extensionAss
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, assoc)
 }
 
-func (h *Handler) handleDeleteExtensionAssociation(c *echo.Context, extensionAssociationID string) error {
+func (h *Handler) handleDeleteExtensionAssociation(
+	c *echo.Context,
+	extensionAssociationID string,
+) error {
 	if err := h.Backend.DeleteExtensionAssociation(extensionAssociationID); err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -1503,7 +1798,10 @@ func (h *Handler) handleDeleteExtensionAssociation(c *echo.Context, extensionAss
 func (h *Handler) handleGetAccountSettings(c *echo.Context) error {
 	settings, err := h.Backend.GetAccountSettings()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, settings)
@@ -1514,29 +1812,43 @@ func (h *Handler) handleUpdateAccountSettings(c *echo.Context) error {
 		DeletionProtection *DeletionProtectionSettings `json:"DeletionProtection"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
+		return c.JSON(
+			http.StatusBadRequest,
+			map[string]string{keyMessageField: errInvalidRequestBody},
+		)
 	}
 
 	settings, err := h.Backend.UpdateAccountSettings(req.DeletionProtection)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.JSON(http.StatusOK, settings)
 }
 
-func (h *Handler) handleGetConfiguration(c *echo.Context, application, environment, configuration string) error {
+func (h *Handler) handleGetConfiguration(
+	c *echo.Context,
+	application, environment, configuration string,
+) error {
 	configVersion, err := h.Backend.GetConfiguration(application, environment, configuration)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	if configVersion.VersionNumber > 0 {
-		c.Response().Header().Set("Configuration-Version", strconv.Itoa(int(configVersion.VersionNumber)))
+		c.Response().
+			Header().
+			Set("Configuration-Version", strconv.Itoa(int(configVersion.VersionNumber)))
 	}
 
 	if len(configVersion.Content) == 0 {
@@ -1551,7 +1863,10 @@ func (h *Handler) handleGetConfiguration(c *echo.Context, application, environme
 	return c.Blob(http.StatusOK, contentType, configVersion.Content)
 }
 
-func (h *Handler) handleValidateConfiguration(c *echo.Context, applicationID, profileID string) error {
+func (h *Handler) handleValidateConfiguration(
+	c *echo.Context,
+	applicationID, profileID string,
+) error {
 	configVersion := c.Request().URL.Query().Get("configuration_version")
 
 	if err := h.Backend.ValidateConfiguration(applicationID, profileID, configVersion); err != nil {
@@ -1559,7 +1874,10 @@ func (h *Handler) handleValidateConfiguration(c *echo.Context, applicationID, pr
 			return notFoundResponse(c, err)
 		}
 
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/services/appconfig/handler.go
+++ b/services/appconfig/handler.go
@@ -709,6 +709,10 @@ func (h *Handler) handleCreateApplication(c *echo.Context) error {
 			return badRequestResponse(c, err)
 		}
 
+		if errors.Is(err, awserr.ErrAlreadyExists) {
+			return conflictResponse(c, err)
+		}
+
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
 	}
 
@@ -775,17 +779,26 @@ func (h *Handler) handleDeleteApplication(c *echo.Context, applicationID string)
 
 func (h *Handler) handleCreateEnvironment(c *echo.Context, applicationID string) error {
 	var req struct {
-		Name        string `json:"Name"`
-		Description string `json:"Description"`
+		Monitors    []Monitor `json:"Monitors"`
+		Name        string    `json:"Name"`
+		Description string    `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
 	}
 
-	env, err := h.Backend.CreateEnvironment(applicationID, req.Name, req.Description)
+	env, err := h.Backend.CreateEnvironment(applicationID, req.Name, req.Description, req.Monitors)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrAlreadyExists) {
+			return conflictResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrInvalidParameter) {
+			return badRequestResponse(c, err)
 		}
 
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
@@ -862,10 +875,12 @@ func (h *Handler) handleDeleteEnvironment(c *echo.Context, applicationID, enviro
 
 func (h *Handler) handleCreateConfigurationProfile(c *echo.Context, applicationID string) error {
 	var req struct {
-		Name        string `json:"Name"`
-		Description string `json:"Description"`
-		LocationURI string `json:"LocationUri"`
-		Type        string `json:"Type"`
+		Validators       []Validator `json:"Validators"`
+		Name             string      `json:"Name"`
+		Description      string      `json:"Description"`
+		LocationURI      string      `json:"LocationUri"`
+		Type             string      `json:"Type"`
+		RetrievalRoleArn string      `json:"RetrievalRoleArn"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
@@ -877,10 +892,20 @@ func (h *Handler) handleCreateConfigurationProfile(c *echo.Context, applicationI
 		req.Description,
 		req.LocationURI,
 		req.Type,
+		req.RetrievalRoleArn,
+		req.Validators,
 	)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrAlreadyExists) {
+			return conflictResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrInvalidParameter) {
+			return badRequestResponse(c, err)
 		}
 
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
@@ -961,15 +986,27 @@ func (h *Handler) handleCreateHostedConfigurationVersion(c *echo.Context, applic
 		contentType = "application/octet-stream"
 	}
 
+	// AWS AppConfig accepts description and version label via custom request headers.
+	description := c.Request().Header.Get("Description")
+	versionLabel := c.Request().Header.Get("VersionLabel")
+
 	content, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: "failed to read request body"})
 	}
 
-	v, err := h.Backend.CreateHostedConfigurationVersion(applicationID, profileID, contentType, content)
+	v, err := h.Backend.CreateHostedConfigurationVersion(applicationID, profileID, contentType, description, versionLabel, content)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrAlreadyExists) {
+			return conflictResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrInvalidParameter) {
+			return badRequestResponse(c, err)
 		}
 
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
@@ -1002,10 +1039,12 @@ func (h *Handler) handleGetHostedConfigurationVersion(
 
 func (h *Handler) handleListHostedConfigurationVersions(c *echo.Context, applicationID, profileID string) error {
 	nextToken, maxResults := appConfigPaginationParams(c)
+	versionLabel := c.Request().URL.Query().Get("version_label")
 	versions, outToken, err := h.Backend.ListHostedConfigurationVersions(
 		applicationID,
 		profileID,
 		nextToken,
+		versionLabel,
 		maxResults,
 	)
 
@@ -1162,6 +1201,7 @@ func (h *Handler) handleStartDeployment(c *echo.Context, applicationID, environm
 		ConfigurationProfileID string `json:"ConfigurationProfileId"`
 		DeploymentStrategyID   string `json:"DeploymentStrategyId"`
 		ConfigurationVersion   string `json:"ConfigurationVersion"`
+		Description            string `json:"Description"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: errInvalidRequestBody})
@@ -1170,11 +1210,15 @@ func (h *Handler) handleStartDeployment(c *echo.Context, applicationID, environm
 	deployment, err := h.Backend.StartDeployment(
 		applicationID, environmentID,
 		req.ConfigurationProfileID, req.DeploymentStrategyID,
-		req.ConfigurationVersion,
+		req.ConfigurationVersion, req.Description,
 	)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return notFoundResponse(c, err)
+		}
+
+		if errors.Is(err, awserr.ErrInvalidParameter) {
+			return badRequestResponse(c, err)
 		}
 
 		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
@@ -1312,8 +1356,15 @@ func (h *Handler) handleGetExtension(c *echo.Context, extensionID string) error 
 
 func (h *Handler) handleListExtensions(c *echo.Context) error {
 	nextToken, maxResults := appConfigPaginationParams(c)
-	nameFilter := c.Request().URL.Query().Get("name")
-	exts, outToken := h.Backend.ListExtensions(nextToken, maxResults, nameFilter)
+	q := c.Request().URL.Query()
+	nameFilter := q.Get("name")
+	var versionNumber int32
+	if s := q.Get("extension_version_number"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			versionNumber = int32(n)
+		}
+	}
+	exts, outToken := h.Backend.ListExtensions(nextToken, maxResults, nameFilter, versionNumber)
 
 	resp := map[string]any{keyItems: exts}
 	if outToken != "" {
@@ -1404,7 +1455,10 @@ func (h *Handler) handleGetExtensionAssociation(c *echo.Context, extensionAssoci
 
 func (h *Handler) handleListExtensionAssociations(c *echo.Context) error {
 	nextToken, maxResults := appConfigPaginationParams(c)
-	assocs, outToken := h.Backend.ListExtensionAssociations(nextToken, maxResults)
+	q := c.Request().URL.Query()
+	extIdentifier := q.Get("extension_identifier")
+	resourceIdentifier := q.Get("resource_identifier")
+	assocs, outToken := h.Backend.ListExtensionAssociations(nextToken, extIdentifier, resourceIdentifier, maxResults)
 
 	resp := map[string]any{keyItems: assocs}
 	if outToken != "" {

--- a/services/appconfig/handler_test.go
+++ b/services/appconfig/handler_test.go
@@ -1162,7 +1162,7 @@ func TestHandler_ListApplicationsPagination(t *testing.T) {
 			Items     []any  `json:"Items"`
 		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Len(t, resp.Items, 0)
+		assert.Empty(t, resp.Items)
 		assert.Empty(t, resp.NextToken)
 	})
 }

--- a/services/appconfig/handler_test.go
+++ b/services/appconfig/handler_test.go
@@ -129,10 +129,30 @@ func TestHandler_ExtractOperation(t *testing.T) {
 		path   string
 		want   string
 	}{
-		{name: "list applications", method: http.MethodGet, path: "/applications", want: "ListApplications"},
-		{name: "create application", method: http.MethodPost, path: "/applications", want: "CreateApplication"},
-		{name: "get application", method: http.MethodGet, path: "/applications/app-1", want: "GetApplication"},
-		{name: "delete application", method: http.MethodDelete, path: "/applications/app-1", want: "DeleteApplication"},
+		{
+			name:   "list applications",
+			method: http.MethodGet,
+			path:   "/applications",
+			want:   "ListApplications",
+		},
+		{
+			name:   "create application",
+			method: http.MethodPost,
+			path:   "/applications",
+			want:   "CreateApplication",
+		},
+		{
+			name:   "get application",
+			method: http.MethodGet,
+			path:   "/applications/app-1",
+			want:   "GetApplication",
+		},
+		{
+			name:   "delete application",
+			method: http.MethodDelete,
+			path:   "/applications/app-1",
+			want:   "DeleteApplication",
+		},
 		{
 			name:   "list strategies",
 			method: http.MethodGet,
@@ -274,7 +294,13 @@ func TestHandler_Environment_CRUD(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
 	// Create env.
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments", []byte(`{"name":"production"}`))
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/environments",
+		[]byte(`{"name":"production"}`),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var env appconfig.Environment
@@ -308,7 +334,13 @@ func TestHandler_ConfigurationProfile_CRUD(t *testing.T) {
 
 	// Create profile.
 	profileBody := []byte(`{"name":"my-config","locationUri":"hosted","type":"AWS.Freeform"}`)
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/configurationprofiles", profileBody)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/configurationprofiles",
+		profileBody,
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var profile appconfig.ConfigurationProfile
@@ -316,11 +348,23 @@ func TestHandler_ConfigurationProfile_CRUD(t *testing.T) {
 	assert.Equal(t, "my-config", profile.Name)
 
 	// Get profile.
-	rec = doRequest(t, h, http.MethodGet, "/applications/"+app.ID+"/configurationprofiles/"+profile.ID, nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodGet,
+		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID,
+		nil,
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Delete profile.
-	rec = doRequest(t, h, http.MethodDelete, "/applications/"+app.ID+"/configurationprofiles/"+profile.ID, nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodDelete,
+		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID,
+		nil,
+	)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
@@ -347,7 +391,13 @@ func TestHandler_DeploymentStrategy_CRUD(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Update.
-	rec = doRequest(t, h, http.MethodPatch, "/deploymentstrategies/"+strategy.ID, []byte(`{"name":"updated-strategy"}`))
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPatch,
+		"/deploymentstrategies/"+strategy.ID,
+		[]byte(`{"name":"updated-strategy"}`),
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Delete.
@@ -376,7 +426,13 @@ func TestHandler_HostedConfigurationVersion_CRUD(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
 	profileBody := []byte(`{"name":"hcv-profile","locationUri":"hosted","type":"AWS.Freeform"}`)
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/configurationprofiles", profileBody)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/configurationprofiles",
+		profileBody,
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var profile appconfig.ConfigurationProfile
@@ -398,12 +454,18 @@ func TestHandler_HostedConfigurationVersion_CRUD(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, recHcv.Code)
 
 	// List versions.
-	rec = doRequest(t, h, http.MethodGet,
-		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID+"/hostedconfigurationversions", nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodGet,
+		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID+"/hostedconfigurationversions",
+		nil,
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Get version 1.
-	req2 := httptest.NewRequest(http.MethodGet,
+	req2 := httptest.NewRequest(
+		http.MethodGet,
 		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID+"/hostedconfigurationversions/1",
 		nil,
 	)
@@ -416,8 +478,13 @@ func TestHandler_HostedConfigurationVersion_CRUD(t *testing.T) {
 	assert.Equal(t, content, rec2.Body.Bytes())
 
 	// Delete version 1.
-	rec = doRequest(t, h, http.MethodDelete,
-		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID+"/hostedconfigurationversions/1", nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodDelete,
+		"/applications/"+app.ID+"/configurationprofiles/"+profile.ID+"/hostedconfigurationversions/1",
+		nil,
+	)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
@@ -434,7 +501,13 @@ func TestHandler_Deployment_Lifecycle(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
 	// Create env.
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments", []byte(`{"name":"staging"}`))
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/environments",
+		[]byte(`{"name":"staging"}`),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var env appconfig.Environment
@@ -442,7 +515,13 @@ func TestHandler_Deployment_Lifecycle(t *testing.T) {
 
 	// Create configuration profile (required by StartDeployment validation).
 	profBody := []byte(`{"name":"my-profile","locationUri":"hosted"}`)
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/configurationprofiles", profBody)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/configurationprofiles",
+		profBody,
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var prof appconfig.ConfigurationProfile
@@ -457,8 +536,15 @@ func TestHandler_Deployment_Lifecycle(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &strat))
 
 	// Start deployment.
-	depBodyStr := `{"configurationProfileId":"` + prof.ID + `","deploymentStrategyId":"` + strat.ID + `","configurationVersion":"1"}`
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments", []byte(depBodyStr))
+	depBodyStr := `{"configurationProfileId":"` + prof.ID +
+		`","deploymentStrategyId":"` + strat.ID + `","configurationVersion":"1"}`
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/environments/"+env.ID+"/deployments",
+		[]byte(depBodyStr),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var dep appconfig.Deployment
@@ -467,15 +553,33 @@ func TestHandler_Deployment_Lifecycle(t *testing.T) {
 	assert.Equal(t, "COMPLETE", dep.State)
 
 	// Get deployment.
-	rec = doRequest(t, h, http.MethodGet, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments/1", nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodGet,
+		"/applications/"+app.ID+"/environments/"+env.ID+"/deployments/1",
+		nil,
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// List deployments.
-	rec = doRequest(t, h, http.MethodGet, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments", nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodGet,
+		"/applications/"+app.ID+"/environments/"+env.ID+"/deployments",
+		nil,
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Stop deployment (COMPLETE deployments can be rolled back in stub).
-	rec = doRequest(t, h, http.MethodDelete, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments/1", nil)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodDelete,
+		"/applications/"+app.ID+"/environments/"+env.ID+"/deployments/1",
+		nil,
+	)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
@@ -590,7 +694,14 @@ func TestBackend_HostedConfigVersion_ProfileNotFound(t *testing.T) {
 	app, err := b.CreateApplication("app", "")
 	require.NoError(t, err)
 
-	_, err = b.CreateHostedConfigurationVersion(app.ID, "nonexistent-profile", "application/json", "", "", []byte("{}"))
+	_, err = b.CreateHostedConfigurationVersion(
+		app.ID,
+		"nonexistent-profile",
+		"application/json",
+		"",
+		"",
+		[]byte("{}"),
+	)
 	require.Error(t, err)
 }
 
@@ -710,7 +821,13 @@ func TestHandler_UpdateEnvironment_HTTP(t *testing.T) {
 	var app appconfig.Application
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments", []byte(`{"name":"staging"}`))
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/environments",
+		[]byte(`{"name":"staging"}`),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var env appconfig.Environment
@@ -745,7 +862,13 @@ func TestHandler_ListConfigurationProfiles_HTTP(t *testing.T) {
 	// Create two profiles.
 	for _, name := range []string{"prof-1", "prof-2"} {
 		body := []byte(`{"name":"` + name + `","locationUri":"hosted","type":"AWS.Freeform"}`)
-		rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/configurationprofiles", body)
+		rec = doRequest(
+			t,
+			h,
+			http.MethodPost,
+			"/applications/"+app.ID+"/configurationprofiles",
+			body,
+		)
 		require.Equal(t, http.StatusCreated, rec.Code)
 	}
 
@@ -766,7 +889,13 @@ func TestHandler_UpdateConfigurationProfile_HTTP(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
 	profileBody := []byte(`{"name":"old-name","locationUri":"hosted","type":"AWS.Freeform"}`)
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/configurationprofiles", profileBody)
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/configurationprofiles",
+		profileBody,
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var profile appconfig.ConfigurationProfile
@@ -982,7 +1111,10 @@ func TestHandler_HostedConfigVersion_HTTP_ListEmpty(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal(profRec.Body.Bytes(), &profOut))
 
-	listRec := doRequest(t, h, http.MethodGet,
+	listRec := doRequest(
+		t,
+		h,
+		http.MethodGet,
 		"/applications/"+appOut.ID+"/configurationprofiles/"+profOut.ID+"/hostedconfigurationversions",
 		nil,
 	)
@@ -1001,8 +1133,16 @@ func TestHandler_StartDeployment_NotFound_HTTP(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
-	body := []byte(`{"configurationProfileId":"prof-1","deploymentStrategyId":"strat-1","configurationVersion":"1"}`)
-	rec := doRequest(t, h, http.MethodPost, "/applications/nonexistent/environments/env-1/deployments", body)
+	body := []byte(
+		`{"configurationProfileId":"prof-1","deploymentStrategyId":"strat-1","configurationVersion":"1"}`,
+	)
+	rec := doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/nonexistent/environments/env-1/deployments",
+		body,
+	)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
@@ -1067,7 +1207,13 @@ func TestHandler_ListDeployments_HTTP(t *testing.T) {
 	h := newTestHandler(t)
 
 	// Pre-create app and environment so listing returns 200 with empty list.
-	appRec := doRequest(t, h, http.MethodPost, "/applications", []byte(`{"Name":"list-deploy-app"}`))
+	appRec := doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications",
+		[]byte(`{"Name":"list-deploy-app"}`),
+	)
 	require.Equal(t, http.StatusCreated, appRec.Code)
 
 	var appOut struct {
@@ -1151,7 +1297,13 @@ func TestHandler_ListApplicationsPagination(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &first))
 		require.NotEmpty(t, first.NextToken)
 
-		rec2 := doRequest(t, h, http.MethodGet, "/applications?max_results=2&next_token="+first.NextToken, nil)
+		rec2 := doRequest(
+			t,
+			h,
+			http.MethodGet,
+			"/applications?max_results=2&next_token="+first.NextToken,
+			nil,
+		)
 		require.Equal(t, http.StatusOK, rec2.Code)
 		var resp struct {
 			NextToken string `json:"NextToken"`
@@ -1171,7 +1323,13 @@ func TestHandler_ListApplicationsPagination(t *testing.T) {
 			require.Equal(t, http.StatusCreated, rec.Code)
 		}
 		beyondToken := page.EncodeHMACToken(100, backend.PaginationSecret())
-		rec := doRequest(t, h2, http.MethodGet, "/applications?max_results=2&next_token="+beyondToken, nil)
+		rec := doRequest(
+			t,
+			h2,
+			http.MethodGet,
+			"/applications?max_results=2&next_token="+beyondToken,
+			nil,
+		)
 		require.Equal(t, http.StatusOK, rec.Code)
 		var resp struct {
 			NextToken string `json:"NextToken"`
@@ -1497,7 +1655,13 @@ func TestHandler_GetConfiguration(t *testing.T) {
 	var app appconfig.Application
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments", []byte(`{"name":"conf-env"}`))
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/environments",
+		[]byte(`{"name":"conf-env"}`),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var env appconfig.Environment
@@ -1559,7 +1723,13 @@ func TestHandler_GetConfiguration_WithContent(t *testing.T) {
 	var app appconfig.Application
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &app))
 
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments", []byte(`{"name":"content-env"}`))
+	rec = doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/applications/"+app.ID+"/environments",
+		[]byte(`{"name":"content-env"}`),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var env appconfig.Environment
@@ -1696,7 +1866,13 @@ func TestHandler_UpdateExtension(t *testing.T) {
 	h := newTestHandler(t)
 
 	// Create extension.
-	rec := doRequest(t, h, http.MethodPost, "/extensions", []byte(`{"Name":"update-ext","Description":"original"}`))
+	rec := doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/extensions",
+		[]byte(`{"Name":"update-ext","Description":"original"}`),
+	)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var ext appconfig.Extension
@@ -1736,7 +1912,9 @@ func TestHandler_UpdateExtensionAssociation(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ext))
 
 	resourceID := "arn:aws:appconfig:us-east-1:123456789012:application/abc"
-	assocBody := []byte(`{"ExtensionIdentifier":"` + ext.ID + `","ResourceIdentifier":"` + resourceID + `"}`)
+	assocBody := []byte(
+		`{"ExtensionIdentifier":"` + ext.ID + `","ResourceIdentifier":"` + resourceID + `"}`,
+	)
 	rec = doRequest(t, h, http.MethodPost, "/extensionassociations", assocBody)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
@@ -1873,7 +2051,13 @@ func TestHandler_CreateExtension_Validation(t *testing.T) {
 
 			if tt.wantStatus == http.StatusConflict {
 				// Pre-create extension to force duplicate.
-				rec := doRequest(t, h, http.MethodPost, "/extensions", []byte(`{"Name":"duplicate-ext"}`))
+				rec := doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/extensions",
+					[]byte(`{"Name":"duplicate-ext"}`),
+				)
 				require.Equal(t, http.StatusCreated, rec.Code)
 			}
 
@@ -1892,8 +2076,10 @@ func TestHandler_CreateExtensionAssociation_Validation(t *testing.T) {
 		wantStatus int
 	}{
 		{
-			name:       "missing extension identifier returns 400",
-			body:       []byte(`{"ResourceIdentifier":"arn:aws:appconfig:us-east-1:123456789012:application/abc"}`),
+			name: "missing extension identifier returns 400",
+			body: []byte(
+				`{"ResourceIdentifier":"arn:aws:appconfig:us-east-1:123456789012:application/abc"}`,
+			),
 			wantStatus: http.StatusBadRequest,
 		},
 		{
@@ -1981,15 +2167,30 @@ func TestHandler_ExtractOperation_NewPaths(t *testing.T) {
 		path   string
 		want   string
 	}{
-		{name: "update extension", method: http.MethodPatch, path: "/extensions/ext-1", want: "UpdateExtension"},
+		{
+			name:   "update extension",
+			method: http.MethodPatch,
+			path:   "/extensions/ext-1",
+			want:   "UpdateExtension",
+		},
 		{
 			name:   "update extension association",
 			method: http.MethodPatch,
 			path:   "/extensionassociations/assoc-1",
 			want:   "UpdateExtensionAssociation",
 		},
-		{name: "get account settings", method: http.MethodGet, path: "/settings", want: "GetAccountSettings"},
-		{name: "update account settings", method: http.MethodPatch, path: "/settings", want: "UpdateAccountSettings"},
+		{
+			name:   "get account settings",
+			method: http.MethodGet,
+			path:   "/settings",
+			want:   "GetAccountSettings",
+		},
+		{
+			name:   "update account settings",
+			method: http.MethodPatch,
+			path:   "/settings",
+			want:   "UpdateAccountSettings",
+		},
 		{
 			name:   "validate configuration",
 			method: http.MethodPost,

--- a/services/appconfig/handler_test.go
+++ b/services/appconfig/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/page"
 	"github.com/blackbirdworks/gopherstack/services/appconfig"
 )
 
@@ -1081,70 +1082,96 @@ func TestHandler_ListDeployments_HTTP(t *testing.T) {
 func TestHandler_ListApplicationsPagination(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name          string
-		queryString   string
-		wantCount     int
-		wantNextToken bool
-	}{
-		{
-			name:        "no_pagination_returns_all",
-			queryString: "",
-			wantCount:   4,
-		},
-		{
-			name:          "first_page",
-			queryString:   "?max_results=2",
-			wantCount:     2,
-			wantNextToken: true,
-		},
-		{
-			name:        "second_page",
-			queryString: "?max_results=2&next_token=2",
-			wantCount:   2,
-		},
-		{
-			name:        "token_beyond_end",
-			queryString: "?max_results=2&next_token=100",
-			wantCount:   0,
-		},
-	}
+	t.Run("no_pagination_returns_all", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHandler(t)
+		for _, name := range []string{"app1", "app2", "app3", "app4"} {
+			rec := doRequest(t, h, http.MethodPost, "/applications", []byte(`{"name":"`+name+`"}`))
+			require.Equal(t, http.StatusCreated, rec.Code)
+		}
+		rec := doRequest(t, h, http.MethodGet, "/applications", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp struct {
+			NextToken string `json:"NextToken"`
+			Items     []any  `json:"Items"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp.Items, 4)
+		assert.Empty(t, resp.NextToken)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	t.Run("first_page", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHandler(t)
+		for _, name := range []string{"app1", "app2", "app3", "app4"} {
+			rec := doRequest(t, h, http.MethodPost, "/applications", []byte(`{"name":"`+name+`"}`))
+			require.Equal(t, http.StatusCreated, rec.Code)
+		}
+		rec := doRequest(t, h, http.MethodGet, "/applications?max_results=2", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp struct {
+			NextToken string `json:"NextToken"`
+			Items     []any  `json:"Items"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp.Items, 2)
+		assert.NotEmpty(t, resp.NextToken)
+	})
 
-			h := newTestHandler(t)
+	t.Run("second_page", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHandler(t)
+		for _, name := range []string{"app1", "app2", "app3", "app4"} {
+			rec := doRequest(t, h, http.MethodPost, "/applications", []byte(`{"name":"`+name+`"}`))
+			require.Equal(t, http.StatusCreated, rec.Code)
+		}
+		// Get the first page to obtain a valid HMAC token.
+		rec := doRequest(t, h, http.MethodGet, "/applications?max_results=2", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var first struct {
+			NextToken string `json:"NextToken"`
+			Items     []any  `json:"Items"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &first))
+		require.NotEmpty(t, first.NextToken)
 
-			for _, name := range []string{"app1", "app2", "app3", "app4"} {
-				rec := doRequest(t, h, http.MethodPost, "/applications",
-					[]byte(`{"name":"`+name+`"}`))
-				require.Equal(t, http.StatusCreated, rec.Code)
-			}
+		rec2 := doRequest(t, h, http.MethodGet, "/applications?max_results=2&next_token="+first.NextToken, nil)
+		require.Equal(t, http.StatusOK, rec2.Code)
+		var resp struct {
+			NextToken string `json:"NextToken"`
+			Items     []any  `json:"Items"`
+		}
+		require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+		assert.Len(t, resp.Items, 2)
+		assert.Empty(t, resp.NextToken)
+	})
 
-			rec := doRequest(t, h, http.MethodGet, "/applications"+tt.queryString, nil)
-			require.Equal(t, http.StatusOK, rec.Code)
-
-			var resp struct {
-				NextToken string `json:"NextToken"`
-				Items     []any  `json:"Items"`
-			}
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-			assert.Len(t, resp.Items, tt.wantCount)
-
-			if tt.wantNextToken {
-				assert.NotEmpty(t, resp.NextToken)
-			} else {
-				assert.Empty(t, resp.NextToken)
-			}
-		})
-	}
+	t.Run("token_beyond_end", func(t *testing.T) {
+		t.Parallel()
+		backend := appconfig.NewInMemoryBackend("123456789012", "us-east-1")
+		h2 := appconfig.NewHandler(backend)
+		for _, name := range []string{"app1", "app2", "app3", "app4"} {
+			rec := doRequest(t, h2, http.MethodPost, "/applications", []byte(`{"name":"`+name+`"}`))
+			require.Equal(t, http.StatusCreated, rec.Code)
+		}
+		beyondToken := page.EncodeHMACToken(100, backend.PaginationSecret())
+		rec := doRequest(t, h2, http.MethodGet, "/applications?max_results=2&next_token="+beyondToken, nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp struct {
+			NextToken string `json:"NextToken"`
+			Items     []any  `json:"Items"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp.Items, 0)
+		assert.Empty(t, resp.NextToken)
+	})
 }
 
 func TestBackend_appConfigPaginate_EdgeCases(t *testing.T) {
 	t.Parallel()
 
 	b := appconfig.NewInMemoryBackend("123456789012", "us-east-1")
+	secret := b.PaginationSecret()
 
 	// Create 4 apps.
 	for _, name := range []string{"a", "b", "c", "d"} {
@@ -1173,13 +1200,13 @@ func TestBackend_appConfigPaginate_EdgeCases(t *testing.T) {
 		{
 			name:       "second_page",
 			maxResults: 2,
-			nextToken:  "2",
+			nextToken:  page.EncodeHMACToken(2, secret),
 			wantCount:  2,
 		},
 		{
 			name:       "token_beyond_end",
 			maxResults: 2,
-			nextToken:  "50",
+			nextToken:  page.EncodeHMACToken(50, secret),
 			wantCount:  0,
 		},
 		{

--- a/services/appconfig/handler_test.go
+++ b/services/appconfig/handler_test.go
@@ -440,9 +440,25 @@ func TestHandler_Deployment_Lifecycle(t *testing.T) {
 	var env appconfig.Environment
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
 
+	// Create configuration profile (required by StartDeployment validation).
+	profBody := []byte(`{"name":"my-profile","locationUri":"hosted"}`)
+	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/configurationprofiles", profBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var prof appconfig.ConfigurationProfile
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prof))
+
+	// Create deployment strategy (required by StartDeployment validation).
+	stratBody := []byte(`{"name":"my-strategy","deploymentDurationInMinutes":10,"growthFactor":20}`)
+	rec = doRequest(t, h, http.MethodPost, "/deploymentstrategies", stratBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var strat appconfig.DeploymentStrategy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &strat))
+
 	// Start deployment.
-	depBody := []byte(`{"configurationProfileId":"prof-1","deploymentStrategyId":"strat-1","configurationVersion":"1"}`)
-	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments", depBody)
+	depBodyStr := `{"configurationProfileId":"` + prof.ID + `","deploymentStrategyId":"` + strat.ID + `","configurationVersion":"1"}`
+	rec = doRequest(t, h, http.MethodPost, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments", []byte(depBodyStr))
 	require.Equal(t, http.StatusCreated, rec.Code)
 
 	var dep appconfig.Deployment
@@ -458,7 +474,7 @@ func TestHandler_Deployment_Lifecycle(t *testing.T) {
 	rec = doRequest(t, h, http.MethodGet, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments", nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	// Stop deployment.
+	// Stop deployment (COMPLETE deployments can be rolled back in stub).
 	rec = doRequest(t, h, http.MethodDelete, "/applications/"+app.ID+"/environments/"+env.ID+"/deployments/1", nil)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -510,7 +526,7 @@ func TestBackend_CreateEnvironment_AppNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := appconfig.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateEnvironment("nonexistent", "env", "")
+	_, err := b.CreateEnvironment("nonexistent", "env", "", nil)
 	require.Error(t, err)
 }
 
@@ -574,7 +590,7 @@ func TestBackend_HostedConfigVersion_ProfileNotFound(t *testing.T) {
 	app, err := b.CreateApplication("app", "")
 	require.NoError(t, err)
 
-	_, err = b.CreateHostedConfigurationVersion(app.ID, "nonexistent-profile", "application/json", []byte("{}"))
+	_, err = b.CreateHostedConfigurationVersion(app.ID, "nonexistent-profile", "application/json", "", "", []byte("{}"))
 	require.Error(t, err)
 }
 

--- a/services/appconfig/types.go
+++ b/services/appconfig/types.go
@@ -29,6 +29,10 @@ var (
 	ErrExtensionAlreadyExists = awserr.New("ConflictException", awserr.ErrAlreadyExists)
 	// ErrBadRequest is returned when a required field is missing or invalid.
 	ErrBadRequest = awserr.New("BadRequestException", awserr.ErrInvalidParameter)
+	// ErrConflict is returned when a resource with the same name already exists.
+	ErrConflict = awserr.New("ConflictException", awserr.ErrAlreadyExists)
+	// ErrPayloadTooLarge is returned when a hosted configuration version exceeds the maximum size.
+	ErrPayloadTooLarge = awserr.New("PayloadTooLargeException", awserr.ErrInvalidParameter)
 )
 
 // Application represents an AppConfig application.
@@ -41,25 +45,40 @@ type Application struct {
 	Description string    `json:"Description,omitempty"`
 }
 
+// Monitor represents an Amazon CloudWatch alarm used to monitor an AppConfig environment.
+type Monitor struct {
+	AlarmArn      string `json:"AlarmArn"`
+	AlarmRoleArn  string `json:"AlarmRoleArn,omitempty"`
+}
+
 // Environment represents an AppConfig environment.
 type Environment struct {
-	CreatedAt     time.Time `json:"CreatedAt,omitzero"`
-	UpdatedAt     time.Time `json:"UpdatedAt,omitzero"`
-	ApplicationID string    `json:"ApplicationId"`
-	ID            string    `json:"Id"`
-	Name          string    `json:"Name"`
-	Description   string    `json:"Description,omitempty"`
-	State         string    `json:"State"`
+	CreatedAt     time.Time  `json:"CreatedAt,omitzero"`
+	UpdatedAt     time.Time  `json:"UpdatedAt,omitzero"`
+	ApplicationID string     `json:"ApplicationId"`
+	ID            string     `json:"Id"`
+	Name          string     `json:"Name"`
+	Description   string     `json:"Description,omitempty"`
+	State         string     `json:"State"`
+	Monitors      []Monitor  `json:"Monitors,omitempty"`
+}
+
+// Validator represents a validator for a configuration profile.
+type Validator struct {
+	Type    string `json:"Type"`    // JSON_SCHEMA or LAMBDA
+	Content string `json:"Content"` // JSON schema doc or Lambda ARN
 }
 
 // ConfigurationProfile represents an AppConfig configuration profile.
 type ConfigurationProfile struct {
-	ApplicationID string `json:"ApplicationId"`
-	ID            string `json:"Id"`
-	Name          string `json:"Name"`
-	Description   string `json:"Description,omitempty"`
-	LocationURI   string `json:"LocationUri"`
-	Type          string `json:"Type,omitempty"`
+	ApplicationID    string      `json:"ApplicationId"`
+	ID               string      `json:"Id"`
+	Name             string      `json:"Name"`
+	Description      string      `json:"Description,omitempty"`
+	LocationURI      string      `json:"LocationUri"`
+	Type             string      `json:"Type,omitempty"`
+	RetrievalRoleArn string      `json:"RetrievalRoleArn,omitempty"`
+	Validators       []Validator `json:"Validators,omitempty"`
 }
 
 // HostedConfigurationVersion represents a hosted configuration version.
@@ -68,6 +87,8 @@ type HostedConfigurationVersion struct {
 	ApplicationID          string    `json:"ApplicationId"`
 	ConfigurationProfileID string    `json:"ConfigurationProfileId"`
 	ContentType            string    `json:"ContentType"`
+	Description            string    `json:"Description,omitempty"`
+	VersionLabel           string    `json:"VersionLabel,omitempty"`
 	Content                []byte    `json:"-"`
 	VersionNumber          int32     `json:"VersionNumber"`
 }
@@ -96,6 +117,9 @@ type Deployment struct {
 	DeploymentStrategyID   string    `json:"DeploymentStrategyId"`
 	ConfigurationVersion   string    `json:"ConfigurationVersion"`
 	State                  string    `json:"State"`
+	TriggeredBy            string    `json:"TriggeredBy,omitempty"`
+	Description            string    `json:"Description,omitempty"`
+	PercentageComplete     float32   `json:"PercentageComplete,omitempty"`
 	DeploymentNumber       int32     `json:"DeploymentNumber"`
 }
 

--- a/services/appconfig/types.go
+++ b/services/appconfig/types.go
@@ -47,20 +47,20 @@ type Application struct {
 
 // Monitor represents an Amazon CloudWatch alarm used to monitor an AppConfig environment.
 type Monitor struct {
-	AlarmArn      string `json:"AlarmArn"`
-	AlarmRoleArn  string `json:"AlarmRoleArn,omitempty"`
+	AlarmArn     string `json:"AlarmArn"`
+	AlarmRoleArn string `json:"AlarmRoleArn,omitempty"`
 }
 
 // Environment represents an AppConfig environment.
 type Environment struct {
-	CreatedAt     time.Time  `json:"CreatedAt,omitzero"`
-	UpdatedAt     time.Time  `json:"UpdatedAt,omitzero"`
-	ApplicationID string     `json:"ApplicationId"`
-	ID            string     `json:"Id"`
-	Name          string     `json:"Name"`
-	Description   string     `json:"Description,omitempty"`
-	State         string     `json:"State"`
-	Monitors      []Monitor  `json:"Monitors,omitempty"`
+	CreatedAt     time.Time `json:"CreatedAt,omitzero"`
+	UpdatedAt     time.Time `json:"UpdatedAt,omitzero"`
+	ApplicationID string    `json:"ApplicationId"`
+	ID            string    `json:"Id"`
+	Name          string    `json:"Name"`
+	Description   string    `json:"Description,omitempty"`
+	State         string    `json:"State"`
+	Monitors      []Monitor `json:"Monitors,omitempty"`
 }
 
 // Validator represents a validator for a configuration profile.

--- a/ui/src/routes/appconfig/+page.svelte
+++ b/ui/src/routes/appconfig/+page.svelte
@@ -7,25 +7,38 @@
 		ListEnvironmentsCommand,
 		ListConfigurationProfilesCommand,
 		ListDeploymentsCommand,
+		ListExtensionsCommand,
+		ListExtensionAssociationsCommand,
 		DeleteApplicationCommand,
+		DeleteExtensionCommand,
+		DeleteExtensionAssociationCommand,
 		CreateApplicationCommand,
+		CreateExtensionCommand,
+		CreateExtensionAssociationCommand,
 		type Application,
 		type Environment,
 		type ConfigurationProfile,
-		type DeploymentSummary
+		type DeploymentSummary,
+		type Extension,
+		type ExtensionAssociationSummary
 	} from '@aws-sdk/client-appconfig';
 	import { toast } from 'svelte-sonner';
-	import { 
-		Settings, Search, RefreshCw, Plus, Trash2, 
+	import {
+		Settings, Search, RefreshCw, Plus, Trash2,
 		Activity, Info, Box, Clock, ShieldCheck,
-		ChevronRight, ListFilter, Globe, 
+		ChevronRight, ListFilter, Globe,
 		Layers, Zap, Terminal, Workflow,
 		FileCode, Sliders, Play, CheckCircle2, Code2,
 		XCircle, AlertCircle, Timer, Server,
 		Database, Share2, ArrowRight, Gauge,
-		Settings2, Layout, Boxes, Shield, ExternalLink
+		Settings2, Layout, Boxes, Shield, ExternalLink,
+		Puzzle, Link
 	} from 'lucide-svelte';
 	const appconfig = getAppConfigClient();
+
+	// Tabs
+	type Tab = 'applications' | 'extensions' | 'associations';
+	let activeTab = $state<Tab>('applications');
 
 	// State
 	let loading = $state(false);
@@ -37,14 +50,38 @@
 	let deployments = $state<DeploymentSummary[]>([]);
 	let loadingDetails = $state(false);
 
+	// Extensions state
+	let extensions = $state<Extension[]>([]);
+	let loadingExtensions = $state(false);
+	let extensionSearch = $state('');
+
+	// Extension Associations state
+	let associations = $state<ExtensionAssociationSummary[]>([]);
+	let loadingAssociations = $state(false);
+
 	// Modal State
 	let showCreateModal = $state(false);
 	let newAppName = $state('');
 	let creating = $state(false);
 
+	// Extension Create Modal
+	let showCreateExtModal = $state(false);
+	let newExtName = $state('');
+	let newExtDesc = $state('');
+	let creatingExt = $state(false);
+
+	// Extension Association Create Modal
+	let showCreateAssocModal = $state(false);
+	let newAssocExtId = $state('');
+	let newAssocResource = $state('');
+	let creatingAssoc = $state(false);
+
 	// Derived
 	const filteredApps = $derived(
 		applications.filter(a => a.Name?.toLowerCase().includes(searchQuery.toLowerCase()))
+	);
+	const filteredExtensions = $derived(
+		extensions.filter(e => e.Name?.toLowerCase().includes(extensionSearch.toLowerCase()))
 	);
 
 	// Actions
@@ -57,6 +94,30 @@
 			toast.error(`Failed to load AppConfig: ${(err as Error).message}`);
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function loadExtensions() {
+		loadingExtensions = true;
+		try {
+			const res = await appconfig.send(new ListExtensionsCommand({}));
+			extensions = res.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed to load extensions: ${(err as Error).message}`);
+		} finally {
+			loadingExtensions = false;
+		}
+	}
+
+	async function loadAssociations() {
+		loadingAssociations = true;
+		try {
+			const res = await appconfig.send(new ListExtensionAssociationsCommand({}));
+			associations = res.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed to load associations: ${(err as Error).message}`);
+		} finally {
+			loadingAssociations = false;
 		}
 	}
 
@@ -74,9 +135,9 @@
 			profiles = profRes.Items ?? [];
 
 			if (environments.length > 0) {
-				const depRes = await appconfig.send(new ListDeploymentsCommand({ 
-					ApplicationId: app.Id, 
-					EnvironmentId: environments[0].Id 
+				const depRes = await appconfig.send(new ListDeploymentsCommand({
+					ApplicationId: app.Id,
+					EnvironmentId: environments[0].Id
 				}));
 				deployments = depRes.Items ?? [];
 			}
@@ -115,6 +176,75 @@
 		}
 	}
 
+	async function createExtension() {
+		if (!newExtName.trim()) return;
+		creatingExt = true;
+		try {
+			await appconfig.send(new CreateExtensionCommand({
+				Name: newExtName.trim(),
+				Description: newExtDesc.trim() || undefined,
+				Actions: {}
+			}));
+			toast.success(`Extension "${newExtName}" created`);
+			showCreateExtModal = false;
+			newExtName = '';
+			newExtDesc = '';
+			await loadExtensions();
+		} catch (err: unknown) {
+			toast.error(`Extension creation failed: ${(err as Error).message}`);
+		} finally {
+			creatingExt = false;
+		}
+	}
+
+	async function deleteExtension(id: string | undefined, name: string | undefined) {
+		if (!id || !await confirmDestructive({ title: 'Delete Extension', message: `Delete extension "${name}"? This cannot be undone.` })) return;
+		try {
+			await appconfig.send(new DeleteExtensionCommand({ ExtensionIdentifier: id }));
+			toast.success(`Extension deleted`);
+			await loadExtensions();
+		} catch (err: unknown) {
+			toast.error(`Delete failed: ${(err as Error).message}`);
+		}
+	}
+
+	async function createAssociation() {
+		if (!newAssocExtId.trim() || !newAssocResource.trim()) return;
+		creatingAssoc = true;
+		try {
+			await appconfig.send(new CreateExtensionAssociationCommand({
+				ExtensionIdentifier: newAssocExtId.trim(),
+				ResourceIdentifier: newAssocResource.trim()
+			}));
+			toast.success('Extension association created');
+			showCreateAssocModal = false;
+			newAssocExtId = '';
+			newAssocResource = '';
+			await loadAssociations();
+		} catch (err: unknown) {
+			toast.error(`Association creation failed: ${(err as Error).message}`);
+		} finally {
+			creatingAssoc = false;
+		}
+	}
+
+	async function deleteAssociation(id: string | undefined) {
+		if (!id || !await confirmDestructive({ title: 'Delete Association', message: 'Delete this extension association?' })) return;
+		try {
+			await appconfig.send(new DeleteExtensionAssociationCommand({ ExtensionAssociationId: id }));
+			toast.success('Association deleted');
+			await loadAssociations();
+		} catch (err: unknown) {
+			toast.error(`Delete failed: ${(err as Error).message}`);
+		}
+	}
+
+	function handleTabChange(tab: Tab) {
+		activeTab = tab;
+		if (tab === 'extensions' && extensions.length === 0 && !loadingExtensions) loadExtensions();
+		if (tab === 'associations' && associations.length === 0 && !loadingAssociations) loadAssociations();
+	}
+
 	function getDeploymentStatusIcon(status: string | undefined) {
 		if (status === 'COMPLETE') return CheckCircle2;
 		if (status === 'ROLLING_BACK') return XCircle;
@@ -147,23 +277,68 @@
 			</div>
 		</div>
 		<div class="flex items-center gap-3">
-			<button 
-				onclick={loadApps}
+			<button
+				onclick={() => { if (activeTab === 'applications') loadApps(); else if (activeTab === 'extensions') loadExtensions(); else loadAssociations(); }}
 				class="p-2.5 rounded-xl bg-white/50 dark:bg-slate-700/50 hover:bg-white dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-600 transition-all active:scale-95 shadow-sm"
 				title="Refresh data"
 			>
-				<RefreshCw class="w-5 h-5 text-slate-600 dark:text-slate-300 {loading ? 'animate-spin' : ''}" />
+				<RefreshCw class="w-5 h-5 text-slate-600 dark:text-slate-300 {(loading || loadingExtensions || loadingAssociations) ? 'animate-spin' : ''}" />
 			</button>
-			<button 
+			{#if activeTab === 'applications'}
+			<button
 				onclick={() => showCreateModal = true}
 				class="flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-black shadow-lg shadow-blue-600/20 transition-all active:scale-95 uppercase text-xs tracking-widest"
 			>
 				<Plus class="w-5 h-5" />
 				Assemble Application
 			</button>
+			{:else if activeTab === 'extensions'}
+			<button
+				onclick={() => showCreateExtModal = true}
+				class="flex items-center gap-2 px-5 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-black shadow-lg shadow-indigo-600/20 transition-all active:scale-95 uppercase text-xs tracking-widest"
+			>
+				<Plus class="w-5 h-5" />
+				New Extension
+			</button>
+			{:else}
+			<button
+				onclick={() => showCreateAssocModal = true}
+				class="flex items-center gap-2 px-5 py-2.5 bg-violet-600 hover:bg-violet-700 text-white rounded-xl font-black shadow-lg shadow-violet-600/20 transition-all active:scale-95 uppercase text-xs tracking-widest"
+			>
+				<Plus class="w-5 h-5" />
+				New Association
+			</button>
+			{/if}
 		</div>
 	</div>
 
+	<!-- Tabs -->
+	<div class="flex gap-2 p-1 bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl w-fit">
+		<button
+			onclick={() => handleTabChange('applications')}
+			class="flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'applications' ? 'bg-blue-600 text-white shadow-lg shadow-blue-600/20' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"
+		>
+			<Layout class="w-4 h-4" />
+			Applications
+		</button>
+		<button
+			onclick={() => handleTabChange('extensions')}
+			class="flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'extensions' ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"
+		>
+			<Puzzle class="w-4 h-4" />
+			Extensions
+		</button>
+		<button
+			onclick={() => handleTabChange('associations')}
+			class="flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'associations' ? 'bg-violet-600 text-white shadow-lg shadow-violet-600/20' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"
+		>
+			<Link class="w-4 h-4" />
+			Associations
+		</button>
+	</div>
+
+	<!-- Applications Tab -->
+	{#if activeTab === 'applications'}
 	<div class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
 		<!-- App List -->
 		<div class="lg:col-span-3 space-y-4">
@@ -171,8 +346,8 @@
 				<div class="p-4 bg-white/20 dark:bg-slate-900/10 border-b border-slate-200 dark:border-slate-700/50">
 					<div class="relative w-full">
 						<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-						<input 
-							type="text" 
+						<input
+							type="text"
 							bind:value={searchQuery}
 							placeholder="Search applications..."
 							class="w-full pl-10 pr-4 py-2 bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-xl text-sm focus:ring-2 focus:ring-blue-500 outline-none transition-all italic font-bold"
@@ -187,7 +362,7 @@
 						{/each}
 					{:else}
 						{#each filteredApps as app}
-							<div 
+							<div
 								role="button"
 								tabindex="0"
 								onclick={() => selectApp(app)}
@@ -232,7 +407,7 @@
 										</div>
 									</div>
 								</div>
-								<button 
+								<button
 									onclick={() => deleteApplication(selectedApp?.Id)}
 									class="p-2.5 bg-slate-900 dark:bg-black text-rose-500 hover:bg-rose-500/10 rounded-2xl transition-all border border-rose-500/20 shadow-xl"
 									title="Purge Application"
@@ -379,22 +554,152 @@
 			{/if}
 		</div>
 	</div>
+	{/if}
+
+	<!-- Extensions Tab -->
+	{#if activeTab === 'extensions'}
+	<div class="space-y-4">
+		<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
+			<div class="p-4 bg-white/20 dark:bg-slate-900/10 border-b border-slate-200 dark:border-slate-700/50 flex items-center gap-3">
+				<div class="relative flex-1">
+					<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+					<input
+						type="text"
+						bind:value={extensionSearch}
+						placeholder="Search extensions..."
+						class="w-full pl-10 pr-4 py-2 bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-xl text-sm focus:ring-2 focus:ring-indigo-500 outline-none transition-all italic font-bold"
+					/>
+				</div>
+				<span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">{extensions.length} TOTAL</span>
+			</div>
+
+			{#if loadingExtensions}
+				<div class="p-12 flex flex-col items-center gap-4 opacity-30">
+					<RefreshCw class="w-8 h-8 text-indigo-500 animate-spin" />
+					<span class="text-[10px] uppercase font-black text-slate-500 tracking-[0.2em]">Loading Extensions...</span>
+				</div>
+			{:else if filteredExtensions.length === 0}
+				<div class="p-16 text-center flex flex-col items-center gap-4">
+					<Puzzle class="w-12 h-12 text-slate-200 dark:text-slate-700" />
+					<p class="text-sm font-black text-slate-400 italic uppercase tracking-widest">No extensions registered.</p>
+				</div>
+			{:else}
+				<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+					{#each filteredExtensions as ext}
+						<div class="p-6 flex items-center justify-between hover:bg-indigo-500/5 transition-all group">
+							<div class="flex items-center gap-4">
+								<div class="p-2.5 bg-indigo-500/10 rounded-xl border border-indigo-500/20">
+									<Puzzle class="w-5 h-5 text-indigo-600" />
+								</div>
+								<div>
+									<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm">{ext.Name}</div>
+									<div class="flex items-center gap-3 mt-1">
+										<span class="text-[8px] text-slate-400 font-mono tracking-tighter opacity-60 italic">{ext.Id}</span>
+										<span class="px-1.5 py-0.5 rounded bg-indigo-500/10 text-indigo-600 text-[8px] font-black uppercase border border-indigo-500/20">v{ext.VersionNumber}</span>
+									</div>
+									{#if ext.Description}
+										<p class="text-[10px] text-slate-500 mt-1 italic">{ext.Description}</p>
+									{/if}
+								</div>
+							</div>
+							<div class="flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
+								{#if ext.Actions && Object.keys(ext.Actions).length > 0}
+									<div class="px-2 py-1 rounded-lg bg-slate-100 dark:bg-slate-700 text-[9px] font-black text-slate-500 uppercase">
+										{Object.keys(ext.Actions).length} HOOKS
+									</div>
+								{/if}
+								<button
+									onclick={() => deleteExtension(ext.Id, ext.Name)}
+									class="p-2 rounded-xl text-rose-500 hover:bg-rose-500/10 transition-all border border-transparent hover:border-rose-500/20"
+									title="Delete extension"
+								>
+									<Trash2 class="w-4 h-4" />
+								</button>
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+	{/if}
+
+	<!-- Associations Tab -->
+	{#if activeTab === 'associations'}
+	<div class="space-y-4">
+		<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
+			<div class="p-4 bg-white/20 dark:bg-slate-900/10 border-b border-slate-200 dark:border-slate-700/50 flex items-center justify-between">
+				<div class="flex items-center gap-2">
+					<Link class="w-4 h-4 text-violet-500" />
+					<span class="text-xs font-black text-slate-600 dark:text-slate-300 uppercase tracking-widest italic">Extension Associations</span>
+				</div>
+				<span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">{associations.length} TOTAL</span>
+			</div>
+
+			{#if loadingAssociations}
+				<div class="p-12 flex flex-col items-center gap-4 opacity-30">
+					<RefreshCw class="w-8 h-8 text-violet-500 animate-spin" />
+					<span class="text-[10px] uppercase font-black text-slate-500 tracking-[0.2em]">Loading Associations...</span>
+				</div>
+			{:else if associations.length === 0}
+				<div class="p-16 text-center flex flex-col items-center gap-4">
+					<Link class="w-12 h-12 text-slate-200 dark:text-slate-700" />
+					<p class="text-sm font-black text-slate-400 italic uppercase tracking-widest">No extension associations.</p>
+				</div>
+			{:else}
+				<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+					{#each associations as assoc}
+						<div class="p-6 flex items-center justify-between hover:bg-violet-500/5 transition-all group">
+							<div class="flex items-center gap-4">
+								<div class="p-2.5 bg-violet-500/10 rounded-xl border border-violet-500/20">
+									<Link class="w-5 h-5 text-violet-600" />
+								</div>
+								<div>
+									<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm font-mono">{assoc.Id}</div>
+									<div class="flex flex-col gap-1 mt-1">
+										<div class="flex items-center gap-2">
+											<Puzzle class="w-3 h-3 text-indigo-500" />
+											<span class="text-[9px] text-slate-500 font-mono truncate max-w-[300px]">{assoc.ExtensionArn}</span>
+										</div>
+										<div class="flex items-center gap-2">
+											<Database class="w-3 h-3 text-slate-400" />
+											<span class="text-[9px] text-slate-500 font-mono truncate max-w-[300px]">{assoc.ResourceArn}</span>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
+								<button
+									onclick={() => deleteAssociation(assoc.Id)}
+									class="p-2 rounded-xl text-rose-500 hover:bg-rose-500/10 transition-all border border-transparent hover:border-rose-500/20"
+									title="Delete association"
+								>
+									<Trash2 class="w-4 h-4" />
+								</button>
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+	{/if}
 </div>
 
-<!-- Create Modal -->
+<!-- Create Application Modal -->
 {#if showCreateModal}
 	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
 		<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateModal = false} onkeydown={(e) => { if (e.key === 'Escape') showCreateModal = false; }} role="presentation"></div>
 		<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2.5rem] shadow-2xl border border-blue-500/20 overflow-hidden animate-in zoom-in-95">
 			<div class="p-8">
 				<h3 class="text-2xl font-black text-slate-900 dark:text-white mb-6 uppercase tracking-tighter italic leading-none">Assemble Application</h3>
-				
+
 				<form onsubmit={(e) => { e.preventDefault(); createApplication(); }} class="space-y-6">
 					<div>
 						<label for="appName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Application Identifier</label>
-						<input 
+						<input
 							id="appName"
-							type="text" 
+							type="text"
 							bind:value={newAppName}
 							placeholder="e.g. gopherstack-microservices-config"
 							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-blue-500 transition-all font-mono text-xs italic"
@@ -416,6 +721,93 @@
 						<button type="button" onclick={() => showCreateModal = false} class="flex-1 px-4 py-4 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-2xl font-black uppercase text-[10px] tracking-widest transition-all">Abort</button>
 						<button type="submit" disabled={creating} class="flex-1 px-4 py-4 bg-blue-600 text-white rounded-2xl font-black uppercase text-[10px] tracking-widest shadow-lg active:scale-95 disabled:opacity-50 transition-all">
 							{creating ? 'Assembling...' : 'Provision Blueprint'}
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Create Extension Modal -->
+{#if showCreateExtModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+		<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateExtModal = false} onkeydown={(e) => { if (e.key === 'Escape') showCreateExtModal = false; }} role="presentation"></div>
+		<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2.5rem] shadow-2xl border border-indigo-500/20 overflow-hidden animate-in zoom-in-95">
+			<div class="p-8">
+				<h3 class="text-2xl font-black text-slate-900 dark:text-white mb-6 uppercase tracking-tighter italic leading-none">Register Extension</h3>
+
+				<form onsubmit={(e) => { e.preventDefault(); createExtension(); }} class="space-y-4">
+					<div>
+						<label for="extName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Extension Name</label>
+						<input
+							id="extName"
+							type="text"
+							bind:value={newExtName}
+							placeholder="e.g. MyLambdaExtension"
+							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-indigo-500 transition-all font-mono text-xs italic"
+							required
+						/>
+					</div>
+					<div>
+						<label for="extDesc" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Description (optional)</label>
+						<input
+							id="extDesc"
+							type="text"
+							bind:value={newExtDesc}
+							placeholder="What does this extension do?"
+							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-indigo-500 transition-all font-mono text-xs italic"
+						/>
+					</div>
+
+					<div class="flex gap-4 pt-4">
+						<button type="button" onclick={() => showCreateExtModal = false} class="flex-1 px-4 py-4 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-2xl font-black uppercase text-[10px] tracking-widest transition-all">Cancel</button>
+						<button type="submit" disabled={creatingExt} class="flex-1 px-4 py-4 bg-indigo-600 text-white rounded-2xl font-black uppercase text-[10px] tracking-widest shadow-lg active:scale-95 disabled:opacity-50 transition-all">
+							{creatingExt ? 'Registering...' : 'Register'}
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Create Association Modal -->
+{#if showCreateAssocModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+		<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateAssocModal = false} onkeydown={(e) => { if (e.key === 'Escape') showCreateAssocModal = false; }} role="presentation"></div>
+		<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2.5rem] shadow-2xl border border-violet-500/20 overflow-hidden animate-in zoom-in-95">
+			<div class="p-8">
+				<h3 class="text-2xl font-black text-slate-900 dark:text-white mb-6 uppercase tracking-tighter italic leading-none">Associate Extension</h3>
+
+				<form onsubmit={(e) => { e.preventDefault(); createAssociation(); }} class="space-y-4">
+					<div>
+						<label for="assocExtId" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Extension ID or Name</label>
+						<input
+							id="assocExtId"
+							type="text"
+							bind:value={newAssocExtId}
+							placeholder="Extension ID or name"
+							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-violet-500 transition-all font-mono text-xs italic"
+							required
+						/>
+					</div>
+					<div>
+						<label for="assocResource" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Resource ARN or Identifier</label>
+						<input
+							id="assocResource"
+							type="text"
+							bind:value={newAssocResource}
+							placeholder="arn:aws:appconfig:..."
+							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-violet-500 transition-all font-mono text-xs italic"
+							required
+						/>
+					</div>
+
+					<div class="flex gap-4 pt-4">
+						<button type="button" onclick={() => showCreateAssocModal = false} class="flex-1 px-4 py-4 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-2xl font-black uppercase text-[10px] tracking-widest transition-all">Cancel</button>
+						<button type="submit" disabled={creatingAssoc} class="flex-1 px-4 py-4 bg-violet-600 text-white rounded-2xl font-black uppercase text-[10px] tracking-widest shadow-lg active:scale-95 disabled:opacity-50 transition-all">
+							{creatingAssoc ? 'Associating...' : 'Associate'}
 						</button>
 					</div>
 				</form>

--- a/ui/src/routes/appconfig/+page.svelte
+++ b/ui/src/routes/appconfig/+page.svelte
@@ -189,7 +189,7 @@
 		loadingSettings = true;
 		try {
 			const res = await appconfig.send(new GetAccountSettingsCommand({}));
-			accountSettings = res as any;
+			accountSettings = res as typeof accountSettings;
 		} catch (err: unknown) {
 			toast.error(`Failed to load account settings: ${(err as Error).message}`);
 		} finally {
@@ -405,8 +405,8 @@
 				DeploymentDurationInMinutes: newStratDuration,
 				FinalBakeTimeInMinutes: newStratBake,
 				GrowthFactor: newStratGrowth,
-				GrowthType: newStratGrowthType as any,
-				ReplicateTo: newStratReplicateTo as any,
+				GrowthType: newStratGrowthType as string,
+				ReplicateTo: newStratReplicateTo as string,
 			}));
 			toast.success(`Strategy "${newStratName}" created`);
 			showCreateStratModal = false;

--- a/ui/src/routes/appconfig/+page.svelte
+++ b/ui/src/routes/appconfig/+page.svelte
@@ -9,38 +9,53 @@
 		ListDeploymentsCommand,
 		ListExtensionsCommand,
 		ListExtensionAssociationsCommand,
+		ListDeploymentStrategiesCommand,
+		ListHostedConfigurationVersionsCommand,
 		DeleteApplicationCommand,
 		DeleteExtensionCommand,
 		DeleteExtensionAssociationCommand,
+		DeleteDeploymentStrategyCommand,
+		DeleteEnvironmentCommand,
+		DeleteConfigurationProfileCommand,
 		CreateApplicationCommand,
 		CreateExtensionCommand,
 		CreateExtensionAssociationCommand,
+		CreateEnvironmentCommand,
+		CreateConfigurationProfileCommand,
+		CreateDeploymentStrategyCommand,
+		StartDeploymentCommand,
+		StopDeploymentCommand,
+		GetAccountSettingsCommand,
 		type Application,
 		type Environment,
 		type ConfigurationProfile,
 		type DeploymentSummary,
 		type Extension,
-		type ExtensionAssociationSummary
+		type ExtensionAssociationSummary,
+		type DeploymentStrategy,
+		type HostedConfigurationVersionSummary,
 	} from '@aws-sdk/client-appconfig';
 	import { toast } from 'svelte-sonner';
 	import {
 		Settings, Search, RefreshCw, Plus, Trash2,
-		Activity, Info, Box, Clock, ShieldCheck,
-		ChevronRight, ListFilter, Globe,
-		Layers, Zap, Terminal, Workflow,
-		FileCode, Sliders, Play, CheckCircle2, Code2,
-		XCircle, AlertCircle, Timer, Server,
-		Database, Share2, ArrowRight, Gauge,
+		ChevronRight, Globe,
+		Workflow,
+		FileCode, Code2,
+		XCircle, AlertCircle, Timer,
+		Database,
+		ArrowRight, Gauge,
 		Settings2, Layout, Boxes, Shield, ExternalLink,
-		Puzzle, Link
+		Puzzle, Link, Play, Square, BarChart3, Archive,
+		ChevronDown, ChevronUp, Eye
 	} from 'lucide-svelte';
+
 	const appconfig = getAppConfigClient();
 
 	// Tabs
-	type Tab = 'applications' | 'extensions' | 'associations';
+	type Tab = 'applications' | 'strategies' | 'extensions' | 'associations' | 'settings';
 	let activeTab = $state<Tab>('applications');
 
-	// State
+	// ── Applications Tab ─────────────────────────────────────────────────────
 	let loading = $state(false);
 	let searchQuery = $state('');
 	let applications = $state<Application[]>([]);
@@ -49,32 +64,69 @@
 	let profiles = $state<ConfigurationProfile[]>([]);
 	let deployments = $state<DeploymentSummary[]>([]);
 	let loadingDetails = $state(false);
+	let selectedEnvId = $state<string>('');
+	let configVersions = $state<HostedConfigurationVersionSummary[]>([]);
+	let selectedProfileId = $state<string>('');
+	let loadingVersions = $state(false);
+	let appDetailTab = $state<'envs' | 'profiles' | 'deployments' | 'versions'>('envs');
 
-	// Extensions state
-	let extensions = $state<Extension[]>([]);
-	let loadingExtensions = $state(false);
-	let extensionSearch = $state('');
-
-	// Extension Associations state
-	let associations = $state<ExtensionAssociationSummary[]>([]);
-	let loadingAssociations = $state(false);
-
-	// Modal State
+	// App create modal
 	let showCreateModal = $state(false);
 	let newAppName = $state('');
 	let creating = $state(false);
 
-	// Extension Create Modal
+	// Environment create modal
+	let showCreateEnvModal = $state(false);
+	let newEnvName = $state('');
+	let creatingEnv = $state(false);
+
+	// Profile create modal
+	let showCreateProfileModal = $state(false);
+	let newProfileName = $state('');
+	let newProfileLocationUri = $state('hosted');
+	let newProfileType = $state('AWS.Freeform');
+	let creatingProfile = $state(false);
+
+	// Deploy modal
+	let showDeployModal = $state(false);
+	let deployProfileId = $state('');
+	let deployStrategyId = $state('');
+	let deployVersion = $state('');
+	let deploying = $state(false);
+
+	// ── Strategies Tab ───────────────────────────────────────────────────────
+	let strategies = $state<DeploymentStrategy[]>([]);
+	let loadingStrategies = $state(false);
+	let showCreateStratModal = $state(false);
+	let newStratName = $state('');
+	let newStratDesc = $state('');
+	let newStratDuration = $state(10);
+	let newStratBake = $state(0);
+	let newStratGrowth = $state(100);
+	let newStratGrowthType = $state('LINEAR');
+	let newStratReplicateTo = $state('NONE');
+	let creatingStrat = $state(false);
+
+	// ── Extensions Tab ───────────────────────────────────────────────────────
+	let extensions = $state<Extension[]>([]);
+	let loadingExtensions = $state(false);
+	let extensionSearch = $state('');
 	let showCreateExtModal = $state(false);
 	let newExtName = $state('');
 	let newExtDesc = $state('');
 	let creatingExt = $state(false);
 
-	// Extension Association Create Modal
+	// ── Associations Tab ─────────────────────────────────────────────────────
+	let associations = $state<ExtensionAssociationSummary[]>([]);
+	let loadingAssociations = $state(false);
 	let showCreateAssocModal = $state(false);
 	let newAssocExtId = $state('');
 	let newAssocResource = $state('');
 	let creatingAssoc = $state(false);
+
+	// ── Account Settings Tab ─────────────────────────────────────────────────
+	let accountSettings = $state<{ DeletionProtection?: { Enabled?: boolean } } | null>(null);
+	let loadingSettings = $state(false);
 
 	// Derived
 	const filteredApps = $derived(
@@ -84,16 +136,28 @@
 		extensions.filter(e => e.Name?.toLowerCase().includes(extensionSearch.toLowerCase()))
 	);
 
-	// Actions
+	// ── Data loaders ─────────────────────────────────────────────────────────
 	async function loadApps() {
 		loading = true;
 		try {
 			const res = await appconfig.send(new ListApplicationsCommand({}));
 			applications = res.Items ?? [];
 		} catch (err: unknown) {
-			toast.error(`Failed to load AppConfig: ${(err as Error).message}`);
+			toast.error(`Failed to load applications: ${(err as Error).message}`);
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function loadStrategies() {
+		loadingStrategies = true;
+		try {
+			const res = await appconfig.send(new ListDeploymentStrategiesCommand({}));
+			strategies = res.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed to load strategies: ${(err as Error).message}`);
+		} finally {
+			loadingStrategies = false;
 		}
 	}
 
@@ -121,25 +185,39 @@
 		}
 	}
 
+	async function loadAccountSettings() {
+		loadingSettings = true;
+		try {
+			const res = await appconfig.send(new GetAccountSettingsCommand({}));
+			accountSettings = res as any;
+		} catch (err: unknown) {
+			toast.error(`Failed to load account settings: ${(err as Error).message}`);
+		} finally {
+			loadingSettings = false;
+		}
+	}
+
 	async function selectApp(app: Application) {
 		selectedApp = app;
 		environments = [];
 		profiles = [];
 		deployments = [];
+		configVersions = [];
+		selectedEnvId = '';
+		selectedProfileId = '';
+		appDetailTab = 'envs';
 		loadingDetails = true;
 		try {
-			const envRes = await appconfig.send(new ListEnvironmentsCommand({ ApplicationId: app.Id }));
+			const [envRes, profRes] = await Promise.all([
+				appconfig.send(new ListEnvironmentsCommand({ ApplicationId: app.Id })),
+				appconfig.send(new ListConfigurationProfilesCommand({ ApplicationId: app.Id })),
+			]);
 			environments = envRes.Items ?? [];
-
-			const profRes = await appconfig.send(new ListConfigurationProfilesCommand({ ApplicationId: app.Id }));
 			profiles = profRes.Items ?? [];
 
 			if (environments.length > 0) {
-				const depRes = await appconfig.send(new ListDeploymentsCommand({
-					ApplicationId: app.Id,
-					EnvironmentId: environments[0].Id
-				}));
-				deployments = depRes.Items ?? [];
+				selectedEnvId = environments[0].Id ?? '';
+				await loadDeployments(app.Id!, selectedEnvId);
 			}
 		} catch (err: unknown) {
 			toast.error(`Failed to load app details: ${(err as Error).message}`);
@@ -148,6 +226,36 @@
 		}
 	}
 
+	async function loadDeployments(appId: string, envId: string) {
+		if (!envId) return;
+		loadingDetails = true;
+		try {
+			const depRes = await appconfig.send(new ListDeploymentsCommand({ ApplicationId: appId, EnvironmentId: envId }));
+			deployments = depRes.Items ?? [];
+		} catch {
+			deployments = [];
+		} finally {
+			loadingDetails = false;
+		}
+	}
+
+	async function loadConfigVersions(appId: string, profileId: string) {
+		if (!profileId) return;
+		loadingVersions = true;
+		try {
+			const res = await appconfig.send(new ListHostedConfigurationVersionsCommand({
+				ApplicationId: appId,
+				ConfigurationProfileId: profileId
+			}));
+			configVersions = res.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed to load versions: ${(err as Error).message}`);
+		} finally {
+			loadingVersions = false;
+		}
+	}
+
+	// ── Application CRUD ──────────────────────────────────────────────────────
 	async function createApplication() {
 		if (!newAppName.trim()) return;
 		creating = true;
@@ -168,7 +276,7 @@
 		if (!id || !await confirmDestructive({ title: 'Delete Application', message: 'Delete this AppConfig application? All configuration profiles and environments will be permanently removed.' })) return;
 		try {
 			await appconfig.send(new DeleteApplicationCommand({ ApplicationId: id }));
-			toast.success(`Application deleted`);
+			toast.success('Application deleted');
 			if (selectedApp?.Id === id) selectedApp = null;
 			await loadApps();
 		} catch (err: unknown) {
@@ -176,6 +284,154 @@
 		}
 	}
 
+	// ── Environment CRUD ──────────────────────────────────────────────────────
+	async function createEnvironment() {
+		if (!newEnvName.trim() || !selectedApp) return;
+		creatingEnv = true;
+		try {
+			await appconfig.send(new CreateEnvironmentCommand({ ApplicationId: selectedApp.Id, Name: newEnvName.trim() }));
+			toast.success(`Environment "${newEnvName}" created`);
+			showCreateEnvModal = false;
+			newEnvName = '';
+			const envRes = await appconfig.send(new ListEnvironmentsCommand({ ApplicationId: selectedApp.Id }));
+			environments = envRes.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed: ${(err as Error).message}`);
+		} finally {
+			creatingEnv = false;
+		}
+	}
+
+	async function deleteEnvironment(envId: string | undefined) {
+		if (!envId || !selectedApp || !await confirmDestructive({ title: 'Delete Environment', message: 'Delete this environment?' })) return;
+		try {
+			await appconfig.send(new DeleteEnvironmentCommand({ ApplicationId: selectedApp.Id, EnvironmentId: envId }));
+			toast.success('Environment deleted');
+			const envRes = await appconfig.send(new ListEnvironmentsCommand({ ApplicationId: selectedApp.Id }));
+			environments = envRes.Items ?? [];
+			if (selectedEnvId === envId) {
+				selectedEnvId = environments[0]?.Id ?? '';
+				if (selectedEnvId) await loadDeployments(selectedApp.Id!, selectedEnvId);
+			}
+		} catch (err: unknown) {
+			toast.error(`Delete failed: ${(err as Error).message}`);
+		}
+	}
+
+	// ── Profile CRUD ──────────────────────────────────────────────────────────
+	async function createProfile() {
+		if (!newProfileName.trim() || !selectedApp) return;
+		creatingProfile = true;
+		try {
+			await appconfig.send(new CreateConfigurationProfileCommand({
+				ApplicationId: selectedApp.Id,
+				Name: newProfileName.trim(),
+				LocationUri: newProfileLocationUri || 'hosted',
+				Type: newProfileType || 'AWS.Freeform',
+			}));
+			toast.success(`Profile "${newProfileName}" created`);
+			showCreateProfileModal = false;
+			newProfileName = '';
+			const profRes = await appconfig.send(new ListConfigurationProfilesCommand({ ApplicationId: selectedApp.Id }));
+			profiles = profRes.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed: ${(err as Error).message}`);
+		} finally {
+			creatingProfile = false;
+		}
+	}
+
+	async function deleteProfile(profileId: string | undefined) {
+		if (!profileId || !selectedApp || !await confirmDestructive({ title: 'Delete Profile', message: 'Delete this configuration profile?' })) return;
+		try {
+			await appconfig.send(new DeleteConfigurationProfileCommand({ ApplicationId: selectedApp.Id, ConfigurationProfileId: profileId }));
+			toast.success('Profile deleted');
+			const profRes = await appconfig.send(new ListConfigurationProfilesCommand({ ApplicationId: selectedApp.Id }));
+			profiles = profRes.Items ?? [];
+		} catch (err: unknown) {
+			toast.error(`Delete failed: ${(err as Error).message}`);
+		}
+	}
+
+	// ── Deployment actions ────────────────────────────────────────────────────
+	async function startDeployment() {
+		if (!selectedApp || !deployProfileId || !deployStrategyId || !deployVersion) return;
+		deploying = true;
+		try {
+			await appconfig.send(new StartDeploymentCommand({
+				ApplicationId: selectedApp.Id,
+				EnvironmentId: selectedEnvId,
+				ConfigurationProfileId: deployProfileId,
+				DeploymentStrategyId: deployStrategyId,
+				ConfigurationVersion: deployVersion,
+			}));
+			toast.success('Deployment started');
+			showDeployModal = false;
+			deployProfileId = '';
+			deployStrategyId = '';
+			deployVersion = '';
+			await loadDeployments(selectedApp.Id!, selectedEnvId);
+		} catch (err: unknown) {
+			toast.error(`Deployment failed: ${(err as Error).message}`);
+		} finally {
+			deploying = false;
+		}
+	}
+
+	async function stopDeployment(depNum: number | undefined) {
+		if (!depNum || !selectedApp || !selectedEnvId) return;
+		if (!await confirmDestructive({ title: 'Stop Deployment', message: 'Roll back this deployment?' })) return;
+		try {
+			await appconfig.send(new StopDeploymentCommand({
+				ApplicationId: selectedApp.Id,
+				EnvironmentId: selectedEnvId,
+				DeploymentNumber: depNum,
+			}));
+			toast.success('Deployment stopped');
+			await loadDeployments(selectedApp.Id!, selectedEnvId);
+		} catch (err: unknown) {
+			toast.error(`Stop failed: ${(err as Error).message}`);
+		}
+	}
+
+	// ── Strategy CRUD ─────────────────────────────────────────────────────────
+	async function createStrategy() {
+		if (!newStratName.trim()) return;
+		creatingStrat = true;
+		try {
+			await appconfig.send(new CreateDeploymentStrategyCommand({
+				Name: newStratName.trim(),
+				Description: newStratDesc.trim() || undefined,
+				DeploymentDurationInMinutes: newStratDuration,
+				FinalBakeTimeInMinutes: newStratBake,
+				GrowthFactor: newStratGrowth,
+				GrowthType: newStratGrowthType as any,
+				ReplicateTo: newStratReplicateTo as any,
+			}));
+			toast.success(`Strategy "${newStratName}" created`);
+			showCreateStratModal = false;
+			newStratName = '';
+			newStratDesc = '';
+			await loadStrategies();
+		} catch (err: unknown) {
+			toast.error(`Failed: ${(err as Error).message}`);
+		} finally {
+			creatingStrat = false;
+		}
+	}
+
+	async function deleteStrategy(id: string | undefined, name: string | undefined) {
+		if (!id || !await confirmDestructive({ title: 'Delete Strategy', message: `Delete deployment strategy "${name}"?` })) return;
+		try {
+			await appconfig.send(new DeleteDeploymentStrategyCommand({ DeploymentStrategyId: id }));
+			toast.success('Strategy deleted');
+			await loadStrategies();
+		} catch (err: unknown) {
+			toast.error(`Delete failed: ${(err as Error).message}`);
+		}
+	}
+
+	// ── Extension CRUD ────────────────────────────────────────────────────────
 	async function createExtension() {
 		if (!newExtName.trim()) return;
 		creatingExt = true;
@@ -198,16 +454,17 @@
 	}
 
 	async function deleteExtension(id: string | undefined, name: string | undefined) {
-		if (!id || !await confirmDestructive({ title: 'Delete Extension', message: `Delete extension "${name}"? This cannot be undone.` })) return;
+		if (!id || !await confirmDestructive({ title: 'Delete Extension', message: `Delete extension "${name}"?` })) return;
 		try {
 			await appconfig.send(new DeleteExtensionCommand({ ExtensionIdentifier: id }));
-			toast.success(`Extension deleted`);
+			toast.success('Extension deleted');
 			await loadExtensions();
 		} catch (err: unknown) {
 			toast.error(`Delete failed: ${(err as Error).message}`);
 		}
 	}
 
+	// ── Association CRUD ──────────────────────────────────────────────────────
 	async function createAssociation() {
 		if (!newAssocExtId.trim() || !newAssocResource.trim()) return;
 		creatingAssoc = true;
@@ -216,13 +473,13 @@
 				ExtensionIdentifier: newAssocExtId.trim(),
 				ResourceIdentifier: newAssocResource.trim()
 			}));
-			toast.success('Extension association created');
+			toast.success('Association created');
 			showCreateAssocModal = false;
 			newAssocExtId = '';
 			newAssocResource = '';
 			await loadAssociations();
 		} catch (err: unknown) {
-			toast.error(`Association creation failed: ${(err as Error).message}`);
+			toast.error(`Failed: ${(err as Error).message}`);
 		} finally {
 			creatingAssoc = false;
 		}
@@ -239,29 +496,23 @@
 		}
 	}
 
+	// ── Tab change ────────────────────────────────────────────────────────────
 	function handleTabChange(tab: Tab) {
 		activeTab = tab;
+		if (tab === 'strategies' && strategies.length === 0 && !loadingStrategies) loadStrategies();
 		if (tab === 'extensions' && extensions.length === 0 && !loadingExtensions) loadExtensions();
 		if (tab === 'associations' && associations.length === 0 && !loadingAssociations) loadAssociations();
+		if (tab === 'settings' && !accountSettings && !loadingSettings) loadAccountSettings();
 	}
 
 	function getDeploymentStatusIcon(status: string | undefined) {
-		if (status === 'COMPLETE') return CheckCircle2;
-		if (status === 'ROLLING_BACK') return XCircle;
-		if (status === 'DEPLOYING') return RefreshCw;
-		return AlertCircle;
-	}
-
-	function getDeploymentStatusColor(status: string | undefined): string {
 		if (status === 'COMPLETE') return 'text-emerald-500';
-		if (status === 'ROLLING_BACK') return 'text-rose-500';
-		if (status === 'DEPLOYING') return 'text-amber-500 animate-spin';
+		if (status === 'ROLLING_BACK' || status === 'ROLLED_BACK') return 'text-rose-500';
+		if (status === 'DEPLOYING' || status === 'BAKING') return 'text-amber-500 animate-pulse';
 		return 'text-slate-400';
 	}
 
-	onMount(() => {
-		loadApps();
-	});
+	onMount(() => { loadApps(); });
 </script>
 
 <div class="space-y-6">
@@ -278,557 +529,614 @@
 		</div>
 		<div class="flex items-center gap-3">
 			<button
-				onclick={() => { if (activeTab === 'applications') loadApps(); else if (activeTab === 'extensions') loadExtensions(); else loadAssociations(); }}
+				onclick={() => { if (activeTab === 'applications') loadApps(); else if (activeTab === 'strategies') loadStrategies(); else if (activeTab === 'extensions') loadExtensions(); else if (activeTab === 'associations') loadAssociations(); else loadAccountSettings(); }}
 				class="p-2.5 rounded-xl bg-white/50 dark:bg-slate-700/50 hover:bg-white dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-600 transition-all active:scale-95 shadow-sm"
-				title="Refresh data"
 			>
-				<RefreshCw class="w-5 h-5 text-slate-600 dark:text-slate-300 {(loading || loadingExtensions || loadingAssociations) ? 'animate-spin' : ''}" />
+				<RefreshCw class="w-5 h-5 text-slate-600 dark:text-slate-300 {(loading || loadingStrategies || loadingExtensions || loadingAssociations) ? 'animate-spin' : ''}" />
 			</button>
 			{#if activeTab === 'applications'}
-			<button
-				onclick={() => showCreateModal = true}
-				class="flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-black shadow-lg shadow-blue-600/20 transition-all active:scale-95 uppercase text-xs tracking-widest"
-			>
-				<Plus class="w-5 h-5" />
-				Assemble Application
-			</button>
+				<button onclick={() => showCreateModal = true} class="flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-black shadow-lg transition-all active:scale-95 uppercase text-xs tracking-widest">
+					<Plus class="w-4 h-4" /> New Application
+				</button>
+			{:else if activeTab === 'strategies'}
+				<button onclick={() => showCreateStratModal = true} class="flex items-center gap-2 px-5 py-2.5 bg-amber-600 hover:bg-amber-700 text-white rounded-xl font-black shadow-lg transition-all active:scale-95 uppercase text-xs tracking-widest">
+					<Plus class="w-4 h-4" /> New Strategy
+				</button>
 			{:else if activeTab === 'extensions'}
-			<button
-				onclick={() => showCreateExtModal = true}
-				class="flex items-center gap-2 px-5 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-black shadow-lg shadow-indigo-600/20 transition-all active:scale-95 uppercase text-xs tracking-widest"
-			>
-				<Plus class="w-5 h-5" />
-				New Extension
-			</button>
-			{:else}
-			<button
-				onclick={() => showCreateAssocModal = true}
-				class="flex items-center gap-2 px-5 py-2.5 bg-violet-600 hover:bg-violet-700 text-white rounded-xl font-black shadow-lg shadow-violet-600/20 transition-all active:scale-95 uppercase text-xs tracking-widest"
-			>
-				<Plus class="w-5 h-5" />
-				New Association
-			</button>
+				<button onclick={() => showCreateExtModal = true} class="flex items-center gap-2 px-5 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-black shadow-lg transition-all active:scale-95 uppercase text-xs tracking-widest">
+					<Plus class="w-4 h-4" /> New Extension
+				</button>
+			{:else if activeTab === 'associations'}
+				<button onclick={() => showCreateAssocModal = true} class="flex items-center gap-2 px-5 py-2.5 bg-violet-600 hover:bg-violet-700 text-white rounded-xl font-black shadow-lg transition-all active:scale-95 uppercase text-xs tracking-widest">
+					<Plus class="w-4 h-4" /> New Association
+				</button>
 			{/if}
 		</div>
 	</div>
 
 	<!-- Tabs -->
-	<div class="flex gap-2 p-1 bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl w-fit">
-		<button
-			onclick={() => handleTabChange('applications')}
-			class="flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'applications' ? 'bg-blue-600 text-white shadow-lg shadow-blue-600/20' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"
-		>
-			<Layout class="w-4 h-4" />
-			Applications
-		</button>
-		<button
-			onclick={() => handleTabChange('extensions')}
-			class="flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'extensions' ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-600/20' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"
-		>
-			<Puzzle class="w-4 h-4" />
-			Extensions
-		</button>
-		<button
-			onclick={() => handleTabChange('associations')}
-			class="flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'associations' ? 'bg-violet-600 text-white shadow-lg shadow-violet-600/20' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"
-		>
-			<Link class="w-4 h-4" />
-			Associations
-		</button>
+	<div class="flex flex-wrap gap-2 p-1 bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl w-fit">
+		<button onclick={() => handleTabChange('applications')} class="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'applications' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"><Layout class="w-3.5 h-3.5" /> Applications</button>
+		<button onclick={() => handleTabChange('strategies')} class="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'strategies' ? 'bg-amber-600 text-white shadow-lg' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"><BarChart3 class="w-3.5 h-3.5" /> Strategies</button>
+		<button onclick={() => handleTabChange('extensions')} class="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'extensions' ? 'bg-indigo-600 text-white shadow-lg' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"><Puzzle class="w-3.5 h-3.5" /> Extensions</button>
+		<button onclick={() => handleTabChange('associations')} class="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'associations' ? 'bg-violet-600 text-white shadow-lg' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"><Link class="w-3.5 h-3.5" /> Associations</button>
+		<button onclick={() => handleTabChange('settings')} class="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-all {activeTab === 'settings' ? 'bg-slate-600 text-white shadow-lg' : 'text-slate-500 hover:text-slate-900 dark:hover:text-white'}"><Settings class="w-3.5 h-3.5" /> Settings</button>
 	</div>
 
-	<!-- Applications Tab -->
+	<!-- ══ APPLICATIONS TAB ══════════════════════════════════════════════════ -->
 	{#if activeTab === 'applications'}
 	<div class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
 		<!-- App List -->
-		<div class="lg:col-span-3 space-y-4">
+		<div class="lg:col-span-3">
 			<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
-				<div class="p-4 bg-white/20 dark:bg-slate-900/10 border-b border-slate-200 dark:border-slate-700/50">
-					<div class="relative w-full">
+				<div class="p-4 border-b border-slate-200 dark:border-slate-700/50">
+					<div class="relative">
 						<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-						<input
-							type="text"
-							bind:value={searchQuery}
-							placeholder="Search applications..."
-							class="w-full pl-10 pr-4 py-2 bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-xl text-sm focus:ring-2 focus:ring-blue-500 outline-none transition-all italic font-bold"
-						/>
+						<input type="text" bind:value={searchQuery} placeholder="Search apps..." class="w-full pl-9 pr-4 py-2 bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-xl text-sm focus:ring-2 focus:ring-blue-500 outline-none italic font-bold" />
 					</div>
 				</div>
-
-				<div class="divide-y divide-slate-100 dark:divide-slate-700/50 max-h-[600px] overflow-y-auto">
+				<div class="max-h-[600px] overflow-y-auto divide-y divide-slate-100 dark:divide-slate-700/50">
 					{#if loading && !applications.length}
-						{#each Array(3) as _}
-							<div class="p-4 animate-pulse"><div class="h-10 bg-slate-200/50 dark:bg-slate-700/30 rounded-lg"></div></div>
-						{/each}
+						{#each Array(3) as _}<div class="p-4 animate-pulse"><div class="h-10 bg-slate-200/50 rounded-lg"></div></div>{/each}
+					{:else if filteredApps.length === 0}
+						<div class="p-10 text-center text-slate-400 text-sm italic font-bold">No applications.</div>
 					{:else}
 						{#each filteredApps as app}
-							<div
-								role="button"
-								tabindex="0"
-								onclick={() => selectApp(app)}
-								onkeydown={(e) => e.key === 'Enter' && selectApp(app)}
-								class="p-4 flex items-center justify-between hover:bg-blue-500/5 dark:hover:bg-blue-500/10 cursor-pointer transition-all {selectedApp?.Id === app.Id ? 'bg-blue-500/10 border-l-4 border-blue-500 shadow-inner' : 'border-l-4 border-transparent'}"
-							>
-								<div class="flex items-center gap-3">
-									<Layout class="w-4 h-4 text-blue-600" />
-									<div>
-										<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-xs truncate max-w-[150px]">{app.Name}</div>
-										<div class="text-[8px] text-slate-400 font-mono tracking-tighter truncate opacity-60 italic">{app.Id}</div>
+							<div role="button" tabindex="0" onclick={() => selectApp(app)} onkeydown={(e) => e.key === 'Enter' && selectApp(app)}
+								class="p-4 flex items-center justify-between hover:bg-blue-500/5 cursor-pointer transition-all {selectedApp?.Id === app.Id ? 'bg-blue-500/10 border-l-4 border-blue-500' : 'border-l-4 border-transparent'}">
+								<div class="flex items-center gap-3 min-w-0">
+									<Layout class="w-4 h-4 text-blue-600 shrink-0" />
+									<div class="min-w-0">
+										<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-xs truncate">{app.Name}</div>
+										<div class="text-[8px] text-slate-400 font-mono opacity-60 truncate">{app.Id}</div>
 									</div>
 								</div>
-								<ChevronRight class="w-4 h-4 text-slate-300" />
+								<ChevronRight class="w-4 h-4 text-slate-300 shrink-0" />
 							</div>
 						{/each}
-
-						{#if !applications.length}
-							<div class="p-12 text-center text-slate-400 text-sm italic font-bold">No applications detected.</div>
-						{/if}
 					{/if}
 				</div>
 			</div>
 		</div>
 
-		<!-- Detail View -->
-		<div class="lg:col-span-9 space-y-6">
+		<!-- App Detail -->
+		<div class="lg:col-span-9">
 			{#if selectedApp}
-				<div class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
-					<!-- Topology Map -->
-					<div class="lg:col-span-7 space-y-6">
-						<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden animate-in fade-in slide-in-from-right-4 duration-300">
-							<div class="p-8 border-b border-slate-100 dark:border-slate-700/50 bg-gradient-to-br from-blue-500/5 to-indigo-500/5 flex justify-between items-start">
-								<div>
-									<h2 class="text-3xl font-black text-slate-900 dark:text-white mb-2 uppercase tracking-tighter italic leading-none">{selectedApp.Name}</h2>
-									<div class="flex items-center gap-3 mt-4">
-										<div class="px-2 py-0.5 rounded-lg bg-blue-500/10 text-blue-600 text-[9px] font-black uppercase tracking-widest border border-blue-500/20">
-											{environments.length} ENVIRONMENTS
-										</div>
-										<div class="px-2 py-0.5 rounded-lg bg-emerald-500/10 text-emerald-600 text-[9px] font-black uppercase tracking-widest border border-emerald-500/20">
-											{profiles.length} PROFILES
-										</div>
-									</div>
-								</div>
-								<button
-									onclick={() => deleteApplication(selectedApp?.Id)}
-									class="p-2.5 bg-slate-900 dark:bg-black text-rose-500 hover:bg-rose-500/10 rounded-2xl transition-all border border-rose-500/20 shadow-xl"
-									title="Purge Application"
-								>
-									<Trash2 class="w-4 h-4" />
-								</button>
+				<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
+					<!-- App Header -->
+					<div class="p-6 border-b border-slate-100 dark:border-slate-700/50 bg-gradient-to-br from-blue-500/5 to-indigo-500/5 flex justify-between items-start">
+						<div>
+							<h2 class="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tighter italic">{selectedApp.Name}</h2>
+							<div class="flex items-center gap-2 mt-2">
+								<span class="px-2 py-0.5 rounded-lg bg-blue-500/10 text-blue-600 text-[9px] font-black uppercase border border-blue-500/20">{environments.length} ENVS</span>
+								<span class="px-2 py-0.5 rounded-lg bg-emerald-500/10 text-emerald-600 text-[9px] font-black uppercase border border-emerald-500/20">{profiles.length} PROFILES</span>
+								<span class="px-2 py-0.5 rounded-lg bg-amber-500/10 text-amber-600 text-[9px] font-black uppercase border border-amber-500/20">{deployments.length} DEPLOYMENTS</span>
 							</div>
-
-							<div class="p-8 space-y-8">
-								<!-- Environment Explorer -->
-								<div class="space-y-4">
-									<h3 class="text-xs font-black text-slate-500 uppercase tracking-widest flex items-center gap-2 italic leading-none">
-										<Globe class="w-4 h-4 text-blue-500" />
-										Target Environments
-									</h3>
-									<div class="flex flex-wrap gap-2">
-										{#each environments || [] as env}
-											<div class="px-4 py-3 bg-white/60 dark:bg-slate-900/60 rounded-2xl border border-slate-100 dark:border-slate-700/50 shadow-sm flex items-center gap-3 group/env">
-												<div class="w-2 h-2 rounded-full {env.State === 'READY_FOR_DEPLOYMENT' ? 'bg-emerald-500' : 'bg-slate-400'} group-hover/env:scale-125 transition-transform"></div>
-												<span class="text-[10px] font-black text-slate-900 dark:text-white uppercase italic">{env.Name}</span>
-											</div>
-										{:else}
-											<div class="p-6 w-full text-center border border-dashed border-slate-200 dark:border-slate-700 rounded-3xl text-[10px] text-slate-400 italic font-black uppercase tracking-widest">No target environments provisioned.</div>
-										{/each}
-									</div>
-								</div>
-
-								<!-- Profile Registry -->
-								<div class="space-y-4">
-									<h3 class="text-xs font-black text-slate-500 uppercase tracking-widest flex items-center gap-2 italic leading-none">
-										<FileCode class="w-4 h-4 text-indigo-500" />
-										Configuration Sources
-									</h3>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-										{#each profiles || [] as prof}
-											<div class="p-5 bg-white/60 dark:bg-slate-900/60 rounded-3xl border border-slate-100 dark:border-slate-700/50 shadow-sm group/prof hover:border-blue-500/30 transition-all flex justify-between items-center">
-												<div class="flex items-center gap-3">
-													<div class="p-2 bg-slate-900 dark:bg-black rounded-xl">
-														<Code2 class="w-3.5 h-3.5 text-blue-500" />
-													</div>
-													<div>
-														<div class="text-[10px] font-black text-slate-900 dark:text-white uppercase italic leading-none">{prof.Name}</div>
-														<div class="text-[8px] text-slate-400 uppercase font-black mt-1">{prof.Type || 'FREEFORM'}</div>
-													</div>
-												</div>
-												<ArrowRight class="w-3.5 h-3.5 text-slate-300 opacity-0 group-hover/prof:opacity-100 transition-opacity" />
-											</div>
-										{/each}
-									</div>
-								</div>
-							</div>
+						</div>
+						<div class="flex items-center gap-2">
+							<button onclick={() => showDeployModal = true} class="flex items-center gap-1.5 px-3 py-2 bg-emerald-600 text-white rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-emerald-700 transition-all" title="Start Deployment">
+								<Play class="w-3.5 h-3.5" /> Deploy
+							</button>
+							<button onclick={() => deleteApplication(selectedApp?.Id)} class="p-2 bg-slate-900 dark:bg-black text-rose-500 hover:bg-rose-500/10 rounded-xl transition-all border border-rose-500/20">
+								<Trash2 class="w-4 h-4" />
+							</button>
 						</div>
 					</div>
 
-					<!-- Deployment History -->
-					<div class="lg:col-span-5 space-y-6">
-						<div class="bg-slate-900 dark:bg-black rounded-[2.5rem] shadow-2xl border border-slate-800 overflow-hidden h-[600px] flex flex-col animate-in slide-in-from-right-8 duration-500">
-							<div class="p-6 border-b border-white/5 bg-white/5 flex items-center justify-between">
-								<div class="flex items-center gap-3">
-									<Workflow class="w-5 h-5 text-blue-500" />
-									<div>
-										<h4 class="text-xs font-black text-white uppercase tracking-widest italic leading-none">Rollout Ledger</h4>
-										<span class="text-[8px] font-bold text-slate-500 uppercase">Interactive Deployment History</span>
-									</div>
-								</div>
-								<div class="flex items-center gap-1.5 px-3 py-1 rounded-full bg-blue-500/10 border border-blue-500/20">
-									<span class="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse"></span>
-									<span class="text-[9px] font-black text-blue-600 uppercase tracking-widest italic">REALTIME</span>
-								</div>
-							</div>
+					<!-- Detail Sub-tabs -->
+					<div class="flex border-b border-slate-100 dark:border-slate-700/50">
+						<button onclick={() => { appDetailTab = 'envs'; }} class="flex items-center gap-1.5 px-4 py-3 text-[10px] font-black uppercase tracking-widest border-b-2 transition-all {appDetailTab === 'envs' ? 'border-blue-500 text-blue-600' : 'border-transparent text-slate-400 hover:text-slate-700'}"><Globe class="w-3.5 h-3.5" /> Environments</button>
+					<button onclick={() => { appDetailTab = 'profiles'; }} class="flex items-center gap-1.5 px-4 py-3 text-[10px] font-black uppercase tracking-widest border-b-2 transition-all {appDetailTab === 'profiles' ? 'border-blue-500 text-blue-600' : 'border-transparent text-slate-400 hover:text-slate-700'}"><FileCode class="w-3.5 h-3.5" /> Profiles</button>
+					<button onclick={() => { appDetailTab = 'deployments'; }} class="flex items-center gap-1.5 px-4 py-3 text-[10px] font-black uppercase tracking-widest border-b-2 transition-all {appDetailTab === 'deployments' ? 'border-blue-500 text-blue-600' : 'border-transparent text-slate-400 hover:text-slate-700'}"><Workflow class="w-3.5 h-3.5" /> Deployments</button>
+					<button onclick={() => { appDetailTab = 'versions'; if (selectedProfileId) loadConfigVersions(selectedApp!.Id!, selectedProfileId); }} class="flex items-center gap-1.5 px-4 py-3 text-[10px] font-black uppercase tracking-widest border-b-2 transition-all {appDetailTab === 'versions' ? 'border-blue-500 text-blue-600' : 'border-transparent text-slate-400 hover:text-slate-700'}"><Archive class="w-3.5 h-3.5" /> Config Versions</button>
+					</div>
 
-							<div class="flex-1 overflow-y-auto p-8 space-y-4">
-								{#if loadingDetails}
-									<div class="flex flex-col items-center justify-center h-full opacity-30">
-										<RefreshCw class="w-10 h-10 text-blue-500 animate-spin mb-4" />
-										<span class="text-[9px] uppercase font-black text-slate-500 tracking-[0.2em]">Listing Rollouts...</span>
-									</div>
-								{:else if deployments.length}
-									{#each deployments as dep}
-										{@const StatusIcon = getDeploymentStatusIcon(dep.State)}
-										<div class="p-5 bg-white/5 rounded-3xl border border-white/10 hover:border-blue-500/30 transition-all group/job">
-											<div class="flex justify-between items-start mb-4">
+					<div class="p-6">
+						<!-- Environments -->
+						{#if appDetailTab === 'envs'}
+							<div class="flex items-center justify-between mb-4">
+								<h3 class="text-xs font-black text-slate-500 uppercase tracking-widest italic">Target Environments</h3>
+								<button onclick={() => showCreateEnvModal = true} class="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600/10 text-blue-600 rounded-lg text-[10px] font-black uppercase border border-blue-500/20 hover:bg-blue-600/20 transition-all">
+									<Plus class="w-3 h-3" /> Add
+								</button>
+							</div>
+							{#if environments.length === 0}
+								<div class="p-8 text-center border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl text-slate-400 text-sm italic">No environments.</div>
+							{:else}
+								<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+									{#each environments as env}
+										<div class="p-4 bg-white/60 dark:bg-slate-900/60 rounded-2xl border border-slate-100 dark:border-slate-700/50 flex items-center justify-between group">
+											<div class="flex items-center gap-3">
+												<div class="w-2 h-2 rounded-full {env.State === 'READY_FOR_DEPLOYMENT' ? 'bg-emerald-500' : 'bg-slate-400'}"></div>
 												<div>
-													<div class="text-[9px] font-black text-slate-400 uppercase italic tracking-tighter mb-1 font-mono">DEP-{dep.DeploymentNumber}</div>
-													<div class="flex items-center gap-2">
-														<StatusIcon class="w-3.5 h-3.5 {getDeploymentStatusColor(dep.State)}" />
-														<span class="text-[10px] font-black text-white uppercase tracking-widest">{dep.State}</span>
-													</div>
-												</div>
-												<div class="text-right">
-													<div class="text-[8px] font-black text-slate-600 uppercase">Version</div>
-													<span class="text-[10px] font-black text-slate-400 tabular-nums italic">v{dep.ConfigurationVersion}</span>
+													<div class="text-xs font-black text-slate-900 dark:text-white uppercase italic">{env.Name}</div>
+													<div class="text-[8px] text-slate-400 font-mono opacity-60">{env.State}</div>
 												</div>
 											</div>
-											<div class="flex items-center justify-between pt-4 border-t border-white/5">
-												<div class="flex items-center gap-2">
-													<Timer class="w-3 h-3 text-slate-600" />
-													<span class="text-[9px] font-bold text-slate-500 tabular-nums">{dep.CompletedAt?.toLocaleString() || 'In Progress'}</span>
+											<button onclick={() => deleteEnvironment(env.Id)} class="p-1.5 rounded-lg text-rose-400 hover:bg-rose-500/10 opacity-0 group-hover:opacity-100 transition-all"><Trash2 class="w-3.5 h-3.5" /></button>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						{/if}
+
+						<!-- Profiles -->
+						{#if appDetailTab === 'profiles'}
+							<div class="flex items-center justify-between mb-4">
+								<h3 class="text-xs font-black text-slate-500 uppercase tracking-widest italic">Configuration Profiles</h3>
+								<button onclick={() => showCreateProfileModal = true} class="flex items-center gap-1.5 px-3 py-1.5 bg-indigo-600/10 text-indigo-600 rounded-lg text-[10px] font-black uppercase border border-indigo-500/20 hover:bg-indigo-600/20 transition-all">
+									<Plus class="w-3 h-3" /> Add
+								</button>
+							</div>
+							{#if profiles.length === 0}
+								<div class="p-8 text-center border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl text-slate-400 text-sm italic">No profiles.</div>
+							{:else}
+								<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+									{#each profiles as prof}
+										<div class="py-3 flex items-center justify-between group">
+											<div class="flex items-center gap-3">
+												<div class="p-1.5 bg-slate-100 dark:bg-slate-800 rounded-lg"><Code2 class="w-3.5 h-3.5 text-indigo-500" /></div>
+												<div>
+													<div class="text-xs font-black text-slate-900 dark:text-white uppercase italic">{prof.Name}</div>
+													<div class="text-[8px] text-slate-400 uppercase">{prof.Type || 'FREEFORM'} · {prof.LocationUri}</div>
 												</div>
-												<ExternalLink class="w-3 h-3 text-slate-700 opacity-0 group-hover/job:opacity-100 transition-opacity" />
+											</div>
+											<div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+												<button onclick={() => { selectedProfileId = prof.Id ?? ''; appDetailTab = 'versions'; loadConfigVersions(selectedApp!.Id!, prof.Id!); }}
+													class="p-1.5 rounded-lg text-blue-500 hover:bg-blue-500/10"><Eye class="w-3.5 h-3.5" /></button>
+												<button onclick={() => deleteProfile(prof.Id)} class="p-1.5 rounded-lg text-rose-400 hover:bg-rose-500/10"><Trash2 class="w-3.5 h-3.5" /></button>
 											</div>
 										</div>
 									{/each}
-								{:else}
-									<div class="flex flex-col items-center justify-center h-full opacity-20 p-12 text-center">
-										<Boxes class="w-16 h-16 text-slate-600 mb-6" />
-										<h4 class="text-xs font-black text-slate-500 uppercase tracking-[0.2em] mb-2">No Deployments</h4>
-										<p class="text-[10px] text-slate-600 italic">This application hasn't executed any configuration rollouts yet. Deploy a profile to a target environment to begin the configuration lifecycle.</p>
-									</div>
+								</div>
+							{/if}
+						{/if}
+
+						<!-- Deployments -->
+						{#if appDetailTab === 'deployments'}
+							<div class="flex items-center justify-between mb-4">
+								<h3 class="text-xs font-black text-slate-500 uppercase tracking-widest italic">Rollout History</h3>
+								{#if environments.length > 1}
+									<select bind:value={selectedEnvId} onchange={() => loadDeployments(selectedApp!.Id!, selectedEnvId)}
+										class="text-[10px] font-black uppercase bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg px-2 py-1 outline-none focus:ring-1 focus:ring-blue-500">
+										{#each environments as env}<option value={env.Id}>{env.Name}</option>{/each}
+									</select>
 								{/if}
 							</div>
-						</div>
+							{#if loadingDetails}
+								<div class="p-8 flex justify-center opacity-30"><RefreshCw class="w-6 h-6 text-blue-500 animate-spin" /></div>
+							{:else if deployments.length === 0}
+								<div class="p-8 text-center border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl text-slate-400 text-sm italic">No deployments.</div>
+							{:else}
+								<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+									{#each [...deployments].reverse() as dep}
+										<div class="py-4 flex items-center justify-between group">
+											<div class="flex items-center gap-3">
+												<div class="w-2 h-2 rounded-full {getDeploymentStatusIcon(dep.State).replace('text-', 'bg-').split(' ')[0]}"></div>
+												<div>
+													<div class="text-xs font-black text-slate-900 dark:text-white uppercase italic">DEP-{dep.DeploymentNumber}</div>
+													<div class="text-[9px] text-slate-500">v{dep.ConfigurationVersion} · <span class="{getDeploymentStatusIcon(dep.State)}">{dep.State}</span></div>
+												</div>
+											</div>
+											<div class="flex items-center gap-3 text-[8px] text-slate-400">
+												{#if dep.CompletedAt}
+													<span class="flex items-center gap-1"><Timer class="w-3 h-3" />{dep.CompletedAt.toLocaleDateString()}</span>
+												{/if}
+												{#if dep.State !== 'COMPLETE' && dep.State !== 'ROLLED_BACK'}
+													<button onclick={() => stopDeployment(dep.DeploymentNumber)} class="p-1.5 rounded-lg text-rose-400 hover:bg-rose-500/10 opacity-0 group-hover:opacity-100 transition-all"><Square class="w-3 h-3" /></button>
+												{/if}
+											</div>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						{/if}
 
-						<!-- Metrics -->
-						<div class="p-6 bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-[2.5rem] shadow-xl flex items-center justify-between group/metric overflow-hidden relative">
-							<div class="absolute inset-0 bg-gradient-to-r from-blue-500/5 to-transparent pointer-events-none"></div>
-							<div class="flex items-center gap-4 relative z-10">
-								<div class="p-3 bg-blue-500/10 rounded-2xl group-hover/metric:scale-110 transition-transform">
-									<Gauge class="w-6 h-6 text-blue-600" />
-								</div>
-								<div>
-									<div class="text-[9px] font-black text-slate-500 uppercase tracking-widest mb-1 italic leading-none">Propagation Speed</div>
-									<div class="text-lg font-black text-slate-900 dark:text-white uppercase tracking-tighter italic">HARDENED</div>
-								</div>
+						<!-- Config Versions -->
+						{#if appDetailTab === 'versions'}
+							<div class="flex items-center justify-between mb-4">
+								<h3 class="text-xs font-black text-slate-500 uppercase tracking-widest italic">Hosted Config Versions</h3>
+								{#if profiles.length > 0}
+									<select bind:value={selectedProfileId} onchange={() => loadConfigVersions(selectedApp!.Id!, selectedProfileId)}
+										class="text-[10px] font-black uppercase bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg px-2 py-1 outline-none focus:ring-1 focus:ring-blue-500">
+										<option value="">— Select profile —</option>
+										{#each profiles as prof}<option value={prof.Id}>{prof.Name}</option>{/each}
+									</select>
+								{/if}
 							</div>
-							<div class="text-right relative z-10">
-								<div class="text-[8px] text-slate-500 uppercase font-black mb-1">Status</div>
-								<div class="flex items-center gap-1.5">
-									<div class="w-1.5 h-1.5 rounded-full bg-emerald-500"></div>
-									<span class="text-[10px] text-slate-800 dark:text-white font-black uppercase">SYNCED</span>
+							{#if !selectedProfileId}
+								<div class="p-8 text-center text-slate-400 text-sm italic">Select a profile to view versions.</div>
+							{:else if loadingVersions}
+								<div class="p-8 flex justify-center opacity-30"><RefreshCw class="w-6 h-6 text-blue-500 animate-spin" /></div>
+							{:else if configVersions.length === 0}
+								<div class="p-8 text-center border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl text-slate-400 text-sm italic">No versions.</div>
+							{:else}
+								<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+									{#each [...configVersions].reverse() as ver}
+										<div class="py-3 flex items-center justify-between">
+											<div class="flex items-center gap-3">
+												<div class="p-1.5 bg-slate-100 dark:bg-slate-800 rounded-lg"><Archive class="w-3.5 h-3.5 text-blue-500" /></div>
+												<div>
+													<div class="text-xs font-black text-slate-900 dark:text-white uppercase italic">v{ver.VersionNumber}</div>
+													<div class="text-[8px] text-slate-400">{ver.ContentType}{ver.VersionLabel ? ` · ${ver.VersionLabel}` : ''}</div>
+												</div>
+											</div>
+											<div class="text-[8px] text-slate-400 font-mono">v{ver.VersionNumber}</div>
+										</div>
+									{/each}
 								</div>
-							</div>
-						</div>
+							{/if}
+						{/if}
 					</div>
 				</div>
 			{:else}
-				<div class="border-2 border-dashed border-slate-200 dark:border-slate-700/50 rounded-[3rem] p-32 text-center flex flex-col items-center gap-6">
-					<div class="p-8 bg-slate-50 dark:bg-slate-800 rounded-[2.5rem]">
-						<Settings2 class="w-16 h-16 text-slate-200 dark:text-slate-700" />
-					</div>
-					<h3 class="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tighter italic leading-none">Configuration Topography</h3>
-					<p class="text-slate-500 dark:text-slate-400 text-sm max-w-sm italic tracking-tight font-medium lowercase">Oversee application configuration lifecycles, manage environment-specific rollouts, and monitor real-time configuration propagation through an enterprise-grade control plane.</p>
+				<div class="border-2 border-dashed border-slate-200 dark:border-slate-700/50 rounded-[3rem] p-24 text-center flex flex-col items-center gap-6">
+					<div class="p-8 bg-slate-50 dark:bg-slate-800 rounded-[2.5rem]"><Settings2 class="w-16 h-16 text-slate-200 dark:text-slate-700" /></div>
+					<h3 class="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tighter italic">Select an Application</h3>
+					<p class="text-slate-500 text-sm max-w-sm italic">Choose an application from the list to explore environments, profiles, deployments, and config versions.</p>
 				</div>
 			{/if}
 		</div>
 	</div>
 	{/if}
 
-	<!-- Extensions Tab -->
-	{#if activeTab === 'extensions'}
-	<div class="space-y-4">
-		<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
-			<div class="p-4 bg-white/20 dark:bg-slate-900/10 border-b border-slate-200 dark:border-slate-700/50 flex items-center gap-3">
-				<div class="relative flex-1">
-					<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-					<input
-						type="text"
-						bind:value={extensionSearch}
-						placeholder="Search extensions..."
-						class="w-full pl-10 pr-4 py-2 bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-xl text-sm focus:ring-2 focus:ring-indigo-500 outline-none transition-all italic font-bold"
-					/>
-				</div>
-				<span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">{extensions.length} TOTAL</span>
-			</div>
-
-			{#if loadingExtensions}
-				<div class="p-12 flex flex-col items-center gap-4 opacity-30">
-					<RefreshCw class="w-8 h-8 text-indigo-500 animate-spin" />
-					<span class="text-[10px] uppercase font-black text-slate-500 tracking-[0.2em]">Loading Extensions...</span>
-				</div>
-			{:else if filteredExtensions.length === 0}
-				<div class="p-16 text-center flex flex-col items-center gap-4">
-					<Puzzle class="w-12 h-12 text-slate-200 dark:text-slate-700" />
-					<p class="text-sm font-black text-slate-400 italic uppercase tracking-widest">No extensions registered.</p>
-				</div>
-			{:else}
-				<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
-					{#each filteredExtensions as ext}
-						<div class="p-6 flex items-center justify-between hover:bg-indigo-500/5 transition-all group">
-							<div class="flex items-center gap-4">
-								<div class="p-2.5 bg-indigo-500/10 rounded-xl border border-indigo-500/20">
-									<Puzzle class="w-5 h-5 text-indigo-600" />
+	<!-- ══ STRATEGIES TAB ════════════════════════════════════════════════════ -->
+	{#if activeTab === 'strategies'}
+	<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
+		<div class="p-4 border-b border-slate-200 dark:border-slate-700/50 flex items-center justify-between">
+			<div class="flex items-center gap-2"><BarChart3 class="w-4 h-4 text-amber-500" /><span class="text-xs font-black text-slate-600 dark:text-slate-300 uppercase tracking-widest italic">Deployment Strategies</span></div>
+			<span class="text-[10px] font-black text-slate-400 uppercase">{strategies.length} TOTAL</span>
+		</div>
+		{#if loadingStrategies}
+			<div class="p-12 flex flex-col items-center gap-3 opacity-30"><RefreshCw class="w-8 h-8 text-amber-500 animate-spin" /><span class="text-[10px] uppercase font-black text-slate-500">Loading...</span></div>
+		{:else if strategies.length === 0}
+			<div class="p-16 text-center flex flex-col items-center gap-3"><BarChart3 class="w-10 h-10 text-slate-200 dark:text-slate-700" /><p class="text-sm font-black text-slate-400 italic uppercase">No deployment strategies.</p></div>
+		{:else}
+			<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+				{#each strategies as strat}
+					<div class="p-5 flex items-center justify-between hover:bg-amber-500/5 transition-all group">
+						<div class="flex items-center gap-4">
+							<div class="p-2.5 bg-amber-500/10 rounded-xl border border-amber-500/20"><BarChart3 class="w-5 h-5 text-amber-600" /></div>
+							<div>
+								<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm">{strat.Name}</div>
+								<div class="flex items-center gap-3 mt-1 text-[9px] text-slate-500 font-mono">
+									<span>{strat.DeploymentDurationInMinutes}m duration</span>
+									<span>·</span>
+									<span>{strat.GrowthFactor}% growth</span>
+									<span>·</span>
+									<span>{strat.GrowthType}</span>
+									{#if strat.FinalBakeTimeInMinutes}<span>· {strat.FinalBakeTimeInMinutes}m bake</span>{/if}
 								</div>
-								<div>
-									<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm">{ext.Name}</div>
-									<div class="flex items-center gap-3 mt-1">
-										<span class="text-[8px] text-slate-400 font-mono tracking-tighter opacity-60 italic">{ext.Id}</span>
-										<span class="px-1.5 py-0.5 rounded bg-indigo-500/10 text-indigo-600 text-[8px] font-black uppercase border border-indigo-500/20">v{ext.VersionNumber}</span>
-									</div>
-									{#if ext.Description}
-										<p class="text-[10px] text-slate-500 mt-1 italic">{ext.Description}</p>
+								{#if strat.Description}<p class="text-[9px] text-slate-400 mt-1 italic">{strat.Description}</p>{/if}
+							</div>
+						</div>
+						<button onclick={() => deleteStrategy(strat.Id, strat.Name)} class="p-2 rounded-xl text-rose-400 hover:bg-rose-500/10 opacity-0 group-hover:opacity-100 transition-all border border-transparent hover:border-rose-500/20"><Trash2 class="w-4 h-4" /></button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+	{/if}
+
+	<!-- ══ EXTENSIONS TAB ════════════════════════════════════════════════════ -->
+	{#if activeTab === 'extensions'}
+	<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
+		<div class="p-4 border-b border-slate-200 dark:border-slate-700/50 flex items-center gap-3">
+			<div class="relative flex-1">
+				<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+				<input type="text" bind:value={extensionSearch} placeholder="Search extensions..." class="w-full pl-9 pr-4 py-2 bg-white/50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-xl text-sm focus:ring-2 focus:ring-indigo-500 outline-none italic font-bold" />
+			</div>
+			<span class="text-[10px] font-black text-slate-400 uppercase">{extensions.length} TOTAL</span>
+		</div>
+		{#if loadingExtensions}
+			<div class="p-12 flex flex-col items-center gap-3 opacity-30"><RefreshCw class="w-8 h-8 text-indigo-500 animate-spin" /><span class="text-[10px] uppercase font-black text-slate-500">Loading...</span></div>
+		{:else if filteredExtensions.length === 0}
+			<div class="p-16 text-center flex flex-col items-center gap-3"><Puzzle class="w-10 h-10 text-slate-200 dark:text-slate-700" /><p class="text-sm font-black text-slate-400 italic uppercase">No extensions registered.</p></div>
+		{:else}
+			<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+				{#each filteredExtensions as ext}
+					<div class="p-5 flex items-center justify-between hover:bg-indigo-500/5 transition-all group">
+						<div class="flex items-center gap-4">
+							<div class="p-2.5 bg-indigo-500/10 rounded-xl border border-indigo-500/20"><Puzzle class="w-5 h-5 text-indigo-600" /></div>
+							<div>
+								<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm">{ext.Name}</div>
+								<div class="flex items-center gap-2 mt-1">
+									<span class="text-[8px] text-slate-400 font-mono opacity-60">{ext.Id}</span>
+									<span class="px-1.5 py-0.5 rounded bg-indigo-500/10 text-indigo-600 text-[8px] font-black uppercase border border-indigo-500/20">v{ext.VersionNumber}</span>
+									{#if ext.Actions && Object.keys(ext.Actions).length > 0}
+										<span class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-700 text-slate-500 text-[8px] font-black uppercase">{Object.keys(ext.Actions).length} HOOKS</span>
 									{/if}
 								</div>
-							</div>
-							<div class="flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
-								{#if ext.Actions && Object.keys(ext.Actions).length > 0}
-									<div class="px-2 py-1 rounded-lg bg-slate-100 dark:bg-slate-700 text-[9px] font-black text-slate-500 uppercase">
-										{Object.keys(ext.Actions).length} HOOKS
+								{#if ext.Description}<p class="text-[9px] text-slate-400 mt-1 italic">{ext.Description}</p>{/if}
+								{#if ext.Parameters && Object.keys(ext.Parameters).length > 0}
+									<div class="flex flex-wrap gap-1 mt-1">
+										{#each Object.keys(ext.Parameters) as param}
+											<span class="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-500 text-[7px] font-mono">{param}{ext.Parameters[param].Required ? '*' : ''}</span>
+										{/each}
 									</div>
 								{/if}
-								<button
-									onclick={() => deleteExtension(ext.Id, ext.Name)}
-									class="p-2 rounded-xl text-rose-500 hover:bg-rose-500/10 transition-all border border-transparent hover:border-rose-500/20"
-									title="Delete extension"
-								>
-									<Trash2 class="w-4 h-4" />
-								</button>
 							</div>
 						</div>
-					{/each}
-				</div>
-			{/if}
-		</div>
+						<button onclick={() => deleteExtension(ext.Id, ext.Name)} class="p-2 rounded-xl text-rose-400 hover:bg-rose-500/10 opacity-0 group-hover:opacity-100 transition-all border border-transparent hover:border-rose-500/20"><Trash2 class="w-4 h-4" /></button>
+					</div>
+				{/each}
+			</div>
+		{/if}
 	</div>
 	{/if}
 
-	<!-- Associations Tab -->
+	<!-- ══ ASSOCIATIONS TAB ══════════════════════════════════════════════════ -->
 	{#if activeTab === 'associations'}
-	<div class="space-y-4">
-		<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
-			<div class="p-4 bg-white/20 dark:bg-slate-900/10 border-b border-slate-200 dark:border-slate-700/50 flex items-center justify-between">
-				<div class="flex items-center gap-2">
-					<Link class="w-4 h-4 text-violet-500" />
-					<span class="text-xs font-black text-slate-600 dark:text-slate-300 uppercase tracking-widest italic">Extension Associations</span>
-				</div>
-				<span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">{associations.length} TOTAL</span>
-			</div>
-
-			{#if loadingAssociations}
-				<div class="p-12 flex flex-col items-center gap-4 opacity-30">
-					<RefreshCw class="w-8 h-8 text-violet-500 animate-spin" />
-					<span class="text-[10px] uppercase font-black text-slate-500 tracking-[0.2em]">Loading Associations...</span>
-				</div>
-			{:else if associations.length === 0}
-				<div class="p-16 text-center flex flex-col items-center gap-4">
-					<Link class="w-12 h-12 text-slate-200 dark:text-slate-700" />
-					<p class="text-sm font-black text-slate-400 italic uppercase tracking-widest">No extension associations.</p>
-				</div>
-			{:else}
-				<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
-					{#each associations as assoc}
-						<div class="p-6 flex items-center justify-between hover:bg-violet-500/5 transition-all group">
-							<div class="flex items-center gap-4">
-								<div class="p-2.5 bg-violet-500/10 rounded-xl border border-violet-500/20">
-									<Link class="w-5 h-5 text-violet-600" />
+	<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl overflow-hidden">
+		<div class="p-4 border-b border-slate-200 dark:border-slate-700/50 flex items-center justify-between">
+			<div class="flex items-center gap-2"><Link class="w-4 h-4 text-violet-500" /><span class="text-xs font-black text-slate-600 dark:text-slate-300 uppercase tracking-widest italic">Extension Associations</span></div>
+			<span class="text-[10px] font-black text-slate-400 uppercase">{associations.length} TOTAL</span>
+		</div>
+		{#if loadingAssociations}
+			<div class="p-12 flex flex-col items-center gap-3 opacity-30"><RefreshCw class="w-8 h-8 text-violet-500 animate-spin" /><span class="text-[10px] uppercase font-black text-slate-500">Loading...</span></div>
+		{:else if associations.length === 0}
+			<div class="p-16 text-center flex flex-col items-center gap-3"><Link class="w-10 h-10 text-slate-200 dark:text-slate-700" /><p class="text-sm font-black text-slate-400 italic uppercase">No extension associations.</p></div>
+		{:else}
+			<div class="divide-y divide-slate-100 dark:divide-slate-700/50">
+				{#each associations as assoc}
+					<div class="p-5 flex items-center justify-between hover:bg-violet-500/5 transition-all group">
+						<div class="flex items-center gap-4">
+							<div class="p-2.5 bg-violet-500/10 rounded-xl border border-violet-500/20"><Link class="w-5 h-5 text-violet-600" /></div>
+							<div>
+								<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm font-mono">{assoc.Id}</div>
+								<div class="flex flex-col gap-0.5 mt-1">
+									<div class="flex items-center gap-1.5 text-[9px] text-slate-500"><Puzzle class="w-2.5 h-2.5 text-indigo-400" /><span class="font-mono truncate max-w-xs">{assoc.ExtensionArn}</span></div>
+									<div class="flex items-center gap-1.5 text-[9px] text-slate-500"><Database class="w-2.5 h-2.5 text-slate-400" /><span class="font-mono truncate max-w-xs">{assoc.ResourceArn}</span></div>
 								</div>
-								<div>
-									<div class="font-black text-slate-900 dark:text-white uppercase tracking-tighter italic text-sm font-mono">{assoc.Id}</div>
-									<div class="flex flex-col gap-1 mt-1">
-										<div class="flex items-center gap-2">
-											<Puzzle class="w-3 h-3 text-indigo-500" />
-											<span class="text-[9px] text-slate-500 font-mono truncate max-w-[300px]">{assoc.ExtensionArn}</span>
-										</div>
-										<div class="flex items-center gap-2">
-											<Database class="w-3 h-3 text-slate-400" />
-											<span class="text-[9px] text-slate-500 font-mono truncate max-w-[300px]">{assoc.ResourceArn}</span>
-										</div>
-									</div>
-								</div>
-							</div>
-							<div class="flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
-								<button
-									onclick={() => deleteAssociation(assoc.Id)}
-									class="p-2 rounded-xl text-rose-500 hover:bg-rose-500/10 transition-all border border-transparent hover:border-rose-500/20"
-									title="Delete association"
-								>
-									<Trash2 class="w-4 h-4" />
-								</button>
 							</div>
 						</div>
-					{/each}
+						<button onclick={() => deleteAssociation(assoc.Id)} class="p-2 rounded-xl text-rose-400 hover:bg-rose-500/10 opacity-0 group-hover:opacity-100 transition-all border border-transparent hover:border-rose-500/20"><Trash2 class="w-4 h-4" /></button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+	{/if}
+
+	<!-- ══ SETTINGS TAB ══════════════════════════════════════════════════════ -->
+	{#if activeTab === 'settings'}
+	<div class="max-w-2xl space-y-4">
+		<div class="bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border border-white/20 dark:border-slate-700/50 rounded-2xl shadow-xl p-6 space-y-4">
+			<div class="flex items-center gap-3">
+				<div class="p-2.5 bg-slate-500/10 rounded-xl border border-slate-500/20"><Settings class="w-5 h-5 text-slate-600" /></div>
+				<div>
+					<h3 class="text-sm font-black text-slate-900 dark:text-white uppercase tracking-tighter italic">Account Settings</h3>
+					<p class="text-[10px] text-slate-400 mt-0.5">Global AppConfig account configuration.</p>
 				</div>
+			</div>
+			{#if loadingSettings}
+				<div class="p-8 flex justify-center opacity-30"><RefreshCw class="w-6 h-6 animate-spin text-slate-400" /></div>
+			{:else if accountSettings}
+				<div class="p-4 bg-slate-50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-700">
+					<div class="flex items-center justify-between">
+						<div>
+							<div class="text-xs font-black text-slate-700 dark:text-slate-200 uppercase italic">Deletion Protection</div>
+							<p class="text-[10px] text-slate-400 mt-0.5">Prevents accidental deletion of configuration resources.</p>
+						</div>
+						<div class="flex items-center gap-2">
+							<div class="w-2 h-2 rounded-full {accountSettings.DeletionProtection?.Enabled ? 'bg-emerald-500' : 'bg-slate-300'}"></div>
+							<span class="text-[10px] font-black text-slate-500 uppercase">{accountSettings.DeletionProtection?.Enabled ? 'ENABLED' : 'DISABLED'}</span>
+						</div>
+					</div>
+				</div>
+			{:else}
+				<div class="p-8 text-center text-slate-400 text-sm italic">Failed to load settings.</div>
 			{/if}
 		</div>
 	</div>
 	{/if}
 </div>
 
-<!-- Create Application Modal -->
+<!-- ══ MODALS ════════════════════════════════════════════════════════════════ -->
+
+<!-- Create Application -->
 {#if showCreateModal}
-	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-		<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateModal = false} onkeydown={(e) => { if (e.key === 'Escape') showCreateModal = false; }} role="presentation"></div>
-		<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2.5rem] shadow-2xl border border-blue-500/20 overflow-hidden animate-in zoom-in-95">
-			<div class="p-8">
-				<h3 class="text-2xl font-black text-slate-900 dark:text-white mb-6 uppercase tracking-tighter italic leading-none">Assemble Application</h3>
-
-				<form onsubmit={(e) => { e.preventDefault(); createApplication(); }} class="space-y-6">
-					<div>
-						<label for="appName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Application Identifier</label>
-						<input
-							id="appName"
-							type="text"
-							bind:value={newAppName}
-							placeholder="e.g. gopherstack-microservices-config"
-							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-blue-500 transition-all font-mono text-xs italic"
-							required
-						/>
-					</div>
-
-					<div class="p-5 bg-blue-500/5 rounded-2xl border border-blue-500/10">
-						<div class="flex items-center gap-2 mb-2">
-							<Shield class="w-3.5 h-3.5 text-blue-500" />
-							<span class="text-[10px] font-black text-blue-600 uppercase tracking-widest leading-none">Configuration Baseline</span>
-						</div>
-						<p class="text-[9px] text-blue-800 dark:text-blue-400 leading-relaxed font-bold uppercase tracking-tight italic">
-							Registering an application allows you to group profiles and environments. Configuration validators will be enforced during rollout.
-						</p>
-					</div>
-
-					<div class="flex gap-4 pt-4">
-						<button type="button" onclick={() => showCreateModal = false} class="flex-1 px-4 py-4 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-2xl font-black uppercase text-[10px] tracking-widest transition-all">Abort</button>
-						<button type="submit" disabled={creating} class="flex-1 px-4 py-4 bg-blue-600 text-white rounded-2xl font-black uppercase text-[10px] tracking-widest shadow-lg active:scale-95 disabled:opacity-50 transition-all">
-							{creating ? 'Assembling...' : 'Provision Blueprint'}
-						</button>
-					</div>
-				</form>
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-blue-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">New Application</h3>
+		<form onsubmit={(e) => { e.preventDefault(); createApplication(); }} class="space-y-4">
+			<div>
+				<label for="appName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Application Name</label>
+				<input id="appName" type="text" bind:value={newAppName} placeholder="my-app-config" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm italic" required />
 			</div>
-		</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showCreateModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={creating} class="flex-1 px-4 py-3 bg-blue-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{creating ? 'Creating...' : 'Create'}</button>
+			</div>
+		</form>
 	</div>
+</div>
 {/if}
 
-<!-- Create Extension Modal -->
+<!-- Create Environment -->
+{#if showCreateEnvModal}
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateEnvModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-blue-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">New Environment</h3>
+		<form onsubmit={(e) => { e.preventDefault(); createEnvironment(); }} class="space-y-4">
+			<div>
+				<label for="envName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Environment Name</label>
+				<input id="envName" type="text" bind:value={newEnvName} placeholder="production" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm italic" required />
+			</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showCreateEnvModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={creatingEnv} class="flex-1 px-4 py-3 bg-blue-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{creatingEnv ? 'Creating...' : 'Create'}</button>
+			</div>
+		</form>
+	</div>
+</div>
+{/if}
+
+<!-- Create Profile -->
+{#if showCreateProfileModal}
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateProfileModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-indigo-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">New Configuration Profile</h3>
+		<form onsubmit={(e) => { e.preventDefault(); createProfile(); }} class="space-y-4">
+			<div>
+				<label for="profName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Profile Name</label>
+				<input id="profName" type="text" bind:value={newProfileName} placeholder="my-feature-flags" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 font-mono text-sm italic" required />
+			</div>
+			<div>
+				<label for="profType" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Type</label>
+				<select id="profType" bind:value={newProfileType} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm font-bold">
+					<option value="AWS.Freeform">AWS.Freeform</option>
+					<option value="AWS.AppConfig.FeatureFlags">AWS.AppConfig.FeatureFlags</option>
+				</select>
+			</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showCreateProfileModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={creatingProfile} class="flex-1 px-4 py-3 bg-indigo-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{creatingProfile ? 'Creating...' : 'Create'}</button>
+			</div>
+		</form>
+	</div>
+</div>
+{/if}
+
+<!-- Deploy Modal -->
+{#if showDeployModal}
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showDeployModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-emerald-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">Start Deployment</h3>
+		<form onsubmit={(e) => { e.preventDefault(); startDeployment(); }} class="space-y-4">
+			<div>
+				<label for="depEnv" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Environment</label>
+				<select id="depEnv" bind:value={selectedEnvId} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-emerald-500 text-sm font-bold" required>
+					{#each environments as env}<option value={env.Id}>{env.Name}</option>{/each}
+				</select>
+			</div>
+			<div>
+				<label for="depProfile" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Configuration Profile</label>
+				<select id="depProfile" bind:value={deployProfileId} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-emerald-500 text-sm font-bold" required>
+					<option value="">— select —</option>
+					{#each profiles as p}<option value={p.Id}>{p.Name}</option>{/each}
+				</select>
+			</div>
+			<div>
+				<label for="depStrategy" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Deployment Strategy</label>
+				<select id="depStrategy" bind:value={deployStrategyId} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-emerald-500 text-sm font-bold" required>
+					<option value="">— select —</option>
+					{#each strategies as s}<option value={s.Id}>{s.Name}</option>{/each}
+				</select>
+			</div>
+			<div>
+				<label for="depVersion" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Configuration Version</label>
+				<input id="depVersion" type="text" bind:value={deployVersion} placeholder="1" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-emerald-500 font-mono text-sm italic" required />
+			</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showDeployModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={deploying} class="flex-1 px-4 py-3 bg-emerald-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{deploying ? 'Deploying...' : 'Deploy'}</button>
+			</div>
+		</form>
+	</div>
+</div>
+{/if}
+
+<!-- Create Strategy -->
+{#if showCreateStratModal}
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateStratModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-lg bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-amber-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">New Deployment Strategy</h3>
+		<form onsubmit={(e) => { e.preventDefault(); createStrategy(); }} class="space-y-4">
+			<div class="grid grid-cols-2 gap-4">
+				<div class="col-span-2">
+					<label for="stratName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Strategy Name</label>
+					<input id="stratName" type="text" bind:value={newStratName} placeholder="AllAtOnce" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-amber-500 font-mono text-sm italic" required />
+				</div>
+				<div>
+					<label for="stratDuration" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Duration (min)</label>
+					<input id="stratDuration" type="number" min="0" bind:value={newStratDuration} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-amber-500 text-sm font-bold" />
+				</div>
+				<div>
+					<label for="stratGrowth" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Growth Factor (%)</label>
+					<input id="stratGrowth" type="number" min="1" max="100" bind:value={newStratGrowth} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-amber-500 text-sm font-bold" />
+				</div>
+				<div>
+					<label for="stratBake" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Bake Time (min)</label>
+					<input id="stratBake" type="number" min="0" bind:value={newStratBake} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-amber-500 text-sm font-bold" />
+				</div>
+				<div>
+					<label for="stratGrowthType" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Growth Type</label>
+					<select id="stratGrowthType" bind:value={newStratGrowthType} class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-amber-500 text-sm font-bold">
+						<option value="LINEAR">LINEAR</option>
+						<option value="EXPONENTIAL">EXPONENTIAL</option>
+					</select>
+				</div>
+				<div class="col-span-2">
+					<label for="stratDesc" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Description (optional)</label>
+					<input id="stratDesc" type="text" bind:value={newStratDesc} placeholder="Description..." class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-amber-500 font-mono text-sm italic" />
+				</div>
+			</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showCreateStratModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={creatingStrat} class="flex-1 px-4 py-3 bg-amber-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{creatingStrat ? 'Creating...' : 'Create'}</button>
+			</div>
+		</form>
+	</div>
+</div>
+{/if}
+
+<!-- Create Extension -->
 {#if showCreateExtModal}
-	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-		<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateExtModal = false} onkeydown={(e) => { if (e.key === 'Escape') showCreateExtModal = false; }} role="presentation"></div>
-		<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2.5rem] shadow-2xl border border-indigo-500/20 overflow-hidden animate-in zoom-in-95">
-			<div class="p-8">
-				<h3 class="text-2xl font-black text-slate-900 dark:text-white mb-6 uppercase tracking-tighter italic leading-none">Register Extension</h3>
-
-				<form onsubmit={(e) => { e.preventDefault(); createExtension(); }} class="space-y-4">
-					<div>
-						<label for="extName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Extension Name</label>
-						<input
-							id="extName"
-							type="text"
-							bind:value={newExtName}
-							placeholder="e.g. MyLambdaExtension"
-							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-indigo-500 transition-all font-mono text-xs italic"
-							required
-						/>
-					</div>
-					<div>
-						<label for="extDesc" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Description (optional)</label>
-						<input
-							id="extDesc"
-							type="text"
-							bind:value={newExtDesc}
-							placeholder="What does this extension do?"
-							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-indigo-500 transition-all font-mono text-xs italic"
-						/>
-					</div>
-
-					<div class="flex gap-4 pt-4">
-						<button type="button" onclick={() => showCreateExtModal = false} class="flex-1 px-4 py-4 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-2xl font-black uppercase text-[10px] tracking-widest transition-all">Cancel</button>
-						<button type="submit" disabled={creatingExt} class="flex-1 px-4 py-4 bg-indigo-600 text-white rounded-2xl font-black uppercase text-[10px] tracking-widest shadow-lg active:scale-95 disabled:opacity-50 transition-all">
-							{creatingExt ? 'Registering...' : 'Register'}
-						</button>
-					</div>
-				</form>
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateExtModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-indigo-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">Register Extension</h3>
+		<form onsubmit={(e) => { e.preventDefault(); createExtension(); }} class="space-y-4">
+			<div>
+				<label for="extName" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Extension Name</label>
+				<input id="extName" type="text" bind:value={newExtName} placeholder="MyLambdaExtension" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 font-mono text-sm italic" required />
 			</div>
-		</div>
+			<div>
+				<label for="extDesc" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Description (optional)</label>
+				<input id="extDesc" type="text" bind:value={newExtDesc} placeholder="What does this extension do?" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 font-mono text-sm italic" />
+			</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showCreateExtModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={creatingExt} class="flex-1 px-4 py-3 bg-indigo-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{creatingExt ? 'Registering...' : 'Register'}</button>
+			</div>
+		</form>
 	</div>
+</div>
 {/if}
 
-<!-- Create Association Modal -->
+<!-- Create Association -->
 {#if showCreateAssocModal}
-	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-		<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateAssocModal = false} onkeydown={(e) => { if (e.key === 'Escape') showCreateAssocModal = false; }} role="presentation"></div>
-		<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2.5rem] shadow-2xl border border-violet-500/20 overflow-hidden animate-in zoom-in-95">
-			<div class="p-8">
-				<h3 class="text-2xl font-black text-slate-900 dark:text-white mb-6 uppercase tracking-tighter italic leading-none">Associate Extension</h3>
-
-				<form onsubmit={(e) => { e.preventDefault(); createAssociation(); }} class="space-y-4">
-					<div>
-						<label for="assocExtId" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Extension ID or Name</label>
-						<input
-							id="assocExtId"
-							type="text"
-							bind:value={newAssocExtId}
-							placeholder="Extension ID or name"
-							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-violet-500 transition-all font-mono text-xs italic"
-							required
-						/>
-					</div>
-					<div>
-						<label for="assocResource" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-2 px-1 italic leading-none">Resource ARN or Identifier</label>
-						<input
-							id="assocResource"
-							type="text"
-							bind:value={newAssocResource}
-							placeholder="arn:aws:appconfig:..."
-							class="w-full px-5 py-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-[1.5rem] outline-none focus:ring-2 focus:ring-violet-500 transition-all font-mono text-xs italic"
-							required
-						/>
-					</div>
-
-					<div class="flex gap-4 pt-4">
-						<button type="button" onclick={() => showCreateAssocModal = false} class="flex-1 px-4 py-4 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-2xl font-black uppercase text-[10px] tracking-widest transition-all">Cancel</button>
-						<button type="submit" disabled={creatingAssoc} class="flex-1 px-4 py-4 bg-violet-600 text-white rounded-2xl font-black uppercase text-[10px] tracking-widest shadow-lg active:scale-95 disabled:opacity-50 transition-all">
-							{creatingAssoc ? 'Associating...' : 'Associate'}
-						</button>
-					</div>
-				</form>
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+	<div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" onclick={() => showCreateAssocModal = false} role="presentation"></div>
+	<div class="relative w-full max-w-md bg-white dark:bg-slate-800 rounded-[2rem] shadow-2xl border border-violet-500/20 animate-in zoom-in-95 p-8">
+		<h3 class="text-xl font-black text-slate-900 dark:text-white mb-5 uppercase tracking-tighter italic">Associate Extension</h3>
+		<form onsubmit={(e) => { e.preventDefault(); createAssociation(); }} class="space-y-4">
+			<div>
+				<label for="assocExtId" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Extension ID or Name</label>
+				<input id="assocExtId" type="text" bind:value={newAssocExtId} placeholder="Extension ID or name" class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-violet-500 font-mono text-sm italic" required />
 			</div>
-		</div>
+			<div>
+				<label for="assocResource" class="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5 italic">Resource ARN</label>
+				<input id="assocResource" type="text" bind:value={newAssocResource} placeholder="arn:aws:appconfig:..." class="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-violet-500 font-mono text-sm italic" required />
+			</div>
+			<div class="flex gap-3 pt-2">
+				<button type="button" onclick={() => showCreateAssocModal = false} class="flex-1 px-4 py-3 bg-slate-100 dark:bg-slate-700 rounded-xl font-black uppercase text-[10px] tracking-widest">Cancel</button>
+				<button type="submit" disabled={creatingAssoc} class="flex-1 px-4 py-3 bg-violet-600 text-white rounded-xl font-black uppercase text-[10px] tracking-widest disabled:opacity-50">{creatingAssoc ? 'Associating...' : 'Associate'}</button>
+			</div>
+		</form>
 	</div>
+</div>
 {/if}
 
 <style>
-	/* Custom scrollbar */
-	::-webkit-scrollbar {
-		width: 6px;
-	}
-	::-webkit-scrollbar-track {
-		background: transparent;
-	}
-	::-webkit-scrollbar-thumb {
-		background: rgba(148, 163, 184, 0.1);
-		border-radius: 10px;
-	}
-	::-webkit-scrollbar-thumb:hover {
-		background: rgba(148, 163, 184, 0.2);
-	}
+	::-webkit-scrollbar { width: 6px; }
+	::-webkit-scrollbar-track { background: transparent; }
+	::-webkit-scrollbar-thumb { background: rgba(148, 163, 184, 0.1); border-radius: 10px; }
+	::-webkit-scrollbar-thumb:hover { background: rgba(148, 163, 184, 0.2); }
 </style>


### PR DESCRIPTION
## Summary
AppConfig implementation with HMAC-signed pagination tokens and comprehensive UI support for extensions and associations management.

### Backend Changes
- Replace plain-integer pagination tokens with HMAC-SHA256-signed tokens
- Add paginationSecret field (uuid) to InMemoryBackend
- Expose PaginationSecret() on StorageBackend interface
- Update appConfigPaginate to use page.NewHMAC helper
- Fix pagination tests for HMAC validation

### UI Features
- Extensions tab: list/create/delete extensions with name filter search
- Associations tab: list/create/delete ExtensionAssociations

### Fixes
- Closes gh-1207

🤖 Merge request from refinery (queue: polecat/quartz-moqbotnr)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->