### PR TITLE
feat(transcribe): 29 missing ops, start-job UI, vocab CRUD, call analytics

### DIFF
--- a/services/transcribe/backend.go
+++ b/services/transcribe/backend.go
@@ -162,7 +162,9 @@ func (b *InMemoryBackend) ensureNonNilMaps() {
 }
 
 // StartTranscriptionJob creates a new transcription job with synthetic results.
-func (b *InMemoryBackend) StartTranscriptionJob(jobName, languageCode, mediaFileURI string) (*TranscriptionJob, error) {
+func (b *InMemoryBackend) StartTranscriptionJob(
+	jobName, languageCode, mediaFileURI string,
+) (*TranscriptionJob, error) {
 	if jobName == "" {
 		return nil, fmt.Errorf("%w: TranscriptionJobName is required", ErrValidation)
 	}
@@ -211,7 +213,9 @@ func (b *InMemoryBackend) GetTranscriptionJob(jobName string) (*TranscriptionJob
 }
 
 // ListTranscriptionJobs returns transcription jobs, optionally filtered by status, with pagination.
-func (b *InMemoryBackend) ListTranscriptionJobs(statusFilter, nextToken string) ([]TranscriptionJob, string) {
+func (b *InMemoryBackend) ListTranscriptionJobs(
+	statusFilter, nextToken string,
+) ([]TranscriptionJob, string) {
 	b.mu.RLock("ListTranscriptionJobs")
 	defer b.mu.RUnlock()
 
@@ -224,19 +228,7 @@ func (b *InMemoryBackend) ListTranscriptionJobs(statusFilter, nextToken string) 
 
 	sort.Slice(all, func(i, j int) bool { return all[i].JobName < all[j].JobName })
 
-	startIdx := parseNextToken(nextToken)
-	if startIdx >= len(all) {
-		return []TranscriptionJob{}, ""
-	}
-	end := startIdx + transcribeDefaultPageSize
-	var outToken string
-	if end < len(all) {
-		outToken = strconv.Itoa(end)
-	} else {
-		end = len(all)
-	}
-
-	return all[startIdx:end], outToken
+	return paginateList(all, nextToken)
 }
 
 // DeleteTranscriptionJob removes a transcription job by name.
@@ -258,7 +250,9 @@ func (b *InMemoryBackend) DeleteTranscriptionJob(jobName string) error {
 }
 
 // CreateCallAnalyticsCategory creates a new Call Analytics category.
-func (b *InMemoryBackend) CreateCallAnalyticsCategory(categoryName, inputType string) (*CallAnalyticsCategory, error) {
+func (b *InMemoryBackend) CreateCallAnalyticsCategory(
+	categoryName, inputType string,
+) (*CallAnalyticsCategory, error) {
 	if categoryName == "" {
 		return nil, fmt.Errorf("%w: CategoryName is required", ErrValidation)
 	}
@@ -303,7 +297,9 @@ func (b *InMemoryBackend) DeleteCallAnalyticsCategory(categoryName string) error
 }
 
 // CreateLanguageModel creates a new custom language model.
-func (b *InMemoryBackend) CreateLanguageModel(modelName, baseModelName, languageCode string) (*LanguageModel, error) {
+func (b *InMemoryBackend) CreateLanguageModel(
+	modelName, baseModelName, languageCode string,
+) (*LanguageModel, error) {
 	if modelName == "" {
 		return nil, fmt.Errorf("%w: ModelName is required", ErrValidation)
 	}
@@ -377,7 +373,11 @@ func (b *InMemoryBackend) CreateMedicalVocabulary(
 	defer b.mu.Unlock()
 
 	if _, ok := b.medicalVocabularies[vocabularyName]; ok {
-		return nil, fmt.Errorf("%w: medical vocabulary %s already exists", ErrAlreadyExists, vocabularyName)
+		return nil, fmt.Errorf(
+			"%w: medical vocabulary %s already exists",
+			ErrAlreadyExists,
+			vocabularyName,
+		)
 	}
 
 	now := time.Now()
@@ -396,7 +396,9 @@ func (b *InMemoryBackend) CreateMedicalVocabulary(
 }
 
 // CreateVocabulary creates a new custom vocabulary.
-func (b *InMemoryBackend) CreateVocabulary(vocabularyName, languageCode string) (*Vocabulary, error) {
+func (b *InMemoryBackend) CreateVocabulary(
+	vocabularyName, languageCode string,
+) (*Vocabulary, error) {
 	if vocabularyName == "" {
 		return nil, fmt.Errorf("%w: VocabularyName is required", ErrValidation)
 	}
@@ -427,7 +429,9 @@ func (b *InMemoryBackend) CreateVocabulary(vocabularyName, languageCode string) 
 }
 
 // CreateVocabularyFilter creates a new custom vocabulary filter.
-func (b *InMemoryBackend) CreateVocabularyFilter(vocabularyFilterName, languageCode string) (*VocabularyFilter, error) {
+func (b *InMemoryBackend) CreateVocabularyFilter(
+	vocabularyFilterName, languageCode string,
+) (*VocabularyFilter, error) {
 	if vocabularyFilterName == "" {
 		return nil, fmt.Errorf("%w: VocabularyFilterName is required", ErrValidation)
 	}
@@ -440,7 +444,11 @@ func (b *InMemoryBackend) CreateVocabularyFilter(vocabularyFilterName, languageC
 	defer b.mu.Unlock()
 
 	if _, ok := b.vocabularyFilters[vocabularyFilterName]; ok {
-		return nil, fmt.Errorf("%w: vocabulary filter %s already exists", ErrAlreadyExists, vocabularyFilterName)
+		return nil, fmt.Errorf(
+			"%w: vocabulary filter %s already exists",
+			ErrAlreadyExists,
+			vocabularyFilterName,
+		)
 	}
 
 	now := time.Now()
@@ -580,6 +588,593 @@ func (b *InMemoryBackend) AddVocabularyFilterInternal(f *VocabularyFilter) {
 
 	cp := *f
 	b.vocabularyFilters[f.VocabularyFilterName] = &cp
+}
+
+// --- Call Analytics jobs ---
+
+// StartCallAnalyticsJob creates a new Call Analytics job.
+func (b *InMemoryBackend) StartCallAnalyticsJob(
+	jobName, languageCode, _ string,
+) (*CallAnalyticsJob, error) {
+	if jobName == "" {
+		return nil, fmt.Errorf("%w: CallAnalyticsJobName is required", ErrValidation)
+	}
+
+	b.mu.Lock("StartCallAnalyticsJob")
+	defer b.mu.Unlock()
+
+	if _, ok := b.callAnalyticsJobs[jobName]; ok {
+		return nil, fmt.Errorf(
+			"%w: call analytics job %s already exists",
+			ErrAlreadyExists,
+			jobName,
+		)
+	}
+
+	now := time.Now()
+	job := &CallAnalyticsJob{
+		CallAnalyticsJobName:   jobName,
+		CallAnalyticsJobStatus: jobStatusCompleted,
+		LanguageCode:           languageCode,
+		CreationTime:           now,
+		CompletionTime:         now,
+	}
+	b.callAnalyticsJobs[jobName] = job
+
+	cp := *job
+
+	return &cp, nil
+}
+
+// GetCallAnalyticsJob returns a Call Analytics job by name.
+func (b *InMemoryBackend) GetCallAnalyticsJob(jobName string) (*CallAnalyticsJob, error) {
+	b.mu.RLock("GetCallAnalyticsJob")
+	defer b.mu.RUnlock()
+
+	job, ok := b.callAnalyticsJobs[jobName]
+	if !ok {
+		return nil, fmt.Errorf("%w: call analytics job %s not found", ErrNotFound, jobName)
+	}
+
+	cp := *job
+
+	return &cp, nil
+}
+
+// ListCallAnalyticsJobs returns Call Analytics jobs with optional status filter and pagination.
+func (b *InMemoryBackend) ListCallAnalyticsJobs(
+	statusFilter, nextToken string,
+) ([]CallAnalyticsJob, string) {
+	b.mu.RLock("ListCallAnalyticsJobs")
+	defer b.mu.RUnlock()
+
+	all := make([]CallAnalyticsJob, 0, len(b.callAnalyticsJobs))
+	for _, j := range b.callAnalyticsJobs {
+		if statusFilter == "" || j.CallAnalyticsJobStatus == statusFilter {
+			all = append(all, *j)
+		}
+	}
+
+	sort.Slice(
+		all,
+		func(i, j int) bool { return all[i].CallAnalyticsJobName < all[j].CallAnalyticsJobName },
+	)
+
+	return paginateList(all, nextToken)
+}
+
+// --- Call Analytics categories (Get/Update/List) ---
+
+// GetCallAnalyticsCategory returns a Call Analytics category by name.
+func (b *InMemoryBackend) GetCallAnalyticsCategory(
+	categoryName string,
+) (*CallAnalyticsCategory, error) {
+	b.mu.RLock("GetCallAnalyticsCategory")
+	defer b.mu.RUnlock()
+
+	cat, ok := b.callAnalyticsCategories[categoryName]
+	if !ok {
+		return nil, fmt.Errorf("%w: category %s not found", ErrNotFound, categoryName)
+	}
+
+	cp := *cat
+
+	return &cp, nil
+}
+
+// UpdateCallAnalyticsCategory updates an existing Call Analytics category.
+func (b *InMemoryBackend) UpdateCallAnalyticsCategory(
+	categoryName, inputType string,
+) (*CallAnalyticsCategory, error) {
+	if categoryName == "" {
+		return nil, fmt.Errorf("%w: CategoryName is required", ErrValidation)
+	}
+
+	b.mu.Lock("UpdateCallAnalyticsCategory")
+	defer b.mu.Unlock()
+
+	cat, ok := b.callAnalyticsCategories[categoryName]
+	if !ok {
+		return nil, fmt.Errorf("%w: category %s not found", ErrNotFound, categoryName)
+	}
+
+	cat.InputType = inputType
+	cat.LastUpdateTime = time.Now()
+
+	cp := *cat
+
+	return &cp, nil
+}
+
+// ListCallAnalyticsCategories returns all Call Analytics categories with pagination.
+func (b *InMemoryBackend) ListCallAnalyticsCategories(
+	nextToken string,
+) ([]CallAnalyticsCategory, string) {
+	b.mu.RLock("ListCallAnalyticsCategories")
+	defer b.mu.RUnlock()
+
+	all := make([]CallAnalyticsCategory, 0, len(b.callAnalyticsCategories))
+	for _, c := range b.callAnalyticsCategories {
+		all = append(all, *c)
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].CategoryName < all[j].CategoryName })
+
+	return paginateList(all, nextToken)
+}
+
+// --- Vocabulary CRUD ---
+
+// GetVocabulary returns a custom vocabulary by name.
+func (b *InMemoryBackend) GetVocabulary(vocabularyName string) (*Vocabulary, error) {
+	b.mu.RLock("GetVocabulary")
+	defer b.mu.RUnlock()
+
+	v, ok := b.vocabularies[vocabularyName]
+	if !ok {
+		return nil, fmt.Errorf("%w: vocabulary %s not found", ErrNotFound, vocabularyName)
+	}
+
+	cp := *v
+
+	return &cp, nil
+}
+
+// UpdateVocabulary updates an existing custom vocabulary.
+func (b *InMemoryBackend) UpdateVocabulary(
+	vocabularyName, languageCode string,
+) (*Vocabulary, error) {
+	if vocabularyName == "" {
+		return nil, fmt.Errorf("%w: VocabularyName is required", ErrValidation)
+	}
+
+	b.mu.Lock("UpdateVocabulary")
+	defer b.mu.Unlock()
+
+	v, ok := b.vocabularies[vocabularyName]
+	if !ok {
+		return nil, fmt.Errorf("%w: vocabulary %s not found", ErrNotFound, vocabularyName)
+	}
+
+	if languageCode != "" {
+		v.LanguageCode = languageCode
+	}
+
+	v.LastModifiedTime = time.Now()
+
+	cp := *v
+
+	return &cp, nil
+}
+
+// DeleteVocabulary removes a custom vocabulary by name.
+func (b *InMemoryBackend) DeleteVocabulary(vocabularyName string) error {
+	if vocabularyName == "" {
+		return fmt.Errorf("%w: VocabularyName is required", ErrValidation)
+	}
+
+	b.mu.Lock("DeleteVocabulary")
+	defer b.mu.Unlock()
+
+	if _, ok := b.vocabularies[vocabularyName]; !ok {
+		return fmt.Errorf("%w: vocabulary %s not found", ErrNotFound, vocabularyName)
+	}
+
+	delete(b.vocabularies, vocabularyName)
+
+	return nil
+}
+
+// ListVocabularies returns custom vocabularies with optional state filter and pagination.
+func (b *InMemoryBackend) ListVocabularies(stateFilter, nextToken string) ([]Vocabulary, string) {
+	b.mu.RLock("ListVocabularies")
+	defer b.mu.RUnlock()
+
+	all := make([]Vocabulary, 0, len(b.vocabularies))
+	for _, v := range b.vocabularies {
+		if stateFilter == "" || v.VocabularyState == stateFilter {
+			all = append(all, *v)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].VocabularyName < all[j].VocabularyName })
+
+	return paginateList(all, nextToken)
+}
+
+// --- Vocabulary filter CRUD ---
+
+// GetVocabularyFilter returns a custom vocabulary filter by name.
+func (b *InMemoryBackend) GetVocabularyFilter(
+	vocabularyFilterName string,
+) (*VocabularyFilter, error) {
+	b.mu.RLock("GetVocabularyFilter")
+	defer b.mu.RUnlock()
+
+	f, ok := b.vocabularyFilters[vocabularyFilterName]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: vocabulary filter %s not found",
+			ErrNotFound,
+			vocabularyFilterName,
+		)
+	}
+
+	cp := *f
+
+	return &cp, nil
+}
+
+// UpdateVocabularyFilter updates an existing vocabulary filter.
+func (b *InMemoryBackend) UpdateVocabularyFilter(
+	vocabularyFilterName, languageCode string,
+) (*VocabularyFilter, error) {
+	if vocabularyFilterName == "" {
+		return nil, fmt.Errorf("%w: VocabularyFilterName is required", ErrValidation)
+	}
+
+	b.mu.Lock("UpdateVocabularyFilter")
+	defer b.mu.Unlock()
+
+	f, ok := b.vocabularyFilters[vocabularyFilterName]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: vocabulary filter %s not found",
+			ErrNotFound,
+			vocabularyFilterName,
+		)
+	}
+
+	if languageCode != "" {
+		f.LanguageCode = languageCode
+	}
+
+	f.LastModifiedTime = time.Now()
+
+	cp := *f
+
+	return &cp, nil
+}
+
+// DeleteVocabularyFilter removes a vocabulary filter by name.
+func (b *InMemoryBackend) DeleteVocabularyFilter(vocabularyFilterName string) error {
+	if vocabularyFilterName == "" {
+		return fmt.Errorf("%w: VocabularyFilterName is required", ErrValidation)
+	}
+
+	b.mu.Lock("DeleteVocabularyFilter")
+	defer b.mu.Unlock()
+
+	if _, ok := b.vocabularyFilters[vocabularyFilterName]; !ok {
+		return fmt.Errorf("%w: vocabulary filter %s not found", ErrNotFound, vocabularyFilterName)
+	}
+
+	delete(b.vocabularyFilters, vocabularyFilterName)
+
+	return nil
+}
+
+// ListVocabularyFilters returns all vocabulary filters with pagination.
+func (b *InMemoryBackend) ListVocabularyFilters(nextToken string) ([]VocabularyFilter, string) {
+	b.mu.RLock("ListVocabularyFilters")
+	defer b.mu.RUnlock()
+
+	all := make([]VocabularyFilter, 0, len(b.vocabularyFilters))
+	for _, f := range b.vocabularyFilters {
+		all = append(all, *f)
+	}
+
+	sort.Slice(
+		all,
+		func(i, j int) bool { return all[i].VocabularyFilterName < all[j].VocabularyFilterName },
+	)
+
+	return paginateList(all, nextToken)
+}
+
+// --- Medical vocabulary CRUD ---
+
+// GetMedicalVocabulary returns a medical vocabulary by name.
+func (b *InMemoryBackend) GetMedicalVocabulary(vocabularyName string) (*MedicalVocabulary, error) {
+	b.mu.RLock("GetMedicalVocabulary")
+	defer b.mu.RUnlock()
+
+	v, ok := b.medicalVocabularies[vocabularyName]
+	if !ok {
+		return nil, fmt.Errorf("%w: medical vocabulary %s not found", ErrNotFound, vocabularyName)
+	}
+
+	cp := *v
+
+	return &cp, nil
+}
+
+// UpdateMedicalVocabulary updates an existing medical vocabulary.
+func (b *InMemoryBackend) UpdateMedicalVocabulary(
+	vocabularyName, languageCode, vocabularyFileURI string,
+) (*MedicalVocabulary, error) {
+	if vocabularyName == "" {
+		return nil, fmt.Errorf("%w: VocabularyName is required", ErrValidation)
+	}
+
+	b.mu.Lock("UpdateMedicalVocabulary")
+	defer b.mu.Unlock()
+
+	v, ok := b.medicalVocabularies[vocabularyName]
+	if !ok {
+		return nil, fmt.Errorf("%w: medical vocabulary %s not found", ErrNotFound, vocabularyName)
+	}
+
+	if languageCode != "" {
+		v.LanguageCode = languageCode
+	}
+
+	if vocabularyFileURI != "" {
+		v.VocabularyFileURI = vocabularyFileURI
+	}
+
+	v.LastModifiedTime = time.Now()
+
+	cp := *v
+
+	return &cp, nil
+}
+
+// DeleteMedicalVocabulary removes a medical vocabulary by name.
+func (b *InMemoryBackend) DeleteMedicalVocabulary(vocabularyName string) error {
+	if vocabularyName == "" {
+		return fmt.Errorf("%w: VocabularyName is required", ErrValidation)
+	}
+
+	b.mu.Lock("DeleteMedicalVocabulary")
+	defer b.mu.Unlock()
+
+	if _, ok := b.medicalVocabularies[vocabularyName]; !ok {
+		return fmt.Errorf("%w: medical vocabulary %s not found", ErrNotFound, vocabularyName)
+	}
+
+	delete(b.medicalVocabularies, vocabularyName)
+
+	return nil
+}
+
+// ListMedicalVocabularies returns medical vocabularies with optional state filter and pagination.
+func (b *InMemoryBackend) ListMedicalVocabularies(
+	stateFilter, nextToken string,
+) ([]MedicalVocabulary, string) {
+	b.mu.RLock("ListMedicalVocabularies")
+	defer b.mu.RUnlock()
+
+	all := make([]MedicalVocabulary, 0, len(b.medicalVocabularies))
+	for _, v := range b.medicalVocabularies {
+		if stateFilter == "" || v.VocabularyState == stateFilter {
+			all = append(all, *v)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].VocabularyName < all[j].VocabularyName })
+
+	return paginateList(all, nextToken)
+}
+
+// --- Medical Scribe jobs ---
+
+// StartMedicalScribeJob creates a new Medical Scribe job.
+func (b *InMemoryBackend) StartMedicalScribeJob(jobName, _ string) (*MedicalScribeJob, error) {
+	if jobName == "" {
+		return nil, fmt.Errorf("%w: MedicalScribeJobName is required", ErrValidation)
+	}
+
+	b.mu.Lock("StartMedicalScribeJob")
+	defer b.mu.Unlock()
+
+	if _, ok := b.medicalScribeJobs[jobName]; ok {
+		return nil, fmt.Errorf(
+			"%w: medical scribe job %s already exists",
+			ErrAlreadyExists,
+			jobName,
+		)
+	}
+
+	now := time.Now()
+	job := &MedicalScribeJob{
+		MedicalScribeJobName:   jobName,
+		MedicalScribeJobStatus: jobStatusCompleted,
+		CreationTime:           now,
+		CompletionTime:         now,
+	}
+	b.medicalScribeJobs[jobName] = job
+
+	cp := *job
+
+	return &cp, nil
+}
+
+// GetMedicalScribeJob returns a Medical Scribe job by name.
+func (b *InMemoryBackend) GetMedicalScribeJob(jobName string) (*MedicalScribeJob, error) {
+	b.mu.RLock("GetMedicalScribeJob")
+	defer b.mu.RUnlock()
+
+	job, ok := b.medicalScribeJobs[jobName]
+	if !ok {
+		return nil, fmt.Errorf("%w: medical scribe job %s not found", ErrNotFound, jobName)
+	}
+
+	cp := *job
+
+	return &cp, nil
+}
+
+// ListMedicalScribeJobs returns Medical Scribe jobs with optional status filter and pagination.
+func (b *InMemoryBackend) ListMedicalScribeJobs(
+	statusFilter, nextToken string,
+) ([]MedicalScribeJob, string) {
+	b.mu.RLock("ListMedicalScribeJobs")
+	defer b.mu.RUnlock()
+
+	all := make([]MedicalScribeJob, 0, len(b.medicalScribeJobs))
+	for _, j := range b.medicalScribeJobs {
+		if statusFilter == "" || j.MedicalScribeJobStatus == statusFilter {
+			all = append(all, *j)
+		}
+	}
+
+	sort.Slice(
+		all,
+		func(i, j int) bool { return all[i].MedicalScribeJobName < all[j].MedicalScribeJobName },
+	)
+
+	return paginateList(all, nextToken)
+}
+
+// --- Medical Transcription jobs ---
+
+// StartMedicalTranscriptionJob creates a new Medical Transcription job.
+func (b *InMemoryBackend) StartMedicalTranscriptionJob(
+	jobName, languageCode, _ string,
+) (*MedicalTranscriptionJob, error) {
+	if jobName == "" {
+		return nil, fmt.Errorf("%w: MedicalTranscriptionJobName is required", ErrValidation)
+	}
+
+	b.mu.Lock("StartMedicalTranscriptionJob")
+	defer b.mu.Unlock()
+
+	if _, ok := b.medicalTranscriptionJobs[jobName]; ok {
+		return nil, fmt.Errorf(
+			"%w: medical transcription job %s already exists",
+			ErrAlreadyExists,
+			jobName,
+		)
+	}
+
+	now := time.Now()
+	job := &MedicalTranscriptionJob{
+		MedicalTranscriptionJobName: jobName,
+		TranscriptionJobStatus:      jobStatusCompleted,
+		LanguageCode:                languageCode,
+		CreationTime:                now,
+		CompletionTime:              now,
+	}
+	b.medicalTranscriptionJobs[jobName] = job
+
+	cp := *job
+
+	return &cp, nil
+}
+
+// GetMedicalTranscriptionJob returns a Medical Transcription job by name.
+func (b *InMemoryBackend) GetMedicalTranscriptionJob(
+	jobName string,
+) (*MedicalTranscriptionJob, error) {
+	b.mu.RLock("GetMedicalTranscriptionJob")
+	defer b.mu.RUnlock()
+
+	job, ok := b.medicalTranscriptionJobs[jobName]
+	if !ok {
+		return nil, fmt.Errorf("%w: medical transcription job %s not found", ErrNotFound, jobName)
+	}
+
+	cp := *job
+
+	return &cp, nil
+}
+
+// ListMedicalTranscriptionJobs returns Medical Transcription jobs with optional status filter and pagination.
+func (b *InMemoryBackend) ListMedicalTranscriptionJobs(
+	statusFilter, nextToken string,
+) ([]MedicalTranscriptionJob, string) {
+	b.mu.RLock("ListMedicalTranscriptionJobs")
+	defer b.mu.RUnlock()
+
+	all := make([]MedicalTranscriptionJob, 0, len(b.medicalTranscriptionJobs))
+	for _, j := range b.medicalTranscriptionJobs {
+		if statusFilter == "" || j.TranscriptionJobStatus == statusFilter {
+			all = append(all, *j)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].MedicalTranscriptionJobName < all[j].MedicalTranscriptionJobName
+	})
+
+	return paginateList(all, nextToken)
+}
+
+// --- Language model (Describe/List) ---
+
+// DescribeLanguageModel returns a language model by name.
+func (b *InMemoryBackend) DescribeLanguageModel(modelName string) (*LanguageModel, error) {
+	b.mu.RLock("DescribeLanguageModel")
+	defer b.mu.RUnlock()
+
+	m, ok := b.languageModels[modelName]
+	if !ok {
+		return nil, fmt.Errorf("%w: language model %s not found", ErrNotFound, modelName)
+	}
+
+	cp := *m
+
+	return &cp, nil
+}
+
+// ListLanguageModels returns language models with optional status filter and pagination.
+func (b *InMemoryBackend) ListLanguageModels(
+	statusFilter, nextToken string,
+) ([]LanguageModel, string) {
+	b.mu.RLock("ListLanguageModels")
+	defer b.mu.RUnlock()
+
+	all := make([]LanguageModel, 0, len(b.languageModels))
+	for _, m := range b.languageModels {
+		if statusFilter == "" || m.ModelStatus == statusFilter {
+			all = append(all, *m)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].ModelName < all[j].ModelName })
+
+	return paginateList(all, nextToken)
+}
+
+// paginateList applies pagination to a pre-sorted slice using a token-based offset.
+// It returns the page slice and the next-page token (empty string if last page).
+func paginateList[T any](all []T, nextToken string) ([]T, string) {
+	startIdx := parseNextToken(nextToken)
+	if startIdx >= len(all) {
+		return []T{}, ""
+	}
+
+	end := startIdx + transcribeDefaultPageSize
+
+	var outToken string
+	if end < len(all) {
+		outToken = strconv.Itoa(end)
+	} else {
+		end = len(all)
+	}
+
+	return all[startIdx:end], outToken
 }
 
 // parseNextToken parses a pagination token (integer offset) into a slice index.

--- a/services/transcribe/handler.go
+++ b/services/transcribe/handler.go
@@ -50,22 +50,7 @@ func (h *Handler) Name() string { return "Transcribe" }
 
 // GetSupportedOperations returns the list of supported Transcribe operations.
 func (h *Handler) GetSupportedOperations() []string {
-	return []string{
-		"CreateCallAnalyticsCategory",
-		"CreateLanguageModel",
-		"CreateMedicalVocabulary",
-		"CreateVocabulary",
-		"CreateVocabularyFilter",
-		"DeleteCallAnalyticsCategory",
-		"DeleteCallAnalyticsJob",
-		"DeleteLanguageModel",
-		"DeleteMedicalScribeJob",
-		"DeleteMedicalTranscriptionJob",
-		"DeleteTranscriptionJob",
-		"GetTranscriptionJob",
-		"ListTranscriptionJobs",
-		"StartTranscriptionJob",
-	}
+	return allSupportedOps()
 }
 
 // ChaosServiceName returns the lowercase AWS service name for fault rule matching.
@@ -150,7 +135,7 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		return service.HandleTarget(
 			c, logger.Load(c.Request().Context()),
 			"Transcribe", "application/x-amz-json-1.1",
-			h.GetSupportedOperations(),
+			allSupportedOps(),
 			h.dispatch,
 			h.handleError,
 		)
@@ -159,20 +144,59 @@ func (h *Handler) Handler() echo.HandlerFunc {
 
 func (h *Handler) buildOps() map[string]service.JSONOpFunc {
 	return map[string]service.JSONOpFunc{
-		"StartTranscriptionJob":         service.WrapOp(h.handleStartTranscriptionJob),
-		"GetTranscriptionJob":           service.WrapOp(h.handleGetTranscriptionJob),
-		"ListTranscriptionJobs":         service.WrapOp(h.handleListTranscriptionJobs),
-		"DeleteTranscriptionJob":        service.WrapOp(h.handleDeleteTranscriptionJob),
-		"CreateCallAnalyticsCategory":   service.WrapOp(h.handleCreateCallAnalyticsCategory),
-		"DeleteCallAnalyticsCategory":   service.WrapOp(h.handleDeleteCallAnalyticsCategory),
-		"CreateLanguageModel":           service.WrapOp(h.handleCreateLanguageModel),
-		"DeleteLanguageModel":           service.WrapOp(h.handleDeleteLanguageModel),
-		"CreateMedicalVocabulary":       service.WrapOp(h.handleCreateMedicalVocabulary),
-		"CreateVocabulary":              service.WrapOp(h.handleCreateVocabulary),
-		"CreateVocabularyFilter":        service.WrapOp(h.handleCreateVocabularyFilter),
-		"DeleteCallAnalyticsJob":        service.WrapOp(h.handleDeleteCallAnalyticsJob),
-		"DeleteMedicalScribeJob":        service.WrapOp(h.handleDeleteMedicalScribeJob),
+		// Transcription jobs
+		"StartTranscriptionJob":  service.WrapOp(h.handleStartTranscriptionJob),
+		"GetTranscriptionJob":    service.WrapOp(h.handleGetTranscriptionJob),
+		"ListTranscriptionJobs":  service.WrapOp(h.handleListTranscriptionJobs),
+		"DeleteTranscriptionJob": service.WrapOp(h.handleDeleteTranscriptionJob),
+		// Call Analytics categories
+		"CreateCallAnalyticsCategory": service.WrapOp(h.handleCreateCallAnalyticsCategory),
+		"DeleteCallAnalyticsCategory": service.WrapOp(h.handleDeleteCallAnalyticsCategory),
+		"GetCallAnalyticsCategory":    service.WrapOp(h.handleGetCallAnalyticsCategory),
+		"UpdateCallAnalyticsCategory": service.WrapOp(h.handleUpdateCallAnalyticsCategory),
+		"ListCallAnalyticsCategories": service.WrapOp(h.handleListCallAnalyticsCategories),
+		// Call Analytics jobs
+		"StartCallAnalyticsJob":  service.WrapOp(h.handleStartCallAnalyticsJob),
+		"GetCallAnalyticsJob":    service.WrapOp(h.handleGetCallAnalyticsJob),
+		"ListCallAnalyticsJobs":  service.WrapOp(h.handleListCallAnalyticsJobs),
+		"DeleteCallAnalyticsJob": service.WrapOp(h.handleDeleteCallAnalyticsJob),
+		// Language models
+		"CreateLanguageModel":   service.WrapOp(h.handleCreateLanguageModel),
+		"DeleteLanguageModel":   service.WrapOp(h.handleDeleteLanguageModel),
+		"DescribeLanguageModel": service.WrapOp(h.handleDescribeLanguageModel),
+		"ListLanguageModels":    service.WrapOp(h.handleListLanguageModels),
+		// Vocabularies
+		"CreateVocabulary": service.WrapOp(h.handleCreateVocabulary),
+		"GetVocabulary":    service.WrapOp(h.handleGetVocabulary),
+		"UpdateVocabulary": service.WrapOp(h.handleUpdateVocabulary),
+		"DeleteVocabulary": service.WrapOp(h.handleDeleteVocabulary),
+		"ListVocabularies": service.WrapOp(h.handleListVocabularies),
+		// Vocabulary filters
+		"CreateVocabularyFilter": service.WrapOp(h.handleCreateVocabularyFilter),
+		"GetVocabularyFilter":    service.WrapOp(h.handleGetVocabularyFilter),
+		"UpdateVocabularyFilter": service.WrapOp(h.handleUpdateVocabularyFilter),
+		"DeleteVocabularyFilter": service.WrapOp(h.handleDeleteVocabularyFilter),
+		"ListVocabularyFilters":  service.WrapOp(h.handleListVocabularyFilters),
+		// Medical vocabularies
+		"CreateMedicalVocabulary": service.WrapOp(h.handleCreateMedicalVocabulary),
+		"GetMedicalVocabulary":    service.WrapOp(h.handleGetMedicalVocabulary),
+		"UpdateMedicalVocabulary": service.WrapOp(h.handleUpdateMedicalVocabulary),
+		"DeleteMedicalVocabulary": service.WrapOp(h.handleDeleteMedicalVocabulary),
+		"ListMedicalVocabularies": service.WrapOp(h.handleListMedicalVocabularies),
+		// Medical Scribe jobs
+		"StartMedicalScribeJob":  service.WrapOp(h.handleStartMedicalScribeJob),
+		"GetMedicalScribeJob":    service.WrapOp(h.handleGetMedicalScribeJob),
+		"ListMedicalScribeJobs":  service.WrapOp(h.handleListMedicalScribeJobs),
+		"DeleteMedicalScribeJob": service.WrapOp(h.handleDeleteMedicalScribeJob),
+		// Medical Transcription jobs
+		"StartMedicalTranscriptionJob":  service.WrapOp(h.handleStartMedicalTranscriptionJob),
+		"GetMedicalTranscriptionJob":    service.WrapOp(h.handleGetMedicalTranscriptionJob),
+		"ListMedicalTranscriptionJobs":  service.WrapOp(h.handleListMedicalTranscriptionJobs),
 		"DeleteMedicalTranscriptionJob": service.WrapOp(h.handleDeleteMedicalTranscriptionJob),
+		// Tags
+		"TagResource":         service.WrapOp(h.handleTagResource),
+		"UntagResource":       service.WrapOp(h.handleUntagResource),
+		"ListTagsForResource": service.WrapOp(h.handleListTagsForResource),
 	}
 }
 

--- a/services/transcribe/handler_ops.go
+++ b/services/transcribe/handler_ops.go
@@ -1,0 +1,887 @@
+package transcribe
+
+import (
+	"context"
+)
+
+// --- GetCallAnalyticsJob ---
+
+type getCallAnalyticsJobInput struct {
+	CallAnalyticsJobName string `json:"CallAnalyticsJobName"`
+}
+
+type callAnalyticsJobOutput struct {
+	CallAnalyticsJobName   string `json:"CallAnalyticsJobName"`
+	CallAnalyticsJobStatus string `json:"CallAnalyticsJobStatus"`
+	LanguageCode           string `json:"LanguageCode"`
+}
+
+type getCallAnalyticsJobOutput struct {
+	CallAnalyticsJob *callAnalyticsJobOutput `json:"CallAnalyticsJob"`
+}
+
+func (h *Handler) handleGetCallAnalyticsJob(
+	_ context.Context,
+	in *getCallAnalyticsJobInput,
+) (*getCallAnalyticsJobOutput, error) {
+	job, err := h.Backend.GetCallAnalyticsJob(in.CallAnalyticsJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getCallAnalyticsJobOutput{
+		CallAnalyticsJob: &callAnalyticsJobOutput{
+			CallAnalyticsJobName:   job.CallAnalyticsJobName,
+			CallAnalyticsJobStatus: job.CallAnalyticsJobStatus,
+			LanguageCode:           job.LanguageCode,
+		},
+	}, nil
+}
+
+// --- StartCallAnalyticsJob ---
+
+type startCallAnalyticsJobInput struct {
+	CallAnalyticsJobName string          `json:"CallAnalyticsJobName"`
+	LanguageCode         string          `json:"LanguageCode"`
+	Media                transcribeMedia `json:"Media"`
+}
+
+type startCallAnalyticsJobOutput struct {
+	CallAnalyticsJob *callAnalyticsJobOutput `json:"CallAnalyticsJob"`
+}
+
+func (h *Handler) handleStartCallAnalyticsJob(
+	_ context.Context,
+	in *startCallAnalyticsJobInput,
+) (*startCallAnalyticsJobOutput, error) {
+	job, err := h.Backend.StartCallAnalyticsJob(
+		in.CallAnalyticsJobName,
+		in.LanguageCode,
+		in.Media.MediaFileURI,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startCallAnalyticsJobOutput{
+		CallAnalyticsJob: &callAnalyticsJobOutput{
+			CallAnalyticsJobName:   job.CallAnalyticsJobName,
+			CallAnalyticsJobStatus: job.CallAnalyticsJobStatus,
+			LanguageCode:           job.LanguageCode,
+		},
+	}, nil
+}
+
+// --- ListCallAnalyticsJobs ---
+
+type listCallAnalyticsJobsInput struct {
+	Status    string `json:"Status"`
+	NextToken string `json:"NextToken"`
+}
+
+type callAnalyticsJobSummary struct {
+	CallAnalyticsJobName   string `json:"CallAnalyticsJobName"`
+	CallAnalyticsJobStatus string `json:"CallAnalyticsJobStatus"`
+	LanguageCode           string `json:"LanguageCode"`
+}
+
+type listCallAnalyticsJobsOutput struct {
+	NextToken                 string                    `json:"NextToken,omitempty"`
+	CallAnalyticsJobSummaries []callAnalyticsJobSummary `json:"CallAnalyticsJobSummaries"`
+}
+
+func (h *Handler) handleListCallAnalyticsJobs(
+	_ context.Context,
+	in *listCallAnalyticsJobsInput,
+) (*listCallAnalyticsJobsOutput, error) {
+	jobs, nextToken := h.Backend.ListCallAnalyticsJobs(in.Status, in.NextToken)
+
+	summaries := make([]callAnalyticsJobSummary, 0, len(jobs))
+	for _, j := range jobs {
+		summaries = append(summaries, callAnalyticsJobSummary{
+			CallAnalyticsJobName:   j.CallAnalyticsJobName,
+			CallAnalyticsJobStatus: j.CallAnalyticsJobStatus,
+			LanguageCode:           j.LanguageCode,
+		})
+	}
+
+	return &listCallAnalyticsJobsOutput{
+		CallAnalyticsJobSummaries: summaries,
+		NextToken:                 nextToken,
+	}, nil
+}
+
+// --- GetCallAnalyticsCategory ---
+
+type getCallAnalyticsCategoryInput struct {
+	CategoryName string `json:"CategoryName"`
+}
+
+type getCallAnalyticsCategoryOutput struct {
+	CategoryProperties *callAnalyticsCategoryProperties `json:"CategoryProperties"`
+}
+
+func (h *Handler) handleGetCallAnalyticsCategory(
+	_ context.Context,
+	in *getCallAnalyticsCategoryInput,
+) (*getCallAnalyticsCategoryOutput, error) {
+	cat, err := h.Backend.GetCallAnalyticsCategory(in.CategoryName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getCallAnalyticsCategoryOutput{
+		CategoryProperties: &callAnalyticsCategoryProperties{
+			CategoryName: cat.CategoryName,
+			InputType:    cat.InputType,
+		},
+	}, nil
+}
+
+// --- UpdateCallAnalyticsCategory ---
+
+type updateCallAnalyticsCategoryInput struct {
+	CategoryName string `json:"CategoryName"`
+	InputType    string `json:"InputType"`
+}
+
+type updateCallAnalyticsCategoryOutput struct {
+	CategoryProperties *callAnalyticsCategoryProperties `json:"CategoryProperties"`
+}
+
+func (h *Handler) handleUpdateCallAnalyticsCategory(
+	_ context.Context,
+	in *updateCallAnalyticsCategoryInput,
+) (*updateCallAnalyticsCategoryOutput, error) {
+	cat, err := h.Backend.UpdateCallAnalyticsCategory(in.CategoryName, in.InputType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateCallAnalyticsCategoryOutput{
+		CategoryProperties: &callAnalyticsCategoryProperties{
+			CategoryName: cat.CategoryName,
+			InputType:    cat.InputType,
+		},
+	}, nil
+}
+
+// --- ListCallAnalyticsCategories ---
+
+type listCallAnalyticsCategoriesInput struct {
+	NextToken string `json:"NextToken"`
+}
+
+type listCallAnalyticsCategoriesOutput struct {
+	NextToken  string                            `json:"NextToken,omitempty"`
+	Categories []callAnalyticsCategoryProperties `json:"Categories"`
+}
+
+func (h *Handler) handleListCallAnalyticsCategories(
+	_ context.Context,
+	in *listCallAnalyticsCategoriesInput,
+) (*listCallAnalyticsCategoriesOutput, error) {
+	cats, nextToken := h.Backend.ListCallAnalyticsCategories(in.NextToken)
+
+	result := make([]callAnalyticsCategoryProperties, 0, len(cats))
+	for _, c := range cats {
+		result = append(result, callAnalyticsCategoryProperties{
+			CategoryName: c.CategoryName,
+			InputType:    c.InputType,
+		})
+	}
+
+	return &listCallAnalyticsCategoriesOutput{
+		Categories: result,
+		NextToken:  nextToken,
+	}, nil
+}
+
+// --- GetMedicalScribeJob ---
+
+type getMedicalScribeJobInput struct {
+	MedicalScribeJobName string `json:"MedicalScribeJobName"`
+}
+
+type medicalScribeJobOutput struct {
+	MedicalScribeJobName   string `json:"MedicalScribeJobName"`
+	MedicalScribeJobStatus string `json:"MedicalScribeJobStatus"`
+}
+
+type getMedicalScribeJobOutput struct {
+	MedicalScribeJob *medicalScribeJobOutput `json:"MedicalScribeJob"`
+}
+
+func (h *Handler) handleGetMedicalScribeJob(
+	_ context.Context,
+	in *getMedicalScribeJobInput,
+) (*getMedicalScribeJobOutput, error) {
+	job, err := h.Backend.GetMedicalScribeJob(in.MedicalScribeJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getMedicalScribeJobOutput{
+		MedicalScribeJob: &medicalScribeJobOutput{
+			MedicalScribeJobName:   job.MedicalScribeJobName,
+			MedicalScribeJobStatus: job.MedicalScribeJobStatus,
+		},
+	}, nil
+}
+
+// --- StartMedicalScribeJob ---
+
+type startMedicalScribeJobInput struct {
+	MedicalScribeJobName string          `json:"MedicalScribeJobName"`
+	Media                transcribeMedia `json:"Media"`
+}
+
+type startMedicalScribeJobOutput struct {
+	MedicalScribeJob *medicalScribeJobOutput `json:"MedicalScribeJob"`
+}
+
+func (h *Handler) handleStartMedicalScribeJob(
+	_ context.Context,
+	in *startMedicalScribeJobInput,
+) (*startMedicalScribeJobOutput, error) {
+	job, err := h.Backend.StartMedicalScribeJob(in.MedicalScribeJobName, in.Media.MediaFileURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startMedicalScribeJobOutput{
+		MedicalScribeJob: &medicalScribeJobOutput{
+			MedicalScribeJobName:   job.MedicalScribeJobName,
+			MedicalScribeJobStatus: job.MedicalScribeJobStatus,
+		},
+	}, nil
+}
+
+// --- ListMedicalScribeJobs ---
+
+type listMedicalScribeJobsInput struct {
+	Status    string `json:"Status"`
+	NextToken string `json:"NextToken"`
+}
+
+type listMedicalScribeJobsOutput struct {
+	NextToken                 string                   `json:"NextToken,omitempty"`
+	MedicalScribeJobSummaries []medicalScribeJobOutput `json:"MedicalScribeJobSummaries"`
+}
+
+func (h *Handler) handleListMedicalScribeJobs(
+	_ context.Context,
+	in *listMedicalScribeJobsInput,
+) (*listMedicalScribeJobsOutput, error) {
+	jobs, nextToken := h.Backend.ListMedicalScribeJobs(in.Status, in.NextToken)
+
+	summaries := make([]medicalScribeJobOutput, 0, len(jobs))
+	for _, j := range jobs {
+		summaries = append(summaries, medicalScribeJobOutput{
+			MedicalScribeJobName:   j.MedicalScribeJobName,
+			MedicalScribeJobStatus: j.MedicalScribeJobStatus,
+		})
+	}
+
+	return &listMedicalScribeJobsOutput{
+		MedicalScribeJobSummaries: summaries,
+		NextToken:                 nextToken,
+	}, nil
+}
+
+// --- GetMedicalTranscriptionJob ---
+
+type getMedicalTranscriptionJobInput struct {
+	MedicalTranscriptionJobName string `json:"MedicalTranscriptionJobName"`
+}
+
+type medicalTranscriptionJobOutput struct {
+	MedicalTranscriptionJobName string `json:"MedicalTranscriptionJobName"`
+	TranscriptionJobStatus      string `json:"TranscriptionJobStatus"`
+	LanguageCode                string `json:"LanguageCode"`
+}
+
+type getMedicalTranscriptionJobOutput struct {
+	MedicalTranscriptionJob *medicalTranscriptionJobOutput `json:"MedicalTranscriptionJob"`
+}
+
+func (h *Handler) handleGetMedicalTranscriptionJob(
+	_ context.Context,
+	in *getMedicalTranscriptionJobInput,
+) (*getMedicalTranscriptionJobOutput, error) {
+	job, err := h.Backend.GetMedicalTranscriptionJob(in.MedicalTranscriptionJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getMedicalTranscriptionJobOutput{
+		MedicalTranscriptionJob: &medicalTranscriptionJobOutput{
+			MedicalTranscriptionJobName: job.MedicalTranscriptionJobName,
+			TranscriptionJobStatus:      job.TranscriptionJobStatus,
+			LanguageCode:                job.LanguageCode,
+		},
+	}, nil
+}
+
+// --- StartMedicalTranscriptionJob ---
+
+type startMedicalTranscriptionJobInput struct {
+	MedicalTranscriptionJobName string          `json:"MedicalTranscriptionJobName"`
+	LanguageCode                string          `json:"LanguageCode"`
+	Media                       transcribeMedia `json:"Media"`
+}
+
+type startMedicalTranscriptionJobOutput struct {
+	MedicalTranscriptionJob *medicalTranscriptionJobOutput `json:"MedicalTranscriptionJob"`
+}
+
+func (h *Handler) handleStartMedicalTranscriptionJob(
+	_ context.Context,
+	in *startMedicalTranscriptionJobInput,
+) (*startMedicalTranscriptionJobOutput, error) {
+	job, err := h.Backend.StartMedicalTranscriptionJob(
+		in.MedicalTranscriptionJobName,
+		in.LanguageCode,
+		in.Media.MediaFileURI,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startMedicalTranscriptionJobOutput{
+		MedicalTranscriptionJob: &medicalTranscriptionJobOutput{
+			MedicalTranscriptionJobName: job.MedicalTranscriptionJobName,
+			TranscriptionJobStatus:      job.TranscriptionJobStatus,
+			LanguageCode:                job.LanguageCode,
+		},
+	}, nil
+}
+
+// --- ListMedicalTranscriptionJobs ---
+
+type listMedicalTranscriptionJobsInput struct {
+	Status    string `json:"Status"`
+	NextToken string `json:"NextToken"`
+}
+
+type listMedicalTranscriptionJobsOutput struct {
+	NextToken                        string                          `json:"NextToken,omitempty"`
+	MedicalTranscriptionJobSummaries []medicalTranscriptionJobOutput `json:"MedicalTranscriptionJobSummaries"`
+}
+
+func (h *Handler) handleListMedicalTranscriptionJobs(
+	_ context.Context,
+	in *listMedicalTranscriptionJobsInput,
+) (*listMedicalTranscriptionJobsOutput, error) {
+	jobs, nextToken := h.Backend.ListMedicalTranscriptionJobs(in.Status, in.NextToken)
+
+	summaries := make([]medicalTranscriptionJobOutput, 0, len(jobs))
+	for _, j := range jobs {
+		summaries = append(summaries, medicalTranscriptionJobOutput{
+			MedicalTranscriptionJobName: j.MedicalTranscriptionJobName,
+			TranscriptionJobStatus:      j.TranscriptionJobStatus,
+			LanguageCode:                j.LanguageCode,
+		})
+	}
+
+	return &listMedicalTranscriptionJobsOutput{
+		MedicalTranscriptionJobSummaries: summaries,
+		NextToken:                        nextToken,
+	}, nil
+}
+
+// --- GetVocabulary ---
+
+type getVocabularyInput struct {
+	VocabularyName string `json:"VocabularyName"`
+}
+
+type getVocabularyOutput struct {
+	VocabularyName  string `json:"VocabularyName"`
+	LanguageCode    string `json:"LanguageCode"`
+	VocabularyState string `json:"VocabularyState"`
+}
+
+func (h *Handler) handleGetVocabulary(
+	_ context.Context,
+	in *getVocabularyInput,
+) (*getVocabularyOutput, error) {
+	v, err := h.Backend.GetVocabulary(in.VocabularyName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getVocabularyOutput{
+		VocabularyName:  v.VocabularyName,
+		LanguageCode:    v.LanguageCode,
+		VocabularyState: v.VocabularyState,
+	}, nil
+}
+
+// --- UpdateVocabulary ---
+
+type updateVocabularyInput struct {
+	VocabularyName string `json:"VocabularyName"`
+	LanguageCode   string `json:"LanguageCode"`
+}
+
+type updateVocabularyOutput struct {
+	VocabularyName  string `json:"VocabularyName"`
+	LanguageCode    string `json:"LanguageCode"`
+	VocabularyState string `json:"VocabularyState"`
+}
+
+func (h *Handler) handleUpdateVocabulary(
+	_ context.Context,
+	in *updateVocabularyInput,
+) (*updateVocabularyOutput, error) {
+	v, err := h.Backend.UpdateVocabulary(in.VocabularyName, in.LanguageCode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateVocabularyOutput{
+		VocabularyName:  v.VocabularyName,
+		LanguageCode:    v.LanguageCode,
+		VocabularyState: v.VocabularyState,
+	}, nil
+}
+
+// --- DeleteVocabulary ---
+
+type deleteVocabularyInput struct {
+	VocabularyName string `json:"VocabularyName"`
+}
+
+func (h *Handler) handleDeleteVocabulary(
+	_ context.Context,
+	in *deleteVocabularyInput,
+) (*struct{}, error) {
+	if err := h.Backend.DeleteVocabulary(in.VocabularyName); err != nil {
+		return nil, err
+	}
+
+	return &struct{}{}, nil
+}
+
+// --- ListVocabularies ---
+
+type listVocabulariesInput struct {
+	StateEquals string `json:"StateEquals"`
+	NextToken   string `json:"NextToken"`
+}
+
+type vocabularySummary struct {
+	VocabularyName  string `json:"VocabularyName"`
+	LanguageCode    string `json:"LanguageCode"`
+	VocabularyState string `json:"VocabularyState"`
+}
+
+type listVocabulariesOutput struct {
+	NextToken    string              `json:"NextToken,omitempty"`
+	Vocabularies []vocabularySummary `json:"Vocabularies"`
+}
+
+func (h *Handler) handleListVocabularies(
+	_ context.Context,
+	in *listVocabulariesInput,
+) (*listVocabulariesOutput, error) {
+	vocabs, nextToken := h.Backend.ListVocabularies(in.StateEquals, in.NextToken)
+
+	result := make([]vocabularySummary, 0, len(vocabs))
+	for _, v := range vocabs {
+		result = append(result, vocabularySummary{
+			VocabularyName:  v.VocabularyName,
+			LanguageCode:    v.LanguageCode,
+			VocabularyState: v.VocabularyState,
+		})
+	}
+
+	return &listVocabulariesOutput{
+		Vocabularies: result,
+		NextToken:    nextToken,
+	}, nil
+}
+
+// --- GetVocabularyFilter ---
+
+type getVocabularyFilterInput struct {
+	VocabularyFilterName string `json:"VocabularyFilterName"`
+}
+
+type vocabularyFilterOutput struct {
+	VocabularyFilterName string `json:"VocabularyFilterName"`
+	LanguageCode         string `json:"LanguageCode"`
+}
+
+type getVocabularyFilterOutput struct {
+	VocabularyFilterName string `json:"VocabularyFilterName"`
+	LanguageCode         string `json:"LanguageCode"`
+}
+
+func (h *Handler) handleGetVocabularyFilter(
+	_ context.Context,
+	in *getVocabularyFilterInput,
+) (*getVocabularyFilterOutput, error) {
+	f, err := h.Backend.GetVocabularyFilter(in.VocabularyFilterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getVocabularyFilterOutput{
+		VocabularyFilterName: f.VocabularyFilterName,
+		LanguageCode:         f.LanguageCode,
+	}, nil
+}
+
+// --- UpdateVocabularyFilter ---
+
+type updateVocabularyFilterInput struct {
+	VocabularyFilterName string `json:"VocabularyFilterName"`
+	LanguageCode         string `json:"LanguageCode"`
+}
+
+func (h *Handler) handleUpdateVocabularyFilter(
+	_ context.Context,
+	in *updateVocabularyFilterInput,
+) (*vocabularyFilterOutput, error) {
+	f, err := h.Backend.UpdateVocabularyFilter(in.VocabularyFilterName, in.LanguageCode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vocabularyFilterOutput{
+		VocabularyFilterName: f.VocabularyFilterName,
+		LanguageCode:         f.LanguageCode,
+	}, nil
+}
+
+// --- DeleteVocabularyFilter ---
+
+type deleteVocabularyFilterInput struct {
+	VocabularyFilterName string `json:"VocabularyFilterName"`
+}
+
+func (h *Handler) handleDeleteVocabularyFilter(
+	_ context.Context,
+	in *deleteVocabularyFilterInput,
+) (*struct{}, error) {
+	if err := h.Backend.DeleteVocabularyFilter(in.VocabularyFilterName); err != nil {
+		return nil, err
+	}
+
+	return &struct{}{}, nil
+}
+
+// --- ListVocabularyFilters ---
+
+type listVocabularyFiltersInput struct {
+	NextToken string `json:"NextToken"`
+}
+
+type listVocabularyFiltersOutput struct {
+	NextToken         string                   `json:"NextToken,omitempty"`
+	VocabularyFilters []vocabularyFilterOutput `json:"VocabularyFilters"`
+}
+
+func (h *Handler) handleListVocabularyFilters(
+	_ context.Context,
+	in *listVocabularyFiltersInput,
+) (*listVocabularyFiltersOutput, error) {
+	filters, nextToken := h.Backend.ListVocabularyFilters(in.NextToken)
+
+	result := make([]vocabularyFilterOutput, 0, len(filters))
+	for _, f := range filters {
+		result = append(result, vocabularyFilterOutput{
+			VocabularyFilterName: f.VocabularyFilterName,
+			LanguageCode:         f.LanguageCode,
+		})
+	}
+
+	return &listVocabularyFiltersOutput{
+		VocabularyFilters: result,
+		NextToken:         nextToken,
+	}, nil
+}
+
+// --- GetMedicalVocabulary ---
+
+type getMedicalVocabularyInput struct {
+	VocabularyName string `json:"VocabularyName"`
+}
+
+type getMedicalVocabularyOutput struct {
+	VocabularyName  string `json:"VocabularyName"`
+	LanguageCode    string `json:"LanguageCode"`
+	VocabularyState string `json:"VocabularyState"`
+}
+
+func (h *Handler) handleGetMedicalVocabulary(
+	_ context.Context,
+	in *getMedicalVocabularyInput,
+) (*getMedicalVocabularyOutput, error) {
+	v, err := h.Backend.GetMedicalVocabulary(in.VocabularyName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getMedicalVocabularyOutput{
+		VocabularyName:  v.VocabularyName,
+		LanguageCode:    v.LanguageCode,
+		VocabularyState: v.VocabularyState,
+	}, nil
+}
+
+// --- UpdateMedicalVocabulary ---
+
+type updateMedicalVocabularyInput struct {
+	VocabularyName    string `json:"VocabularyName"`
+	LanguageCode      string `json:"LanguageCode"`
+	VocabularyFileURI string `json:"VocabularyFileUri"`
+}
+
+type updateMedicalVocabularyOutput struct {
+	VocabularyName  string `json:"VocabularyName"`
+	LanguageCode    string `json:"LanguageCode"`
+	VocabularyState string `json:"VocabularyState"`
+}
+
+func (h *Handler) handleUpdateMedicalVocabulary(
+	_ context.Context,
+	in *updateMedicalVocabularyInput,
+) (*updateMedicalVocabularyOutput, error) {
+	v, err := h.Backend.UpdateMedicalVocabulary(
+		in.VocabularyName,
+		in.LanguageCode,
+		in.VocabularyFileURI,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateMedicalVocabularyOutput{
+		VocabularyName:  v.VocabularyName,
+		LanguageCode:    v.LanguageCode,
+		VocabularyState: v.VocabularyState,
+	}, nil
+}
+
+// --- DeleteMedicalVocabulary ---
+
+type deleteMedicalVocabularyInput struct {
+	VocabularyName string `json:"VocabularyName"`
+}
+
+func (h *Handler) handleDeleteMedicalVocabulary(
+	_ context.Context,
+	in *deleteMedicalVocabularyInput,
+) (*struct{}, error) {
+	if err := h.Backend.DeleteMedicalVocabulary(in.VocabularyName); err != nil {
+		return nil, err
+	}
+
+	return &struct{}{}, nil
+}
+
+// --- ListMedicalVocabularies ---
+
+type listMedicalVocabulariesInput struct {
+	StateEquals string `json:"StateEquals"`
+	NextToken   string `json:"NextToken"`
+}
+
+type medicalVocabularySummary struct {
+	VocabularyName  string `json:"VocabularyName"`
+	LanguageCode    string `json:"LanguageCode"`
+	VocabularyState string `json:"VocabularyState"`
+}
+
+type listMedicalVocabulariesOutput struct {
+	NextToken    string                     `json:"NextToken,omitempty"`
+	Vocabularies []medicalVocabularySummary `json:"Vocabularies"`
+}
+
+func (h *Handler) handleListMedicalVocabularies(
+	_ context.Context,
+	in *listMedicalVocabulariesInput,
+) (*listMedicalVocabulariesOutput, error) {
+	vocabs, nextToken := h.Backend.ListMedicalVocabularies(in.StateEquals, in.NextToken)
+
+	result := make([]medicalVocabularySummary, 0, len(vocabs))
+	for _, v := range vocabs {
+		result = append(result, medicalVocabularySummary{
+			VocabularyName:  v.VocabularyName,
+			LanguageCode:    v.LanguageCode,
+			VocabularyState: v.VocabularyState,
+		})
+	}
+
+	return &listMedicalVocabulariesOutput{
+		Vocabularies: result,
+		NextToken:    nextToken,
+	}, nil
+}
+
+// --- DescribeLanguageModel ---
+
+type describeLanguageModelInput struct {
+	ModelName string `json:"ModelName"`
+}
+
+type languageModelOutput struct {
+	ModelName     string `json:"ModelName"`
+	BaseModelName string `json:"BaseModelName"`
+	LanguageCode  string `json:"LanguageCode"`
+	ModelStatus   string `json:"ModelStatus"`
+}
+
+type describeLanguageModelOutput struct {
+	LanguageModel *languageModelOutput `json:"LanguageModel"`
+}
+
+func (h *Handler) handleDescribeLanguageModel(
+	_ context.Context,
+	in *describeLanguageModelInput,
+) (*describeLanguageModelOutput, error) {
+	m, err := h.Backend.DescribeLanguageModel(in.ModelName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &describeLanguageModelOutput{
+		LanguageModel: &languageModelOutput{
+			ModelName:     m.ModelName,
+			BaseModelName: m.BaseModelName,
+			LanguageCode:  m.LanguageCode,
+			ModelStatus:   m.ModelStatus,
+		},
+	}, nil
+}
+
+// --- ListLanguageModels ---
+
+type listLanguageModelsInput struct {
+	NextToken    string `json:"NextToken"`
+	StatusEquals string `json:"StatusEquals"`
+}
+
+type listLanguageModelsOutput struct {
+	NextToken string                `json:"NextToken,omitempty"`
+	Models    []languageModelOutput `json:"Models"`
+}
+
+func (h *Handler) handleListLanguageModels(
+	_ context.Context,
+	in *listLanguageModelsInput,
+) (*listLanguageModelsOutput, error) {
+	models, nextToken := h.Backend.ListLanguageModels(in.StatusEquals, in.NextToken)
+
+	result := make([]languageModelOutput, 0, len(models))
+	for _, m := range models {
+		result = append(result, languageModelOutput{
+			ModelName:     m.ModelName,
+			BaseModelName: m.BaseModelName,
+			LanguageCode:  m.LanguageCode,
+			ModelStatus:   m.ModelStatus,
+		})
+	}
+
+	return &listLanguageModelsOutput{
+		Models:    result,
+		NextToken: nextToken,
+	}, nil
+}
+
+// --- Tags (no-op stubs) ---
+
+type tagResourceInput struct {
+	Tags        map[string]string `json:"Tags"`
+	ResourceArn string            `json:"ResourceArn"`
+}
+
+func (h *Handler) handleTagResource(
+	_ context.Context,
+	_ *tagResourceInput,
+) (*struct{}, error) {
+	return &struct{}{}, nil
+}
+
+type untagResourceInput struct {
+	ResourceArn string   `json:"ResourceArn"`
+	TagKeys     []string `json:"TagKeys"`
+}
+
+func (h *Handler) handleUntagResource(
+	_ context.Context,
+	_ *untagResourceInput,
+) (*struct{}, error) {
+	return &struct{}{}, nil
+}
+
+type listTagsForResourceInput struct {
+	ResourceArn string `json:"ResourceArn"`
+}
+
+type listTagsForResourceOutput struct {
+	Tags        map[string]string `json:"Tags"`
+	ResourceArn string            `json:"ResourceArn,omitempty"`
+}
+
+func (h *Handler) handleListTagsForResource(
+	_ context.Context,
+	in *listTagsForResourceInput,
+) (*listTagsForResourceOutput, error) {
+	return &listTagsForResourceOutput{
+		ResourceArn: in.ResourceArn,
+		Tags:        map[string]string{},
+	}, nil
+}
+
+// allSupportedOps returns all 43 supported operations in sorted order.
+func allSupportedOps() []string {
+	return []string{
+		"CreateCallAnalyticsCategory",
+		"CreateLanguageModel",
+		"CreateMedicalVocabulary",
+		"CreateVocabulary",
+		"CreateVocabularyFilter",
+		"DeleteCallAnalyticsCategory",
+		"DeleteCallAnalyticsJob",
+		"DeleteLanguageModel",
+		"DeleteMedicalScribeJob",
+		"DeleteMedicalTranscriptionJob",
+		"DeleteMedicalVocabulary",
+		"DeleteTranscriptionJob",
+		"DeleteVocabulary",
+		"DeleteVocabularyFilter",
+		"DescribeLanguageModel",
+		"GetCallAnalyticsCategory",
+		"GetCallAnalyticsJob",
+		"GetMedicalScribeJob",
+		"GetMedicalTranscriptionJob",
+		"GetMedicalVocabulary",
+		"GetTranscriptionJob",
+		"GetVocabulary",
+		"GetVocabularyFilter",
+		"ListCallAnalyticsCategories",
+		"ListCallAnalyticsJobs",
+		"ListLanguageModels",
+		"ListMedicalScribeJobs",
+		"ListMedicalTranscriptionJobs",
+		"ListMedicalVocabularies",
+		"ListTagsForResource",
+		"ListTranscriptionJobs",
+		"ListVocabularies",
+		"ListVocabularyFilters",
+		"StartCallAnalyticsJob",
+		"StartMedicalScribeJob",
+		"StartMedicalTranscriptionJob",
+		"StartTranscriptionJob",
+		"TagResource",
+		"UntagResource",
+		"UpdateCallAnalyticsCategory",
+		"UpdateMedicalVocabulary",
+		"UpdateVocabulary",
+		"UpdateVocabularyFilter",
+	}
+}

--- a/services/transcribe/handler_refinement1_test.go
+++ b/services/transcribe/handler_refinement1_test.go
@@ -46,7 +46,7 @@ func TestRefinement1_HandlerOpsLen(t *testing.T) {
 
 	b := transcribe.NewInMemoryBackend()
 	h := transcribe.NewHandler(b)
-	assert.Len(t, h.GetSupportedOperations(), 14)
+	assert.Len(t, h.GetSupportedOperations(), 43)
 }
 
 // TestRefinement1_SDKOpsSorted verifies GetSupportedOperations is sorted.
@@ -117,13 +117,13 @@ func TestRefinement1_HandlerReset(t *testing.T) {
 	assert.Equal(t, 0, transcribe.JobCount(b))
 }
 
-// TestRefinement1_HandlerOpsCount verifies the cached dispatch has 14 entries.
+// TestRefinement1_HandlerOpsCount verifies the cached dispatch has 43 entries.
 func TestRefinement1_HandlerOpsCount(t *testing.T) {
 	t.Parallel()
 
 	b := transcribe.NewInMemoryBackend()
 	h := transcribe.NewHandler(b)
-	assert.Equal(t, 14, transcribe.HandlerOpsLen(h))
+	assert.Equal(t, 43, transcribe.HandlerOpsLen(h))
 }
 
 // TestRefinement1_ConflictIs409 verifies that duplicate resources produce HTTP 409.

--- a/services/transcribe/interfaces.go
+++ b/services/transcribe/interfaces.go
@@ -22,10 +22,50 @@ type StorageBackend interface {
 	CreateVocabulary(vocabularyName, languageCode string) (*Vocabulary, error)
 	CreateVocabularyFilter(vocabularyFilterName, languageCode string) (*VocabularyFilter, error)
 
-	// Job cleanup
+	// Call Analytics jobs
+	StartCallAnalyticsJob(jobName, languageCode, mediaFileURI string) (*CallAnalyticsJob, error)
+	GetCallAnalyticsJob(jobName string) (*CallAnalyticsJob, error)
+	ListCallAnalyticsJobs(statusFilter, nextToken string) ([]CallAnalyticsJob, string)
 	DeleteCallAnalyticsJob(jobName string) error
+
+	// Call Analytics categories (Get/Update/List)
+	GetCallAnalyticsCategory(categoryName string) (*CallAnalyticsCategory, error)
+	UpdateCallAnalyticsCategory(categoryName, inputType string) (*CallAnalyticsCategory, error)
+	ListCallAnalyticsCategories(nextToken string) ([]CallAnalyticsCategory, string)
+
+	// Vocabulary CRUD
+	GetVocabulary(vocabularyName string) (*Vocabulary, error)
+	UpdateVocabulary(vocabularyName, languageCode string) (*Vocabulary, error)
+	DeleteVocabulary(vocabularyName string) error
+	ListVocabularies(stateFilter, nextToken string) ([]Vocabulary, string)
+
+	// Vocabulary filter CRUD
+	GetVocabularyFilter(vocabularyFilterName string) (*VocabularyFilter, error)
+	UpdateVocabularyFilter(vocabularyFilterName, languageCode string) (*VocabularyFilter, error)
+	DeleteVocabularyFilter(vocabularyFilterName string) error
+	ListVocabularyFilters(nextToken string) ([]VocabularyFilter, string)
+
+	// Medical vocabulary CRUD
+	GetMedicalVocabulary(vocabularyName string) (*MedicalVocabulary, error)
+	UpdateMedicalVocabulary(vocabularyName, languageCode, vocabularyFileURI string) (*MedicalVocabulary, error)
+	DeleteMedicalVocabulary(vocabularyName string) error
+	ListMedicalVocabularies(stateFilter, nextToken string) ([]MedicalVocabulary, string)
+
+	// Medical Scribe jobs
+	StartMedicalScribeJob(jobName, mediaFileURI string) (*MedicalScribeJob, error)
+	GetMedicalScribeJob(jobName string) (*MedicalScribeJob, error)
+	ListMedicalScribeJobs(statusFilter, nextToken string) ([]MedicalScribeJob, string)
 	DeleteMedicalScribeJob(jobName string) error
+
+	// Medical Transcription jobs
+	StartMedicalTranscriptionJob(jobName, languageCode, mediaFileURI string) (*MedicalTranscriptionJob, error)
+	GetMedicalTranscriptionJob(jobName string) (*MedicalTranscriptionJob, error)
+	ListMedicalTranscriptionJobs(statusFilter, nextToken string) ([]MedicalTranscriptionJob, string)
 	DeleteMedicalTranscriptionJob(jobName string) error
+
+	// Language model CRUD
+	DescribeLanguageModel(modelName string) (*LanguageModel, error)
+	ListLanguageModels(statusFilter, nextToken string) ([]LanguageModel, string)
 
 	// Lifecycle
 	Snapshot() []byte

--- a/services/transcribe/sdk_completeness_test.go
+++ b/services/transcribe/sdk_completeness_test.go
@@ -17,35 +17,5 @@ func TestSDKCompleteness(t *testing.T) {
 
 	backend := transcribe.NewInMemoryBackend()
 	h := transcribe.NewHandler(backend)
-	sdkcheck.CheckCompleteness(t, &transcribesdk.Client{}, h.GetSupportedOperations(), []string{
-		"DeleteMedicalVocabulary",
-		"DeleteVocabulary",
-		"DeleteVocabularyFilter",
-		"DescribeLanguageModel",
-		"GetCallAnalyticsCategory",
-		"GetCallAnalyticsJob",
-		"GetMedicalScribeJob",
-		"GetMedicalTranscriptionJob",
-		"GetMedicalVocabulary",
-		"GetVocabulary",
-		"GetVocabularyFilter",
-		"ListCallAnalyticsCategories",
-		"ListCallAnalyticsJobs",
-		"ListLanguageModels",
-		"ListMedicalScribeJobs",
-		"ListMedicalTranscriptionJobs",
-		"ListMedicalVocabularies",
-		"ListTagsForResource",
-		"ListVocabularies",
-		"ListVocabularyFilters",
-		"StartCallAnalyticsJob",
-		"StartMedicalScribeJob",
-		"StartMedicalTranscriptionJob",
-		"TagResource",
-		"UntagResource",
-		"UpdateCallAnalyticsCategory",
-		"UpdateMedicalVocabulary",
-		"UpdateVocabulary",
-		"UpdateVocabularyFilter",
-	})
+	sdkcheck.CheckCompleteness(t, &transcribesdk.Client{}, h.GetSupportedOperations(), []string{})
 }

--- a/ui/src/routes/transcribe/+page.svelte
+++ b/ui/src/routes/transcribe/+page.svelte
@@ -4,38 +4,189 @@
 	import {
 		ListTranscriptionJobsCommand,
 		ListVocabulariesCommand,
+		ListCallAnalyticsJobsCommand,
+		StartTranscriptionJobCommand,
+		CreateVocabularyCommand,
+		DeleteVocabularyCommand,
+		StartCallAnalyticsJobCommand,
+		DeleteCallAnalyticsJobCommand,
 		type TranscriptionJobSummary,
-		type VocabularyInfo
+		type VocabularyInfo,
+		type CallAnalyticsJobSummary
 	} from '@aws-sdk/client-transcribe';
 	import { toast } from 'svelte-sonner';
-	import { Mic, RefreshCw, Search, BookOpen, Activity, CheckCircle } from 'lucide-svelte';
+	import {
+		Mic,
+		RefreshCw,
+		Search,
+		BookOpen,
+		Activity,
+		CheckCircle,
+		Plus,
+		Trash2,
+		Phone
+	} from 'lucide-svelte';
 
 	const tr = getTranscribeClient();
 
 	let loading = $state(false);
-	let activeTab = $state<'jobs' | 'vocabularies'>('jobs');
+	let activeTab = $state<'jobs' | 'vocabularies' | 'analytics'>('jobs');
 	let searchQuery = $state('');
 	let jobs = $state<TranscriptionJobSummary[]>([]);
 	let vocabularies = $state<VocabularyInfo[]>([]);
+	let analyticsJobs = $state<CallAnalyticsJobSummary[]>([]);
 
-	const filteredJobs = $derived(jobs.filter((j) => (j.TranscriptionJobName ?? '').toLowerCase().includes(searchQuery.toLowerCase())));
-	const filteredVocabularies = $derived(vocabularies.filter((v) => (v.VocabularyName ?? '').toLowerCase().includes(searchQuery.toLowerCase())));
+	// Start job form
+	let showStartJobForm = $state(false);
+	let newJobName = $state('');
+	let newJobLanguage = $state('en-US');
+	let newJobMediaUri = $state('');
+	let submittingJob = $state(false);
 
-	const completedJobs = $derived(jobs.filter((j) => j.TranscriptionJobStatus === 'COMPLETED').length);
+	// Vocab create form
+	let showCreateVocabForm = $state(false);
+	let newVocabName = $state('');
+	let newVocabLanguage = $state('en-US');
+	let submittingVocab = $state(false);
+
+	// Analytics job form
+	let showStartAnalyticsForm = $state(false);
+	let newAnalyticsJobName = $state('');
+	let newAnalyticsLanguage = $state('en-US');
+	let newAnalyticsMediaUri = $state('');
+	let submittingAnalytics = $state(false);
+
+	const filteredJobs = $derived(
+		jobs.filter((j) =>
+			(j.TranscriptionJobName ?? '').toLowerCase().includes(searchQuery.toLowerCase())
+		)
+	);
+	const filteredVocabularies = $derived(
+		vocabularies.filter((v) =>
+			(v.VocabularyName ?? '').toLowerCase().includes(searchQuery.toLowerCase())
+		)
+	);
+	const filteredAnalyticsJobs = $derived(
+		analyticsJobs.filter((j) =>
+			(j.CallAnalyticsJobName ?? '').toLowerCase().includes(searchQuery.toLowerCase())
+		)
+	);
+
+	const completedJobs = $derived(
+		jobs.filter((j) => j.TranscriptionJobStatus === 'COMPLETED').length
+	);
 
 	async function loadData() {
 		loading = true;
 		try {
-			const [jobsResp, vocResp] = await Promise.all([
+			const [jobsResp, vocResp, analyticsResp] = await Promise.all([
 				tr.send(new ListTranscriptionJobsCommand({})),
-				tr.send(new ListVocabulariesCommand({}))
+				tr.send(new ListVocabulariesCommand({})),
+				tr.send(new ListCallAnalyticsJobsCommand({}))
 			]);
 			jobs = jobsResp.TranscriptionJobSummaries ?? [];
 			vocabularies = vocResp.Vocabularies ?? [];
+			analyticsJobs = analyticsResp.CallAnalyticsJobSummaries ?? [];
 		} catch (e) {
 			toast.error('Failed to load Transcribe data: ' + String(e));
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function startTranscriptionJob() {
+		if (!newJobName.trim() || !newJobMediaUri.trim()) {
+			toast.error('Job name and media URI are required');
+			return;
+		}
+		submittingJob = true;
+		try {
+			await tr.send(
+				new StartTranscriptionJobCommand({
+					TranscriptionJobName: newJobName.trim(),
+					LanguageCode: newJobLanguage as 'en-US',
+					Media: { MediaFileUri: newJobMediaUri.trim() }
+				})
+			);
+			toast.success('Transcription job started: ' + newJobName.trim());
+			newJobName = '';
+			newJobMediaUri = '';
+			showStartJobForm = false;
+			await loadData();
+		} catch (e) {
+			toast.error('Failed to start job: ' + String(e));
+		} finally {
+			submittingJob = false;
+		}
+	}
+
+	async function createVocabulary() {
+		if (!newVocabName.trim()) {
+			toast.error('Vocabulary name is required');
+			return;
+		}
+		submittingVocab = true;
+		try {
+			await tr.send(
+				new CreateVocabularyCommand({
+					VocabularyName: newVocabName.trim(),
+					LanguageCode: newVocabLanguage as 'en-US'
+				})
+			);
+			toast.success('Vocabulary created: ' + newVocabName.trim());
+			newVocabName = '';
+			showCreateVocabForm = false;
+			await loadData();
+		} catch (e) {
+			toast.error('Failed to create vocabulary: ' + String(e));
+		} finally {
+			submittingVocab = false;
+		}
+	}
+
+	async function deleteVocabulary(name: string) {
+		try {
+			await tr.send(new DeleteVocabularyCommand({ VocabularyName: name }));
+			toast.success('Vocabulary deleted: ' + name);
+			await loadData();
+		} catch (e) {
+			toast.error('Failed to delete vocabulary: ' + String(e));
+		}
+	}
+
+	async function startCallAnalyticsJob() {
+		if (!newAnalyticsJobName.trim() || !newAnalyticsMediaUri.trim()) {
+			toast.error('Job name and media URI are required');
+			return;
+		}
+		submittingAnalytics = true;
+		try {
+			await tr.send(
+				new StartCallAnalyticsJobCommand({
+					CallAnalyticsJobName: newAnalyticsJobName.trim(),
+					LanguageCode: newAnalyticsLanguage as 'en-US',
+					Media: { MediaFileUri: newAnalyticsMediaUri.trim() }
+				})
+			);
+			toast.success('Call analytics job started: ' + newAnalyticsJobName.trim());
+			newAnalyticsJobName = '';
+			newAnalyticsMediaUri = '';
+			showStartAnalyticsForm = false;
+			await loadData();
+		} catch (e) {
+			toast.error('Failed to start analytics job: ' + String(e));
+		} finally {
+			submittingAnalytics = false;
+		}
+	}
+
+	async function deleteCallAnalyticsJob(name: string) {
+		try {
+			await tr.send(new DeleteCallAnalyticsJobCommand({ CallAnalyticsJobName: name }));
+			toast.success('Call analytics job deleted: ' + name);
+			await loadData();
+		} catch (e) {
+			toast.error('Failed to delete analytics job: ' + String(e));
 		}
 	}
 
@@ -48,66 +199,280 @@
 			<Mic class="w-7 h-7 text-red-500" />
 			<div>
 				<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Amazon Transcribe</h1>
-				<p class="text-sm text-gray-500 dark:text-gray-400">Automatic speech recognition to convert audio to text</p>
+				<p class="text-sm text-gray-500 dark:text-gray-400">
+					Automatic speech recognition to convert audio to text
+				</p>
 			</div>
 		</div>
-		<button onclick={loadData} title="Refresh" class="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 text-sm">
+		<button
+			onclick={loadData}
+			title="Refresh"
+			class="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 text-sm"
+		>
 			<RefreshCw class="w-4 h-4" /> Refresh
 		</button>
 	</div>
 
 	<div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3">
-			<div class="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg"><Activity class="w-5 h-5 text-red-600 dark:text-red-400" /></div>
-			<div><p class="text-2xl font-bold text-gray-900 dark:text-white">{jobs.length}</p><p class="text-sm text-gray-500 dark:text-gray-400">Transcription Jobs</p></div>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3"
+		>
+			<div class="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg">
+				<Activity class="w-5 h-5 text-red-600 dark:text-red-400" />
+			</div>
+			<div>
+				<p class="text-2xl font-bold text-gray-900 dark:text-white">{jobs.length}</p>
+				<p class="text-sm text-gray-500 dark:text-gray-400">Transcription Jobs</p>
+			</div>
 		</div>
-		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3">
-			<div class="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg"><CheckCircle class="w-5 h-5 text-green-600 dark:text-green-400" /></div>
-			<div><p class="text-2xl font-bold text-gray-900 dark:text-white">{completedJobs}</p><p class="text-sm text-gray-500 dark:text-gray-400">Completed</p></div>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3"
+		>
+			<div class="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
+				<CheckCircle class="w-5 h-5 text-green-600 dark:text-green-400" />
+			</div>
+			<div>
+				<p class="text-2xl font-bold text-gray-900 dark:text-white">{completedJobs}</p>
+				<p class="text-sm text-gray-500 dark:text-gray-400">Completed</p>
+			</div>
 		</div>
-		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3">
-			<div class="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg"><BookOpen class="w-5 h-5 text-blue-600 dark:text-blue-400" /></div>
-			<div><p class="text-2xl font-bold text-gray-900 dark:text-white">{vocabularies.length}</p><p class="text-sm text-gray-500 dark:text-gray-400">Vocabularies</p></div>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3"
+		>
+			<div class="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+				<BookOpen class="w-5 h-5 text-blue-600 dark:text-blue-400" />
+			</div>
+			<div>
+				<p class="text-2xl font-bold text-gray-900 dark:text-white">{vocabularies.length}</p>
+				<p class="text-sm text-gray-500 dark:text-gray-400">Vocabularies</p>
+			</div>
 		</div>
-		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3">
-			<div class="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg"><Mic class="w-5 h-5 text-purple-600 dark:text-purple-400" /></div>
-			<div><p class="text-2xl font-bold text-gray-900 dark:text-white">{jobs.filter((j) => j.TranscriptionJobStatus === 'IN_PROGRESS').length}</p><p class="text-sm text-gray-500 dark:text-gray-400">In Progress</p></div>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3"
+		>
+			<div class="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
+				<Phone class="w-5 h-5 text-purple-600 dark:text-purple-400" />
+			</div>
+			<div>
+				<p class="text-2xl font-bold text-gray-900 dark:text-white">{analyticsJobs.length}</p>
+				<p class="text-sm text-gray-500 dark:text-gray-400">Analytics Jobs</p>
+			</div>
 		</div>
 	</div>
 
-	<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-		<div class="p-4 border-b border-slate-200 dark:border-slate-700 flex flex-col sm:flex-row gap-3 justify-between">
+	<div
+		class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700"
+	>
+		<div
+			class="p-4 border-b border-slate-200 dark:border-slate-700 flex flex-col sm:flex-row gap-3 justify-between"
+		>
 			<div class="flex gap-2">
-				{#each [['jobs', 'Transcription Jobs'], ['vocabularies', 'Vocabularies']] as [tab, label]}
-					<button onclick={() => { activeTab = tab as typeof activeTab; searchQuery = ''; }}
-						class="px-4 py-2 rounded-lg text-sm font-medium {activeTab === tab ? 'bg-red-600 text-white' : 'bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600'}">
+				{#each [['jobs', 'Transcription Jobs'], ['vocabularies', 'Vocabularies'], ['analytics', 'Call Analytics']] as [tab, label]}
+					<button
+						onclick={() => {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							activeTab = tab as any;
+							searchQuery = '';
+						}}
+						class="px-4 py-2 rounded-lg text-sm font-medium {activeTab === tab
+							? 'bg-red-600 text-white'
+							: 'bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600'}"
+					>
 						{label}
 					</button>
 				{/each}
 			</div>
-			<div class="relative">
-				<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-				<input bind:value={searchQuery} placeholder="Search..." class="pl-9 pr-4 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white w-full sm:w-64" />
+			<div class="flex items-center gap-2">
+				<div class="relative">
+					<Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+					<input
+						bind:value={searchQuery}
+						placeholder="Search..."
+						class="pl-9 pr-4 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white w-full sm:w-64"
+					/>
+				</div>
+				{#if activeTab === 'jobs'}
+					<button
+						onclick={() => (showStartJobForm = !showStartJobForm)}
+						class="flex items-center gap-1 px-3 py-2 rounded-lg bg-red-600 text-white text-sm hover:bg-red-700"
+					>
+						<Plus class="w-4 h-4" /> Start Job
+					</button>
+				{:else if activeTab === 'vocabularies'}
+					<button
+						onclick={() => (showCreateVocabForm = !showCreateVocabForm)}
+						class="flex items-center gap-1 px-3 py-2 rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700"
+					>
+						<Plus class="w-4 h-4" /> Create
+					</button>
+				{:else if activeTab === 'analytics'}
+					<button
+						onclick={() => (showStartAnalyticsForm = !showStartAnalyticsForm)}
+						class="flex items-center gap-1 px-3 py-2 rounded-lg bg-purple-600 text-white text-sm hover:bg-purple-700"
+					>
+						<Plus class="w-4 h-4" /> Start Job
+					</button>
+				{/if}
 			</div>
 		</div>
+
+		{#if showStartJobForm && activeTab === 'jobs'}
+			<div class="p-4 border-b border-slate-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700/30">
+				<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+					Start Transcription Job
+				</h3>
+				<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+					<input
+						bind:value={newJobName}
+						placeholder="Job name"
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					/>
+					<select
+						bind:value={newJobLanguage}
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					>
+						<option value="en-US">English (US)</option>
+						<option value="en-GB">English (UK)</option>
+						<option value="es-US">Spanish (US)</option>
+						<option value="fr-FR">French</option>
+						<option value="de-DE">German</option>
+					</select>
+					<input
+						bind:value={newJobMediaUri}
+						placeholder="s3://bucket/key.mp3"
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					/>
+				</div>
+				<div class="flex gap-2 mt-3">
+					<button
+						onclick={startTranscriptionJob}
+						disabled={submittingJob}
+						class="px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+					>
+						{submittingJob ? 'Starting...' : 'Start'}
+					</button>
+					<button
+						onclick={() => (showStartJobForm = false)}
+						class="px-4 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#if showCreateVocabForm && activeTab === 'vocabularies'}
+			<div class="p-4 border-b border-slate-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700/30">
+				<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-3">Create Vocabulary</h3>
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					<input
+						bind:value={newVocabName}
+						placeholder="Vocabulary name"
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					/>
+					<select
+						bind:value={newVocabLanguage}
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					>
+						<option value="en-US">English (US)</option>
+						<option value="en-GB">English (UK)</option>
+						<option value="es-US">Spanish (US)</option>
+						<option value="fr-FR">French</option>
+						<option value="de-DE">German</option>
+					</select>
+				</div>
+				<div class="flex gap-2 mt-3">
+					<button
+						onclick={createVocabulary}
+						disabled={submittingVocab}
+						class="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+					>
+						{submittingVocab ? 'Creating...' : 'Create'}
+					</button>
+					<button
+						onclick={() => (showCreateVocabForm = false)}
+						class="px-4 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#if showStartAnalyticsForm && activeTab === 'analytics'}
+			<div class="p-4 border-b border-slate-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700/30">
+				<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+					Start Call Analytics Job
+				</h3>
+				<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+					<input
+						bind:value={newAnalyticsJobName}
+						placeholder="Job name"
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					/>
+					<select
+						bind:value={newAnalyticsLanguage}
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					>
+						<option value="en-US">English (US)</option>
+						<option value="en-GB">English (UK)</option>
+						<option value="es-US">Spanish (US)</option>
+					</select>
+					<input
+						bind:value={newAnalyticsMediaUri}
+						placeholder="s3://bucket/call.mp3"
+						class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white"
+					/>
+				</div>
+				<div class="flex gap-2 mt-3">
+					<button
+						onclick={startCallAnalyticsJob}
+						disabled={submittingAnalytics}
+						class="px-4 py-2 text-sm rounded-lg bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-50"
+					>
+						{submittingAnalytics ? 'Starting...' : 'Start'}
+					</button>
+					<button
+						onclick={() => (showStartAnalyticsForm = false)}
+						class="px-4 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-600"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+
 		<div class="p-4">
 			{#if loading}
 				<div class="text-center py-8 text-gray-500 dark:text-gray-400">Loading...</div>
 			{:else if activeTab === 'jobs'}
 				{#if filteredJobs.length === 0}
-					<div class="text-center py-8 text-gray-500 dark:text-gray-400">No transcription jobs found</div>
+					<div class="text-center py-8 text-gray-500 dark:text-gray-400">
+						No transcription jobs found
+					</div>
 				{:else}
 					<div class="space-y-2">
 						{#each filteredJobs as job}
-							<div class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-slate-700/50">
+							<div
+								class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-slate-700/50"
+							>
 								<div class="flex items-center gap-3">
 									<Mic class="w-5 h-5 text-red-500" />
 									<div>
-										<p class="font-medium text-gray-900 dark:text-white">{job.TranscriptionJobName}</p>
+										<p class="font-medium text-gray-900 dark:text-white">
+											{job.TranscriptionJobName}
+										</p>
 										<p class="text-xs text-gray-500 dark:text-gray-400">{job.LanguageCode}</p>
 									</div>
 								</div>
-								<span class="text-xs px-2 py-1 rounded-full {job.TranscriptionJobStatus === 'COMPLETED' ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400' : job.TranscriptionJobStatus === 'FAILED' ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400' : 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'}">{job.TranscriptionJobStatus}</span>
+								<span
+									class="text-xs px-2 py-1 rounded-full {job.TranscriptionJobStatus === 'COMPLETED'
+										? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
+										: job.TranscriptionJobStatus === 'FAILED'
+											? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
+											: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'}"
+									>{job.TranscriptionJobStatus}</span
+								>
 							</div>
 						{/each}
 					</div>
@@ -118,7 +483,9 @@
 				{:else}
 					<div class="space-y-2">
 						{#each filteredVocabularies as vocab}
-							<div class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-slate-700/50">
+							<div
+								class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-slate-700/50"
+							>
 								<div class="flex items-center gap-3">
 									<BookOpen class="w-5 h-5 text-blue-500" />
 									<div>
@@ -126,7 +493,60 @@
 										<p class="text-xs text-gray-500 dark:text-gray-400">{vocab.LanguageCode}</p>
 									</div>
 								</div>
-								<span class="text-xs px-2 py-1 rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">{vocab.VocabularyState}</span>
+								<div class="flex items-center gap-2">
+									<span
+										class="text-xs px-2 py-1 rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400"
+										>{vocab.VocabularyState}</span
+									>
+									<button
+										onclick={() => deleteVocabulary(vocab.VocabularyName ?? '')}
+										title="Delete vocabulary"
+										class="p-1 text-red-500 hover:text-red-700 dark:hover:text-red-400"
+									>
+										<Trash2 class="w-4 h-4" />
+									</button>
+								</div>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			{:else if activeTab === 'analytics'}
+				{#if filteredAnalyticsJobs.length === 0}
+					<div class="text-center py-8 text-gray-500 dark:text-gray-400">
+						No call analytics jobs found
+					</div>
+				{:else}
+					<div class="space-y-2">
+						{#each filteredAnalyticsJobs as job}
+							<div
+								class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-slate-700/50"
+							>
+								<div class="flex items-center gap-3">
+									<Phone class="w-5 h-5 text-purple-500" />
+									<div>
+										<p class="font-medium text-gray-900 dark:text-white">
+											{job.CallAnalyticsJobName}
+										</p>
+										<p class="text-xs text-gray-500 dark:text-gray-400">{job.LanguageCode}</p>
+									</div>
+								</div>
+								<div class="flex items-center gap-2">
+									<span
+										class="text-xs px-2 py-1 rounded-full {job.CallAnalyticsJobStatus === 'COMPLETED'
+											? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
+											: job.CallAnalyticsJobStatus === 'FAILED'
+												? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
+												: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'}"
+										>{job.CallAnalyticsJobStatus}</span
+									>
+									<button
+										onclick={() => deleteCallAnalyticsJob(job.CallAnalyticsJobName ?? '')}
+										title="Delete job"
+										class="p-1 text-red-500 hover:text-red-700 dark:hover:text-red-400"
+									>
+										<Trash2 class="w-4 h-4" />
+									</button>
+								</div>
 							</div>
 						{/each}
 					</div>


### PR DESCRIPTION
## Summary

- Implements all 29 missing Transcribe SDK operations (Get/Start/List for call analytics jobs, medical scribe/transcription; Get/Update/Delete for vocabularies, vocab filters, medical vocabularies; Describe/List for language models; Tag stubs)
- Adds start transcription job UI form (name, language, media URI)
- Adds vocabulary CRUD UI (create form + delete button per row)
- Adds Call Analytics tab with job list, start-job form, and delete

## Test plan

- [ ] `go test ./services/transcribe/...` passes (SDK completeness + all existing tests)
- [ ] `golangci-lint run ./services/transcribe/...` — 0 issues
- [ ] `cd ui && npm run lint && npm run fmt:check` — 0 issues
- [ ] Start a transcription job via UI form, confirm it appears in list
- [ ] Create and delete a vocabulary via UI
- [ ] Start and delete a call analytics job via UI

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->