### PR TITLE
feat(cloudtrail): add 33 missing SDK ops, event data stores UI

### DIFF
--- a/services/cloudtrail/backend.go
+++ b/services/cloudtrail/backend.go
@@ -3,6 +3,7 @@ package cloudtrail
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/arn"
@@ -126,8 +127,24 @@ type Trail struct {
 	HasCustomEventSelectors    bool            `json:"hasCustomEventSelectors"`
 }
 
+// Import represents a CloudTrail import resource.
+type Import struct {
+	CreatedTimestamp time.Time `json:"createdTimestamp"`
+	UpdatedTimestamp time.Time `json:"updatedTimestamp"`
+	ImportID         string    `json:"importId"`
+	ImportSource     string    `json:"importSource,omitempty"`
+	ImportStatus     string    `json:"importStatus"`
+	Destinations     []string  `json:"destinations,omitempty"`
+}
+
+// InsightSelector represents a CloudTrail insight selector.
+type InsightSelector struct {
+	InsightType string `json:"InsightType"`
+}
+
 // InMemoryBackend is the in-memory store for CloudTrail resources.
 type InMemoryBackend struct {
+	mu               *lockmetrics.RWMutex
 	trails           map[string]*Trail
 	trailsByARN      map[string]string
 	channels         map[string]*Channel
@@ -141,13 +158,15 @@ type InMemoryBackend struct {
 	edsByName        map[string]string // name → EDS ID
 	queries          map[string]*Query
 	resourcePolicies map[string]*ResourcePolicy
-	mu               *lockmetrics.RWMutex
+	imports          map[string]*Import
+	insightSelectors map[string][]InsightSelector // trail ARN → selectors
 	accountID        string
 	region           string
 	channelCounter   int
 	dashboardCounter int
 	edsCounter       int
 	queryCounter     int
+	importCounter    int
 }
 
 // NewInMemoryBackend creates a new in-memory CloudTrail backend.
@@ -166,6 +185,8 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		edsByName:        make(map[string]string),
 		queries:          make(map[string]*Query),
 		resourcePolicies: make(map[string]*ResourcePolicy),
+		imports:          make(map[string]*Import),
+		insightSelectors: make(map[string][]InsightSelector),
 		accountID:        accountID,
 		region:           region,
 		mu:               lockmetrics.New("cloudtrail"),
@@ -203,10 +224,13 @@ func (b *InMemoryBackend) Reset() {
 	b.edsByName = make(map[string]string)
 	b.queries = make(map[string]*Query)
 	b.resourcePolicies = make(map[string]*ResourcePolicy)
+	b.imports = make(map[string]*Import)
+	b.insightSelectors = make(map[string][]InsightSelector)
 	b.channelCounter = 0
 	b.dashboardCounter = 0
 	b.edsCounter = 0
 	b.queryCounter = 0
+	b.importCounter = 0
 }
 
 // Region returns the AWS region this backend is configured for.
@@ -740,7 +764,7 @@ func (b *InMemoryBackend) CreateEventDataStore(
 		EventDataStoreID:     id,
 		EventDataStoreARN:    edsARN,
 		Name:                 name,
-		Status:               "ENABLED",
+		Status:               statusEnabled,
 		MultiRegionEnabled:   multiRegionEnabled,
 		OrganizationEnabled:  organizationEnabled,
 		TerminationProtected: terminationProtected,
@@ -866,4 +890,523 @@ func (b *InMemoryBackend) DescribeQuery(queryID string) (*Query, error) {
 	cp := *q
 
 	return &cp, nil
+}
+
+// GetEventDataStore returns an event data store by ID or ARN.
+func (b *InMemoryBackend) GetEventDataStore(edsIDOrARN string) (*EventDataStore, error) {
+	b.mu.RLock("GetEventDataStore")
+	defer b.mu.RUnlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	cp := *eds
+
+	return &cp, nil
+}
+
+// UpdateEventDataStore updates an existing event data store.
+func (b *InMemoryBackend) UpdateEventDataStore(
+	edsIDOrARN string,
+	name string,
+	multiRegionEnabled, organizationEnabled, terminationProtected *bool,
+	retentionPeriod *int32,
+) (*EventDataStore, error) {
+	b.mu.Lock("UpdateEventDataStore")
+	defer b.mu.Unlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	if name != "" && name != eds.Name {
+		delete(b.edsByName, eds.Name)
+		eds.Name = name
+		b.edsByName[name] = id
+	}
+	if multiRegionEnabled != nil {
+		eds.MultiRegionEnabled = *multiRegionEnabled
+	}
+	if organizationEnabled != nil {
+		eds.OrganizationEnabled = *organizationEnabled
+	}
+	if terminationProtected != nil {
+		eds.TerminationProtected = *terminationProtected
+	}
+	if retentionPeriod != nil {
+		eds.RetentionPeriod = *retentionPeriod
+	}
+	eds.UpdatedTimestamp = time.Now().UTC()
+	cp := *eds
+
+	return &cp, nil
+}
+
+// ListEventDataStores returns all event data stores.
+func (b *InMemoryBackend) ListEventDataStores() []*EventDataStore {
+	b.mu.RLock("ListEventDataStores")
+	defer b.mu.RUnlock()
+
+	list := make([]*EventDataStore, 0, len(b.eventDataStores))
+	for _, eds := range b.eventDataStores {
+		cp := *eds
+		list = append(list, &cp)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].EventDataStoreARN < list[j].EventDataStoreARN })
+
+	return list
+}
+
+// RestoreEventDataStore restores a deleted event data store (sets status to ENABLED).
+func (b *InMemoryBackend) RestoreEventDataStore(edsIDOrARN string) (*EventDataStore, error) {
+	b.mu.Lock("RestoreEventDataStore")
+	defer b.mu.Unlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	eds.Status = statusEnabled
+	eds.UpdatedTimestamp = time.Now().UTC()
+	cp := *eds
+
+	return &cp, nil
+}
+
+// StartEventDataStoreIngestion starts ingestion for an event data store.
+func (b *InMemoryBackend) StartEventDataStoreIngestion(edsIDOrARN string) error {
+	b.mu.Lock("StartEventDataStoreIngestion")
+	defer b.mu.Unlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	eds.Status = statusEnabled
+	eds.UpdatedTimestamp = time.Now().UTC()
+
+	return nil
+}
+
+// StopEventDataStoreIngestion stops ingestion for an event data store.
+func (b *InMemoryBackend) StopEventDataStoreIngestion(edsIDOrARN string) error {
+	b.mu.Lock("StopEventDataStoreIngestion")
+	defer b.mu.Unlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	eds.Status = "STOPPED_INGESTION"
+	eds.UpdatedTimestamp = time.Now().UTC()
+
+	return nil
+}
+
+// GetChannel returns a channel by ID or ARN.
+func (b *InMemoryBackend) GetChannel(channelIDOrARN string) (*Channel, error) {
+	b.mu.RLock("GetChannel")
+	defer b.mu.RUnlock()
+
+	id := channelIDOrARN
+	if mapped, ok := b.channelsByARN[channelIDOrARN]; ok {
+		id = mapped
+	}
+	ch, ok := b.channels[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: channel %s not found", ErrChannelNotFound, channelIDOrARN)
+	}
+	cp := *ch
+
+	return &cp, nil
+}
+
+// UpdateChannel updates an existing channel.
+func (b *InMemoryBackend) UpdateChannel(channelIDOrARN string, destinations []Destination) (*Channel, error) {
+	b.mu.Lock("UpdateChannel")
+	defer b.mu.Unlock()
+
+	id := channelIDOrARN
+	if mapped, ok := b.channelsByARN[channelIDOrARN]; ok {
+		id = mapped
+	}
+	ch, ok := b.channels[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: channel %s not found", ErrChannelNotFound, channelIDOrARN)
+	}
+	if destinations != nil {
+		ch.Destinations = destinations
+	}
+	cp := *ch
+
+	return &cp, nil
+}
+
+// ListChannels returns all channels.
+func (b *InMemoryBackend) ListChannels() []*Channel {
+	b.mu.RLock("ListChannels")
+	defer b.mu.RUnlock()
+
+	list := make([]*Channel, 0, len(b.channels))
+	for _, ch := range b.channels {
+		cp := *ch
+		list = append(list, &cp)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].ChannelARN < list[j].ChannelARN })
+
+	return list
+}
+
+// GetDashboard returns a dashboard by ID or ARN.
+func (b *InMemoryBackend) GetDashboard(dashIDOrARN string) (*Dashboard, error) {
+	b.mu.RLock("GetDashboard")
+	defer b.mu.RUnlock()
+
+	id := dashIDOrARN
+	if mapped, ok := b.dashboardsByARN[dashIDOrARN]; ok {
+		id = mapped
+	}
+	d, ok := b.dashboards[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: dashboard %s not found", ErrDashboardNotFound, dashIDOrARN)
+	}
+	cp := *d
+
+	return &cp, nil
+}
+
+// UpdateDashboard updates an existing dashboard.
+func (b *InMemoryBackend) UpdateDashboard(dashIDOrARN string, name string) (*Dashboard, error) {
+	b.mu.Lock("UpdateDashboard")
+	defer b.mu.Unlock()
+
+	id := dashIDOrARN
+	if mapped, ok := b.dashboardsByARN[dashIDOrARN]; ok {
+		id = mapped
+	}
+	d, ok := b.dashboards[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: dashboard %s not found", ErrDashboardNotFound, dashIDOrARN)
+	}
+	if name != "" && name != d.Name {
+		delete(b.dashboardsByName, d.Name)
+		d.Name = name
+		b.dashboardsByName[name] = id
+	}
+	cp := *d
+
+	return &cp, nil
+}
+
+// ListDashboards returns all dashboards.
+func (b *InMemoryBackend) ListDashboards() []*Dashboard {
+	b.mu.RLock("ListDashboards")
+	defer b.mu.RUnlock()
+
+	list := make([]*Dashboard, 0, len(b.dashboards))
+	for _, d := range b.dashboards {
+		cp := *d
+		list = append(list, &cp)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].DashboardARN < list[j].DashboardARN })
+
+	return list
+}
+
+// StartDashboardRefresh triggers a refresh of a dashboard (sets status to REFRESHING).
+func (b *InMemoryBackend) StartDashboardRefresh(dashIDOrARN string) (*Dashboard, error) {
+	b.mu.Lock("StartDashboardRefresh")
+	defer b.mu.Unlock()
+
+	id := dashIDOrARN
+	if mapped, ok := b.dashboardsByARN[dashIDOrARN]; ok {
+		id = mapped
+	}
+	d, ok := b.dashboards[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: dashboard %s not found", ErrDashboardNotFound, dashIDOrARN)
+	}
+	d.Status = "REFRESHING"
+	cp := *d
+
+	return &cp, nil
+}
+
+// GetQueryResults returns results for a completed query (stub returns empty rows).
+func (b *InMemoryBackend) GetQueryResults(queryID string) (*Query, error) {
+	b.mu.RLock("GetQueryResults")
+	defer b.mu.RUnlock()
+
+	q, ok := b.queries[queryID]
+	if !ok {
+		return nil, fmt.Errorf("%w: query %s not found", ErrQueryNotFound, queryID)
+	}
+	cp := *q
+
+	return &cp, nil
+}
+
+// ListQueries returns all queries.
+func (b *InMemoryBackend) ListQueries() []*Query {
+	b.mu.RLock("ListQueries")
+	defer b.mu.RUnlock()
+
+	list := make([]*Query, 0, len(b.queries))
+	for _, q := range b.queries {
+		cp := *q
+		list = append(list, &cp)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].QueryID < list[j].QueryID })
+
+	return list
+}
+
+// StartImport creates an import job.
+func (b *InMemoryBackend) StartImport(destinations []string, importSource string) (*Import, error) {
+	b.mu.Lock("StartImport")
+	defer b.mu.Unlock()
+
+	b.importCounter++
+	id := fmt.Sprintf("import-%06d", b.importCounter)
+	now := time.Now().UTC()
+	imp := &Import{
+		ImportID:         id,
+		Destinations:     destinations,
+		ImportSource:     importSource,
+		ImportStatus:     "INITIALIZING",
+		CreatedTimestamp: now,
+		UpdatedTimestamp: now,
+	}
+	b.imports[id] = imp
+	cp := *imp
+
+	return &cp, nil
+}
+
+// GetImport returns an import by ID.
+func (b *InMemoryBackend) GetImport(importID string) (*Import, error) {
+	b.mu.RLock("GetImport")
+	defer b.mu.RUnlock()
+
+	imp, ok := b.imports[importID]
+	if !ok {
+		return nil, fmt.Errorf("%w: import %s not found", ErrNotFound, importID)
+	}
+	cp := *imp
+
+	return &cp, nil
+}
+
+// ListImports returns all imports.
+func (b *InMemoryBackend) ListImports() []*Import {
+	b.mu.RLock("ListImports")
+	defer b.mu.RUnlock()
+
+	list := make([]*Import, 0, len(b.imports))
+	for _, imp := range b.imports {
+		cp := *imp
+		list = append(list, &cp)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].ImportID < list[j].ImportID })
+
+	return list
+}
+
+// StopImport stops an in-progress import.
+func (b *InMemoryBackend) StopImport(importID string) (*Import, error) {
+	b.mu.Lock("StopImport")
+	defer b.mu.Unlock()
+
+	imp, ok := b.imports[importID]
+	if !ok {
+		return nil, fmt.Errorf("%w: import %s not found", ErrNotFound, importID)
+	}
+	imp.ImportStatus = "STOPPED"
+	imp.UpdatedTimestamp = time.Now().UTC()
+	cp := *imp
+
+	return &cp, nil
+}
+
+// PutInsightSelectors sets insight selectors for a trail.
+func (b *InMemoryBackend) PutInsightSelectors(trailNameOrARN string, selectors []InsightSelector) error {
+	b.mu.Lock("PutInsightSelectors")
+	defer b.mu.Unlock()
+
+	t := b.findByNameOrARNLocked(trailNameOrARN)
+	if t == nil {
+		return fmt.Errorf("%w: trail %s not found", ErrNotFound, trailNameOrARN)
+	}
+	b.insightSelectors[t.TrailARN] = selectors
+
+	return nil
+}
+
+// GetInsightSelectors returns insight selectors for a trail.
+func (b *InMemoryBackend) GetInsightSelectors(trailNameOrARN string) (string, []InsightSelector, error) {
+	b.mu.RLock("GetInsightSelectors")
+	defer b.mu.RUnlock()
+
+	t := b.findByNameOrARNLocked(trailNameOrARN)
+	if t == nil {
+		return "", nil, fmt.Errorf("%w: trail %s not found", ErrNotFound, trailNameOrARN)
+	}
+	sels := b.insightSelectors[t.TrailARN]
+	cp := make([]InsightSelector, len(sels))
+	copy(cp, sels)
+
+	return t.TrailARN, cp, nil
+}
+
+// GetResourcePolicy returns the resource policy for the given ARN.
+func (b *InMemoryBackend) GetResourcePolicy(resourceARN string) (*ResourcePolicy, error) {
+	b.mu.RLock("GetResourcePolicy")
+	defer b.mu.RUnlock()
+
+	rp, ok := b.resourcePolicies[resourceARN]
+	if !ok {
+		return nil, fmt.Errorf("%w: resource policy for %s not found", ErrNotFound, resourceARN)
+	}
+	cp := *rp
+
+	return &cp, nil
+}
+
+// PutResourcePolicy sets the resource policy for the given ARN.
+func (b *InMemoryBackend) PutResourcePolicy(resourceARN, policy string) *ResourcePolicy {
+	b.mu.Lock("PutResourcePolicy")
+	defer b.mu.Unlock()
+
+	rp := &ResourcePolicy{ResourceARN: resourceARN, ResourcePolicy: policy}
+	b.resourcePolicies[resourceARN] = rp
+	cp := *rp
+
+	return &cp
+}
+
+// RegisterOrganizationDelegatedAdmin is a no-op that registers an org delegated admin.
+func (b *InMemoryBackend) RegisterOrganizationDelegatedAdmin(accountID string) error {
+	if accountID == "" {
+		return fmt.Errorf("%w: MemberAccountId is required", ErrValidation)
+	}
+
+	return nil
+}
+
+// DisableFederation disables federation for an event data store (no-op, returns EDS).
+func (b *InMemoryBackend) DisableFederation(edsIDOrARN string) (*EventDataStore, error) {
+	b.mu.Lock("DisableFederation")
+	defer b.mu.Unlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	cp := *eds
+
+	return &cp, nil
+}
+
+// EnableFederation enables federation for an event data store (no-op, returns EDS).
+func (b *InMemoryBackend) EnableFederation(edsIDOrARN, _ string) (*EventDataStore, error) {
+	b.mu.Lock("EnableFederation")
+	defer b.mu.Unlock()
+
+	id := edsIDOrARN
+	if mapped, ok := b.edsByARN[edsIDOrARN]; ok {
+		id = mapped
+	}
+	eds, ok := b.eventDataStores[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: event data store %s not found", ErrEventDataStoreNotFound, edsIDOrARN)
+	}
+	cp := *eds
+
+	return &cp, nil
+}
+
+// GenerateQuery generates a query for an event data store (stub).
+func (b *InMemoryBackend) GenerateQuery(_ []string, requestedQueryMaxResults int32) (*Query, error) {
+	b.mu.Lock("GenerateQuery")
+	defer b.mu.Unlock()
+
+	b.queryCounter++
+	qid := fmt.Sprintf("query-%06d", b.queryCounter)
+	q := &Query{
+		QueryID:      qid,
+		QueryString:  "SELECT * FROM events LIMIT " + strconv.Itoa(int(requestedQueryMaxResults)),
+		QueryStatus:  "QUEUED",
+		CreationTime: time.Now().UTC(),
+	}
+	b.queries[qid] = q
+	cp := *q
+
+	return &cp, nil
+}
+
+// GetEventConfiguration returns event configuration (stub).
+func (b *InMemoryBackend) GetEventConfiguration(resourceARN string) map[string]any {
+	return map[string]any{
+		keyResourceArn:       resourceARN,
+		"EventConfiguration": []any{},
+	}
+}
+
+// PutEventConfiguration sets event configuration (no-op stub).
+func (b *InMemoryBackend) PutEventConfiguration(resourceARN string) error {
+	if resourceARN == "" {
+		return fmt.Errorf("%w: ResourceArn is required", ErrValidation)
+	}
+
+	return nil
+}
+
+// SearchSampleQueries returns empty sample queries (stub).
+func (b *InMemoryBackend) SearchSampleQueries() []map[string]any {
+	return []map[string]any{}
+}
+
+// ListPublicKeys returns empty public keys (stub).
+func (b *InMemoryBackend) ListPublicKeys() []map[string]any {
+	return []map[string]any{}
+}
+
+// ListInsightsData returns empty insights data (stub).
+func (b *InMemoryBackend) ListInsightsData() []map[string]any {
+	return []map[string]any{}
+}
+
+// ListInsightsMetricData returns empty insights metric data (stub).
+func (b *InMemoryBackend) ListInsightsMetricData() []map[string]any {
+	return []map[string]any{}
+}
+
+// ListImportFailures returns empty import failures (stub).
+func (b *InMemoryBackend) ListImportFailures(_ string) []map[string]any {
+	return []map[string]any{}
 }

--- a/services/cloudtrail/handler.go
+++ b/services/cloudtrail/handler.go
@@ -17,6 +17,19 @@ const (
 	cloudtrailTargetPrefix  = "CloudTrail_20131101."
 	keyTrailARN             = "TrailARN"
 	keyName                 = "Name"
+	keyQueryID              = "QueryId"
+	keyQueryStatus          = "QueryStatus"
+	keyChannelArn           = "ChannelArn"
+	keySource               = "Source"
+	keyDestinations         = "Destinations"
+	keyDashboardArn         = "DashboardArn"
+	keyStatus               = "Status"
+	keyEDSArn               = "EventDataStoreArn"
+	keyImportID             = "ImportId"
+	keyImportStatus         = "ImportStatus"
+	keyResourceArn          = "ResourceArn"
+	statusEnabled           = "ENABLED"
+	statusDisabled          = "DISABLED"
 )
 
 var errInvalidRequest = errors.New("invalid request")
@@ -41,6 +54,7 @@ func (h *Handler) Name() string { return "CloudTrail" }
 // GetSupportedOperations returns the list of supported CloudTrail operations.
 func (h *Handler) GetSupportedOperations() []string {
 	return []string{
+		"AddTags",
 		"CancelQuery",
 		"CreateChannel",
 		"CreateDashboard",
@@ -54,17 +68,51 @@ func (h *Handler) GetSupportedOperations() []string {
 		"DeregisterOrganizationDelegatedAdmin",
 		"DescribeQuery",
 		"DescribeTrails",
+		"DisableFederation",
+		"EnableFederation",
+		"GenerateQuery",
+		"GetChannel",
+		"GetDashboard",
+		"GetEventConfiguration",
+		"GetEventDataStore",
 		"GetEventSelectors",
+		"GetImport",
+		"GetInsightSelectors",
+		"GetQueryResults",
+		"GetResourcePolicy",
 		"GetTrail",
 		"GetTrailStatus",
-		"AddTags",
+		"ListChannels",
+		"ListDashboards",
+		"ListEventDataStores",
+		"ListImportFailures",
+		"ListImports",
+		"ListInsightsData",
+		"ListInsightsMetricData",
+		"ListPublicKeys",
+		"ListQueries",
 		"ListTags",
 		"ListTrails",
 		"LookupEvents",
+		"PutEventConfiguration",
 		"PutEventSelectors",
+		"PutInsightSelectors",
+		"PutResourcePolicy",
+		"RegisterOrganizationDelegatedAdmin",
 		"RemoveTags",
+		"RestoreEventDataStore",
+		"SearchSampleQueries",
+		"StartDashboardRefresh",
+		"StartEventDataStoreIngestion",
+		"StartImport",
 		"StartLogging",
+		"StartQuery",
+		"StopEventDataStoreIngestion",
+		"StopImport",
 		"StopLogging",
+		"UpdateChannel",
+		"UpdateDashboard",
+		"UpdateEventDataStore",
 		"UpdateTrail",
 	}
 }
@@ -155,16 +203,51 @@ func (h *Handler) buildOps() map[string]func(*echo.Context, []byte) error {
 		"DeregisterOrganizationDelegatedAdmin": h.handleDeregisterOrganizationDelegatedAdmin,
 		"DescribeQuery":                        h.handleDescribeQuery,
 		"DescribeTrails":                       h.handleDescribeTrails,
+		"DisableFederation":                    h.handleDisableFederation,
+		"EnableFederation":                     h.handleEnableFederation,
+		"GenerateQuery":                        h.handleGenerateQuery,
+		"GetChannel":                           h.handleGetChannel,
+		"GetDashboard":                         h.handleGetDashboard,
+		"GetEventConfiguration":                h.handleGetEventConfiguration,
+		"GetEventDataStore":                    h.handleGetEventDataStore,
 		"GetEventSelectors":                    h.handleGetEventSelectors,
+		"GetImport":                            h.handleGetImport,
+		"GetInsightSelectors":                  h.handleGetInsightSelectors,
+		"GetQueryResults":                      h.handleGetQueryResults,
+		"GetResourcePolicy":                    h.handleGetResourcePolicy,
 		"GetTrail":                             h.handleGetTrail,
 		"GetTrailStatus":                       h.handleGetTrailStatus,
+		"ListChannels":                         h.handleListChannels,
+		"ListDashboards":                       h.handleListDashboards,
+		"ListEventDataStores":                  h.handleListEventDataStores,
+		"ListImportFailures":                   h.handleListImportFailures,
+		"ListImports":                          h.handleListImports,
+		"ListInsightsData":                     h.handleListInsightsData,
+		"ListInsightsMetricData":               h.handleListInsightsMetricData,
+		"ListPublicKeys":                       h.handleListPublicKeys,
+		"ListQueries":                          h.handleListQueries,
 		"ListTags":                             h.handleListTags,
 		"ListTrails":                           h.handleListTrails,
 		"LookupEvents":                         h.handleLookupEvents,
+		"PutEventConfiguration":                h.handlePutEventConfiguration,
 		"PutEventSelectors":                    h.handlePutEventSelectors,
+		"PutInsightSelectors":                  h.handlePutInsightSelectors,
+		"PutResourcePolicy":                    h.handlePutResourcePolicy,
+		"RegisterOrganizationDelegatedAdmin":   h.handleRegisterOrganizationDelegatedAdmin,
 		"RemoveTags":                           h.handleRemoveTags,
+		"RestoreEventDataStore":                h.handleRestoreEventDataStore,
+		"SearchSampleQueries":                  h.handleSearchSampleQueries,
+		"StartDashboardRefresh":                h.handleStartDashboardRefresh,
+		"StartEventDataStoreIngestion":         h.handleStartEventDataStoreIngestion,
+		"StartImport":                          h.handleStartImport,
 		"StartLogging":                         h.handleStartLogging,
+		"StartQuery":                           h.handleStartQuery,
+		"StopEventDataStoreIngestion":          h.handleStopEventDataStoreIngestion,
+		"StopImport":                           h.handleStopImport,
 		"StopLogging":                          h.handleStopLogging,
+		"UpdateChannel":                        h.handleUpdateChannel,
+		"UpdateDashboard":                      h.handleUpdateDashboard,
+		"UpdateEventDataStore":                 h.handleUpdateEventDataStore,
 		"UpdateTrail":                          h.handleUpdateTrail,
 	}
 }
@@ -577,6 +660,35 @@ func (h *Handler) handleListTrails(c *echo.Context, _ []byte) error {
 	return c.JSON(http.StatusOK, map[string]any{"Trails": items})
 }
 
+// --- StartQuery ---
+
+type startQueryBody struct {
+	QueryStatement string `json:"QueryStatement"`
+	EventDataStore string `json:"EventDataStore"`
+	DeliveryS3URI  string `json:"DeliveryS3Uri"`
+}
+
+func (h *Handler) handleStartQuery(c *echo.Context, body []byte) error {
+	var in startQueryBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if in.QueryStatement == "" {
+		return c.JSON(
+			http.StatusBadRequest,
+			errResp("InvalidParameterCombinationException", "QueryStatement is required"),
+		)
+	}
+
+	q, err := h.Backend.StartQuery(in.QueryStatement, in.EventDataStore, in.DeliveryS3URI)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{keyQueryID: q.QueryID})
+}
+
 // --- LookupEvents ---
 
 // handleLookupEvents returns an empty list of CloudTrail events (stub).
@@ -613,10 +725,10 @@ func (h *Handler) handleCreateChannel(c *echo.Context, body []byte) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		"ChannelArn":   ch.ChannelARN,
-		keyName:        ch.Name,
-		"Source":       ch.Source,
-		"Destinations": ch.Destinations,
+		keyChannelArn:   ch.ChannelARN,
+		keyName:         ch.Name,
+		keySource:       ch.Source,
+		keyDestinations: ch.Destinations,
 	})
 }
 
@@ -667,10 +779,10 @@ func (h *Handler) handleCreateDashboard(c *echo.Context, body []byte) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		"DashboardArn": d.DashboardARN,
-		keyName:        d.Name,
-		"Type":         d.Type,
-		"Status":       d.Status,
+		keyDashboardArn: d.DashboardARN,
+		keyName:         d.Name,
+		"Type":          d.Type,
+		keyStatus:       d.Status,
 	})
 }
 
@@ -731,9 +843,9 @@ func (h *Handler) handleCreateEventDataStore(c *echo.Context, body []byte) error
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		"EventDataStoreArn":            eds.EventDataStoreARN,
+		keyEDSArn:                      eds.EventDataStoreARN,
 		keyName:                        eds.Name,
-		"Status":                       eds.Status,
+		keyStatus:                      eds.Status,
 		"MultiRegionEnabled":           eds.MultiRegionEnabled,
 		"OrganizationEnabled":          eds.OrganizationEnabled,
 		"TerminationProtectionEnabled": eds.TerminationProtected,
@@ -821,8 +933,8 @@ func (h *Handler) handleCancelQuery(c *echo.Context, body []byte) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		"QueryId":     q.QueryID,
-		"QueryStatus": q.QueryStatus,
+		keyQueryID:     q.QueryID,
+		keyQueryStatus: q.QueryStatus,
 	})
 }
 
@@ -849,9 +961,9 @@ func (h *Handler) handleDescribeQuery(c *echo.Context, body []byte) error {
 	}
 
 	resp := map[string]any{
-		"QueryId":     q.QueryID,
-		"QueryString": q.QueryString,
-		"QueryStatus": q.QueryStatus,
+		keyQueryID:     q.QueryID,
+		"QueryString":  q.QueryString,
+		keyQueryStatus: q.QueryStatus,
 	}
 	if q.DeliveryS3URI != "" {
 		resp["DeliveryS3Uri"] = q.DeliveryS3URI
@@ -861,6 +973,704 @@ func (h *Handler) handleDescribeQuery(c *echo.Context, body []byte) error {
 	}
 
 	return c.JSON(http.StatusOK, resp)
+}
+
+// --- GetEventDataStore ---
+
+type getEventDataStoreBody struct {
+	EventDataStore string `json:"EventDataStore"`
+}
+
+func (h *Handler) handleGetEventDataStore(c *echo.Context, body []byte) error {
+	var in getEventDataStoreBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	eds, err := h.Backend.GetEventDataStore(in.EventDataStore)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, edsToMap(eds))
+}
+
+// --- UpdateEventDataStore ---
+
+type updateEventDataStoreBody struct {
+	RetentionPeriod              *int32 `json:"RetentionPeriod"`
+	MultiRegionEnabled           *bool  `json:"MultiRegionEnabled"`
+	OrganizationEnabled          *bool  `json:"OrganizationEnabled"`
+	TerminationProtectionEnabled *bool  `json:"TerminationProtectionEnabled"`
+	EventDataStore               string `json:"EventDataStore"`
+	Name                         string `json:"Name"`
+}
+
+func (h *Handler) handleUpdateEventDataStore(c *echo.Context, body []byte) error {
+	var in updateEventDataStoreBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	eds, err := h.Backend.UpdateEventDataStore(
+		in.EventDataStore, in.Name,
+		in.MultiRegionEnabled, in.OrganizationEnabled, in.TerminationProtectionEnabled,
+		in.RetentionPeriod,
+	)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, edsToMap(eds))
+}
+
+// --- ListEventDataStores ---
+
+func (h *Handler) handleListEventDataStores(c *echo.Context, _ []byte) error {
+	list := h.Backend.ListEventDataStores()
+	items := make([]map[string]any, 0, len(list))
+	for _, eds := range list {
+		items = append(items, edsToMap(eds))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"EventDataStores": items})
+}
+
+// --- RestoreEventDataStore ---
+
+type restoreEventDataStoreBody struct {
+	EventDataStore string `json:"EventDataStore"`
+}
+
+func (h *Handler) handleRestoreEventDataStore(c *echo.Context, body []byte) error {
+	var in restoreEventDataStoreBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	eds, err := h.Backend.RestoreEventDataStore(in.EventDataStore)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, edsToMap(eds))
+}
+
+// --- StartEventDataStoreIngestion ---
+
+type startEventDataStoreIngestionBody struct {
+	EventDataStore string `json:"EventDataStore"`
+}
+
+func (h *Handler) handleStartEventDataStoreIngestion(c *echo.Context, body []byte) error {
+	var in startEventDataStoreIngestionBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if err := h.Backend.StartEventDataStoreIngestion(in.EventDataStore); err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+// --- StopEventDataStoreIngestion ---
+
+type stopEventDataStoreIngestionBody struct {
+	EventDataStore string `json:"EventDataStore"`
+}
+
+func (h *Handler) handleStopEventDataStoreIngestion(c *echo.Context, body []byte) error {
+	var in stopEventDataStoreIngestionBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if err := h.Backend.StopEventDataStoreIngestion(in.EventDataStore); err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+// --- GetChannel ---
+
+type getChannelBody struct {
+	Channel string `json:"Channel"`
+}
+
+func (h *Handler) handleGetChannel(c *echo.Context, body []byte) error {
+	var in getChannelBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	ch, err := h.Backend.GetChannel(in.Channel)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyChannelArn:   ch.ChannelARN,
+		keyName:         ch.Name,
+		keySource:       ch.Source,
+		keyDestinations: ch.Destinations,
+	})
+}
+
+// --- UpdateChannel ---
+
+type updateChannelBody struct {
+	Channel      string        `json:"Channel"`
+	Destinations []Destination `json:"Destinations"`
+}
+
+func (h *Handler) handleUpdateChannel(c *echo.Context, body []byte) error {
+	var in updateChannelBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	ch, err := h.Backend.UpdateChannel(in.Channel, in.Destinations)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyChannelArn:   ch.ChannelARN,
+		keyName:         ch.Name,
+		keySource:       ch.Source,
+		keyDestinations: ch.Destinations,
+	})
+}
+
+// --- ListChannels ---
+
+func (h *Handler) handleListChannels(c *echo.Context, _ []byte) error {
+	list := h.Backend.ListChannels()
+	items := make([]map[string]any, 0, len(list))
+	for _, ch := range list {
+		items = append(items, map[string]any{
+			keyChannelArn: ch.ChannelARN,
+			keyName:       ch.Name,
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"Channels": items})
+}
+
+// --- GetDashboard ---
+
+type getDashboardBody struct {
+	DashboardID string `json:"DashboardId"`
+}
+
+func (h *Handler) handleGetDashboard(c *echo.Context, body []byte) error {
+	var in getDashboardBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	d, err := h.Backend.GetDashboard(in.DashboardID)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, dashToMap(d))
+}
+
+// --- UpdateDashboard ---
+
+type updateDashboardBody struct {
+	DashboardID string `json:"DashboardId"`
+	Name        string `json:"Name"`
+}
+
+func (h *Handler) handleUpdateDashboard(c *echo.Context, body []byte) error {
+	var in updateDashboardBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	d, err := h.Backend.UpdateDashboard(in.DashboardID, in.Name)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, dashToMap(d))
+}
+
+// --- ListDashboards ---
+
+func (h *Handler) handleListDashboards(c *echo.Context, _ []byte) error {
+	list := h.Backend.ListDashboards()
+	items := make([]map[string]any, 0, len(list))
+	for _, d := range list {
+		items = append(items, dashToMap(d))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"Dashboards": items})
+}
+
+// --- StartDashboardRefresh ---
+
+type startDashboardRefreshBody struct {
+	DashboardID string `json:"DashboardId"`
+}
+
+func (h *Handler) handleStartDashboardRefresh(c *echo.Context, body []byte) error {
+	var in startDashboardRefreshBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	d, err := h.Backend.StartDashboardRefresh(in.DashboardID)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyDashboardArn: d.DashboardARN,
+		keyStatus:       d.Status,
+	})
+}
+
+// --- GetQueryResults ---
+
+type getQueryResultsBody struct {
+	QueryID        string `json:"QueryId"`
+	EventDataStore string `json:"EventDataStore"`
+}
+
+func (h *Handler) handleGetQueryResults(c *echo.Context, body []byte) error {
+	var in getQueryResultsBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if in.QueryID == "" {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "QueryId is required"))
+	}
+
+	q, err := h.Backend.GetQueryResults(in.QueryID)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyQueryID:        q.QueryID,
+		keyQueryStatus:    q.QueryStatus,
+		"QueryResultRows": []any{},
+	})
+}
+
+// --- ListQueries ---
+
+func (h *Handler) handleListQueries(c *echo.Context, _ []byte) error {
+	list := h.Backend.ListQueries()
+	items := make([]map[string]any, 0, len(list))
+	for _, q := range list {
+		items = append(items, map[string]any{
+			keyQueryID:     q.QueryID,
+			keyQueryStatus: q.QueryStatus,
+			"CreationTime": q.CreationTime,
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"Queries": items})
+}
+
+// --- StartImport ---
+
+type startImportBody struct {
+	ImportSource struct {
+		S3 *struct {
+			S3LocationURI string `json:"S3LocationUri"`
+		} `json:"S3"`
+	} `json:"ImportSource"`
+	Destinations []string `json:"Destinations"`
+}
+
+func (h *Handler) handleStartImport(c *echo.Context, body []byte) error {
+	var in startImportBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	var src string
+	if in.ImportSource.S3 != nil {
+		src = in.ImportSource.S3.S3LocationURI
+	}
+
+	imp, err := h.Backend.StartImport(in.Destinations, src)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyImportID:     imp.ImportID,
+		keyImportStatus: imp.ImportStatus,
+		keyDestinations: imp.Destinations,
+	})
+}
+
+// --- GetImport ---
+
+type getImportBody struct {
+	ImportID string `json:"ImportId"`
+}
+
+func (h *Handler) handleGetImport(c *echo.Context, body []byte) error {
+	var in getImportBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	imp, err := h.Backend.GetImport(in.ImportID)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyImportID:     imp.ImportID,
+		keyImportStatus: imp.ImportStatus,
+		keyDestinations: imp.Destinations,
+	})
+}
+
+// --- ListImports ---
+
+func (h *Handler) handleListImports(c *echo.Context, _ []byte) error {
+	list := h.Backend.ListImports()
+	items := make([]map[string]any, 0, len(list))
+	for _, imp := range list {
+		items = append(items, map[string]any{
+			keyImportID:     imp.ImportID,
+			keyImportStatus: imp.ImportStatus,
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"Imports": items})
+}
+
+// --- StopImport ---
+
+type stopImportBody struct {
+	ImportID string `json:"ImportId"`
+}
+
+func (h *Handler) handleStopImport(c *echo.Context, body []byte) error {
+	var in stopImportBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	imp, err := h.Backend.StopImport(in.ImportID)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyImportID:     imp.ImportID,
+		keyImportStatus: imp.ImportStatus,
+	})
+}
+
+// --- ListImportFailures ---
+
+type listImportFailuresBody struct {
+	ImportID string `json:"ImportId"`
+}
+
+func (h *Handler) handleListImportFailures(c *echo.Context, body []byte) error {
+	var in listImportFailuresBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	failures := h.Backend.ListImportFailures(in.ImportID)
+
+	return c.JSON(http.StatusOK, map[string]any{"Failures": failures})
+}
+
+// --- PutInsightSelectors ---
+
+type putInsightSelectorsBody struct {
+	TrailName        string            `json:"TrailName"`
+	InsightSelectors []InsightSelector `json:"InsightSelectors"`
+}
+
+func (h *Handler) handlePutInsightSelectors(c *echo.Context, body []byte) error {
+	var in putInsightSelectorsBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if err := h.Backend.PutInsightSelectors(in.TrailName, in.InsightSelectors); err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		"TrailARN":         in.TrailName,
+		"InsightSelectors": in.InsightSelectors,
+	})
+}
+
+// --- GetInsightSelectors ---
+
+type getInsightSelectorsBody struct {
+	TrailName string `json:"TrailName"`
+}
+
+func (h *Handler) handleGetInsightSelectors(c *echo.Context, body []byte) error {
+	var in getInsightSelectorsBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	trailARN, selectors, err := h.Backend.GetInsightSelectors(in.TrailName)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyTrailARN:        trailARN,
+		"InsightSelectors": selectors,
+	})
+}
+
+// --- GetResourcePolicy ---
+
+type getResourcePolicyBody struct {
+	ResourceArn string `json:"ResourceArn"`
+}
+
+func (h *Handler) handleGetResourcePolicy(c *echo.Context, body []byte) error {
+	var in getResourcePolicyBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	rp, err := h.Backend.GetResourcePolicy(in.ResourceArn)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyResourceArn:   rp.ResourceARN,
+		"ResourcePolicy": rp.ResourcePolicy,
+	})
+}
+
+// --- PutResourcePolicy ---
+
+type putResourcePolicyBody struct {
+	ResourceArn    string `json:"ResourceArn"`
+	ResourcePolicy string `json:"ResourcePolicy"`
+}
+
+func (h *Handler) handlePutResourcePolicy(c *echo.Context, body []byte) error {
+	var in putResourcePolicyBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	rp := h.Backend.PutResourcePolicy(in.ResourceArn, in.ResourcePolicy)
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyResourceArn:   rp.ResourceARN,
+		"ResourcePolicy": rp.ResourcePolicy,
+	})
+}
+
+// --- RegisterOrganizationDelegatedAdmin ---
+
+type registerOrgDelegatedAdminBody struct {
+	MemberAccountID string `json:"MemberAccountId"`
+}
+
+func (h *Handler) handleRegisterOrganizationDelegatedAdmin(c *echo.Context, body []byte) error {
+	var in registerOrgDelegatedAdminBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if err := h.Backend.RegisterOrganizationDelegatedAdmin(in.MemberAccountID); err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+// --- DisableFederation ---
+
+type disableFederationBody struct {
+	EventDataStore string `json:"EventDataStore"`
+}
+
+func (h *Handler) handleDisableFederation(c *echo.Context, body []byte) error {
+	var in disableFederationBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	eds, err := h.Backend.DisableFederation(in.EventDataStore)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyEDSArn:          eds.EventDataStoreARN,
+		"FederationStatus": statusDisabled,
+	})
+}
+
+// --- EnableFederation ---
+
+type enableFederationBody struct {
+	EventDataStore    string `json:"EventDataStore"`
+	FederationRoleArn string `json:"FederationRoleArn"`
+}
+
+func (h *Handler) handleEnableFederation(c *echo.Context, body []byte) error {
+	var in enableFederationBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	eds, err := h.Backend.EnableFederation(in.EventDataStore, in.FederationRoleArn)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyEDSArn:           eds.EventDataStoreARN,
+		"FederationStatus":  statusEnabled,
+		"FederationRoleArn": in.FederationRoleArn,
+	})
+}
+
+// --- GenerateQuery ---
+
+type generateQueryBody struct {
+	EventDataStores          []string `json:"EventDataStores"`
+	RequestedQueryMaxResults int32    `json:"RequestedQueryMaxResults"`
+}
+
+func (h *Handler) handleGenerateQuery(c *echo.Context, body []byte) error {
+	var in generateQueryBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	maxResults := in.RequestedQueryMaxResults
+	if maxResults == 0 {
+		maxResults = 1000
+	}
+
+	q, err := h.Backend.GenerateQuery(in.EventDataStores, maxResults)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyQueryID:    q.QueryID,
+		"QueryString": q.QueryString,
+	})
+}
+
+// --- GetEventConfiguration ---
+
+type getEventConfigurationBody struct {
+	ResourceArn string `json:"ResourceArn"`
+}
+
+func (h *Handler) handleGetEventConfiguration(c *echo.Context, body []byte) error {
+	var in getEventConfigurationBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	result := h.Backend.GetEventConfiguration(in.ResourceArn)
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// --- PutEventConfiguration ---
+
+type putEventConfigurationBody struct {
+	ResourceArn string `json:"ResourceArn"`
+}
+
+func (h *Handler) handlePutEventConfiguration(c *echo.Context, body []byte) error {
+	var in putEventConfigurationBody
+	if err := json.Unmarshal(body, &in); err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterCombinationException", "invalid request body"))
+	}
+
+	if err := h.Backend.PutEventConfiguration(in.ResourceArn); err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+// --- SearchSampleQueries ---
+
+func (h *Handler) handleSearchSampleQueries(c *echo.Context, _ []byte) error {
+	results := h.Backend.SearchSampleQueries()
+
+	return c.JSON(http.StatusOK, map[string]any{"SampleQueries": results})
+}
+
+// --- ListPublicKeys ---
+
+func (h *Handler) handleListPublicKeys(c *echo.Context, _ []byte) error {
+	keys := h.Backend.ListPublicKeys()
+
+	return c.JSON(http.StatusOK, map[string]any{"PublicKeyList": keys})
+}
+
+// --- ListInsightsData ---
+
+func (h *Handler) handleListInsightsData(c *echo.Context, _ []byte) error {
+	data := h.Backend.ListInsightsData()
+
+	return c.JSON(http.StatusOK, map[string]any{"Insights": data})
+}
+
+// --- ListInsightsMetricData ---
+
+func (h *Handler) handleListInsightsMetricData(c *echo.Context, _ []byte) error {
+	data := h.Backend.ListInsightsMetricData()
+
+	return c.JSON(http.StatusOK, map[string]any{"Values": data})
+}
+
+// edsToMap converts an EventDataStore to the JSON map used in API responses.
+func edsToMap(eds *EventDataStore) map[string]any {
+	return map[string]any{
+		keyEDSArn:                      eds.EventDataStoreARN,
+		keyName:                        eds.Name,
+		keyStatus:                      eds.Status,
+		"MultiRegionEnabled":           eds.MultiRegionEnabled,
+		"OrganizationEnabled":          eds.OrganizationEnabled,
+		"TerminationProtectionEnabled": eds.TerminationProtected,
+		"RetentionPeriod":              eds.RetentionPeriod,
+		"CreatedTimestamp":             eds.CreatedTimestamp,
+		"UpdatedTimestamp":             eds.UpdatedTimestamp,
+	}
+}
+
+// dashToMap converts a Dashboard to the JSON map used in API responses.
+func dashToMap(d *Dashboard) map[string]any {
+	return map[string]any{
+		keyDashboardArn: d.DashboardARN,
+		keyName:         d.Name,
+		"Type":          d.Type,
+		keyStatus:       d.Status,
+	}
 }
 
 // trailToMap converts a Trail to the JSON map used in API responses.

--- a/services/cloudtrail/sdk_completeness_test.go
+++ b/services/cloudtrail/sdk_completeness_test.go
@@ -17,41 +17,5 @@ func TestSDKCompleteness(t *testing.T) {
 
 	backend := cloudtrail.NewInMemoryBackend("000000000000", "us-east-1")
 	h := cloudtrail.NewHandler(backend)
-	sdkcheck.CheckCompleteness(t, &cloudtrailsdk.Client{}, h.GetSupportedOperations(), []string{
-		"DisableFederation",
-		"EnableFederation",
-		"GenerateQuery",
-		"GetChannel",
-		"GetDashboard",
-		"GetEventConfiguration",
-		"GetEventDataStore",
-		"GetImport",
-		"GetInsightSelectors",
-		"GetQueryResults",
-		"GetResourcePolicy",
-		"ListChannels",
-		"ListDashboards",
-		"ListEventDataStores",
-		"ListImportFailures",
-		"ListImports",
-		"ListInsightsData",
-		"ListInsightsMetricData",
-		"ListPublicKeys",
-		"ListQueries",
-		"PutEventConfiguration",
-		"PutInsightSelectors",
-		"PutResourcePolicy",
-		"RegisterOrganizationDelegatedAdmin",
-		"RestoreEventDataStore",
-		"SearchSampleQueries",
-		"StartDashboardRefresh",
-		"StartEventDataStoreIngestion",
-		"StartImport",
-		"StartQuery",
-		"StopEventDataStoreIngestion",
-		"StopImport",
-		"UpdateChannel",
-		"UpdateDashboard",
-		"UpdateEventDataStore",
-	})
+	sdkcheck.CheckCompleteness(t, &cloudtrailsdk.Client{}, h.GetSupportedOperations(), []string{})
 }

--- a/ui/src/routes/cloudtrail/+page.svelte
+++ b/ui/src/routes/cloudtrail/+page.svelte
@@ -10,8 +10,13 @@
 		StopLoggingCommand,
 		CreateTrailCommand,
 		DeleteTrailCommand,
+		ListEventDataStoresCommand,
+		CreateEventDataStoreCommand,
+		DeleteEventDataStoreCommand,
+		StartEventDataStoreIngestionCommand,
+		StopEventDataStoreIngestionCommand,
 		type Trail,
-		type TrailInfo,
+		type EventDataStore,
 		type Event as CloudTrailEvent,
 		type LookupAttribute
 	} from '@aws-sdk/client-cloudtrail';
@@ -27,13 +32,14 @@
 		CheckCircle,
 		XCircle,
 		Clock,
-		Filter
+		Filter,
+		Database
 	} from 'lucide-svelte';
 
 	const ct = getCloudTrailClient();
 
 	let loading = $state(false);
-	let activeTab = $state<'trails' | 'events'>('trails');
+	let activeTab = $state<'trails' | 'events' | 'datastores'>('trails');
 	let searchQuery = $state('');
 
 	// Trails
@@ -53,6 +59,16 @@
 	let eventEndTime = $state('');
 	let maxResults = $state(50);
 
+	// Event Data Stores
+	let eventDataStores = $state<EventDataStore[]>([]);
+	let loadingDataStores = $state(false);
+	let dsSearchQuery = $state('');
+	let showCreateDSModal = $state(false);
+	let creatingDS = $state(false);
+	let newDSName = $state('');
+	let newDSMultiRegion = $state(false);
+	let newDSRetentionPeriod = $state(90);
+
 	const filteredTrails = $derived(
 		trails.filter(
 			(t) =>
@@ -67,6 +83,12 @@
 				(e.EventName ?? '').toLowerCase().includes(eventFilter.toLowerCase()) ||
 				(e.Username ?? '').toLowerCase().includes(eventFilter.toLowerCase()) ||
 				(e.EventSource ?? '').toLowerCase().includes(eventFilter.toLowerCase())
+		)
+	);
+
+	const filteredDataStores = $derived(
+		eventDataStores.filter((ds) =>
+			(ds.Name ?? '').toLowerCase().includes(dsSearchQuery.toLowerCase())
 		)
 	);
 
@@ -170,10 +192,87 @@
 		}
 	}
 
+	async function loadDataStores() {
+		loadingDataStores = true;
+		try {
+			const res = await ct.send(new ListEventDataStoresCommand({}));
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			eventDataStores = (res.EventDataStores ?? []) as any;
+		} catch (e) {
+			toast.error(`Failed to load event data stores: ${e}`);
+		} finally {
+			loadingDataStores = false;
+		}
+	}
+
+	async function createEventDataStore() {
+		if (!newDSName.trim()) return;
+		creatingDS = true;
+		try {
+			await ct.send(
+				new CreateEventDataStoreCommand({
+					Name: newDSName.trim(),
+					MultiRegionEnabled: newDSMultiRegion,
+					RetentionPeriod: newDSRetentionPeriod
+				})
+			);
+			toast.success(`Event data store "${newDSName}" created`);
+			showCreateDSModal = false;
+			newDSName = '';
+			newDSMultiRegion = false;
+			newDSRetentionPeriod = 90;
+			await loadDataStores();
+		} catch (e) {
+			toast.error(`Failed to create event data store: ${e}`);
+		} finally {
+			creatingDS = false;
+		}
+	}
+
+	async function deleteEventDataStore(ds: EventDataStore) {
+		if (
+			!ds.EventDataStoreArn ||
+			!(await confirmDestructive({
+				title: 'Delete Event Data Store',
+				message: `Delete event data store "${ds.Name}"? All stored events will be lost.`
+			}))
+		)
+			return;
+		try {
+			await ct.send(new DeleteEventDataStoreCommand({ EventDataStore: ds.EventDataStoreArn }));
+			toast.success(`Event data store "${ds.Name}" deleted`);
+			await loadDataStores();
+		} catch (e) {
+			toast.error(`Failed to delete event data store: ${e}`);
+		}
+	}
+
+	async function toggleDSIngestion(ds: EventDataStore) {
+		if (!ds.EventDataStoreArn) return;
+		const isEnabled = ds.Status === 'ENABLED';
+		try {
+			if (isEnabled) {
+				await ct.send(
+					new StopEventDataStoreIngestionCommand({ EventDataStore: ds.EventDataStoreArn })
+				);
+				toast.success(`Stopped ingestion for "${ds.Name}"`);
+			} else {
+				await ct.send(
+					new StartEventDataStoreIngestionCommand({ EventDataStore: ds.EventDataStoreArn })
+				);
+				toast.success(`Started ingestion for "${ds.Name}"`);
+			}
+			await loadDataStores();
+		} catch (e) {
+			toast.error(`Failed to toggle ingestion: ${e}`);
+		}
+	}
+
 	async function onTabChange(tab: typeof activeTab) {
 		activeTab = tab;
 		if (tab === 'trails') await loadTrails();
-		else await lookupEvents();
+		else if (tab === 'events') await lookupEvents();
+		else await loadDataStores();
 	}
 
 	onMount(() => loadTrails());
@@ -199,7 +298,7 @@
 
 	<!-- Tabs -->
 	<div class="flex border-b">
-		{#each [{ id: 'trails', label: 'Trails' }, { id: 'events', label: 'Event History' }] as tab}
+		{#each [{ id: 'trails', label: 'Trails' }, { id: 'events', label: 'Event History' }, { id: 'datastores', label: 'Event Data Stores' }] as tab}
 			<button
 				onclick={() => onTabChange(tab.id as typeof activeTab)}
 				class="px-4 py-2 text-sm font-medium border-b-2 transition-colors {activeTab === tab.id ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}"
@@ -411,6 +510,156 @@
 		</div>
 	{/if}
 </div>
+
+<!-- Create Event Data Store Modal -->
+{#if showCreateDSModal}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="w-full max-w-md rounded-lg bg-background p-6 shadow-xl">
+			<h2 class="text-lg font-semibold mb-4">Create Event Data Store</h2>
+			<div class="space-y-3">
+				<div>
+					<label for="ds-name" class="block text-sm font-medium mb-1">Name *</label>
+					<input
+						id="ds-name"
+						type="text"
+						bind:value={newDSName}
+						placeholder="my-event-data-store"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+				</div>
+				<div>
+					<label for="ds-retention" class="block text-sm font-medium mb-1"
+						>Retention Period (days)</label
+					>
+					<input
+						id="ds-retention"
+						type="number"
+						bind:value={newDSRetentionPeriod}
+						min="7"
+						max="2557"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+				</div>
+				<div class="flex items-center gap-2">
+					<input
+						id="ds-multi"
+						type="checkbox"
+						bind:checked={newDSMultiRegion}
+						class="rounded"
+					/>
+					<label for="ds-multi" class="text-sm">Multi-region enabled</label>
+				</div>
+			</div>
+			<div class="mt-4 flex justify-end gap-2">
+				<button
+					onclick={() => (showCreateDSModal = false)}
+					class="rounded-md border px-4 py-2 text-sm hover:bg-accent"
+				>
+					Cancel
+				</button>
+				<button
+					onclick={createEventDataStore}
+					disabled={creatingDS || !newDSName.trim()}
+					class="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+				>
+					{creatingDS ? 'Creating...' : 'Create Store'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Event Data Stores Tab -->
+{#if activeTab === 'datastores'}
+	<div class="flex items-center justify-between gap-4">
+		<div class="relative flex-1">
+			<Search class="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+			<input
+				type="text"
+				placeholder="Search event data stores..."
+				bind:value={dsSearchQuery}
+				class="w-full rounded-md border bg-background pl-9 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+			/>
+		</div>
+		<button
+			onclick={() => (showCreateDSModal = true)}
+			class="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
+		>
+			<Plus class="h-4 w-4" />
+			Create Store
+		</button>
+	</div>
+
+	{#if loadingDataStores}
+		<div class="flex justify-center py-12">
+			<RefreshCw class="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	{:else if filteredDataStores.length === 0}
+		<div class="flex flex-col items-center justify-center py-12 text-muted-foreground">
+			<Database class="h-12 w-12 mb-3 opacity-30" />
+			<p>No event data stores found</p>
+			<p class="text-sm">Create an event data store to collect and query events</p>
+		</div>
+	{:else}
+		<div class="rounded-lg border overflow-hidden">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Name</th>
+						<th class="px-4 py-3 text-left font-medium">Status</th>
+						<th class="px-4 py-3 text-left font-medium">Retention (days)</th>
+						<th class="px-4 py-3 text-left font-medium">Multi-Region</th>
+						<th class="px-4 py-3 text-right font-medium">Actions</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					{#each filteredDataStores as ds}
+						<tr class="hover:bg-muted/30">
+							<td class="px-4 py-3 font-medium">{ds.Name ?? '—'}</td>
+							<td class="px-4 py-3">
+								{#if ds.Status === 'ENABLED'}
+									<span class="flex items-center gap-1 text-green-600">
+										<CheckCircle class="h-4 w-4" />
+										Enabled
+									</span>
+								{:else}
+									<span class="flex items-center gap-1 text-muted-foreground">
+										<XCircle class="h-4 w-4" />
+										{ds.Status ?? 'Unknown'}
+									</span>
+								{/if}
+							</td>
+							<td class="px-4 py-3 text-muted-foreground">{ds.RetentionPeriod ?? '—'}</td>
+							<td class="px-4 py-3 text-muted-foreground">
+								{ds.MultiRegionEnabled ? 'Yes' : 'No'}
+							</td>
+							<td class="px-4 py-3 text-right flex justify-end gap-1">
+								<button
+									onclick={() => toggleDSIngestion(ds)}
+									class="rounded p-1 hover:bg-accent"
+									title={ds.Status === 'ENABLED' ? 'Stop ingestion' : 'Start ingestion'}
+								>
+									{#if ds.Status === 'ENABLED'}
+										<Square class="h-4 w-4 text-yellow-500" />
+									{:else}
+										<Play class="h-4 w-4 text-green-500" />
+									{/if}
+								</button>
+								<button
+									onclick={() => deleteEventDataStore(ds)}
+									class="rounded p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950"
+									title="Delete event data store"
+								>
+									<Trash2 class="h-4 w-4" />
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+{/if}
 
 <!-- Create Trail Modal -->
 {#if showCreateModal}


### PR DESCRIPTION
## Summary

- Implemented all 33 missing CloudTrail SDK operations (federation, channels, dashboards, event data stores, queries, imports, insights, resource policies, org admin)
- Added `StartQuery` handler that was missing from the dispatch table
- Added Event Data Stores tab to CloudTrail UI with list, create, delete, and toggle ingestion
- Extracted repeated string keys to named constants to satisfy linter
- `golangci-lint run ./services/cloudtrail/... 2>&1 | grep -v "^level="` → 0 issues
- `npm run lint && npm run fmt:check` → 0 issues

## Test plan

- [ ] `go test ./services/cloudtrail/...` passes (TestSDKCompleteness green)
- [ ] `golangci-lint run ./services/cloudtrail/...` — 0 issues
- [ ] `npm run lint && npm run fmt:check` — 0 issues
- [ ] Event Data Stores tab shows in CloudTrail UI
- [ ] Create/delete/toggle ingestion works in UI

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->