### PR TITLE
feat(bedrockruntime): circular invocation buffer and Converse playground

### DIFF
--- a/services/bedrockruntime/backend.go
+++ b/services/bedrockruntime/backend.go
@@ -63,6 +63,50 @@ type ListAsyncInvokesFilter struct {
 	StatusEquals string
 }
 
+// invocationRing is a fixed-szacity circular buffer for Invocation records.
+// Once full, new writes overwrite the oldest entry (FIFO eviction).
+type invocationRing struct {
+	buf   []*Invocation
+	head  int // index of the oldest entry
+	count int // number of valid entries (0 ≤ count ≤ sz)
+}
+
+// newInvocationRing allocates a ring with the given szacity.
+func newInvocationRing(sz int) invocationRing {
+	return invocationRing{buf: make([]*Invocation, sz)}
+}
+
+// push appends inv, evicting the oldest entry when the ring is full.
+func (r *invocationRing) push(inv *Invocation) {
+	sz := len(r.buf)
+	if r.count < sz {
+		r.buf[(r.head+r.count)%sz] = inv
+		r.count++
+	} else {
+		// Overwrite oldest slot and advance head.
+		r.buf[r.head] = inv
+		r.head = (r.head + 1) % sz
+	}
+}
+
+// snapshot returns all entries in insertion order (oldest first).
+func (r *invocationRing) snapshot() []*Invocation {
+	out := make([]*Invocation, r.count)
+	sz := len(r.buf)
+
+	for i := range r.count {
+		out[i] = r.buf[(r.head+i)%sz]
+	}
+
+	return out
+}
+
+// reset discards all entries without reallocating the buffer.
+func (r *invocationRing) reset() {
+	r.head = 0
+	r.count = 0
+}
+
 // InMemoryBackend stores Bedrock Runtime state in memory.
 type InMemoryBackend struct {
 	mu                 *lockmetrics.RWMutex
@@ -70,14 +114,14 @@ type InMemoryBackend struct {
 	tokenIndex         map[string]string // clientRequestToken → invocationArn (idempotency)
 	accountID          string
 	region             string
-	invocations        []*Invocation
+	invocations        invocationRing
 	asyncInvokeCounter int
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		invocations:  make([]*Invocation, 0),
+		invocations:  newInvocationRing(maxInvocationHistory),
 		asyncInvokes: make(map[string]*AsyncInvoke),
 		tokenIndex:   make(map[string]string),
 		accountID:    accountID,
@@ -91,7 +135,7 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.invocations = make([]*Invocation, 0)
+	b.invocations.reset()
 	b.asyncInvokes = make(map[string]*AsyncInvoke)
 	b.tokenIndex = make(map[string]string)
 	b.asyncInvokeCounter = 0
@@ -112,27 +156,24 @@ func (b *InMemoryBackend) RecordInvocation(operation, modelID, input, output str
 		Output:    output,
 		CreatedAt: time.Now().UTC(),
 	}
-	b.invocations = append(b.invocations, inv)
-
-	if len(b.invocations) > maxInvocationHistory {
-		b.invocations = b.invocations[len(b.invocations)-maxInvocationHistory:]
-	}
+	b.invocations.push(inv)
 
 	cp := *inv
 
 	return &cp
 }
 
-// ListInvocations returns all recorded invocations.
+// ListInvocations returns all recorded invocations in insertion order (oldest first).
 func (b *InMemoryBackend) ListInvocations() []*Invocation {
 	b.mu.RLock("ListInvocations")
 	defer b.mu.RUnlock()
 
-	out := make([]*Invocation, 0, len(b.invocations))
+	raw := b.invocations.snapshot()
+	out := make([]*Invocation, len(raw))
 
-	for _, inv := range b.invocations {
+	for i, inv := range raw {
 		cp := *inv
-		out = append(out, &cp)
+		out[i] = &cp
 	}
 
 	return out
@@ -147,17 +188,17 @@ func (b *InMemoryBackend) Purge(ctx context.Context, cutoff time.Time) {
 	b.mu.Lock("Purge")
 	defer b.mu.Unlock()
 
-	n := 0
-	for _, inv := range b.invocations {
+	keep := b.invocations.snapshot()
+	b.invocations.reset()
+
+	for _, inv := range keep {
 		if ctx.Err() != nil {
 			return
 		}
 		if !inv.CreatedAt.Before(cutoff) {
-			b.invocations[n] = inv
-			n++
+			b.invocations.push(inv)
 		}
 	}
-	b.invocations = b.invocations[:n]
 }
 
 // StartAsyncInvoke creates a new asynchronous model invocation and returns it.

--- a/ui/src/routes/bedrockruntime/+page.svelte
+++ b/ui/src/routes/bedrockruntime/+page.svelte
@@ -3,26 +3,37 @@
 	import { getBedrockRuntimeClient } from '$lib/aws-client';
 	import {
 		InvokeModelCommand,
-		ListAsyncInvokesCommand
+		ListAsyncInvokesCommand,
+		ConverseCommand
 	} from '@aws-sdk/client-bedrock-runtime';
 	import { toast } from 'svelte-sonner';
-	import { Zap, RefreshCw, Search, Send, Activity, MessageSquare } from 'lucide-svelte';
+	import { Zap, RefreshCw, Send, Activity, MessageSquare } from 'lucide-svelte';
 
 	interface AsyncInvokeSummary {
 		invocationArn?: string;
 		[key: string]: unknown;
 	}
 
+	interface ConverseTurn {
+		role: 'user' | 'assistant';
+		text: string;
+	}
+
 	const br = getBedrockRuntimeClient();
 
 	let loading = $state(false);
-	let activeTab = $state<'invoke' | 'asyncInvocations'>('invoke');
-	let searchQuery = $state('');
+	let activeTab = $state<'invoke' | 'converse' | 'asyncInvocations'>('invoke');
 	let modelId = $state('amazon.titan-text-express-v1');
 	let prompt = $state('What is Amazon Web Services?');
 	let modelResponse = $state<string | null>(null);
 	let invoking = $state(false);
 	let asyncInvocations = $state<AsyncInvokeSummary[]>([]);
+
+	// Converse playground state
+	let converseModelId = $state('anthropic.claude-instant-v1');
+	let converseInput = $state('');
+	let converseTurns = $state<ConverseTurn[]>([]);
+	let conversing = $state(false);
 
 	const supportedModels = [
 		{ id: 'amazon.titan-text-express-v1', label: 'Titan Text Express' },
@@ -33,11 +44,19 @@
 		{ id: 'cohere.command-text-v14', label: 'Command' }
 	];
 
+	const converseModels = [
+		{ id: 'anthropic.claude-instant-v1', label: 'Claude Instant' },
+		{ id: 'anthropic.claude-v2', label: 'Claude v2' },
+		{ id: 'amazon.titan-text-express-v1', label: 'Titan Text Express' },
+		{ id: 'amazon.titan-text-lite-v1', label: 'Titan Text Lite' }
+	];
+
 	async function loadAsyncInvocations() {
 		loading = true;
 		try {
 			const resp = await br.send(new ListAsyncInvokesCommand({}));
-			asyncInvocations = (resp as { asyncInvokeSummaries?: AsyncInvokeSummary[] }).asyncInvokeSummaries ?? [];
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			asyncInvocations = (resp as any).asyncInvokeSummaries ?? [];
 		} catch (e) {
 			toast.error('Failed to load async invocations: ' + String(e));
 		} finally {
@@ -64,6 +83,41 @@
 		} finally {
 			invoking = false;
 		}
+	}
+
+	async function sendConverseMessage() {
+		const text = converseInput.trim();
+		if (!text) {
+			toast.error('Please enter a message');
+			return;
+		}
+		converseTurns = [...converseTurns, { role: 'user', text }];
+		converseInput = '';
+		conversing = true;
+		try {
+			const messages = converseTurns.map((t) => ({
+				role: t.role,
+				content: [{ text: t.text }]
+			}));
+			const resp = await br.send(
+				new ConverseCommand({ modelId: converseModelId, messages })
+			);
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const output = (resp as any).output?.message?.content?.[0]?.text ?? '(no response)';
+			converseTurns = [...converseTurns, { role: 'assistant', text: output }];
+		} catch (e) {
+			toast.error('Converse failed: ' + String(e));
+			// Remove the user turn we optimistically added
+			converseTurns = converseTurns.slice(0, -1);
+			converseInput = text;
+		} finally {
+			conversing = false;
+		}
+	}
+
+	function clearConversation() {
+		converseTurns = [];
+		converseInput = '';
 	}
 
 	onMount(loadAsyncInvocations);
@@ -94,12 +148,12 @@
 		</div>
 		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 flex items-center gap-3">
 			<div class="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg"><MessageSquare class="w-5 h-5 text-green-600 dark:text-green-400" /></div>
-			<div><p class="text-2xl font-bold text-gray-900 dark:text-white">{modelResponse ? 1 : 0}</p><p class="text-sm text-gray-500 dark:text-gray-400">Responses</p></div>
+			<div><p class="text-2xl font-bold text-gray-900 dark:text-white">{converseTurns.length}</p><p class="text-sm text-gray-500 dark:text-gray-400">Converse Turns</p></div>
 		</div>
 	</div>
 
 	<div class="flex gap-2">
-		{#each [['invoke', 'Invoke Model'], ['asyncInvocations', 'Async Invocations']] as [tab, label]}
+		{#each [['invoke', 'Invoke Model'], ['converse', 'Converse Playground'], ['asyncInvocations', 'Async Invocations']] as [tab, label]}
 			<button onclick={() => { activeTab = tab as typeof activeTab; }}
 				class="px-4 py-2 rounded-lg text-sm font-medium {activeTab === tab ? 'bg-yellow-500 text-white' : 'bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600'}">
 				{label}
@@ -131,6 +185,58 @@
 					<p class="text-sm text-gray-900 dark:text-white whitespace-pre-wrap">{modelResponse}</p>
 				</div>
 			{/if}
+		</div>
+	{:else if activeTab === 'converse'}
+		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 space-y-4">
+			<div class="flex items-center justify-between">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Converse Playground</h2>
+				<button onclick={clearConversation} class="px-3 py-1.5 text-xs rounded-lg border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700">
+					Clear
+				</button>
+			</div>
+			<div>
+				<label for="converse-model-id" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Model</label>
+				<select id="converse-model-id" bind:value={converseModelId} class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white text-sm">
+					{#each converseModels as model}
+						<option value={model.id}>{model.label} ({model.id})</option>
+					{/each}
+				</select>
+			</div>
+			<div class="min-h-48 max-h-96 overflow-y-auto space-y-3 p-3 bg-gray-50 dark:bg-slate-900/50 rounded-lg">
+				{#if converseTurns.length === 0}
+					<p class="text-center text-sm text-gray-400 dark:text-gray-500 py-8">Start a conversation below</p>
+				{:else}
+					{#each converseTurns as turn}
+						<div class="flex {turn.role === 'user' ? 'justify-end' : 'justify-start'}">
+							<div class="max-w-[80%] px-4 py-2 rounded-2xl text-sm whitespace-pre-wrap
+								{turn.role === 'user'
+									? 'bg-yellow-500 text-white rounded-br-sm'
+									: 'bg-white dark:bg-slate-700 text-gray-900 dark:text-white border border-gray-200 dark:border-slate-600 rounded-bl-sm'}">
+								{turn.text}
+							</div>
+						</div>
+					{/each}
+					{#if conversing}
+						<div class="flex justify-start">
+							<div class="px-4 py-2 rounded-2xl rounded-bl-sm bg-white dark:bg-slate-700 border border-gray-200 dark:border-slate-600 text-sm text-gray-400 dark:text-gray-500">
+								Thinking...
+							</div>
+						</div>
+					{/if}
+				{/if}
+			</div>
+			<div class="flex gap-2">
+				<textarea
+					bind:value={converseInput}
+					onkeydown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendConverseMessage(); } }}
+					rows={2}
+					placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+					class="flex-1 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-white text-sm resize-none"
+				></textarea>
+				<button onclick={sendConverseMessage} disabled={conversing || !converseInput.trim()} class="flex items-center gap-2 px-4 py-2 bg-yellow-500 hover:bg-yellow-600 disabled:opacity-50 text-white rounded-lg text-sm font-medium self-end">
+					<Send class="w-4 h-4" /> Send
+				</button>
+			</div>
 		</div>
 	{:else if activeTab === 'asyncInvocations'}
 		<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">


### PR DESCRIPTION
## Summary

- Replace O(n) slice truncation with a fixed-capacity ring buffer (`invocationRing`) for `InMemoryBackend` invocation history — no allocations on overflow, O(1) write
- Add **Converse Playground** tab to the Bedrock Runtime UI: model selector, chat bubble UI, Enter-to-send, optimistic user turn with rollback on error, Clear button

## Test plan

- [ ] `go test ./services/bedrockruntime/...` passes (existing cap/truncation tests exercise ring behaviour)
- [ ] `golangci-lint run ./services/bedrockruntime/...` — 0 issues
- [ ] `cd ui && npm run lint && npm run fmt:check` — 0 issues
- [ ] UI: Converse Playground tab appears, messages send and render in chat bubbles

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->