### PR TITLE
feat(msk): implement 34 missing SDK ops and full UI dashboard

### DIFF
--- a/services/kafka/backend.go
+++ b/services/kafka/backend.go
@@ -154,17 +154,32 @@ func (b *InMemoryBackend) Reset() {
 
 // clusterARN builds an ARN for an MSK cluster.
 func (b *InMemoryBackend) clusterARN(name string) string {
-	return arn.Build("kafka", b.region, b.accountID, fmt.Sprintf("cluster/%s/%s", name, uuid.New().String()))
+	return arn.Build(
+		"kafka",
+		b.region,
+		b.accountID,
+		fmt.Sprintf("cluster/%s/%s", name, uuid.New().String()),
+	)
 }
 
 // configurationARN builds an ARN for an MSK configuration.
 func (b *InMemoryBackend) configurationARN(name string) string {
-	return arn.Build("kafka", b.region, b.accountID, fmt.Sprintf("configuration/%s/%s", name, uuid.New().String()))
+	return arn.Build(
+		"kafka",
+		b.region,
+		b.accountID,
+		fmt.Sprintf("configuration/%s/%s", name, uuid.New().String()),
+	)
 }
 
 // replicatorARN builds an ARN for an MSK replicator.
 func (b *InMemoryBackend) replicatorARN(name string) string {
-	return arn.Build("kafka", b.region, b.accountID, fmt.Sprintf("replicator/%s/%s", name, uuid.New().String()))
+	return arn.Build(
+		"kafka",
+		b.region,
+		b.accountID,
+		fmt.Sprintf("replicator/%s/%s", name, uuid.New().String()),
+	)
 }
 
 // vpcConnectionARN builds an ARN for an MSK VPC connection.
@@ -689,6 +704,652 @@ func (b *InMemoryBackend) DeleteVpcConnection(vpcConnectionArn string) error {
 	return nil
 }
 
+// --- Replicator describe/list/update operations ---
+
+// DescribeReplicator retrieves a replicator by ARN.
+func (b *InMemoryBackend) DescribeReplicator(replicatorArn string) (*Replicator, error) {
+	b.mu.RLock("DescribeReplicator")
+	defer b.mu.RUnlock()
+
+	r, ok := b.replicators[replicatorArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return cloneReplicator(r), nil
+}
+
+// ListReplicators returns all replicators sorted by name.
+func (b *InMemoryBackend) ListReplicators() []*Replicator {
+	b.mu.RLock("ListReplicators")
+	defer b.mu.RUnlock()
+
+	out := make([]*Replicator, 0, len(b.replicators))
+	for _, r := range b.replicators {
+		out = append(out, cloneReplicator(r))
+	}
+
+	slices.SortFunc(out, func(a, b *Replicator) int {
+		if a.ReplicatorName < b.ReplicatorName {
+			return -1
+		}
+		if a.ReplicatorName > b.ReplicatorName {
+			return 1
+		}
+
+		return 0
+	})
+
+	return out
+}
+
+// UpdateReplicationInfo updates the replicator description.
+func (b *InMemoryBackend) UpdateReplicationInfo(
+	replicatorArn, description string,
+) (*Replicator, error) {
+	b.mu.Lock("UpdateReplicationInfo")
+	defer b.mu.Unlock()
+
+	r, ok := b.replicators[replicatorArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	r.Description = description
+
+	return cloneReplicator(r), nil
+}
+
+// --- Topic describe/list/update operations ---
+
+// DescribeTopic retrieves a topic by cluster ARN and topic name.
+func (b *InMemoryBackend) DescribeTopic(clusterArn, topicName string) (*Topic, error) {
+	b.mu.RLock("DescribeTopic")
+	defer b.mu.RUnlock()
+
+	key := topicKey(clusterArn, topicName)
+	t, ok := b.topics[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return cloneTopic(t), nil
+}
+
+// DescribeTopicPartitions retrieves a topic's partition count.
+func (b *InMemoryBackend) DescribeTopicPartitions(clusterArn, topicName string) (*Topic, error) {
+	return b.DescribeTopic(clusterArn, topicName)
+}
+
+// ListTopics returns all topics for a cluster sorted by topic name.
+func (b *InMemoryBackend) ListTopics(clusterArn string) ([]*Topic, error) {
+	b.mu.RLock("ListTopics")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	prefix := clusterArn + topicKeySeparator
+	out := make([]*Topic, 0)
+
+	for k, t := range b.topics {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, cloneTopic(t))
+		}
+	}
+
+	slices.SortFunc(out, func(a, b *Topic) int {
+		if a.TopicName < b.TopicName {
+			return -1
+		}
+		if a.TopicName > b.TopicName {
+			return 1
+		}
+
+		return 0
+	})
+
+	return out, nil
+}
+
+// UpdateTopic updates a topic's config entries and/or partition count.
+func (b *InMemoryBackend) UpdateTopic(
+	clusterArn, topicName string,
+	numPartitions int32,
+	configEntries map[string]string,
+) (*Topic, error) {
+	b.mu.Lock("UpdateTopic")
+	defer b.mu.Unlock()
+
+	key := topicKey(clusterArn, topicName)
+	t, ok := b.topics[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	if numPartitions > 0 {
+		t.NumPartitions = numPartitions
+	}
+
+	if configEntries != nil {
+		maps.Copy(t.ConfigEntries, configEntries)
+	}
+
+	return cloneTopic(t), nil
+}
+
+// --- VPC connection describe/list/reject operations ---
+
+// DescribeVpcConnection retrieves a VPC connection by ARN.
+func (b *InMemoryBackend) DescribeVpcConnection(vpcConnectionArn string) (*VpcConnection, error) {
+	b.mu.RLock("DescribeVpcConnection")
+	defer b.mu.RUnlock()
+
+	v, ok := b.vpcConnections[vpcConnectionArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return cloneVpcConnection(v), nil
+}
+
+// ListVpcConnections returns all VPC connections sorted by ARN.
+func (b *InMemoryBackend) ListVpcConnections() []*VpcConnection {
+	b.mu.RLock("ListVpcConnections")
+	defer b.mu.RUnlock()
+
+	out := make([]*VpcConnection, 0, len(b.vpcConnections))
+	for _, v := range b.vpcConnections {
+		out = append(out, cloneVpcConnection(v))
+	}
+
+	slices.SortFunc(out, func(a, b *VpcConnection) int {
+		if a.VpcConnectionArn < b.VpcConnectionArn {
+			return -1
+		}
+		if a.VpcConnectionArn > b.VpcConnectionArn {
+			return 1
+		}
+
+		return 0
+	})
+
+	return out
+}
+
+// ListClientVpcConnections returns all VPC connections for a given cluster.
+func (b *InMemoryBackend) ListClientVpcConnections(clusterArn string) ([]*VpcConnection, error) {
+	b.mu.RLock("ListClientVpcConnections")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	out := make([]*VpcConnection, 0)
+
+	for _, v := range b.vpcConnections {
+		if v.TargetClusterArn == clusterArn {
+			out = append(out, cloneVpcConnection(v))
+		}
+	}
+
+	slices.SortFunc(out, func(a, b *VpcConnection) int {
+		if a.VpcConnectionArn < b.VpcConnectionArn {
+			return -1
+		}
+		if a.VpcConnectionArn > b.VpcConnectionArn {
+			return 1
+		}
+
+		return 0
+	})
+
+	return out, nil
+}
+
+// RejectClientVpcConnection rejects (deletes) a VPC connection.
+func (b *InMemoryBackend) RejectClientVpcConnection(vpcConnectionArn string) error {
+	return b.DeleteVpcConnection(vpcConnectionArn)
+}
+
+// --- Cluster policy get/put operations ---
+
+// GetClusterPolicy retrieves the policy document for a cluster.
+func (b *InMemoryBackend) GetClusterPolicy(clusterArn string) (string, error) {
+	b.mu.RLock("GetClusterPolicy")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return "", ErrNotFound
+	}
+
+	policy := b.clusterPolicies[clusterArn]
+
+	return policy, nil
+}
+
+// PutClusterPolicy sets the policy document for a cluster.
+func (b *InMemoryBackend) PutClusterPolicy(clusterArn, policy string) error {
+	b.mu.Lock("PutClusterPolicy")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return ErrNotFound
+	}
+
+	b.clusterPolicies[clusterArn] = policy
+
+	return nil
+}
+
+// --- Cluster operation list operations ---
+
+// ListClusterOperations returns all cluster operations for a cluster.
+func (b *InMemoryBackend) ListClusterOperations(clusterArn string) ([]*ClusterOperation, error) {
+	b.mu.RLock("ListClusterOperations")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	out := make([]*ClusterOperation, 0)
+
+	for _, op := range b.clusterOperations {
+		if op.ClusterArn == clusterArn {
+			out = append(out, cloneClusterOperation(op))
+		}
+	}
+
+	slices.SortFunc(out, func(a, b *ClusterOperation) int {
+		if a.ClusterOperationArn < b.ClusterOperationArn {
+			return -1
+		}
+		if a.ClusterOperationArn > b.ClusterOperationArn {
+			return 1
+		}
+
+		return 0
+	})
+
+	return out, nil
+}
+
+// DescribeClusterOperationV2 retrieves a cluster operation (V2) by ARN.
+func (b *InMemoryBackend) DescribeClusterOperationV2(
+	clusterOperationArn string,
+) (*ClusterOperation, error) {
+	return b.DescribeClusterOperation(clusterOperationArn)
+}
+
+// ListClusterOperationsV2 returns all cluster operations for a cluster (V2).
+func (b *InMemoryBackend) ListClusterOperationsV2(clusterArn string) ([]*ClusterOperation, error) {
+	return b.ListClusterOperations(clusterArn)
+}
+
+// --- Configuration revision operations ---
+
+// ConfigurationRevision represents a revision of an MSK configuration.
+type ConfigurationRevision struct {
+	ConfigurationArn string `json:"configurationArn"`
+	Description      string `json:"description,omitempty"`
+	ServerProperties string `json:"serverProperties,omitempty"`
+	Revision         int64  `json:"revision"`
+}
+
+// DescribeConfigurationRevision retrieves a configuration revision.
+// In this stub, revision 1 always refers to the current configuration state.
+func (b *InMemoryBackend) DescribeConfigurationRevision(
+	configArn string,
+	revision int64,
+) (*ConfigurationRevision, error) {
+	b.mu.RLock("DescribeConfigurationRevision")
+	defer b.mu.RUnlock()
+
+	c, ok := b.configurations[configArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return &ConfigurationRevision{
+		ConfigurationArn: c.Arn,
+		Revision:         revision,
+		Description:      c.Description,
+		ServerProperties: c.ServerProperties,
+	}, nil
+}
+
+// UpdateConfiguration updates a configuration's server properties and description.
+func (b *InMemoryBackend) UpdateConfiguration(
+	configArn, description, serverProperties string,
+) (*Configuration, error) {
+	b.mu.Lock("UpdateConfiguration")
+	defer b.mu.Unlock()
+
+	c, ok := b.configurations[configArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	if description != "" {
+		c.Description = description
+	}
+
+	if serverProperties != "" {
+		c.ServerProperties = serverProperties
+	}
+
+	return cloneConfiguration(c), nil
+}
+
+// ListConfigurationRevisions lists revisions for a configuration.
+// In this stub, every configuration has a single revision (revision 1).
+func (b *InMemoryBackend) ListConfigurationRevisions(
+	configArn string,
+) ([]*ConfigurationRevision, error) {
+	b.mu.RLock("ListConfigurationRevisions")
+	defer b.mu.RUnlock()
+
+	c, ok := b.configurations[configArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return []*ConfigurationRevision{
+		{
+			ConfigurationArn: c.Arn,
+			Revision:         1,
+			Description:      c.Description,
+			ServerProperties: c.ServerProperties,
+		},
+	}, nil
+}
+
+// --- Broker / cluster update operations ---
+
+// UpdateBrokerCount updates the number of broker nodes in a cluster.
+func (b *InMemoryBackend) UpdateBrokerCount(
+	clusterArn string,
+	numBrokers int32,
+) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateBrokerCount")
+	defer b.mu.Unlock()
+
+	c, ok := b.clusters[clusterArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	c.NumberOfBrokerNodes = numBrokers
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_BROKER_COUNT")
+
+	return op, nil
+}
+
+// UpdateBrokerStorage updates the EBS storage size for broker nodes.
+func (b *InMemoryBackend) UpdateBrokerStorage(
+	clusterArn string,
+	volumeSize int32,
+) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateBrokerStorage")
+	defer b.mu.Unlock()
+
+	c, ok := b.clusters[clusterArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	if c.BrokerNodeGroupInfo.StorageInfo == nil {
+		c.BrokerNodeGroupInfo.StorageInfo = &StorageInfo{}
+	}
+
+	if c.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo == nil {
+		c.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo = &EBSStorageInfo{}
+	}
+
+	c.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.VolumeSize = volumeSize
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_BROKER_STORAGE")
+
+	return op, nil
+}
+
+// UpdateBrokerType updates the instance type for broker nodes.
+func (b *InMemoryBackend) UpdateBrokerType(
+	clusterArn, instanceType string,
+) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateBrokerType")
+	defer b.mu.Unlock()
+
+	c, ok := b.clusters[clusterArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	c.BrokerNodeGroupInfo.InstanceType = instanceType
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_BROKER_TYPE")
+
+	return op, nil
+}
+
+// UpdateClusterConfiguration updates the configuration for a cluster.
+func (b *InMemoryBackend) UpdateClusterConfiguration(
+	clusterArn, _ string,
+	_ int64,
+) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateClusterConfiguration")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CLUSTER_CONFIGURATION")
+
+	return op, nil
+}
+
+// UpdateClusterKafkaVersion updates the Kafka version for a cluster.
+func (b *InMemoryBackend) UpdateClusterKafkaVersion(
+	clusterArn, targetKafkaVersion string,
+) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateClusterKafkaVersion")
+	defer b.mu.Unlock()
+
+	c, ok := b.clusters[clusterArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	c.KafkaVersion = targetKafkaVersion
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CLUSTER_KAFKA_VERSION")
+
+	return op, nil
+}
+
+// UpdateConnectivity updates connectivity settings for a cluster (stub: no-op).
+func (b *InMemoryBackend) UpdateConnectivity(clusterArn string) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateConnectivity")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CONNECTIVITY")
+
+	return op, nil
+}
+
+// UpdateMonitoring updates monitoring settings for a cluster (stub: no-op).
+func (b *InMemoryBackend) UpdateMonitoring(clusterArn string) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateMonitoring")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_MONITORING")
+
+	return op, nil
+}
+
+// UpdateRebalancing updates rebalancing settings for a cluster (stub: no-op).
+func (b *InMemoryBackend) UpdateRebalancing(clusterArn string) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateRebalancing")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_REBALANCING")
+
+	return op, nil
+}
+
+// UpdateSecurity updates security settings for a cluster (stub: no-op).
+func (b *InMemoryBackend) UpdateSecurity(clusterArn string) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateSecurity")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_SECURITY")
+
+	return op, nil
+}
+
+// UpdateStorage updates storage settings for a cluster (stub: no-op).
+func (b *InMemoryBackend) UpdateStorage(clusterArn string) (*ClusterOperation, error) {
+	b.mu.Lock("UpdateStorage")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "UPDATE_STORAGE")
+
+	return op, nil
+}
+
+// RebootBroker initiates a broker reboot operation.
+func (b *InMemoryBackend) RebootBroker(clusterArn string, _ []string) (*ClusterOperation, error) {
+	b.mu.Lock("RebootBroker")
+	defer b.mu.Unlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	op := b.newClusterOperationLocked(clusterArn, "REBOOT_BROKER")
+
+	return op, nil
+}
+
+// --- SCRAM secret list operations ---
+
+// ListScramSecrets returns all SCRAM secrets for a cluster.
+func (b *InMemoryBackend) ListScramSecrets(clusterArn string) ([]string, error) {
+	b.mu.RLock("ListScramSecrets")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	secrets := b.scramSecrets[clusterArn]
+	out := make([]string, len(secrets))
+	copy(out, secrets)
+
+	return out, nil
+}
+
+// --- Misc read ops ---
+
+// ListNodes returns broker node stubs for a cluster.
+func (b *InMemoryBackend) ListNodes(clusterArn string) ([]*BrokerNode, error) {
+	b.mu.RLock("ListNodes")
+	defer b.mu.RUnlock()
+
+	c, ok := b.clusters[clusterArn]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	out := make([]*BrokerNode, 0, int(c.NumberOfBrokerNodes))
+
+	for i := range c.NumberOfBrokerNodes {
+		out = append(out, &BrokerNode{
+			BrokerID:     i + 1,
+			InstanceType: c.BrokerNodeGroupInfo.InstanceType,
+		})
+	}
+
+	return out, nil
+}
+
+// ListKafkaVersions returns a static list of supported Kafka versions.
+func (b *InMemoryBackend) ListKafkaVersions() []*MSKVersion {
+	return []*MSKVersion{
+		{Version: "3.6.0", Status: ClusterStateActive},
+		{Version: "3.5.1", Status: ClusterStateActive},
+		{Version: "3.4.0", Status: ClusterStateActive},
+		{Version: "2.8.1", Status: ClusterStateActive},
+		{Version: "2.8.0", Status: "DEPRECATED"},
+		{Version: "2.6.0", Status: "DEPRECATED"},
+	}
+}
+
+// GetCompatibleKafkaVersions returns Kafka versions compatible with the given source version.
+func (b *InMemoryBackend) GetCompatibleKafkaVersions(clusterArn string) ([]*MSKVersion, error) {
+	b.mu.RLock("GetCompatibleKafkaVersions")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.clusters[clusterArn]; !ok {
+		return nil, ErrNotFound
+	}
+
+	return []*MSKVersion{
+		{Version: "3.6.0", Status: ClusterStateActive},
+		{Version: "3.5.1", Status: ClusterStateActive},
+	}, nil
+}
+
+// BrokerNode represents a stub broker node.
+type BrokerNode struct {
+	InstanceType string `json:"instanceType,omitempty"`
+	BrokerID     int32  `json:"brokerId"`
+}
+
+// MSKVersion represents an available Kafka version.
+type MSKVersion struct {
+	Version string `json:"version"`
+	Status  string `json:"status"`
+}
+
+// newClusterOperationLocked creates and stores a cluster operation.
+// MUST be called with b.mu write lock held.
+func (b *InMemoryBackend) newClusterOperationLocked(
+	clusterArn, operationType string,
+) *ClusterOperation {
+	clusterOperationArn := b.clusterOperationARN(clusterArn)
+	op := &ClusterOperation{
+		ClusterOperationArn: clusterOperationArn,
+		ClusterArn:          clusterArn,
+		OperationType:       operationType,
+		OperationState:      ClusterOperationStateUpdateComplete,
+	}
+	b.clusterOperations[clusterOperationArn] = op
+
+	return cloneClusterOperation(op)
+}
+
 // --- Cluster policy operations ---
 
 // DeleteClusterPolicy deletes the policy attached to an MSK cluster.
@@ -708,7 +1369,9 @@ func (b *InMemoryBackend) DeleteClusterPolicy(clusterArn string) error {
 // --- Cluster operation operations ---
 
 // DescribeClusterOperation retrieves a cluster operation by ARN.
-func (b *InMemoryBackend) DescribeClusterOperation(clusterOperationArn string) (*ClusterOperation, error) {
+func (b *InMemoryBackend) DescribeClusterOperation(
+	clusterOperationArn string,
+) (*ClusterOperation, error) {
 	b.mu.RLock("DescribeClusterOperation")
 	defer b.mu.RUnlock()
 
@@ -721,7 +1384,9 @@ func (b *InMemoryBackend) DescribeClusterOperation(clusterOperationArn string) (
 }
 
 // AddClusterOperationInternal adds a cluster operation for testing purposes.
-func (b *InMemoryBackend) AddClusterOperationInternal(clusterArn, operationType string) *ClusterOperation {
+func (b *InMemoryBackend) AddClusterOperationInternal(
+	clusterArn, operationType string,
+) *ClusterOperation {
 	b.mu.Lock("AddClusterOperationInternal")
 	defer b.mu.Unlock()
 

--- a/services/kafka/handler.go
+++ b/services/kafka/handler.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"net/http"
 	"net/url"
@@ -17,47 +18,90 @@ import (
 )
 
 const (
-	opBatchAssociateScramSecret    = "BatchAssociateScramSecret"
-	opBatchDisassociateScramSecret = "BatchDisassociateScramSecret"
-	opCreateCluster                = "CreateCluster"
-	opCreateClusterV2              = "CreateClusterV2"
-	opCreateConfiguration          = "CreateConfiguration"
-	opCreateReplicator             = "CreateReplicator"
-	opCreateTopic                  = "CreateTopic"
-	opCreateVpcConnection          = "CreateVpcConnection"
-	opDeleteCluster                = "DeleteCluster"
-	opDeleteClusterPolicy          = "DeleteClusterPolicy"
-	opDeleteConfiguration          = "DeleteConfiguration"
-	opDeleteReplicator             = "DeleteReplicator"
-	opDeleteTopic                  = "DeleteTopic"
-	opDeleteVpcConnection          = "DeleteVpcConnection"
-	opDescribeCluster              = "DescribeCluster"
-	opDescribeClusterOperation     = "DescribeClusterOperation"
-	opDescribeClusterV2            = "DescribeClusterV2"
-	opDescribeConfiguration        = "DescribeConfiguration"
-	opGetBootstrapBrokers          = "GetBootstrapBrokers"
-	opListClusters                 = "ListClusters"
-	opListClustersV2               = "ListClustersV2"
-	opListConfigurations           = "ListConfigurations"
-	opListTagsForResource          = "ListTagsForResource"
-	opTagResource                  = "TagResource"
-	opUntagResource                = "UntagResource"
+	opBatchAssociateScramSecret     = "BatchAssociateScramSecret"
+	opBatchDisassociateScramSecret  = "BatchDisassociateScramSecret"
+	opCreateCluster                 = "CreateCluster"
+	opCreateClusterV2               = "CreateClusterV2"
+	opCreateConfiguration           = "CreateConfiguration"
+	opCreateReplicator              = "CreateReplicator"
+	opCreateTopic                   = "CreateTopic"
+	opCreateVpcConnection           = "CreateVpcConnection"
+	opDeleteCluster                 = "DeleteCluster"
+	opDeleteClusterPolicy           = "DeleteClusterPolicy"
+	opDeleteConfiguration           = "DeleteConfiguration"
+	opDeleteReplicator              = "DeleteReplicator"
+	opDeleteTopic                   = "DeleteTopic"
+	opDeleteVpcConnection           = "DeleteVpcConnection"
+	opDescribeCluster               = "DescribeCluster"
+	opDescribeClusterOperation      = "DescribeClusterOperation"
+	opDescribeClusterOperationV2    = "DescribeClusterOperationV2"
+	opDescribeClusterV2             = "DescribeClusterV2"
+	opDescribeConfiguration         = "DescribeConfiguration"
+	opDescribeConfigurationRevision = "DescribeConfigurationRevision"
+	opDescribeReplicator            = "DescribeReplicator"
+	opDescribeTopic                 = "DescribeTopic"
+	opDescribeTopicPartitions       = "DescribeTopicPartitions"
+	opDescribeVpcConnection         = "DescribeVpcConnection"
+	opGetBootstrapBrokers           = "GetBootstrapBrokers"
+	opGetClusterPolicy              = "GetClusterPolicy"
+	opGetCompatibleKafkaVersions    = "GetCompatibleKafkaVersions"
+	opListClientVpcConnections      = "ListClientVpcConnections"
+	opListClusterOperations         = "ListClusterOperations"
+	opListClusterOperationsV2       = "ListClusterOperationsV2"
+	opListClusters                  = "ListClusters"
+	opListClustersV2                = "ListClustersV2"
+	opListConfigurationRevisions    = "ListConfigurationRevisions"
+	opListConfigurations            = "ListConfigurations"
+	opListKafkaVersions             = "ListKafkaVersions"
+	opListNodes                     = "ListNodes"
+	opListReplicators               = "ListReplicators"
+	opListScramSecrets              = "ListScramSecrets"
+	opListTagsForResource           = "ListTagsForResource"
+	opListTopics                    = "ListTopics"
+	opListVpcConnections            = "ListVpcConnections"
+	opPutClusterPolicy              = "PutClusterPolicy"
+	opRebootBroker                  = "RebootBroker"
+	opRejectClientVpcConnection     = "RejectClientVpcConnection"
+	opTagResource                   = "TagResource"
+	opUntagResource                 = "UntagResource"
+	opUpdateBrokerCount             = "UpdateBrokerCount"
+	opUpdateBrokerStorage           = "UpdateBrokerStorage"
+	opUpdateBrokerType              = "UpdateBrokerType"
+	opUpdateClusterConfiguration    = "UpdateClusterConfiguration"
+	opUpdateClusterKafkaVersion     = "UpdateClusterKafkaVersion"
+	opUpdateConfiguration           = "UpdateConfiguration"
+	opUpdateConnectivity            = "UpdateConnectivity"
+	opUpdateMonitoring              = "UpdateMonitoring"
+	opUpdateRebalancing             = "UpdateRebalancing"
+	opUpdateReplicationInfo         = "UpdateReplicationInfo"
+	opUpdateSecurity                = "UpdateSecurity"
+	opUpdateStorage                 = "UpdateStorage"
+	opUpdateTopic                   = "UpdateTopic"
 )
 
 const (
-	clustersV1Prefix       = "/v1/clusters/"
-	clustersV2Prefix       = "/api/v2/clusters/"
-	configurationsPrefix   = "/v1/configurations/"
-	tagsPrefix             = "/v1/tags/"
-	bootstrapBrokersSuffix = "/bootstrap-brokers"
-	scramSecretsSuffix     = "/scram-secrets"
-	topicsSuffix           = "/topics"
-	policySuffix           = "/policy"
-	operationsPrefix       = "/v1/operations/"
-	replicatorsPrefix      = "/replication/v1/replicators/"
-	replicatorsRoot        = "/replication/v1/replicators"
-	vpcConnectionPrefix    = "/v1/vpc-connection/"
-	vpcConnectionRoot      = "/v1/vpc-connection"
+	clustersV1Prefix          = "/v1/clusters/"
+	clustersV2Prefix          = "/api/v2/clusters/"
+	configurationsPrefix      = "/v1/configurations/"
+	tagsPrefix                = "/v1/tags/"
+	bootstrapBrokersSuffix    = "/bootstrap-brokers"
+	scramSecretsSuffix        = "/scram-secrets"
+	topicsSuffix              = "/topics"
+	topicPartitionsSuffix     = "/topic-partitions"
+	policySuffix              = "/policy"
+	operationsPrefix          = "/v1/operations/"
+	operationsV2Prefix        = "/api/v2/operations/"
+	replicatorsPrefix         = "/replication/v1/replicators/"
+	replicatorsRoot           = "/replication/v1/replicators"
+	vpcConnectionPrefix       = "/v1/vpc-connection/"
+	vpcConnectionRoot         = "/v1/vpc-connection"
+	kafkaVersionsRoot         = "/v1/kafka-versions"
+	compatibleVersionsSuffix  = "/compatible-kafka-versions"
+	nodesSuffix               = "/nodes"
+	rebootBrokerSuffix        = "/reboot-broker"
+	clientVpcConnectionSuffix = "/client-vpc-connections"
+	rejectVpcConnectionSuffix = "/reject-client-vpc-connection"
+	revisionsSuffix           = "/revisions"
 
 	arnMaxParts           = 6 // arn:partition:service:region:account:resource
 	arnMinPartsForService = 3 // minimum ARN parts needed to read service field at index 2
@@ -103,15 +147,49 @@ func (h *Handler) GetSupportedOperations() []string {
 		opDeleteVpcConnection,
 		opDescribeCluster,
 		opDescribeClusterOperation,
+		opDescribeClusterOperationV2,
 		opDescribeClusterV2,
 		opDescribeConfiguration,
+		opDescribeConfigurationRevision,
+		opDescribeReplicator,
+		opDescribeTopic,
+		opDescribeTopicPartitions,
+		opDescribeVpcConnection,
 		opGetBootstrapBrokers,
+		opGetClusterPolicy,
+		opGetCompatibleKafkaVersions,
+		opListClientVpcConnections,
+		opListClusterOperations,
+		opListClusterOperationsV2,
 		opListClusters,
 		opListClustersV2,
+		opListConfigurationRevisions,
 		opListConfigurations,
+		opListKafkaVersions,
+		opListNodes,
+		opListReplicators,
+		opListScramSecrets,
 		opListTagsForResource,
+		opListTopics,
+		opListVpcConnections,
+		opPutClusterPolicy,
+		opRebootBroker,
+		opRejectClientVpcConnection,
 		opTagResource,
 		opUntagResource,
+		opUpdateBrokerCount,
+		opUpdateBrokerStorage,
+		opUpdateBrokerType,
+		opUpdateClusterConfiguration,
+		opUpdateClusterKafkaVersion,
+		opUpdateConfiguration,
+		opUpdateConnectivity,
+		opUpdateMonitoring,
+		opUpdateRebalancing,
+		opUpdateReplicationInfo,
+		opUpdateSecurity,
+		opUpdateStorage,
+		opUpdateTopic,
 	}
 }
 
@@ -133,9 +211,11 @@ func (h *Handler) RouteMatcher() service.Matcher {
 			strings.HasPrefix(p, "/api/v2/clusters") ||
 			strings.HasPrefix(p, "/v1/configurations") ||
 			strings.HasPrefix(p, "/v1/operations/") ||
+			strings.HasPrefix(p, "/api/v2/operations/") ||
 			strings.HasPrefix(p, "/replication/v1/replicators") ||
 			p == vpcConnectionRoot ||
 			strings.HasPrefix(p, vpcConnectionPrefix) ||
+			p == kafkaVersionsRoot ||
 			isKafkaTagsPath(p)
 	}
 }
@@ -259,11 +339,13 @@ func parseClusterAndConfigPath(method, path string) (string, string) {
 	return "", ""
 }
 
-// parseExtendedOpsPath handles operations, replicators, and VPC connection paths.
+// parseExtendedOpsPath handles operations, replicators, VPC connections, and misc paths.
 func parseExtendedOpsPath(method, path string) (string, string) {
 	switch {
 	case strings.HasPrefix(path, operationsPrefix):
 		return parseOperationResource(method, path[len(operationsPrefix):])
+	case strings.HasPrefix(path, operationsV2Prefix):
+		return parseOperationV2Resource(method, path[len(operationsV2Prefix):])
 	case path == replicatorsRoot || path == replicatorsRoot+"/":
 		return parseReplicatorsRoot(method)
 	case strings.HasPrefix(path, replicatorsPrefix):
@@ -272,6 +354,10 @@ func parseExtendedOpsPath(method, path string) (string, string) {
 		return parseVpcConnectionRoot(method)
 	case strings.HasPrefix(path, vpcConnectionPrefix):
 		return parseVpcConnectionResource(method, path[len(vpcConnectionPrefix):])
+	case path == kafkaVersionsRoot || path == kafkaVersionsRoot+"/":
+		if method == http.MethodGet {
+			return opListKafkaVersions, ""
+		}
 	}
 
 	return "", ""
@@ -288,33 +374,54 @@ func parseClusterRootV1(method string) (string, string) {
 	return "", ""
 }
 
+//nolint:cyclop,gocognit,gocyclo,funlen // complexity is inherent to the number of path sub-patterns handled
 func parseClusterResourceV1(method, remainder string) (string, string) {
 	decoded, _ := url.PathUnescape(remainder)
+
+	// /topic-partitions/{topicName}: must be checked before /topics suffix.
+	if idx := strings.Index(decoded, topicPartitionsSuffix+"/"); idx != -1 {
+		arnStr := decoded[:idx]
+		topicName := decoded[idx+len(topicPartitionsSuffix)+1:]
+
+		if method == http.MethodGet {
+			return opDescribeTopicPartitions, arnStr + topicKeySeparator + topicName
+		}
+
+		return "", ""
+	}
 
 	// /topics/{topicName}: must be checked before /topics suffix.
 	if idx := strings.Index(decoded, topicsSuffix+"/"); idx != -1 {
 		arnStr := decoded[:idx]
 		topicName := decoded[idx+len(topicsSuffix)+1:]
 
-		if method == http.MethodDelete {
+		switch method {
+		case http.MethodDelete:
 			return opDeleteTopic, arnStr + topicKeySeparator + topicName
+		case http.MethodGet:
+			return opDescribeTopic, arnStr + topicKeySeparator + topicName
+		case http.MethodPut:
+			return opUpdateTopic, arnStr + topicKeySeparator + topicName
 		}
 
 		return "", ""
 	}
 
-	// /topics (no trailing topic name): CreateTopic.
+	// /topics (no trailing topic name): CreateTopic (POST) or ListTopics (GET).
 	if strings.HasSuffix(decoded, topicsSuffix) {
 		arnStr := decoded[:len(decoded)-len(topicsSuffix)]
 
-		if method == http.MethodPost {
+		switch method {
+		case http.MethodPost:
 			return opCreateTopic, arnStr
+		case http.MethodGet:
+			return opListTopics, arnStr
 		}
 
 		return "", ""
 	}
 
-	// /scram-secrets: BatchAssociateScramSecret (POST) or BatchDisassociateScramSecret (PATCH).
+	// /scram-secrets: BatchAssociateScramSecret (POST), BatchDisassociateScramSecret (PATCH), ListScramSecrets (GET).
 	if strings.HasSuffix(decoded, scramSecretsSuffix) {
 		arnStr := decoded[:len(decoded)-len(scramSecretsSuffix)]
 
@@ -323,17 +430,24 @@ func parseClusterResourceV1(method, remainder string) (string, string) {
 			return opBatchAssociateScramSecret, arnStr
 		case http.MethodPatch:
 			return opBatchDisassociateScramSecret, arnStr
+		case http.MethodGet:
+			return opListScramSecrets, arnStr
 		}
 
 		return "", ""
 	}
 
-	// /policy: DeleteClusterPolicy.
+	// /policy: DeleteClusterPolicy (DELETE), GetClusterPolicy (GET), PutClusterPolicy (PUT).
 	if strings.HasSuffix(decoded, policySuffix) {
 		arnStr := decoded[:len(decoded)-len(policySuffix)]
 
-		if method == http.MethodDelete {
+		switch method {
+		case http.MethodDelete:
 			return opDeleteClusterPolicy, arnStr
+		case http.MethodGet:
+			return opGetClusterPolicy, arnStr
+		case http.MethodPut:
+			return opPutClusterPolicy, arnStr
 		}
 
 		return "", ""
@@ -350,11 +464,80 @@ func parseClusterResourceV1(method, remainder string) (string, string) {
 		return "", ""
 	}
 
+	// /compatible-kafka-versions: GetCompatibleKafkaVersions.
+	if strings.HasSuffix(decoded, compatibleVersionsSuffix) {
+		arnStr := decoded[:len(decoded)-len(compatibleVersionsSuffix)]
+
+		if method == http.MethodGet {
+			return opGetCompatibleKafkaVersions, arnStr
+		}
+
+		return "", ""
+	}
+
+	// /nodes: ListNodes.
+	if strings.HasSuffix(decoded, nodesSuffix) {
+		arnStr := decoded[:len(decoded)-len(nodesSuffix)]
+
+		if method == http.MethodGet {
+			return opListNodes, arnStr
+		}
+
+		return "", ""
+	}
+
+	// /reboot-broker: RebootBroker.
+	if strings.HasSuffix(decoded, rebootBrokerSuffix) {
+		arnStr := decoded[:len(decoded)-len(rebootBrokerSuffix)]
+
+		if method == http.MethodPut {
+			return opRebootBroker, arnStr
+		}
+
+		return "", ""
+	}
+
+	// /client-vpc-connections: ListClientVpcConnections.
+	if strings.HasSuffix(decoded, clientVpcConnectionSuffix) {
+		arnStr := decoded[:len(decoded)-len(clientVpcConnectionSuffix)]
+
+		if method == http.MethodGet {
+			return opListClientVpcConnections, arnStr
+		}
+
+		return "", ""
+	}
+
+	// /reject-client-vpc-connection/{vpcConnectionArn}: RejectClientVpcConnection.
+	if idx := strings.Index(decoded, rejectVpcConnectionSuffix+"/"); idx != -1 {
+		vpcConnectionArn := decoded[idx+len(rejectVpcConnectionSuffix)+1:]
+
+		if method == http.MethodPut {
+			return opRejectClientVpcConnection, vpcConnectionArn
+		}
+
+		return "", ""
+	}
+
+	// /operations: ListClusterOperations (GET).
+	if strings.HasSuffix(decoded, "/operations") {
+		arnStr := decoded[:len(decoded)-len("/operations")]
+
+		if method == http.MethodGet {
+			return opListClusterOperations, arnStr
+		}
+
+		return "", ""
+	}
+
 	switch method {
 	case http.MethodGet:
 		return opDescribeCluster, decoded
 	case http.MethodDelete:
 		return opDeleteCluster, decoded
+	case http.MethodPut:
+		// PUT on a cluster ARN with update sub-ops handled inline — distinguish by query/body not path.
+		// These specific update endpoints use dedicated paths, so fallthrough to empty.
 	}
 
 	return "", ""
@@ -373,6 +556,39 @@ func parseClusterRootV2(method string) (string, string) {
 
 func parseClusterResourceV2(method, remainder string) (string, string) {
 	decoded, _ := url.PathUnescape(remainder)
+
+	// /operations: ListClusterOperationsV2.
+	if strings.HasSuffix(decoded, "/operations") {
+		arnStr := decoded[:len(decoded)-len("/operations")]
+
+		if method == http.MethodGet {
+			return opListClusterOperationsV2, arnStr
+		}
+
+		return "", ""
+	}
+
+	// Update sub-operations via PUT with specific suffixes.
+	if method == http.MethodPut {
+		for suffix, op := range map[string]string{
+			"/broker-count":   opUpdateBrokerCount,
+			"/broker-storage": opUpdateBrokerStorage,
+			"/broker-type":    opUpdateBrokerType,
+			"/configuration":  opUpdateClusterConfiguration,
+			"/kafka-version":  opUpdateClusterKafkaVersion,
+			"/connectivity":   opUpdateConnectivity,
+			"/monitoring":     opUpdateMonitoring,
+			"/rebalancing":    opUpdateRebalancing,
+			"/security":       opUpdateSecurity,
+			"/storage":        opUpdateStorage,
+		} {
+			if strings.HasSuffix(decoded, suffix) {
+				arnStr := decoded[:len(decoded)-len(suffix)]
+
+				return op, arnStr
+			}
+		}
+	}
 
 	if method == http.MethodGet {
 		return opDescribeClusterV2, decoded
@@ -395,11 +611,35 @@ func parseConfigurationRoot(method string) (string, string) {
 func parseConfigurationResource(method, remainder string) (string, string) {
 	decoded, _ := url.PathUnescape(remainder)
 
+	// /revisions/{revision}: DescribeConfigurationRevision (GET) or ListConfigurationRevisions (GET on root).
+	if idx := strings.Index(decoded, revisionsSuffix+"/"); idx != -1 {
+		configArn := decoded[:idx]
+		revision := decoded[idx+len(revisionsSuffix)+1:]
+
+		if method == http.MethodGet {
+			return opDescribeConfigurationRevision, configArn + topicKeySeparator + revision
+		}
+
+		return "", ""
+	}
+
+	if strings.HasSuffix(decoded, revisionsSuffix) {
+		configArn := decoded[:len(decoded)-len(revisionsSuffix)]
+
+		if method == http.MethodGet {
+			return opListConfigurationRevisions, configArn
+		}
+
+		return "", ""
+	}
+
 	switch method {
 	case http.MethodGet:
 		return opDescribeConfiguration, decoded
 	case http.MethodDelete:
 		return opDeleteConfiguration, decoded
+	case http.MethodPut:
+		return opUpdateConfiguration, decoded
 	}
 
 	return "", ""
@@ -430,9 +670,22 @@ func parseOperationResource(method, remainder string) (string, string) {
 	return "", ""
 }
 
+func parseOperationV2Resource(method, remainder string) (string, string) {
+	decoded, _ := url.PathUnescape(remainder)
+
+	if method == http.MethodGet {
+		return opDescribeClusterOperationV2, decoded
+	}
+
+	return "", ""
+}
+
 func parseReplicatorsRoot(method string) (string, string) {
-	if method == http.MethodPost {
+	switch method {
+	case http.MethodPost:
 		return opCreateReplicator, ""
+	case http.MethodGet:
+		return opListReplicators, ""
 	}
 
 	return "", ""
@@ -441,16 +694,24 @@ func parseReplicatorsRoot(method string) (string, string) {
 func parseReplicatorResource(method, remainder string) (string, string) {
 	decoded, _ := url.PathUnescape(remainder)
 
-	if method == http.MethodDelete {
+	switch method {
+	case http.MethodDelete:
 		return opDeleteReplicator, decoded
+	case http.MethodGet:
+		return opDescribeReplicator, decoded
+	case http.MethodPut:
+		return opUpdateReplicationInfo, decoded
 	}
 
 	return "", ""
 }
 
 func parseVpcConnectionRoot(method string) (string, string) {
-	if method == http.MethodPost {
+	switch method {
+	case http.MethodPost:
 		return opCreateVpcConnection, ""
+	case http.MethodGet:
+		return opListVpcConnections, ""
 	}
 
 	return "", ""
@@ -459,8 +720,11 @@ func parseVpcConnectionRoot(method string) (string, string) {
 func parseVpcConnectionResource(method, remainder string) (string, string) {
 	decoded, _ := url.PathUnescape(remainder)
 
-	if method == http.MethodDelete {
+	switch method {
+	case http.MethodDelete:
 		return opDeleteVpcConnection, decoded
+	case http.MethodGet:
+		return opDescribeVpcConnection, decoded
 	}
 
 	return "", ""
@@ -473,6 +737,10 @@ func (h *Handler) dispatch(c *echo.Context, op, resource string, body []byte) er
 	}
 
 	if ok, err := h.dispatchNewOps(c, op, resource, body); ok {
+		return err
+	}
+
+	if ok, err := h.dispatchUpdateOps(c, op, resource, body); ok {
 		return err
 	}
 
@@ -523,27 +791,152 @@ func (h *Handler) dispatchCoreOps(c *echo.Context, op, resource string, body []b
 // dispatchNewOps handles SCRAM secrets, replicator, topic, VPC connection, and cluster policy operations.
 // Returns (true, err) if the operation was handled, (false, nil) otherwise.
 func (h *Handler) dispatchNewOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if ok, err := h.dispatchScramAndReplicatorOps(c, op, resource, body); ok {
+		return ok, err
+	}
+
+	if ok, err := h.dispatchTopicAndVpcOps(c, op, resource, body); ok {
+		return ok, err
+	}
+
+	return h.dispatchPolicyAndMiscOps(c, op, resource, body)
+}
+
+// dispatchScramAndReplicatorOps handles SCRAM and replicator ops.
+// Returns (true, err) if handled.
+func (h *Handler) dispatchScramAndReplicatorOps(
+	c *echo.Context,
+	op, resource string,
+	body []byte,
+) (bool, error) {
 	switch op {
 	case opBatchAssociateScramSecret:
 		return true, h.handleBatchAssociateScramSecret(c, resource, body)
 	case opBatchDisassociateScramSecret:
 		return true, h.handleBatchDisassociateScramSecret(c, resource, body)
+	case opListScramSecrets:
+		return true, h.handleListScramSecrets(c, resource)
 	case opCreateReplicator:
 		return true, h.handleCreateReplicator(c, body)
 	case opDeleteReplicator:
 		return true, h.handleDeleteReplicator(c, resource)
+	case opDescribeReplicator:
+		return true, h.handleDescribeReplicator(c, resource)
+	case opListReplicators:
+		return true, h.handleListReplicators(c)
+	case opUpdateReplicationInfo:
+		return true, h.handleUpdateReplicationInfo(c, resource, body)
+	}
+
+	return false, nil
+}
+
+// dispatchTopicAndVpcOps handles topic and VPC connection ops.
+// Returns (true, err) if handled.
+func (h *Handler) dispatchTopicAndVpcOps(
+	c *echo.Context,
+	op, resource string,
+	body []byte,
+) (bool, error) {
+	switch op {
 	case opCreateTopic:
 		return true, h.handleCreateTopic(c, resource, body)
 	case opDeleteTopic:
 		return true, h.handleDeleteTopic(c, resource)
+	case opDescribeTopic:
+		return true, h.handleDescribeTopic(c, resource)
+	case opDescribeTopicPartitions:
+		return true, h.handleDescribeTopicPartitions(c, resource)
+	case opListTopics:
+		return true, h.handleListTopics(c, resource)
+	case opUpdateTopic:
+		return true, h.handleUpdateTopic(c, resource, body)
 	case opCreateVpcConnection:
 		return true, h.handleCreateVpcConnection(c, body)
 	case opDeleteVpcConnection:
 		return true, h.handleDeleteVpcConnection(c, resource)
+	case opDescribeVpcConnection:
+		return true, h.handleDescribeVpcConnection(c, resource)
+	case opListVpcConnections:
+		return true, h.handleListVpcConnections(c)
+	case opListClientVpcConnections:
+		return true, h.handleListClientVpcConnections(c, resource)
+	case opRejectClientVpcConnection:
+		return true, h.handleRejectClientVpcConnection(c, resource)
+	}
+
+	return false, nil
+}
+
+// dispatchPolicyAndMiscOps handles cluster policy, operations, configuration revision,
+// and node/version ops. Returns (true, err) if handled.
+func (h *Handler) dispatchPolicyAndMiscOps(
+	c *echo.Context,
+	op, resource string,
+	body []byte,
+) (bool, error) {
+	switch op {
 	case opDeleteClusterPolicy:
 		return true, h.handleDeleteClusterPolicy(c, resource)
+	case opGetClusterPolicy:
+		return true, h.handleGetClusterPolicy(c, resource)
+	case opPutClusterPolicy:
+		return true, h.handlePutClusterPolicy(c, resource, body)
 	case opDescribeClusterOperation:
 		return true, h.handleDescribeClusterOperation(c, resource)
+	case opDescribeClusterOperationV2:
+		return true, h.handleDescribeClusterOperationV2(c, resource)
+	case opListClusterOperations:
+		return true, h.handleListClusterOperations(c, resource)
+	case opListClusterOperationsV2:
+		return true, h.handleListClusterOperationsV2(c, resource)
+	case opDescribeConfigurationRevision:
+		return true, h.handleDescribeConfigurationRevision(c, resource)
+	case opListConfigurationRevisions:
+		return true, h.handleListConfigurationRevisions(c, resource)
+	case opUpdateConfiguration:
+		return true, h.handleUpdateConfiguration(c, resource, body)
+	case opListKafkaVersions:
+		return true, h.handleListKafkaVersions(c)
+	case opGetCompatibleKafkaVersions:
+		return true, h.handleGetCompatibleKafkaVersions(c, resource)
+	case opListNodes:
+		return true, h.handleListNodes(c, resource)
+	case opRebootBroker:
+		return true, h.handleRebootBroker(c, resource, body)
+	}
+
+	return false, nil
+}
+
+// dispatchUpdateOps handles cluster and broker update operations.
+// Returns (true, err) if the operation was handled, (false, nil) otherwise.
+func (h *Handler) dispatchUpdateOps(
+	c *echo.Context,
+	op, resource string,
+	body []byte,
+) (bool, error) {
+	switch op {
+	case opUpdateBrokerCount:
+		return true, h.handleUpdateBrokerCount(c, resource, body)
+	case opUpdateBrokerStorage:
+		return true, h.handleUpdateBrokerStorage(c, resource, body)
+	case opUpdateBrokerType:
+		return true, h.handleUpdateBrokerType(c, resource, body)
+	case opUpdateClusterConfiguration:
+		return true, h.handleUpdateClusterConfiguration(c, resource, body)
+	case opUpdateClusterKafkaVersion:
+		return true, h.handleUpdateClusterKafkaVersion(c, resource, body)
+	case opUpdateConnectivity:
+		return true, h.handleUpdateConnectivity(c, resource, body)
+	case opUpdateMonitoring:
+		return true, h.handleUpdateMonitoring(c, resource, body)
+	case opUpdateRebalancing:
+		return true, h.handleUpdateRebalancing(c, resource, body)
+	case opUpdateSecurity:
+		return true, h.handleUpdateSecurity(c, resource, body)
+	case opUpdateStorage:
+		return true, h.handleUpdateStorage(c, resource, body)
 	}
 
 	return false, nil
@@ -727,7 +1120,13 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 		numBrokers = in.Provisioned.NumberOfBrokerNodes
 	}
 
-	cluster, err := h.Backend.CreateCluster(in.ClusterName, kafkaVersion, numBrokers, brokerInfo, in.Tags)
+	cluster, err := h.Backend.CreateCluster(
+		in.ClusterName,
+		kafkaVersion,
+		numBrokers,
+		brokerInfo,
+		in.Tags,
+	)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -857,7 +1256,12 @@ func (h *Handler) handleCreateConfiguration(c *echo.Context, body []byte) error 
 		)
 	}
 
-	config, err := h.Backend.CreateConfiguration(in.Name, in.Description, in.KafkaVersions, in.ServerProperties)
+	config, err := h.Backend.CreateConfiguration(
+		in.Name,
+		in.Description,
+		in.KafkaVersions,
+		in.ServerProperties,
+	)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -948,10 +1352,19 @@ type batchScramSecretOutput struct {
 // SCRAM secret handlers
 // ----------------------------------------
 
-func (h *Handler) handleBatchAssociateScramSecret(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleBatchAssociateScramSecret(
+	c *echo.Context,
+	clusterArn string,
+	body []byte,
+) error {
 	var in scramSecretInput
 	if err := json.Unmarshal(body, &in); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid request body: "+err.Error())
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
 	}
 
 	errs, err := h.Backend.BatchAssociateScramSecret(clusterArn, in.SecretArnList)
@@ -962,10 +1375,19 @@ func (h *Handler) handleBatchAssociateScramSecret(c *echo.Context, clusterArn st
 	return c.JSON(http.StatusOK, batchScramSecretOutput{UnprocessedScramSecrets: errs})
 }
 
-func (h *Handler) handleBatchDisassociateScramSecret(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleBatchDisassociateScramSecret(
+	c *echo.Context,
+	clusterArn string,
+	body []byte,
+) error {
 	var in scramSecretInput
 	if err := json.Unmarshal(body, &in); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid request body: "+err.Error())
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
 	}
 
 	errs, err := h.Backend.BatchDisassociateScramSecret(clusterArn, in.SecretArnList)
@@ -1000,7 +1422,12 @@ type createReplicatorOutput struct {
 func (h *Handler) handleCreateReplicator(c *echo.Context, body []byte) error {
 	var in createReplicatorInput
 	if err := json.Unmarshal(body, &in); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid request body: "+err.Error())
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
 	}
 
 	replicator, err := h.Backend.CreateReplicator(
@@ -1053,7 +1480,12 @@ type createTopicOutput struct {
 func (h *Handler) handleCreateTopic(c *echo.Context, clusterArn string, body []byte) error {
 	var in createTopicInput
 	if err := json.Unmarshal(body, &in); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid request body: "+err.Error())
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
 	}
 
 	topic, err := h.Backend.CreateTopic(
@@ -1078,7 +1510,12 @@ func (h *Handler) handleCreateTopic(c *echo.Context, clusterArn string, body []b
 func (h *Handler) handleDeleteTopic(c *echo.Context, resource string) error {
 	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
 	if len(parts) != topicKeySeparatorParts {
-		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid resource: missing topic name")
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid resource: missing topic name",
+		)
 	}
 
 	clusterArn, topicName := parts[0], parts[1]
@@ -1115,10 +1552,20 @@ type createVpcConnectionOutput struct {
 func (h *Handler) handleCreateVpcConnection(c *echo.Context, body []byte) error {
 	var in createVpcConnectionInput
 	if err := json.Unmarshal(body, &in); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid request body: "+err.Error())
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
 	}
 
-	conn, err := h.Backend.CreateVpcConnection(in.TargetClusterArn, in.VpcID, in.Authentication, in.Tags)
+	conn, err := h.Backend.CreateVpcConnection(
+		in.TargetClusterArn,
+		in.VpcID,
+		in.Authentication,
+		in.Tags,
+	)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1163,13 +1610,663 @@ type describeClusterOperationOutput struct {
 // Cluster operation handlers
 // ----------------------------------------
 
-func (h *Handler) handleDescribeClusterOperation(c *echo.Context, clusterOperationArn string) error {
+func (h *Handler) handleDescribeClusterOperation(
+	c *echo.Context,
+	clusterOperationArn string,
+) error {
 	op, err := h.Backend.DescribeClusterOperation(clusterOperationArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
 
 	return c.JSON(http.StatusOK, describeClusterOperationOutput{ClusterOperationInfo: op})
+}
+
+// ----------------------------------------
+// SCRAM list handler
+// ----------------------------------------
+
+type listScramSecretsOutput struct {
+	SecretArnList []string `json:"secretArnList"`
+}
+
+func (h *Handler) handleListScramSecrets(c *echo.Context, clusterArn string) error {
+	secrets, err := h.Backend.ListScramSecrets(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listScramSecretsOutput{SecretArnList: secrets})
+}
+
+// ----------------------------------------
+// Replicator describe/list/update handlers
+// ----------------------------------------
+
+type listReplicatorsOutput struct {
+	Replicators []*Replicator `json:"replicators"`
+}
+
+type updateReplicationInfoInput struct {
+	Description string `json:"description,omitempty"`
+}
+
+type updateReplicationInfoOutput struct {
+	ReplicatorArn   string `json:"replicatorArn"`
+	ReplicatorState string `json:"replicatorState"`
+}
+
+func (h *Handler) handleDescribeReplicator(c *echo.Context, replicatorArn string) error {
+	r, err := h.Backend.DescribeReplicator(replicatorArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, r)
+}
+
+func (h *Handler) handleListReplicators(c *echo.Context) error {
+	replicators := h.Backend.ListReplicators()
+
+	return c.JSON(http.StatusOK, listReplicatorsOutput{Replicators: replicators})
+}
+
+func (h *Handler) handleUpdateReplicationInfo(
+	c *echo.Context,
+	replicatorArn string,
+	body []byte,
+) error {
+	var in updateReplicationInfoInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	r, err := h.Backend.UpdateReplicationInfo(replicatorArn, in.Description)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, updateReplicationInfoOutput{
+		ReplicatorArn:   r.ReplicatorArn,
+		ReplicatorState: r.ReplicatorState,
+	})
+}
+
+// ----------------------------------------
+// Topic describe/list/update handlers
+// ----------------------------------------
+
+type listTopicsOutput struct {
+	Topics []*Topic `json:"topics"`
+}
+
+type updateTopicInput struct {
+	ConfigEntries map[string]string `json:"configEntries,omitempty"`
+	NumPartitions int32             `json:"numPartitions"`
+}
+
+func (h *Handler) handleDescribeTopic(c *echo.Context, resource string) error {
+	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
+	if len(parts) != topicKeySeparatorParts {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid resource: missing topic name",
+		)
+	}
+
+	topic, err := h.Backend.DescribeTopic(parts[0], parts[1])
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, topic)
+}
+
+func (h *Handler) handleDescribeTopicPartitions(c *echo.Context, resource string) error {
+	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
+	if len(parts) != topicKeySeparatorParts {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid resource: missing topic name",
+		)
+	}
+
+	topic, err := h.Backend.DescribeTopicPartitions(parts[0], parts[1])
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, topic)
+}
+
+func (h *Handler) handleListTopics(c *echo.Context, clusterArn string) error {
+	topics, err := h.Backend.ListTopics(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listTopicsOutput{Topics: topics})
+}
+
+func (h *Handler) handleUpdateTopic(c *echo.Context, resource string, body []byte) error {
+	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
+	if len(parts) != topicKeySeparatorParts {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid resource: missing topic name",
+		)
+	}
+
+	var in updateTopicInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	topic, err := h.Backend.UpdateTopic(parts[0], parts[1], in.NumPartitions, in.ConfigEntries)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, topic)
+}
+
+// ----------------------------------------
+// VPC connection describe/list handlers
+// ----------------------------------------
+
+type listVpcConnectionsOutput struct {
+	VpcConnections []*VpcConnection `json:"vpcConnections"`
+}
+
+func (h *Handler) handleDescribeVpcConnection(c *echo.Context, vpcConnectionArn string) error {
+	v, err := h.Backend.DescribeVpcConnection(vpcConnectionArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, v)
+}
+
+func (h *Handler) handleListVpcConnections(c *echo.Context) error {
+	conns := h.Backend.ListVpcConnections()
+
+	return c.JSON(http.StatusOK, listVpcConnectionsOutput{VpcConnections: conns})
+}
+
+func (h *Handler) handleListClientVpcConnections(c *echo.Context, clusterArn string) error {
+	conns, err := h.Backend.ListClientVpcConnections(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listVpcConnectionsOutput{VpcConnections: conns})
+}
+
+func (h *Handler) handleRejectClientVpcConnection(c *echo.Context, vpcConnectionArn string) error {
+	if err := h.Backend.RejectClientVpcConnection(vpcConnectionArn); err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// ----------------------------------------
+// Cluster policy get/put handlers
+// ----------------------------------------
+
+type getClusterPolicyOutput struct {
+	Policy string `json:"policy"`
+}
+
+type putClusterPolicyInput struct {
+	Policy string `json:"policy"`
+}
+
+func (h *Handler) handleGetClusterPolicy(c *echo.Context, clusterArn string) error {
+	policy, err := h.Backend.GetClusterPolicy(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, getClusterPolicyOutput{Policy: policy})
+}
+
+func (h *Handler) handlePutClusterPolicy(c *echo.Context, clusterArn string, body []byte) error {
+	var in putClusterPolicyInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	if err := h.Backend.PutClusterPolicy(clusterArn, in.Policy); err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// ----------------------------------------
+// Cluster operation list/V2 handlers
+// ----------------------------------------
+
+type listClusterOperationsOutput struct {
+	ClusterOperationInfoList []*ClusterOperation `json:"clusterOperationInfoList"`
+}
+
+type describeClusterOperationV2Output struct {
+	ClusterOperationInfo *ClusterOperation `json:"clusterOperationInfo"`
+}
+
+type listClusterOperationsV2Output struct {
+	ClusterOperationInfoList []*ClusterOperation `json:"clusterOperationInfoList"`
+}
+
+func (h *Handler) handleDescribeClusterOperationV2(
+	c *echo.Context,
+	clusterOperationArn string,
+) error {
+	op, err := h.Backend.DescribeClusterOperationV2(clusterOperationArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, describeClusterOperationV2Output{ClusterOperationInfo: op})
+}
+
+func (h *Handler) handleListClusterOperations(c *echo.Context, clusterArn string) error {
+	ops, err := h.Backend.ListClusterOperations(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listClusterOperationsOutput{ClusterOperationInfoList: ops})
+}
+
+func (h *Handler) handleListClusterOperationsV2(c *echo.Context, clusterArn string) error {
+	ops, err := h.Backend.ListClusterOperationsV2(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listClusterOperationsV2Output{ClusterOperationInfoList: ops})
+}
+
+// ----------------------------------------
+// Configuration revision handlers
+// ----------------------------------------
+
+type listConfigurationRevisionsOutput struct {
+	Revisions []*ConfigurationRevision `json:"revisions"`
+}
+
+type updateConfigurationInput struct {
+	Description      string `json:"description,omitempty"`
+	ServerProperties string `json:"serverProperties,omitempty"`
+}
+
+func (h *Handler) handleDescribeConfigurationRevision(c *echo.Context, resource string) error {
+	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
+	if len(parts) != topicKeySeparatorParts {
+		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid resource")
+	}
+
+	configArn := parts[0]
+	revisionStr := parts[1]
+
+	var revision int64
+	if _, err := fmt.Sscanf(revisionStr, "%d", &revision); err != nil {
+		revision = 1
+	}
+
+	rev, err := h.Backend.DescribeConfigurationRevision(configArn, revision)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, rev)
+}
+
+func (h *Handler) handleListConfigurationRevisions(c *echo.Context, configArn string) error {
+	revisions, err := h.Backend.ListConfigurationRevisions(configArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listConfigurationRevisionsOutput{Revisions: revisions})
+}
+
+func (h *Handler) handleUpdateConfiguration(c *echo.Context, configArn string, body []byte) error {
+	var in updateConfigurationInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	config, err := h.Backend.UpdateConfiguration(configArn, in.Description, in.ServerProperties)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, createConfigurationOutput{Arn: config.Arn, Name: config.Name})
+}
+
+// ----------------------------------------
+// Kafka versions / nodes / compatible handlers
+// ----------------------------------------
+
+type listKafkaVersionsOutput struct {
+	KafkaVersions []*MSKVersion `json:"kafkaVersions"`
+}
+
+type compatibleKafkaVersionsOutput struct {
+	CompatibleKafkaVersions []*MSKVersion `json:"compatibleKafkaVersions"`
+}
+
+type listNodesOutput struct {
+	NodeInfoList []*BrokerNode `json:"nodeInfoList"`
+}
+
+func (h *Handler) handleListKafkaVersions(c *echo.Context) error {
+	versions := h.Backend.ListKafkaVersions()
+
+	return c.JSON(http.StatusOK, listKafkaVersionsOutput{KafkaVersions: versions})
+}
+
+func (h *Handler) handleGetCompatibleKafkaVersions(c *echo.Context, clusterArn string) error {
+	versions, err := h.Backend.GetCompatibleKafkaVersions(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, compatibleKafkaVersionsOutput{CompatibleKafkaVersions: versions})
+}
+
+func (h *Handler) handleListNodes(c *echo.Context, clusterArn string) error {
+	nodes, err := h.Backend.ListNodes(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, listNodesOutput{NodeInfoList: nodes})
+}
+
+// ----------------------------------------
+// Broker reboot handler
+// ----------------------------------------
+
+type rebootBrokerInput struct {
+	BrokerIDs []string `json:"brokerIds"`
+}
+
+type clusterOperationOutput struct {
+	ClusterOperationArn string `json:"clusterOperationArn"`
+}
+
+func (h *Handler) handleRebootBroker(c *echo.Context, clusterArn string, body []byte) error {
+	var in rebootBrokerInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	op, err := h.Backend.RebootBroker(clusterArn, in.BrokerIDs)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+// ----------------------------------------
+// Cluster update handlers
+// ----------------------------------------
+
+type updateBrokerCountInput struct {
+	CurrentVersion            string `json:"currentVersion"`
+	TargetNumberOfBrokerNodes int32  `json:"targetNumberOfBrokerNodes"`
+}
+
+type updateBrokerStorageInput struct {
+	CurrentVersion            string                `json:"currentVersion"`
+	TargetBrokerEBSVolumeInfo []brokerEBSVolumeInfo `json:"targetBrokerEBSVolumeInfo"`
+}
+
+type brokerEBSVolumeInfo struct {
+	KafkaBrokerNodeID string `json:"kafkaBrokerNodeId"`
+	VolumeSizeGB      int32  `json:"volumeSizeGB"`
+}
+
+type updateBrokerTypeInput struct {
+	CurrentVersion     string `json:"currentVersion"`
+	TargetInstanceType string `json:"targetInstanceType"`
+}
+
+type updateClusterConfigurationInput struct {
+	CurrentVersion    string            `json:"currentVersion"`
+	ConfigurationInfo ConfigurationInfo `json:"configurationInfo"`
+}
+
+type updateClusterKafkaVersionInput struct {
+	CurrentVersion     string `json:"currentVersion"`
+	TargetKafkaVersion string `json:"targetKafkaVersion"`
+}
+
+func (h *Handler) handleUpdateBrokerCount(c *echo.Context, clusterArn string, body []byte) error {
+	var in updateBrokerCountInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	op, err := h.Backend.UpdateBrokerCount(clusterArn, in.TargetNumberOfBrokerNodes)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateBrokerStorage(c *echo.Context, clusterArn string, body []byte) error {
+	var in updateBrokerStorageInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	var volumeSize int32
+	if len(in.TargetBrokerEBSVolumeInfo) > 0 {
+		volumeSize = in.TargetBrokerEBSVolumeInfo[0].VolumeSizeGB
+	}
+
+	op, err := h.Backend.UpdateBrokerStorage(clusterArn, volumeSize)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateBrokerType(c *echo.Context, clusterArn string, body []byte) error {
+	var in updateBrokerTypeInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	op, err := h.Backend.UpdateBrokerType(clusterArn, in.TargetInstanceType)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateClusterConfiguration(
+	c *echo.Context,
+	clusterArn string,
+	body []byte,
+) error {
+	var in updateClusterConfigurationInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	op, err := h.Backend.UpdateClusterConfiguration(
+		clusterArn,
+		in.ConfigurationInfo.Arn,
+		in.ConfigurationInfo.Revision,
+	)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateClusterKafkaVersion(
+	c *echo.Context,
+	clusterArn string,
+	body []byte,
+) error {
+	var in updateClusterKafkaVersionInput
+	if err := json.Unmarshal(body, &in); err != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"invalid request body: "+err.Error(),
+		)
+	}
+
+	op, err := h.Backend.UpdateClusterKafkaVersion(clusterArn, in.TargetKafkaVersion)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateConnectivity(c *echo.Context, clusterArn string, _ []byte) error {
+	op, err := h.Backend.UpdateConnectivity(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateMonitoring(c *echo.Context, clusterArn string, _ []byte) error {
+	op, err := h.Backend.UpdateMonitoring(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateRebalancing(c *echo.Context, clusterArn string, _ []byte) error {
+	op, err := h.Backend.UpdateRebalancing(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateSecurity(c *echo.Context, clusterArn string, _ []byte) error {
+	op, err := h.Backend.UpdateSecurity(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
+}
+
+func (h *Handler) handleUpdateStorage(c *echo.Context, clusterArn string, _ []byte) error {
+	op, err := h.Backend.UpdateStorage(clusterArn)
+	if err != nil {
+		return h.writeBackendError(c, err)
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		clusterOperationOutput{ClusterOperationArn: op.ClusterOperationArn},
+	)
 }
 
 // ----------------------------------------

--- a/services/kafka/interfaces.go
+++ b/services/kafka/interfaces.go
@@ -36,6 +36,9 @@ type StorageBackend interface {
 	// Replicator operations
 	CreateReplicator(name, description, serviceExecutionRoleArn string, tags map[string]string) (*Replicator, error)
 	DeleteReplicator(replicatorArn string) error
+	DescribeReplicator(replicatorArn string) (*Replicator, error)
+	ListReplicators() []*Replicator
+	UpdateReplicationInfo(replicatorArn, description string) (*Replicator, error)
 
 	// Topic operations
 	CreateTopic(
@@ -44,16 +47,55 @@ type StorageBackend interface {
 		configEntries map[string]string,
 	) (*Topic, error)
 	DeleteTopic(clusterArn, topicName string) error
+	DescribeTopic(clusterArn, topicName string) (*Topic, error)
+	DescribeTopicPartitions(clusterArn, topicName string) (*Topic, error)
+	ListTopics(clusterArn string) ([]*Topic, error)
+	UpdateTopic(clusterArn, topicName string, numPartitions int32, configEntries map[string]string) (*Topic, error)
 
 	// VPC connection operations
 	CreateVpcConnection(targetClusterArn, vpcID, authentication string, tags map[string]string) (*VpcConnection, error)
 	DeleteVpcConnection(vpcConnectionArn string) error
+	DescribeVpcConnection(vpcConnectionArn string) (*VpcConnection, error)
+	ListVpcConnections() []*VpcConnection
+	ListClientVpcConnections(clusterArn string) ([]*VpcConnection, error)
+	RejectClientVpcConnection(vpcConnectionArn string) error
 
 	// Cluster policy operations
 	DeleteClusterPolicy(clusterArn string) error
+	GetClusterPolicy(clusterArn string) (string, error)
+	PutClusterPolicy(clusterArn, policy string) error
 
 	// Cluster operation operations
 	DescribeClusterOperation(clusterOperationArn string) (*ClusterOperation, error)
+	DescribeClusterOperationV2(clusterOperationArn string) (*ClusterOperation, error)
+	ListClusterOperations(clusterArn string) ([]*ClusterOperation, error)
+	ListClusterOperationsV2(clusterArn string) ([]*ClusterOperation, error)
+
+	// Configuration revision operations
+	DescribeConfigurationRevision(configArn string, revision int64) (*ConfigurationRevision, error)
+	UpdateConfiguration(configArn, description, serverProperties string) (*Configuration, error)
+	ListConfigurationRevisions(configArn string) ([]*ConfigurationRevision, error)
+
+	// Broker / cluster update operations
+	UpdateBrokerCount(clusterArn string, numBrokers int32) (*ClusterOperation, error)
+	UpdateBrokerStorage(clusterArn string, volumeSize int32) (*ClusterOperation, error)
+	UpdateBrokerType(clusterArn, instanceType string) (*ClusterOperation, error)
+	UpdateClusterConfiguration(clusterArn, configArn string, revision int64) (*ClusterOperation, error)
+	UpdateClusterKafkaVersion(clusterArn, targetKafkaVersion string) (*ClusterOperation, error)
+	UpdateConnectivity(clusterArn string) (*ClusterOperation, error)
+	UpdateMonitoring(clusterArn string) (*ClusterOperation, error)
+	UpdateRebalancing(clusterArn string) (*ClusterOperation, error)
+	UpdateSecurity(clusterArn string) (*ClusterOperation, error)
+	UpdateStorage(clusterArn string) (*ClusterOperation, error)
+	RebootBroker(clusterArn string, brokerIDs []string) (*ClusterOperation, error)
+
+	// SCRAM secret list
+	ListScramSecrets(clusterArn string) ([]string, error)
+
+	// Node / version ops
+	ListNodes(clusterArn string) ([]*BrokerNode, error)
+	ListKafkaVersions() []*MSKVersion
+	GetCompatibleKafkaVersions(clusterArn string) ([]*MSKVersion, error)
 
 	// Lifecycle
 	Reset()

--- a/services/kafka/sdk_completeness_test.go
+++ b/services/kafka/sdk_completeness_test.go
@@ -17,40 +17,5 @@ func TestSDKCompleteness(t *testing.T) {
 
 	backend := kafka.NewInMemoryBackend("000000000000", "us-east-1")
 	h := kafka.NewHandler(backend)
-	sdkcheck.CheckCompleteness(t, &kafkasdk.Client{}, h.GetSupportedOperations(), []string{
-		"DescribeClusterOperationV2",
-		"DescribeConfigurationRevision",
-		"DescribeReplicator",
-		"DescribeTopic",
-		"DescribeTopicPartitions",
-		"DescribeVpcConnection",
-		"GetClusterPolicy",
-		"GetCompatibleKafkaVersions",
-		"ListClientVpcConnections",
-		"ListClusterOperations",
-		"ListClusterOperationsV2",
-		"ListConfigurationRevisions",
-		"ListKafkaVersions",
-		"ListNodes",
-		"ListReplicators",
-		"ListScramSecrets",
-		"ListTopics",
-		"ListVpcConnections",
-		"PutClusterPolicy",
-		"RebootBroker",
-		"RejectClientVpcConnection",
-		"UpdateBrokerCount",
-		"UpdateBrokerStorage",
-		"UpdateBrokerType",
-		"UpdateClusterConfiguration",
-		"UpdateClusterKafkaVersion",
-		"UpdateConfiguration",
-		"UpdateConnectivity",
-		"UpdateMonitoring",
-		"UpdateRebalancing",
-		"UpdateReplicationInfo",
-		"UpdateSecurity",
-		"UpdateStorage",
-		"UpdateTopic",
-	})
+	sdkcheck.CheckCompleteness(t, &kafkasdk.Client{}, h.GetSupportedOperations(), []string{})
 }

--- a/ui/src/routes/msk/+page.svelte
+++ b/ui/src/routes/msk/+page.svelte
@@ -9,8 +9,22 @@
 		DeleteClusterCommand,
 		ListNodesCommand,
 		ListKafkaVersionsCommand,
-		type Cluster,
-		type NodeInfo
+		ListConfigurationsCommand,
+		CreateConfigurationCommand,
+		DeleteConfigurationCommand,
+		ListReplicatorsCommand,
+		CreateReplicatorCommand,
+		DeleteReplicatorCommand,
+		ListVpcConnectionsCommand,
+		DeleteVpcConnectionCommand,
+		GetBootstrapBrokersCommand,
+		ListClusterOperationsV2Command,
+		type ClusterInfo,
+		type NodeInfo,
+		type Configuration,
+		type ReplicatorSummary,
+		type VpcConnection,
+		type ClusterOperationV2
 	} from '@aws-sdk/client-kafka';
 	import { toast } from 'svelte-sonner';
 	import {
@@ -20,49 +34,79 @@
 		Plus,
 		Trash2,
 		Eye,
-		Server
+		Server,
+		Layers,
+		GitBranch,
+		Network,
+		Activity,
+		ChevronRight
 	} from 'lucide-svelte';
 
 	const msk = getMSKClient();
 
-	let loading = $state(false);
-	let activeTab = $state<'clusters' | 'versions'>('clusters');
+	type Tab = 'clusters' | 'configs' | 'replicators' | 'vpc' | 'versions';
+	let activeTab = $state<Tab>('clusters');
 	let searchQuery = $state('');
+	let loading = $state(false);
 
-	// Clusters
-	let clusters = $state<Cluster[]>([]);
-	let selectedCluster = $state<Cluster | null>(null);
+	// ─── Clusters ───────────────────────────────────────────────
+	let clusters = $state<ClusterInfo[]>([]);
+	let selectedCluster = $state<ClusterInfo | null>(null);
 	let clusterNodes = $state<NodeInfo[]>([]);
-	let loadingNodes = $state(false);
-	let showCreateModal = $state(false);
-	let creating = $state(false);
-
-	// Form
+	let clusterOps = $state<ClusterOperationV2[]>([]);
+	let bootstrapBrokers = $state('');
+	let loadingDetail = $state(false);
+	let showCreateClusterModal = $state(false);
+	let creatingCluster = $state(false);
 	let newClusterName = $state('');
 	let newBrokerCount = $state(3);
 	let newBrokerType = $state('kafka.m5.large');
 	let newKafkaVersion = $state('2.8.1');
 	let newStorageSize = $state(100);
 
-	// Versions
-	let kafkaVersions = $state<Array<{ Version?: string; Status?: string }>>([]);
-
 	const filteredClusters = $derived(
-		clusters.filter(
-			(c) =>
-				(c.ActiveOperationArn?.toLowerCase().includes(searchQuery.toLowerCase())) ||
-				(c.ClusterName ?? '').toLowerCase().includes(searchQuery.toLowerCase())
-		)
+		clusters.filter((c) => (c.ClusterName ?? '').toLowerCase().includes(searchQuery.toLowerCase()))
 	);
 
-	function clusterStateBadge(state?: string) {
-		if (state === 'ACTIVE') return 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900';
-		if (state === 'CREATING') return 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900';
-		if (state === 'DELETING') return 'text-yellow-700 bg-yellow-100 dark:text-yellow-300 dark:bg-yellow-900';
-		if (state === 'FAILED') return 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900';
-		return 'text-muted-foreground bg-muted';
+	// ─── Configurations ─────────────────────────────────────────
+	let configurations = $state<Configuration[]>([]);
+	let showCreateConfigModal = $state(false);
+	let creatingConfig = $state(false);
+	let newConfigName = $state('');
+	let newConfigProperties = $state('auto.create.topics.enable=false\ndefault.replication.factor=3');
+
+	// ─── Replicators ────────────────────────────────────────────
+	let replicators = $state<ReplicatorSummary[]>([]);
+	let showCreateReplicatorModal = $state(false);
+	let creatingReplicator = $state(false);
+	let newReplicatorName = $state('');
+	let newReplicatorRoleArn = $state('');
+
+	// ─── VPC Connections ────────────────────────────────────────
+	let vpcConnections = $state<VpcConnection[]>([]);
+
+	// ─── Kafka Versions ─────────────────────────────────────────
+	let kafkaVersions = $state<Array<{ Version?: string; Status?: string }>>([]);
+
+	// ─── Helpers ────────────────────────────────────────────────
+	function stateBadge(state?: string) {
+		switch (state) {
+			case 'ACTIVE':
+				return 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900';
+			case 'CREATING':
+				return 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900';
+			case 'DELETING':
+				return 'text-yellow-700 bg-yellow-100 dark:text-yellow-300 dark:bg-yellow-900';
+			case 'FAILED':
+				return 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900';
+			case 'RUNNING':
+				return 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900';
+			default:
+				return 'text-muted-foreground bg-muted';
+		}
 	}
 
+	// ─── Cluster actions ────────────────────────────────────────
 	async function loadClusters() {
 		loading = true;
 		try {
@@ -75,6 +119,234 @@
 		}
 	}
 
+	async function viewCluster(cluster: ClusterInfo) {
+		if (!cluster.ClusterArn) return;
+		selectedCluster = cluster;
+		loadingDetail = true;
+		clusterNodes = [];
+		clusterOps = [];
+		bootstrapBrokers = '';
+		try {
+			const [nodesRes, opsRes, brokerRes] = await Promise.allSettled([
+				msk.send(new ListNodesCommand({ ClusterArn: cluster.ClusterArn, MaxResults: 100 })),
+				msk.send(
+					new ListClusterOperationsV2Command({ ClusterArn: cluster.ClusterArn, MaxResults: 20 })
+				),
+				msk.send(new GetBootstrapBrokersCommand({ ClusterArn: cluster.ClusterArn }))
+			]);
+			if (nodesRes.status === 'fulfilled') clusterNodes = nodesRes.value.NodeInfoList ?? [];
+			if (opsRes.status === 'fulfilled')
+				clusterOps = opsRes.value.ClusterOperationInfoList ?? [];
+			if (brokerRes.status === 'fulfilled')
+				bootstrapBrokers =
+					brokerRes.value.BootstrapBrokerString ??
+					brokerRes.value.BootstrapBrokerStringTls ??
+					'';
+		} catch (e) {
+			toast.error(`Failed to load cluster detail: ${e}`);
+		} finally {
+			loadingDetail = false;
+		}
+	}
+
+	async function deleteCluster(cluster: ClusterInfo) {
+		if (
+			!cluster.ClusterArn ||
+			!(await confirmDestructive({
+				title: 'Delete MSK Cluster',
+				message: `Delete cluster "${cluster.ClusterName}"? All broker data will be permanently removed.`
+			}))
+		)
+			return;
+		try {
+			await msk.send(
+				new DeleteClusterCommand({
+					ClusterArn: cluster.ClusterArn,
+					CurrentVersion: cluster.CurrentVersion
+				})
+			);
+			toast.success(`Cluster "${cluster.ClusterName}" deletion initiated`);
+			if (selectedCluster?.ClusterArn === cluster.ClusterArn) selectedCluster = null;
+			await loadClusters();
+		} catch (e) {
+			toast.error(`Failed to delete cluster: ${e}`);
+		}
+	}
+
+	async function createCluster() {
+		if (!newClusterName.trim()) return;
+		creatingCluster = true;
+		try {
+			await msk.send(
+				new CreateClusterV2Command({
+					ClusterName: newClusterName.trim(),
+					Provisioned: {
+						BrokerNodeGroupInfo: {
+							InstanceType: newBrokerType,
+							ClientSubnets: [],
+							BrokerAZDistribution: 'DEFAULT',
+							StorageInfo: { EbsStorageInfo: { VolumeSize: newStorageSize } }
+						},
+						NumberOfBrokerNodes: newBrokerCount,
+						KafkaVersion: newKafkaVersion
+					}
+				})
+			);
+			toast.success(`Cluster "${newClusterName}" creation initiated`);
+			showCreateClusterModal = false;
+			newClusterName = '';
+			await loadClusters();
+		} catch (e) {
+			toast.error(`Failed to create cluster: ${e}`);
+		} finally {
+			creatingCluster = false;
+		}
+	}
+
+	// ─── Configuration actions ──────────────────────────────────
+	async function loadConfigurations() {
+		loading = true;
+		try {
+			const res = await msk.send(new ListConfigurationsCommand({ MaxResults: 100 }));
+			configurations = res.Configurations ?? [];
+		} catch (e) {
+			toast.error(`Failed to load configurations: ${e}`);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function createConfiguration() {
+		if (!newConfigName.trim()) return;
+		creatingConfig = true;
+		try {
+			await msk.send(
+				new CreateConfigurationCommand({
+					Name: newConfigName.trim(),
+					ServerProperties: Buffer.from(newConfigProperties).toString('base64')
+				})
+			);
+			toast.success(`Configuration "${newConfigName}" created`);
+			showCreateConfigModal = false;
+			newConfigName = '';
+			await loadConfigurations();
+		} catch (e) {
+			toast.error(`Failed to create configuration: ${e}`);
+		} finally {
+			creatingConfig = false;
+		}
+	}
+
+	async function deleteConfiguration(config: Configuration) {
+		if (
+			!config.Arn ||
+			!(await confirmDestructive({
+				title: 'Delete Configuration',
+				message: `Delete configuration "${config.Name}"?`
+			}))
+		)
+			return;
+		try {
+			await msk.send(new DeleteConfigurationCommand({ Arn: config.Arn }));
+			toast.success(`Configuration "${config.Name}" deleted`);
+			await loadConfigurations();
+		} catch (e) {
+			toast.error(`Failed to delete configuration: ${e}`);
+		}
+	}
+
+	// ─── Replicator actions ──────────────────────────────────────
+	async function loadReplicators() {
+		loading = true;
+		try {
+			const res = await msk.send(new ListReplicatorsCommand({ MaxResults: 100 }));
+			replicators = res.Replicators ?? [];
+		} catch (e) {
+			toast.error(`Failed to load replicators: ${e}`);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function createReplicator() {
+		if (!newReplicatorName.trim()) return;
+		creatingReplicator = true;
+		try {
+			await msk.send(
+				new CreateReplicatorCommand({
+					ReplicatorName: newReplicatorName.trim(),
+					ServiceExecutionRoleArn: newReplicatorRoleArn.trim() || 'arn:aws:iam::000000000000:role/MSKRole',
+					KafkaClusters: [],
+					ReplicationInfoList: []
+				})
+			);
+			toast.success(`Replicator "${newReplicatorName}" created`);
+			showCreateReplicatorModal = false;
+			newReplicatorName = '';
+			newReplicatorRoleArn = '';
+			await loadReplicators();
+		} catch (e) {
+			toast.error(`Failed to create replicator: ${e}`);
+		} finally {
+			creatingReplicator = false;
+		}
+	}
+
+	async function deleteReplicator(r: ReplicatorSummary) {
+		if (
+			!r.ReplicatorArn ||
+			!(await confirmDestructive({
+				title: 'Delete Replicator',
+				message: `Delete replicator "${r.ReplicatorName}"?`
+			}))
+		)
+			return;
+		try {
+			await msk.send(
+				new DeleteReplicatorCommand({
+					ReplicatorArn: r.ReplicatorArn,
+					CurrentVersion: r.CurrentVersion
+				})
+			);
+			toast.success(`Replicator "${r.ReplicatorName}" deleted`);
+			await loadReplicators();
+		} catch (e) {
+			toast.error(`Failed to delete replicator: ${e}`);
+		}
+	}
+
+	// ─── VPC connection actions ──────────────────────────────────
+	async function loadVpcConnections() {
+		loading = true;
+		try {
+			const res = await msk.send(new ListVpcConnectionsCommand({ MaxResults: 100 }));
+			vpcConnections = res.VpcConnections ?? [];
+		} catch (e) {
+			toast.error(`Failed to load VPC connections: ${e}`);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function deleteVpcConnection(v: VpcConnection) {
+		if (
+			!v.VpcConnectionArn ||
+			!(await confirmDestructive({
+				title: 'Delete VPC Connection',
+				message: `Delete VPC connection for VPC "${v.VpcId}"?`
+			}))
+		)
+			return;
+		try {
+			await msk.send(new DeleteVpcConnectionCommand({ Arn: v.VpcConnectionArn }));
+			toast.success('VPC connection deleted');
+			await loadVpcConnections();
+		} catch (e) {
+			toast.error(`Failed to delete VPC connection: ${e}`);
+		}
+	}
+
+	// ─── Kafka versions ──────────────────────────────────────────
 	async function loadVersions() {
 		loading = true;
 		try {
@@ -90,82 +362,35 @@
 		}
 	}
 
-	async function viewCluster(cluster: Cluster) {
-		if (!cluster.ClusterArn) return;
-		selectedCluster = cluster;
-		loadingNodes = true;
-		clusterNodes = [];
-		try {
-			const nodesRes = await msk.send(
-				new ListNodesCommand({ ClusterArn: cluster.ClusterArn, MaxResults: 100 })
-			);
-			clusterNodes = nodesRes.NodeInfoList ?? [];
-		} catch (e) {
-			toast.error(`Failed to load nodes: ${e}`);
-		} finally {
-			loadingNodes = false;
-		}
-	}
-
-	async function deleteCluster(cluster: Cluster) {
-		if (!cluster.ClusterArn || !await confirmDestructive({ title: 'Delete MSK Cluster', message: `Delete cluster "${cluster.ClusterName}"? All broker data will be permanently removed.` })) return;
-		try {
-			await msk.send(
-				new DeleteClusterCommand({
-					ClusterArn: cluster.ClusterArn,
-					CurrentVersion: cluster.CurrentVersion
-				})
-			);
-			toast.success(`Cluster "${cluster.ClusterName}" deletion initiated`);
-			await loadClusters();
-		} catch (e) {
-			toast.error(`Failed to delete cluster: ${e}`);
-		}
-	}
-
-	async function createCluster() {
-		if (!newClusterName.trim()) return;
-		creating = true;
-		try {
-			await msk.send(
-				new CreateClusterV2Command({
-					ClusterName: newClusterName.trim(),
-					Provisioned: {
-						BrokerNodeGroupInfo: {
-							InstanceType: newBrokerType,
-							ClientSubnets: [],
-							BrokerAZDistribution: 'DEFAULT',
-							StorageInfo: {
-								EbsStorageInfo: { VolumeSize: newStorageSize }
-							}
-						},
-						NumberOfBrokerNodes: newBrokerCount,
-						KafkaVersion: newKafkaVersion
-					}
-				})
-			);
-			toast.success(`Cluster "${newClusterName}" creation initiated`);
-			showCreateModal = false;
-			newClusterName = '';
-			await loadClusters();
-		} catch (e) {
-			toast.error(`Failed to create cluster: ${e}`);
-		} finally {
-			creating = false;
-		}
-	}
-
-	async function onTabChange(tab: typeof activeTab) {
+	// ─── Tab switching ───────────────────────────────────────────
+	async function onTabChange(tab: Tab) {
 		activeTab = tab;
 		searchQuery = '';
-		if (tab === 'clusters') await loadClusters();
-		else await loadVersions();
+		selectedCluster = null;
+		switch (tab) {
+			case 'clusters':
+				await loadClusters();
+				break;
+			case 'configs':
+				await loadConfigurations();
+				break;
+			case 'replicators':
+				await loadReplicators();
+				break;
+			case 'vpc':
+				await loadVpcConnections();
+				break;
+			case 'versions':
+				await loadVersions();
+				break;
+		}
 	}
 
 	onMount(() => loadClusters());
 </script>
 
 <div class="space-y-6">
+	<!-- Header -->
 	<div class="flex items-center justify-between">
 		<div class="flex items-center gap-3">
 			<Database class="h-8 w-8 text-orange-600" />
@@ -185,17 +410,24 @@
 
 	<!-- Tabs -->
 	<div class="flex border-b">
-		{#each [{ id: 'clusters', label: 'Clusters' }, { id: 'versions', label: 'Kafka Versions' }] as tab}
+		{#each [
+			{ id: 'clusters', label: 'Clusters', icon: Server },
+			{ id: 'configs', label: 'Configurations', icon: Layers },
+			{ id: 'replicators', label: 'Replicators', icon: GitBranch },
+			{ id: 'vpc', label: 'VPC Connections', icon: Network },
+			{ id: 'versions', label: 'Kafka Versions', icon: Activity }
+		] as tab}
 			<button
-				onclick={() => onTabChange(tab.id as typeof activeTab)}
-				class="px-4 py-2 text-sm font-medium border-b-2 transition-colors {activeTab === tab.id ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+				onclick={() => onTabChange(tab.id as Tab)}
+				class="flex items-center gap-1.5 px-4 py-2 text-sm font-medium border-b-2 transition-colors {activeTab === tab.id ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}"
 			>
+				<tab.icon class="h-4 w-4" />
 				{tab.label}
 			</button>
 		{/each}
 	</div>
 
-	<!-- Clusters Tab -->
+	<!-- ─── Clusters Tab ─────────────────────────────────────── -->
 	{#if activeTab === 'clusters'}
 		<div class="flex items-center justify-between gap-4">
 			<div class="relative flex-1">
@@ -208,7 +440,7 @@
 				/>
 			</div>
 			<button
-				onclick={() => (showCreateModal = true)}
+				onclick={() => (showCreateClusterModal = true)}
 				class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
 			>
 				<Plus class="h-4 w-4" />
@@ -217,9 +449,7 @@
 		</div>
 
 		{#if loading}
-			<div class="flex justify-center py-12">
-				<RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" />
-			</div>
+			<div class="flex justify-center py-12"><RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" /></div>
 		{:else if filteredClusters.length === 0}
 			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground">
 				<Database class="h-12 w-12 mb-3 opacity-30" />
@@ -240,27 +470,24 @@
 					</thead>
 					<tbody class="divide-y">
 						{#each filteredClusters as cluster}
-							<tr class="hover:bg-muted/30 cursor-pointer" onclick={() => viewCluster(cluster)}>
-								<td class="px-4 py-3 font-medium">{cluster.ClusterName}</td>
-								<td class="px-4 py-3 text-muted-foreground capitalize">
-									{cluster.ClusterType ?? '—'}
+							<tr
+								class="hover:bg-muted/30 cursor-pointer {selectedCluster?.ClusterArn === cluster.ClusterArn ? 'bg-muted/50' : ''}"
+								onclick={() => viewCluster(cluster)}
+							>
+								<td class="px-4 py-3 font-medium flex items-center gap-1">
+									{cluster.ClusterName}
+									{#if selectedCluster?.ClusterArn === cluster.ClusterArn}
+										<ChevronRight class="h-3 w-3 text-primary" />
+									{/if}
 								</td>
+								<td class="px-4 py-3 text-muted-foreground capitalize">{cluster.ClusterType ?? '—'}</td>
 								<td class="px-4 py-3">
-									<span class="rounded-full px-2 py-0.5 text-xs font-medium {clusterStateBadge(cluster.State)}">
+									<span class="rounded-full px-2 py-0.5 text-xs font-medium {stateBadge(cluster.State)}">
 										{cluster.State ?? '—'}
 									</span>
 								</td>
-								<td class="px-4 py-3 text-muted-foreground">
-									{cluster.CurrentVersion ?? '—'}
-								</td>
-								<td class="px-4 py-3 text-right flex justify-end gap-1">
-									<button
-										onclick={(e) => { e.stopPropagation(); viewCluster(cluster); }}
-										class="rounded p-1 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-950"
-										title="View nodes"
-									>
-										<Eye class="h-4 w-4" />
-									</button>
+								<td class="px-4 py-3 text-muted-foreground">{cluster.CurrentVersion ?? '—'}</td>
+								<td class="px-4 py-3 text-right">
 									<button
 										onclick={(e) => { e.stopPropagation(); deleteCluster(cluster); }}
 										class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950"
@@ -274,58 +501,250 @@
 					</tbody>
 				</table>
 			</div>
+		{/if}
 
-			<!-- Cluster Nodes Panel -->
-			{#if selectedCluster}
-				<div class="rounded-lg border p-4 space-y-3">
-					<div class="flex items-center justify-between">
-						<h3 class="font-semibold flex items-center gap-2">
-							<Server class="h-5 w-5" />
-							{selectedCluster.ClusterName} — Broker Nodes
-						</h3>
-						<button onclick={() => (selectedCluster = null)} class="text-xs text-muted-foreground hover:text-foreground">
-							Close
-						</button>
+		<!-- Cluster Detail Panel -->
+		{#if selectedCluster}
+			<div class="rounded-lg border p-4 space-y-4">
+				<div class="flex items-center justify-between">
+					<h3 class="font-semibold flex items-center gap-2">
+						<Server class="h-5 w-5" />
+						{selectedCluster.ClusterName}
+					</h3>
+					<button onclick={() => (selectedCluster = null)} class="text-xs text-muted-foreground hover:text-foreground">Close</button>
+				</div>
+
+				{#if bootstrapBrokers}
+					<div class="rounded bg-muted/50 px-3 py-2 text-xs font-mono text-muted-foreground break-all">
+						<span class="font-semibold text-foreground">Bootstrap Brokers:</span> {bootstrapBrokers}
 					</div>
-					{#if loadingNodes}
-						<RefreshCw class="h-5 w-5 animate-spin text-muted-foreground" />
-					{:else if clusterNodes.length === 0}
-						<p class="text-sm text-muted-foreground">No nodes found.</p>
-					{:else}
-						<div class="rounded border overflow-hidden">
-							<table class="w-full text-sm">
-								<thead class="bg-muted/50">
-									<tr>
-										<th class="px-3 py-2 text-left font-medium">Broker ID</th>
-										<th class="px-3 py-2 text-left font-medium">Instance Type</th>
-										<th class="px-3 py-2 text-left font-medium">Endpoint</th>
-									</tr>
-								</thead>
-								<tbody class="divide-y">
-									{#each clusterNodes as node}
+				{/if}
+
+				{#if loadingDetail}
+					<RefreshCw class="h-5 w-5 animate-spin text-muted-foreground" />
+				{:else}
+					<!-- Broker Nodes -->
+					<div>
+						<h4 class="text-sm font-medium mb-2">Broker Nodes</h4>
+						{#if clusterNodes.length === 0}
+							<p class="text-sm text-muted-foreground">No nodes found.</p>
+						{:else}
+							<div class="rounded border overflow-hidden">
+								<table class="w-full text-sm">
+									<thead class="bg-muted/50">
 										<tr>
-											<td class="px-3 py-2">{node.BrokerNodeInfo?.BrokerId ?? '—'}</td>
-											<td class="px-3 py-2">{node.InstanceType ?? '—'}</td>
-											<td class="px-3 py-2 text-xs text-muted-foreground truncate max-w-[250px]">
-												{node.BrokerNodeInfo?.Endpoints?.[0] ?? '—'}
-											</td>
+											<th class="px-3 py-2 text-left font-medium">Broker ID</th>
+											<th class="px-3 py-2 text-left font-medium">Instance Type</th>
+											<th class="px-3 py-2 text-left font-medium">Endpoint</th>
 										</tr>
-									{/each}
-								</tbody>
-							</table>
+									</thead>
+									<tbody class="divide-y">
+										{#each clusterNodes as node}
+											<tr>
+												<td class="px-3 py-2">{node.BrokerNodeInfo?.BrokerId ?? '—'}</td>
+												<td class="px-3 py-2">{node.InstanceType ?? '—'}</td>
+												<td class="px-3 py-2 text-xs text-muted-foreground truncate max-w-[250px]">
+													{node.BrokerNodeInfo?.Endpoints?.[0] ?? '—'}
+												</td>
+											</tr>
+										{/each}
+									</tbody>
+								</table>
+							</div>
+						{/if}
+					</div>
+
+					<!-- Recent Operations -->
+					{#if clusterOps.length > 0}
+						<div>
+							<h4 class="text-sm font-medium mb-2">Recent Operations</h4>
+							<div class="rounded border overflow-hidden">
+								<table class="w-full text-sm">
+									<thead class="bg-muted/50">
+										<tr>
+											<th class="px-3 py-2 text-left font-medium">Type</th>
+											<th class="px-3 py-2 text-left font-medium">State</th>
+										</tr>
+									</thead>
+									<tbody class="divide-y">
+										{#each clusterOps as op}
+											<tr>
+												<td class="px-3 py-2">{op.OperationType ?? '—'}</td>
+												<td class="px-3 py-2">
+													<span class="rounded-full px-2 py-0.5 text-xs font-medium {stateBadge(op.OperationState)}">
+														{op.OperationState ?? '—'}
+													</span>
+												</td>
+											</tr>
+										{/each}
+									</tbody>
+								</table>
+							</div>
 						</div>
 					{/if}
-				</div>
-			{/if}
+				{/if}
+			</div>
 		{/if}
 	{/if}
 
-	<!-- Versions Tab -->
+	<!-- ─── Configurations Tab ───────────────────────────────── -->
+	{#if activeTab === 'configs'}
+		<div class="flex justify-end">
+			<button
+				onclick={() => (showCreateConfigModal = true)}
+				class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
+			>
+				<Plus class="h-4 w-4" />
+				Create Configuration
+			</button>
+		</div>
+		{#if loading}
+			<div class="flex justify-center py-12"><RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" /></div>
+		{:else if configurations.length === 0}
+			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground">
+				<Layers class="h-12 w-12 mb-3 opacity-30" />
+				<p>No configurations found</p>
+			</div>
+		{:else}
+			<div class="rounded-lg border overflow-hidden">
+				<table class="w-full text-sm">
+					<thead class="bg-muted/50">
+						<tr>
+							<th class="px-4 py-3 text-left font-medium">Name</th>
+							<th class="px-4 py-3 text-left font-medium">Description</th>
+							<th class="px-4 py-3 text-left font-medium">Kafka Versions</th>
+							<th class="px-4 py-3 text-right font-medium">Actions</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y">
+						{#each configurations as config}
+							<tr class="hover:bg-muted/30">
+								<td class="px-4 py-3 font-medium">{config.Name ?? '—'}</td>
+								<td class="px-4 py-3 text-muted-foreground">{config.Description ?? '—'}</td>
+								<td class="px-4 py-3 text-muted-foreground text-xs">{(config.KafkaVersions ?? []).join(', ') || '—'}</td>
+								<td class="px-4 py-3 text-right">
+									<button
+										onclick={() => deleteConfiguration(config)}
+										class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950"
+										title="Delete"
+									>
+										<Trash2 class="h-4 w-4" />
+									</button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{/if}
+
+	<!-- ─── Replicators Tab ─────────────────────────────────── -->
+	{#if activeTab === 'replicators'}
+		<div class="flex justify-end">
+			<button
+				onclick={() => (showCreateReplicatorModal = true)}
+				class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
+			>
+				<Plus class="h-4 w-4" />
+				Create Replicator
+			</button>
+		</div>
+		{#if loading}
+			<div class="flex justify-center py-12"><RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" /></div>
+		{:else if replicators.length === 0}
+			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground">
+				<GitBranch class="h-12 w-12 mb-3 opacity-30" />
+				<p>No replicators found</p>
+			</div>
+		{:else}
+			<div class="rounded-lg border overflow-hidden">
+				<table class="w-full text-sm">
+					<thead class="bg-muted/50">
+						<tr>
+							<th class="px-4 py-3 text-left font-medium">Name</th>
+							<th class="px-4 py-3 text-left font-medium">State</th>
+							<th class="px-4 py-3 text-right font-medium">Actions</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y">
+						{#each replicators as r}
+							<tr class="hover:bg-muted/30">
+								<td class="px-4 py-3 font-medium">{r.ReplicatorName ?? '—'}</td>
+								<td class="px-4 py-3">
+									<span class="rounded-full px-2 py-0.5 text-xs font-medium {stateBadge(r.ReplicatorState)}">
+										{r.ReplicatorState ?? '—'}
+									</span>
+								</td>
+								<td class="px-4 py-3 text-right">
+									<button
+										onclick={() => deleteReplicator(r)}
+										class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950"
+										title="Delete"
+									>
+										<Trash2 class="h-4 w-4" />
+									</button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{/if}
+
+	<!-- ─── VPC Connections Tab ─────────────────────────────── -->
+	{#if activeTab === 'vpc'}
+		{#if loading}
+			<div class="flex justify-center py-12"><RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" /></div>
+		{:else if vpcConnections.length === 0}
+			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground">
+				<Network class="h-12 w-12 mb-3 opacity-30" />
+				<p>No VPC connections found</p>
+				<p class="text-sm">VPC connections are created via CreateVpcConnection API</p>
+			</div>
+		{:else}
+			<div class="rounded-lg border overflow-hidden">
+				<table class="w-full text-sm">
+					<thead class="bg-muted/50">
+						<tr>
+							<th class="px-4 py-3 text-left font-medium">VPC ID</th>
+							<th class="px-4 py-3 text-left font-medium">State</th>
+							<th class="px-4 py-3 text-left font-medium">Authentication</th>
+							<th class="px-4 py-3 text-right font-medium">Actions</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y">
+						{#each vpcConnections as v}
+							<tr class="hover:bg-muted/30">
+								<td class="px-4 py-3 font-mono font-medium">{v.VpcId ?? '—'}</td>
+								<td class="px-4 py-3">
+									<span class="rounded-full px-2 py-0.5 text-xs font-medium {stateBadge(v.State)}">
+										{v.State ?? '—'}
+									</span>
+								</td>
+								<td class="px-4 py-3 text-muted-foreground">{v.Authentication ?? '—'}</td>
+								<td class="px-4 py-3 text-right">
+									<button
+										onclick={() => deleteVpcConnection(v)}
+										class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950"
+										title="Delete"
+									>
+										<Trash2 class="h-4 w-4" />
+									</button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{/if}
+
+	<!-- ─── Kafka Versions Tab ──────────────────────────────── -->
 	{#if activeTab === 'versions'}
 		{#if loading}
-			<div class="flex justify-center py-12">
-				<RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" />
-			</div>
+			<div class="flex justify-center py-12"><RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" /></div>
 		{:else}
 			<div class="rounded-lg border overflow-hidden">
 				<table class="w-full text-sm">
@@ -340,7 +759,7 @@
 							<tr class="hover:bg-muted/30">
 								<td class="px-4 py-3 font-mono font-medium">{version.Version}</td>
 								<td class="px-4 py-3">
-									<span class="rounded-full px-2 py-0.5 text-xs font-medium {version.Status === 'ACTIVE' ? 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900' : 'text-muted-foreground bg-muted'}">
+									<span class="rounded-full px-2 py-0.5 text-xs font-medium {stateBadge(version.Status)}">
 										{version.Status ?? '—'}
 									</span>
 								</td>
@@ -353,38 +772,26 @@
 	{/if}
 </div>
 
-<!-- Create Cluster Modal -->
-{#if showCreateModal}
+<!-- ─── Create Cluster Modal ──────────────────────────────────── -->
+{#if showCreateClusterModal}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
 		<div class="w-full max-w-md rounded-lg bg-background p-6 shadow-xl">
 			<h2 class="text-lg font-semibold mb-4">Create MSK Cluster</h2>
 			<div class="space-y-3">
 				<div>
 					<label for="cluster-name" class="block text-sm font-medium mb-1">Cluster Name *</label>
-					<input
-						id="cluster-name"
-						type="text"
-						bind:value={newClusterName}
-						placeholder="my-kafka-cluster"
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-					/>
+					<input id="cluster-name" type="text" bind:value={newClusterName} placeholder="my-kafka-cluster"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
 				</div>
 				<div>
 					<label for="kafka-version" class="block text-sm font-medium mb-1">Kafka Version</label>
-					<input
-						id="kafka-version"
-						type="text"
-						bind:value={newKafkaVersion}
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-					/>
+					<input id="kafka-version" type="text" bind:value={newKafkaVersion}
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
 				</div>
 				<div>
 					<label for="broker-type" class="block text-sm font-medium mb-1">Broker Instance Type</label>
-					<select
-						id="broker-type"
-						bind:value={newBrokerType}
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-					>
+					<select id="broker-type" bind:value={newBrokerType}
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary">
 						{#each ['kafka.t3.small', 'kafka.m5.large', 'kafka.m5.xlarge', 'kafka.m5.2xlarge', 'kafka.m5.4xlarge'] as t}
 							<option value={t}>{t}</option>
 						{/each}
@@ -392,40 +799,77 @@
 				</div>
 				<div>
 					<label for="broker-count" class="block text-sm font-medium mb-1">Number of Brokers</label>
-					<input
-						id="broker-count"
-						type="number"
-						min={1}
-						max={15}
-						bind:value={newBrokerCount}
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-					/>
+					<input id="broker-count" type="number" min={1} max={15} bind:value={newBrokerCount}
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
 				</div>
 				<div>
 					<label for="storage-size" class="block text-sm font-medium mb-1">EBS Storage (GB)</label>
-					<input
-						id="storage-size"
-						type="number"
-						min={1}
-						max={16384}
-						bind:value={newStorageSize}
-						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-					/>
+					<input id="storage-size" type="number" min={1} max={16384} bind:value={newStorageSize}
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
 				</div>
 			</div>
 			<div class="mt-4 flex justify-end gap-2">
-				<button
-					onclick={() => (showCreateModal = false)}
-					class="rounded-md border px-4 py-2 text-sm hover:bg-accent"
-				>
-					Cancel
+				<button onclick={() => (showCreateClusterModal = false)} class="rounded-md border px-4 py-2 text-sm hover:bg-accent">Cancel</button>
+				<button onclick={createCluster} disabled={creatingCluster || !newClusterName.trim()}
+					class="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+					{creatingCluster ? 'Creating...' : 'Create Cluster'}
 				</button>
-				<button
-					onclick={createCluster}
-					disabled={creating || !newClusterName.trim()}
-					class="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-				>
-					{creating ? 'Creating...' : 'Create Cluster'}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- ─── Create Configuration Modal ────────────────────────────── -->
+{#if showCreateConfigModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="w-full max-w-md rounded-lg bg-background p-6 shadow-xl">
+			<h2 class="text-lg font-semibold mb-4">Create MSK Configuration</h2>
+			<div class="space-y-3">
+				<div>
+					<label for="config-name" class="block text-sm font-medium mb-1">Configuration Name *</label>
+					<input id="config-name" type="text" bind:value={newConfigName} placeholder="my-config"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
+				</div>
+				<div>
+					<label for="config-props" class="block text-sm font-medium mb-1">Server Properties</label>
+					<textarea id="config-props" bind:value={newConfigProperties} rows={5}
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary"></textarea>
+				</div>
+			</div>
+			<div class="mt-4 flex justify-end gap-2">
+				<button onclick={() => (showCreateConfigModal = false)} class="rounded-md border px-4 py-2 text-sm hover:bg-accent">Cancel</button>
+				<button onclick={createConfiguration} disabled={creatingConfig || !newConfigName.trim()}
+					class="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+					{creatingConfig ? 'Creating...' : 'Create Configuration'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- ─── Create Replicator Modal ────────────────────────────────── -->
+{#if showCreateReplicatorModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="w-full max-w-md rounded-lg bg-background p-6 shadow-xl">
+			<h2 class="text-lg font-semibold mb-4">Create MSK Replicator</h2>
+			<div class="space-y-3">
+				<div>
+					<label for="replicator-name" class="block text-sm font-medium mb-1">Replicator Name *</label>
+					<input id="replicator-name" type="text" bind:value={newReplicatorName} placeholder="my-replicator"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
+				</div>
+				<div>
+					<label for="replicator-role" class="block text-sm font-medium mb-1">Service Execution Role ARN</label>
+					<input id="replicator-role" type="text" bind:value={newReplicatorRoleArn}
+						placeholder="arn:aws:iam::000000000000:role/MSKRole"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
+				</div>
+			</div>
+			<div class="mt-4 flex justify-end gap-2">
+				<button onclick={() => (showCreateReplicatorModal = false)} class="rounded-md border px-4 py-2 text-sm hover:bg-accent">Cancel</button>
+				<button onclick={createReplicator} disabled={creatingReplicator || !newReplicatorName.trim()}
+					class="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+					{creatingReplicator ? 'Creating...' : 'Create Replicator'}
 				</button>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

- Implements all 34 MSK operations previously listed as `notImplemented` in `sdk_completeness_test.go` — `notImplemented` slice is now empty
- Adds backend methods, interface definitions, HTTP routing, and handlers for every new operation (replicator describe/list/update, topic describe/list/update/partitions, VPC connection describe/list/client/reject, cluster policy get/put, cluster operations list/V2, configuration revisions describe/list/update, broker updates count/storage/type/connectivity/monitoring/rebalancing/security/storage, reboot broker, list SCRAM secrets, list nodes, list Kafka versions, get compatible versions)
- Replaces the minimal UI with a full multi-tab dashboard: Clusters (with broker nodes + recent operations panel), Configurations, Replicators, VPC Connections, and Kafka Versions

## Test plan

- [ ] `go test ./services/kafka/...` — all tests pass, `TestSDKCompleteness` passes with empty `notImplemented`
- [ ] `golangci-lint run ./services/kafka/...` — 0 issues
- [ ] `cd ui && npm run lint && npm run fmt:check` — 0 issues
- [ ] UI: open MSK page, verify all 5 tabs render and CRUD actions work

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->