### PR TITLE
feat(mediaconvert): 4 missing SDK ops, job/template UI, native deep clone

### DIFF
--- a/services/mediaconvert/backend.go
+++ b/services/mediaconvert/backend.go
@@ -40,6 +40,14 @@ const (
 	jobStatusCanceled = "CANCELED"
 	// pricingPlanOnDemand is the default pricing plan.
 	pricingPlanOnDemand = "ON_DEMAND"
+	// jobPhaseProbing is the initial processing phase of a submitted job.
+	jobPhaseProbing = "PROBING"
+	// priorityMin is the minimum allowed job/template priority.
+	priorityMin = -50
+	// priorityMax is the maximum allowed job/template priority.
+	priorityMax = 50
+	// orderAscending is the ascending list order value used by AWS MediaConvert.
+	orderAscending = "ASCENDING"
 )
 
 // epochSeconds converts a [time.Time] to a float64 Unix epoch seconds value,
@@ -127,22 +135,28 @@ type JobTiming struct {
 
 // Job represents a MediaConvert transcoding job.
 type Job struct {
-	Settings           map[string]any    `json:"settings,omitempty"`
-	Tags               map[string]string `json:"tags,omitempty"`
-	UserMetadata       map[string]string `json:"userMetadata,omitempty"`
-	Timing             *JobTiming        `json:"timing,omitempty"`
-	Arn                string            `json:"arn"`
-	ID                 string            `json:"id"`
-	Queue              string            `json:"queue,omitempty"`
-	QueueArn           string            `json:"queueArn,omitempty"`
-	Role               string            `json:"role"`
-	Status             string            `json:"status"`
-	JobTemplate        string            `json:"jobTemplate,omitempty"`
-	ErrorMessage       string            `json:"errorMessage,omitempty"`
-	BillingTagsSource  string            `json:"billingTagsSource,omitempty"`
-	AccelerationStatus string            `json:"accelerationStatus,omitempty"`
-	ErrorCode          int               `json:"errorCode,omitempty"`
-	CreatedAt          float64           `json:"createdAt"`
+	Settings              map[string]any    `json:"settings,omitempty"`
+	Tags                  map[string]string `json:"tags,omitempty"`
+	UserMetadata          map[string]string `json:"userMetadata,omitempty"`
+	Timing                *JobTiming        `json:"timing,omitempty"`
+	Arn                   string            `json:"arn"`
+	ID                    string            `json:"id"`
+	Queue                 string            `json:"queue,omitempty"`
+	QueueArn              string            `json:"queueArn,omitempty"`
+	Role                  string            `json:"role"`
+	Status                string            `json:"status"`
+	CurrentPhase          string            `json:"currentPhase,omitempty"`
+	JobTemplate           string            `json:"jobTemplate,omitempty"`
+	ErrorMessage          string            `json:"errorMessage,omitempty"`
+	BillingTagsSource     string            `json:"billingTagsSource,omitempty"`
+	AccelerationStatus    string            `json:"accelerationStatus,omitempty"`
+	StatusUpdateInterval  string            `json:"statusUpdateInterval,omitempty"`
+	SimulateReservedQueue string            `json:"simulateReservedQueue,omitempty"`
+	CreatedAt             float64           `json:"createdAt"`
+	ErrorCode             int               `json:"errorCode,omitempty"`
+	JobPercentComplete    int               `json:"jobPercentComplete"`
+	Priority              int               `json:"priority"`
+	RetryCount            int               `json:"retryCount"`
 }
 
 // Preset represents a MediaConvert output preset.
@@ -165,8 +179,16 @@ type Policy struct {
 	S3Inputs    string `json:"s3Inputs,omitempty"`
 }
 
+// jobsQuery stores the parameters of a StartJobsQuery call for deferred execution.
+type jobsQuery struct {
+	order      string
+	filterList []map[string]any
+	maxResults int
+}
+
 // InMemoryBackend is the in-memory store for MediaConvert resources.
 type InMemoryBackend struct {
+	queries      map[string]*jobsQuery
 	queues       map[string]*Queue
 	jobTemplates map[string]*JobTemplate
 	jobs         map[string]*Job
@@ -182,6 +204,7 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new in-memory MediaConvert backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
+		queries:      make(map[string]*jobsQuery),
 		queues:       make(map[string]*Queue),
 		jobTemplates: make(map[string]*JobTemplate),
 		jobs:         make(map[string]*Job),
@@ -205,6 +228,7 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
+	b.queries = make(map[string]*jobsQuery)
 	b.queues = make(map[string]*Queue)
 	b.jobTemplates = make(map[string]*JobTemplate)
 	b.jobs = make(map[string]*Job)
@@ -270,6 +294,10 @@ func (b *InMemoryBackend) CreateQueue(
 
 	if status == "" {
 		status = statusActive
+	}
+
+	if status != statusActive && status != statusPaused {
+		return nil, fmt.Errorf("%w: status must be ACTIVE or PAUSED", ErrValidation)
 	}
 
 	now := epochSeconds(time.Now())
@@ -391,6 +419,22 @@ func (b *InMemoryBackend) DeleteQueue(name string) error {
 	return nil
 }
 
+// resolveQueueLocked looks up a queue by name or ARN.
+// Caller must hold at least a read lock.
+func (b *InMemoryBackend) resolveQueueLocked(queue string) (*Queue, error) {
+	if strings.HasPrefix(queue, "arn:") {
+		for _, cq := range b.queues {
+			if cq.Arn == queue {
+				return cq, nil
+			}
+		}
+	} else if q, ok := b.queues[queue]; ok {
+		return q, nil
+	}
+
+	return nil, fmt.Errorf("%w: queue %s not found", ErrNotFound, queue)
+}
+
 // CreateJobTemplate creates a new MediaConvert job template.
 func (b *InMemoryBackend) CreateJobTemplate(
 	name, description, category, queue string,
@@ -407,6 +451,10 @@ func (b *InMemoryBackend) CreateJobTemplate(
 
 	if _, ok := b.jobTemplates[name]; ok {
 		return nil, fmt.Errorf("%w: job template %s already exists", ErrAlreadyExists, name)
+	}
+
+	if priority < priorityMin || priority > priorityMax {
+		return nil, fmt.Errorf("%w: priority must be between %d and %d", ErrValidation, priorityMin, priorityMax)
 	}
 
 	now := epochSeconds(time.Now())
@@ -487,6 +535,10 @@ func (b *InMemoryBackend) UpdateJobTemplate(
 	}
 
 	if priority != nil {
+		if *priority < priorityMin || *priority > priorityMax {
+			return nil, fmt.Errorf("%w: priority must be between %d and %d", ErrValidation, priorityMin, priorityMax)
+		}
+
 		jt.Priority = *priority
 	}
 
@@ -529,34 +581,37 @@ func (b *InMemoryBackend) CreateJob(
 		return nil, fmt.Errorf("%w: role is required", ErrValidation)
 	}
 
-	// Resolve queue ARN from queue name.
+	// Resolve queue ARN from queue name or ARN.
 	queueArn := ""
 	if queue != "" {
-		q, ok := b.queues[queue]
-		if !ok {
-			return nil, fmt.Errorf("%w: queue %s not found", ErrNotFound, queue)
+		resolved, err := b.resolveQueueLocked(queue)
+		if err != nil {
+			return nil, err
 		}
 
-		queueArn = q.Arn
+		queueArn = resolved.Arn
 	}
 
 	now := epochSeconds(time.Now())
 	id := generateJobID()
 	j := &Job{
-		Arn:                arn.Build("mediaconvert", b.region, b.accountID, "jobs/"+id),
-		ID:                 id,
-		Role:               role,
-		Queue:              queue,
-		QueueArn:           queueArn,
-		JobTemplate:        jobTemplate,
-		Status:             jobStatusSubmitted,
-		Settings:           deepCloneMap(settings),
-		Tags:               nonNilTagsCopy(tags),
-		UserMetadata:       nonNilTagsCopy(userMetadata),
-		BillingTagsSource:  billingTagsSource,
-		AccelerationStatus: "NOT_APPLICABLE",
-		Timing:             &JobTiming{SubmitTime: now},
-		CreatedAt:          now,
+		Arn:                   arn.Build("mediaconvert", b.region, b.accountID, "jobs/"+id),
+		ID:                    id,
+		Role:                  role,
+		Queue:                 queue,
+		QueueArn:              queueArn,
+		JobTemplate:           jobTemplate,
+		Status:                jobStatusSubmitted,
+		CurrentPhase:          jobPhaseProbing,
+		Settings:              deepCloneMap(settings),
+		Tags:                  nonNilTagsCopy(tags),
+		UserMetadata:          nonNilTagsCopy(userMetadata),
+		BillingTagsSource:     billingTagsSource,
+		AccelerationStatus:    "NOT_APPLICABLE",
+		SimulateReservedQueue: "DISABLED",
+		StatusUpdateInterval:  "SECONDS_60",
+		Timing:                &JobTiming{SubmitTime: now},
+		CreatedAt:             now,
 	}
 	b.jobs[id] = j
 
@@ -865,19 +920,92 @@ func (b *InMemoryBackend) DisassociateCertificate(certARN string) error {
 	return nil
 }
 
-// StartJobsQuery creates an asynchronous job query and returns a query ID.
-// The results can be retrieved via GetJobsQueryResults using the returned ID.
-func (b *InMemoryBackend) StartJobsQuery() (string, error) {
-	return uuid.NewString(), nil
+// StartJobsQuery stores a jobs query and returns a query ID for deferred retrieval.
+// Filters use key-value pairs where key is a field name (e.g. "queue", "status")
+// and values are the allowed values for that field.
+func (b *InMemoryBackend) StartJobsQuery(filterList []map[string]any, maxResults int, order string) (string, error) {
+	id := uuid.NewString()
+
+	b.mu.Lock("StartJobsQuery")
+	defer b.mu.Unlock()
+
+	b.queries[id] = &jobsQuery{
+		filterList: filterList,
+		maxResults: maxResults,
+		order:      order,
+	}
+
+	return id, nil
 }
 
-// GetJobsQueryResults returns the result set for a query started by StartJobsQuery.
-// This mock returns an empty set; real results would be fetched from async storage.
-func (b *InMemoryBackend) GetJobsQueryResults(_ string) []*Job {
+// GetJobsQueryResults returns jobs matching the stored query for the given ID.
+// If the queryID is unknown (not from a prior StartJobsQuery call), returns empty.
+func (b *InMemoryBackend) GetJobsQueryResults(queryID string) []*Job {
 	b.mu.RLock("GetJobsQueryResults")
 	defer b.mu.RUnlock()
 
-	return []*Job{}
+	q, ok := b.queries[queryID]
+	if !ok {
+		return []*Job{}
+	}
+
+	list := make([]*Job, 0, len(b.jobs))
+
+	for _, j := range b.jobs {
+		if !jobMatchesFilters(j, q.filterList) {
+			continue
+		}
+
+		list = append(list, cloneJob(j))
+	}
+
+	if q.order == orderAscending {
+		sort.Slice(list, func(i, j int) bool { return list[i].CreatedAt < list[j].CreatedAt })
+	} else {
+		sort.Slice(list, func(i, j int) bool { return list[i].CreatedAt > list[j].CreatedAt })
+	}
+
+	if q.maxResults > 0 && len(list) > q.maxResults {
+		list = list[:q.maxResults]
+	}
+
+	return list
+}
+
+// jobMatchesFilters returns true if the job satisfies all provided query filters.
+// Each filter map must have a "key" and a "values" field; any value match passes.
+func jobMatchesFilters(j *Job, filters []map[string]any) bool {
+	for _, f := range filters {
+		key, _ := f["key"].(string)
+		vals, _ := f["values"].([]any)
+
+		var jobVal string
+
+		switch key {
+		case "queue", "Queue":
+			jobVal = j.Queue
+		case "status", "Status":
+			jobVal = j.Status
+		default:
+			continue
+		}
+
+		matched := false
+
+		for _, v := range vals {
+			if vs, ok := v.(string); ok && vs == jobVal {
+				matched = true
+
+				break
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	return true
 }
 
 // CreateResourceShare records a resource-share request for the given job ID.

--- a/services/mediaconvert/backend.go
+++ b/services/mediaconvert/backend.go
@@ -1,7 +1,6 @@
 package mediaconvert
 
 import (
-	"encoding/json"
 	"fmt"
 	"maps"
 	"sort"
@@ -49,23 +48,35 @@ func epochSeconds(t time.Time) float64 {
 	return float64(t.Unix())
 }
 
-// deepCopySettings returns a deep copy of a settings map, or nil if input is nil.
-func deepCopySettings(s map[string]any) map[string]any {
-	if s == nil {
+// deepCloneMap returns a deep copy of a settings map, or nil if input is nil.
+func deepCloneMap(m map[string]any) map[string]any {
+	if m == nil {
 		return nil
 	}
 
-	data, err := json.Marshal(s)
-	if err != nil {
-		return nil
-	}
-
-	var cp map[string]any
-	if unmarshalErr := json.Unmarshal(data, &cp); unmarshalErr != nil {
-		return nil
+	cp := make(map[string]any, len(m))
+	for k, v := range m {
+		cp[k] = deepCloneValue(v)
 	}
 
 	return cp
+}
+
+// deepCloneValue recursively clones a value, handling nested maps and slices.
+func deepCloneValue(v any) any {
+	switch vt := v.(type) {
+	case map[string]any:
+		return deepCloneMap(vt)
+	case []any:
+		cp := make([]any, len(vt))
+		for i, item := range vt {
+			cp[i] = deepCloneValue(item)
+		}
+
+		return cp
+	default:
+		return v
+	}
 }
 
 // nonNilTagsCopy returns a copy of the given tags map; never returns nil.
@@ -406,7 +417,7 @@ func (b *InMemoryBackend) CreateJobTemplate(
 		Category:    category,
 		Queue:       queue,
 		Priority:    priority,
-		Settings:    deepCopySettings(settings),
+		Settings:    deepCloneMap(settings),
 		Tags:        nonNilTagsCopy(tags),
 		Type:        presetCustom,
 		CreatedAt:   now,
@@ -480,7 +491,7 @@ func (b *InMemoryBackend) UpdateJobTemplate(
 	}
 
 	if settings != nil {
-		jt.Settings = deepCopySettings(settings)
+		jt.Settings = deepCloneMap(settings)
 	}
 
 	jt.LastUpdated = epochSeconds(time.Now())
@@ -539,7 +550,7 @@ func (b *InMemoryBackend) CreateJob(
 		QueueArn:           queueArn,
 		JobTemplate:        jobTemplate,
 		Status:             jobStatusSubmitted,
-		Settings:           deepCopySettings(settings),
+		Settings:           deepCloneMap(settings),
 		Tags:               nonNilTagsCopy(tags),
 		UserMetadata:       nonNilTagsCopy(userMetadata),
 		BillingTagsSource:  billingTagsSource,
@@ -686,7 +697,7 @@ func (b *InMemoryBackend) CreatePreset(
 		Name:        name,
 		Description: description,
 		Category:    category,
-		Settings:    deepCopySettings(settings),
+		Settings:    deepCloneMap(settings),
 		Tags:        nonNilTagsCopy(tags),
 		Type:        presetCustom,
 		CreatedAt:   now,
@@ -748,7 +759,7 @@ func (b *InMemoryBackend) UpdatePreset(name, description, category string, setti
 	}
 
 	if settings != nil {
-		p.Settings = deepCopySettings(settings)
+		p.Settings = deepCloneMap(settings)
 	}
 
 	p.LastUpdated = epochSeconds(time.Now())
@@ -854,8 +865,14 @@ func (b *InMemoryBackend) DisassociateCertificate(certARN string) error {
 	return nil
 }
 
-// GetJobsQueryResults returns an empty jobs query result set for the given query ID.
-// Because StartJobsQuery is not implemented, all query IDs return an empty result.
+// StartJobsQuery creates an asynchronous job query and returns a query ID.
+// The results can be retrieved via GetJobsQueryResults using the returned ID.
+func (b *InMemoryBackend) StartJobsQuery() (string, error) {
+	return uuid.NewString(), nil
+}
+
+// GetJobsQueryResults returns the result set for a query started by StartJobsQuery.
+// This mock returns an empty set; real results would be fetched from async storage.
 func (b *InMemoryBackend) GetJobsQueryResults(_ string) []*Job {
 	b.mu.RLock("GetJobsQueryResults")
 	defer b.mu.RUnlock()
@@ -891,7 +908,7 @@ func cloneQueue(q *Queue) *Queue {
 
 func cloneJobTemplate(jt *JobTemplate) *JobTemplate {
 	cp := *jt
-	cp.Settings = deepCopySettings(jt.Settings)
+	cp.Settings = deepCloneMap(jt.Settings)
 	cp.Tags = nonNilTagsCopy(jt.Tags)
 
 	return &cp
@@ -899,7 +916,7 @@ func cloneJobTemplate(jt *JobTemplate) *JobTemplate {
 
 func cloneJob(j *Job) *Job {
 	cp := *j
-	cp.Settings = deepCopySettings(j.Settings)
+	cp.Settings = deepCloneMap(j.Settings)
 	cp.Tags = nonNilTagsCopy(j.Tags)
 	cp.UserMetadata = nonNilTagsCopy(j.UserMetadata)
 
@@ -913,7 +930,7 @@ func cloneJob(j *Job) *Job {
 
 func clonePreset(p *Preset) *Preset {
 	cp := *p
-	cp.Settings = deepCopySettings(p.Settings)
+	cp.Settings = deepCloneMap(p.Settings)
 	cp.Tags = nonNilTagsCopy(p.Tags)
 
 	return &cp

--- a/services/mediaconvert/handler.go
+++ b/services/mediaconvert/handler.go
@@ -48,6 +48,10 @@ const (
 	opUpdateJobTemplate       = "UpdateJobTemplate"
 	opUpdatePreset            = "UpdatePreset"
 	opUpdateQueue             = "UpdateQueue"
+	opListVersions            = "ListVersions"
+	opProbe                   = "Probe"
+	opSearchJobs              = "SearchJobs"
+	opStartJobsQuery          = "StartJobsQuery"
 )
 
 const (
@@ -63,6 +67,9 @@ const (
 	certificatesPath   = "/2017-08-29/certificates"
 	jobsQueriesPath    = "/2017-08-29/jobsQueries"
 	resourceSharesPath = "/2017-08-29/resourceShares"
+	versionsPath       = "/2017-08-29/versions"
+	probePath          = "/2017-08-29/probe"
+	searchPath         = "/2017-08-29/search"
 )
 
 // Handler is the Echo HTTP handler for Amazon MediaConvert operations.
@@ -116,6 +123,10 @@ func (h *Handler) GetSupportedOperations() []string {
 		opUpdateJobTemplate,
 		opUpdatePreset,
 		opUpdateQueue,
+		opListVersions,
+		opProbe,
+		opSearchJobs,
+		opStartJobsQuery,
 	}
 }
 
@@ -233,6 +244,10 @@ func (h *Handler) dispatchReadOnlyNewOps(c *echo.Context, route mcRoute) (bool, 
 		return true, h.handleDisassociateCertificate(c, route.resource)
 	case opGetJobsQueryResults:
 		return true, h.handleGetJobsQueryResults(c, route.resource)
+	case opListVersions:
+		return true, h.handleListVersions(c)
+	case opSearchJobs:
+		return true, h.handleSearchJobs(c)
 	}
 
 	return false, nil
@@ -268,6 +283,10 @@ func (h *Handler) dispatchMutating(c *echo.Context, route mcRoute, readBody func
 		return h.handleAssociateCertificate(c, body)
 	case opCreateResourceShare:
 		return h.handleCreateResourceShare(c, body)
+	case opProbe:
+		return h.handleProbe(c, body)
+	case opStartJobsQuery:
+		return h.handleStartJobsQuery(c, body)
 	}
 
 	return c.JSON(
@@ -299,13 +318,33 @@ func parseRoute(method, path string) mcRoute {
 		return parseTagRoute(method, strings.TrimPrefix(path, tagsPath))
 	case strings.HasPrefix(path, certificatesPath):
 		return parseCertificateRoute(method, strings.TrimPrefix(path, certificatesPath))
-	case path == policyPath:
+	}
+
+	return parseStaticPathRoute(method, path)
+}
+
+// parseStaticPathRoute handles non-prefix (exact-match) path routes.
+func parseStaticPathRoute(method, path string) mcRoute {
+	switch path {
+	case policyPath:
 		return parsePolicyRoute(method)
-	case path == endpointsPath:
+	case endpointsPath:
 		return mcRoute{operation: opDescribeEndpoints}
-	case path == resourceSharesPath:
+	case resourceSharesPath:
 		if method == http.MethodPost {
 			return mcRoute{operation: opCreateResourceShare}
+		}
+	case versionsPath:
+		if method == http.MethodGet {
+			return mcRoute{operation: opListVersions}
+		}
+	case probePath:
+		if method == http.MethodPost {
+			return mcRoute{operation: opProbe}
+		}
+	case searchPath:
+		if method == http.MethodGet {
+			return mcRoute{operation: opSearchJobs}
 		}
 	}
 
@@ -457,6 +496,10 @@ func parseJobsQueriesRoute(method, suffix string) mcRoute {
 
 	if id != "" && method == http.MethodGet {
 		return mcRoute{operation: opGetJobsQueryResults, resource: id}
+	}
+
+	if id == "" && method == http.MethodPost {
+		return mcRoute{operation: opStartJobsQuery}
 	}
 
 	return mcRoute{operation: opUnknown}
@@ -981,6 +1024,111 @@ func (h *Handler) handleCreateResourceShare(c *echo.Context, body []byte) error 
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+// --- ListVersions handler ---
+
+type listVersionsOutput struct {
+	NextToken string         `json:"nextToken,omitempty"`
+	Versions  []versionEntry `json:"versions"`
+}
+
+type versionEntry struct {
+	Version string `json:"version"`
+}
+
+func (h *Handler) handleListVersions(c *echo.Context) error {
+	out := listVersionsOutput{
+		Versions: []versionEntry{{Version: "2017-08-29"}},
+	}
+
+	return c.JSON(http.StatusOK, out)
+}
+
+// --- Probe handler ---
+
+type probeInput struct {
+	InputFiles []map[string]any `json:"inputFiles,omitempty"`
+}
+
+type probeOutput struct {
+	ProbeResults []map[string]any `json:"probeResults"`
+}
+
+func (h *Handler) handleProbe(c *echo.Context, body []byte) error {
+	var in probeInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errorResponse("BadRequestException", "invalid request body"))
+	}
+
+	results := make([]map[string]any, 0, len(in.InputFiles))
+	for _, f := range in.InputFiles {
+		result := map[string]any{
+			"probeResult": map[string]any{
+				"container": map[string]any{"format": "mp4"},
+				"inputFile": f,
+			},
+		}
+		results = append(results, result)
+	}
+
+	return c.JSON(http.StatusOK, probeOutput{ProbeResults: results})
+}
+
+// --- SearchJobs handler ---
+
+type searchJobsOutput struct {
+	NextToken string `json:"nextToken,omitempty"`
+	Jobs      []*Job `json:"jobs"`
+}
+
+func (h *Handler) handleSearchJobs(c *echo.Context) error {
+	q := c.Request().URL.Query()
+	statusFilter := q.Get("status")
+	queueFilter := q.Get("queue")
+
+	jobs := h.Backend.ListJobs()
+	if jobs == nil {
+		jobs = []*Job{}
+	}
+
+	filtered := jobs[:0:0]
+	for _, j := range jobs {
+		if statusFilter != "" && j.Status != statusFilter {
+			continue
+		}
+		if queueFilter != "" && j.Queue != queueFilter {
+			continue
+		}
+		filtered = append(filtered, j)
+	}
+
+	return c.JSON(http.StatusOK, searchJobsOutput{Jobs: filtered})
+}
+
+// --- StartJobsQuery handler ---
+
+type startJobsQueryInput struct {
+	MaxResults *int             `json:"maxResults,omitempty"`
+	FilterList []map[string]any `json:"filterList,omitempty"`
+}
+
+type startJobsQueryOutput struct {
+	QueryID string `json:"queryId"`
+}
+
+func (h *Handler) handleStartJobsQuery(c *echo.Context, body []byte) error {
+	var in startJobsQueryInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errorResponse("BadRequestException", "invalid request body"))
+	}
+
+	queryID, err := h.Backend.StartJobsQuery()
+	if err != nil {
+		return h.writeError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, startJobsQueryOutput{QueryID: queryID})
 }
 
 // --- Error handling ---

--- a/services/mediaconvert/handler.go
+++ b/services/mediaconvert/handler.go
@@ -3,6 +3,7 @@ package mediaconvert
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -15,6 +16,10 @@ import (
 
 const (
 	opUnknown = "Unknown"
+)
+
+const (
+	orderDescending = "DESCENDING"
 )
 
 const (
@@ -556,7 +561,13 @@ func (h *Handler) handleListQueues(c *echo.Context) error {
 		queues = []*Queue{}
 	}
 
-	return c.JSON(http.StatusOK, queuesListOutput{Queues: queues})
+	q := c.Request().URL.Query()
+
+	if q.Get("order") == orderDescending {
+		reverseSlice(queues)
+	}
+
+	return c.JSON(http.StatusOK, queuesListOutput{Queues: limitSlice(queues, parseMaxResults(q.Get("maxResults")))})
 }
 
 type updateQueueInput struct {
@@ -647,7 +658,28 @@ func (h *Handler) handleListJobTemplates(c *echo.Context) error {
 		templates = []*JobTemplate{}
 	}
 
-	return c.JSON(http.StatusOK, jobTemplatesListOutput{JobTemplates: templates})
+	q := c.Request().URL.Query()
+	category := q.Get("category")
+
+	if category != "" {
+		filtered := templates[:0:0]
+
+		for _, t := range templates {
+			if t.Category == category {
+				filtered = append(filtered, t)
+			}
+		}
+
+		templates = filtered
+	}
+
+	if q.Get("order") == orderDescending {
+		reverseSlice(templates)
+	}
+
+	out := jobTemplatesListOutput{JobTemplates: limitSlice(templates, parseMaxResults(q.Get("maxResults")))}
+
+	return c.JSON(http.StatusOK, out)
 }
 
 type updateJobTemplateInput struct {
@@ -741,6 +773,41 @@ func (h *Handler) handleListJobs(c *echo.Context) error {
 	jobs := h.Backend.ListJobs()
 	if jobs == nil {
 		jobs = []*Job{}
+	}
+
+	q := c.Request().URL.Query()
+	statusFilter := q.Get("status")
+	queueFilter := q.Get("queue")
+	order := q.Get("order")
+	maxResults := parseMaxResults(q.Get("maxResults"))
+
+	if statusFilter != "" || queueFilter != "" {
+		filtered := jobs[:0:0]
+
+		for _, j := range jobs {
+			if statusFilter != "" && j.Status != statusFilter {
+				continue
+			}
+
+			if queueFilter != "" && j.Queue != queueFilter && j.QueueArn != queueFilter {
+				continue
+			}
+
+			filtered = append(filtered, j)
+		}
+
+		jobs = filtered
+	}
+
+	// Backend returns newest-first by default; ASCENDING reverses that order.
+	if order == orderAscending {
+		for i, j := 0, len(jobs)-1; i < j; i, j = i+1, j-1 {
+			jobs[i], jobs[j] = jobs[j], jobs[i]
+		}
+	}
+
+	if maxResults > 0 && len(jobs) > maxResults {
+		jobs = jobs[:maxResults]
 	}
 
 	return c.JSON(http.StatusOK, jobsListOutput{Jobs: jobs, TotalCount: len(jobs)})
@@ -878,7 +945,26 @@ func (h *Handler) handleListPresets(c *echo.Context) error {
 		presets = []*Preset{}
 	}
 
-	return c.JSON(http.StatusOK, presetsListOutput{Presets: presets})
+	q := c.Request().URL.Query()
+	category := q.Get("category")
+
+	if category != "" {
+		filtered := presets[:0:0]
+
+		for _, p := range presets {
+			if p.Category == category {
+				filtered = append(filtered, p)
+			}
+		}
+
+		presets = filtered
+	}
+
+	if q.Get("order") == orderDescending {
+		reverseSlice(presets)
+	}
+
+	return c.JSON(http.StatusOK, presetsListOutput{Presets: limitSlice(presets, parseMaxResults(q.Get("maxResults")))})
 }
 
 func (h *Handler) handleDeletePreset(c *echo.Context, name string) error {
@@ -1029,17 +1115,21 @@ func (h *Handler) handleCreateResourceShare(c *echo.Context, body []byte) error 
 // --- ListVersions handler ---
 
 type listVersionsOutput struct {
-	NextToken string         `json:"nextToken,omitempty"`
-	Versions  []versionEntry `json:"versions"`
+	NextToken string             `json:"nextToken,omitempty"`
+	Versions  []jobEngineVersion `json:"versions"`
 }
 
-type versionEntry struct {
-	Version string `json:"version"`
+// jobEngineVersion mirrors the AWS MediaConvert JobEngineVersion type.
+type jobEngineVersion struct {
+	ExpirationDate *float64 `json:"expirationDate,omitempty"`
+	Version        string   `json:"version"`
 }
 
 func (h *Handler) handleListVersions(c *echo.Context) error {
 	out := listVersionsOutput{
-		Versions: []versionEntry{{Version: "2017-08-29"}},
+		Versions: []jobEngineVersion{
+			{Version: "2017-08-29"},
+		},
 	}
 
 	return c.JSON(http.StatusOK, out)
@@ -1086,6 +1176,8 @@ func (h *Handler) handleSearchJobs(c *echo.Context) error {
 	q := c.Request().URL.Query()
 	statusFilter := q.Get("status")
 	queueFilter := q.Get("queue")
+	order := q.Get("order")
+	maxResults := parseMaxResults(q.Get("maxResults"))
 
 	jobs := h.Backend.ListJobs()
 	if jobs == nil {
@@ -1097,10 +1189,23 @@ func (h *Handler) handleSearchJobs(c *echo.Context) error {
 		if statusFilter != "" && j.Status != statusFilter {
 			continue
 		}
-		if queueFilter != "" && j.Queue != queueFilter {
+
+		if queueFilter != "" && j.Queue != queueFilter && j.QueueArn != queueFilter {
 			continue
 		}
+
 		filtered = append(filtered, j)
+	}
+
+	// Backend returns newest-first by default; ASCENDING reverses that order.
+	if order == orderAscending {
+		for i, j := 0, len(filtered)-1; i < j; i, j = i+1, j-1 {
+			filtered[i], filtered[j] = filtered[j], filtered[i]
+		}
+	}
+
+	if maxResults > 0 && len(filtered) > maxResults {
+		filtered = filtered[:maxResults]
 	}
 
 	return c.JSON(http.StatusOK, searchJobsOutput{Jobs: filtered})
@@ -1109,6 +1214,7 @@ func (h *Handler) handleSearchJobs(c *echo.Context) error {
 // --- StartJobsQuery handler ---
 
 type startJobsQueryInput struct {
+	Order      string           `json:"order,omitempty"`
 	MaxResults *int             `json:"maxResults,omitempty"`
 	FilterList []map[string]any `json:"filterList,omitempty"`
 }
@@ -1123,12 +1229,49 @@ func (h *Handler) handleStartJobsQuery(c *echo.Context, body []byte) error {
 		return c.JSON(http.StatusBadRequest, errorResponse("BadRequestException", "invalid request body"))
 	}
 
-	queryID, err := h.Backend.StartJobsQuery()
+	maxResults := 0
+	if in.MaxResults != nil {
+		maxResults = *in.MaxResults
+	}
+
+	queryID, err := h.Backend.StartJobsQuery(in.FilterList, maxResults, in.Order)
 	if err != nil {
 		return h.writeError(c, err)
 	}
 
 	return c.JSON(http.StatusOK, startJobsQueryOutput{QueryID: queryID})
+}
+
+// reverseSlice reverses items in-place.
+func reverseSlice[T any](items []T) {
+	for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+		items[i], items[j] = items[j], items[i]
+	}
+}
+
+// limitSlice returns at most maxResults items; 0 means no limit.
+func limitSlice[T any](items []T, maxResults int) []T {
+	if maxResults > 0 && len(items) > maxResults {
+		return items[:maxResults]
+	}
+
+	return items
+}
+
+// parseMaxResults converts a query-parameter string to a non-negative int,
+// returning 0 (no limit) when the string is empty or unparseable.
+func parseMaxResults(s string) int {
+	if s == "" {
+		return 0
+	}
+
+	var n int
+
+	if _, err := fmt.Sscanf(s, "%d", &n); err != nil || n < 0 {
+		return 0
+	}
+
+	return n
 }
 
 // --- Error handling ---

--- a/services/mediaconvert/interfaces.go
+++ b/services/mediaconvert/interfaces.go
@@ -56,6 +56,7 @@ type StorageBackend interface {
 
 	// Jobs query / resource share operations
 	GetJobsQueryResults(queryID string) []*Job
+	StartJobsQuery() (string, error)
 	CreateResourceShare(jobID string) (string, error)
 
 	// Tag operations

--- a/services/mediaconvert/interfaces.go
+++ b/services/mediaconvert/interfaces.go
@@ -56,7 +56,7 @@ type StorageBackend interface {
 
 	// Jobs query / resource share operations
 	GetJobsQueryResults(queryID string) []*Job
-	StartJobsQuery() (string, error)
+	StartJobsQuery(filterList []map[string]any, maxResults int, order string) (string, error)
 	CreateResourceShare(jobID string) (string, error)
 
 	// Tag operations

--- a/services/mediaconvert/persistence.go
+++ b/services/mediaconvert/persistence.go
@@ -95,6 +95,7 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
+	b.queries = make(map[string]*jobsQuery)
 	b.queues = snap.Queues
 	b.jobTemplates = snap.JobTemplates
 	b.jobs = snap.Jobs

--- a/services/mediaconvert/sdk_completeness_test.go
+++ b/services/mediaconvert/sdk_completeness_test.go
@@ -17,10 +17,5 @@ func TestSDKCompleteness(t *testing.T) {
 
 	backend := mediaconvert.NewInMemoryBackend("000000000000", "us-east-1")
 	h := mediaconvert.NewHandler(backend)
-	sdkcheck.CheckCompleteness(t, &mediaconvertsdk.Client{}, h.GetSupportedOperations(), []string{
-		"ListVersions",
-		"Probe",
-		"SearchJobs",
-		"StartJobsQuery",
-	})
+	sdkcheck.CheckCompleteness(t, &mediaconvertsdk.Client{}, h.GetSupportedOperations(), nil)
 }

--- a/ui/src/routes/appconfig/+page.svelte
+++ b/ui/src/routes/appconfig/+page.svelte
@@ -405,8 +405,10 @@
 				DeploymentDurationInMinutes: newStratDuration,
 				FinalBakeTimeInMinutes: newStratBake,
 				GrowthFactor: newStratGrowth,
-				GrowthType: newStratGrowthType as string,
-				ReplicateTo: newStratReplicateTo as string,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				GrowthType: newStratGrowthType as any,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				ReplicateTo: newStratReplicateTo as any,
 			}));
 			toast.success(`Strategy "${newStratName}" created`);
 			showCreateStratModal = false;

--- a/ui/src/routes/appconfig/+page.svelte
+++ b/ui/src/routes/appconfig/+page.svelte
@@ -619,7 +619,7 @@
 							<button onclick={() => showDeployModal = true} class="flex items-center gap-1.5 px-3 py-2 bg-emerald-600 text-white rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-emerald-700 transition-all" title="Start Deployment">
 								<Play class="w-3.5 h-3.5" /> Deploy
 							</button>
-							<button onclick={() => deleteApplication(selectedApp?.Id)} class="p-2 bg-slate-900 dark:bg-black text-rose-500 hover:bg-rose-500/10 rounded-xl transition-all border border-rose-500/20">
+							<button title="Delete Application" onclick={() => deleteApplication(selectedApp?.Id)} class="p-2 bg-slate-900 dark:bg-black text-rose-500 hover:bg-rose-500/10 rounded-xl transition-all border border-rose-500/20">
 								<Trash2 class="w-4 h-4" />
 							</button>
 						</div>

--- a/ui/src/routes/appconfig/page.test.ts
+++ b/ui/src/routes/appconfig/page.test.ts
@@ -24,6 +24,8 @@ describe("AppConfig Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSend.mockReset();
+    // Default fallback for any unexpected API calls
+    mockSend.mockResolvedValue({ Items: [] });
   });
 
   it("renders page title and create button", () => {
@@ -32,7 +34,7 @@ describe("AppConfig Page", () => {
     render(AppConfigPage);
 
     expect(screen.getByText("AppConfig Orchestration")).toBeInTheDocument();
-    expect(screen.getByText("Assemble Application")).toBeInTheDocument();
+    expect(screen.getByText("New Application")).toBeInTheDocument();
   });
 
   it("displays loaded applications", async () => {
@@ -72,7 +74,7 @@ describe("AppConfig Page", () => {
       { timeout: 3000 },
     );
 
-    const searchInput = screen.getByPlaceholderText("Search applications...");
+    const searchInput = screen.getByPlaceholderText("Search apps...");
     await fireEvent.input(searchInput, { target: { value: "beta" } });
 
     await waitFor(() => {
@@ -87,12 +89,12 @@ describe("AppConfig Page", () => {
 
     render(AppConfigPage);
 
-    const createBtn = screen.getByText("Assemble Application");
+    const createBtn = screen.getByText("New Application");
     await fireEvent.click(createBtn);
 
-    expect(screen.getByText("Assemble Application", { selector: "h3" })).toBeInTheDocument();
+    expect(screen.getByText("New Application", { selector: "h3" })).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText("e.g. gopherstack-microservices-config"),
+      screen.getByPlaceholderText("my-app-config"),
     ).toBeInTheDocument();
   });
 
@@ -101,17 +103,17 @@ describe("AppConfig Page", () => {
 
     render(AppConfigPage);
 
-    await fireEvent.click(screen.getByText("Assemble Application"));
+    await fireEvent.click(screen.getByText("New Application"));
 
     expect(
-      screen.getByPlaceholderText("e.g. gopherstack-microservices-config"),
+      screen.getByPlaceholderText("my-app-config"),
     ).toBeInTheDocument();
 
-    await fireEvent.click(screen.getByText("Abort"));
+    await fireEvent.click(screen.getByText("Cancel"));
 
     await waitFor(() => {
       expect(
-        screen.queryByPlaceholderText("e.g. gopherstack-microservices-config"),
+        screen.queryByPlaceholderText("my-app-config"),
       ).not.toBeInTheDocument();
     });
   });
@@ -123,9 +125,9 @@ describe("AppConfig Page", () => {
 
     render(AppConfigPage);
 
-    await fireEvent.click(screen.getByText("Assemble Application"));
+    await fireEvent.click(screen.getByText("New Application"));
 
-    const nameInput = screen.getByPlaceholderText("e.g. gopherstack-microservices-config");
+    const nameInput = screen.getByPlaceholderText("my-app-config");
     await fireEvent.input(nameInput, { target: { value: "new-config" } });
 
     const form = nameInput.closest("form")!;
@@ -170,6 +172,15 @@ describe("AppConfig Page", () => {
     await waitFor(
       () => {
         expect(screen.getByText("production")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Click Profiles tab to see profiles
+    await fireEvent.click(screen.getByText("Profiles"));
+
+    await waitFor(
+      () => {
         expect(screen.getByText("feature-flags")).toBeInTheDocument();
       },
       { timeout: 3000 },
@@ -197,7 +208,7 @@ describe("AppConfig Page", () => {
 
     await waitFor(
       () => {
-        expect(screen.getByText("No applications detected.")).toBeInTheDocument();
+        expect(screen.getByText("No applications.")).toBeInTheDocument();
       },
       { timeout: 3000 },
     );
@@ -231,12 +242,12 @@ describe("AppConfig Page", () => {
 
     await waitFor(
       () => {
-        expect(screen.getByTitle("Purge Application")).toBeInTheDocument();
+        expect(screen.getByTitle("Delete Application")).toBeInTheDocument();
       },
       { timeout: 3000 },
     );
 
-    await fireEvent.click(screen.getByTitle("Purge Application"));
+    await fireEvent.click(screen.getByTitle("Delete Application"));
 
     await waitFor(
       () => {

--- a/ui/src/routes/mediaconvert/+page.svelte
+++ b/ui/src/routes/mediaconvert/+page.svelte
@@ -5,6 +5,9 @@
 		ListJobsCommand,
 		ListQueuesCommand,
 		ListJobTemplatesCommand,
+		CreateJobCommand,
+		CreateJobTemplateCommand,
+		UpdateJobTemplateCommand,
 		type Job,
 		type Queue,
 		type JobTemplate
@@ -22,7 +25,10 @@
 		XCircle,
 		ChevronRight,
 		Play,
-		Pause
+		Pause,
+		Plus,
+		X,
+		Edit
 	} from 'lucide-svelte';
 
 	const mediaConvert = getMediaConvertClient();
@@ -35,6 +41,24 @@
 	let templates = $state<JobTemplate[]>([]);
 	let selectedJob = $state<Job | null>(null);
 	let selectedQueue = $state<Queue | null>(null);
+	let selectedTemplate = $state<JobTemplate | null>(null);
+
+	// Job creation modal state
+	let showCreateJob = $state(false);
+	let createJobRole = $state('');
+	let createJobQueue = $state('');
+	let createJobTemplate = $state('');
+	let createJobSubmitting = $state(false);
+
+	// Template create/edit modal state
+	let showTemplateModal = $state(false);
+	let templateModalMode = $state<'create' | 'edit'>('create');
+	let templateName = $state('');
+	let templateDescription = $state('');
+	let templateCategory = $state('');
+	let templateQueue = $state('');
+	let templatePriority = $state(0);
+	let templateSubmitting = $state(false);
 
 	const filteredJobs = $derived(
 		jobs.filter(
@@ -114,6 +138,7 @@
 		searchQuery = '';
 		selectedJob = null;
 		selectedQueue = null;
+		selectedTemplate = null;
 		if (tab === 'jobs' && jobs.length === 0) await loadJobs();
 		else if (tab === 'queues' && queues.length === 0) await loadQueues();
 		else if (tab === 'templates' && templates.length === 0) await loadTemplates();
@@ -123,6 +148,96 @@
 		if (activeTab === 'jobs') { jobs = []; await loadJobs(); }
 		else if (activeTab === 'queues') { queues = []; await loadQueues(); }
 		else { templates = []; await loadTemplates(); }
+	}
+
+	function openCreateJob() {
+		createJobRole = '';
+		createJobQueue = '';
+		createJobTemplate = '';
+		showCreateJob = true;
+	}
+
+	async function submitCreateJob() {
+		if (!createJobRole.trim()) {
+			toast.error('Role ARN is required');
+			return;
+		}
+		createJobSubmitting = true;
+		try {
+			await mediaConvert.send(new CreateJobCommand({
+				Role: createJobRole.trim(),
+				Queue: createJobQueue.trim() || undefined,
+				JobTemplate: createJobTemplate.trim() || undefined,
+				Settings: { Inputs: [] }
+			}));
+			toast.success('Job created');
+			showCreateJob = false;
+			jobs = [];
+			await loadJobs();
+		} catch (err: unknown) {
+			toast.error(`Failed to create job: ${(err as Error).message}`);
+		} finally {
+			createJobSubmitting = false;
+		}
+	}
+
+	function openCreateTemplate() {
+		templateModalMode = 'create';
+		templateName = '';
+		templateDescription = '';
+		templateCategory = '';
+		templateQueue = '';
+		templatePriority = 0;
+		showTemplateModal = true;
+	}
+
+	function openEditTemplate(t: JobTemplate) {
+		templateModalMode = 'edit';
+		templateName = t.Name ?? '';
+		templateDescription = t.Description ?? '';
+		templateCategory = t.Category ?? '';
+		templateQueue = t.Queue ?? '';
+		templatePriority = t.Priority ?? 0;
+		showTemplateModal = true;
+	}
+
+	async function submitTemplateModal() {
+		if (templateModalMode === 'create' && !templateName.trim()) {
+			toast.error('Template name is required');
+			return;
+		}
+		templateSubmitting = true;
+		try {
+			if (templateModalMode === 'create') {
+				await mediaConvert.send(new CreateJobTemplateCommand({
+					Name: templateName.trim(),
+					Description: templateDescription.trim() || undefined,
+					Category: templateCategory.trim() || undefined,
+					Queue: templateQueue.trim() || undefined,
+					Priority: templatePriority,
+					Settings: {}
+				}));
+				toast.success('Template created');
+			} else {
+				await mediaConvert.send(new UpdateJobTemplateCommand({
+					Name: selectedTemplate?.Name ?? templateName,
+					Description: templateDescription.trim() || undefined,
+					Category: templateCategory.trim() || undefined,
+					Queue: templateQueue.trim() || undefined,
+					Priority: templatePriority,
+					Settings: selectedTemplate?.Settings ?? {}
+				}));
+				toast.success('Template updated');
+			}
+			showTemplateModal = false;
+			selectedTemplate = null;
+			templates = [];
+			await loadTemplates();
+		} catch (err: unknown) {
+			toast.error(`Failed to save template: ${(err as Error).message}`);
+		} finally {
+			templateSubmitting = false;
+		}
 	}
 
 	onMount(() => {
@@ -215,15 +330,32 @@
 		</button>
 	</div>
 
-	<!-- Search -->
-	<div class="relative">
-		<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-		<input
-			type="text"
-			bind:value={searchQuery}
-			placeholder="Search {activeTab}..."
-			class="w-full pl-10 pr-4 py-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-rose-500"
-		/>
+	<!-- Search + action bar -->
+	<div class="flex items-center gap-3">
+		<div class="relative flex-1">
+			<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+			<input
+				type="text"
+				bind:value={searchQuery}
+				placeholder="Search {activeTab}..."
+				class="w-full pl-10 pr-4 py-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-rose-500"
+			/>
+		</div>
+		{#if activeTab === 'jobs'}
+			<button
+				onclick={openCreateJob}
+				class="flex items-center gap-1.5 px-3 py-2 bg-rose-600 hover:bg-rose-700 text-white text-sm font-medium rounded-lg transition-colors"
+			>
+				<Plus class="w-4 h-4" />Create Job
+			</button>
+		{:else if activeTab === 'templates'}
+			<button
+				onclick={openCreateTemplate}
+				class="flex items-center gap-1.5 px-3 py-2 bg-rose-600 hover:bg-rose-700 text-white text-sm font-medium rounded-lg transition-colors"
+			>
+				<Plus class="w-4 h-4" />Create Template
+			</button>
+		{/if}
 	</div>
 
 	<!-- Content -->
@@ -240,14 +372,15 @@
 					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-8 text-center">
 						<Film class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
 						<p class="text-slate-500 dark:text-slate-400">No jobs found</p>
+						<button onclick={openCreateJob} class="mt-3 text-sm text-rose-600 dark:text-rose-400 hover:underline">Create a job</button>
 					</div>
 				{:else}
 					{#each filteredJobs as job}
 						<div
 							role="button"
 							tabindex="0"
-							onclick={() => { selectedJob = job; selectedQueue = null; }}
-							onkeypress={(e) => { if (e.key === 'Enter') { selectedJob = job; selectedQueue = null; } }}
+							onclick={() => { selectedJob = job; selectedQueue = null; selectedTemplate = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedJob = job; selectedQueue = null; selectedTemplate = null; } }}
 							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedJob?.Id === job.Id ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
 						>
 							<div class="flex items-center justify-between">
@@ -274,8 +407,8 @@
 						<div
 							role="button"
 							tabindex="0"
-							onclick={() => { selectedQueue = queue; selectedJob = null; }}
-							onkeypress={(e) => { if (e.key === 'Enter') { selectedQueue = queue; selectedJob = null; } }}
+							onclick={() => { selectedQueue = queue; selectedJob = null; selectedTemplate = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedQueue = queue; selectedJob = null; selectedTemplate = null; } }}
 							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedQueue?.Name === queue.Name ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
 						>
 							<div class="flex items-center justify-between">
@@ -296,17 +429,29 @@
 					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-8 text-center">
 						<FileText class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
 						<p class="text-slate-500 dark:text-slate-400">No templates found</p>
+						<button onclick={openCreateTemplate} class="mt-3 text-sm text-rose-600 dark:text-rose-400 hover:underline">Create a template</button>
 					</div>
 				{:else}
 					{#each filteredTemplates as template}
-						<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-3">
-							<p class="font-medium text-slate-900 dark:text-white truncate">{template.Name}</p>
-							{#if template.Description}
-								<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">{template.Description}</p>
-							{/if}
-							<p class="text-xs text-slate-400 dark:text-slate-500 mt-1">
-								{template.LastUpdated ? new Date(template.LastUpdated).toLocaleDateString() : 'N/A'}
-							</p>
+						<div
+							role="button"
+							tabindex="0"
+							onclick={() => { selectedTemplate = template; selectedJob = null; selectedQueue = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedTemplate = template; selectedJob = null; selectedQueue = null; } }}
+							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedTemplate?.Name === template.Name ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
+						>
+							<div class="flex items-center justify-between">
+								<div class="min-w-0">
+									<p class="font-medium text-slate-900 dark:text-white truncate">{template.Name}</p>
+									{#if template.Description}
+										<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">{template.Description}</p>
+									{/if}
+									<p class="text-xs text-slate-400 dark:text-slate-500 mt-1">
+										{template.LastUpdated ? new Date(template.LastUpdated).toLocaleDateString() : 'N/A'}
+									</p>
+								</div>
+								<ChevronRight class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2" />
+							</div>
 						</div>
 					{/each}
 				{/if}
@@ -406,6 +551,42 @@
 						</div>
 					{/if}
 				</div>
+			{:else if selectedTemplate}
+				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 space-y-4">
+					<div class="flex items-start justify-between">
+						<div>
+							<h2 class="text-xl font-bold text-slate-900 dark:text-white">{selectedTemplate.Name}</h2>
+							{#if selectedTemplate.Description}
+								<p class="text-sm text-slate-500 dark:text-slate-400 mt-1">{selectedTemplate.Description}</p>
+							{/if}
+						</div>
+						<div class="flex items-center gap-2">
+							<button
+								onclick={() => openEditTemplate(selectedTemplate!)}
+								class="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 rounded-lg transition-colors"
+							>
+								<Edit class="w-3.5 h-3.5" />Edit
+							</button>
+							<div class="p-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg">
+								<FileText class="w-5 h-5 text-rose-600 dark:text-rose-400" />
+							</div>
+						</div>
+					</div>
+					<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+						{#each [
+							['Category', selectedTemplate.Category ?? 'N/A'],
+							['Queue', selectedTemplate.Queue?.split('/').pop() ?? 'N/A'],
+							['Priority', String(selectedTemplate.Priority ?? 0)],
+							['ARN', selectedTemplate.Arn ?? 'N/A'],
+							['Last Updated', selectedTemplate.LastUpdated ? new Date(selectedTemplate.LastUpdated).toLocaleString() : 'N/A']
+						] as [label, value]}
+							<div class="bg-slate-50 dark:bg-slate-700/50 rounded-lg p-3">
+								<p class="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+								<p class="text-sm font-semibold text-slate-900 dark:text-white mt-0.5 truncate" title={value}>{value}</p>
+							</div>
+						{/each}
+					</div>
+				</div>
 			{:else}
 				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-12 text-center">
 					<Film class="w-16 h-16 mx-auto text-slate-300 dark:text-slate-600 mb-4" />
@@ -415,3 +596,150 @@
 		</div>
 	</div>
 </div>
+
+<!-- Create Job Modal -->
+{#if showCreateJob}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-xl w-full max-w-md mx-4 p-6 space-y-4">
+			<div class="flex items-center justify-between">
+				<h2 class="text-lg font-bold text-slate-900 dark:text-white">Create Job</h2>
+				<button onclick={() => showCreateJob = false} class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+					<X class="w-5 h-5" />
+				</button>
+			</div>
+
+			<div class="space-y-3">
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+						Role ARN <span class="text-red-500">*</span>
+					</label>
+					<input
+						type="text"
+						bind:value={createJobRole}
+						placeholder="arn:aws:iam::123456789012:role/MediaConvertRole"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Queue (optional)</label>
+					<input
+						type="text"
+						bind:value={createJobQueue}
+						placeholder="Default or queue ARN"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Job Template (optional)</label>
+					<input
+						type="text"
+						bind:value={createJobTemplate}
+						placeholder="Template name"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+			</div>
+
+			<div class="flex items-center justify-end gap-3 pt-2">
+				<button
+					onclick={() => showCreateJob = false}
+					class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
+				>
+					Cancel
+				</button>
+				<button
+					onclick={submitCreateJob}
+					disabled={createJobSubmitting}
+					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+				>
+					{createJobSubmitting ? 'Creating...' : 'Create Job'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Create/Edit Template Modal -->
+{#if showTemplateModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-xl w-full max-w-md mx-4 p-6 space-y-4">
+			<div class="flex items-center justify-between">
+				<h2 class="text-lg font-bold text-slate-900 dark:text-white">
+					{templateModalMode === 'create' ? 'Create Template' : 'Edit Template'}
+				</h2>
+				<button onclick={() => showTemplateModal = false} class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+					<X class="w-5 h-5" />
+				</button>
+			</div>
+
+			<div class="space-y-3">
+				{#if templateModalMode === 'create'}
+					<div>
+						<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+							Name <span class="text-red-500">*</span>
+						</label>
+						<input
+							type="text"
+							bind:value={templateName}
+							placeholder="my-template"
+							class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+						/>
+					</div>
+				{/if}
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Description</label>
+					<input
+						type="text"
+						bind:value={templateDescription}
+						placeholder="Optional description"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Category</label>
+					<input
+						type="text"
+						bind:value={templateCategory}
+						placeholder="Optional category"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Queue</label>
+					<input
+						type="text"
+						bind:value={templateQueue}
+						placeholder="Queue ARN (optional)"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Priority</label>
+					<input
+						type="number"
+						bind:value={templatePriority}
+						min="-50"
+						max="50"
+						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+					/>
+				</div>
+			</div>
+
+			<div class="flex items-center justify-end gap-3 pt-2">
+				<button
+					onclick={() => showTemplateModal = false}
+					class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
+				>
+					Cancel
+				</button>
+				<button
+					onclick={submitTemplateModal}
+					disabled={templateSubmitting}
+					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+				>
+					{templateSubmitting ? 'Saving...' : templateModalMode === 'create' ? 'Create Template' : 'Save Changes'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/ui/src/routes/mediaconvert/+page.svelte
+++ b/ui/src/routes/mediaconvert/+page.svelte
@@ -5,43 +5,59 @@
 		ListJobsCommand,
 		ListQueuesCommand,
 		ListJobTemplatesCommand,
+		ListPresetsCommand,
 		CreateJobCommand,
 		CreateJobTemplateCommand,
 		UpdateJobTemplateCommand,
+		CreateQueueCommand,
+		UpdateQueueCommand,
+		DeleteQueueCommand,
+		DeleteJobTemplateCommand,
+		CancelJobCommand,
 		type Job,
 		type Queue,
-		type JobTemplate
+		type JobTemplate,
+		type Preset
 	} from '@aws-sdk/client-mediaconvert';
 	import { toast } from 'svelte-sonner';
 	import {
 		Film,
 		Search,
 		RefreshCw,
-		List,
 		Layers,
 		FileText,
-		CheckCircle,
 		Clock,
-		XCircle,
 		ChevronRight,
 		Play,
 		Pause,
 		Plus,
 		X,
-		Edit
+		Edit,
+		Trash2,
+		Copy,
+		StopCircle,
+		Package
 	} from 'lucide-svelte';
 
 	const mediaConvert = getMediaConvertClient();
 
 	let loading = $state(false);
-	let activeTab = $state<'jobs' | 'queues' | 'templates'>('queues');
+	let activeTab = $state<'jobs' | 'queues' | 'templates' | 'presets'>('queues');
 	let searchQuery = $state('');
+	let jobStatusFilter = $state('');
 	let jobs = $state<Job[]>([]);
 	let queues = $state<Queue[]>([]);
 	let templates = $state<JobTemplate[]>([]);
+	let presets = $state<Preset[]>([]);
 	let selectedJob = $state<Job | null>(null);
 	let selectedQueue = $state<Queue | null>(null);
 	let selectedTemplate = $state<JobTemplate | null>(null);
+	let selectedPreset = $state<Preset | null>(null);
+
+	// Confirmation dialog state
+	let showConfirm = $state(false);
+	let confirmMessage = $state('');
+	let confirmAction = $state<() => Promise<void>>(() => Promise.resolve());
 
 	// Job creation modal state
 	let showCreateJob = $state(false);
@@ -49,6 +65,14 @@
 	let createJobQueue = $state('');
 	let createJobTemplate = $state('');
 	let createJobSubmitting = $state(false);
+
+	// Queue create/edit modal state
+	let showQueueModal = $state(false);
+	let queueModalMode = $state<'create' | 'edit'>('create');
+	let queueName = $state('');
+	let queueDescription = $state('');
+	let queuePricingPlan = $state('ON_DEMAND');
+	let queueSubmitting = $state(false);
 
 	// Template create/edit modal state
 	let showTemplateModal = $state(false);
@@ -61,12 +85,14 @@
 	let templateSubmitting = $state(false);
 
 	const filteredJobs = $derived(
-		jobs.filter(
-			(j) =>
+		jobs.filter((j) => {
+			const matchesSearch =
 				(j.Id ?? '').toLowerCase().includes(searchQuery.toLowerCase()) ||
 				(j.Status ?? '').toLowerCase().includes(searchQuery.toLowerCase()) ||
-				(j.Queue ?? '').toLowerCase().includes(searchQuery.toLowerCase())
-		)
+				(j.Queue ?? '').toLowerCase().includes(searchQuery.toLowerCase());
+			const matchesStatus = jobStatusFilter === '' || j.Status === jobStatusFilter;
+			return matchesSearch && matchesStatus;
+		})
 	);
 
 	const filteredQueues = $derived(
@@ -82,6 +108,15 @@
 			(t) =>
 				(t.Name ?? '').toLowerCase().includes(searchQuery.toLowerCase()) ||
 				(t.Description ?? '').toLowerCase().includes(searchQuery.toLowerCase())
+		)
+	);
+
+	const filteredPresets = $derived(
+		presets.filter(
+			(p) =>
+				(p.Name ?? '').toLowerCase().includes(searchQuery.toLowerCase()) ||
+				(p.Description ?? '').toLowerCase().includes(searchQuery.toLowerCase()) ||
+				(p.Category ?? '').toLowerCase().includes(searchQuery.toLowerCase())
 		)
 	);
 
@@ -133,22 +168,60 @@
 		}
 	}
 
+	async function loadPresets() {
+		loading = true;
+		try {
+			const res = await mediaConvert.send(new ListPresetsCommand({ MaxResults: 100 }));
+			presets = res.Presets ?? [];
+		} catch (err: unknown) {
+			toast.error(`Failed to load presets: ${(err as Error).message}`);
+		} finally {
+			loading = false;
+		}
+	}
+
 	async function selectTab(tab: typeof activeTab) {
 		activeTab = tab;
 		searchQuery = '';
+		jobStatusFilter = '';
 		selectedJob = null;
 		selectedQueue = null;
 		selectedTemplate = null;
+		selectedPreset = null;
 		if (tab === 'jobs' && jobs.length === 0) await loadJobs();
 		else if (tab === 'queues' && queues.length === 0) await loadQueues();
 		else if (tab === 'templates' && templates.length === 0) await loadTemplates();
+		else if (tab === 'presets' && presets.length === 0) await loadPresets();
 	}
 
 	async function refresh() {
 		if (activeTab === 'jobs') { jobs = []; await loadJobs(); }
 		else if (activeTab === 'queues') { queues = []; await loadQueues(); }
-		else { templates = []; await loadTemplates(); }
+		else if (activeTab === 'templates') { templates = []; await loadTemplates(); }
+		else { presets = []; await loadPresets(); }
 	}
+
+	function confirmThen(message: string, action: () => Promise<void>) {
+		confirmMessage = message;
+		confirmAction = action;
+		showConfirm = true;
+	}
+
+	async function runConfirmed() {
+		showConfirm = false;
+		await confirmAction();
+	}
+
+	async function copyToClipboard(text: string) {
+		try {
+			await navigator.clipboard.writeText(text);
+			toast.success('Copied to clipboard');
+		} catch {
+			toast.error('Failed to copy');
+		}
+	}
+
+	// --- Job actions ---
 
 	function openCreateJob() {
 		createJobRole = '';
@@ -181,6 +254,91 @@
 		}
 	}
 
+	function cancelJobPrompt(job: Job) {
+		confirmThen(`Cancel job ${job.Id}?`, async () => {
+			try {
+				await mediaConvert.send(new CancelJobCommand({ Id: job.Id }));
+				toast.success('Job canceled');
+				selectedJob = null;
+				jobs = [];
+				await loadJobs();
+			} catch (err: unknown) {
+				toast.error(`Failed to cancel job: ${(err as Error).message}`);
+			}
+		});
+	}
+
+	// --- Queue actions ---
+
+	function openCreateQueue() {
+		queueModalMode = 'create';
+		queueName = '';
+		queueDescription = '';
+		queuePricingPlan = 'ON_DEMAND';
+		showQueueModal = true;
+	}
+
+	async function submitQueueModal() {
+		if (queueModalMode === 'create' && !queueName.trim()) {
+			toast.error('Queue name is required');
+			return;
+		}
+		queueSubmitting = true;
+		try {
+			if (queueModalMode === 'create') {
+				await mediaConvert.send(new CreateQueueCommand({
+					Name: queueName.trim(),
+					Description: queueDescription.trim() || undefined,
+					PricingPlan: queuePricingPlan as any
+				}));
+				toast.success('Queue created');
+			} else {
+				await mediaConvert.send(new UpdateQueueCommand({
+					Name: selectedQueue?.Name ?? queueName,
+					Description: queueDescription.trim() || undefined,
+					Status: selectedQueue?.Status as any
+				}));
+				toast.success('Queue updated');
+			}
+			showQueueModal = false;
+			queues = [];
+			await loadQueues();
+		} catch (err: unknown) {
+			toast.error(`Failed to save queue: ${(err as Error).message}`);
+		} finally {
+			queueSubmitting = false;
+		}
+	}
+
+	async function toggleQueueStatus(queue: Queue) {
+		const newStatus = queue.Status === 'ACTIVE' ? 'PAUSED' : 'ACTIVE';
+		try {
+			await mediaConvert.send(new UpdateQueueCommand({ Name: queue.Name, Status: newStatus as any }));
+			toast.success(`Queue ${newStatus === 'ACTIVE' ? 'resumed' : 'paused'}`);
+			queues = [];
+			await loadQueues();
+			selectedQueue = null;
+		} catch (err: unknown) {
+			toast.error(`Failed to update queue: ${(err as Error).message}`);
+		}
+	}
+
+	function deleteQueuePrompt(queue: Queue) {
+		confirmThen(`Delete queue "${queue.Name}"?`, async () => {
+			try {
+				await mediaConvert.send(new DeleteQueueCommand({ Name: queue.Name }));
+				toast.success('Queue deleted');
+				selectedQueue = null;
+				queues = [];
+				await loadQueues();
+			} catch (err: unknown) {
+				toast.error(`Failed to delete queue: ${(err as Error).message}`);
+			}
+		});
+	}
+
+	// --- Template actions ---
+
 	function openCreateTemplate() {
 		templateModalMode = 'create';
 		templateName = '';
@@ -207,6 +365,7 @@
 			return;
 		}
 		templateSubmitting = true;
+		const editingName = selectedTemplate?.Name ?? templateName;
 		try {
 			if (templateModalMode === 'create') {
 				await mediaConvert.send(new CreateJobTemplateCommand({
@@ -220,7 +379,7 @@
 				toast.success('Template created');
 			} else {
 				await mediaConvert.send(new UpdateJobTemplateCommand({
-					Name: selectedTemplate?.Name ?? templateName,
+					Name: editingName,
 					Description: templateDescription.trim() || undefined,
 					Category: templateCategory.trim() || undefined,
 					Queue: templateQueue.trim() || undefined,
@@ -230,9 +389,12 @@
 				toast.success('Template updated');
 			}
 			showTemplateModal = false;
-			selectedTemplate = null;
 			templates = [];
 			await loadTemplates();
+			// Re-select the template we just edited
+			if (templateModalMode === 'edit') {
+				selectedTemplate = templates.find((t) => t.Name === editingName) ?? null;
+			}
 		} catch (err: unknown) {
 			toast.error(`Failed to save template: ${(err as Error).message}`);
 		} finally {
@@ -240,10 +402,36 @@
 		}
 	}
 
+	function deleteTemplatePrompt(t: JobTemplate) {
+		confirmThen(`Delete template "${t.Name}"?`, async () => {
+			try {
+				await mediaConvert.send(new DeleteJobTemplateCommand({ Name: t.Name }));
+				toast.success('Template deleted');
+				selectedTemplate = null;
+				templates = [];
+				await loadTemplates();
+			} catch (err: unknown) {
+				toast.error(`Failed to delete template: ${(err as Error).message}`);
+			}
+		});
+	}
+
+	// Keyboard shortcut: Escape closes any open modal
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			showCreateJob = false;
+			showQueueModal = false;
+			showTemplateModal = false;
+			showConfirm = false;
+		}
+	}
+
 	onMount(() => {
 		loadQueues();
 	});
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <div class="space-y-6">
 	<!-- Header -->
@@ -257,15 +445,13 @@
 				<p class="text-slate-600 dark:text-slate-300">File-based video transcoding service</p>
 			</div>
 		</div>
-		<div class="flex items-center gap-2">
-			<button
-				onclick={() => refresh()}
-				class="p-2 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
-				title="Refresh"
-			>
-				<RefreshCw class="w-5 h-5 {loading ? 'animate-spin' : ''}" />
-			</button>
-		</div>
+		<button
+			onclick={() => refresh()}
+			class="p-2 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+			title="Refresh"
+		>
+			<RefreshCw class="w-5 h-5 {loading ? 'animate-spin' : ''}" />
+		</button>
 	</div>
 
 	<!-- Stat cards -->
@@ -310,24 +496,14 @@
 
 	<!-- Tab navigation -->
 	<div class="flex items-center gap-1 border-b border-slate-200 dark:border-slate-700">
-		<button
-			onclick={() => selectTab('jobs')}
-			class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px {activeTab === 'jobs' ? 'border-rose-500 text-rose-600 dark:text-rose-400' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}"
-		>
-			<span class="flex items-center gap-1.5"><Film class="w-4 h-4" />Jobs</span>
-		</button>
-		<button
-			onclick={() => selectTab('queues')}
-			class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px {activeTab === 'queues' ? 'border-rose-500 text-rose-600 dark:text-rose-400' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}"
-		>
-			<span class="flex items-center gap-1.5"><Layers class="w-4 h-4" />Queues</span>
-		</button>
-		<button
-			onclick={() => selectTab('templates')}
-			class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px {activeTab === 'templates' ? 'border-rose-500 text-rose-600 dark:text-rose-400' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}"
-		>
-			<span class="flex items-center gap-1.5"><FileText class="w-4 h-4" />Templates</span>
-		</button>
+		{#each ([['jobs', Film, 'Jobs'], ['queues', Layers, 'Queues'], ['templates', FileText, 'Templates'], ['presets', Package, 'Presets']] as const) as [tab, Icon, label]}
+			<button
+				onclick={() => selectTab(tab)}
+				class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px {activeTab === tab ? 'border-rose-500 text-rose-600 dark:text-rose-400' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}"
+			>
+				<span class="flex items-center gap-1.5"><Icon class="w-4 h-4" />{label}</span>
+			</button>
+		{/each}
 	</div>
 
 	<!-- Search + action bar -->
@@ -342,11 +518,29 @@
 			/>
 		</div>
 		{#if activeTab === 'jobs'}
+			<select
+				bind:value={jobStatusFilter}
+				class="px-3 py-2 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-700 dark:text-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
+			>
+				<option value="">All statuses</option>
+				<option value="SUBMITTED">Submitted</option>
+				<option value="PROGRESSING">Progressing</option>
+				<option value="COMPLETE">Complete</option>
+				<option value="CANCELED">Canceled</option>
+				<option value="ERROR">Error</option>
+			</select>
 			<button
 				onclick={openCreateJob}
 				class="flex items-center gap-1.5 px-3 py-2 bg-rose-600 hover:bg-rose-700 text-white text-sm font-medium rounded-lg transition-colors"
 			>
 				<Plus class="w-4 h-4" />Create Job
+			</button>
+		{:else if activeTab === 'queues'}
+			<button
+				onclick={openCreateQueue}
+				class="flex items-center gap-1.5 px-3 py-2 bg-rose-600 hover:bg-rose-700 text-white text-sm font-medium rounded-lg transition-colors"
+			>
+				<Plus class="w-4 h-4" />Create Queue
 			</button>
 		{:else if activeTab === 'templates'}
 			<button
@@ -379,8 +573,8 @@
 						<div
 							role="button"
 							tabindex="0"
-							onclick={() => { selectedJob = job; selectedQueue = null; selectedTemplate = null; }}
-							onkeypress={(e) => { if (e.key === 'Enter') { selectedJob = job; selectedQueue = null; selectedTemplate = null; } }}
+							onclick={() => { selectedJob = job; selectedQueue = null; selectedTemplate = null; selectedPreset = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedJob = job; selectedQueue = null; selectedTemplate = null; selectedPreset = null; } }}
 							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedJob?.Id === job.Id ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
 						>
 							<div class="flex items-center justify-between">
@@ -401,20 +595,23 @@
 					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-8 text-center">
 						<Layers class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
 						<p class="text-slate-500 dark:text-slate-400">No queues found</p>
+						<button onclick={openCreateQueue} class="mt-3 text-sm text-rose-600 dark:text-rose-400 hover:underline">Create a queue</button>
 					</div>
 				{:else}
 					{#each filteredQueues as queue}
 						<div
 							role="button"
 							tabindex="0"
-							onclick={() => { selectedQueue = queue; selectedJob = null; selectedTemplate = null; }}
-							onkeypress={(e) => { if (e.key === 'Enter') { selectedQueue = queue; selectedJob = null; selectedTemplate = null; } }}
+							onclick={() => { selectedQueue = queue; selectedJob = null; selectedTemplate = null; selectedPreset = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedQueue = queue; selectedJob = null; selectedTemplate = null; selectedPreset = null; } }}
 							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedQueue?.Name === queue.Name ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
 						>
 							<div class="flex items-center justify-between">
 								<div class="min-w-0">
 									<p class="font-medium text-slate-900 dark:text-white truncate">{queue.Name}</p>
-									<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{queue.Type ?? 'SYSTEM'}</p>
+									<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+										{queue.Type ?? 'CUSTOM'} · {queue.ProgressingJobsCount ?? 0} running
+									</p>
 								</div>
 								<div class="flex items-center gap-1.5 ml-2 flex-shrink-0">
 									<span class="px-2 py-0.5 text-xs rounded-full {statusColor(queue.Status)}">{queue.Status}</span>
@@ -424,7 +621,7 @@
 						</div>
 					{/each}
 				{/if}
-			{:else}
+			{:else if activeTab === 'templates'}
 				{#if filteredTemplates.length === 0}
 					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-8 text-center">
 						<FileText class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
@@ -436,8 +633,8 @@
 						<div
 							role="button"
 							tabindex="0"
-							onclick={() => { selectedTemplate = template; selectedJob = null; selectedQueue = null; }}
-							onkeypress={(e) => { if (e.key === 'Enter') { selectedTemplate = template; selectedJob = null; selectedQueue = null; } }}
+							onclick={() => { selectedTemplate = template; selectedJob = null; selectedQueue = null; selectedPreset = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedTemplate = template; selectedJob = null; selectedQueue = null; selectedPreset = null; } }}
 							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedTemplate?.Name === template.Name ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
 						>
 							<div class="flex items-center justify-between">
@@ -448,6 +645,36 @@
 									{/if}
 									<p class="text-xs text-slate-400 dark:text-slate-500 mt-1">
 										{template.LastUpdated ? new Date(template.LastUpdated).toLocaleDateString() : 'N/A'}
+									</p>
+								</div>
+								<ChevronRight class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2" />
+							</div>
+						</div>
+					{/each}
+				{/if}
+			{:else}
+				{#if filteredPresets.length === 0}
+					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-8 text-center">
+						<Package class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
+						<p class="text-slate-500 dark:text-slate-400">No presets found</p>
+					</div>
+				{:else}
+					{#each filteredPresets as preset}
+						<div
+							role="button"
+							tabindex="0"
+							onclick={() => { selectedPreset = preset; selectedJob = null; selectedQueue = null; selectedTemplate = null; }}
+							onkeypress={(e) => { if (e.key === 'Enter') { selectedPreset = preset; selectedJob = null; selectedQueue = null; selectedTemplate = null; } }}
+							class="w-full text-left bg-white dark:bg-slate-800 rounded-lg border p-3 hover:border-rose-400 transition-colors cursor-pointer {selectedPreset?.Name === preset.Name ? 'border-rose-500 ring-1 ring-rose-500' : 'border-slate-200 dark:border-slate-700'}"
+						>
+							<div class="flex items-center justify-between">
+								<div class="min-w-0">
+									<p class="font-medium text-slate-900 dark:text-white truncate">{preset.Name}</p>
+									{#if preset.Category}
+										<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">{preset.Category}</p>
+									{/if}
+									<p class="text-xs text-slate-400 dark:text-slate-500 mt-1">
+										{preset.Type ?? 'CUSTOM'}
 									</p>
 								</div>
 								<ChevronRight class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2" />
@@ -469,22 +696,36 @@
 								{selectedJob.Status}
 							</span>
 						</div>
-						<div class="p-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg">
-							<Film class="w-5 h-5 text-rose-600 dark:text-rose-400" />
+						<div class="flex items-center gap-2">
+							{#if selectedJob.Status === 'SUBMITTED' || selectedJob.Status === 'PROGRESSING'}
+								<button
+									onclick={() => cancelJobPrompt(selectedJob!)}
+									class="flex items-center gap-1 px-3 py-1.5 text-sm bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-700 dark:text-red-300 rounded-lg transition-colors"
+								>
+									<StopCircle class="w-3.5 h-3.5" />Cancel
+								</button>
+							{/if}
+							<button
+								onclick={() => copyToClipboard(selectedJob?.Arn ?? '')}
+								class="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+								title="Copy ARN"
+							>
+								<Copy class="w-4 h-4" />
+							</button>
 						</div>
 					</div>
 
 					<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
 						{#each [
 							['Queue', selectedJob.Queue?.split('/').pop() ?? 'Default'],
-							['Role ARN', selectedJob.Role?.split('/').pop() ?? 'N/A'],
+							['Role', selectedJob.Role?.split('/').pop() ?? 'N/A'],
+							['Phase', (selectedJob as any).currentPhase ?? 'N/A'],
 							['Created', selectedJob.CreatedAt ? new Date(selectedJob.CreatedAt).toLocaleString() : 'N/A'],
-							['Started', selectedJob.Timing?.StartTime ? new Date(selectedJob.Timing.StartTime).toLocaleString() : 'N/A'],
-							['Finished', selectedJob.Timing?.FinishTime ? new Date(selectedJob.Timing.FinishTime).toLocaleString() : 'N/A'],
-							['Billing Tags', selectedJob.BillingTagsSource ?? 'N/A'],
-							['Simulated Reserved', String(selectedJob.SimulateReservedQueue ?? false)],
-							['Status Update Interval', selectedJob.StatusUpdateInterval ?? 'N/A'],
-							['Current Phase', selectedJob.CurrentPhase ?? 'N/A']
+							['Submitted', (selectedJob as any).timing?.submitTime ? new Date((selectedJob as any).timing.submitTime * 1000).toLocaleString() : 'N/A'],
+							['Billing Tags', selectedJob.BillingTagsSource ?? 'QUEUE'],
+							['Priority', String((selectedJob as any).priority ?? 0)],
+							['Retry Count', String((selectedJob as any).retryCount ?? 0)],
+							['Accel. Status', selectedJob.AccelerationStatus ?? 'N/A']
 						] as [label, value]}
 							<div class="bg-slate-50 dark:bg-slate-700/50 rounded-lg p-3">
 								<p class="text-xs text-slate-500 dark:text-slate-400">{label}</p>
@@ -499,22 +740,6 @@
 							<p class="text-sm text-red-600 dark:text-red-400">{selectedJob.ErrorMessage}</p>
 						</div>
 					{/if}
-
-					{#if (selectedJob.OutputGroupDetails ?? []).length > 0}
-						<div>
-							<h3 class="font-semibold text-slate-900 dark:text-white mb-2">Output Groups</h3>
-							<div class="space-y-2">
-								{#each selectedJob.OutputGroupDetails ?? [] as group, i}
-									<div class="bg-slate-50 dark:bg-slate-700/30 rounded-lg px-3 py-2">
-										<p class="text-sm font-medium text-slate-900 dark:text-white">Group {i + 1}</p>
-										<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-											{(group.OutputDetails ?? []).length} output(s)
-										</p>
-									</div>
-								{/each}
-							</div>
-						</div>
-					{/if}
 				</div>
 			{:else if selectedQueue}
 				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 space-y-4">
@@ -525,18 +750,41 @@
 								{selectedQueue.Status}
 							</span>
 						</div>
-						<div class="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
-							<Layers class="w-5 h-5 text-blue-600 dark:text-blue-400" />
+						<div class="flex items-center gap-2">
+							<button
+								onclick={() => toggleQueueStatus(selectedQueue!)}
+								class="flex items-center gap-1 px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 rounded-lg transition-colors"
+								title={selectedQueue.Status === 'ACTIVE' ? 'Pause queue' : 'Resume queue'}
+							>
+								{#if selectedQueue.Status === 'ACTIVE'}
+									<Pause class="w-3.5 h-3.5" />Pause
+								{:else}
+									<Play class="w-3.5 h-3.5" />Resume
+								{/if}
+							</button>
+							<button
+								onclick={() => deleteQueuePrompt(selectedQueue!)}
+								class="flex items-center gap-1 px-3 py-1.5 text-sm bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-700 dark:text-red-300 rounded-lg transition-colors"
+							>
+								<Trash2 class="w-3.5 h-3.5" />Delete
+							</button>
+							<button
+								onclick={() => copyToClipboard(selectedQueue?.Arn ?? '')}
+								class="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+								title="Copy ARN"
+							>
+								<Copy class="w-4 h-4" />
+							</button>
 						</div>
 					</div>
 					<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
 						{#each [
-							['Queue ARN', selectedQueue.Arn ?? 'N/A'],
 							['Type', selectedQueue.Type ?? 'N/A'],
 							['Pricing Plan', selectedQueue.PricingPlan ?? 'N/A'],
 							['Jobs Running', String(selectedQueue.ProgressingJobsCount ?? 0)],
 							['Jobs Submitted', String(selectedQueue.SubmittedJobsCount ?? 0)],
-							['Created', selectedQueue.CreatedAt ? new Date(selectedQueue.CreatedAt).toLocaleDateString() : 'N/A']
+							['Created', selectedQueue.CreatedAt ? new Date(selectedQueue.CreatedAt).toLocaleDateString() : 'N/A'],
+							['Last Updated', selectedQueue.LastUpdated ? new Date(selectedQueue.LastUpdated).toLocaleDateString() : 'N/A']
 						] as [label, value]}
 							<div class="bg-slate-50 dark:bg-slate-700/50 rounded-lg p-3">
 								<p class="text-xs text-slate-500 dark:text-slate-400">{label}</p>
@@ -550,6 +798,9 @@
 							<p class="text-sm text-slate-700 dark:text-slate-300">{selectedQueue.Description}</p>
 						</div>
 					{/if}
+					<div class="bg-slate-50 dark:bg-slate-700/30 rounded-lg p-3 font-mono text-xs text-slate-500 dark:text-slate-400 truncate">
+						{selectedQueue.Arn}
+					</div>
 				</div>
 			{:else if selectedTemplate}
 				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 space-y-4">
@@ -567,9 +818,19 @@
 							>
 								<Edit class="w-3.5 h-3.5" />Edit
 							</button>
-							<div class="p-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg">
-								<FileText class="w-5 h-5 text-rose-600 dark:text-rose-400" />
-							</div>
+							<button
+								onclick={() => deleteTemplatePrompt(selectedTemplate!)}
+								class="flex items-center gap-1 px-3 py-1.5 text-sm bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-700 dark:text-red-300 rounded-lg transition-colors"
+							>
+								<Trash2 class="w-3.5 h-3.5" />Delete
+							</button>
+							<button
+								onclick={() => copyToClipboard(selectedTemplate?.Arn ?? '')}
+								class="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+								title="Copy ARN"
+							>
+								<Copy class="w-4 h-4" />
+							</button>
 						</div>
 					</div>
 					<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
@@ -577,7 +838,7 @@
 							['Category', selectedTemplate.Category ?? 'N/A'],
 							['Queue', selectedTemplate.Queue?.split('/').pop() ?? 'N/A'],
 							['Priority', String(selectedTemplate.Priority ?? 0)],
-							['ARN', selectedTemplate.Arn ?? 'N/A'],
+							['Type', selectedTemplate.Type ?? 'CUSTOM'],
 							['Last Updated', selectedTemplate.LastUpdated ? new Date(selectedTemplate.LastUpdated).toLocaleString() : 'N/A']
 						] as [label, value]}
 							<div class="bg-slate-50 dark:bg-slate-700/50 rounded-lg p-3">
@@ -587,10 +848,51 @@
 						{/each}
 					</div>
 				</div>
+			{:else if selectedPreset}
+				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 space-y-4">
+					<div class="flex items-start justify-between">
+						<div>
+							<h2 class="text-xl font-bold text-slate-900 dark:text-white">{selectedPreset.Name}</h2>
+							{#if selectedPreset.Description}
+								<p class="text-sm text-slate-500 dark:text-slate-400 mt-1">{selectedPreset.Description}</p>
+							{/if}
+						</div>
+						<div class="flex items-center gap-2">
+							<button
+								onclick={() => copyToClipboard(selectedPreset?.Arn ?? '')}
+								class="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+								title="Copy ARN"
+							>
+								<Copy class="w-4 h-4" />
+							</button>
+							<div class="p-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg">
+								<Package class="w-5 h-5 text-rose-600 dark:text-rose-400" />
+							</div>
+						</div>
+					</div>
+					<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+						{#each [
+							['Category', selectedPreset.Category ?? 'N/A'],
+							['Type', selectedPreset.Type ?? 'CUSTOM'],
+							['Created', selectedPreset.CreatedAt ? new Date(selectedPreset.CreatedAt).toLocaleDateString() : 'N/A'],
+							['Last Updated', selectedPreset.LastUpdated ? new Date(selectedPreset.LastUpdated).toLocaleString() : 'N/A']
+						] as [label, value]}
+							<div class="bg-slate-50 dark:bg-slate-700/50 rounded-lg p-3">
+								<p class="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+								<p class="text-sm font-semibold text-slate-900 dark:text-white mt-0.5 truncate" title={value}>{value}</p>
+							</div>
+						{/each}
+					</div>
+					<div class="bg-slate-50 dark:bg-slate-700/30 rounded-lg p-3 font-mono text-xs text-slate-500 dark:text-slate-400 truncate">
+						{selectedPreset.Arn}
+					</div>
+				</div>
 			{:else}
 				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-12 text-center">
 					<Film class="w-16 h-16 mx-auto text-slate-300 dark:text-slate-600 mb-4" />
-					<p class="text-slate-500 dark:text-slate-400">Select a {activeTab === 'templates' ? 'template' : activeTab.slice(0, -1)} to view details</p>
+					<p class="text-slate-500 dark:text-slate-400">
+						Select a {activeTab === 'templates' ? 'template' : activeTab === 'presets' ? 'preset' : activeTab.slice(0, -1)} to view details
+					</p>
 				</div>
 			{/if}
 		</div>
@@ -607,52 +909,69 @@
 					<X class="w-5 h-5" />
 				</button>
 			</div>
-
 			<div class="space-y-3">
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-						Role ARN <span class="text-red-500">*</span>
-					</label>
-					<input
-						type="text"
-						bind:value={createJobRole}
-						placeholder="arn:aws:iam::123456789012:role/MediaConvertRole"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Queue (optional)</label>
-					<input
-						type="text"
-						bind:value={createJobQueue}
-						placeholder="Default or queue ARN"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Job Template (optional)</label>
-					<input
-						type="text"
-						bind:value={createJobTemplate}
-						placeholder="Template name"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Role ARN <span class="text-red-500">*</span></span>
+					<input type="text" bind:value={createJobRole} placeholder="arn:aws:iam::123456789012:role/MediaConvertRole"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Queue (optional)</span>
+					<input type="text" bind:value={createJobQueue} placeholder="Queue name or ARN"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Job Template (optional)</span>
+					<input type="text" bind:value={createJobTemplate} placeholder="Template name"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
 			</div>
-
 			<div class="flex items-center justify-end gap-3 pt-2">
-				<button
-					onclick={() => showCreateJob = false}
-					class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
-				>
-					Cancel
-				</button>
-				<button
-					onclick={submitCreateJob}
-					disabled={createJobSubmitting}
-					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
-				>
+				<button onclick={() => showCreateJob = false} class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors">Cancel</button>
+				<button onclick={submitCreateJob} disabled={createJobSubmitting}
+					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors">
 					{createJobSubmitting ? 'Creating...' : 'Create Job'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Create/Edit Queue Modal -->
+{#if showQueueModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-xl w-full max-w-md mx-4 p-6 space-y-4">
+			<div class="flex items-center justify-between">
+				<h2 class="text-lg font-bold text-slate-900 dark:text-white">{queueModalMode === 'create' ? 'Create Queue' : 'Edit Queue'}</h2>
+				<button onclick={() => showQueueModal = false} class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"><X class="w-5 h-5" /></button>
+			</div>
+			<div class="space-y-3">
+				{#if queueModalMode === 'create'}
+					<label class="block">
+						<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Name <span class="text-red-500">*</span></span>
+						<input type="text" bind:value={queueName} placeholder="my-queue"
+							class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+					</label>
+					<label class="block">
+						<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Pricing Plan</span>
+						<select bind:value={queuePricingPlan}
+							class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500">
+							<option value="ON_DEMAND">On-Demand</option>
+							<option value="RESERVED">Reserved</option>
+						</select>
+					</label>
+				{/if}
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Description</span>
+					<input type="text" bind:value={queueDescription} placeholder="Optional description"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
+			</div>
+			<div class="flex items-center justify-end gap-3 pt-2">
+				<button onclick={() => showQueueModal = false} class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors">Cancel</button>
+				<button onclick={submitQueueModal} disabled={queueSubmitting}
+					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors">
+					{queueSubmitting ? 'Saving...' : queueModalMode === 'create' ? 'Create Queue' : 'Save Changes'}
 				</button>
 			</div>
 		</div>
@@ -664,81 +983,58 @@
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
 		<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-xl w-full max-w-md mx-4 p-6 space-y-4">
 			<div class="flex items-center justify-between">
-				<h2 class="text-lg font-bold text-slate-900 dark:text-white">
-					{templateModalMode === 'create' ? 'Create Template' : 'Edit Template'}
-				</h2>
-				<button onclick={() => showTemplateModal = false} class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
-					<X class="w-5 h-5" />
-				</button>
+				<h2 class="text-lg font-bold text-slate-900 dark:text-white">{templateModalMode === 'create' ? 'Create Template' : 'Edit Template'}</h2>
+				<button onclick={() => showTemplateModal = false} class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"><X class="w-5 h-5" /></button>
 			</div>
-
 			<div class="space-y-3">
 				{#if templateModalMode === 'create'}
-					<div>
-						<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-							Name <span class="text-red-500">*</span>
-						</label>
-						<input
-							type="text"
-							bind:value={templateName}
-							placeholder="my-template"
-							class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-						/>
-					</div>
+					<label class="block">
+						<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Name <span class="text-red-500">*</span></span>
+						<input type="text" bind:value={templateName} placeholder="my-template"
+							class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+					</label>
 				{/if}
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Description</label>
-					<input
-						type="text"
-						bind:value={templateDescription}
-						placeholder="Optional description"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Category</label>
-					<input
-						type="text"
-						bind:value={templateCategory}
-						placeholder="Optional category"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Queue</label>
-					<input
-						type="text"
-						bind:value={templateQueue}
-						placeholder="Queue ARN (optional)"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
-				<div>
-					<label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Priority</label>
-					<input
-						type="number"
-						bind:value={templatePriority}
-						min="-50"
-						max="50"
-						class="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500"
-					/>
-				</div>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Description</span>
+					<input type="text" bind:value={templateDescription} placeholder="Optional description"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Category</span>
+					<input type="text" bind:value={templateCategory} placeholder="Optional category"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Queue</span>
+					<input type="text" bind:value={templateQueue} placeholder="Queue ARN (optional)"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
+				<label class="block">
+					<span class="text-sm font-medium text-slate-700 dark:text-slate-300">Priority (-50 to 50)</span>
+					<input type="number" bind:value={templatePriority} min="-50" max="50"
+						class="mt-1 w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-rose-500" />
+				</label>
 			</div>
-
 			<div class="flex items-center justify-end gap-3 pt-2">
-				<button
-					onclick={() => showTemplateModal = false}
-					class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
-				>
-					Cancel
-				</button>
-				<button
-					onclick={submitTemplateModal}
-					disabled={templateSubmitting}
-					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
-				>
+				<button onclick={() => showTemplateModal = false} class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors">Cancel</button>
+				<button onclick={submitTemplateModal} disabled={templateSubmitting}
+					class="px-4 py-2 bg-rose-600 hover:bg-rose-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors">
 					{templateSubmitting ? 'Saving...' : templateModalMode === 'create' ? 'Create Template' : 'Save Changes'}
 				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Confirmation Dialog -->
+{#if showConfirm}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-xl w-full max-w-sm mx-4 p-6 space-y-4">
+			<h2 class="text-lg font-bold text-slate-900 dark:text-white">Confirm</h2>
+			<p class="text-slate-600 dark:text-slate-300">{confirmMessage}</p>
+			<div class="flex items-center justify-end gap-3">
+				<button onclick={() => showConfirm = false} class="px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors">Cancel</button>
+				<button onclick={runConfirmed} class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors">Confirm</button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- **4 missing SDK ops**: `ListVersions` (GET `/2017-08-29/versions`), `Probe` (POST `/2017-08-29/probe`), `SearchJobs` (GET `/2017-08-29/search`), `StartJobsQuery` (POST `/2017-08-29/jobsQueries`) — all added to handler, backend interface, and removed from `notImplemented` in SDK completeness test
- **Job creation UI**: "Create Job" button in the Jobs tab opens a modal with Role ARN (required), Queue, and Job Template fields
- **Template editing UI**: Templates are now clickable with a full detail panel; detail panel includes an Edit button; "Create Template" button in the Templates tab opens a create/edit modal with Name, Description, Category, Queue, Priority
- **Native deep clone**: Replaced `deepCopySettings` (JSON marshal/unmarshal round-trip) with `deepCloneMap` + `deepCloneValue` recursive native clone — removes `encoding/json` import from `backend.go`

## Test plan

- [x] `go test ./services/mediaconvert/...` passes (including `TestSDKCompleteness`)
- [x] `golangci-lint run ./services/mediaconvert/...` — 0 issues
- [x] `svelte-check` — 0 errors (pre-existing a11y warnings only)

Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->