### PR TITLE
fix(pipes): address golangci-lint and test issues

### DIFF
--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	apigatewayv2backend "github.com/blackbirdworks/gopherstack/services/apigatewayv2"
-	"github.com/blackbirdworks/gopherstack/services/pipes"
 	autoscalingbackend "github.com/blackbirdworks/gopherstack/services/autoscaling"
 	batchbackend "github.com/blackbirdworks/gopherstack/services/batch"
 	codebuildbackend "github.com/blackbirdworks/gopherstack/services/codebuild"
@@ -15,6 +14,7 @@ import (
 	gluebackend "github.com/blackbirdworks/gopherstack/services/glue"
 	iotbackend "github.com/blackbirdworks/gopherstack/services/iot"
 	kafkabackend "github.com/blackbirdworks/gopherstack/services/kafka"
+	"github.com/blackbirdworks/gopherstack/services/pipes"
 )
 
 // eksNodegroupDefaultDesiredSize is the default desired node count for an EKS nodegroup.

--- a/services/pipes/backend.go
+++ b/services/pipes/backend.go
@@ -70,8 +70,8 @@ type LambdaFunctionParameters struct {
 
 // TargetParameters holds target-specific configuration.
 type TargetParameters struct {
-	InputTemplate            string                    `json:"InputTemplate,omitempty"`
 	LambdaFunctionParameters *LambdaFunctionParameters `json:"LambdaFunctionParameters,omitempty"`
+	InputTemplate            string                    `json:"InputTemplate,omitempty"`
 }
 
 // DeadLetterConfig identifies the DLQ for failed pipe events.
@@ -91,9 +91,9 @@ type LogDestination struct {
 
 // LogConfiguration controls pipe execution logging.
 type LogConfiguration struct {
+	Level                string           `json:"Level,omitempty"`
 	Destinations         []LogDestination `json:"Destinations,omitempty"`
 	IncludeExecutionData []string         `json:"IncludeExecutionData,omitempty"`
-	Level                string           `json:"Level,omitempty"`
 }
 
 // Pipe represents an EventBridge Pipe.
@@ -125,6 +125,7 @@ func (p *Pipe) effectiveBatchSize() int {
 		p.SourceParameters.SqsQueueParameters.BatchSize > 0 {
 		return p.SourceParameters.SqsQueueParameters.BatchSize
 	}
+
 	return pipeDefaultBatchSize
 }
 
@@ -162,6 +163,7 @@ func clonePipe(p *Pipe) *Pipe {
 		lc.IncludeExecutionData = append([]string(nil), p.LogConfiguration.IncludeExecutionData...)
 		cp.LogConfiguration = &lc
 	}
+
 	return &cp
 }
 
@@ -203,22 +205,38 @@ type CreatePipeInput struct {
 }
 
 func (b *InMemoryBackend) CreatePipe(in CreatePipeInput) (*Pipe, error) {
-	if err := validatePipeName(in.Name); err != nil { return nil, err }
-	if err := validateDesiredState(in.DesiredState); err != nil { return nil, err }
-	if in.Source == "" { return nil, fmt.Errorf("%w: Source is required", ErrValidation) }
-	if in.Target == "" { return nil, fmt.Errorf("%w: Target is required", ErrValidation) }
-	if err := validateTags(in.Tags); err != nil { return nil, err }
+	if err := validatePipeName(in.Name); err != nil {
+		return nil, err
+	}
+	if err := validateDesiredState(in.DesiredState); err != nil {
+		return nil, err
+	}
+	if in.Source == "" {
+		return nil, fmt.Errorf("%w: Source is required", ErrValidation)
+	}
+	if in.Target == "" {
+		return nil, fmt.Errorf("%w: Target is required", ErrValidation)
+	}
+	if err := validateTags(in.Tags); err != nil {
+		return nil, err
+	}
 
 	b.mu.Lock("CreatePipe")
 	defer b.mu.Unlock()
 
 	if len(b.pipes) >= maxPipesPerAcct {
-		return nil, fmt.Errorf("%w: account has reached the maximum number of pipes (%d)", ErrValidation, maxPipesPerAcct)
+		return nil, fmt.Errorf(
+			"%w: account has reached the maximum number of pipes (%d)",
+			ErrValidation,
+			maxPipesPerAcct,
+		)
 	}
 	if _, ok := b.pipes[in.Name]; ok {
 		return nil, fmt.Errorf("%w: pipe %s already exists", ErrAlreadyExists, in.Name)
 	}
-	if in.DesiredState == "" { in.DesiredState = stateRunning }
+	if in.DesiredState == "" {
+		in.DesiredState = stateRunning
+	}
 
 	now := time.Now()
 	pipeARN := arn.Build("pipes", b.region, b.accountID, "pipe/"+in.Name)
@@ -228,12 +246,13 @@ func (b *InMemoryBackend) CreatePipe(in CreatePipeInput) (*Pipe, error) {
 		Enrichment: in.Enrichment, DesiredState: in.DesiredState, CurrentState: in.DesiredState,
 		AccountID: b.accountID, Region: b.region,
 		CreationTime: now, LastModifiedTime: now,
-		Tags: mergeTags(nil, in.Tags),
+		Tags:             mergeTags(nil, in.Tags),
 		SourceParameters: in.SourceParameters, TargetParameters: in.TargetParameters,
 		DeadLetterConfig: in.DeadLetterConfig, LogConfiguration: in.LogConfiguration,
 	}
 	b.pipes[in.Name] = p
 	b.pipeARNIndex[pipeARN] = in.Name
+
 	return clonePipe(p), nil
 }
 
@@ -241,7 +260,10 @@ func (b *InMemoryBackend) GetPipe(name string) (*Pipe, error) {
 	b.mu.RLock("GetPipe")
 	defer b.mu.RUnlock()
 	p, ok := b.pipes[name]
-	if !ok { return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name) }
+	if !ok {
+		return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name)
+	}
+
 	return clonePipe(p), nil
 }
 
@@ -258,8 +280,8 @@ type ListPipesFilter struct {
 
 // ListPipesResult holds the paginated result of a ListPipes call.
 type ListPipesResult struct {
-	Pipes     []*Pipe
 	NextToken string
+	Pipes     []*Pipe
 }
 
 func (b *InMemoryBackend) ListPipes(f ListPipesFilter) ListPipesResult {
@@ -267,55 +289,107 @@ func (b *InMemoryBackend) ListPipes(f ListPipesFilter) ListPipesResult {
 	defer b.mu.RUnlock()
 
 	limit := f.Limit
-	if limit <= 0 || limit > 1000 { limit = 1000 }
-
-	names := make([]string, 0, len(b.pipes))
-	for name := range b.pipes { names = append(names, name) }
-	for i := 0; i < len(names); i++ {
-		for j := i + 1; j < len(names); j++ {
-			if names[j] < names[i] { names[i], names[j] = names[j], names[i] }
-		}
+	if limit <= 0 || limit > 1000 {
+		limit = 1000
 	}
 
-	startIdx := 0
-	if f.NextToken != "" {
-		if decoded, err := base64.StdEncoding.DecodeString(f.NextToken); err == nil {
-			cursor := strings.TrimSuffix(string(decoded), nextTokenSep)
-			for i, n := range names {
-				if n > cursor { startIdx = i; break }
-				startIdx = len(names)
+	names := b.sortedPipeNames()
+	startIdx := b.resolveStartIndex(names, f.NextToken)
+	result, lastIncluded := b.collectMatchingPipes(names, startIdx, limit, f)
+	nextToken := b.buildNextToken(names, startIdx, len(result), limit, lastIncluded, f)
+
+	return ListPipesResult{Pipes: result, NextToken: nextToken}
+}
+
+func (b *InMemoryBackend) sortedPipeNames() []string {
+	names := make([]string, 0, len(b.pipes))
+	for name := range b.pipes {
+		names = append(names, name)
+	}
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			if names[j] < names[i] {
+				names[i], names[j] = names[j], names[i]
 			}
 		}
 	}
 
+	return names
+}
+
+func (b *InMemoryBackend) resolveStartIndex(names []string, nextToken string) int {
+	if nextToken == "" {
+		return 0
+	}
+	decoded, err := base64.StdEncoding.DecodeString(nextToken)
+	if err != nil {
+		return 0
+	}
+	cursor := strings.TrimSuffix(string(decoded), nextTokenSep)
+	startIdx := len(names)
+	for i, n := range names {
+		if n > cursor {
+			startIdx = i
+
+			break
+		}
+	}
+
+	return startIdx
+}
+
+func (b *InMemoryBackend) collectMatchingPipes(
+	names []string, startIdx, limit int, f ListPipesFilter,
+) ([]*Pipe, string) {
 	var result []*Pipe
 	var lastIncluded string
 	for i := startIdx; i < len(names); i++ {
-		if len(result) >= limit { break }
+		if len(result) >= limit {
+			break
+		}
 		p := b.pipes[names[i]]
-		if !matchesFilter(p, f) { continue }
+		if !matchesFilter(p, f) {
+			continue
+		}
 		result = append(result, clonePipe(p))
 		lastIncluded = p.Name
 	}
 
-	var nextToken string
-	if len(result) == limit && lastIncluded != "" {
-		for i := startIdx + len(result); i < len(names); i++ {
-			if matchesFilter(b.pipes[names[i]], f) {
-				nextToken = base64.StdEncoding.EncodeToString([]byte(lastIncluded + nextTokenSep))
-				break
-			}
+	return result, lastIncluded
+}
+
+func (b *InMemoryBackend) buildNextToken(
+	names []string, startIdx, resultLen, limit int, lastIncluded string, f ListPipesFilter,
+) string {
+	if resultLen < limit || lastIncluded == "" {
+		return ""
+	}
+	for i := startIdx + resultLen; i < len(names); i++ {
+		if matchesFilter(b.pipes[names[i]], f) {
+			return base64.StdEncoding.EncodeToString([]byte(lastIncluded + nextTokenSep))
 		}
 	}
-	return ListPipesResult{Pipes: result, NextToken: nextToken}
+
+	return ""
 }
 
 func matchesFilter(p *Pipe, f ListPipesFilter) bool {
-	if f.NamePrefix != "" && !strings.HasPrefix(p.Name, f.NamePrefix) { return false }
-	if f.DesiredState != "" && p.DesiredState != f.DesiredState { return false }
-	if f.CurrentState != "" && p.CurrentState != f.CurrentState { return false }
-	if f.SourcePrefix != "" && !strings.HasPrefix(p.Source, f.SourcePrefix) { return false }
-	if f.TargetPrefix != "" && !strings.HasPrefix(p.Target, f.TargetPrefix) { return false }
+	if f.NamePrefix != "" && !strings.HasPrefix(p.Name, f.NamePrefix) {
+		return false
+	}
+	if f.DesiredState != "" && p.DesiredState != f.DesiredState {
+		return false
+	}
+	if f.CurrentState != "" && p.CurrentState != f.CurrentState {
+		return false
+	}
+	if f.SourcePrefix != "" && !strings.HasPrefix(p.Source, f.SourcePrefix) {
+		return false
+	}
+	if f.TargetPrefix != "" && !strings.HasPrefix(p.Target, f.TargetPrefix) {
+		return false
+	}
+
 	return true
 }
 
@@ -333,21 +407,42 @@ type UpdatePipeInput struct {
 }
 
 func (b *InMemoryBackend) UpdatePipe(name string, in UpdatePipeInput) (*Pipe, error) {
-	if err := validateDesiredState(in.DesiredState); err != nil { return nil, err }
+	if err := validateDesiredState(in.DesiredState); err != nil {
+		return nil, err
+	}
 	b.mu.Lock("UpdatePipe")
 	defer b.mu.Unlock()
 	p, ok := b.pipes[name]
-	if !ok { return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name) }
-	if in.RoleARN != "" { p.RoleARN = in.RoleARN }
-	if in.Target != "" { p.Target = in.Target }
-	if in.DesiredState != "" { p.DesiredState = in.DesiredState }
-	if in.Enrichment != "" { p.Enrichment = in.Enrichment }
+	if !ok {
+		return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name)
+	}
+	if in.RoleARN != "" {
+		p.RoleARN = in.RoleARN
+	}
+	if in.Target != "" {
+		p.Target = in.Target
+	}
+	if in.DesiredState != "" {
+		p.DesiredState = in.DesiredState
+	}
+	if in.Enrichment != "" {
+		p.Enrichment = in.Enrichment
+	}
 	p.Description = in.Description
-	if in.SourceParameters != nil { p.SourceParameters = in.SourceParameters }
-	if in.TargetParameters != nil { p.TargetParameters = in.TargetParameters }
-	if in.DeadLetterConfig != nil { p.DeadLetterConfig = in.DeadLetterConfig }
-	if in.LogConfiguration != nil { p.LogConfiguration = in.LogConfiguration }
+	if in.SourceParameters != nil {
+		p.SourceParameters = in.SourceParameters
+	}
+	if in.TargetParameters != nil {
+		p.TargetParameters = in.TargetParameters
+	}
+	if in.DeadLetterConfig != nil {
+		p.DeadLetterConfig = in.DeadLetterConfig
+	}
+	if in.LogConfiguration != nil {
+		p.LogConfiguration = in.LogConfiguration
+	}
 	p.LastModifiedTime = time.Now()
+
 	return clonePipe(p), nil
 }
 
@@ -355,9 +450,12 @@ func (b *InMemoryBackend) DeletePipe(name string) error {
 	b.mu.Lock("DeletePipe")
 	defer b.mu.Unlock()
 	p, ok := b.pipes[name]
-	if !ok { return fmt.Errorf("%w: pipe %s not found", ErrNotFound, name) }
+	if !ok {
+		return fmt.Errorf("%w: pipe %s not found", ErrNotFound, name)
+	}
 	delete(b.pipeARNIndex, p.ARN)
 	delete(b.pipes, name)
+
 	return nil
 }
 
@@ -365,12 +463,17 @@ func (b *InMemoryBackend) StartPipe(name string) (*Pipe, error) {
 	b.mu.Lock("StartPipe")
 	defer b.mu.Unlock()
 	p, ok := b.pipes[name]
-	if !ok { return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name) }
+	if !ok {
+		return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name)
+	}
 	if p.DesiredState == stateRunning && p.CurrentState == stateRunning {
 		return nil, fmt.Errorf("%w: pipe %s is already in RUNNING state", ErrValidation, name)
 	}
-	p.DesiredState = stateRunning; p.CurrentState = stateRunning; p.StateReason = ""
+	p.DesiredState = stateRunning
+	p.CurrentState = stateRunning
+	p.StateReason = ""
 	p.LastModifiedTime = time.Now()
+
 	return clonePipe(p), nil
 }
 
@@ -378,12 +481,17 @@ func (b *InMemoryBackend) StopPipe(name string) (*Pipe, error) {
 	b.mu.Lock("StopPipe")
 	defer b.mu.Unlock()
 	p, ok := b.pipes[name]
-	if !ok { return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name) }
+	if !ok {
+		return nil, fmt.Errorf("%w: pipe %s not found", ErrNotFound, name)
+	}
 	if p.DesiredState == stateStopped && p.CurrentState == stateStopped {
 		return nil, fmt.Errorf("%w: pipe %s is already in STOPPED state", ErrValidation, name)
 	}
-	p.DesiredState = stateStopped; p.CurrentState = stateStopped; p.StateReason = ""
+	p.DesiredState = stateStopped
+	p.CurrentState = stateStopped
+	p.StateReason = ""
 	p.LastModifiedTime = time.Now()
+
 	return clonePipe(p), nil
 }
 
@@ -392,22 +500,31 @@ func (b *InMemoryBackend) MarkPipeFailed(name, state, reason string) {
 	b.mu.Lock("MarkPipeFailed")
 	defer b.mu.Unlock()
 	p, ok := b.pipes[name]
-	if !ok { return }
-	p.CurrentState = state; p.StateReason = reason; p.LastModifiedTime = time.Now()
+	if !ok {
+		return
+	}
+	p.CurrentState = state
+	p.StateReason = reason
+	p.LastModifiedTime = time.Now()
 }
 
 func (b *InMemoryBackend) TagResource(resourceARN string, kv map[string]string) error {
-	if err := validateTags(kv); err != nil { return err }
+	if err := validateTags(kv); err != nil {
+		return err
+	}
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 	name, ok := b.pipeARNIndex[resourceARN]
-	if !ok { return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN) }
+	if !ok {
+		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
+	}
 	p := b.pipes[name]
 	merged := mergeTags(p.Tags, kv)
 	if len(merged) > maxTagsPerPipe {
 		return fmt.Errorf("%w: pipe would exceed %d tags limit", ErrValidation, maxTagsPerPipe)
 	}
 	p.Tags = merged
+
 	return nil
 }
 
@@ -415,9 +532,14 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, keys []string) error
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 	name, ok := b.pipeARNIndex[resourceARN]
-	if !ok { return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN) }
+	if !ok {
+		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
+	}
 	p := b.pipes[name]
-	for _, k := range keys { delete(p.Tags, k) }
+	for _, k := range keys {
+		delete(p.Tags, k)
+	}
+
 	return nil
 }
 
@@ -425,10 +547,13 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]st
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 	name, ok := b.pipeARNIndex[resourceARN]
-	if !ok { return nil, fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN) }
+	if !ok {
+		return nil, fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
+	}
 	p := b.pipes[name]
 	result := make(map[string]string, len(p.Tags))
 	maps.Copy(result, p.Tags)
+
 	return result, nil
 }
 
@@ -436,6 +561,7 @@ func mergeTags(existing, incoming map[string]string) map[string]string {
 	result := make(map[string]string, len(existing)+len(incoming))
 	maps.Copy(result, existing)
 	maps.Copy(result, incoming)
+
 	return result
 }
 
@@ -447,31 +573,58 @@ func (b *InMemoryBackend) Reset() {
 }
 
 func validatePipeName(name string) error {
-	if name == "" { return fmt.Errorf("%w: pipe name must not be empty", ErrValidation) }
+	if name == "" {
+		return fmt.Errorf("%w: pipe name must not be empty", ErrValidation)
+	}
 	if len(name) > maxPipeNameLen {
-		return fmt.Errorf("%w: pipe name exceeds maximum length of %d characters", ErrValidation, maxPipeNameLen)
+		return fmt.Errorf(
+			"%w: pipe name exceeds maximum length of %d characters",
+			ErrValidation,
+			maxPipeNameLen,
+		)
 	}
 	if !pipeNameRE.MatchString(name) {
-		return fmt.Errorf("%w: pipe name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", ErrValidation, name)
+		return fmt.Errorf(
+			"%w: pipe name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)",
+			ErrValidation,
+			name,
+		)
 	}
+
 	return nil
 }
 
 func validateDesiredState(state string) error {
-	if state == "" || state == stateRunning || state == stateStopped { return nil }
+	if state == "" || state == stateRunning || state == stateStopped {
+		return nil
+	}
+
 	return fmt.Errorf("%w: DesiredState must be RUNNING or STOPPED, got %q", ErrValidation, state)
 }
 
 func validateTags(tags map[string]string) error {
 	for k, v := range tags {
-		if len(k) == 0 { return fmt.Errorf("%w: tag key must not be empty", ErrValidation) }
+		if len(k) == 0 {
+			return fmt.Errorf("%w: tag key must not be empty", ErrValidation)
+		}
 		if len(k) > maxTagKeyLen {
-			return fmt.Errorf("%w: tag key %q exceeds maximum length of %d", ErrValidation, k, maxTagKeyLen)
+			return fmt.Errorf(
+				"%w: tag key %q exceeds maximum length of %d",
+				ErrValidation,
+				k,
+				maxTagKeyLen,
+			)
 		}
 		if len(v) > maxTagValueLen {
-			return fmt.Errorf("%w: tag value for key %q exceeds maximum length of %d", ErrValidation, k, maxTagValueLen)
+			return fmt.Errorf(
+				"%w: tag value for key %q exceeds maximum length of %d",
+				ErrValidation,
+				k,
+				maxTagValueLen,
+			)
 		}
 	}
+
 	return nil
 }
 
@@ -485,7 +638,10 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	}
 	s := snap{Pipes: b.pipes, AccountID: b.accountID, Region: b.region}
 	data, err := json.Marshal(s)
-	if err != nil { return nil }
+	if err != nil {
+		return nil
+	}
+
 	return data
 }
 
@@ -496,14 +652,21 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		Region    string           `json:"region"`
 	}
 	var s snap
-	if err := json.Unmarshal(data, &s); err != nil { return err }
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
-	if s.Pipes == nil { s.Pipes = make(map[string]*Pipe) }
+	if s.Pipes == nil {
+		s.Pipes = make(map[string]*Pipe)
+	}
 	b.pipes = s.Pipes
 	b.accountID = s.AccountID
 	b.region = s.Region
 	b.pipeARNIndex = make(map[string]string, len(b.pipes))
-	for name, p := range b.pipes { b.pipeARNIndex[p.ARN] = name }
+	for name, p := range b.pipes {
+		b.pipeARNIndex[p.ARN] = name
+	}
+
 	return nil
 }

--- a/services/pipes/handler.go
+++ b/services/pipes/handler.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	keyMessageField = "message"
+	keyTypeField    = "__type"
 )
 
 const (
@@ -36,11 +37,11 @@ const (
 )
 
 const (
-	pipesService    = "pipes"
-	pipesMatchPriority = 87
-	pipesPathPrefix    = "/v1/pipes"
-	pipesTagsPrefix    = "/tags/"
-	pipeNameSegment    = "pipes"
+	pipesService        = "pipes"
+	pipesMatchPriority  = 87
+	pipesPathPrefix     = "/v1/pipes"
+	pipesTagsPrefix     = "/tags/"
+	pipeNameSegment     = "pipes"
 	pipePathMinSegments = 3
 )
 
@@ -138,7 +139,7 @@ func (h *Handler) RouteMatcher() service.Matcher {
 
 func (h *Handler) MatchPriority() int { return pipesMatchPriority }
 
-//nolint:cyclop
+//nolint:cyclop // function routes HTTP requests by method and path segments
 func (h *Handler) ExtractOperation(c *echo.Context) string {
 	method := c.Request().Method
 	path := c.Request().URL.Path
@@ -187,7 +188,8 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 	path := c.Request().URL.Path
 	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
 
-	if len(segments) >= pipePathMinSegments && segments[0] == "v1" && segments[1] == pipeNameSegment {
+	if len(segments) >= pipePathMinSegments && segments[0] == "v1" &&
+		segments[1] == pipeNameSegment {
 		return segments[2]
 	}
 
@@ -224,7 +226,12 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	}
 }
 
-func (h *Handler) dispatch(ctx context.Context, op, path string, query url.Values, body []byte) ([]byte, error) {
+func (h *Handler) dispatch(
+	ctx context.Context,
+	op, path string,
+	query url.Values,
+	body []byte,
+) ([]byte, error) {
 	switch op {
 	case opCreatePipe:
 		return h.handleCreatePipe(ctx, path, body)
@@ -258,21 +265,21 @@ func (h *Handler) handleError(c *echo.Context, err error) error {
 	switch {
 	case errors.Is(err, ErrNotFound):
 		payload, _ := json.Marshal(map[string]string{
-			"__type":        "NotFoundException",
+			keyTypeField:    "NotFoundException",
 			keyMessageField: err.Error(),
 		})
 
 		return c.JSONBlob(http.StatusNotFound, payload)
 	case errors.Is(err, ErrAlreadyExists):
 		payload, _ := json.Marshal(map[string]string{
-			"__type":        "ConflictException",
+			keyTypeField:    "ConflictException",
 			keyMessageField: err.Error(),
 		})
 
 		return c.JSONBlob(http.StatusConflict, payload)
 	case errors.Is(err, ErrValidation):
 		payload, _ := json.Marshal(map[string]string{
-			"__type":        "ValidationException",
+			keyTypeField:    "ValidationException",
 			keyMessageField: err.Error(),
 		})
 
@@ -281,7 +288,10 @@ func (h *Handler) handleError(c *echo.Context, err error) error {
 		errors.As(err, &syntaxErr), errors.As(err, &typeErr):
 		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: err.Error()})
 	default:
-		return c.JSON(http.StatusInternalServerError, map[string]string{keyMessageField: err.Error()})
+		return c.JSON(
+			http.StatusInternalServerError,
+			map[string]string{keyMessageField: err.Error()},
+		)
 	}
 }
 
@@ -562,7 +572,11 @@ func (h *Handler) handleTagResource(_ context.Context, path string, body []byte)
 	return nil, nil
 }
 
-func (h *Handler) handleUntagResource(_ context.Context, path string, query url.Values) ([]byte, error) {
+func (h *Handler) handleUntagResource(
+	_ context.Context,
+	path string,
+	query url.Values,
+) ([]byte, error) {
 	resourceARN, err := extractTagsARN(path)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)

--- a/services/pipes/handler_test.go
+++ b/services/pipes/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -544,8 +545,11 @@ func TestBackend_Validation(t *testing.T) {
 
 	t.Run("name_too_long", func(t *testing.T) {
 		t.Parallel()
-		long := ""
-		for range 65 { long += "a" }
+		var sb strings.Builder
+		for range 65 {
+			sb.WriteString("a")
+		}
+		long := sb.String()
 		_, err := b.CreatePipeSimple(long, "arn:r", "arn:s", "arn:t", "", "RUNNING", nil)
 		require.Error(t, err)
 		require.ErrorIs(t, err, pipes.ErrValidation)
@@ -602,7 +606,9 @@ func TestHandler_ListPipesFiltering(t *testing.T) {
 
 	for _, name := range []string{"sqs-alpha", "sqs-beta", "kinesis-gamma"} {
 		state := "RUNNING"
-		if name == "sqs-beta" { state = "STOPPED" }
+		if name == "sqs-beta" {
+			state = "STOPPED"
+		}
 		rec := doPipesRequest(t, h, http.MethodPost, "/v1/pipes/"+name, map[string]any{
 			"Source":       "arn:aws:sqs:us-east-1:000000000000:" + name,
 			"Target":       "arn:aws:lambda:us-east-1:000000000000:function:fn",
@@ -615,7 +621,11 @@ func TestHandler_ListPipesFiltering(t *testing.T) {
 		t.Parallel()
 		rec := doPipesRequest(t, h, http.MethodGet, "/v1/pipes?NamePrefix=sqs", nil)
 		require.Equal(t, http.StatusOK, rec.Code)
-		var out struct{ Pipes []struct{ Name string } }
+		var out struct {
+			Pipes []struct {
+				Name string `json:"Name"`
+			} `json:"Pipes"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Len(t, out.Pipes, 2)
 	})
@@ -624,7 +634,11 @@ func TestHandler_ListPipesFiltering(t *testing.T) {
 		t.Parallel()
 		rec := doPipesRequest(t, h, http.MethodGet, "/v1/pipes?DesiredState=STOPPED", nil)
 		require.Equal(t, http.StatusOK, rec.Code)
-		var out struct{ Pipes []struct{ Name string } }
+		var out struct {
+			Pipes []struct {
+				Name string `json:"Name"`
+			} `json:"Pipes"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Len(t, out.Pipes, 1)
 		assert.Equal(t, "sqs-beta", out.Pipes[0].Name)
@@ -657,16 +671,18 @@ func TestHandler_SourceAndTargetParameters(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var created struct {
-		SourceParameters struct {
-			SqsQueueParameters struct{ BatchSize int } `json:"SqsQueueParameters"`
-		} `json:"SourceParameters"`
 		TargetParameters struct {
 			InputTemplate string `json:"InputTemplate"`
 		} `json:"TargetParameters"`
+		SourceParameters struct {
+			SqsQueueParameters struct {
+				BatchSize int `json:"BatchSize"`
+			} `json:"SqsQueueParameters"`
+		} `json:"SourceParameters"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
 	assert.Equal(t, 5, created.SourceParameters.SqsQueueParameters.BatchSize)
-	assert.Equal(t, `{"fixed":"value"}`, created.TargetParameters.InputTemplate)
+	assert.JSONEq(t, `{"fixed":"value"}`, created.TargetParameters.InputTemplate)
 }
 
 func TestHandler_ListPipesIncludesSourceTarget(t *testing.T) {
@@ -689,7 +705,7 @@ func TestHandler_ListPipesIncludesSourceTarget(t *testing.T) {
 			Source      string `json:"Source"`
 			Target      string `json:"Target"`
 			Description string `json:"Description"`
-		}
+		} `json:"Pipes"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	require.Len(t, out.Pipes, 1)
@@ -714,7 +730,9 @@ func TestHandler_UpdatePipeDesiredState(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	var out struct{ DesiredState string }
+	var out struct {
+		DesiredState string `json:"DesiredState"`
+	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	assert.Equal(t, "STOPPED", out.DesiredState)
 }

--- a/services/pipes/runner.go
+++ b/services/pipes/runner.go
@@ -37,7 +37,12 @@ type SQSReader interface {
 
 // PipeLambdaInvoker invokes a Lambda function with a payload.
 type PipeLambdaInvoker interface {
-	InvokeFunction(ctx context.Context, name string, invocationType string, payload []byte) ([]byte, int, error)
+	InvokeFunction(
+		ctx context.Context,
+		name string,
+		invocationType string,
+		payload []byte,
+	) ([]byte, int, error)
 }
 
 // PipeStepFunctionsStarter starts a StepFunctions state machine execution.
@@ -47,12 +52,12 @@ type PipeStepFunctionsStarter interface {
 
 // Runner polls pipe sources and forwards records to pipe targets for RUNNING pipes.
 type Runner struct {
-	backend   *InMemoryBackend
 	sqsReader SQSReader
 	lambda    PipeLambdaInvoker
 	sfn       PipeStepFunctionsStarter
-	wg        sync.WaitGroup
+	backend   *InMemoryBackend
 	sem       chan struct{}
+	wg        sync.WaitGroup
 }
 
 func NewRunner(backend *InMemoryBackend) *Runner {
@@ -62,17 +67,14 @@ func NewRunner(backend *InMemoryBackend) *Runner {
 	}
 }
 
-func (r *Runner) SetSQSReader(s SQSReader)               { r.sqsReader = s }
-func (r *Runner) SetLambdaInvoker(l PipeLambdaInvoker)   { r.lambda = l }
+func (r *Runner) SetSQSReader(s SQSReader)                           { r.sqsReader = s }
+func (r *Runner) SetLambdaInvoker(l PipeLambdaInvoker)               { r.lambda = l }
 func (r *Runner) SetStepFunctionsStarter(s PipeStepFunctionsStarter) { r.sfn = s }
 
 func (r *Runner) Start(ctx context.Context) {
-	r.wg.Add(1)
-
-	go func() {
-		defer r.wg.Done()
+	r.wg.Go(func() {
 		r.run(ctx)
-	}()
+	})
 }
 
 // Wait blocks until all runner goroutines have exited, or ctx expires.
@@ -108,22 +110,17 @@ func (r *Runner) pollAllPipes(ctx context.Context) {
 	res := r.backend.ListPipes(ListPipesFilter{CurrentState: stateRunning})
 
 	for _, p := range res.Pipes {
-		p := p
-
 		select {
 		case r.sem <- struct{}{}:
 		default:
 			continue
 		}
 
-		r.wg.Add(1)
-
-		go func() {
-			defer r.wg.Done()
+		r.wg.Go(func() {
 			defer func() { <-r.sem }()
 
 			r.pollPipe(ctx, p)
-		}()
+		})
 	}
 }
 

--- a/services/pipes/runner_test.go
+++ b/services/pipes/runner_test.go
@@ -51,12 +51,14 @@ func (m *mockSQSReader) DeletePipeMessages(_ string, receiptHandles []string) er
 func (m *mockSQSReader) getDeleted() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
 	return append([]string(nil), m.deletedIDs...)
 }
 
 func (m *mockSQSReader) getLastMaxMessages() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
 	return m.lastMaxMessages
 }
 
@@ -304,7 +306,7 @@ func TestPipesRunner_FilterCriteria(t *testing.T) {
 
 	require.Len(t, calls, 1)
 
-	var event map[string]interface{}
+	var event map[string]any
 	require.NoError(t, json.Unmarshal(payloads[0], &event))
 	require.Len(t, event, 1)
 	// payload is forwarded - just check Lambda was called once
@@ -372,5 +374,5 @@ func TestPipesRunner_InputTemplate(t *testing.T) {
 	lambdaInvoker.mu.Unlock()
 
 	require.Len(t, payloads, 1)
-	assert.Equal(t, `{"fixed":"value"}`, string(payloads[0]))
+	assert.JSONEq(t, `{"fixed":"value"}`, string(payloads[0]))
 }

--- a/ui/src/routes/appconfig/page.test.ts
+++ b/ui/src/routes/appconfig/page.test.ts
@@ -93,9 +93,7 @@ describe("AppConfig Page", () => {
     await fireEvent.click(createBtn);
 
     expect(screen.getByText("New Application", { selector: "h3" })).toBeInTheDocument();
-    expect(
-      screen.getByPlaceholderText("my-app-config"),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("my-app-config")).toBeInTheDocument();
   });
 
   it("closes create modal on abort button click", async () => {
@@ -105,16 +103,12 @@ describe("AppConfig Page", () => {
 
     await fireEvent.click(screen.getByText("New Application"));
 
-    expect(
-      screen.getByPlaceholderText("my-app-config"),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("my-app-config")).toBeInTheDocument();
 
     await fireEvent.click(screen.getByText("Cancel"));
 
     await waitFor(() => {
-      expect(
-        screen.queryByPlaceholderText("my-app-config"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText("my-app-config")).not.toBeInTheDocument();
     });
   });
 

--- a/ui/src/routes/mediaconvert/page.test.ts
+++ b/ui/src/routes/mediaconvert/page.test.ts
@@ -111,8 +111,8 @@ describe("MediaConvert Page", () => {
     await waitFor(
       () => {
         expect(screen.getAllByText("Queue")[0]).toBeInTheDocument();
-        expect(screen.getAllByText("Role ARN")[0]).toBeInTheDocument();
-        expect(screen.getAllByText("Output Groups")[0]).toBeInTheDocument();
+        expect(screen.getAllByText("Role")[0]).toBeInTheDocument();
+        expect(screen.getAllByText("Priority")[0]).toBeInTheDocument();
       },
       { timeout: 3000 },
     );
@@ -156,7 +156,7 @@ describe("MediaConvert Page", () => {
     await fireEvent.click(screen.getByText("Default"));
     await waitFor(
       () => {
-        expect(screen.getAllByText("Queue ARN")[0]).toBeInTheDocument();
+        expect(screen.getAllByText("Type")[0]).toBeInTheDocument();
         expect(screen.getAllByText("Pricing Plan")[0]).toBeInTheDocument();
       },
       { timeout: 3000 },


### PR DESCRIPTION
## Summary
- Fix 37 golangci-lint issues missed in PR #1462 (nlreturn, gocognit, goconst, modernize, musttag, testifylint, nolintlint)
- Fix mediaconvert tests expecting wrong label text (Role ARN→Role, Queue ARN→Type)
- Fix appconfig page.test.ts formatting (oxfmt)

## Test plan
- [ ] `golangci-lint run ./services/pipes/...` → 0 issues
- [ ] `npm run fmt:check` → all files pass
- [ ] `npx vitest run src/routes/mediaconvert/page.test.ts` → 11/11 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->