### PR TITLE
feat(ecr): implement lifecycle policy evaluation, image scan simulation, and auth token improvements

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2347,8 +2347,8 @@ func initializeServices(appCtx *service.AppContext) ([]service.Registerable, err
 	// Wire CloudWatch Logs subscription filter delivery to Lambda, Kinesis, and Firehose.
 	wireCWLogsSubscriptionFilters(byName["CloudWatchLogs"], byName["Lambda"], byName["Kinesis"], byName["Firehose"])
 
-	t // Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
-	twireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
+	// Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
+	wireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
 
 	// Wire Firehose → S3 and Lambda for actual record delivery and transformation.
 	wireFirehoseDelivery(byName["Firehose"], byName["S3"], byName["Lambda"])

--- a/cli.go
+++ b/cli.go
@@ -2347,6 +2347,9 @@ func initializeServices(appCtx *service.AppContext) ([]service.Registerable, err
 	// Wire CloudWatch Logs subscription filter delivery to Lambda, Kinesis, and Firehose.
 	wireCWLogsSubscriptionFilters(byName["CloudWatchLogs"], byName["Lambda"], byName["Kinesis"], byName["Firehose"])
 
+	t // Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
+	twireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
+
 	// Wire Firehose → S3 and Lambda for actual record delivery and transformation.
 	wireFirehoseDelivery(byName["Firehose"], byName["S3"], byName["Lambda"])
 
@@ -3432,17 +3435,19 @@ func wireCWLogsMetricEmitter(cwlogsReg, cwReg service.Registerable) {
 		return
 	}
 
-	cwlogsBk.SetMetricEmitter(cwlogsbackend.MetricEmitterFunc(func(namespace, name string, value float64, unit string) error {
-		return cwBk.PutMetricData(namespace, []cwbackend.MetricDatum{
-			{
-				MetricName: name,
-				Namespace:  namespace,
-				Value:      value,
-				Unit:       unit,
-				Timestamp:  time.Now(),
-			},
-		})
-	}))
+	cwlogsBk.SetMetricEmitter(
+		cwlogsbackend.MetricEmitterFunc(func(namespace, name string, value float64, unit string) error {
+			return cwBk.PutMetricData(namespace, []cwbackend.MetricDatum{
+				{
+					MetricName: name,
+					Namespace:  namespace,
+					Value:      value,
+					Unit:       unit,
+					Timestamp:  time.Now(),
+				},
+			})
+		}),
+	)
 }
 
 // wireIAMToSTS connects the IAM backend to STS so that AssumeRole can validate

--- a/services/ecr/backend.go
+++ b/services/ecr/backend.go
@@ -18,6 +18,7 @@ const (
 	scanTypeBasic       = "BASIC"
 	scanStatusComplete  = "COMPLETE"
 	imageStatusActive   = "ACTIVE"
+	msgNoScanFindings   = "The scan completed successfully with no findings."
 )
 
 var (
@@ -1042,14 +1043,11 @@ func (b *InMemoryBackend) StartLifecyclePolicyPreview(
 		policyText = b.lifecyclePolicies[repositoryName]
 	}
 
-	images := make([]ImageIdentifier, 0, len(b.images[repositoryName]))
-	for _, img := range b.images[repositoryName] {
-		images = append(images, img.ImageID)
-	}
+	expired := evaluateLifecyclePolicy(policyText, b.images[repositoryName])
 
 	preview := &LifecyclePolicyPreviewResult{
 		LifecyclePolicyText: policyText,
-		PreviewResults:      images,
+		PreviewResults:      expired,
 		RepositoryName:      repositoryName,
 		RegistryID:          b.accountID,
 		Status:              scanStatusComplete,
@@ -1396,7 +1394,7 @@ func (b *InMemoryBackend) DescribeImageScanFindings(
 			RepositoryName:        repositoryName,
 			RegistryID:            b.accountID,
 			Status:                scanStatusComplete,
-			Description:           "The scan completed successfully with no findings.",
+			Description:           msgNoScanFindings,
 			CompletedAt:           time.Now(),
 		}
 	}
@@ -1423,15 +1421,7 @@ func (b *InMemoryBackend) StartImageScan(
 		b.imageScanFindings[repositoryName] = make(map[string]*ImageScanFindingsResult)
 	}
 
-	result := &ImageScanFindingsResult{
-		FindingSeverityCounts: map[string]int32{},
-		ImageID:               img.ImageID,
-		RepositoryName:        repositoryName,
-		RegistryID:            b.accountID,
-		Status:                scanStatusComplete,
-		Description:           "The scan completed successfully with no findings.",
-		CompletedAt:           time.Now(),
-	}
+	result := generateMockScanFindings(img.ImageDigest, repositoryName, b.accountID, img.ImageID)
 	b.imageScanFindings[repositoryName][img.ImageDigest] = result
 
 	return &ImageScanStartResult{

--- a/services/ecr/backend_iface_test.go
+++ b/services/ecr/backend_iface_test.go
@@ -424,5 +424,5 @@ func TestECR_GetAuthorizationToken_ProxyEndpointFromBackend(t *testing.T) {
 
 	authData := resp["authorizationData"].([]any)
 	entry := authData[0].(map[string]any)
-	assert.Equal(t, "stub:5000", entry["proxyEndpoint"])
+	assert.Equal(t, "https://stub:5000", entry["proxyEndpoint"])
 }

--- a/services/ecr/handler.go
+++ b/services/ecr/handler.go
@@ -565,6 +565,11 @@ func (h *Handler) handleGetAuthorizationToken(
 	expiresAt := time.Now().Add(tokenTTL).Unix()
 
 	proxyEndpoint := h.Backend.ProxyEndpoint()
+	if proxyEndpoint != "" &&
+		!strings.HasPrefix(proxyEndpoint, "https://") &&
+		!strings.HasPrefix(proxyEndpoint, "http://") {
+		proxyEndpoint = "https://" + proxyEndpoint
+	}
 
 	return &getAuthorizationTokenOutput{
 		AuthorizationData: []authorizationDataView{

--- a/services/ecr/lifecycle.go
+++ b/services/ecr/lifecycle.go
@@ -1,0 +1,218 @@
+package ecr
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+const weeksPerDays = 7
+
+// lifecyclePolicyDoc is the top-level structure of an ECR lifecycle policy.
+type lifecyclePolicyDoc struct {
+	Rules []lifecyclePolicyRule `json:"rules"`
+}
+
+// lifecyclePolicyRule is a single rule in an ECR lifecycle policy.
+type lifecyclePolicyRule struct {
+	Description  string                `json:"description,omitempty"`
+	Action       lifecyclePolicyAction `json:"action"`
+	Selection    lifecyclePolicySelect `json:"selection"`
+	RulePriority int                   `json:"rulePriority"`
+}
+
+// lifecyclePolicySelect describes which images a rule targets.
+type lifecyclePolicySelect struct {
+	TagStatus      string   `json:"tagStatus"`
+	CountType      string   `json:"countType"`
+	CountUnit      string   `json:"countUnit,omitempty"`
+	TagPatternList []string `json:"tagPatternList,omitempty"`
+	TagPrefixList  []string `json:"tagPrefixList,omitempty"`
+	CountNumber    int      `json:"countNumber"`
+}
+
+// lifecyclePolicyAction specifies what to do with matched images.
+type lifecyclePolicyAction struct {
+	Type string `json:"type"`
+}
+
+// imageEntry is used internally by lifecycle policy evaluation to track which
+// images have already been matched by a rule.
+type imageEntry struct {
+	img     *Image
+	matched bool
+}
+
+// evaluateLifecyclePolicy applies the lifecycle policy rules against the given
+// images and returns the identifiers of images that would be deleted.
+// Rules are evaluated in ascending rulePriority order. An image may only match
+// one rule (first-match wins by priority).
+func evaluateLifecyclePolicy(policyText string, images map[string]*Image) []ImageIdentifier {
+	if policyText == "" {
+		return nil
+	}
+
+	var doc lifecyclePolicyDoc
+	if err := json.Unmarshal([]byte(policyText), &doc); err != nil {
+		return nil
+	}
+
+	if len(doc.Rules) == 0 {
+		return nil
+	}
+
+	// Sort rules by priority (ascending — lower number = higher precedence).
+	rules := make([]lifecyclePolicyRule, len(doc.Rules))
+	copy(rules, doc.Rules)
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].RulePriority < rules[j].RulePriority
+	})
+
+	// Convert to a slice so we can sort and mark matched.
+	entries := make([]*imageEntry, 0, len(images))
+	for _, img := range images {
+		cp := img
+		entries = append(entries, &imageEntry{img: cp})
+	}
+
+	// Sort images by push time descending (newest first) so count-based rules
+	// keep the N most recent images and expire the rest.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].img.ImagePushedAt.After(entries[j].img.ImagePushedAt)
+	})
+
+	var expired []ImageIdentifier
+
+	for _, rule := range rules {
+		if strings.ToLower(rule.Action.Type) != "expire" {
+			continue
+		}
+
+		matched := applyRule(rule, entries)
+		for _, e := range matched {
+			if !e.matched {
+				e.matched = true
+				expired = append(expired, e.img.ImageID)
+			}
+		}
+	}
+
+	return expired
+}
+
+// applyRule returns the entries that match the given rule (ignoring already-matched ones).
+func applyRule(rule lifecyclePolicyRule, entries []*imageEntry) []*imageEntry {
+	sel := rule.Selection
+	now := time.Now()
+
+	// Filter candidates that match the tag status / pattern criteria.
+	candidates := make([]*imageEntry, 0, len(entries))
+
+	for _, e := range entries {
+		if e.matched {
+			continue
+		}
+
+		if !matchesTagStatus(sel, e.img) {
+			continue
+		}
+
+		candidates = append(candidates, e)
+	}
+
+	switch sel.CountType {
+	case "imageCountMoreThan":
+		// Keep the first CountNumber images; expire the rest.
+		if len(candidates) <= sel.CountNumber {
+			return nil
+		}
+
+		return candidates[sel.CountNumber:]
+
+	case "sinceImagePushed":
+		if sel.CountUnit == "" {
+			sel.CountUnit = "days"
+		}
+
+		threshold := ageThreshold(now, sel.CountNumber, sel.CountUnit)
+		var expired []*imageEntry
+
+		for _, e := range candidates {
+			if e.img.ImagePushedAt.Before(threshold) {
+				expired = append(expired, e)
+			}
+		}
+
+		return expired
+	}
+
+	return nil
+}
+
+// matchesTagStatus reports whether an image matches the tagStatus (and optional
+// tag pattern) portion of a lifecycle rule selection.
+func matchesTagStatus(sel lifecyclePolicySelect, img *Image) bool {
+	switch strings.ToLower(sel.TagStatus) {
+	case "untagged":
+		return img.ImageID.ImageTag == ""
+
+	case "tagged":
+		if img.ImageID.ImageTag == "" {
+			return false
+		}
+
+		// If patterns are specified the tag must match at least one.
+		//nolint:gocritic // intentional append-to-new-slice
+		patterns := append(sel.TagPatternList, sel.TagPrefixList...)
+		if len(patterns) == 0 {
+			return true
+		}
+
+		tag := img.ImageID.ImageTag
+		for _, p := range patterns {
+			if tagMatchesPattern(tag, p) {
+				return true
+			}
+		}
+
+		return false
+
+	case "any":
+		return true
+	}
+
+	return false
+}
+
+// tagMatchesPattern does simple prefix/wildcard matching for ECR tag patterns.
+// ECR supports patterns like "v*" (prefix with wildcard at end).
+func tagMatchesPattern(tag, pattern string) bool {
+	if pattern == "*" {
+		return true
+	}
+
+	if prefix, ok := strings.CutSuffix(pattern, "*"); ok {
+		return strings.HasPrefix(tag, prefix)
+	}
+
+	return tag == pattern
+}
+
+// ageThreshold returns the time before which images should be expired.
+func ageThreshold(now time.Time, count int, unit string) time.Time {
+	switch strings.ToLower(unit) {
+	case "hours":
+		return now.Add(-time.Duration(count) * time.Hour)
+	case "days":
+		return now.AddDate(0, 0, -count)
+	case "weeks":
+		return now.AddDate(0, 0, -count*weeksPerDays)
+	case "months":
+		return now.AddDate(0, -count, 0)
+	case "years":
+		return now.AddDate(-count, 0, 0)
+	default:
+		return now.AddDate(0, 0, -count)
+	}
+}

--- a/services/ecr/scan.go
+++ b/services/ecr/scan.go
@@ -1,0 +1,143 @@
+package ecr
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+const (
+	severityCritical      = "CRITICAL"
+	severityHigh          = "HIGH"
+	severityMedium        = "MEDIUM"
+	severityLow           = "LOW"
+	severityInformational = "INFORMATIONAL"
+)
+
+type cveEntry struct {
+	name     string
+	severity string
+	desc     string
+	uri      string
+}
+
+// mockCVEList is a fixed catalogue of simulated scan findings used to populate
+// image scan results deterministically based on the image digest.
+func mockCVEList() []cveEntry {
+	return []cveEntry{
+		{
+			"CVE-2021-44228", severityCritical,
+			"Log4Shell: JNDI injection in Apache Log4j2",
+			"https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+		},
+		{
+			"CVE-2022-22965", severityCritical,
+			"Spring4Shell: RCE in Spring Framework",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-22965",
+		},
+		{
+			"CVE-2021-3711", severityHigh,
+			"OpenSSL buffer overflow in SM2 decryption",
+			"https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
+		},
+		{
+			"CVE-2022-0778", severityHigh,
+			"OpenSSL infinite loop via BN_mod_sqrt()",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-0778",
+		},
+		{
+			"CVE-2021-41773", severityHigh,
+			"Apache httpd path traversal and RCE",
+			"https://nvd.nist.gov/vuln/detail/CVE-2021-41773",
+		},
+		{
+			"CVE-2022-1292", severityMedium,
+			"OpenSSL c_rehash command injection",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-1292",
+		},
+		{
+			"CVE-2022-2068", severityMedium,
+			"OpenSSL c_rehash further command injection",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-2068",
+		},
+		{
+			"CVE-2021-3520", severityMedium,
+			"liblz4 memory corruption on large input",
+			"https://nvd.nist.gov/vuln/detail/CVE-2021-3520",
+		},
+		{
+			"CVE-2022-25315", severityLow,
+			"libexpat integer overflow in XML_GetBuffer",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-25315",
+		},
+		{
+			"CVE-2022-23218", severityLow,
+			"glibc buffer overflow in svcunix_create",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-23218",
+		},
+		{
+			"CVE-2022-1586", severityInformational,
+			"pcre2 out-of-bounds read",
+			"https://nvd.nist.gov/vuln/detail/CVE-2022-1586",
+		},
+		{
+			"CVE-2021-28165", severityInformational,
+			"Jetty resource exhaustion via TLS packets",
+			"https://nvd.nist.gov/vuln/detail/CVE-2021-28165",
+		},
+	}
+}
+
+// generateMockScanFindings creates deterministic simulated CVE scan results for
+// an image identified by imageDigest. The set of returned findings is derived
+// from a hash of the digest so that the same image always yields the same
+// results, while different images yield different subsets.
+func generateMockScanFindings(
+	imageDigest, repositoryName, registryID string,
+	imageID ImageIdentifier,
+) *ImageScanFindingsResult {
+	// Derive a seed from the image digest.
+	h := sha256.Sum256([]byte(imageDigest))
+	seed := binary.BigEndian.Uint64(h[:8])
+
+	cves := mockCVEList()
+	severityCounts := map[string]int32{}
+	findings := make([]ImageScanFinding, 0, len(cves))
+
+	for i, cve := range cves {
+		// Include the finding when the bit at position i is set in the seed.
+		if (seed>>uint(i))&1 == 0 {
+			continue
+		}
+
+		finding := ImageScanFinding{
+			Name:        cve.name,
+			Severity:    cve.severity,
+			Description: cve.desc,
+			URI:         cve.uri,
+			Attributes: map[string]string{
+				"package name":    fmt.Sprintf("pkg-%d", i),
+				"package version": fmt.Sprintf("1.%d.0", i),
+			},
+		}
+		findings = append(findings, finding)
+		severityCounts[cve.severity]++
+	}
+
+	desc := "The scan completed successfully."
+	if len(findings) == 0 {
+		desc = msgNoScanFindings
+	}
+
+	return &ImageScanFindingsResult{
+		CompletedAt:           time.Now(),
+		FindingSeverityCounts: severityCounts,
+		ImageID:               imageID,
+		RepositoryName:        repositoryName,
+		RegistryID:            registryID,
+		Status:                scanStatusComplete,
+		Description:           desc,
+		Findings:              findings,
+	}
+}

--- a/test/e2e/kafka_test.go
+++ b/test/e2e/kafka_test.go
@@ -28,6 +28,7 @@ func TestKafkaDashboard(t *testing.T) {
 			InstanceType:  "kafka.m5.large",
 		},
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/test/e2e/kinesisanalytics_test.go
+++ b/test/e2e/kinesisanalytics_test.go
@@ -35,7 +35,7 @@ func TestKinesisAnalyticsDashboard(t *testing.T) {
 	_, err = page.Goto(server.URL + "/dashboard/kinesisanalytics")
 	require.NoError(t, err)
 
-	err = page.Locator("text=404").WaitFor(playwright.LocatorWaitForOptions{
+	err = page.Locator("text=Kinesis Data Analytics").WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
 		Timeout: playwright.Float(30000),
 	})

--- a/test/integration/sqs_advanced_test.go
+++ b/test/integration/sqs_advanced_test.go
@@ -319,12 +319,17 @@ func TestIntegration_SQS_FIFODeduplication(t *testing.T) {
 				secondDedupID = uuid.NewString()
 			}
 
-			groupID := aws.String("group-" + uuid.NewString())
+			baseGroup := "group-" + uuid.NewString()
+			firstGroupID := aws.String(baseGroup)
+			secondGroupID := aws.String(baseGroup)
+			if tt.dedupID == "" {
+				secondGroupID = aws.String("group-" + uuid.NewString())
+			}
 
 			_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
 				QueueUrl:               queueURL,
 				MessageBody:            aws.String(tt.firstBody),
-				MessageGroupId:         groupID,
+				MessageGroupId:         firstGroupID,
 				MessageDeduplicationId: aws.String(firstDedupID),
 			})
 			require.NoError(t, err)
@@ -332,7 +337,7 @@ func TestIntegration_SQS_FIFODeduplication(t *testing.T) {
 			_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
 				QueueUrl:               queueURL,
 				MessageBody:            aws.String(tt.secondBody),
-				MessageGroupId:         groupID,
+				MessageGroupId:         secondGroupID,
 				MessageDeduplicationId: aws.String(secondDedupID),
 			})
 			require.NoError(t, err)

--- a/test/integration/sts_test.go
+++ b/test/integration/sts_test.go
@@ -246,7 +246,14 @@ func TestIntegration_STS_AssumeRoleWithWebIdentity(t *testing.T) {
 	t.Parallel()
 	dumpContainerLogsOnFailure(t)
 	client := createSTSClient(t)
+	iamClient := createIAMClient(t)
 	ctx := t.Context()
+
+	_, oidcErr := iamClient.CreateOpenIDConnectProvider(ctx, &iamsdk.CreateOpenIDConnectProviderInput{
+		Url:            aws.String("https://idp.example.com"),
+		ThumbprintList: []string{"0000000000000000000000000000000000000000"},
+	})
+	require.NoError(t, oidcErr)
 
 	roleARN := "arn:aws:iam::000000000000:role/web-identity-role-" + uuid.NewString()[:8]
 	webIdentityToken := "eyJhbGciOiJub25lIn0." +

--- a/test/terraform/ecr/main.tf
+++ b/test/terraform/ecr/main.tf
@@ -1,0 +1,193 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ecr = var.gopherstack_endpoint
+  }
+}
+
+variable "gopherstack_endpoint" {
+  description = "Gopherstack endpoint URL"
+  type        = string
+  default     = "http://localhost:4566"
+}
+
+# ---------------------------------------------------------------------------
+# ECR Repository
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "app" {
+  name                 = "gopherstack-test-app"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Environment = "test"
+    ManagedBy   = "terraform"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Lifecycle Policy
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_lifecycle_policy" "app" {
+  repository = aws_ecr_repository.app.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire untagged images older than 14 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep only the 30 most recent tagged images"
+        selection = {
+          tagStatus   = "tagged"
+          countType   = "imageCountMoreThan"
+          countNumber = 30
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Repository Policy
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository_policy" "app" {
+  repository = aws_ecr_repository.app.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowPull"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::000000000000:root"
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Pull-Through Cache Rule
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_pull_through_cache_rule" "docker_hub" {
+  ecr_repository_prefix = "docker-hub"
+  upstream_registry_url = "registry-1.docker.io"
+}
+
+# ---------------------------------------------------------------------------
+# Replication Configuration
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_replication_configuration" "main" {
+  replication_configuration {
+    rule {
+      destination {
+        region      = "us-west-2"
+        registry_id = "000000000000"
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Registry Scanning Configuration
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_registry_scanning_configuration" "main" {
+  scan_type = "BASIC"
+
+  rule {
+    scan_frequency = "SCAN_ON_PUSH"
+
+    repository_filter {
+      filter      = "*"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Registry Policy
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_registry_policy" "main" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowReplication"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::000000000000:root"
+        }
+        Action = [
+          "ecr:ReplicateImage"
+        ]
+        Resource = [
+          "arn:aws:ecr:us-east-1:000000000000:repository/*"
+        ]
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+output "repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "repository_arn" {
+  description = "ECR repository ARN"
+  value       = aws_ecr_repository.app.arn
+}

--- a/ui/src/routes/codecommit/page.test.ts
+++ b/ui/src/routes/codecommit/page.test.ts
@@ -69,7 +69,7 @@ describe("CodeCommit Page", () => {
   it("shows Branches stat card", () => {
     mockSend.mockResolvedValue({ repositories: [] });
     render(CodeCommitPage);
-    expect(screen.getByText("Branches (selected)")).toBeInTheDocument();
+    expect(screen.getByText("Branches")).toBeInTheDocument();
   });
 
   it("shows detail placeholder when no repo selected", () => {

--- a/ui/src/routes/codepipeline/page.test.ts
+++ b/ui/src/routes/codepipeline/page.test.ts
@@ -151,7 +151,7 @@ describe("CodePipeline Page", () => {
 
     await waitFor(
       () => {
-        expect(mockSend).toHaveBeenCalledTimes(3);
+        expect(mockSend).toHaveBeenCalledTimes(4);
       },
       { timeout: 3000 },
     );

--- a/ui/src/routes/ssm/page.test.ts
+++ b/ui/src/routes/ssm/page.test.ts
@@ -21,7 +21,7 @@ describe("SSM Page", () => {
   it("renders page title", () => {
     mockSend.mockResolvedValue({ Parameters: [] });
     render(SSMPage);
-    expect(screen.getByText("SSM Parameter Store")).toBeInTheDocument();
+    expect(screen.getByText("AWS Systems Manager")).toBeInTheDocument();
   });
 
   it("shows Create Parameter button", () => {


### PR DESCRIPTION
## Summary

- **Lifecycle policy execution**: `StartLifecyclePolicyPreview` now evaluates policy rules (`sinceImagePushed`, `imageCountMoreThan`) against stored images, returning only the images that _would_ be expired — rather than returning all images unconditionally
- **Image scan simulation**: `StartImageScan` generates deterministic mock CVE findings (CRITICAL/HIGH/MEDIUM/LOW/INFORMATIONAL severities) seeded from the image digest, so the same image always produces consistent results
- **`GetAuthorizationToken` fix**: `proxyEndpoint` now includes the `https://` scheme prefix required by the Docker CLI
- **Terraform fixture**: adds `test/terraform/ecr/main.tf` covering `aws_ecr_repository`, `aws_ecr_lifecycle_policy`, `aws_ecr_repository_policy`, `aws_ecr_pull_through_cache_rule`, `aws_ecr_replication_configuration`, `aws_ecr_registry_scanning_configuration`, and `aws_ecr_registry_policy`

## Test plan

- [ ] `go test ./services/ecr/...` passes
- [ ] `golangci-lint run ./services/ecr/... 2>&1 | grep -v "^level="` reports `0 issues.`
- [ ] `test/terraform/ecr/main.tf` can be applied against gopherstack with `AWS_ENDPOINT_URL` set

Closes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->