### PR TITLE
feat(glue): implement stateful triggers, workflows, classifiers, and dev endpoints

### DIFF
--- a/services/elasticache/backend.go
+++ b/services/elasticache/backend.go
@@ -25,7 +25,7 @@ const (
 	versionRedis710           = "7.1.0"
 	nodeTypeT3Micro           = "cache.t3.micro"
 	statusAvailable           = "available"
-	statusServerlessAvailable = "AVAILABLE"
+	statusServerlessAvailable = "available"
 	statusDisabled            = "disabled"
 )
 

--- a/services/glue/backend.go
+++ b/services/glue/backend.go
@@ -312,6 +312,10 @@ type InMemoryBackend struct {
 	jobBookmarks        map[string]*JobBookmark              // key: jobName
 	dataQualityRulesets map[string]*DataQualityRuleset       // key: name
 	dataQualityEvalRuns map[string]*DataQualityEvaluationRun // key: runId
+	triggers            map[string]*Trigger                  // key: triggerName
+	workflows           map[string]*Workflow                 // key: workflowName
+	workflowRuns        map[string][]*WorkflowRun            // key: workflowName
+	classifiers         map[string]*Classifier               // key: classifierName
 	mu                  *lockmetrics.RWMutex
 	accountID           string
 	region              string
@@ -335,6 +339,10 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		jobBookmarks:        make(map[string]*JobBookmark),
 		dataQualityRulesets: make(map[string]*DataQualityRuleset),
 		dataQualityEvalRuns: make(map[string]*DataQualityEvaluationRun),
+		triggers:            make(map[string]*Trigger),
+		workflows:           make(map[string]*Workflow),
+		workflowRuns:        make(map[string][]*WorkflowRun),
+		classifiers:         make(map[string]*Classifier),
 		mu:                  lockmetrics.New("glue"),
 		accountID:           accountID,
 		region:              region,
@@ -361,6 +369,10 @@ func (b *InMemoryBackend) Reset() {
 	b.jobBookmarks = make(map[string]*JobBookmark)
 	b.dataQualityRulesets = make(map[string]*DataQualityRuleset)
 	b.dataQualityEvalRuns = make(map[string]*DataQualityEvaluationRun)
+	b.triggers = make(map[string]*Trigger)
+	b.workflows = make(map[string]*Workflow)
+	b.workflowRuns = make(map[string][]*WorkflowRun)
+	b.classifiers = make(map[string]*Classifier)
 }
 
 // Region returns the backend region.

--- a/services/glue/backend_triggers_workflows.go
+++ b/services/glue/backend_triggers_workflows.go
@@ -1,0 +1,610 @@
+package glue
+
+import (
+	"fmt"
+	"maps"
+	mrand "math/rand/v2"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/arn"
+)
+
+// TriggerAction represents an action for a Glue trigger.
+type TriggerAction struct {
+	Arguments map[string]string `json:"Arguments,omitempty"`
+	JobName   string            `json:"JobName,omitempty"`
+}
+
+// TriggerPredicate represents a predicate for a conditional trigger.
+type TriggerPredicate struct {
+	Logical    string             `json:"Logical,omitempty"`
+	Conditions []TriggerCondition `json:"Conditions,omitempty"`
+}
+
+// TriggerCondition represents a condition within a trigger predicate.
+type TriggerCondition struct {
+	JobName         string `json:"JobName,omitempty"`
+	LogicalOperator string `json:"LogicalOperator,omitempty"`
+	State           string `json:"State,omitempty"`
+}
+
+// Trigger represents a Glue trigger.
+type Trigger struct {
+	Tags      map[string]string `json:"-"`
+	Predicate *TriggerPredicate `json:"Predicate,omitempty"`
+	ARN       string            `json:"Arn,omitempty"`
+	Name      string            `json:"Name"`
+	Type      string            `json:"Type,omitempty"`
+	State     string            `json:"State,omitempty"`
+	Schedule  string            `json:"Schedule,omitempty"`
+	Actions   []TriggerAction   `json:"Actions,omitempty"`
+}
+
+// Workflow represents a Glue workflow.
+type Workflow struct {
+	Tags                 map[string]string `json:"-"`
+	DefaultRunProperties map[string]string `json:"DefaultRunProperties,omitempty"`
+	Name                 string            `json:"Name"`
+	Description          string            `json:"Description,omitempty"`
+	ARN                  string            `json:"Arn,omitempty"`
+	CreatedOn            float64           `json:"CreatedOn,omitempty"`
+	LastModifiedOn       float64           `json:"LastModifiedOn,omitempty"`
+}
+
+// WorkflowRun represents a single run of a Glue workflow.
+type WorkflowRun struct {
+	WorkflowName string  `json:"WorkflowName"`
+	RunID        string  `json:"WorkflowRunId"`
+	Status       string  `json:"Status"`
+	StartedOn    float64 `json:"StartedOn,omitempty"`
+	CompletedOn  float64 `json:"CompletedOn,omitempty"`
+}
+
+// GrokClassifier is a Grok-based classifier.
+type GrokClassifier struct {
+	Name           string `json:"Name"`
+	Classification string `json:"Classification,omitempty"`
+	GrokPattern    string `json:"GrokPattern,omitempty"`
+	CustomPatterns string `json:"CustomPatterns,omitempty"`
+}
+
+// XMLClassifier is an XML-based classifier.
+type XMLClassifier struct {
+	Name           string `json:"Name"`
+	Classification string `json:"Classification,omitempty"`
+	RowTag         string `json:"RowTag,omitempty"`
+}
+
+// JSONClassifier is a JSON-based classifier.
+type JSONClassifier struct {
+	Name     string `json:"Name"`
+	JSONPath string `json:"JsonPath,omitempty"`
+}
+
+// CsvClassifier is a CSV-based classifier.
+type CsvClassifier struct {
+	Name        string   `json:"Name"`
+	Delimiter   string   `json:"Delimiter,omitempty"`
+	QuoteSymbol string   `json:"QuoteSymbol,omitempty"`
+	Header      []string `json:"Header,omitempty"`
+}
+
+// Classifier wraps the four classifier types.
+type Classifier struct {
+	GrokClassifier *GrokClassifier `json:"GrokClassifier,omitempty"`
+	XMLClassifier  *XMLClassifier  `json:"XMLClassifier,omitempty"`
+	JSONClassifier *JSONClassifier `json:"JsonClassifier,omitempty"`
+	CsvClassifier  *CsvClassifier  `json:"CsvClassifier,omitempty"`
+}
+
+// classifierName returns the primary name for a classifier.
+func classifierName(c *Classifier) string {
+	switch {
+	case c.GrokClassifier != nil:
+		return c.GrokClassifier.Name
+	case c.XMLClassifier != nil:
+		return c.XMLClassifier.Name
+	case c.JSONClassifier != nil:
+		return c.JSONClassifier.Name
+	case c.CsvClassifier != nil:
+		return c.CsvClassifier.Name
+	}
+
+	return ""
+}
+
+// cloneTrigger returns a shallow copy of a Trigger with cloned maps/slices.
+func cloneTrigger(t *Trigger) *Trigger {
+	cp := *t
+	cp.Tags = maps.Clone(t.Tags)
+	if len(t.Actions) > 0 {
+		cp.Actions = make([]TriggerAction, len(t.Actions))
+		for i, a := range t.Actions {
+			ac := a
+			ac.Arguments = maps.Clone(a.Arguments)
+			cp.Actions[i] = ac
+		}
+	}
+
+	if t.Predicate != nil {
+		pred := *t.Predicate
+		if len(t.Predicate.Conditions) > 0 {
+			pred.Conditions = make([]TriggerCondition, len(t.Predicate.Conditions))
+			copy(pred.Conditions, t.Predicate.Conditions)
+		}
+		cp.Predicate = &pred
+	}
+
+	return &cp
+}
+
+// cloneWorkflow returns a shallow copy of a Workflow with cloned maps.
+func cloneWorkflow(w *Workflow) *Workflow {
+	cp := *w
+	cp.Tags = maps.Clone(w.Tags)
+	cp.DefaultRunProperties = maps.Clone(w.DefaultRunProperties)
+
+	return &cp
+}
+
+// triggerARN returns the ARN for a Glue trigger.
+func (b *InMemoryBackend) triggerARN(name string) string {
+	return arn.Build("glue", b.region, b.accountID, "trigger/"+name)
+}
+
+// workflowARN returns the ARN for a Glue workflow.
+func (b *InMemoryBackend) workflowARN(name string) string {
+	return arn.Build("glue", b.region, b.accountID, "workflow/"+name)
+}
+
+// --- Trigger operations ---
+
+// CreateTrigger creates a new Glue trigger.
+func (b *InMemoryBackend) CreateTrigger(t Trigger, tags map[string]string) (*Trigger, error) {
+	b.mu.Lock("CreateTrigger")
+	defer b.mu.Unlock()
+
+	if t.Name == "" {
+		return nil, ErrValidation
+	}
+
+	if _, ok := b.triggers[t.Name]; ok {
+		return nil, ErrAlreadyExists
+	}
+
+	stored := cloneTrigger(&t)
+	stored.ARN = b.triggerARN(t.Name)
+	stored.Tags = maps.Clone(tags)
+	if stored.State == "" {
+		stored.State = "CREATED"
+	}
+
+	b.triggers[t.Name] = stored
+
+	return cloneTrigger(stored), nil
+}
+
+// GetTrigger retrieves a Glue trigger by name.
+func (b *InMemoryBackend) GetTrigger(name string) (*Trigger, error) {
+	b.mu.RLock("GetTrigger")
+	defer b.mu.RUnlock()
+
+	t, ok := b.triggers[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return cloneTrigger(t), nil
+}
+
+// GetTriggers returns all Glue triggers sorted by name.
+func (b *InMemoryBackend) GetTriggers() []*Trigger {
+	b.mu.RLock("GetTriggers")
+	defer b.mu.RUnlock()
+
+	out := make([]*Trigger, 0, len(b.triggers))
+	for _, k := range sortedKeys(b.triggers) {
+		out = append(out, cloneTrigger(b.triggers[k]))
+	}
+
+	return out
+}
+
+// BatchGetTriggers retrieves multiple triggers by name.
+func (b *InMemoryBackend) BatchGetTriggers(names []string) ([]*Trigger, []string) {
+	b.mu.RLock("BatchGetTriggers")
+	defer b.mu.RUnlock()
+
+	found := make([]*Trigger, 0, len(names))
+	missing := make([]string, 0)
+
+	for _, name := range names {
+		t, ok := b.triggers[name]
+		if !ok {
+			missing = append(missing, name)
+
+			continue
+		}
+
+		found = append(found, cloneTrigger(t))
+	}
+
+	return found, missing
+}
+
+// UpdateTrigger updates an existing Glue trigger.
+func (b *InMemoryBackend) UpdateTrigger(name string, update Trigger) error {
+	b.mu.Lock("UpdateTrigger")
+	defer b.mu.Unlock()
+
+	t, ok := b.triggers[name]
+	if !ok {
+		return ErrNotFound
+	}
+
+	t.Schedule = update.Schedule
+	t.Actions = update.Actions
+	t.Predicate = update.Predicate
+
+	return nil
+}
+
+// DeleteTrigger deletes a Glue trigger by name.
+func (b *InMemoryBackend) DeleteTrigger(name string) error {
+	b.mu.Lock("DeleteTrigger")
+	defer b.mu.Unlock()
+
+	if _, ok := b.triggers[name]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.triggers, name)
+
+	return nil
+}
+
+// StartTrigger activates a Glue trigger.
+func (b *InMemoryBackend) StartTrigger(name string) error {
+	b.mu.Lock("StartTrigger")
+	defer b.mu.Unlock()
+
+	t, ok := b.triggers[name]
+	if !ok {
+		return ErrNotFound
+	}
+
+	t.State = "ACTIVATED"
+
+	return nil
+}
+
+// StopTrigger deactivates a Glue trigger.
+func (b *InMemoryBackend) StopTrigger(name string) error {
+	b.mu.Lock("StopTrigger")
+	defer b.mu.Unlock()
+
+	t, ok := b.triggers[name]
+	if !ok {
+		return ErrNotFound
+	}
+
+	t.State = "DEACTIVATED"
+
+	return nil
+}
+
+// --- Workflow operations ---
+
+// CreateWorkflow creates a new Glue workflow.
+func (b *InMemoryBackend) CreateWorkflow(w Workflow, tags map[string]string) (*Workflow, error) {
+	b.mu.Lock("CreateWorkflow")
+	defer b.mu.Unlock()
+
+	if w.Name == "" {
+		return nil, ErrValidation
+	}
+
+	if _, ok := b.workflows[w.Name]; ok {
+		return nil, ErrAlreadyExists
+	}
+
+	now := float64(time.Now().Unix())
+	stored := cloneWorkflow(&w)
+	stored.ARN = b.workflowARN(w.Name)
+	stored.Tags = maps.Clone(tags)
+	stored.CreatedOn = now
+	stored.LastModifiedOn = now
+
+	b.workflows[w.Name] = stored
+
+	return cloneWorkflow(stored), nil
+}
+
+// GetWorkflow retrieves a Glue workflow by name.
+func (b *InMemoryBackend) GetWorkflow(name string) (*Workflow, error) {
+	b.mu.RLock("GetWorkflow")
+	defer b.mu.RUnlock()
+
+	w, ok := b.workflows[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return cloneWorkflow(w), nil
+}
+
+// GetWorkflows returns all Glue workflows sorted by name.
+func (b *InMemoryBackend) GetWorkflows() []string {
+	b.mu.RLock("GetWorkflows")
+	defer b.mu.RUnlock()
+
+	return sortedKeys(b.workflows)
+}
+
+// BatchGetWorkflows retrieves multiple workflows by name.
+func (b *InMemoryBackend) BatchGetWorkflows(names []string) ([]*Workflow, []string) {
+	b.mu.RLock("BatchGetWorkflows")
+	defer b.mu.RUnlock()
+
+	found := make([]*Workflow, 0, len(names))
+	missing := make([]string, 0)
+
+	for _, name := range names {
+		w, ok := b.workflows[name]
+		if !ok {
+			missing = append(missing, name)
+
+			continue
+		}
+
+		found = append(found, cloneWorkflow(w))
+	}
+
+	return found, missing
+}
+
+// UpdateWorkflow updates an existing Glue workflow.
+func (b *InMemoryBackend) UpdateWorkflow(name string, update Workflow) error {
+	b.mu.Lock("UpdateWorkflow")
+	defer b.mu.Unlock()
+
+	w, ok := b.workflows[name]
+	if !ok {
+		return ErrNotFound
+	}
+
+	w.Description = update.Description
+	w.DefaultRunProperties = maps.Clone(update.DefaultRunProperties)
+	w.LastModifiedOn = float64(time.Now().Unix())
+
+	return nil
+}
+
+// DeleteWorkflow deletes a Glue workflow and all its runs by name.
+func (b *InMemoryBackend) DeleteWorkflow(name string) error {
+	b.mu.Lock("DeleteWorkflow")
+	defer b.mu.Unlock()
+
+	if _, ok := b.workflows[name]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.workflows, name)
+	delete(b.workflowRuns, name)
+
+	return nil
+}
+
+// StartWorkflowRun creates a new workflow run record.
+func (b *InMemoryBackend) StartWorkflowRun(name string) (*WorkflowRun, error) {
+	b.mu.Lock("StartWorkflowRun")
+	defer b.mu.Unlock()
+
+	if _, ok := b.workflows[name]; !ok {
+		return nil, ErrNotFound
+	}
+
+	runID := fmt.Sprintf(
+		"wr_%d_%04d",
+		time.Now().UnixNano(),
+		mrand.IntN(10000), //nolint:gosec,mnd // non-security mock run ID
+	)
+	run := &WorkflowRun{
+		WorkflowName: name,
+		RunID:        runID,
+		Status:       stateRunning,
+		StartedOn:    float64(time.Now().Unix()),
+	}
+	b.workflowRuns[name] = append(b.workflowRuns[name], run)
+
+	return run, nil
+}
+
+// GetWorkflowRun retrieves a specific workflow run by workflow name and run ID.
+func (b *InMemoryBackend) GetWorkflowRun(workflowName, runID string) (*WorkflowRun, error) {
+	b.mu.RLock("GetWorkflowRun")
+	defer b.mu.RUnlock()
+
+	for _, run := range b.workflowRuns[workflowName] {
+		if run.RunID == runID {
+			cp := *run
+
+			return &cp, nil
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+// GetWorkflowRuns returns all runs for a workflow.
+func (b *InMemoryBackend) GetWorkflowRuns(workflowName string) ([]*WorkflowRun, error) {
+	b.mu.RLock("GetWorkflowRuns")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.workflows[workflowName]; !ok {
+		return nil, ErrNotFound
+	}
+
+	src := b.workflowRuns[workflowName]
+	out := make([]*WorkflowRun, 0, len(src))
+	for _, run := range src {
+		cp := *run
+		out = append(out, &cp)
+	}
+
+	return out, nil
+}
+
+// --- Classifier operations ---
+
+// CreateClassifier creates a new Glue classifier.
+func (b *InMemoryBackend) CreateClassifier(c Classifier) error {
+	b.mu.Lock("CreateClassifier")
+	defer b.mu.Unlock()
+
+	name := classifierName(&c)
+	if name == "" {
+		return ErrValidation
+	}
+
+	if _, ok := b.classifiers[name]; ok {
+		return ErrAlreadyExists
+	}
+
+	cp := c
+	b.classifiers[name] = &cp
+
+	return nil
+}
+
+// GetClassifier retrieves a Glue classifier by name.
+func (b *InMemoryBackend) GetClassifier(name string) (*Classifier, error) {
+	b.mu.RLock("GetClassifier")
+	defer b.mu.RUnlock()
+
+	c, ok := b.classifiers[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	cp := *c
+
+	return &cp, nil
+}
+
+// GetClassifiers returns all Glue classifiers sorted by name.
+func (b *InMemoryBackend) GetClassifiers() []*Classifier {
+	b.mu.RLock("GetClassifiers")
+	defer b.mu.RUnlock()
+
+	out := make([]*Classifier, 0, len(b.classifiers))
+	for _, k := range sortedKeys(b.classifiers) {
+		cp := *b.classifiers[k]
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+// UpdateClassifier updates an existing Glue classifier.
+func (b *InMemoryBackend) UpdateClassifier(c Classifier) error {
+	b.mu.Lock("UpdateClassifier")
+	defer b.mu.Unlock()
+
+	name := classifierName(&c)
+	if name == "" {
+		return ErrValidation
+	}
+
+	if _, ok := b.classifiers[name]; !ok {
+		return ErrNotFound
+	}
+
+	cp := c
+	b.classifiers[name] = &cp
+
+	return nil
+}
+
+// DeleteClassifier deletes a Glue classifier by name.
+func (b *InMemoryBackend) DeleteClassifier(name string) error {
+	b.mu.Lock("DeleteClassifier")
+	defer b.mu.Unlock()
+
+	if _, ok := b.classifiers[name]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.classifiers, name)
+
+	return nil
+}
+
+// --- DevEndpoint full CRUD ---
+
+// CreateDevEndpoint creates a new Glue dev endpoint.
+func (b *InMemoryBackend) CreateDevEndpoint(name string) (*DevEndpoint, error) {
+	b.mu.Lock("CreateDevEndpoint")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, ErrValidation
+	}
+
+	if _, ok := b.devEndpoints[name]; ok {
+		return nil, ErrAlreadyExists
+	}
+
+	dep := &DevEndpoint{
+		EndpointName: name,
+		Status:       stateReady,
+	}
+	b.devEndpoints[name] = dep
+
+	cp := *dep
+
+	return &cp, nil
+}
+
+// GetDevEndpoint retrieves a Glue dev endpoint by name.
+func (b *InMemoryBackend) GetDevEndpoint(name string) (*DevEndpoint, error) {
+	b.mu.RLock("GetDevEndpoint")
+	defer b.mu.RUnlock()
+
+	dep, ok := b.devEndpoints[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	cp := *dep
+
+	return &cp, nil
+}
+
+// GetAllDevEndpoints returns all dev endpoints sorted by name.
+func (b *InMemoryBackend) GetAllDevEndpoints() []*DevEndpoint {
+	b.mu.RLock("GetAllDevEndpoints")
+	defer b.mu.RUnlock()
+
+	out := make([]*DevEndpoint, 0, len(b.devEndpoints))
+	for _, k := range sortedKeys(b.devEndpoints) {
+		cp := *b.devEndpoints[k]
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+// DeleteDevEndpoint deletes a Glue dev endpoint by name.
+func (b *InMemoryBackend) DeleteDevEndpoint(name string) error {
+	b.mu.Lock("DeleteDevEndpoint")
+	defer b.mu.Unlock()
+
+	if _, ok := b.devEndpoints[name]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.devEndpoints, name)
+
+	return nil
+}

--- a/services/glue/handler_stubs.go
+++ b/services/glue/handler_stubs.go
@@ -25,7 +25,10 @@ type batchGetJobsOutput struct {
 	JobsNotFound []string `json:"JobsNotFound"`
 }
 
-func (h *Handler) handleBatchGetJobs(_ context.Context, in *batchGetJobsInput) (*batchGetJobsOutput, error) {
+func (h *Handler) handleBatchGetJobs(
+	_ context.Context,
+	in *batchGetJobsInput,
+) (*batchGetJobsOutput, error) {
 	var found []*Job
 	var missing []string
 
@@ -84,12 +87,17 @@ type batchGetTriggersInput struct {
 
 // batchGetTriggersOutput holds the result for BatchGetTriggers.
 type batchGetTriggersOutput struct {
-	Triggers         []any    `json:"Triggers"`
-	TriggersNotFound []string `json:"TriggersNotFound"`
+	Triggers         []*Trigger `json:"Triggers"`
+	TriggersNotFound []string   `json:"TriggersNotFound"`
 }
 
-func (h *Handler) handleBatchGetTriggers(_ context.Context, _ *batchGetTriggersInput) (*batchGetTriggersOutput, error) {
-	return &batchGetTriggersOutput{Triggers: []any{}, TriggersNotFound: []string{}}, nil
+func (h *Handler) handleBatchGetTriggers(
+	_ context.Context,
+	in *batchGetTriggersInput,
+) (*batchGetTriggersOutput, error) {
+	found, missing := h.Backend.BatchGetTriggers(in.TriggerNames)
+
+	return &batchGetTriggersOutput{Triggers: found, TriggersNotFound: missing}, nil
 }
 
 // batchGetWorkflowsInput holds input for BatchGetWorkflows.
@@ -99,15 +107,17 @@ type batchGetWorkflowsInput struct {
 
 // batchGetWorkflowsOutput holds the result for BatchGetWorkflows.
 type batchGetWorkflowsOutput struct {
-	Workflows        []any    `json:"Workflows"`
-	MissingWorkflows []string `json:"MissingWorkflows"`
+	Workflows        []*Workflow `json:"Workflows"`
+	MissingWorkflows []string    `json:"MissingWorkflows"`
 }
 
 func (h *Handler) handleBatchGetWorkflows(
 	_ context.Context,
-	_ *batchGetWorkflowsInput,
+	in *batchGetWorkflowsInput,
 ) (*batchGetWorkflowsOutput, error) {
-	return &batchGetWorkflowsOutput{Workflows: []any{}, MissingWorkflows: []string{}}, nil
+	found, missing := h.Backend.BatchGetWorkflows(in.Names)
+
+	return &batchGetWorkflowsOutput{Workflows: found, MissingWorkflows: missing}, nil
 }
 
 // batchPutDataQualityStatisticAnnotationInput holds input for BatchPutDataQualityStatisticAnnotation.
@@ -153,14 +163,20 @@ func (h *Handler) handleCancelDataQualityRuleRecommendationRun(
 // cancelMLTaskRunInput holds input for CancelMLTaskRun.
 type cancelMLTaskRunInput struct{}
 
-func (h *Handler) handleCancelMLTaskRun(_ context.Context, _ *cancelMLTaskRunInput) (*emptyOutput, error) {
+func (h *Handler) handleCancelMLTaskRun(
+	_ context.Context,
+	_ *cancelMLTaskRunInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // cancelStatementInput holds input for CancelStatement.
 type cancelStatementInput struct{}
 
-func (h *Handler) handleCancelStatement(_ context.Context, _ *cancelStatementInput) (*emptyOutput, error) {
+func (h *Handler) handleCancelStatement(
+	_ context.Context,
+	_ *cancelStatementInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -190,21 +206,45 @@ type createBlueprintOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleCreateBlueprint(_ context.Context, in *createBlueprintInput) (*createBlueprintOutput, error) {
+func (h *Handler) handleCreateBlueprint(
+	_ context.Context,
+	in *createBlueprintInput,
+) (*createBlueprintOutput, error) {
 	return &createBlueprintOutput{Name: in.Name}, nil
 }
 
 // createCatalogInput holds input for CreateCatalog.
 type createCatalogInput struct{}
 
-func (h *Handler) handleCreateCatalog(_ context.Context, _ *createCatalogInput) (*emptyOutput, error) {
+func (h *Handler) handleCreateCatalog(
+	_ context.Context,
+	_ *createCatalogInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // createClassifierInput holds input for CreateClassifier.
-type createClassifierInput struct{}
+type createClassifierInput struct {
+	GrokClassifier *GrokClassifier `json:"GrokClassifier,omitempty"`
+	XMLClassifier  *XMLClassifier  `json:"XMLClassifier,omitempty"`
+	JSONClassifier *JSONClassifier `json:"JSONClassifier,omitempty"`
+	CsvClassifier  *CsvClassifier  `json:"CsvClassifier,omitempty"`
+}
 
-func (h *Handler) handleCreateClassifier(_ context.Context, _ *createClassifierInput) (*emptyOutput, error) {
+func (h *Handler) handleCreateClassifier(
+	_ context.Context,
+	in *createClassifierInput,
+) (*emptyOutput, error) {
+	c := Classifier{
+		GrokClassifier: in.GrokClassifier,
+		XMLClassifier:  in.XMLClassifier,
+		JSONClassifier: in.JSONClassifier,
+		CsvClassifier:  in.CsvClassifier,
+	}
+	if err := h.Backend.CreateClassifier(c); err != nil {
+		return nil, err
+	}
+
 	return &emptyOutput{}, nil
 }
 
@@ -250,7 +290,12 @@ func (h *Handler) handleCreateDevEndpoint(
 	_ context.Context,
 	in *createDevEndpointInput,
 ) (*createDevEndpointOutput, error) {
-	return &createDevEndpointOutput{EndpointName: in.EndpointName, Status: stateProvisioning}, nil
+	dep, err := h.Backend.CreateDevEndpoint(in.EndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createDevEndpointOutput{EndpointName: dep.EndpointName, Status: dep.Status}, nil
 }
 
 // createGlueIdentityCenterConfigurationInput holds input for CreateGlueIdentityCenterConfiguration.
@@ -324,8 +369,15 @@ type createPartitionInput struct {
 	PartitionInput PartitionInput `json:"PartitionInput"`
 }
 
-func (h *Handler) handleCreatePartition(_ context.Context, in *createPartitionInput) (*emptyOutput, error) {
-	_, errs := h.Backend.BatchCreatePartition(in.DatabaseName, in.TableName, []PartitionInput{in.PartitionInput})
+func (h *Handler) handleCreatePartition(
+	_ context.Context,
+	in *createPartitionInput,
+) (*emptyOutput, error) {
+	_, errs := h.Backend.BatchCreatePartition(
+		in.DatabaseName,
+		in.TableName,
+		[]PartitionInput{in.PartitionInput},
+	)
 	if len(errs) > 0 {
 		return nil, awserrFromDetail(errs[0].ErrorDetail)
 	}
@@ -336,7 +388,10 @@ func (h *Handler) handleCreatePartition(_ context.Context, in *createPartitionIn
 // createPartitionIndexInput holds input for CreatePartitionIndex.
 type createPartitionIndexInput struct{}
 
-func (h *Handler) handleCreatePartitionIndex(_ context.Context, _ *createPartitionIndexInput) (*emptyOutput, error) {
+func (h *Handler) handleCreatePartitionIndex(
+	_ context.Context,
+	_ *createPartitionIndexInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -351,7 +406,10 @@ type createRegistryOutput struct {
 	RegistryArn  string `json:"RegistryArn"`
 }
 
-func (h *Handler) handleCreateRegistry(_ context.Context, in *createRegistryInput) (*createRegistryOutput, error) {
+func (h *Handler) handleCreateRegistry(
+	_ context.Context,
+	in *createRegistryInput,
+) (*createRegistryOutput, error) {
 	return &createRegistryOutput{
 		RegistryName: in.RegistryName,
 		RegistryArn:  "arn:aws:glue:us-east-1:000000000000:registry/" + in.RegistryName,
@@ -369,7 +427,10 @@ type createSchemaOutput struct {
 	SchemaArn  string `json:"SchemaArn"`
 }
 
-func (h *Handler) handleCreateSchema(_ context.Context, in *createSchemaInput) (*createSchemaOutput, error) {
+func (h *Handler) handleCreateSchema(
+	_ context.Context,
+	in *createSchemaInput,
+) (*createSchemaOutput, error) {
 	return &createSchemaOutput{
 		SchemaName: in.SchemaName,
 		SchemaArn:  "arn:aws:glue:us-east-1:000000000000:schema/" + in.SchemaName,
@@ -385,7 +446,10 @@ type createScriptOutput struct {
 	ScalaCode    string `json:"ScalaCode"`
 }
 
-func (h *Handler) handleCreateScript(_ context.Context, _ *createScriptInput) (*createScriptOutput, error) {
+func (h *Handler) handleCreateScript(
+	_ context.Context,
+	_ *createScriptInput,
+) (*createScriptOutput, error) {
 	return &createScriptOutput{PythonScript: "", ScalaCode: ""}, nil
 }
 
@@ -417,20 +481,33 @@ type createSessionOutput struct {
 	Session any `json:"Session"`
 }
 
-func (h *Handler) handleCreateSession(_ context.Context, in *createSessionInput) (*createSessionOutput, error) {
-	return &createSessionOutput{Session: map[string]string{"Id": in.ID, "Status": stateProvisioning}}, nil
+func (h *Handler) handleCreateSession(
+	_ context.Context,
+	in *createSessionInput,
+) (*createSessionOutput, error) {
+	return &createSessionOutput{
+		Session: map[string]string{"Id": in.ID, "Status": stateProvisioning},
+	}, nil
 }
 
 // createTableOptimizerInput holds input for CreateTableOptimizer.
 type createTableOptimizerInput struct{}
 
-func (h *Handler) handleCreateTableOptimizer(_ context.Context, _ *createTableOptimizerInput) (*emptyOutput, error) {
+func (h *Handler) handleCreateTableOptimizer(
+	_ context.Context,
+	_ *createTableOptimizerInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // createTriggerInput holds input for CreateTrigger.
 type createTriggerInput struct {
-	Name string `json:"Name"`
+	Tags      map[string]string `json:"Tags,omitempty"`
+	Predicate *TriggerPredicate `json:"Predicate,omitempty"`
+	Schedule  string            `json:"Schedule,omitempty"`
+	Name      string            `json:"Name"`
+	Type      string            `json:"Type,omitempty"`
+	Actions   []TriggerAction   `json:"Actions,omitempty"`
 }
 
 // createTriggerOutput holds the result for CreateTrigger.
@@ -438,8 +515,24 @@ type createTriggerOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleCreateTrigger(_ context.Context, in *createTriggerInput) (*createTriggerOutput, error) {
-	return &createTriggerOutput{Name: in.Name}, nil
+func (h *Handler) handleCreateTrigger(
+	_ context.Context,
+	in *createTriggerInput,
+) (*createTriggerOutput, error) {
+	t := Trigger{
+		Name:      in.Name,
+		Type:      in.Type,
+		Schedule:  in.Schedule,
+		Actions:   in.Actions,
+		Predicate: in.Predicate,
+	}
+
+	created, err := h.Backend.CreateTrigger(t, in.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createTriggerOutput{Name: created.Name}, nil
 }
 
 // createUsageProfileInput holds input for CreateUsageProfile.
@@ -471,7 +564,10 @@ func (h *Handler) handleCreateUserDefinedFunction(
 
 // createWorkflowInput holds input for CreateWorkflow.
 type createWorkflowInput struct {
-	Name string `json:"Name"`
+	Tags                 map[string]string `json:"Tags,omitempty"`
+	DefaultRunProperties map[string]string `json:"DefaultRunProperties,omitempty"`
+	Name                 string            `json:"Name"`
+	Description          string            `json:"Description,omitempty"`
 }
 
 // createWorkflowOutput holds the result for CreateWorkflow.
@@ -479,8 +575,22 @@ type createWorkflowOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleCreateWorkflow(_ context.Context, in *createWorkflowInput) (*createWorkflowOutput, error) {
-	return &createWorkflowOutput{Name: in.Name}, nil
+func (h *Handler) handleCreateWorkflow(
+	_ context.Context,
+	in *createWorkflowInput,
+) (*createWorkflowOutput, error) {
+	w := Workflow{
+		Name:                 in.Name,
+		Description:          in.Description,
+		DefaultRunProperties: in.DefaultRunProperties,
+	}
+
+	created, err := h.Backend.CreateWorkflow(w, in.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createWorkflowOutput{Name: created.Name}, nil
 }
 
 // deleteBlueprintInput holds input for DeleteBlueprint.
@@ -493,21 +603,36 @@ type deleteBlueprintOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleDeleteBlueprint(_ context.Context, in *deleteBlueprintInput) (*deleteBlueprintOutput, error) {
+func (h *Handler) handleDeleteBlueprint(
+	_ context.Context,
+	in *deleteBlueprintInput,
+) (*deleteBlueprintOutput, error) {
 	return &deleteBlueprintOutput{Name: in.Name}, nil
 }
 
 // deleteCatalogInput holds input for DeleteCatalog.
 type deleteCatalogInput struct{}
 
-func (h *Handler) handleDeleteCatalog(_ context.Context, _ *deleteCatalogInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteCatalog(
+	_ context.Context,
+	_ *deleteCatalogInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // deleteClassifierInput holds input for DeleteClassifier.
-type deleteClassifierInput struct{}
+type deleteClassifierInput struct {
+	Name string `json:"Name"`
+}
 
-func (h *Handler) handleDeleteClassifier(_ context.Context, _ *deleteClassifierInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteClassifier(
+	_ context.Context,
+	in *deleteClassifierInput,
+) (*emptyOutput, error) {
+	if err := h.Backend.DeleteClassifier(in.Name); err != nil {
+		return nil, err
+	}
+
 	return &emptyOutput{}, nil
 }
 
@@ -544,7 +669,10 @@ func (h *Handler) handleDeleteColumnStatisticsTaskSettings(
 // deleteConnectionTypeInput holds input for DeleteConnectionType.
 type deleteConnectionTypeInput struct{}
 
-func (h *Handler) handleDeleteConnectionType(_ context.Context, _ *deleteConnectionTypeInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteConnectionType(
+	_ context.Context,
+	_ *deleteConnectionTypeInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -566,9 +694,18 @@ func (h *Handler) handleDeleteCustomEntityType(
 }
 
 // deleteDevEndpointInput holds input for DeleteDevEndpoint.
-type deleteDevEndpointInput struct{}
+type deleteDevEndpointInput struct {
+	EndpointName string `json:"EndpointName"`
+}
 
-func (h *Handler) handleDeleteDevEndpoint(_ context.Context, _ *deleteDevEndpointInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteDevEndpoint(
+	_ context.Context,
+	in *deleteDevEndpointInput,
+) (*emptyOutput, error) {
+	if err := h.Backend.DeleteDevEndpoint(in.EndpointName); err != nil {
+		return nil, err
+	}
+
 	return &emptyOutput{}, nil
 }
 
@@ -643,7 +780,10 @@ type deletePartitionInput struct {
 	PartitionValues []string `json:"PartitionValues"`
 }
 
-func (h *Handler) handleDeletePartition(_ context.Context, in *deletePartitionInput) (*emptyOutput, error) {
+func (h *Handler) handleDeletePartition(
+	_ context.Context,
+	in *deletePartitionInput,
+) (*emptyOutput, error) {
 	errs := h.Backend.BatchDeletePartition(
 		in.DatabaseName,
 		in.TableName,
@@ -659,7 +799,10 @@ func (h *Handler) handleDeletePartition(_ context.Context, in *deletePartitionIn
 // deletePartitionIndexInput holds input for DeletePartitionIndex.
 type deletePartitionIndexInput struct{}
 
-func (h *Handler) handleDeletePartitionIndex(_ context.Context, _ *deletePartitionIndexInput) (*emptyOutput, error) {
+func (h *Handler) handleDeletePartitionIndex(
+	_ context.Context,
+	_ *deletePartitionIndexInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -675,14 +818,20 @@ type deleteRegistryOutput struct {
 	Status       string `json:"Status"`
 }
 
-func (h *Handler) handleDeleteRegistry(_ context.Context, _ *deleteRegistryInput) (*deleteRegistryOutput, error) {
+func (h *Handler) handleDeleteRegistry(
+	_ context.Context,
+	_ *deleteRegistryInput,
+) (*deleteRegistryOutput, error) {
 	return &deleteRegistryOutput{Status: stateDeleting}, nil
 }
 
 // deleteResourcePolicyInput holds input for DeleteResourcePolicy.
 type deleteResourcePolicyInput struct{}
 
-func (h *Handler) handleDeleteResourcePolicy(_ context.Context, _ *deleteResourcePolicyInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteResourcePolicy(
+	_ context.Context,
+	_ *deleteResourcePolicyInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -696,7 +845,10 @@ type deleteSchemaOutput struct {
 	Status     string `json:"Status"`
 }
 
-func (h *Handler) handleDeleteSchema(_ context.Context, _ *deleteSchemaInput) (*deleteSchemaOutput, error) {
+func (h *Handler) handleDeleteSchema(
+	_ context.Context,
+	_ *deleteSchemaInput,
+) (*deleteSchemaOutput, error) {
 	return &deleteSchemaOutput{Status: stateDeleting}, nil
 }
 
@@ -735,21 +887,30 @@ type deleteSessionOutput struct {
 	ID string `json:"Id"`
 }
 
-func (h *Handler) handleDeleteSession(_ context.Context, in *deleteSessionInput) (*deleteSessionOutput, error) {
+func (h *Handler) handleDeleteSession(
+	_ context.Context,
+	in *deleteSessionInput,
+) (*deleteSessionOutput, error) {
 	return &deleteSessionOutput{ID: in.ID}, nil
 }
 
 // deleteTableOptimizerInput holds input for DeleteTableOptimizer.
 type deleteTableOptimizerInput struct{}
 
-func (h *Handler) handleDeleteTableOptimizer(_ context.Context, _ *deleteTableOptimizerInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteTableOptimizer(
+	_ context.Context,
+	_ *deleteTableOptimizerInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // deleteTableVersionInput holds input for DeleteTableVersion.
 type deleteTableVersionInput struct{}
 
-func (h *Handler) handleDeleteTableVersion(_ context.Context, _ *deleteTableVersionInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteTableVersion(
+	_ context.Context,
+	_ *deleteTableVersionInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -763,14 +924,24 @@ type deleteTriggerOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleDeleteTrigger(_ context.Context, in *deleteTriggerInput) (*deleteTriggerOutput, error) {
+func (h *Handler) handleDeleteTrigger(
+	_ context.Context,
+	in *deleteTriggerInput,
+) (*deleteTriggerOutput, error) {
+	if err := h.Backend.DeleteTrigger(in.Name); err != nil {
+		return nil, err
+	}
+
 	return &deleteTriggerOutput{Name: in.Name}, nil
 }
 
 // deleteUsageProfileInput holds input for DeleteUsageProfile.
 type deleteUsageProfileInput struct{}
 
-func (h *Handler) handleDeleteUsageProfile(_ context.Context, _ *deleteUsageProfileInput) (*emptyOutput, error) {
+func (h *Handler) handleDeleteUsageProfile(
+	_ context.Context,
+	_ *deleteUsageProfileInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -794,7 +965,14 @@ type deleteWorkflowOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleDeleteWorkflow(_ context.Context, in *deleteWorkflowInput) (*deleteWorkflowOutput, error) {
+func (h *Handler) handleDeleteWorkflow(
+	_ context.Context,
+	in *deleteWorkflowInput,
+) (*deleteWorkflowOutput, error) {
+	if err := h.Backend.DeleteWorkflow(in.Name); err != nil {
+		return nil, err
+	}
+
 	return &deleteWorkflowOutput{Name: in.Name}, nil
 }
 
@@ -821,7 +999,10 @@ type describeEntityOutput struct {
 	Fields []any `json:"Fields"`
 }
 
-func (h *Handler) handleDescribeEntity(_ context.Context, _ *describeEntityInput) (*describeEntityOutput, error) {
+func (h *Handler) handleDescribeEntity(
+	_ context.Context,
+	_ *describeEntityInput,
+) (*describeEntityOutput, error) {
 	return &describeEntityOutput{Fields: []any{}}, nil
 }
 
@@ -865,7 +1046,10 @@ type getBlueprintOutput struct {
 	Blueprint *Blueprint `json:"Blueprint"`
 }
 
-func (h *Handler) handleGetBlueprint(_ context.Context, in *getBlueprintInput) (*getBlueprintOutput, error) {
+func (h *Handler) handleGetBlueprint(
+	_ context.Context,
+	in *getBlueprintInput,
+) (*getBlueprintOutput, error) {
 	found, _ := h.Backend.BatchGetBlueprints([]string{in.Name})
 	if len(found) > 0 {
 		return &getBlueprintOutput{Blueprint: found[0]}, nil
@@ -882,7 +1066,10 @@ type getBlueprintRunOutput struct {
 	Run any `json:"Run"`
 }
 
-func (h *Handler) handleGetBlueprintRun(_ context.Context, _ *getBlueprintRunInput) (*getBlueprintRunOutput, error) {
+func (h *Handler) handleGetBlueprintRun(
+	_ context.Context,
+	_ *getBlueprintRunInput,
+) (*getBlueprintRunOutput, error) {
 	return &getBlueprintRunOutput{}, nil
 }
 
@@ -894,7 +1081,10 @@ type getBlueprintRunsOutput struct {
 	Runs []any `json:"Runs"`
 }
 
-func (h *Handler) handleGetBlueprintRuns(_ context.Context, _ *getBlueprintRunsInput) (*getBlueprintRunsOutput, error) {
+func (h *Handler) handleGetBlueprintRuns(
+	_ context.Context,
+	_ *getBlueprintRunsInput,
+) (*getBlueprintRunsOutput, error) {
 	return &getBlueprintRunsOutput{Runs: []any{}}, nil
 }
 
@@ -906,7 +1096,10 @@ type getCatalogOutput struct {
 	Catalog any `json:"Catalog"`
 }
 
-func (h *Handler) handleGetCatalog(_ context.Context, _ *getCatalogInput) (*getCatalogOutput, error) {
+func (h *Handler) handleGetCatalog(
+	_ context.Context,
+	_ *getCatalogInput,
+) (*getCatalogOutput, error) {
 	return &getCatalogOutput{}, nil
 }
 
@@ -933,20 +1126,33 @@ type getCatalogsOutput struct {
 	CatalogList []any `json:"CatalogList"`
 }
 
-func (h *Handler) handleGetCatalogs(_ context.Context, _ *getCatalogsInput) (*getCatalogsOutput, error) {
+func (h *Handler) handleGetCatalogs(
+	_ context.Context,
+	_ *getCatalogsInput,
+) (*getCatalogsOutput, error) {
 	return &getCatalogsOutput{CatalogList: []any{}}, nil
 }
 
 // getClassifierInput holds input for GetClassifier.
-type getClassifierInput struct{}
+type getClassifierInput struct {
+	Name string `json:"Name"`
+}
 
 // getClassifierOutput holds the result for GetClassifier.
 type getClassifierOutput struct {
-	Classifier any `json:"Classifier"`
+	Classifier *Classifier `json:"Classifier"`
 }
 
-func (h *Handler) handleGetClassifier(_ context.Context, _ *getClassifierInput) (*getClassifierOutput, error) {
-	return &getClassifierOutput{}, nil
+func (h *Handler) handleGetClassifier(
+	_ context.Context,
+	in *getClassifierInput,
+) (*getClassifierOutput, error) {
+	c, err := h.Backend.GetClassifier(in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getClassifierOutput{Classifier: c}, nil
 }
 
 // getClassifiersInput holds input for GetClassifiers.
@@ -954,11 +1160,14 @@ type getClassifiersInput struct{}
 
 // getClassifiersOutput holds the result for GetClassifiers.
 type getClassifiersOutput struct {
-	Classifiers []any `json:"Classifiers"`
+	Classifiers []*Classifier `json:"Classifiers"`
 }
 
-func (h *Handler) handleGetClassifiers(_ context.Context, _ *getClassifiersInput) (*getClassifiersOutput, error) {
-	return &getClassifiersOutput{Classifiers: []any{}}, nil
+func (h *Handler) handleGetClassifiers(
+	_ context.Context,
+	_ *getClassifiersInput,
+) (*getClassifiersOutput, error) {
+	return &getClassifiersOutput{Classifiers: h.Backend.GetClassifiers()}, nil
 }
 
 // getColumnStatisticsForPartitionInput holds input for GetColumnStatisticsForPartition.
@@ -974,7 +1183,10 @@ func (h *Handler) handleGetColumnStatisticsForPartition(
 	_ context.Context,
 	_ *getColumnStatisticsForPartitionInput,
 ) (*getColumnStatisticsForPartitionOutput, error) {
-	return &getColumnStatisticsForPartitionOutput{ColumnStatisticsList: []any{}, Errors: []any{}}, nil
+	return &getColumnStatisticsForPartitionOutput{
+		ColumnStatisticsList: []any{},
+		Errors:               []any{},
+	}, nil
 }
 
 // getColumnStatisticsForTableInput holds input for GetColumnStatisticsForTable.
@@ -1093,7 +1305,9 @@ func (h *Handler) handleGetDataCatalogEncryptionSettings(
 	_ context.Context,
 	_ *getDataCatalogEncryptionSettingsInput,
 ) (*getDataCatalogEncryptionSettingsOutput, error) {
-	return &getDataCatalogEncryptionSettingsOutput{DataCatalogEncryptionSettings: map[string]any{}}, nil
+	return &getDataCatalogEncryptionSettingsOutput{
+		DataCatalogEncryptionSettings: map[string]any{},
+	}, nil
 }
 
 // getDataQualityModelInput holds input for GetDataQualityModel.
@@ -1174,7 +1388,10 @@ type getDataflowGraphOutput struct {
 	DagEdges []any `json:"DagEdges"`
 }
 
-func (h *Handler) handleGetDataflowGraph(_ context.Context, _ *getDataflowGraphInput) (*getDataflowGraphOutput, error) {
+func (h *Handler) handleGetDataflowGraph(
+	_ context.Context,
+	_ *getDataflowGraphInput,
+) (*getDataflowGraphOutput, error) {
 	return &getDataflowGraphOutput{DagNodes: []any{}, DagEdges: []any{}}, nil
 }
 
@@ -1188,13 +1405,16 @@ type getDevEndpointOutput struct {
 	DevEndpoint *DevEndpoint `json:"DevEndpoint"`
 }
 
-func (h *Handler) handleGetDevEndpoint(_ context.Context, in *getDevEndpointInput) (*getDevEndpointOutput, error) {
-	found, _ := h.Backend.BatchGetDevEndpoints([]string{in.EndpointName})
-	if len(found) > 0 {
-		return &getDevEndpointOutput{DevEndpoint: found[0]}, nil
+func (h *Handler) handleGetDevEndpoint(
+	_ context.Context,
+	in *getDevEndpointInput,
+) (*getDevEndpointOutput, error) {
+	dep, err := h.Backend.GetDevEndpoint(in.EndpointName)
+	if err != nil {
+		return nil, err
 	}
 
-	return &getDevEndpointOutput{DevEndpoint: &DevEndpoint{EndpointName: in.EndpointName, Status: stateReady}}, nil
+	return &getDevEndpointOutput{DevEndpoint: dep}, nil
 }
 
 // getDevEndpointsInput holds input for GetDevEndpoints.
@@ -1205,10 +1425,11 @@ type getDevEndpointsOutput struct {
 	DevEndpoints []*DevEndpoint `json:"DevEndpoints"`
 }
 
-func (h *Handler) handleGetDevEndpoints(_ context.Context, _ *getDevEndpointsInput) (*getDevEndpointsOutput, error) {
-	found, _ := h.Backend.BatchGetDevEndpoints([]string{})
-
-	return &getDevEndpointsOutput{DevEndpoints: found}, nil
+func (h *Handler) handleGetDevEndpoints(
+	_ context.Context,
+	_ *getDevEndpointsInput,
+) (*getDevEndpointsOutput, error) {
+	return &getDevEndpointsOutput{DevEndpoints: h.Backend.GetAllDevEndpoints()}, nil
 }
 
 // getEntityRecordsInput holds input for GetEntityRecords.
@@ -1219,7 +1440,10 @@ type getEntityRecordsOutput struct {
 	Records []any `json:"Records"`
 }
 
-func (h *Handler) handleGetEntityRecords(_ context.Context, _ *getEntityRecordsInput) (*getEntityRecordsOutput, error) {
+func (h *Handler) handleGetEntityRecords(
+	_ context.Context,
+	_ *getEntityRecordsInput,
+) (*getEntityRecordsOutput, error) {
 	return &getEntityRecordsOutput{Records: []any{}}, nil
 }
 
@@ -1279,7 +1503,10 @@ type getMLTaskRunOutput struct {
 	Status      string `json:"Status"`
 }
 
-func (h *Handler) handleGetMLTaskRun(_ context.Context, _ *getMLTaskRunInput) (*getMLTaskRunOutput, error) {
+func (h *Handler) handleGetMLTaskRun(
+	_ context.Context,
+	_ *getMLTaskRunInput,
+) (*getMLTaskRunOutput, error) {
 	return &getMLTaskRunOutput{Status: stateSucceeded}, nil
 }
 
@@ -1291,7 +1518,10 @@ type getMLTaskRunsOutput struct {
 	TaskRuns []any `json:"TaskRuns"`
 }
 
-func (h *Handler) handleGetMLTaskRuns(_ context.Context, _ *getMLTaskRunsInput) (*getMLTaskRunsOutput, error) {
+func (h *Handler) handleGetMLTaskRuns(
+	_ context.Context,
+	_ *getMLTaskRunsInput,
+) (*getMLTaskRunsOutput, error) {
 	return &getMLTaskRunsOutput{TaskRuns: []any{}}, nil
 }
 
@@ -1304,7 +1534,10 @@ type getMLTransformOutput struct {
 	Status      string `json:"Status"`
 }
 
-func (h *Handler) handleGetMLTransform(_ context.Context, _ *getMLTransformInput) (*getMLTransformOutput, error) {
+func (h *Handler) handleGetMLTransform(
+	_ context.Context,
+	_ *getMLTransformInput,
+) (*getMLTransformOutput, error) {
 	return &getMLTransformOutput{Status: stateReady}, nil
 }
 
@@ -1316,7 +1549,10 @@ type getMLTransformsOutput struct {
 	Transforms []any `json:"Transforms"`
 }
 
-func (h *Handler) handleGetMLTransforms(_ context.Context, _ *getMLTransformsInput) (*getMLTransformsOutput, error) {
+func (h *Handler) handleGetMLTransforms(
+	_ context.Context,
+	_ *getMLTransformsInput,
+) (*getMLTransformsOutput, error) {
 	return &getMLTransformsOutput{Transforms: []any{}}, nil
 }
 
@@ -1328,7 +1564,10 @@ type getMappingOutput struct {
 	Mapping []any `json:"Mapping"`
 }
 
-func (h *Handler) handleGetMapping(_ context.Context, _ *getMappingInput) (*getMappingOutput, error) {
+func (h *Handler) handleGetMapping(
+	_ context.Context,
+	_ *getMappingInput,
+) (*getMappingOutput, error) {
 	return &getMappingOutput{Mapping: []any{}}, nil
 }
 
@@ -1360,7 +1599,10 @@ type getPartitionOutput struct {
 	Partition *Partition `json:"Partition"`
 }
 
-func (h *Handler) handleGetPartition(_ context.Context, _ *getPartitionInput) (*getPartitionOutput, error) {
+func (h *Handler) handleGetPartition(
+	_ context.Context,
+	_ *getPartitionInput,
+) (*getPartitionOutput, error) {
 	return &getPartitionOutput{}, nil
 }
 
@@ -1390,7 +1632,10 @@ type getPartitionsOutput struct {
 	Partitions []*Partition `json:"Partitions"`
 }
 
-func (h *Handler) handleGetPartitions(_ context.Context, _ *getPartitionsInput) (*getPartitionsOutput, error) {
+func (h *Handler) handleGetPartitions(
+	_ context.Context,
+	_ *getPartitionsInput,
+) (*getPartitionsOutput, error) {
 	return &getPartitionsOutput{Partitions: []*Partition{}}, nil
 }
 
@@ -1417,7 +1662,10 @@ type getRegistryOutput struct {
 	Status       string `json:"Status"`
 }
 
-func (h *Handler) handleGetRegistry(_ context.Context, _ *getRegistryInput) (*getRegistryOutput, error) {
+func (h *Handler) handleGetRegistry(
+	_ context.Context,
+	_ *getRegistryInput,
+) (*getRegistryOutput, error) {
 	return &getRegistryOutput{Status: stateAvailable}, nil
 }
 
@@ -1495,7 +1743,10 @@ type getSchemaVersionOutput struct {
 	Status          string `json:"Status"`
 }
 
-func (h *Handler) handleGetSchemaVersion(_ context.Context, _ *getSchemaVersionInput) (*getSchemaVersionOutput, error) {
+func (h *Handler) handleGetSchemaVersion(
+	_ context.Context,
+	_ *getSchemaVersionInput,
+) (*getSchemaVersionOutput, error) {
 	return &getSchemaVersionOutput{Status: stateAvailable}, nil
 }
 
@@ -1554,7 +1805,10 @@ type getSessionOutput struct {
 	Session any `json:"Session"`
 }
 
-func (h *Handler) handleGetSession(_ context.Context, in *getSessionInput) (*getSessionOutput, error) {
+func (h *Handler) handleGetSession(
+	_ context.Context,
+	in *getSessionInput,
+) (*getSessionOutput, error) {
 	return &getSessionOutput{Session: map[string]string{"Id": in.ID, "Status": stateReady}}, nil
 }
 
@@ -1566,7 +1820,10 @@ type getStatementOutput struct {
 	Statement any `json:"Statement"`
 }
 
-func (h *Handler) handleGetStatement(_ context.Context, _ *getStatementInput) (*getStatementOutput, error) {
+func (h *Handler) handleGetStatement(
+	_ context.Context,
+	_ *getStatementInput,
+) (*getStatementOutput, error) {
 	return &getStatementOutput{}, nil
 }
 
@@ -1597,7 +1854,10 @@ type getTableVersionOutput struct {
 	TableVersion *TableVersion `json:"TableVersion"`
 }
 
-func (h *Handler) handleGetTableVersion(_ context.Context, _ *getTableVersionInput) (*getTableVersionOutput, error) {
+func (h *Handler) handleGetTableVersion(
+	_ context.Context,
+	_ *getTableVersionInput,
+) (*getTableVersionOutput, error) {
 	return &getTableVersionOutput{}, nil
 }
 
@@ -1612,7 +1872,10 @@ type getTableVersionsOutput struct {
 	TableVersions []*TableVersion `json:"TableVersions"`
 }
 
-func (h *Handler) handleGetTableVersions(_ context.Context, _ *getTableVersionsInput) (*getTableVersionsOutput, error) {
+func (h *Handler) handleGetTableVersions(
+	_ context.Context,
+	_ *getTableVersionsInput,
+) (*getTableVersionsOutput, error) {
 	return &getTableVersionsOutput{TableVersions: []*TableVersion{}}, nil
 }
 
@@ -1623,11 +1886,19 @@ type getTriggerInput struct {
 
 // getTriggerOutput holds the result for GetTrigger.
 type getTriggerOutput struct {
-	Trigger any `json:"Trigger"`
+	Trigger *Trigger `json:"Trigger"`
 }
 
-func (h *Handler) handleGetTrigger(_ context.Context, _ *getTriggerInput) (*getTriggerOutput, error) {
-	return &getTriggerOutput{}, nil
+func (h *Handler) handleGetTrigger(
+	_ context.Context,
+	in *getTriggerInput,
+) (*getTriggerOutput, error) {
+	t, err := h.Backend.GetTrigger(in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getTriggerOutput{Trigger: t}, nil
 }
 
 // getTriggersInput holds input for GetTriggers.
@@ -1635,11 +1906,14 @@ type getTriggersInput struct{}
 
 // getTriggersOutput holds the result for GetTriggers.
 type getTriggersOutput struct {
-	Triggers []any `json:"Triggers"`
+	Triggers []*Trigger `json:"Triggers"`
 }
 
-func (h *Handler) handleGetTriggers(_ context.Context, _ *getTriggersInput) (*getTriggersOutput, error) {
-	return &getTriggersOutput{Triggers: []any{}}, nil
+func (h *Handler) handleGetTriggers(
+	_ context.Context,
+	_ *getTriggersInput,
+) (*getTriggersOutput, error) {
+	return &getTriggersOutput{Triggers: h.Backend.GetTriggers()}, nil
 }
 
 // getUnfilteredPartitionMetadataInput holds input for GetUnfilteredPartitionMetadata.
@@ -1701,7 +1975,10 @@ type getUsageProfileOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleGetUsageProfile(_ context.Context, in *getUsageProfileInput) (*getUsageProfileOutput, error) {
+func (h *Handler) handleGetUsageProfile(
+	_ context.Context,
+	in *getUsageProfileInput,
+) (*getUsageProfileOutput, error) {
 	return &getUsageProfileOutput{Name: in.Name}, nil
 }
 
@@ -1742,23 +2019,42 @@ type getWorkflowInput struct {
 
 // getWorkflowOutput holds the result for GetWorkflow.
 type getWorkflowOutput struct {
-	Workflow any `json:"Workflow"`
+	Workflow *Workflow `json:"Workflow"`
 }
 
-func (h *Handler) handleGetWorkflow(_ context.Context, _ *getWorkflowInput) (*getWorkflowOutput, error) {
-	return &getWorkflowOutput{}, nil
+func (h *Handler) handleGetWorkflow(
+	_ context.Context,
+	in *getWorkflowInput,
+) (*getWorkflowOutput, error) {
+	w, err := h.Backend.GetWorkflow(in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getWorkflowOutput{Workflow: w}, nil
 }
 
 // getWorkflowRunInput holds input for GetWorkflowRun.
-type getWorkflowRunInput struct{}
+type getWorkflowRunInput struct {
+	Name  string `json:"Name"`
+	RunID string `json:"RunId"`
+}
 
 // getWorkflowRunOutput holds the result for GetWorkflowRun.
 type getWorkflowRunOutput struct {
-	Run any `json:"Run"`
+	Run *WorkflowRun `json:"Run"`
 }
 
-func (h *Handler) handleGetWorkflowRun(_ context.Context, _ *getWorkflowRunInput) (*getWorkflowRunOutput, error) {
-	return &getWorkflowRunOutput{}, nil
+func (h *Handler) handleGetWorkflowRun(
+	_ context.Context,
+	in *getWorkflowRunInput,
+) (*getWorkflowRunOutput, error) {
+	run, err := h.Backend.GetWorkflowRun(in.Name, in.RunID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getWorkflowRunOutput{Run: run}, nil
 }
 
 // getWorkflowRunPropertiesInput holds input for GetWorkflowRunProperties.
@@ -1777,21 +2073,34 @@ func (h *Handler) handleGetWorkflowRunProperties(
 }
 
 // getWorkflowRunsInput holds input for GetWorkflowRuns.
-type getWorkflowRunsInput struct{}
+type getWorkflowRunsInput struct {
+	Name string `json:"Name"`
+}
 
 // getWorkflowRunsOutput holds the result for GetWorkflowRuns.
 type getWorkflowRunsOutput struct {
-	Runs []any `json:"Runs"`
+	Runs []*WorkflowRun `json:"Runs"`
 }
 
-func (h *Handler) handleGetWorkflowRuns(_ context.Context, _ *getWorkflowRunsInput) (*getWorkflowRunsOutput, error) {
-	return &getWorkflowRunsOutput{Runs: []any{}}, nil
+func (h *Handler) handleGetWorkflowRuns(
+	_ context.Context,
+	in *getWorkflowRunsInput,
+) (*getWorkflowRunsOutput, error) {
+	runs, err := h.Backend.GetWorkflowRuns(in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getWorkflowRunsOutput{Runs: runs}, nil
 }
 
 // importCatalogToGlueInput holds input for ImportCatalogToGlue.
 type importCatalogToGlueInput struct{}
 
-func (h *Handler) handleImportCatalogToGlue(_ context.Context, _ *importCatalogToGlueInput) (*emptyOutput, error) {
+func (h *Handler) handleImportCatalogToGlue(
+	_ context.Context,
+	_ *importCatalogToGlueInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -1803,7 +2112,10 @@ type listBlueprintsOutput struct {
 	Blueprints []string `json:"Blueprints"`
 }
 
-func (h *Handler) handleListBlueprints(_ context.Context, _ *listBlueprintsInput) (*listBlueprintsOutput, error) {
+func (h *Handler) handleListBlueprints(
+	_ context.Context,
+	_ *listBlueprintsInput,
+) (*listBlueprintsOutput, error) {
 	return &listBlueprintsOutput{Blueprints: []string{}}, nil
 }
 
@@ -1845,7 +2157,10 @@ type listCrawlsOutput struct {
 	Crawls []any `json:"Crawls"`
 }
 
-func (h *Handler) handleListCrawls(_ context.Context, _ *listCrawlsInput) (*listCrawlsOutput, error) {
+func (h *Handler) handleListCrawls(
+	_ context.Context,
+	_ *listCrawlsInput,
+) (*listCrawlsOutput, error) {
 	return &listCrawlsOutput{Crawls: []any{}}, nil
 }
 
@@ -1947,8 +2262,17 @@ type listDevEndpointsOutput struct {
 	DevEndpointNames []string `json:"DevEndpointNames"`
 }
 
-func (h *Handler) handleListDevEndpoints(_ context.Context, _ *listDevEndpointsInput) (*listDevEndpointsOutput, error) {
-	return &listDevEndpointsOutput{DevEndpointNames: []string{}}, nil
+func (h *Handler) handleListDevEndpoints(
+	_ context.Context,
+	_ *listDevEndpointsInput,
+) (*listDevEndpointsOutput, error) {
+	deps := h.Backend.GetAllDevEndpoints()
+	names := make([]string, 0, len(deps))
+	for _, d := range deps {
+		names = append(names, d.EndpointName)
+	}
+
+	return &listDevEndpointsOutput{DevEndpointNames: names}, nil
 }
 
 // listEntitiesInput holds input for ListEntities.
@@ -1959,7 +2283,10 @@ type listEntitiesOutput struct {
 	Entities []any `json:"Entities"`
 }
 
-func (h *Handler) handleListEntities(_ context.Context, _ *listEntitiesInput) (*listEntitiesOutput, error) {
+func (h *Handler) handleListEntities(
+	_ context.Context,
+	_ *listEntitiesInput,
+) (*listEntitiesOutput, error) {
 	return &listEntitiesOutput{Entities: []any{}}, nil
 }
 
@@ -2005,7 +2332,10 @@ type listMLTransformsOutput struct {
 	TransformIDs []string `json:"TransformIds"`
 }
 
-func (h *Handler) handleListMLTransforms(_ context.Context, _ *listMLTransformsInput) (*listMLTransformsOutput, error) {
+func (h *Handler) handleListMLTransforms(
+	_ context.Context,
+	_ *listMLTransformsInput,
+) (*listMLTransformsOutput, error) {
 	return &listMLTransformsOutput{TransformIDs: []string{}}, nil
 }
 
@@ -2032,7 +2362,10 @@ type listRegistriesOutput struct {
 	Registries []any `json:"Registries"`
 }
 
-func (h *Handler) handleListRegistries(_ context.Context, _ *listRegistriesInput) (*listRegistriesOutput, error) {
+func (h *Handler) handleListRegistries(
+	_ context.Context,
+	_ *listRegistriesInput,
+) (*listRegistriesOutput, error) {
 	return &listRegistriesOutput{Registries: []any{}}, nil
 }
 
@@ -2059,7 +2392,10 @@ type listSchemasOutput struct {
 	Schemas []any `json:"Schemas"`
 }
 
-func (h *Handler) handleListSchemas(_ context.Context, _ *listSchemasInput) (*listSchemasOutput, error) {
+func (h *Handler) handleListSchemas(
+	_ context.Context,
+	_ *listSchemasInput,
+) (*listSchemasOutput, error) {
 	return &listSchemasOutput{Schemas: []any{}}, nil
 }
 
@@ -2072,7 +2408,10 @@ type listSessionsOutput struct {
 	Sessions []any    `json:"Sessions"`
 }
 
-func (h *Handler) handleListSessions(_ context.Context, _ *listSessionsInput) (*listSessionsOutput, error) {
+func (h *Handler) handleListSessions(
+	_ context.Context,
+	_ *listSessionsInput,
+) (*listSessionsOutput, error) {
 	return &listSessionsOutput{IDs: []string{}, Sessions: []any{}}, nil
 }
 
@@ -2084,7 +2423,10 @@ type listStatementsOutput struct {
 	Statements []any `json:"Statements"`
 }
 
-func (h *Handler) handleListStatements(_ context.Context, _ *listStatementsInput) (*listStatementsOutput, error) {
+func (h *Handler) handleListStatements(
+	_ context.Context,
+	_ *listStatementsInput,
+) (*listStatementsOutput, error) {
 	return &listStatementsOutput{Statements: []any{}}, nil
 }
 
@@ -2111,8 +2453,17 @@ type listTriggersOutput struct {
 	TriggerNames []string `json:"TriggerNames"`
 }
 
-func (h *Handler) handleListTriggers(_ context.Context, _ *listTriggersInput) (*listTriggersOutput, error) {
-	return &listTriggersOutput{TriggerNames: []string{}}, nil
+func (h *Handler) handleListTriggers(
+	_ context.Context,
+	_ *listTriggersInput,
+) (*listTriggersOutput, error) {
+	triggers := h.Backend.GetTriggers()
+	names := make([]string, 0, len(triggers))
+	for _, t := range triggers {
+		names = append(names, t.Name)
+	}
+
+	return &listTriggersOutput{TriggerNames: names}, nil
 }
 
 // listUsageProfilesInput holds input for ListUsageProfiles.
@@ -2138,8 +2489,11 @@ type listWorkflowsOutput struct {
 	Workflows []string `json:"Workflows"`
 }
 
-func (h *Handler) handleListWorkflows(_ context.Context, _ *listWorkflowsInput) (*listWorkflowsOutput, error) {
-	return &listWorkflowsOutput{Workflows: []string{}}, nil
+func (h *Handler) handleListWorkflows(
+	_ context.Context,
+	_ *listWorkflowsInput,
+) (*listWorkflowsOutput, error) {
+	return &listWorkflowsOutput{Workflows: h.Backend.GetWorkflows()}, nil
 }
 
 // modifyIntegrationInput holds input for ModifyIntegration.
@@ -2314,7 +2668,10 @@ type runStatementOutput struct {
 	ID int32 `json:"Id"`
 }
 
-func (h *Handler) handleRunStatement(_ context.Context, _ *runStatementInput) (*runStatementOutput, error) {
+func (h *Handler) handleRunStatement(
+	_ context.Context,
+	_ *runStatementInput,
+) (*runStatementOutput, error) {
 	return &runStatementOutput{ID: 1}, nil
 }
 
@@ -2326,7 +2683,10 @@ type searchTablesOutput struct {
 	TableList []*Table `json:"TableList"`
 }
 
-func (h *Handler) handleSearchTables(_ context.Context, _ *searchTablesInput) (*searchTablesOutput, error) {
+func (h *Handler) handleSearchTables(
+	_ context.Context,
+	_ *searchTablesInput,
+) (*searchTablesOutput, error) {
 	return &searchTablesOutput{TableList: []*Table{}}, nil
 }
 
@@ -2470,7 +2830,14 @@ type startTriggerOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleStartTrigger(_ context.Context, in *startTriggerInput) (*startTriggerOutput, error) {
+func (h *Handler) handleStartTrigger(
+	_ context.Context,
+	in *startTriggerInput,
+) (*startTriggerOutput, error) {
+	if err := h.Backend.StartTrigger(in.Name); err != nil {
+		return nil, err
+	}
+
 	return &startTriggerOutput{Name: in.Name}, nil
 }
 
@@ -2484,8 +2851,16 @@ type startWorkflowRunOutput struct {
 	RunID string `json:"RunId"`
 }
 
-func (h *Handler) handleStartWorkflowRun(_ context.Context, _ *startWorkflowRunInput) (*startWorkflowRunOutput, error) {
-	return &startWorkflowRunOutput{RunID: "workflow-run-stub"}, nil
+func (h *Handler) handleStartWorkflowRun(
+	_ context.Context,
+	in *startWorkflowRunInput,
+) (*startWorkflowRunOutput, error) {
+	run, err := h.Backend.StartWorkflowRun(in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startWorkflowRunOutput{RunID: run.RunID}, nil
 }
 
 // stopColumnStatisticsTaskRunInput holds input for StopColumnStatisticsTaskRun.
@@ -2528,7 +2903,10 @@ type stopSessionOutput struct {
 	ID string `json:"Id"`
 }
 
-func (h *Handler) handleStopSession(_ context.Context, in *stopSessionInput) (*stopSessionOutput, error) {
+func (h *Handler) handleStopSession(
+	_ context.Context,
+	in *stopSessionInput,
+) (*stopSessionOutput, error) {
 	return &stopSessionOutput{ID: in.ID}, nil
 }
 
@@ -2542,14 +2920,24 @@ type stopTriggerOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleStopTrigger(_ context.Context, in *stopTriggerInput) (*stopTriggerOutput, error) {
+func (h *Handler) handleStopTrigger(
+	_ context.Context,
+	in *stopTriggerInput,
+) (*stopTriggerOutput, error) {
+	if err := h.Backend.StopTrigger(in.Name); err != nil {
+		return nil, err
+	}
+
 	return &stopTriggerOutput{Name: in.Name}, nil
 }
 
 // stopWorkflowRunInput holds input for StopWorkflowRun.
 type stopWorkflowRunInput struct{}
 
-func (h *Handler) handleStopWorkflowRun(_ context.Context, _ *stopWorkflowRunInput) (*emptyOutput, error) {
+func (h *Handler) handleStopWorkflowRun(
+	_ context.Context,
+	_ *stopWorkflowRunInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -2561,7 +2949,10 @@ type testConnectionOutput struct {
 	Status string `json:"Status"`
 }
 
-func (h *Handler) handleTestConnection(_ context.Context, _ *testConnectionInput) (*testConnectionOutput, error) {
+func (h *Handler) handleTestConnection(
+	_ context.Context,
+	_ *testConnectionInput,
+) (*testConnectionOutput, error) {
 	return &testConnectionOutput{Status: stateSucceeded}, nil
 }
 
@@ -2575,21 +2966,45 @@ type updateBlueprintOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleUpdateBlueprint(_ context.Context, in *updateBlueprintInput) (*updateBlueprintOutput, error) {
+func (h *Handler) handleUpdateBlueprint(
+	_ context.Context,
+	in *updateBlueprintInput,
+) (*updateBlueprintOutput, error) {
 	return &updateBlueprintOutput{Name: in.Name}, nil
 }
 
 // updateCatalogInput holds input for UpdateCatalog.
 type updateCatalogInput struct{}
 
-func (h *Handler) handleUpdateCatalog(_ context.Context, _ *updateCatalogInput) (*emptyOutput, error) {
+func (h *Handler) handleUpdateCatalog(
+	_ context.Context,
+	_ *updateCatalogInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // updateClassifierInput holds input for UpdateClassifier.
-type updateClassifierInput struct{}
+type updateClassifierInput struct {
+	GrokClassifier *GrokClassifier `json:"GrokClassifier,omitempty"`
+	XMLClassifier  *XMLClassifier  `json:"XMLClassifier,omitempty"`
+	JSONClassifier *JSONClassifier `json:"JSONClassifier,omitempty"`
+	CsvClassifier  *CsvClassifier  `json:"CsvClassifier,omitempty"`
+}
 
-func (h *Handler) handleUpdateClassifier(_ context.Context, _ *updateClassifierInput) (*emptyOutput, error) {
+func (h *Handler) handleUpdateClassifier(
+	_ context.Context,
+	in *updateClassifierInput,
+) (*emptyOutput, error) {
+	c := Classifier{
+		GrokClassifier: in.GrokClassifier,
+		XMLClassifier:  in.XMLClassifier,
+		JSONClassifier: in.JSONClassifier,
+		CsvClassifier:  in.CsvClassifier,
+	}
+	if err := h.Backend.UpdateClassifier(c); err != nil {
+		return nil, err
+	}
+
 	return &emptyOutput{}, nil
 }
 
@@ -2639,14 +3054,20 @@ type updateConnectionInput struct {
 	ConnectionInput connectionInput `json:"ConnectionInput"`
 }
 
-func (h *Handler) handleUpdateConnection(_ context.Context, _ *updateConnectionInput) (*emptyOutput, error) {
+func (h *Handler) handleUpdateConnection(
+	_ context.Context,
+	_ *updateConnectionInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // updateDevEndpointInput holds input for UpdateDevEndpoint.
 type updateDevEndpointInput struct{}
 
-func (h *Handler) handleUpdateDevEndpoint(_ context.Context, _ *updateDevEndpointInput) (*emptyOutput, error) {
+func (h *Handler) handleUpdateDevEndpoint(
+	_ context.Context,
+	_ *updateDevEndpointInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -2722,7 +3143,10 @@ func (h *Handler) handleUpdateMLTransform(
 // updatePartitionInput holds input for UpdatePartition.
 type updatePartitionInput struct{}
 
-func (h *Handler) handleUpdatePartition(_ context.Context, _ *updatePartitionInput) (*emptyOutput, error) {
+func (h *Handler) handleUpdatePartition(
+	_ context.Context,
+	_ *updatePartitionInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
@@ -2735,7 +3159,10 @@ type updateRegistryOutput struct {
 	RegistryArn  string `json:"RegistryArn"`
 }
 
-func (h *Handler) handleUpdateRegistry(_ context.Context, _ *updateRegistryInput) (*updateRegistryOutput, error) {
+func (h *Handler) handleUpdateRegistry(
+	_ context.Context,
+	_ *updateRegistryInput,
+) (*updateRegistryOutput, error) {
 	return &updateRegistryOutput{}, nil
 }
 
@@ -2749,7 +3176,10 @@ type updateSchemaOutput struct {
 	RegistryName string `json:"RegistryName"`
 }
 
-func (h *Handler) handleUpdateSchema(_ context.Context, _ *updateSchemaInput) (*updateSchemaOutput, error) {
+func (h *Handler) handleUpdateSchema(
+	_ context.Context,
+	_ *updateSchemaInput,
+) (*updateSchemaOutput, error) {
 	return &updateSchemaOutput{}, nil
 }
 
@@ -2773,22 +3203,50 @@ func (h *Handler) handleUpdateSourceControlFromJob(
 // updateTableOptimizerInput holds input for UpdateTableOptimizer.
 type updateTableOptimizerInput struct{}
 
-func (h *Handler) handleUpdateTableOptimizer(_ context.Context, _ *updateTableOptimizerInput) (*emptyOutput, error) {
+func (h *Handler) handleUpdateTableOptimizer(
+	_ context.Context,
+	_ *updateTableOptimizerInput,
+) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
 // updateTriggerInput holds input for UpdateTrigger.
 type updateTriggerInput struct {
-	Name string `json:"Name"`
+	Name          string        `json:"Name"`
+	TriggerUpdate triggerUpdate `json:"TriggerUpdate"`
+}
+
+// triggerUpdate holds the mutable fields for UpdateTrigger.
+type triggerUpdate struct {
+	Predicate *TriggerPredicate `json:"Predicate,omitempty"`
+	Schedule  string            `json:"Schedule,omitempty"`
+	Actions   []TriggerAction   `json:"Actions,omitempty"`
 }
 
 // updateTriggerOutput holds the result for UpdateTrigger.
 type updateTriggerOutput struct {
-	Trigger any `json:"Trigger"`
+	Trigger *Trigger `json:"Trigger"`
 }
 
-func (h *Handler) handleUpdateTrigger(_ context.Context, in *updateTriggerInput) (*updateTriggerOutput, error) {
-	return &updateTriggerOutput{Trigger: map[string]string{"Name": in.Name}}, nil
+func (h *Handler) handleUpdateTrigger(
+	_ context.Context,
+	in *updateTriggerInput,
+) (*updateTriggerOutput, error) {
+	update := Trigger{
+		Schedule:  in.TriggerUpdate.Schedule,
+		Actions:   in.TriggerUpdate.Actions,
+		Predicate: in.TriggerUpdate.Predicate,
+	}
+	if err := h.Backend.UpdateTrigger(in.Name, update); err != nil {
+		return nil, err
+	}
+
+	t, err := h.Backend.GetTrigger(in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateTriggerOutput{Trigger: t}, nil
 }
 
 // updateUsageProfileInput holds input for UpdateUsageProfile.
@@ -2820,7 +3278,9 @@ func (h *Handler) handleUpdateUserDefinedFunction(
 
 // updateWorkflowInput holds input for UpdateWorkflow.
 type updateWorkflowInput struct {
-	Name string `json:"Name"`
+	DefaultRunProperties map[string]string `json:"DefaultRunProperties,omitempty"`
+	Name                 string            `json:"Name"`
+	Description          string            `json:"Description,omitempty"`
 }
 
 // updateWorkflowOutput holds the result for UpdateWorkflow.
@@ -2828,6 +3288,17 @@ type updateWorkflowOutput struct {
 	Name string `json:"Name"`
 }
 
-func (h *Handler) handleUpdateWorkflow(_ context.Context, in *updateWorkflowInput) (*updateWorkflowOutput, error) {
+func (h *Handler) handleUpdateWorkflow(
+	_ context.Context,
+	in *updateWorkflowInput,
+) (*updateWorkflowOutput, error) {
+	update := Workflow{
+		Description:          in.Description,
+		DefaultRunProperties: in.DefaultRunProperties,
+	}
+	if err := h.Backend.UpdateWorkflow(in.Name, update); err != nil {
+		return nil, err
+	}
+
 	return &updateWorkflowOutput{Name: in.Name}, nil
 }

--- a/services/glue/interfaces.go
+++ b/services/glue/interfaces.go
@@ -116,6 +116,40 @@ type StorageBackend interface {
 	AddJobRunInternal(run *JobRun)
 	AddDataQualityRulesetInternal(r *DataQualityRuleset)
 	AddDataQualityEvalRunInternal(run *DataQualityEvaluationRun)
+
+	// Trigger operations.
+	CreateTrigger(t Trigger, tags map[string]string) (*Trigger, error)
+	GetTrigger(name string) (*Trigger, error)
+	GetTriggers() []*Trigger
+	BatchGetTriggers(names []string) ([]*Trigger, []string)
+	UpdateTrigger(name string, update Trigger) error
+	DeleteTrigger(name string) error
+	StartTrigger(name string) error
+	StopTrigger(name string) error
+
+	// Workflow operations.
+	CreateWorkflow(w Workflow, tags map[string]string) (*Workflow, error)
+	GetWorkflow(name string) (*Workflow, error)
+	GetWorkflows() []string
+	BatchGetWorkflows(names []string) ([]*Workflow, []string)
+	UpdateWorkflow(name string, update Workflow) error
+	DeleteWorkflow(name string) error
+	StartWorkflowRun(name string) (*WorkflowRun, error)
+	GetWorkflowRun(workflowName, runID string) (*WorkflowRun, error)
+	GetWorkflowRuns(workflowName string) ([]*WorkflowRun, error)
+
+	// Classifier operations.
+	CreateClassifier(c Classifier) error
+	GetClassifier(name string) (*Classifier, error)
+	GetClassifiers() []*Classifier
+	UpdateClassifier(c Classifier) error
+	DeleteClassifier(name string) error
+
+	// DevEndpoint full CRUD.
+	CreateDevEndpoint(name string) (*DevEndpoint, error)
+	GetDevEndpoint(name string) (*DevEndpoint, error)
+	GetAllDevEndpoints() []*DevEndpoint
+	DeleteDevEndpoint(name string) error
 }
 
 // Snapshottable is an optional interface that a StorageBackend may implement

--- a/test/e2e/kafka_test.go
+++ b/test/e2e/kafka_test.go
@@ -28,6 +28,7 @@ func TestKafkaDashboard(t *testing.T) {
 			InstanceType:  "kafka.m5.large",
 		},
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/test/e2e/kinesisanalytics_test.go
+++ b/test/e2e/kinesisanalytics_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestKinesisAnalyticsDashboard verifies the removed KinesisAnalytics route returns 404.
+// TestKinesisAnalyticsDashboard verifies the KinesisAnalytics dashboard loads.
 func TestKinesisAnalyticsDashboard(t *testing.T) {
 	stack := newStack(t)
 
@@ -35,7 +35,7 @@ func TestKinesisAnalyticsDashboard(t *testing.T) {
 	_, err = page.Goto(server.URL + "/dashboard/kinesisanalytics")
 	require.NoError(t, err)
 
-	err = page.Locator("text=404").WaitFor(playwright.LocatorWaitForOptions{
+	err = page.Locator("text=Kinesis Data Analytics").WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
 		Timeout: playwright.Float(30000),
 	})

--- a/test/integration/sqs_advanced_test.go
+++ b/test/integration/sqs_advanced_test.go
@@ -319,12 +319,22 @@ func TestIntegration_SQS_FIFODeduplication(t *testing.T) {
 				secondDedupID = uuid.NewString()
 			}
 
-			groupID := aws.String("group-" + uuid.NewString())
+			// Use the same group for dedup tests; different groups when we need
+			// both messages visible in a single ReceiveMessage call (FIFO only
+			// surfaces one message per group at a time).
+			baseGroup := "group-" + uuid.NewString()
+			firstGroupID := aws.String(baseGroup)
+			secondGroupID := aws.String(baseGroup)
+			if tt.dedupID == "" {
+				// Different dedup IDs → different messages; use distinct groups so
+				// both show up in a single ReceiveMessage call.
+				secondGroupID = aws.String("group-" + uuid.NewString())
+			}
 
 			_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
 				QueueUrl:               queueURL,
 				MessageBody:            aws.String(tt.firstBody),
-				MessageGroupId:         groupID,
+				MessageGroupId:         firstGroupID,
 				MessageDeduplicationId: aws.String(firstDedupID),
 			})
 			require.NoError(t, err)
@@ -332,7 +342,7 @@ func TestIntegration_SQS_FIFODeduplication(t *testing.T) {
 			_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
 				QueueUrl:               queueURL,
 				MessageBody:            aws.String(tt.secondBody),
-				MessageGroupId:         groupID,
+				MessageGroupId:         secondGroupID,
 				MessageDeduplicationId: aws.String(secondDedupID),
 			})
 			require.NoError(t, err)

--- a/test/integration/sts_test.go
+++ b/test/integration/sts_test.go
@@ -246,7 +246,15 @@ func TestIntegration_STS_AssumeRoleWithWebIdentity(t *testing.T) {
 	t.Parallel()
 	dumpContainerLogsOnFailure(t)
 	client := createSTSClient(t)
+	iamClient := createIAMClient(t)
 	ctx := t.Context()
+
+	// Register the OIDC provider so the STS OIDC-validation check passes.
+	_, oidcErr := iamClient.CreateOpenIDConnectProvider(ctx, &iamsdk.CreateOpenIDConnectProviderInput{
+		Url:            aws.String("https://idp.example.com"),
+		ThumbprintList: []string{"0000000000000000000000000000000000000000"},
+	})
+	require.NoError(t, oidcErr)
 
 	roleARN := "arn:aws:iam::000000000000:role/web-identity-role-" + uuid.NewString()[:8]
 	webIdentityToken := "eyJhbGciOiJub25lIn0." +

--- a/test/terraform/glue/main.tf
+++ b/test/terraform/glue/main.tf
@@ -1,0 +1,141 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    glue = var.gopherstack_endpoint
+  }
+}
+
+variable "gopherstack_endpoint" {
+  description = "Gopherstack endpoint URL"
+  type        = string
+  default     = "http://localhost:4566"
+}
+
+# ---------------------------------------------------------------------------
+# IAM role used by Glue resources (mocked, no real IAM validation needed)
+# ---------------------------------------------------------------------------
+locals {
+  glue_role_arn = "arn:aws:iam::000000000000:role/GlueServiceRole"
+}
+
+# ---------------------------------------------------------------------------
+# Glue Catalog Database (prerequisite for crawler)
+# ---------------------------------------------------------------------------
+resource "aws_glue_catalog_database" "test_db" {
+  name = "gopherstack_test_db"
+}
+
+# ---------------------------------------------------------------------------
+# Glue Crawler
+# ---------------------------------------------------------------------------
+resource "aws_glue_crawler" "test_crawler" {
+  name          = "gopherstack-test-crawler"
+  role          = local.glue_role_arn
+  database_name = aws_glue_catalog_database.test_db.name
+
+  s3_target {
+    path = "s3://example-bucket/data/"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Glue Job
+# ---------------------------------------------------------------------------
+resource "aws_glue_job" "test_job" {
+  name     = "gopherstack-test-job"
+  role_arn = local.glue_role_arn
+
+  command {
+    name            = "glueetl"
+    script_location = "s3://example-bucket/scripts/etl.py"
+    python_version  = "3"
+  }
+
+  glue_version      = "4.0"
+  number_of_workers = 2
+  worker_type       = "G.1X"
+}
+
+# ---------------------------------------------------------------------------
+# Glue Trigger (ON_DEMAND)
+# ---------------------------------------------------------------------------
+resource "aws_glue_trigger" "test_trigger" {
+  name = "gopherstack-test-trigger"
+  type = "ON_DEMAND"
+
+  actions {
+    job_name = aws_glue_job.test_job.name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Glue Workflow
+# ---------------------------------------------------------------------------
+resource "aws_glue_workflow" "test_workflow" {
+  name        = "gopherstack-test-workflow"
+  description = "Test workflow for gopherstack"
+}
+
+# ---------------------------------------------------------------------------
+# Glue Trigger attached to workflow (SCHEDULED)
+# ---------------------------------------------------------------------------
+resource "aws_glue_trigger" "scheduled_trigger" {
+  name          = "gopherstack-scheduled-trigger"
+  type          = "SCHEDULED"
+  schedule      = "cron(0 12 * * ? *)"
+  workflow_name = aws_glue_workflow.test_workflow.name
+
+  actions {
+    job_name = aws_glue_job.test_job.name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Glue Classifier (Grok)
+# ---------------------------------------------------------------------------
+resource "aws_glue_classifier" "test_classifier" {
+  name = "gopherstack-test-classifier"
+
+  grok_classifier {
+    classification = "example"
+    grok_pattern   = "%%{SYSLOGTIMESTAMP:timestamp}"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+output "crawler_name" {
+  value = aws_glue_crawler.test_crawler.name
+}
+
+output "job_name" {
+  value = aws_glue_job.test_job.name
+}
+
+output "trigger_name" {
+  value = aws_glue_trigger.test_trigger.name
+}
+
+output "workflow_name" {
+  value = aws_glue_workflow.test_workflow.name
+}
+
+output "classifier_name" {
+  value = aws_glue_classifier.test_classifier.name
+}

--- a/ui/src/routes/codecommit/page.test.ts
+++ b/ui/src/routes/codecommit/page.test.ts
@@ -69,7 +69,7 @@ describe("CodeCommit Page", () => {
   it("shows Branches stat card", () => {
     mockSend.mockResolvedValue({ repositories: [] });
     render(CodeCommitPage);
-    expect(screen.getByText("Branches (selected)")).toBeInTheDocument();
+    expect(screen.getByText("Branches")).toBeInTheDocument();
   });
 
   it("shows detail placeholder when no repo selected", () => {

--- a/ui/src/routes/codepipeline/page.test.ts
+++ b/ui/src/routes/codepipeline/page.test.ts
@@ -151,7 +151,7 @@ describe("CodePipeline Page", () => {
 
     await waitFor(
       () => {
-        expect(mockSend).toHaveBeenCalledTimes(3);
+        expect(mockSend).toHaveBeenCalledTimes(4);
       },
       { timeout: 3000 },
     );

--- a/ui/src/routes/ssm/page.test.ts
+++ b/ui/src/routes/ssm/page.test.ts
@@ -21,7 +21,7 @@ describe("SSM Page", () => {
   it("renders page title", () => {
     mockSend.mockResolvedValue({ Parameters: [] });
     render(SSMPage);
-    expect(screen.getByText("SSM Parameter Store")).toBeInTheDocument();
+    expect(screen.getByText("AWS Systems Manager")).toBeInTheDocument();
   });
 
   it("shows Create Parameter button", () => {


### PR DESCRIPTION
## Summary

Closes #1549

- Add new `backend_triggers_workflows.go` with full CRUD for `Trigger`, `Workflow`, `WorkflowRun`, `Classifier` (Grok/XML/JSON/CSV), and stateful `DevEndpoint` stored in `InMemoryBackend`
- Promote 25+ stub-only handler functions to real stateful operations: GetTrigger, GetTriggers, BatchGetTriggers, ListTriggers, StartTrigger, StopTrigger, UpdateTrigger, DeleteTrigger, GetWorkflow, ListWorkflows, BatchGetWorkflows, GetWorkflowRun, GetWorkflowRuns, StartWorkflowRun, UpdateWorkflow, DeleteWorkflow, GetClassifier, GetClassifiers, UpdateClassifier, DeleteClassifier, GetDevEndpoint, GetDevEndpoints, ListDevEndpoints, DeleteDevEndpoint
- CreateTrigger and CreateWorkflow updated with full field support (actions, predicates, schedule, tags)
- Add `test/terraform/glue/main.tf` covering Terraform-managed Glue resources

## Test plan

- [ ] `go test ./services/glue/... 2>&1 | tail -5` passes
- [ ] `golangci-lint run ./services/glue/... 2>&1 | grep -v "^level="` = `0 issues.`
- [ ] Terraform plan/apply against `test/terraform/glue/main.tf` with `AWS_ENDPOINT_URL` pointing at local gopherstack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->