### PR TITLE
refactor: split complex routing functions to eliminate nolint:cyclop/gocognit/gocyclo directives

### DIFF
--- a/services/acm/handler.go
+++ b/services/acm/handler.go
@@ -450,49 +450,89 @@ func (h *Handler) handleError(_ context.Context, c *echo.Context, action string,
 	return h.handleOpError(c, action, reqErr)
 }
 
-// errUnknownACMAction is returned by dispatchJSON for unrecognised action names.
-var errUnknownACMAction = errors.New("unknown ACM action")
+var (
+	// errUnknownACMAction is returned by dispatchJSON for unrecognised action names.
+	errUnknownACMAction = errors.New("unknown ACM action")
+	// errACMNotHandled is a sentinel used internally to signal that a dispatch
+	// helper did not recognise the action. It is never returned to callers.
+	errACMNotHandled = errors.New("acm: action not handled by this dispatcher")
+)
 
 // dispatchJSON routes a JSON-protocol ACM action to the appropriate handler.
-//
-//nolint:cyclop // dispatch table for 16 operations is inherently wide
 func (h *Handler) dispatchJSON(action string, body []byte) (any, error) {
+	if r, err := h.dispatchCertOps(action, body); !errors.Is(err, errACMNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchCertTagOps(action, body); !errors.Is(err, errACMNotHandled) {
+		return r, err
+	}
+
+	return nil, errUnknownACMAction
+}
+
+// dispatchCertOps handles core certificate operations.
+func (h *Handler) dispatchCertOps(action string, body []byte) (any, error) {
 	switch action {
 	case "RequestCertificate":
+
 		return h.jsonRequestCertificate(body)
 	case "DescribeCertificate":
+
 		return h.jsonDescribeCertificate(body)
 	case "ListCertificates":
+
 		return h.jsonListCertificates(body)
 	case "DeleteCertificate":
+
 		return h.jsonDeleteCertificate(body)
-	case "ListTagsForCertificate":
-		return h.jsonListTagsForCertificate(body)
-	case "AddTagsToCertificate":
-		return h.jsonAddTagsToCertificate(body)
-	case "RemoveTagsFromCertificate":
-		return h.jsonRemoveTagsFromCertificate(body)
 	case "ImportCertificate":
+
 		return h.jsonImportCertificate(body)
 	case "RenewCertificate":
+
 		return h.jsonRenewCertificate(body)
 	case "ExportCertificate":
+
 		return h.jsonExportCertificate(body)
 	case "GetCertificate":
+
 		return h.jsonGetCertificate(body)
+	case "UpdateCertificateOptions":
+
+		return h.jsonUpdateCertificateOptions(body)
+	}
+
+	return nil, errACMNotHandled
+}
+
+// dispatchCertTagOps handles certificate tag and account configuration operations.
+func (h *Handler) dispatchCertTagOps(action string, body []byte) (any, error) {
+	switch action {
+	case "ListTagsForCertificate":
+
+		return h.jsonListTagsForCertificate(body)
+	case "AddTagsToCertificate":
+
+		return h.jsonAddTagsToCertificate(body)
+	case "RemoveTagsFromCertificate":
+
+		return h.jsonRemoveTagsFromCertificate(body)
 	case "GetAccountConfiguration":
+
 		return h.jsonGetAccountConfiguration(body)
 	case "PutAccountConfiguration":
+
 		return h.jsonPutAccountConfiguration(body)
 	case "ResendValidationEmail":
+
 		return h.jsonResendValidationEmail(body)
 	case "RevokeCertificate":
+
 		return h.jsonRevokeCertificate(body)
-	case "UpdateCertificateOptions":
-		return h.jsonUpdateCertificateOptions(body)
-	default:
-		return nil, errUnknownACMAction
 	}
+
+	return nil, errACMNotHandled
 }
 
 func (h *Handler) jsonRequestCertificate(body []byte) (any, error) {

--- a/services/apigateway/handler.go
+++ b/services/apigateway/handler.go
@@ -1110,82 +1110,135 @@ func parseAPIGWAPIKeysPath(method string, segs []string, n int) (string, map[str
 
 // parseAPIGWDomainNamesPath handles /domainnames/... paths.
 //
-//nolint:cyclop // path routing table is inherently a multi-branch switch
+
+// parseAPIGWDomainNamesPath handles /domainnames/... paths.
 func parseAPIGWDomainNamesPath(method string, segs []string, n int) (string, map[string]string, bool) {
-	switch {
-	// GET /domainnames → GetDomainNames
-	case n == 1 && method == http.MethodGet:
-		return opGetDomainNames, nil, true
-	// POST /domainnames → CreateDomainName
-	case n == 1 && method == http.MethodPost:
-		return opCreateDomainName, nil, true
-	// GET /domainnames/{name} → GetDomainName
-	case n == 2 && method == http.MethodGet:
-		return opGetDomainName, map[string]string{keyDomainName: segs[1]}, true
-	// DELETE /domainnames/{name} → DeleteDomainName
-	case n == 2 && method == http.MethodDelete:
-		return opDeleteDomainName, map[string]string{keyDomainName: segs[1]}, true
-	// PATCH /domainnames/{name} → UpdateDomainName
-	case n == 2 && method == http.MethodPatch:
-		return opUpdateDomainName, map[string]string{keyDomainName: segs[1]}, true
-	// GET /domainnames/{name}/basepathmappings → GetBasePathMappings
-	case n == 3 && segs[2] == apiGWSegBasePathMappings && method == http.MethodGet:
-		return opGetBasePathMappings, map[string]string{keyDomainName: segs[1]}, true
-	// POST /domainnames/{name}/basepathmappings → CreateBasePathMapping
-	case n == 3 && segs[2] == apiGWSegBasePathMappings && method == http.MethodPost:
-		return opCreateBasePathMapping, map[string]string{keyDomainName: segs[1]}, true
-	// GET /domainnames/{name}/basepathmappings/{basePath} → GetBasePathMapping
-	case n == 4 && segs[2] == apiGWSegBasePathMappings && method == http.MethodGet:
-		return opGetBasePathMapping, map[string]string{keyDomainName: segs[1], keyBasePath: segs[3]}, true
-	// PATCH /domainnames/{name}/basepathmappings/{basePath} → UpdateBasePathMapping
-	case n == 4 && segs[2] == apiGWSegBasePathMappings && method == http.MethodPatch:
-		return opUpdateBasePathMapping, map[string]string{keyDomainName: segs[1], keyBasePath: segs[3]}, true
-	// DELETE /domainnames/{name}/basepathmappings/{basePath} → DeleteBasePathMapping
-	case n == 4 && segs[2] == apiGWSegBasePathMappings && method == http.MethodDelete:
-		return opDeleteBasePathMapping, map[string]string{keyDomainName: segs[1], keyBasePath: segs[3]}, true
-	// POST /domainnames/{domainName}/accessassociations → CreateDomainNameAccessAssociation
-	case n == 3 && segs[2] == apiGWSegAccessAssociations && method == http.MethodPost:
-		return opCreateDomainNameAccessAssociation, map[string]string{keyDomainName: segs[1]}, true
+	switch n {
+	case 1:
+		switch method {
+		case http.MethodGet:
+			return opGetDomainNames, nil, true
+		case http.MethodPost:
+			return opCreateDomainName, nil, true
+		}
+	case 2:
+		switch method {
+		case http.MethodGet:
+			return opGetDomainName, map[string]string{keyDomainName: segs[1]}, true
+		case http.MethodDelete:
+			return opDeleteDomainName, map[string]string{keyDomainName: segs[1]}, true
+		case http.MethodPatch:
+			return opUpdateDomainName, map[string]string{keyDomainName: segs[1]}, true
+		}
+	case 3:
+		return parseAPIGWDomainNamesDepth3(method, segs)
+	case 4:
+		if segs[2] == apiGWSegBasePathMappings {
+			return parseAPIGWDomainNamesBasePathMapping(method, segs)
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWDomainNamesDepth3 handles /domainnames/{name}/{sub} paths.
+func parseAPIGWDomainNamesDepth3(method string, segs []string) (string, map[string]string, bool) {
+	switch segs[2] {
+	case apiGWSegBasePathMappings:
+		switch method {
+		case http.MethodGet:
+			return opGetBasePathMappings, map[string]string{keyDomainName: segs[1]}, true
+		case http.MethodPost:
+			return opCreateBasePathMapping, map[string]string{keyDomainName: segs[1]}, true
+		}
+	case apiGWSegAccessAssociations:
+		if method == http.MethodPost {
+			return opCreateDomainNameAccessAssociation, map[string]string{keyDomainName: segs[1]}, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWDomainNamesBasePathMapping handles /domainnames/{name}/basepathmappings/{basePath} paths.
+func parseAPIGWDomainNamesBasePathMapping(method string, segs []string) (string, map[string]string, bool) {
+	params := map[string]string{keyDomainName: segs[1], keyBasePath: segs[3]}
+
+	switch method {
+	case http.MethodGet:
+		return opGetBasePathMapping, params, true
+	case http.MethodPatch:
+		return opUpdateBasePathMapping, params, true
+	case http.MethodDelete:
+		return opDeleteBasePathMapping, params, true
 	}
 
 	return apiGWUnknownOp, nil, false
 }
 
 // parseAPIGWUsagePlansPath handles /usageplans/... paths.
-//
-//nolint:cyclop // path routing table is inherently a multi-branch switch
 func parseAPIGWUsagePlansPath(method string, segs []string, n int) (string, map[string]string, bool) {
-	switch {
-	// GET /usageplans → GetUsagePlans
-	case n == 1 && method == http.MethodGet:
-		return opGetUsagePlans, nil, true
-	// POST /usageplans → CreateUsagePlan
-	case n == 1 && method == http.MethodPost:
-		return opCreateUsagePlan, nil, true
-	// GET /usageplans/{id} → GetUsagePlan
-	case n == 2 && method == http.MethodGet:
-		return opGetUsagePlan, map[string]string{keyUsagePlanID: segs[1]}, true
-	// DELETE /usageplans/{id} → DeleteUsagePlan
-	case n == 2 && method == http.MethodDelete:
-		return opDeleteUsagePlan, map[string]string{keyUsagePlanID: segs[1]}, true
-	// PATCH /usageplans/{id} → UpdateUsagePlan
-	case n == 2 && method == http.MethodPatch:
-		return opUpdateUsagePlan, map[string]string{keyUsagePlanID: segs[1]}, true
-	// GET /usageplans/{id}/usage → GetUsage
-	case n == 3 && segs[2] == "usage" && method == http.MethodGet:
-		return opGetUsage, map[string]string{keyUsagePlanID: segs[1]}, true
-	// GET /usageplans/{id}/keys → GetUsagePlanKeys
-	case n == 3 && segs[2] == apiGWSegUsagePlanKeys && method == http.MethodGet:
-		return opGetUsagePlanKeys, map[string]string{keyUsagePlanID: segs[1]}, true
-	// POST /usageplans/{usagePlanId}/keys → CreateUsagePlanKey
-	case n == 3 && segs[2] == apiGWSegUsagePlanKeys && method == http.MethodPost:
-		return opCreateUsagePlanKey, map[string]string{keyUsagePlanID: segs[1]}, true
-	// GET /usageplans/{id}/keys/{keyId} → GetUsagePlanKey
-	case n == 4 && segs[2] == apiGWSegUsagePlanKeys && method == http.MethodGet:
-		return opGetUsagePlanKey, map[string]string{keyUsagePlanID: segs[1], "keyId": segs[3]}, true
-	// DELETE /usageplans/{id}/keys/{keyId} → DeleteUsagePlanKey
-	case n == 4 && segs[2] == apiGWSegUsagePlanKeys && method == http.MethodDelete:
-		return opDeleteUsagePlanKey, map[string]string{keyUsagePlanID: segs[1], "keyId": segs[3]}, true
+	switch n {
+	case 1:
+		switch method {
+		case http.MethodGet:
+			return opGetUsagePlans, nil, true
+		case http.MethodPost:
+			return opCreateUsagePlan, nil, true
+		}
+	case 2:
+		planParam := map[string]string{keyUsagePlanID: segs[1]}
+		switch method {
+		case http.MethodGet:
+			return opGetUsagePlan, planParam, true
+		case http.MethodDelete:
+			return opDeleteUsagePlan, planParam, true
+		case http.MethodPatch:
+			return opUpdateUsagePlan, planParam, true
+		}
+	case 3:
+		return parseAPIGWUsagePlansDepth3(method, segs)
+	case 4:
+		return parseAPIGWUsagePlansDepth4(method, segs)
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWUsagePlansDepth3 handles /usageplans/{id}/{sub} paths.
+func parseAPIGWUsagePlansDepth3(method string, segs []string) (string, map[string]string, bool) {
+	planParam := map[string]string{keyUsagePlanID: segs[1]}
+
+	switch segs[2] {
+	case "usage":
+		if method == http.MethodGet {
+			return opGetUsage, planParam, true
+		}
+	case apiGWSegUsagePlanKeys:
+		switch method {
+		case http.MethodGet:
+			return opGetUsagePlanKeys, planParam, true
+		case http.MethodPost:
+			return opCreateUsagePlanKey, planParam, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWUsagePlansDepth4 handles /usageplans/{id}/keys/{keyId} paths.
+func parseAPIGWUsagePlansDepth4(method string, segs []string) (string, map[string]string, bool) {
+	if segs[2] != apiGWSegUsagePlanKeys {
+		return apiGWUnknownOp, nil, false
+	}
+
+	params := map[string]string{keyUsagePlanID: segs[1], "keyId": segs[3]}
+
+	switch method {
+	case http.MethodGet:
+		return opGetUsagePlanKey, params, true
+	case http.MethodDelete:
+		return opDeleteUsagePlanKey, params, true
 	}
 
 	return apiGWUnknownOp, nil, false
@@ -1193,181 +1246,332 @@ func parseAPIGWUsagePlansPath(method string, segs []string, n int) (string, map[
 
 // parseAPIGWRestAPIsPath handles /restapis/... paths.
 //
-//nolint:cyclop,gocyclo,gocognit,funlen // path routing table is inherently a multi-branch switch
+// parseAPIGWRestAPIsPath handles /restapis/... paths.
+//
+//nolint:funlen // path routing table is inherently a multi-branch switch
 func parseAPIGWRestAPIsPath(method string, segs []string, n int) (string, map[string]string, bool) {
-	switch {
-	// POST /restapis → CreateRestApi
-	case n == 1 && method == http.MethodPost:
-		return opCreateRestAPI, nil, true
-	// GET /restapis → GetRestApis
-	case n == 1 && method == http.MethodGet:
-		return opGetRestApis, nil, true
-	// GET /restapis/{id} → GetRestApi
-	case n == 2 && method == http.MethodGet:
-		return opGetRestAPI, map[string]string{keyRestAPIID: segs[1]}, true
-	// DELETE /restapis/{id} → DeleteRestApi
-	case n == 2 && method == http.MethodDelete:
-		return opDeleteRestAPI, map[string]string{keyRestAPIID: segs[1]}, true
-	// PATCH /restapis/{id} → UpdateRestApi
-	case n == 2 && method == http.MethodPatch:
-		return opUpdateRestAPI, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/resources → GetResources
-	case n == 3 && segs[2] == apiGWSegResources && method == http.MethodGet:
-		return opGetResources, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/resources/{resId} → GetResource
-	case n == 4 && segs[2] == apiGWSegResources && method == http.MethodGet:
-		return opGetResource, map[string]string{keyRestAPIID: segs[1], keyResourceID: segs[3]}, true
-	// POST /restapis/{id}/resources/{parentId} → CreateResource
-	case n == 4 && segs[2] == apiGWSegResources && method == http.MethodPost:
-		return opCreateResource, map[string]string{keyRestAPIID: segs[1], "parentId": segs[3]}, true
-	// PATCH /restapis/{id}/resources/{resId} → UpdateResource
-	case n == 4 && segs[2] == apiGWSegResources && method == http.MethodPatch:
-		return opUpdateResource, map[string]string{keyRestAPIID: segs[1], keyResourceID: segs[3]}, true
-	// DELETE /restapis/{id}/resources/{resId} → DeleteResource
-	case n == 4 && segs[2] == apiGWSegResources && method == http.MethodDelete:
-		return opDeleteResource, map[string]string{keyRestAPIID: segs[1], keyResourceID: segs[3]}, true
-	// /restapis/{id}/resources/{resId}/methods/{httpMethod}[/integration]
-	case n >= 5 && segs[2] == apiGWSegResources && segs[4] == apiGWSegMethods:
+	apiID := ""
+	if n >= 2 {
+		apiID = segs[1]
+	}
+
+	switch n {
+	case 1:
+		switch method {
+		case http.MethodPost:
+			return opCreateRestAPI, nil, true
+		case http.MethodGet:
+			return opGetRestApis, nil, true
+		}
+	case 2:
+		return parseAPIGWRestAPIsDepth2(method, apiID)
+	case 3:
+		return parseAPIGWRestAPIsDepth3(method, segs, apiID)
+	case 4:
+		return parseAPIGWRestAPIsDepth4(method, segs, apiID)
+	default:
+		return parseAPIGWRestAPIsDeepPath(method, segs, n, apiID)
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDepth2 handles /restapis/{id} paths.
+func parseAPIGWRestAPIsDepth2(method, apiID string) (string, map[string]string, bool) {
+	params := map[string]string{keyRestAPIID: apiID}
+	switch method {
+	case http.MethodGet:
+		return opGetRestAPI, params, true
+	case http.MethodDelete:
+		return opDeleteRestAPI, params, true
+	case http.MethodPatch:
+		return opUpdateRestAPI, params, true
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDepth3 handles /restapis/{id}/{subresource} paths.
+func parseAPIGWRestAPIsDepth3(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	apiParam := map[string]string{keyRestAPIID: apiID}
+
+	if op, params, ok := parseAPIGWRestAPIsDepth3Core(method, segs[2], apiParam); ok {
+		return op, params, ok
+	}
+
+	return parseAPIGWRestAPIsDepth3Extended(method, segs[2], apiParam)
+}
+
+// parseAPIGWRestAPIsDepth3Core handles resources, deployments, and stages depth-3 paths.
+func parseAPIGWRestAPIsDepth3Core(method, sub string, apiParam map[string]string) (string, map[string]string, bool) {
+	switch sub {
+	case apiGWSegResources:
+		if method == http.MethodGet {
+			return opGetResources, apiParam, true
+		}
+	case apiGWSegDeployment:
+		switch method {
+		case http.MethodPost:
+			return opCreateDeployment, apiParam, true
+		case http.MethodGet:
+			return opGetDeployments, apiParam, true
+		}
+	case apiGWSegStages:
+		switch method {
+		case http.MethodGet:
+			return opGetStages, apiParam, true
+		case http.MethodPost:
+			return opCreateStage, apiParam, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDepth3Extended handles authorizers, validators, models, and gateway responses depth-3 paths.
+func parseAPIGWRestAPIsDepth3Extended(method, sub string, apiParam map[string]string) (string, map[string]string, bool) {
+	switch sub {
+	case apiGWSegAuthorizers:
+		switch method {
+		case http.MethodPost:
+			return opCreateAuthorizer, apiParam, true
+		case http.MethodGet:
+			return opGetAuthorizers, apiParam, true
+		}
+	case apiGWSegValidators:
+		switch method {
+		case http.MethodPost:
+			return opCreateRequestValidator, apiParam, true
+		case http.MethodGet:
+			return opGetRequestValidators, apiParam, true
+		}
+	case apiGWSegModels:
+		switch method {
+		case http.MethodPost:
+			return opCreateModel, apiParam, true
+		case http.MethodGet:
+			return opGetModels, apiParam, true
+		}
+	case apiGWSegGatewayResponses:
+		if method == http.MethodGet {
+			return opGetGatewayResponses, apiParam, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDepth4 handles /restapis/{id}/{subresource}/{item} paths.
+func parseAPIGWRestAPIsDepth4(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	if op, params, ok := parseAPIGWRestAPIsDepth4Core(method, segs, apiID); ok {
+		return op, params, ok
+	}
+
+	return parseAPIGWRestAPIsDepth4Extended(method, segs, apiID)
+}
+
+// parseAPIGWRestAPIsDepth4Core handles resources, deployments, and stages depth-4 paths.
+func parseAPIGWRestAPIsDepth4Core(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	switch segs[2] {
+	case apiGWSegResources:
+		params := map[string]string{keyRestAPIID: apiID, keyResourceID: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetResource, params, true
+		case http.MethodPost:
+			return opCreateResource, map[string]string{keyRestAPIID: apiID, "parentId": segs[3]}, true
+		case http.MethodPatch:
+			return opUpdateResource, params, true
+		case http.MethodDelete:
+			return opDeleteResource, params, true
+		}
+	case apiGWSegDeployment:
+		params := map[string]string{keyRestAPIID: apiID, keyDeploymentID: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetDeployment, params, true
+		case http.MethodPatch:
+			return opUpdateDeployment, params, true
+		case http.MethodDelete:
+			return opDeleteDeployment, params, true
+		}
+	case apiGWSegStages:
+		params := map[string]string{keyRestAPIID: apiID, keyStageName: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetStage, params, true
+		case http.MethodDelete:
+			return opDeleteStage, params, true
+		case http.MethodPatch:
+			return opUpdateStage, params, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDepth4Extended handles authorizers, validators, models, gateway responses, and doc depth-4 paths.
+func parseAPIGWRestAPIsDepth4Extended(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	if op, params, ok := parseAPIGWRestAPIsDepth4AuthVal(method, segs, apiID); ok {
+		return op, params, ok
+	}
+
+	return parseAPIGWRestAPIsDepth4ModelGW(method, segs, apiID)
+}
+
+// parseAPIGWRestAPIsDepth4AuthVal handles authorizer and validator depth-4 paths.
+func parseAPIGWRestAPIsDepth4AuthVal(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	switch segs[2] {
+	case apiGWSegAuthorizers:
+		params := map[string]string{keyRestAPIID: apiID, keyAuthorizerID: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetAuthorizer, params, true
+		case http.MethodPatch:
+			return opUpdateAuthorizer, params, true
+		case http.MethodDelete:
+			return opDeleteAuthorizer, params, true
+		}
+	case apiGWSegValidators:
+		params := map[string]string{keyRestAPIID: apiID, keyRequestValidatorID: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetRequestValidator, params, true
+		case http.MethodPatch:
+			return opUpdateRequestValidator, params, true
+		case http.MethodDelete:
+			return opDeleteRequestValidator, params, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDepth4ModelGW handles model, gateway response, and documentation depth-4 paths.
+func parseAPIGWRestAPIsDepth4ModelGW(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	switch segs[2] {
+	case apiGWSegModels:
+		params := map[string]string{keyRestAPIID: apiID, keyModelName: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetModel, params, true
+		case http.MethodDelete:
+			return opDeleteModel, params, true
+		case http.MethodPatch:
+			return opUpdateModel, params, true
+		}
+	case apiGWSegGatewayResponses:
+		params := map[string]string{keyRestAPIID: apiID, keyResponseType: segs[3]}
+		switch method {
+		case http.MethodGet:
+			return opGetGatewayResponse, params, true
+		case http.MethodPut:
+			return opPutGatewayResponse, params, true
+		case http.MethodDelete:
+			return opDeleteGatewayResponse, params, true
+		}
+	case apiGWSegDocumentation:
+		return parseAPIGWRestAPIsDocDepth4(method, segs, apiID)
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDocDepth4 handles /restapis/{id}/documentation/{parts|versions} paths.
+func parseAPIGWRestAPIsDocDepth4(method string, segs []string, apiID string) (string, map[string]string, bool) {
+	apiParam := map[string]string{keyRestAPIID: apiID}
+
+	switch segs[3] {
+	case apiGWSegDocParts:
+		switch method {
+		case http.MethodPost:
+			return opCreateDocumentationPart, apiParam, true
+		case http.MethodGet:
+			return opGetDocumentationParts, apiParam, true
+		}
+	case apiGWSegDocVersions:
+		switch method {
+		case http.MethodPost:
+			return opCreateDocumentationVersion, apiParam, true
+		case http.MethodGet:
+			return opGetDocumentationVersions, apiParam, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDeepPath handles /restapis/{id}/... paths with n≥5.
+func parseAPIGWRestAPIsDeepPath(method string, segs []string, n int, apiID string) (string, map[string]string, bool) {
+	if n >= 5 && segs[2] == apiGWSegResources && segs[4] == apiGWSegMethods {
 		return parseAPIGWMethodPath(method, segs)
-	// POST /restapis/{id}/deployments → CreateDeployment
-	case n == 3 && segs[2] == apiGWSegDeployment && method == http.MethodPost:
-		return opCreateDeployment, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/deployments → GetDeployments
-	case n == 3 && segs[2] == apiGWSegDeployment && method == http.MethodGet:
-		return opGetDeployments, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/deployments/{deplId} → GetDeployment
-	case n == 4 && segs[2] == apiGWSegDeployment && method == http.MethodGet:
-		return opGetDeployment, map[string]string{keyRestAPIID: segs[1], keyDeploymentID: segs[3]}, true
-	// PATCH /restapis/{id}/deployments/{deplId} → UpdateDeployment
-	case n == 4 && segs[2] == apiGWSegDeployment && method == http.MethodPatch:
-		return opUpdateDeployment, map[string]string{keyRestAPIID: segs[1], keyDeploymentID: segs[3]}, true
-	// DELETE /restapis/{id}/deployments/{deplId} → DeleteDeployment
-	case n == 4 && segs[2] == apiGWSegDeployment && method == http.MethodDelete:
-		return opDeleteDeployment, map[string]string{keyRestAPIID: segs[1], keyDeploymentID: segs[3]}, true
-	// GET /restapis/{id}/stages → GetStages
-	case n == 3 && segs[2] == apiGWSegStages && method == http.MethodGet:
-		return opGetStages, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/stages/{stageName} → GetStage
-	case n == 4 && segs[2] == apiGWSegStages && method == http.MethodGet:
-		return opGetStage, map[string]string{keyRestAPIID: segs[1], keyStageName: segs[3]}, true
-	// DELETE /restapis/{id}/stages/{stageName} → DeleteStage
-	case n == 4 && segs[2] == apiGWSegStages && method == http.MethodDelete:
-		return opDeleteStage, map[string]string{keyRestAPIID: segs[1], keyStageName: segs[3]}, true
-	// POST /restapis/{id}/authorizers → CreateAuthorizer
-	case n == 3 && segs[2] == apiGWSegAuthorizers && method == http.MethodPost:
-		return opCreateAuthorizer, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/authorizers → GetAuthorizers
-	case n == 3 && segs[2] == apiGWSegAuthorizers && method == http.MethodGet:
-		return opGetAuthorizers, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/authorizers/{authId} → GetAuthorizer
-	case n == 4 && segs[2] == apiGWSegAuthorizers && method == http.MethodGet:
-		return opGetAuthorizer, map[string]string{keyRestAPIID: segs[1], keyAuthorizerID: segs[3]}, true
-	// PATCH /restapis/{id}/authorizers/{authId} → UpdateAuthorizer
-	case n == 4 && segs[2] == apiGWSegAuthorizers && method == http.MethodPatch:
-		return opUpdateAuthorizer, map[string]string{keyRestAPIID: segs[1], keyAuthorizerID: segs[3]}, true
-	// DELETE /restapis/{id}/authorizers/{authId} → DeleteAuthorizer
-	case n == 4 && segs[2] == apiGWSegAuthorizers && method == http.MethodDelete:
-		return opDeleteAuthorizer, map[string]string{keyRestAPIID: segs[1], keyAuthorizerID: segs[3]}, true
-	// POST /restapis/{id}/requestvalidators → CreateRequestValidator
-	case n == 3 && segs[2] == apiGWSegValidators && method == http.MethodPost:
-		return opCreateRequestValidator, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/requestvalidators → GetRequestValidators
-	case n == 3 && segs[2] == apiGWSegValidators && method == http.MethodGet:
-		return opGetRequestValidators, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/requestvalidators/{id} → GetRequestValidator
-	case n == 4 && segs[2] == apiGWSegValidators && method == http.MethodGet:
-		return opGetRequestValidator, map[string]string{keyRestAPIID: segs[1], keyRequestValidatorID: segs[3]}, true
-	// PATCH /restapis/{id}/requestvalidators/{id} → UpdateRequestValidator
-	case n == 4 && segs[2] == apiGWSegValidators && method == http.MethodPatch:
-		return opUpdateRequestValidator, map[string]string{keyRestAPIID: segs[1], keyRequestValidatorID: segs[3]}, true
-	// DELETE /restapis/{id}/requestvalidators/{id} → DeleteRequestValidator
-	case n == 4 && segs[2] == apiGWSegValidators && method == http.MethodDelete:
-		return opDeleteRequestValidator, map[string]string{keyRestAPIID: segs[1], keyRequestValidatorID: segs[3]}, true
-	// POST /restapis/{id}/models → CreateModel
-	case n == 3 && segs[2] == apiGWSegModels && method == http.MethodPost:
-		return opCreateModel, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/models → GetModels
-	case n == 3 && segs[2] == apiGWSegModels && method == http.MethodGet:
-		return opGetModels, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/models/{modelName} → GetModel
-	case n == 4 && segs[2] == apiGWSegModels && method == http.MethodGet:
-		return opGetModel, map[string]string{keyRestAPIID: segs[1], keyModelName: segs[3]}, true
-	// DELETE /restapis/{id}/models/{modelName} → DeleteModel
-	case n == 4 && segs[2] == apiGWSegModels && method == http.MethodDelete:
-		return opDeleteModel, map[string]string{keyRestAPIID: segs[1], keyModelName: segs[3]}, true
-	// PATCH /restapis/{id}/models/{modelName} → UpdateModel
-	case n == 4 && segs[2] == apiGWSegModels && method == http.MethodPatch:
-		return opUpdateModel, map[string]string{keyRestAPIID: segs[1], keyModelName: segs[3]}, true
-	// POST /restapis/{id}/stages → CreateStage (standalone)
-	case n == 3 && segs[2] == apiGWSegStages && method == http.MethodPost:
-		return opCreateStage, map[string]string{keyRestAPIID: segs[1]}, true
-	// PATCH /restapis/{id}/stages/{stageName} → UpdateStage
-	case n == 4 && segs[2] == apiGWSegStages && method == http.MethodPatch:
-		return opUpdateStage, map[string]string{keyRestAPIID: segs[1], keyStageName: segs[3]}, true
-	// DELETE /restapis/{id}/stages/{stageName}/cache → FlushStageCache
-	case n == 5 && segs[2] == apiGWSegStages && segs[4] == "cache" && method == http.MethodDelete:
-		return opFlushStageCache, map[string]string{keyRestAPIID: segs[1], keyStageName: segs[3]}, true
-	// DELETE /restapis/{id}/stages/{stageName}/cache/authorizers → FlushStageAuthorizersCache
-	case n == 6 && segs[2] == apiGWSegStages && segs[4] == "cache" &&
-		segs[5] == "authorizers" && method == http.MethodDelete:
-		return opFlushStageAuthorizersCache, map[string]string{keyRestAPIID: segs[1], keyStageName: segs[3]}, true
-	// POST /restapis/{id}/documentation/parts → CreateDocumentationPart
-	case n == 4 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocParts && method == http.MethodPost:
-		return opCreateDocumentationPart, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/documentation/parts → GetDocumentationParts
-	case n == 4 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocParts && method == http.MethodGet:
-		return opGetDocumentationParts, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/documentation/parts/{docPartId} → GetDocumentationPart
-	case n == 5 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocParts && method == http.MethodGet:
-		return opGetDocumentationPart, map[string]string{keyRestAPIID: segs[1], keyDocPartID: segs[4]}, true
-	// DELETE /restapis/{id}/documentation/parts/{docPartId} → DeleteDocumentationPart
-	case n == 5 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocParts && method == http.MethodDelete:
-		return opDeleteDocumentationPart, map[string]string{keyRestAPIID: segs[1], keyDocPartID: segs[4]}, true
-	// POST /restapis/{id}/documentation/versions → CreateDocumentationVersion
-	case n == 4 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocVersions && method == http.MethodPost:
-		return opCreateDocumentationVersion, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/documentation/versions → GetDocumentationVersions
-	case n == 4 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocVersions && method == http.MethodGet:
-		return opGetDocumentationVersions, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/documentation/versions/{docVersion} → GetDocumentationVersion
-	case n == 5 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocVersions && method == http.MethodGet:
-		return opGetDocumentationVersion, map[string]string{
-			keyRestAPIID:            segs[1],
-			keyDocumentationVersion: segs[4],
-		}, true
-	// DELETE /restapis/{id}/documentation/versions/{docVersion} → DeleteDocumentationVersion
-	case n == 5 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocVersions && method == http.MethodDelete:
-		return opDeleteDocumentationVersion, map[string]string{
-			keyRestAPIID:            segs[1],
-			keyDocumentationVersion: segs[4],
-		}, true
-	// PATCH /restapis/{id}/documentation/parts/{docPartId} → UpdateDocumentationPart
-	case n == 5 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocParts && method == http.MethodPatch:
-		return opUpdateDocumentationPart, map[string]string{keyRestAPIID: segs[1], keyDocPartID: segs[4]}, true
-	// PATCH /restapis/{id}/documentation/versions/{docVersion} → UpdateDocumentationVersion
-	case n == 5 && segs[2] == apiGWSegDocumentation && segs[3] == apiGWSegDocVersions && method == http.MethodPatch:
-		return opUpdateDocumentationVersion, map[string]string{
-			keyRestAPIID:            segs[1],
-			keyDocumentationVersion: segs[4],
-		}, true
-	// GET /restapis/{id}/gatewayresponses → GetGatewayResponses
-	case n == 3 && segs[2] == apiGWSegGatewayResponses && method == http.MethodGet:
-		return opGetGatewayResponses, map[string]string{keyRestAPIID: segs[1]}, true
-	// GET /restapis/{id}/gatewayresponses/{responseType} → GetGatewayResponse
-	case n == 4 && segs[2] == apiGWSegGatewayResponses && method == http.MethodGet:
-		return opGetGatewayResponse, map[string]string{keyRestAPIID: segs[1], keyResponseType: segs[3]}, true
-	// PUT /restapis/{id}/gatewayresponses/{responseType} → PutGatewayResponse
-	case n == 4 && segs[2] == apiGWSegGatewayResponses && method == http.MethodPut:
-		return opPutGatewayResponse, map[string]string{keyRestAPIID: segs[1], keyResponseType: segs[3]}, true
-	// DELETE /restapis/{id}/gatewayresponses/{responseType} → DeleteGatewayResponse
-	case n == 4 && segs[2] == apiGWSegGatewayResponses && method == http.MethodDelete:
-		return opDeleteGatewayResponse, map[string]string{keyRestAPIID: segs[1], keyResponseType: segs[3]}, true
-	// GET /restapis/{id}/models/{modelName}/default_template → GetModelTemplate
-	case n == 5 && segs[2] == apiGWSegModels && segs[4] == "default_template" && method == http.MethodGet:
-		return opGetModelTemplate, map[string]string{keyRestAPIID: segs[1], keyModelName: segs[3]}, true
-	// POST /restapis/{id}/authorizers/{authId}/invocations → TestInvokeAuthorizer
-	case n == 5 && segs[2] == apiGWSegAuthorizers && segs[4] == "invocations" && method == http.MethodPost:
-		return opTestInvokeAuthorizer, map[string]string{keyRestAPIID: segs[1], keyAuthorizerID: segs[3]}, true
+	}
+
+	return parseAPIGWRestAPIsDepth5Plus(method, segs, n, apiID)
+}
+
+// parseAPIGWRestAPIsDepth5Plus handles depth-5+ paths (documentation, stage cache, model template).
+func parseAPIGWRestAPIsDepth5Plus(method string, segs []string, n int, apiID string) (string, map[string]string, bool) {
+	switch segs[2] {
+	case apiGWSegStages:
+		return parseAPIGWRestAPIsStageDeep(method, segs, n, apiID)
+	case apiGWSegDocumentation:
+		return parseAPIGWRestAPIsDocDeep(method, segs, n, apiID)
+	case apiGWSegModels:
+		if n == 5 && segs[4] == "default_template" && method == http.MethodGet {
+			return opGetModelTemplate, map[string]string{keyRestAPIID: apiID, keyModelName: segs[3]}, true
+		}
+	case apiGWSegAuthorizers:
+		if n == 5 && segs[4] == "invocations" && method == http.MethodPost {
+			return opTestInvokeAuthorizer, map[string]string{keyRestAPIID: apiID, keyAuthorizerID: segs[3]}, true
+		}
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsStageDeep handles depth-5+ stage paths (cache flush).
+func parseAPIGWRestAPIsStageDeep(method string, segs []string, n int, apiID string) (string, map[string]string, bool) {
+	stageParams := map[string]string{keyRestAPIID: apiID, keyStageName: segs[3]}
+
+	if n == 5 && segs[4] == "cache" && method == http.MethodDelete {
+		return opFlushStageCache, stageParams, true
+	}
+
+	if n == 6 && segs[4] == "cache" && segs[5] == "authorizers" && method == http.MethodDelete {
+		return opFlushStageAuthorizersCache, stageParams, true
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWRestAPIsDocDeep handles depth-5 documentation parts/versions paths.
+func parseAPIGWRestAPIsDocDeep(method string, segs []string, n int, apiID string) (string, map[string]string, bool) {
+	if n != 5 {
+		return apiGWUnknownOp, nil, false
+	}
+
+	switch segs[3] {
+	case apiGWSegDocParts:
+		params := map[string]string{keyRestAPIID: apiID, keyDocPartID: segs[4]}
+		switch method {
+		case http.MethodGet:
+			return opGetDocumentationPart, params, true
+		case http.MethodDelete:
+			return opDeleteDocumentationPart, params, true
+		case http.MethodPatch:
+			return opUpdateDocumentationPart, params, true
+		}
+	case apiGWSegDocVersions:
+		params := map[string]string{keyRestAPIID: apiID, keyDocumentationVersion: segs[4]}
+		switch method {
+		case http.MethodGet:
+			return opGetDocumentationVersion, params, true
+		case http.MethodDelete:
+			return opDeleteDocumentationVersion, params, true
+		case http.MethodPatch:
+			return opUpdateDocumentationVersion, params, true
+		}
 	}
 
 	return apiGWUnknownOp, nil, false
@@ -1375,9 +1579,10 @@ func parseAPIGWRestAPIsPath(method string, segs []string, n int) (string, map[st
 
 // parseAPIGWMethodPath handles paths under /restapis/{id}/resources/{resId}/methods/{httpMethod}.
 //
-//nolint:cyclop,gocognit,nestif,gocyclo,funlen // method path routing table is inherently a multi-branch switch
+// parseAPIGWMethodPath handles paths under /restapis/{id}/resources/{resId}/methods/{httpMethod}.
+//
+//nolint:nestif,funlen // method path routing table is inherently a multi-branch switch
 func parseAPIGWMethodPath(method string, segs []string) (string, map[string]string, bool) {
-	// segs: [restapis, {id}, resources, {resId}, methods, {httpMethod}, ...]
 	const (
 		idxID         = 1
 		idxResourceID = 3
@@ -1399,67 +1604,102 @@ func parseAPIGWMethodPath(method string, segs []string) (string, map[string]stri
 		keyHTTPMethod: httpMethod,
 	}
 
-	// /restapis/{id}/resources/{resId}/methods/{httpMethod}/integration[/responses/{statusCode}]
-	if len(segs) > idxIntegSeg && segs[idxIntegSeg] == apiGWSegInteg {
-		// /restapis/{id}/resources/{resId}/methods/{httpMethod}/integration/responses/{statusCode}
-		if len(segs) > idxRespSeg && segs[idxRespSeg] == apiGWSegResponses {
-			if len(segs) <= idxRespSeg+1 {
-				return apiGWUnknownOp, nil, false
-			}
-			params := map[string]string{
-				keyRestAPIID:  apiID,
-				keyResourceID: resID,
-				keyHTTPMethod: httpMethod,
-				keyStatusCode: segs[idxRespSeg+1],
-			}
-			switch method {
-			case http.MethodPut:
-				return opPutIntegrationResponse, params, true
-			case http.MethodGet:
-				return opGetIntegrationResponse, params, true
-			case http.MethodDelete:
-				return opDeleteIntegrationResponse, params, true
-			}
-
-			return apiGWUnknownOp, nil, false
+	if len(segs) > idxIntegSeg {
+		if op, params, ok := parseAPIGWMethodSubPath(method, segs, idxIntegSeg, idxRespSeg, apiID, resID, httpMethod, baseParams); ok || op == apiGWUnknownOp {
+			return op, params, ok
 		}
-
-		switch method {
-		case http.MethodPut:
-			return opPutIntegration, baseParams, true
-		case http.MethodGet:
-			return opGetIntegration, baseParams, true
-		case http.MethodDelete:
-			return opDeleteIntegration, baseParams, true
-		}
-
-		return apiGWUnknownOp, nil, false
 	}
 
-	// /restapis/{id}/resources/{resId}/methods/{httpMethod}/responses/{statusCode}
-	if len(segs) > idxIntegSeg && segs[idxIntegSeg] == apiGWSegResponses {
-		if len(segs) <= idxIntegSeg+1 {
+	return parseAPIGWMethodBasePath(method, baseParams)
+}
+
+// parseAPIGWMethodSubPath routes method sub-paths (integration and responses).
+func parseAPIGWMethodSubPath(method string, segs []string, idxInteg, idxResp int, apiID, resID, httpMethod string, baseParams map[string]string) (string, map[string]string, bool) {
+	seg := segs[idxInteg]
+
+	switch seg {
+	case apiGWSegInteg:
+		return parseAPIGWIntegrationPath(method, segs, idxInteg, idxResp, apiID, resID, httpMethod, baseParams)
+	case apiGWSegResponses:
+		return parseAPIGWMethodResponsePath(method, segs, idxInteg, apiID, resID, httpMethod)
+	}
+
+	return "", nil, false
+}
+
+// parseAPIGWIntegrationPath routes integration paths.
+func parseAPIGWIntegrationPath(method string, segs []string, idxInteg, idxResp int, apiID, resID, httpMethod string, baseParams map[string]string) (string, map[string]string, bool) {
+	if len(segs) > idxResp && segs[idxResp] == apiGWSegResponses {
+		if len(segs) <= idxResp+1 {
 			return apiGWUnknownOp, nil, false
 		}
+
 		params := map[string]string{
 			keyRestAPIID:  apiID,
 			keyResourceID: resID,
 			keyHTTPMethod: httpMethod,
-			keyStatusCode: segs[idxIntegSeg+1],
+			keyStatusCode: segs[idxResp+1],
 		}
+
 		switch method {
 		case http.MethodPut:
-			return opPutMethodResponse, params, true
+			return opPutIntegrationResponse, params, true
 		case http.MethodGet:
-			return opGetMethodResponse, params, true
+			return opGetIntegrationResponse, params, true
 		case http.MethodDelete:
-			return opDeleteMethodResponse, params, true
+			return opDeleteIntegrationResponse, params, true
+		case http.MethodPatch:
+			return opUpdateIntegrationResponse, params, true
 		}
 
 		return apiGWUnknownOp, nil, false
 	}
 
-	// /restapis/{id}/resources/{resId}/methods/{httpMethod}
+	switch method {
+	case http.MethodPut:
+		return opPutIntegration, baseParams, true
+	case http.MethodGet:
+		return opGetIntegration, baseParams, true
+	case http.MethodDelete:
+		return opDeleteIntegration, baseParams, true
+	case http.MethodPatch:
+		return opUpdateIntegration, baseParams, true
+	}
+
+	_ = idxInteg
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWMethodResponsePath routes method response paths.
+func parseAPIGWMethodResponsePath(method string, segs []string, idxInteg int, apiID, resID, httpMethod string) (string, map[string]string, bool) {
+	if len(segs) <= idxInteg+1 {
+		return apiGWUnknownOp, nil, false
+	}
+
+	params := map[string]string{
+		keyRestAPIID:  apiID,
+		keyResourceID: resID,
+		keyHTTPMethod: httpMethod,
+		keyStatusCode: segs[idxInteg+1],
+	}
+
+	switch method {
+	case http.MethodPut:
+		return opPutMethodResponse, params, true
+	case http.MethodGet:
+		return opGetMethodResponse, params, true
+	case http.MethodDelete:
+		return opDeleteMethodResponse, params, true
+	case http.MethodPatch:
+		return opUpdateMethodResponse, params, true
+	}
+
+	return apiGWUnknownOp, nil, false
+}
+
+// parseAPIGWMethodBasePath routes the base method path (no sub-segment).
+func parseAPIGWMethodBasePath(method string, baseParams map[string]string) (string, map[string]string, bool) {
 	switch method {
 	case http.MethodPut:
 		return opPutMethod, baseParams, true
@@ -1471,40 +1711,6 @@ func parseAPIGWMethodPath(method string, segs []string) (string, map[string]stri
 		return opTestInvokeMethod, baseParams, true
 	case http.MethodPatch:
 		return opUpdateMethod, baseParams, true
-	}
-
-	// Integration PATCH
-	if len(segs) > idxIntegSeg && segs[idxIntegSeg] == apiGWSegInteg {
-		if method == http.MethodPatch {
-			if len(segs) > idxRespSeg && segs[idxRespSeg] == apiGWSegResponses {
-				if len(segs) > idxRespSeg+1 {
-					params := map[string]string{
-						keyRestAPIID:  apiID,
-						keyResourceID: resID,
-						keyHTTPMethod: httpMethod,
-						keyStatusCode: segs[idxRespSeg+1],
-					}
-
-					return opUpdateIntegrationResponse, params, true
-				}
-			} else {
-				return opUpdateIntegration, baseParams, true
-			}
-		}
-	}
-
-	// MethodResponse PATCH
-	if len(segs) > idxIntegSeg && segs[idxIntegSeg] == apiGWSegResponses {
-		if method == http.MethodPatch && len(segs) > idxIntegSeg+1 {
-			params := map[string]string{
-				keyRestAPIID:  apiID,
-				keyResourceID: resID,
-				keyHTTPMethod: httpMethod,
-				keyStatusCode: segs[idxIntegSeg+1],
-			}
-
-			return opUpdateMethodResponse, params, true
-		}
 	}
 
 	return apiGWUnknownOp, nil, false
@@ -2043,8 +2249,17 @@ func (h *Handler) integrationActions() map[string]actionFn {
 	}
 }
 
-//nolint:gocognit // deployment action map is explicit by design.
+// deploymentActions returns the action map for deployment and stage operations.
 func (h *Handler) deploymentActions() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.deploymentCRUDActions())
+	maps.Copy(m, h.stageActions())
+
+	return m
+}
+
+// deploymentCRUDActions returns actions for deployment CRUD operations.
+func (h *Handler) deploymentCRUDActions() map[string]actionFn {
 	return map[string]actionFn{
 		opCreateDeployment: func(b []byte) (int, any, error) {
 			var input createDeploymentInput
@@ -2093,6 +2308,12 @@ func (h *Handler) deploymentActions() map[string]actionFn {
 
 			return http.StatusNoContent, map[string]any{}, nil
 		},
+	}
+}
+
+// stageActions returns actions for stage operations.
+func (h *Handler) stageActions() map[string]actionFn {
+	return map[string]actionFn{
 		opGetStages: func(b []byte) (int, any, error) {
 			var input getStagesInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2150,8 +2371,19 @@ func (h *Handler) dispatchTable() map[string]actionFn {
 	return table
 }
 
-//nolint:cyclop,funlen,gocognit // action table - one closure per op; complexity unavoidable
+// newResourceActions returns actions for creating new top-level resources.
+//
+//nolint:funlen // action table - one closure per op; complexity unavoidable
 func (h *Handler) newResourceActions() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.newResourceActionsCore())
+	maps.Copy(m, h.newResourceActionsExt())
+
+	return m
+}
+
+// newResourceActionsCore returns actions for API key and usage plan creation.
+func (h *Handler) newResourceActionsCore() map[string]actionFn {
 	return map[string]actionFn{
 		opCreateAPIKey: func(b []byte) (int, any, error) {
 			var input CreateAPIKeyInput
@@ -2205,6 +2437,22 @@ func (h *Handler) newResourceActions() map[string]actionFn {
 
 			return http.StatusCreated, ver, nil
 		},
+	}
+}
+
+// newResourceActionsExt returns actions for domain name and usage plan key creation.
+// newResourceActionsExt returns actions for domain name and extended resource creation.
+func (h *Handler) newResourceActionsExt() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.newResourceActionsDomainName())
+	maps.Copy(m, h.newResourceActionsModelStage())
+
+	return m
+}
+
+// newResourceActionsDomainName returns actions for domain name creation.
+func (h *Handler) newResourceActionsDomainName() map[string]actionFn {
+	return map[string]actionFn{
 		opCreateDomainName: func(b []byte) (int, any, error) {
 			var input CreateDomainNameInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2231,6 +2479,12 @@ func (h *Handler) newResourceActions() map[string]actionFn {
 
 			return http.StatusCreated, assoc, nil
 		},
+	}
+}
+
+// newResourceActionsModelStage returns actions for model, stage, and usage plan creation.
+func (h *Handler) newResourceActionsModelStage() map[string]actionFn {
+	return map[string]actionFn{
 		opCreateModel: func(b []byte) (int, any, error) {
 			var input CreateModelInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2372,8 +2626,38 @@ func (h *Handler) Reset() {
 	}
 }
 
-//nolint:cyclop,funlen,gocognit,gocyclo // action table - one closure per op; complexity unavoidable
+// getDeleteUpdateActions returns the action map for get, delete, and update operations.
+//
+//nolint:funlen // action table - one closure per op; complexity unavoidable
 func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsCore())
+	maps.Copy(m, h.getDeleteUpdateActionsExt())
+	maps.Copy(m, h.getDeleteUpdateActionsUsage())
+
+	return m
+}
+
+// getDeleteUpdateActionsCore returns get/delete/update actions for REST API core resources.
+// getDeleteUpdateActionsCore returns get/delete/update actions for core REST API resources.
+func (h *Handler) getDeleteUpdateActionsCore() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsCore1())
+	maps.Copy(m, h.getDeleteUpdateActionsCore2())
+
+	return m
+}
+
+// getDeleteUpdateActionsCore1 returns actions for API key and REST API get/delete.
+func (h *Handler) getDeleteUpdateActionsCore1() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsCore1a())
+	maps.Copy(m, h.getDeleteUpdateActionsCore1b())
+
+	return m
+}
+
+func (h *Handler) getDeleteUpdateActionsCore1a() map[string]actionFn {
 	return map[string]actionFn{
 		opGetAPIKey: func(b []byte) (int, any, error) {
 			var input getAPIKeyInput
@@ -2418,6 +2702,11 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusAccepted, map[string]any{}, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsCore1b() map[string]actionFn {
+	return map[string]actionFn{
 		opUpdateAPIKey: func(b []byte) (int, any, error) {
 			var input updateAPIKeyInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2430,6 +2719,19 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusOK, key, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsCore2() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsCore2a())
+	maps.Copy(m, h.getDeleteUpdateActionsCore2b())
+
+	return m
+}
+
+func (h *Handler) getDeleteUpdateActionsCore2a() map[string]actionFn {
+	return map[string]actionFn{
 		opGetDomainName: func(b []byte) (int, any, error) {
 			var input getDomainNameInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2462,6 +2764,11 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusOK, map[string]any{keyItem: dns, keyPosition: position}, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsCore2b() map[string]actionFn {
+	return map[string]actionFn{
 		opDeleteDomainName: func(b []byte) (int, any, error) {
 			var input deleteDomainNameInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2497,6 +2804,21 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusOK, map[string]any{keyItem: bpms}, nil
 		},
+	}
+}
+
+// getDeleteUpdateActionsExt returns get/delete/update actions for domain names and base path mappings.
+// getDeleteUpdateActionsExt returns get/delete/update actions for domain names and base path mappings.
+func (h *Handler) getDeleteUpdateActionsExt() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsExt1())
+	maps.Copy(m, h.getDeleteUpdateActionsExt2())
+
+	return m
+}
+
+func (h *Handler) getDeleteUpdateActionsExt1() map[string]actionFn {
+	return map[string]actionFn{
 		opDeleteBasePathMapping: func(b []byte) (int, any, error) {
 			var input deleteBasePathMappingInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2543,6 +2865,19 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusAccepted, map[string]any{}, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsExt2() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsExt2a())
+	maps.Copy(m, h.getDeleteUpdateActionsExt2b())
+
+	return m
+}
+
+func (h *Handler) getDeleteUpdateActionsExt2a() map[string]actionFn {
+	return map[string]actionFn{
 		opUpdateModel: func(b []byte) (int, any, error) {
 			var input updateModelInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2567,6 +2902,11 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusOK, stage, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsExt2b() map[string]actionFn {
+	return map[string]actionFn{
 		opFlushStageCache: func(b []byte) (int, any, error) {
 			var input flushStageCacheInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2616,6 +2956,21 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusOK, map[string]any{keyItem: ps, keyPosition: position}, nil
 		},
+	}
+}
+
+// getDeleteUpdateActionsUsage returns get/delete/update actions for usage plans and keys.
+// getDeleteUpdateActionsUsage returns get/delete/update actions for usage plans, keys, and documentation.
+func (h *Handler) getDeleteUpdateActionsUsage() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsUsage1())
+	maps.Copy(m, h.getDeleteUpdateActionsUsage2())
+
+	return m
+}
+
+func (h *Handler) getDeleteUpdateActionsUsage1() map[string]actionFn {
+	return map[string]actionFn{
 		opDeleteUsagePlan: func(b []byte) (int, any, error) {
 			var input deleteUsagePlanInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2662,6 +3017,19 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusAccepted, map[string]any{}, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsUsage2() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.getDeleteUpdateActionsUsage2a())
+	maps.Copy(m, h.getDeleteUpdateActionsUsage2b())
+
+	return m
+}
+
+func (h *Handler) getDeleteUpdateActionsUsage2a() map[string]actionFn {
+	return map[string]actionFn{
 		opGetDocumentationPart: func(b []byte) (int, any, error) {
 			var input getDocumentationPartInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2686,6 +3054,11 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 
 			return http.StatusOK, map[string]any{keyItem: ps}, nil
 		},
+	}
+}
+
+func (h *Handler) getDeleteUpdateActionsUsage2b() map[string]actionFn {
+	return map[string]actionFn{
 		opDeleteDocumentationPart: func(b []byte) (int, any, error) {
 			var input deleteDocumentationPartInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2735,8 +3108,29 @@ func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 	}
 }
 
-//nolint:cyclop,gocognit,gocyclo,funlen // action table - one closure per op; complexity unavoidable
+// updatePatchActions returns the action map for update and patch operations.
+//
+//nolint:funlen // action table - one closure per op; complexity unavoidable
 func (h *Handler) updatePatchActions() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.updatePatchActionsCore())
+	maps.Copy(m, h.updatePatchActionsDomain())
+	maps.Copy(m, h.updatePatchActionsMisc())
+
+	return m
+}
+
+// updatePatchActionsCore returns update/patch actions for core REST API resources.
+// updatePatchActionsCore returns update/patch actions for core REST API resources.
+func (h *Handler) updatePatchActionsCore() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.updatePatchActionsCore1())
+	maps.Copy(m, h.updatePatchActionsCore2())
+
+	return m
+}
+
+func (h *Handler) updatePatchActionsCore1() map[string]actionFn {
 	return map[string]actionFn{
 		opUpdateRestAPI: func(b []byte) (int, any, error) {
 			var input updateRestAPIHandlerInput
@@ -2782,6 +3176,11 @@ func (h *Handler) updatePatchActions() map[string]actionFn {
 
 			return http.StatusOK, acct, nil
 		},
+	}
+}
+
+func (h *Handler) updatePatchActionsCore2() map[string]actionFn {
+	return map[string]actionFn{
 		opGetTags: func(b []byte) (int, any, error) {
 			var input getTagsInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2840,6 +3239,21 @@ func (h *Handler) updatePatchActions() map[string]actionFn {
 
 			return http.StatusOK, out, nil
 		},
+	}
+}
+
+// updatePatchActionsDomain returns update/patch actions for domain names and related resources.
+// updatePatchActionsDomain returns update/patch actions for domain names and related resources.
+func (h *Handler) updatePatchActionsDomain() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.updatePatchActionsDomain1())
+	maps.Copy(m, h.updatePatchActionsDomain2())
+
+	return m
+}
+
+func (h *Handler) updatePatchActionsDomain1() map[string]actionFn {
+	return map[string]actionFn{
 		opUpdateDomainName: func(b []byte) (int, any, error) {
 			var input UpdateDomainNameInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2888,6 +3302,19 @@ func (h *Handler) updatePatchActions() map[string]actionFn {
 
 			return http.StatusOK, out, nil
 		},
+	}
+}
+
+func (h *Handler) updatePatchActionsDomain2() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.updatePatchActionsDomain2a())
+	maps.Copy(m, h.updatePatchActionsDomain2b())
+
+	return m
+}
+
+func (h *Handler) updatePatchActionsDomain2a() map[string]actionFn {
+	return map[string]actionFn{
 		opUpdateMethod: func(b []byte) (int, any, error) {
 			var input UpdateMethodInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2912,6 +3339,11 @@ func (h *Handler) updatePatchActions() map[string]actionFn {
 
 			return http.StatusOK, out, nil
 		},
+	}
+}
+
+func (h *Handler) updatePatchActionsDomain2b() map[string]actionFn {
+	return map[string]actionFn{
 		opUpdateIntegrationResponse: func(b []byte) (int, any, error) {
 			var input UpdateIntegrationResponseInput
 			if err := json.Unmarshal(b, &input); err != nil {
@@ -2960,6 +3392,21 @@ func (h *Handler) updatePatchActions() map[string]actionFn {
 
 			return http.StatusOK, out, nil
 		},
+	}
+}
+
+// updatePatchActionsMisc returns update/patch actions for models, usage plans, and other resources.
+// updatePatchActionsMisc returns update/patch actions for models, usage plans, and other resources.
+func (h *Handler) updatePatchActionsMisc() map[string]actionFn {
+	m := make(map[string]actionFn)
+	maps.Copy(m, h.updatePatchActionsMisc1())
+	maps.Copy(m, h.updatePatchActionsMisc2())
+
+	return m
+}
+
+func (h *Handler) updatePatchActionsMisc1() map[string]actionFn {
+	return map[string]actionFn{
 		opGetModelTemplate: func(b []byte) (int, any, error) {
 			var params struct {
 				RestAPIID string `json:"restApiId"`
@@ -3030,6 +3477,11 @@ func (h *Handler) updatePatchActions() map[string]actionFn {
 
 			return http.StatusAccepted, nil, nil
 		},
+	}
+}
+
+func (h *Handler) updatePatchActionsMisc2() map[string]actionFn {
+	return map[string]actionFn{
 		opGenerateClientCertificate: func(b []byte) (int, any, error) {
 			var input GenerateClientCertificateInput
 			if err := json.Unmarshal(b, &input); err != nil {

--- a/services/apigateway/persistence.go
+++ b/services/apigateway/persistence.go
@@ -66,8 +66,6 @@ func (b *InMemoryBackend) Snapshot() []byte {
 
 // Restore loads backend state from a JSON snapshot.
 // It implements persistence.Persistable.
-//
-//nolint:cyclop,gocognit // Restore must handle nil-guard for every map in the snapshot
 func (b *InMemoryBackend) Restore(data []byte) error {
 	var snap backendSnapshot
 
@@ -78,41 +76,18 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
-	b.apis = make(map[string]*apiData, len(snap.APIs))
+	b.restoreAPIs(snap.APIs)
+	b.restoreMaps(snap)
 
-	for id, d := range snap.APIs {
-		if d.Resources == nil {
-			d.Resources = make(map[string]*Resource)
-		}
+	return nil
+}
 
-		if d.Deployments == nil {
-			d.Deployments = make(map[string]*Deployment)
-		}
+// restoreAPIs restores API data from the snapshot.
+func (b *InMemoryBackend) restoreAPIs(apis map[string]*apiDataSnapshot) {
+	b.apis = make(map[string]*apiData, len(apis))
 
-		if d.Stages == nil {
-			d.Stages = make(map[string]*Stage)
-		}
-
-		if d.Authorizers == nil {
-			d.Authorizers = make(map[string]*Authorizer)
-		}
-
-		if d.RequestValidators == nil {
-			d.RequestValidators = make(map[string]*RequestValidator)
-		}
-
-		if d.DocumentationParts == nil {
-			d.DocumentationParts = make(map[string]*DocumentationPart)
-		}
-
-		if d.DocumentationVersions == nil {
-			d.DocumentationVersions = make(map[string]*DocumentationVersion)
-		}
-
-		if d.Models == nil {
-			d.Models = make(map[string]*Model)
-		}
-
+	for id, d := range apis {
+		ensureAPIDataMaps(d)
 		b.apis[id] = &apiData{
 			api:                   d.API,
 			resources:             d.Resources,
@@ -125,7 +100,45 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 			models:                d.Models,
 		}
 	}
+}
 
+// ensureAPIDataMaps initialises nil map fields in an API data snapshot.
+func ensureAPIDataMaps(d *apiDataSnapshot) {
+	if d.Resources == nil {
+		d.Resources = make(map[string]*Resource)
+	}
+
+	if d.Deployments == nil {
+		d.Deployments = make(map[string]*Deployment)
+	}
+
+	if d.Stages == nil {
+		d.Stages = make(map[string]*Stage)
+	}
+
+	if d.Authorizers == nil {
+		d.Authorizers = make(map[string]*Authorizer)
+	}
+
+	if d.RequestValidators == nil {
+		d.RequestValidators = make(map[string]*RequestValidator)
+	}
+
+	if d.DocumentationParts == nil {
+		d.DocumentationParts = make(map[string]*DocumentationPart)
+	}
+
+	if d.DocumentationVersions == nil {
+		d.DocumentationVersions = make(map[string]*DocumentationVersion)
+	}
+
+	if d.Models == nil {
+		d.Models = make(map[string]*Model)
+	}
+}
+
+// restoreMaps restores the flat map fields from the snapshot.
+func (b *InMemoryBackend) restoreMaps(snap backendSnapshot) {
 	if snap.APIKeys != nil {
 		b.apiKeys = snap.APIKeys
 	} else {
@@ -161,8 +174,6 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	} else {
 		b.usagePlanKeys = make(map[string]map[string]*UsagePlanKey)
 	}
-
-	return nil
 }
 
 // Snapshot implements persistence.Persistable by delegating to the backend.

--- a/services/appconfig/handler.go
+++ b/services/appconfig/handler.go
@@ -619,141 +619,219 @@ func parseHostedVersionRoute(method, appID, profileID string, parts []string) ap
 }
 
 // Handler returns the Echo handler function for AppConfig operations.
-//
-//nolint:cyclop,gocyclo,funlen // dispatch table requires multiple branches
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
 		log := logger.Load(c.Request().Context())
 		route := parseAppConfigPath(c.Request().Method, c.Request().URL.Path)
 
-		switch route.operation {
-		case opCreateApplication:
-			return h.handleCreateApplication(c)
-		case opGetApplication:
-			return h.handleGetApplication(c, route.applicationID)
-		case opListApplications:
-			return h.handleListApplications(c)
-		case opUpdateApplication:
-			return h.handleUpdateApplication(c, route.applicationID)
-		case opDeleteApplication:
-			return h.handleDeleteApplication(c, route.applicationID)
-		case opCreateEnvironment:
-			return h.handleCreateEnvironment(c, route.applicationID)
-		case opGetEnvironment:
-			return h.handleGetEnvironment(c, route.applicationID, route.environmentID)
-		case opListEnvironments:
-			return h.handleListEnvironments(c, route.applicationID)
-		case opUpdateEnvironment:
-			return h.handleUpdateEnvironment(c, route.applicationID, route.environmentID)
-		case opDeleteEnvironment:
-			return h.handleDeleteEnvironment(c, route.applicationID, route.environmentID)
-		case opCreateConfigurationProfile:
-			return h.handleCreateConfigurationProfile(c, route.applicationID)
-		case opGetConfigurationProfile:
-			return h.handleGetConfigurationProfile(c, route.applicationID, route.profileID)
-		case opListConfigurationProfiles:
-			return h.handleListConfigurationProfiles(c, route.applicationID)
-		case opUpdateConfigurationProfile:
-			return h.handleUpdateConfigurationProfile(c, route.applicationID, route.profileID)
-		case opDeleteConfigurationProfile:
-			return h.handleDeleteConfigurationProfile(c, route.applicationID, route.profileID)
-		case opCreateHostedConfigurationVersion:
-			return h.handleCreateHostedConfigurationVersion(c, route.applicationID, route.profileID)
-		case opGetHostedConfigurationVersion:
-			return h.handleGetHostedConfigurationVersion(
-				c,
-				route.applicationID,
-				route.profileID,
-				route.versionNumber,
-			)
-		case opListHostedConfigurationVersions:
-			return h.handleListHostedConfigurationVersions(c, route.applicationID, route.profileID)
-		case opDeleteHostedConfigurationVersion:
-			return h.handleDeleteHostedConfigurationVersion(
-				c,
-				route.applicationID,
-				route.profileID,
-				route.versionNumber,
-			)
-		case opCreateDeploymentStrategy:
-			return h.handleCreateDeploymentStrategy(c)
-		case opGetDeploymentStrategy:
-			return h.handleGetDeploymentStrategy(c, route.strategyID)
-		case opListDeploymentStrategies:
-			return h.handleListDeploymentStrategies(c)
-		case opUpdateDeploymentStrategy:
-			return h.handleUpdateDeploymentStrategy(c, route.strategyID)
-		case opDeleteDeploymentStrategy:
-			return h.handleDeleteDeploymentStrategy(c, route.strategyID)
-		case opStartDeployment:
-			return h.handleStartDeployment(c, route.applicationID, route.environmentID)
-		case opGetDeployment:
-			return h.handleGetDeployment(
-				c,
-				route.applicationID,
-				route.environmentID,
-				route.deploymentNum,
-			)
-		case opListDeployments:
-			return h.handleListDeployments(c, route.applicationID, route.environmentID)
-		case opStopDeployment:
-			return h.handleStopDeployment(
-				c,
-				route.applicationID,
-				route.environmentID,
-				route.deploymentNum,
-			)
-		case opListTagsForResource:
-			return h.handleListTagsForResource(c, route.resourceArn)
-		case opTagResource:
-			return h.handleTagResource(c, route.resourceArn)
-		case opUntagResource:
-			return h.handleUntagResource(c, route.resourceArn)
-		case opCreateExtension:
-			return h.handleCreateExtension(c)
-		case opGetExtension:
-			return h.handleGetExtension(c, route.extensionID)
-		case opListExtensions:
-			return h.handleListExtensions(c)
-		case opUpdateExtension:
-			return h.handleUpdateExtension(c, route.extensionID)
-		case opDeleteExtension:
-			return h.handleDeleteExtension(c, route.extensionID)
-		case opCreateExtensionAssociation:
-			return h.handleCreateExtensionAssociation(c)
-		case opGetExtensionAssociation:
-			return h.handleGetExtensionAssociation(c, route.extensionAssociationID)
-		case opListExtensionAssociations:
-			return h.handleListExtensionAssociations(c)
-		case opUpdateExtensionAssociation:
-			return h.handleUpdateExtensionAssociation(c, route.extensionAssociationID)
-		case opDeleteExtensionAssociation:
-			return h.handleDeleteExtensionAssociation(c, route.extensionAssociationID)
-		case opGetAccountSettings:
-			return h.handleGetAccountSettings(c)
-		case opUpdateAccountSettings:
-			return h.handleUpdateAccountSettings(c)
-		case opGetConfiguration:
-			return h.handleGetConfiguration(
-				c,
-				route.applicationID,
-				route.environmentID,
-				route.configurationID,
-			)
-		case opValidateConfiguration:
-			return h.handleValidateConfiguration(c, route.applicationID, route.profileID)
-		default:
-			log.Warn(
-				"appconfig: unmatched route",
-				"method",
-				c.Request().Method,
-				"path",
-				c.Request().URL.Path,
-			)
-
-			return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: "not found"})
+		if ok, err := h.dispatchAppConfig(c, route); ok {
+			return err
 		}
+
+		log.Warn(
+			"appconfig: unmatched route",
+			"method", c.Request().Method,
+			"path", c.Request().URL.Path,
+		)
+
+		return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: "not found"})
 	}
+}
+
+// dispatchAppConfig routes a parsed AppConfig route to the appropriate handler.
+func (h *Handler) dispatchAppConfig(c *echo.Context, route appConfigRoute) (bool, error) {
+	if ok, err := h.dispatchApplicationOps(c, route); ok {
+		return true, err
+	}
+
+	if ok, err := h.dispatchProfileVersionOps(c, route); ok {
+		return true, err
+	}
+
+	if ok, err := h.dispatchDeploymentStrategyOps(c, route); ok {
+		return true, err
+	}
+
+	if ok, err := h.dispatchExtensionTagOps(c, route); ok {
+		return true, err
+	}
+
+	return false, nil
+}
+
+// dispatchApplicationOps handles application and environment operations.
+func (h *Handler) dispatchApplicationOps(c *echo.Context, route appConfigRoute) (bool, error) {
+	switch route.operation {
+	case opCreateApplication:
+		return true, h.handleCreateApplication(c)
+	case opGetApplication:
+		return true, h.handleGetApplication(c, route.applicationID)
+	case opListApplications:
+		return true, h.handleListApplications(c)
+	case opUpdateApplication:
+		return true, h.handleUpdateApplication(c, route.applicationID)
+	case opDeleteApplication:
+		return true, h.handleDeleteApplication(c, route.applicationID)
+	case opCreateEnvironment:
+		return true, h.handleCreateEnvironment(c, route.applicationID)
+	case opGetEnvironment:
+		return true, h.handleGetEnvironment(c, route.applicationID, route.environmentID)
+	case opListEnvironments:
+		return true, h.handleListEnvironments(c, route.applicationID)
+	case opUpdateEnvironment:
+		return true, h.handleUpdateEnvironment(c, route.applicationID, route.environmentID)
+	case opDeleteEnvironment:
+		return true, h.handleDeleteEnvironment(c, route.applicationID, route.environmentID)
+	}
+
+	return false, nil
+}
+
+// dispatchProfileVersionOps handles configuration profile and hosted configuration version operations.
+func (h *Handler) dispatchProfileVersionOps(c *echo.Context, route appConfigRoute) (bool, error) {
+	switch route.operation {
+	case opCreateConfigurationProfile:
+		return true, h.handleCreateConfigurationProfile(c, route.applicationID)
+	case opGetConfigurationProfile:
+		return true, h.handleGetConfigurationProfile(c, route.applicationID, route.profileID)
+	case opListConfigurationProfiles:
+		return true, h.handleListConfigurationProfiles(c, route.applicationID)
+	case opUpdateConfigurationProfile:
+		return true, h.handleUpdateConfigurationProfile(c, route.applicationID, route.profileID)
+	case opDeleteConfigurationProfile:
+		return true, h.handleDeleteConfigurationProfile(c, route.applicationID, route.profileID)
+	case opCreateHostedConfigurationVersion:
+		return true, h.handleCreateHostedConfigurationVersion(
+			c,
+			route.applicationID,
+			route.profileID,
+		)
+	case opGetHostedConfigurationVersion:
+		return true, h.handleGetHostedConfigurationVersion(
+			c,
+			route.applicationID,
+			route.profileID,
+			route.versionNumber,
+		)
+	case opListHostedConfigurationVersions:
+		return true, h.handleListHostedConfigurationVersions(
+			c,
+			route.applicationID,
+			route.profileID,
+		)
+	case opDeleteHostedConfigurationVersion:
+		return true, h.handleDeleteHostedConfigurationVersion(
+			c,
+			route.applicationID,
+			route.profileID,
+			route.versionNumber,
+		)
+	}
+
+	return false, nil
+}
+
+// dispatchDeploymentStrategyOps handles deployment strategy and deployment operations.
+func (h *Handler) dispatchDeploymentStrategyOps(
+	c *echo.Context,
+	route appConfigRoute,
+) (bool, error) {
+	switch route.operation {
+	case opCreateDeploymentStrategy:
+		return true, h.handleCreateDeploymentStrategy(c)
+	case opGetDeploymentStrategy:
+		return true, h.handleGetDeploymentStrategy(c, route.strategyID)
+	case opListDeploymentStrategies:
+		return true, h.handleListDeploymentStrategies(c)
+	case opUpdateDeploymentStrategy:
+		return true, h.handleUpdateDeploymentStrategy(c, route.strategyID)
+	case opDeleteDeploymentStrategy:
+		return true, h.handleDeleteDeploymentStrategy(c, route.strategyID)
+	case opStartDeployment:
+		return true, h.handleStartDeployment(c, route.applicationID, route.environmentID)
+	case opGetDeployment:
+		return true, h.handleGetDeployment(
+			c,
+			route.applicationID,
+			route.environmentID,
+			route.deploymentNum,
+		)
+	case opListDeployments:
+		return true, h.handleListDeployments(c, route.applicationID, route.environmentID)
+	case opStopDeployment:
+		return true, h.handleStopDeployment(
+			c,
+			route.applicationID,
+			route.environmentID,
+			route.deploymentNum,
+		)
+	}
+
+	return false, nil
+}
+
+// dispatchExtensionTagOps handles extension, extension association, tagging, and account settings ops.
+func (h *Handler) dispatchExtensionTagOps(c *echo.Context, route appConfigRoute) (bool, error) {
+	if ok, err := h.dispatchTagAccountOps(c, route); ok {
+		return true, err
+	}
+
+	return h.dispatchExtensionAssocOps(c, route)
+}
+
+// dispatchTagAccountOps handles tagging, account settings, extensions, and configuration ops.
+func (h *Handler) dispatchTagAccountOps(c *echo.Context, route appConfigRoute) (bool, error) {
+	switch route.operation {
+	case opListTagsForResource:
+		return true, h.handleListTagsForResource(c, route.resourceArn)
+	case opTagResource:
+		return true, h.handleTagResource(c, route.resourceArn)
+	case opUntagResource:
+		return true, h.handleUntagResource(c, route.resourceArn)
+	case opCreateExtension:
+		return true, h.handleCreateExtension(c)
+	case opGetExtension:
+		return true, h.handleGetExtension(c, route.extensionID)
+	case opListExtensions:
+		return true, h.handleListExtensions(c)
+	case opUpdateExtension:
+		return true, h.handleUpdateExtension(c, route.extensionID)
+	case opDeleteExtension:
+		return true, h.handleDeleteExtension(c, route.extensionID)
+	case opGetAccountSettings:
+		return true, h.handleGetAccountSettings(c)
+	case opUpdateAccountSettings:
+		return true, h.handleUpdateAccountSettings(c)
+	}
+
+	return false, nil
+}
+
+// dispatchExtensionAssocOps handles extension association and configuration retrieval ops.
+func (h *Handler) dispatchExtensionAssocOps(c *echo.Context, route appConfigRoute) (bool, error) {
+	switch route.operation {
+	case opCreateExtensionAssociation:
+		return true, h.handleCreateExtensionAssociation(c)
+	case opGetExtensionAssociation:
+		return true, h.handleGetExtensionAssociation(c, route.extensionAssociationID)
+	case opListExtensionAssociations:
+		return true, h.handleListExtensionAssociations(c)
+	case opUpdateExtensionAssociation:
+		return true, h.handleUpdateExtensionAssociation(c, route.extensionAssociationID)
+	case opDeleteExtensionAssociation:
+		return true, h.handleDeleteExtensionAssociation(c, route.extensionAssociationID)
+	case opGetConfiguration:
+		return true, h.handleGetConfiguration(
+			c,
+			route.applicationID,
+			route.environmentID,
+			route.configurationID,
+		)
+	case opValidateConfiguration:
+		return true, h.handleValidateConfiguration(c, route.applicationID, route.profileID)
+	}
+
+	return false, nil
 }
 
 func notFoundResponse(c *echo.Context, err error) error {

--- a/services/backup/handler.go
+++ b/services/backup/handler.go
@@ -627,13 +627,12 @@ func parseRecoveryPointSubRoute(method, vaultName, rpArn, sub string) backupRout
 	return backupRoute{operation: opUnknown}
 }
 
-//nolint:cyclop // plan sub-resources require branching
+// parsePlanRoute routes backup plan and selection paths.
 func parsePlanRoute(method, suffix string) backupRoute {
 	// suffix is "" or "/{id}" or "/{id}/selections[/{selId}]"
 	id := strings.TrimPrefix(suffix, "/")
 
-	switch {
-	case id == "":
+	if id == "" {
 		// /backup/plans
 		switch method {
 		case http.MethodPut:
@@ -641,46 +640,51 @@ func parsePlanRoute(method, suffix string) backupRoute {
 		case http.MethodGet:
 			return backupRoute{operation: opListBackupPlans}
 		}
-	case strings.Contains(id, "/"):
+
+		return backupRoute{operation: opUnknown}
+	}
+
+	if strings.Contains(id, "/") {
 		// /backup/plans/{id}/selections[/{selId}]
 		parts := strings.SplitN(id, "/", splitTwo)
-		planID := parts[0]
-		rest := parts[1]
 
-		switch {
-		case rest == "selections":
-			switch method {
-			case http.MethodPut:
-				return backupRoute{operation: opCreateBackupSelection, resource: planID}
-			case http.MethodGet:
-				return backupRoute{operation: opListBackupSelections, resource: planID}
-			}
-		case strings.HasPrefix(rest, "selections/"):
-			selID := strings.TrimPrefix(rest, "selections/")
-			if !strings.Contains(selID, "/") {
-				switch method {
-				case http.MethodGet:
-					return backupRoute{
-						operation: opGetBackupSelection,
-						resource:  planID + "|" + selID,
-					}
-				case http.MethodDelete:
-					return backupRoute{
-						operation: opDeleteBackupSelection,
-						resource:  planID + "|" + selID,
-					}
-				}
-			}
-		}
-	default:
-		// /backup/plans/{id}
+		return parsePlanSelectionRoute(method, parts[0], parts[1])
+	}
+
+	// /backup/plans/{id}
+	switch method {
+	case http.MethodGet:
+		return backupRoute{operation: opGetBackupPlan, resource: id}
+	case http.MethodPost:
+		return backupRoute{operation: opUpdateBackupPlan, resource: id}
+	case http.MethodDelete:
+		return backupRoute{operation: opDeleteBackupPlan, resource: id}
+	}
+
+	return backupRoute{operation: opUnknown}
+}
+
+// parsePlanSelectionRoute routes backup plan selection sub-paths.
+func parsePlanSelectionRoute(method, planID, rest string) backupRoute {
+	if rest == "selections" {
 		switch method {
+		case http.MethodPut:
+			return backupRoute{operation: opCreateBackupSelection, resource: planID}
 		case http.MethodGet:
-			return backupRoute{operation: opGetBackupPlan, resource: id}
-		case http.MethodPost:
-			return backupRoute{operation: opUpdateBackupPlan, resource: id}
-		case http.MethodDelete:
-			return backupRoute{operation: opDeleteBackupPlan, resource: id}
+			return backupRoute{operation: opListBackupSelections, resource: planID}
+		}
+
+		return backupRoute{operation: opUnknown}
+	}
+
+	if selID, ok := strings.CutPrefix(rest, "selections/"); ok {
+		if !strings.Contains(selID, "/") {
+			switch method {
+			case http.MethodGet:
+				return backupRoute{operation: opGetBackupSelection, resource: planID + "|" + selID}
+			case http.MethodDelete:
+				return backupRoute{operation: opDeleteBackupSelection, resource: planID + "|" + selID}
+			}
 		}
 	}
 
@@ -930,49 +934,70 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	}
 }
 
-//nolint:cyclop // dispatch table for 24 REST operations is inherently wide
+// dispatch routes a parsed Backup route to the appropriate handler.
 func (h *Handler) dispatch(c *echo.Context, route backupRoute, body []byte) error {
 	if ok, result := h.dispatchNewOps(c, route, body); ok {
 		return result
 	}
 
+	if ok, result := h.dispatchVaultPlanOps(c, route, body); ok {
+		return result
+	}
+
+	if ok, result := h.dispatchJobTagOps(c, route, body); ok {
+		return result
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		errResp("ResourceNotFoundException", "unknown operation: "+route.operation),
+	)
+}
+
+// dispatchVaultPlanOps handles backup vault and backup plan operations.
+func (h *Handler) dispatchVaultPlanOps(c *echo.Context, route backupRoute, body []byte) (bool, error) {
 	switch route.operation {
 	case opCreateBackupVault:
-		return h.handleCreateBackupVault(c, route.resource, body)
+		return true, h.handleCreateBackupVault(c, route.resource, body)
 	case opDescribeBackupVault:
-		return h.handleDescribeBackupVault(c, route.resource)
+		return true, h.handleDescribeBackupVault(c, route.resource)
 	case opListBackupVaults:
-		return h.handleListBackupVaults(c)
+		return true, h.handleListBackupVaults(c)
 	case opDeleteBackupVault:
-		return h.handleDeleteBackupVault(c, route.resource)
+		return true, h.handleDeleteBackupVault(c, route.resource)
 	case opCreateBackupPlan:
-		return h.handleCreateBackupPlan(c, body)
+		return true, h.handleCreateBackupPlan(c, body)
 	case opGetBackupPlan:
-		return h.handleGetBackupPlan(c, route.resource)
+		return true, h.handleGetBackupPlan(c, route.resource)
 	case opListBackupPlans:
-		return h.handleListBackupPlans(c)
+		return true, h.handleListBackupPlans(c)
 	case opUpdateBackupPlan:
-		return h.handleUpdateBackupPlan(c, route.resource, body)
+		return true, h.handleUpdateBackupPlan(c, route.resource, body)
 	case opDeleteBackupPlan:
-		return h.handleDeleteBackupPlan(c, route.resource)
-	case opStartBackupJob:
-		return h.handleStartBackupJob(c, body)
-	case opDescribeBackupJob:
-		return h.handleDescribeBackupJob(c, route.resource)
-	case opListBackupJobs:
-		return h.handleListBackupJobs(c)
-	case opTagResource:
-		return h.handleTagResource(c, route.resource, body)
-	case opUntagResource:
-		return h.handleUntagResource(c, route.resource, body)
-	case opListTags:
-		return h.handleListTags(c, route.resource)
-	default:
-		return c.JSON(
-			http.StatusNotFound,
-			errResp("ResourceNotFoundException", "unknown operation: "+route.operation),
-		)
+		return true, h.handleDeleteBackupPlan(c, route.resource)
 	}
+
+	return false, nil
+}
+
+// dispatchJobTagOps handles backup job and tagging operations.
+func (h *Handler) dispatchJobTagOps(c *echo.Context, route backupRoute, body []byte) (bool, error) {
+	switch route.operation {
+	case opStartBackupJob:
+		return true, h.handleStartBackupJob(c, body)
+	case opDescribeBackupJob:
+		return true, h.handleDescribeBackupJob(c, route.resource)
+	case opListBackupJobs:
+		return true, h.handleListBackupJobs(c)
+	case opTagResource:
+		return true, h.handleTagResource(c, route.resource, body)
+	case opUntagResource:
+		return true, h.handleUntagResource(c, route.resource, body)
+	case opListTags:
+		return true, h.handleListTags(c, route.resource)
+	}
+
+	return false, nil
 }
 
 // dispatchNewOps dispatches additional Backup operations beyond the original set.
@@ -2867,9 +2892,28 @@ func (h *Handler) handleDeleteReportPlan(c *echo.Context, name string) error {
 }
 
 // dispatchStubOps handles stub operations that return minimal valid responses.
-//
-//nolint:cyclop,funlen,gocyclo // large dispatch table for stub operations
 func (h *Handler) dispatchStubOps(c *echo.Context, route backupRoute) (bool, error) {
+	if ok, err := h.dispatchStubSettingsAndJobs(c, route); ok {
+		return true, err
+	}
+
+	if ok, err := h.dispatchStubReportsAndHolds(c, route); ok {
+		return true, err
+	}
+
+	return h.dispatchStubPlanTemplatesAndTiering(c, route)
+}
+
+// dispatchStubSettingsAndJobs handles settings, protected resources, and restore/restore-job stubs.
+func (h *Handler) dispatchStubSettingsAndJobs(c *echo.Context, route backupRoute) (bool, error) {
+	if ok, err := h.dispatchStubSettingsOps(c, route); ok {
+		return true, err
+	}
+
+	return h.dispatchStubRestoreOps(c, route)
+}
+
+func (h *Handler) dispatchStubSettingsOps(c *echo.Context, route backupRoute) (bool, error) {
 	switch route.operation {
 	case opDescribeGlobalSettings:
 		return true, c.JSON(http.StatusOK, map[string]any{
@@ -2906,6 +2950,13 @@ func (h *Handler) dispatchStubOps(c *echo.Context, route backupRoute) (bool, err
 		return true, c.JSON(http.StatusOK, map[string]any{
 			"Results": []any{},
 		})
+	}
+
+	return false, nil
+}
+
+func (h *Handler) dispatchStubRestoreOps(c *echo.Context, route backupRoute) (bool, error) {
+	switch route.operation {
 	case opDescribeRestoreJob:
 		return true, c.JSON(http.StatusOK, map[string]any{
 			keyRestoreJobID: route.resource,
@@ -2936,6 +2987,22 @@ func (h *Handler) dispatchStubOps(c *echo.Context, route backupRoute) (bool, err
 		return true, c.JSON(http.StatusOK, map[string]any{
 			keyRestoreJobID: "restore-" + route.resource,
 		})
+	}
+
+	return false, nil
+}
+
+// dispatchStubReportsAndHolds handles report, scan job, and legal hold stub responses.
+func (h *Handler) dispatchStubReportsAndHolds(c *echo.Context, route backupRoute) (bool, error) {
+	if ok, err := h.dispatchStubReportOps(c, route); ok {
+		return true, err
+	}
+
+	return h.dispatchStubLegalHoldOps(c, route)
+}
+
+func (h *Handler) dispatchStubReportOps(c *echo.Context, route backupRoute) (bool, error) {
+	switch route.operation {
 	case opPutRestoreValidationResult:
 		return true, c.NoContent(http.StatusNoContent)
 	case opDescribeReportJob:
@@ -2970,6 +3037,13 @@ func (h *Handler) dispatchStubOps(c *echo.Context, route backupRoute) (bool, err
 		return true, c.JSON(http.StatusOK, map[string]any{
 			"ScanJobId": "scan-job-" + route.resource,
 		})
+	}
+
+	return false, nil
+}
+
+func (h *Handler) dispatchStubLegalHoldOps(c *echo.Context, route backupRoute) (bool, error) {
+	switch route.operation {
 	case opGetLegalHold:
 		return true, c.JSON(http.StatusOK, map[string]any{
 			"LegalHoldId": route.resource,
@@ -3004,6 +3078,22 @@ func (h *Handler) dispatchStubOps(c *echo.Context, route backupRoute) (bool, err
 		return true, c.JSON(http.StatusOK, map[string]any{
 			"IndexedRecoveryPoints": []any{},
 		})
+	}
+
+	return false, nil
+}
+
+// dispatchStubPlanTemplatesAndTiering handles plan template, job, and tiering stub responses.
+func (h *Handler) dispatchStubPlanTemplatesAndTiering(c *echo.Context, route backupRoute) (bool, error) {
+	if ok, err := h.dispatchStubPlanTemplateOps(c, route); ok {
+		return true, err
+	}
+
+	return h.dispatchStubTieringOps(c, route)
+}
+
+func (h *Handler) dispatchStubPlanTemplateOps(c *echo.Context, route backupRoute) (bool, error) {
+	switch route.operation {
 	case opExportBackupPlanTemplate:
 		return true, c.JSON(http.StatusOK, map[string]any{
 			"BackupPlanTemplateJson": "{}",
@@ -3043,6 +3133,13 @@ func (h *Handler) dispatchStubOps(c *echo.Context, route backupRoute) (bool, err
 			keyCopyJobID:   "copy-job-" + route.resource,
 			"CreationDate": time.Now().UTC().Format(time.RFC3339),
 		})
+	}
+
+	return false, nil
+}
+
+func (h *Handler) dispatchStubTieringOps(c *echo.Context, route backupRoute) (bool, error) {
+	switch route.operation {
 	case opStopBackupJob:
 		return true, c.NoContent(http.StatusNoContent)
 	case opListRestoreAccessBackupVaults:

--- a/services/bedrock/handler.go
+++ b/services/bedrock/handler.go
@@ -35,6 +35,12 @@ const (
 	marketplaceEndpointsPrefix   = "/marketplace-model/endpoints"
 	loggingConfigPath            = "/logging/modelinvocations"
 
+	// Stub response key constants.
+	keyJobArn          = "jobArn"
+	keyStatus          = "status"
+	keyDeploymentArn   = "deploymentArn"
+	jobStatusCompleted = "Completed"
+
 	// Stub operation paths.
 	modelCopyJobsPrefix           = "/model-copy-jobs"
 	modelImportJobsPrefix         = "/model-import-jobs"
@@ -186,38 +192,57 @@ func (h *Handler) ChaosOperations() []string { return h.GetSupportedOperations()
 func (h *Handler) ChaosRegions() []string { return []string{h.Backend.Region()} }
 
 // RouteMatcher returns a function that matches Bedrock requests.
-//
-//nolint:cyclop // extended path list for stub operations is inherently wide
 func (h *Handler) RouteMatcher() service.Matcher {
 	return func(c *echo.Context) bool {
-		path := c.Request().URL.Path
-
-		return strings.HasPrefix(path, guardrailsPrefix) ||
-			strings.HasPrefix(path, foundationModelsPrefix) ||
-			strings.HasPrefix(path, provisionedModelThroughput) ||
-			strings.HasPrefix(path, evaluationJobsPrefix) ||
-			strings.HasPrefix(path, automatedReasoningPrefix) ||
-			strings.HasPrefix(path, modelCustomizationJobsPrefix) ||
-			strings.HasPrefix(path, inferenceProfilesPrefix) ||
-			strings.HasPrefix(path, marketplaceEndpointsPrefix) ||
-			strings.HasPrefix(path, customModelsPrefix) ||
-			strings.HasPrefix(path, modelCopyJobsPrefix) ||
-			strings.HasPrefix(path, modelImportJobsPrefix) ||
-			strings.HasPrefix(path, modelInvocationJobsPrefix) ||
-			strings.HasPrefix(path, promptRoutersPrefix) ||
-			strings.HasPrefix(path, importedModelsPrefix) ||
-			strings.HasPrefix(path, foundationModelAvailPath) ||
-			strings.HasPrefix(path, foundationModelAgreementsPath) ||
-			strings.HasPrefix(path, customModelDeployments2Path) ||
-			path == useCaseForModelAccessPath ||
-			path == enforcedGuardrailsPath ||
-			path == loggingConfigPath ||
-			path == customModelDeploymentsPath ||
-			path == foundationModelAgreement ||
-			path == listTagsForResourcePath ||
-			path == tagResourcePath ||
-			path == untagResourcePath
+		return matchBedrockPath(c.Request().URL.Path)
 	}
+}
+
+// matchBedrockPath returns true if the path matches a known Bedrock API path.
+func matchBedrockPath(path string) bool {
+	return matchBedrockPrefixPaths(path) || matchBedrockExactPaths(path)
+}
+
+// matchBedrockPrefixPaths returns true if path has a known Bedrock prefix.
+func matchBedrockPrefixPaths(path string) bool {
+	return matchBedrockCorePrefixes(path) || matchBedrockExtPrefixes(path)
+}
+
+// matchBedrockCorePrefixes checks the core Bedrock resource prefixes.
+func matchBedrockCorePrefixes(path string) bool {
+	return strings.HasPrefix(path, guardrailsPrefix) ||
+		strings.HasPrefix(path, foundationModelsPrefix) ||
+		strings.HasPrefix(path, provisionedModelThroughput) ||
+		strings.HasPrefix(path, evaluationJobsPrefix) ||
+		strings.HasPrefix(path, automatedReasoningPrefix) ||
+		strings.HasPrefix(path, modelCustomizationJobsPrefix) ||
+		strings.HasPrefix(path, inferenceProfilesPrefix) ||
+		strings.HasPrefix(path, marketplaceEndpointsPrefix) ||
+		strings.HasPrefix(path, customModelsPrefix)
+}
+
+// matchBedrockExtPrefixes checks the extended Bedrock resource prefixes.
+func matchBedrockExtPrefixes(path string) bool {
+	return strings.HasPrefix(path, modelCopyJobsPrefix) ||
+		strings.HasPrefix(path, modelImportJobsPrefix) ||
+		strings.HasPrefix(path, modelInvocationJobsPrefix) ||
+		strings.HasPrefix(path, promptRoutersPrefix) ||
+		strings.HasPrefix(path, importedModelsPrefix) ||
+		strings.HasPrefix(path, foundationModelAvailPath) ||
+		strings.HasPrefix(path, foundationModelAgreementsPath) ||
+		strings.HasPrefix(path, customModelDeployments2Path)
+}
+
+// matchBedrockExactPaths returns true if path exactly matches a known Bedrock path.
+func matchBedrockExactPaths(path string) bool {
+	return path == useCaseForModelAccessPath ||
+		path == enforcedGuardrailsPath ||
+		path == loggingConfigPath ||
+		path == customModelDeploymentsPath ||
+		path == foundationModelAgreement ||
+		path == listTagsForResourcePath ||
+		path == tagResourcePath ||
+		path == untagResourcePath
 }
 
 // MatchPriority returns the routing priority.
@@ -512,123 +537,157 @@ func (h *Handler) dispatchExtended(c *echo.Context, path, method string, body []
 }
 
 // routeStubOps handles stub operations that return minimal valid responses.
-//
-//nolint:cyclop,funlen,gocognit,gocyclo,goconst // large dispatch table for stub operations
 func (h *Handler) routeStubOps(c *echo.Context, path, method string) (bool, error) {
+	if ok, err := h.routeStubJobOps(c, path, method); ok {
+		return true, err
+	}
+
+	if ok, err := h.routeStubModelOps(c, path, method); ok {
+		return true, err
+	}
+
+	return h.routeStubMiscOps(c, path, method)
+}
+
+// routeStubJobOps handles model copy, import, and invocation job stubs.
+func (h *Handler) routeStubJobOps(c *echo.Context, path, method string) (bool, error) {
+	if ok, err := h.routeStubCopyImportOps(c, path, method); ok {
+		return true, err
+	}
+
+	return h.routeStubInvocationOps(c, path, method)
+}
+
+// routeStubCopyImportOps handles model copy and import job stubs.
+func (h *Handler) routeStubCopyImportOps(c *echo.Context, path, method string) (bool, error) {
 	switch {
-	// Model copy jobs.
 	case path == modelCopyJobsPrefix && method == http.MethodPost:
-		return true, c.JSON(
-			http.StatusCreated,
-			map[string]any{"jobArn": "arn:aws:bedrock:us-east-1:000000000000:model-copy-job/stub"},
-		)
+		return true, c.JSON(http.StatusCreated,
+			map[string]any{keyJobArn: "arn:aws:bedrock:us-east-1:000000000000:model-copy-job/stub"})
 	case path == modelCopyJobsPrefix && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"modelCopyJobSummaries": []any{}})
 	case strings.HasPrefix(path, modelCopyJobsPrefix+"/") && method == http.MethodGet:
-		return true, c.JSON(http.StatusOK, map[string]any{"jobArn": path, "status": "Completed"})
-
-	// Model import jobs.
+		return true, c.JSON(http.StatusOK, map[string]any{keyJobArn: path, keyStatus: jobStatusCompleted})
 	case path == modelImportJobsPrefix && method == http.MethodPost:
-		return true, c.JSON(
-			http.StatusCreated,
-			map[string]any{
-				"jobArn": "arn:aws:bedrock:us-east-1:000000000000:model-import-job/stub",
-			},
-		)
+		return true, c.JSON(http.StatusCreated,
+			map[string]any{keyJobArn: "arn:aws:bedrock:us-east-1:000000000000:model-import-job/stub"})
 	case path == modelImportJobsPrefix && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"modelImportJobSummaries": []any{}})
 	case strings.HasPrefix(path, modelImportJobsPrefix+"/") && method == http.MethodGet:
-		return true, c.JSON(http.StatusOK, map[string]any{"jobArn": path, "status": "Completed"})
+		return true, c.JSON(http.StatusOK, map[string]any{keyJobArn: path, keyStatus: jobStatusCompleted})
+	}
 
-	// Model invocation jobs.
+	return false, nil
+}
+
+// routeStubInvocationOps handles model invocation job stubs.
+func (h *Handler) routeStubInvocationOps(c *echo.Context, path, method string) (bool, error) {
+	switch {
 	case path == modelInvocationJobsPrefix && method == http.MethodPost:
-		return true, c.JSON(
-			http.StatusCreated,
-			map[string]any{
-				"jobArn": "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/stub",
-			},
-		)
+		return true, c.JSON(http.StatusCreated,
+			map[string]any{keyJobArn: "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/stub"})
 	case path == modelInvocationJobsPrefix && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"invocationJobSummaries": []any{}})
 	case strings.HasPrefix(path, modelInvocationJobsPrefix+"/") && method == http.MethodGet:
-		return true, c.JSON(http.StatusOK, map[string]any{"jobArn": path, "status": "Completed"})
+		return true, c.JSON(http.StatusOK, map[string]any{keyJobArn: path, keyStatus: jobStatusCompleted})
 	case strings.HasPrefix(path, modelInvocationJobsPrefix+"/") && method == http.MethodDelete:
 		return true, c.NoContent(http.StatusNoContent)
+	}
 
-	// Prompt routers.
+	return false, nil
+}
+
+// routeStubModelOps handles prompt router, imported model, and foundation model stubs.
+func (h *Handler) routeStubModelOps(c *echo.Context, path, method string) (bool, error) {
+	if ok, err := h.routeStubPromptRouterOps(c, path, method); ok {
+		return true, err
+	}
+
+	return h.routeStubFoundationModelOps(c, path, method)
+}
+
+// routeStubPromptRouterOps handles prompt router and imported model stubs.
+func (h *Handler) routeStubPromptRouterOps(c *echo.Context, path, method string) (bool, error) {
+	switch {
 	case path == promptRoutersPrefix && method == http.MethodPost:
-		return true, c.JSON(
-			http.StatusCreated,
-			map[string]any{
-				"promptRouterArn": "arn:aws:bedrock:us-east-1:000000000000:prompt-router/stub",
-			},
-		)
+		return true, c.JSON(http.StatusCreated,
+			map[string]any{"promptRouterArn": "arn:aws:bedrock:us-east-1:000000000000:prompt-router/stub"})
 	case path == promptRoutersPrefix && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"promptRouters": []any{}})
 	case strings.HasPrefix(path, promptRoutersPrefix+"/") && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"promptRouterArn": path})
 	case strings.HasPrefix(path, promptRoutersPrefix+"/") && method == http.MethodDelete:
 		return true, c.NoContent(http.StatusNoContent)
-
-	// Imported models.
 	case path == importedModelsPrefix && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"modelSummaries": []any{}})
 	case strings.HasPrefix(path, importedModelsPrefix+"/") && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"modelArn": path})
 	case strings.HasPrefix(path, importedModelsPrefix+"/") && method == http.MethodDelete:
 		return true, c.NoContent(http.StatusNoContent)
+	}
 
-	// Foundation model availability & agreements.
+	return false, nil
+}
+
+// routeStubFoundationModelOps handles foundation model availability and agreement stubs.
+func (h *Handler) routeStubFoundationModelOps(c *echo.Context, path, method string) (bool, error) {
+	switch {
 	case strings.HasPrefix(path, foundationModelAvailPath+"/") && method == http.MethodGet:
-		return true, c.JSON(
-			http.StatusOK,
-			map[string]any{"agreementAvailability": map[string]string{"status": "AVAILABLE"}},
-		)
+		return true, c.JSON(http.StatusOK,
+			map[string]any{"agreementAvailability": map[string]string{"status": "AVAILABLE"}})
 	case path == foundationModelAgreementsPath && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"modelAgreementOffers": []any{}})
 	case strings.HasPrefix(path, "/delete-foundation-model-agreement") && method == http.MethodDelete:
 		return true, c.NoContent(http.StatusNoContent)
+	}
 
-	// Custom model deployments.
+	return false, nil
+}
+
+// routeStubMiscOps handles custom model deployment, use case, and enforced guardrail stubs.
+func (h *Handler) routeStubMiscOps(c *echo.Context, path, method string) (bool, error) {
+	if ok, err := h.routeStubDeploymentOps(c, path, method); ok {
+		return true, err
+	}
+
+	return h.routeStubAccessOps(c, path, method)
+}
+
+// routeStubDeploymentOps handles custom model deployment stubs.
+func (h *Handler) routeStubDeploymentOps(c *echo.Context, path, method string) (bool, error) {
+	switch {
 	case path == customModelDeployments2Path && method == http.MethodGet:
 		return true, c.JSON(http.StatusOK, map[string]any{"deploymentSummaries": []any{}})
 	case strings.HasPrefix(path, customModelDeployments2Path+"/") && method == http.MethodGet:
-		return true, c.JSON(http.StatusOK, map[string]any{"deploymentArn": path})
+		return true, c.JSON(http.StatusOK, map[string]any{keyDeploymentArn: path})
 	case strings.HasPrefix(path, customModelDeployments2Path+"/") && method == http.MethodPost:
-		return true, c.JSON(
-			http.StatusCreated,
-			map[string]any{
-				"deploymentArn": "arn:aws:bedrock:us-east-1:000000000000:custom-model-deployment/stub",
-			},
-		)
+		return true, c.JSON(http.StatusCreated,
+			map[string]any{keyDeploymentArn: "arn:aws:bedrock:us-east-1:000000000000:custom-model-deployment/stub"})
 	case strings.HasPrefix(path, customModelDeployments2Path+"/") && method == http.MethodPatch:
-		return true, c.JSON(http.StatusOK, map[string]any{"deploymentArn": path})
+		return true, c.JSON(http.StatusOK, map[string]any{keyDeploymentArn: path})
 	case strings.HasPrefix(path, customModelDeployments2Path+"/") && method == http.MethodDelete:
 		return true, c.NoContent(http.StatusNoContent)
+	}
 
-	// Use case for model access.
+	return false, nil
+}
+
+// routeStubAccessOps handles use case for model access and enforced guardrail stubs.
+func (h *Handler) routeStubAccessOps(c *echo.Context, path, method string) (bool, error) {
+	switch {
 	case path == useCaseForModelAccessPath && method == http.MethodGet:
-		return true, c.JSON(
-			http.StatusOK,
-			map[string]any{"useCaseType": "", "useCaseDescription": ""},
-		)
+		return true, c.JSON(http.StatusOK, map[string]any{"useCaseType": "", "useCaseDescription": ""})
 	case path == useCaseForModelAccessPath && method == http.MethodPut:
 		return true, c.NoContent(http.StatusNoContent)
-
-	// Enforced guardrail configuration.
 	case path == enforcedGuardrailsPath && method == http.MethodGet:
-		return true, c.JSON(
-			http.StatusOK,
-			map[string]any{"enforcedGuardrailConfigurations": []any{}},
-		)
+		return true, c.JSON(http.StatusOK, map[string]any{"enforcedGuardrailConfigurations": []any{}})
 	case path == enforcedGuardrailsPath && method == http.MethodPut:
 		return true, c.NoContent(http.StatusNoContent)
 	case path == enforcedGuardrailsPath && method == http.MethodDelete:
 		return true, c.NoContent(http.StatusNoContent)
-
-	default:
-		return false, nil
 	}
+
+	return false, nil
 }
 
 func (h *Handler) routeGuardrail(c *echo.Context, path, method string, body []byte) (bool, error) {

--- a/services/cloudformation/handler_ops.go
+++ b/services/cloudformation/handler_ops.go
@@ -25,8 +25,17 @@ func (h *Handler) dispatchOps(action string, form url.Values, c *echo.Context) (
 	return h.dispatchMiscOps(action, form, c)
 }
 
-//nolint:cyclop // routes across many resource types
+// dispatchStackSetOps handles StackSet lifecycle and instance operations.
 func (h *Handler) dispatchStackSetOps(action string, form url.Values, c *echo.Context) (bool, error) {
+	if handled, err := h.dispatchStackSetCRUDOps(action, form, c); handled {
+		return true, err
+	}
+
+	return h.dispatchStackSetInstanceOps(action, form, c)
+}
+
+// dispatchStackSetCRUDOps handles StackSet CRUD and basic instance operations.
+func (h *Handler) dispatchStackSetCRUDOps(action string, form url.Values, c *echo.Context) (bool, error) {
 	switch action {
 	case "CreateStackSet":
 		return true, h.handleCreateStackSet(form, c)
@@ -46,6 +55,14 @@ func (h *Handler) dispatchStackSetOps(action string, form url.Values, c *echo.Co
 		return true, h.handleUpdateStackInstances(form, c)
 	case "ListStackInstances":
 		return true, h.handleListStackInstances(form, c)
+	}
+
+	return false, nil
+}
+
+// dispatchStackSetInstanceOps handles StackSet instance detail and operation tracking.
+func (h *Handler) dispatchStackSetInstanceOps(action string, form url.Values, c *echo.Context) (bool, error) {
+	switch action {
 	case "DescribeStackInstance":
 		return true, h.handleDescribeStackInstance(form, c)
 	case "DetectStackSetDrift":
@@ -64,13 +81,22 @@ func (h *Handler) dispatchStackSetOps(action string, form url.Values, c *echo.Co
 		return true, h.handleImportStacksToStackSet(form, c)
 	case "ListStackInstanceResourceDrifts":
 		return true, h.handleListStackInstanceResourceDrifts(form, c)
-	default:
-		return false, nil
 	}
+
+	return false, nil
 }
 
-//nolint:cyclop // routes across many resource types
+// dispatchTemplateAndScanOps handles generated template and resource scan operations.
 func (h *Handler) dispatchTemplateAndScanOps(action string, form url.Values, c *echo.Context) (bool, error) {
+	if handled, err := h.dispatchGeneratedTemplateOps(action, form, c); handled {
+		return true, err
+	}
+
+	return h.dispatchResourceScanOps(action, form, c)
+}
+
+// dispatchGeneratedTemplateOps handles generated template CRUD operations.
+func (h *Handler) dispatchGeneratedTemplateOps(action string, form url.Values, c *echo.Context) (bool, error) {
 	switch action {
 	case "CreateGeneratedTemplate":
 		return true, h.handleCreateGeneratedTemplate(form, c)
@@ -84,6 +110,14 @@ func (h *Handler) dispatchTemplateAndScanOps(action string, form url.Values, c *
 		return true, h.handleGetGeneratedTemplate(form, c)
 	case "ListGeneratedTemplates":
 		return true, h.handleListGeneratedTemplates(form, c)
+	}
+
+	return false, nil
+}
+
+// dispatchResourceScanOps handles resource scan and stack refactor operations.
+func (h *Handler) dispatchResourceScanOps(action string, form url.Values, c *echo.Context) (bool, error) {
+	switch action {
 	case "StartResourceScan":
 		return true, h.handleStartResourceScan(form, c)
 	case "DescribeResourceScan":
@@ -104,13 +138,22 @@ func (h *Handler) dispatchTemplateAndScanOps(action string, form url.Values, c *
 		return true, h.handleListStackRefactors(form, c)
 	case "ListStackRefactorActions":
 		return true, h.handleListStackRefactorActions(form, c)
-	default:
-		return false, nil
 	}
+
+	return false, nil
 }
 
-//nolint:cyclop // routes across many resource types
+// dispatchTypeOps handles CloudFormation type/extension registration and management.
 func (h *Handler) dispatchTypeOps(action string, form url.Values, c *echo.Context) (bool, error) {
+	if handled, err := h.dispatchTypeRegistrationOps(action, form, c); handled {
+		return true, err
+	}
+
+	return h.dispatchTypeManagementOps(action, form, c)
+}
+
+// dispatchTypeRegistrationOps handles type registration and activation operations.
+func (h *Handler) dispatchTypeRegistrationOps(action string, form url.Values, c *echo.Context) (bool, error) {
 	switch action {
 	case "ActivateType":
 		return true, h.handleActivateType(form, c)
@@ -128,6 +171,16 @@ func (h *Handler) dispatchTypeOps(action string, form url.Values, c *echo.Contex
 		return true, h.handleSetTypeConfiguration(form, c)
 	case "BatchDescribeTypeConfigurations":
 		return true, h.handleBatchDescribeTypeConfigurations(form, c)
+	case "TestType":
+		return true, h.handleTestType(form, c)
+	}
+
+	return false, nil
+}
+
+// dispatchTypeManagementOps handles type listing, publishing, and access management.
+func (h *Handler) dispatchTypeManagementOps(action string, form url.Values, c *echo.Context) (bool, error) {
+	switch action {
 	case "ListTypes":
 		return true, h.handleListTypes(form, c)
 	case "ListTypeVersions":
@@ -136,8 +189,6 @@ func (h *Handler) dispatchTypeOps(action string, form url.Values, c *echo.Contex
 		return true, h.handleListTypeRegistrations(form, c)
 	case "DescribeTypeRegistration":
 		return true, h.handleDescribeTypeRegistration(form, c)
-	case "TestType":
-		return true, h.handleTestType(form, c)
 	case "RegisterPublisher":
 		return true, h.handleRegisterPublisher(form, c)
 	case "DescribePublisher":
@@ -148,9 +199,9 @@ func (h *Handler) dispatchTypeOps(action string, form url.Values, c *echo.Contex
 		return true, h.handleDeactivateOrganizationsAccess(c)
 	case "DescribeOrganizationsAccess":
 		return true, h.handleDescribeOrganizationsAccess(c)
-	default:
-		return false, nil
 	}
+
+	return false, nil
 }
 
 func (h *Handler) dispatchMiscOps(action string, form url.Values, c *echo.Context) (bool, error) {

--- a/services/cloudfront/handler.go
+++ b/services/cloudfront/handler.go
@@ -453,60 +453,75 @@ func xmlResp(c *echo.Context, status int, body string) error {
 
 // parseCFPath maps HTTP method + path to (operationName, resourceID).
 //
-//nolint:cyclop,funlen,gocognit,gocyclo,lll,nlreturn // dispatch table for many REST operations is inherently wide
+// parseCFPath maps an HTTP method + URL path to a CloudFront operation name and resource identifier.
+//
+//nolint:funlen,lll,nlreturn // dispatch table for many REST operations is inherently wide
 func parseCFPath(method, path, resourceParam string) (string, string) {
 	suffix := strings.TrimPrefix(path, cfPathPrefix)
 
+	if op, id := parseCFDistributionPath(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFPolicyPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFEncryptionKeyPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFConnectionPath(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFDistributionsByPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	return parseCFPathCore(method, suffix, resourceParam)
+}
+
+// parseCFDistributionPath routes distribution and distribution-tenant paths.
+func parseCFDistributionPath(method, suffix, resourceParam string) (string, string) {
+	if op, id := parseCFDistributionCorePath(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	return parseCFOAIPath(method, suffix)
+}
+
+// parseCFDistributionCorePath routes core distribution paths.
+// parseCFDistributionCorePath routes core distribution paths.
+func parseCFDistributionCorePath(method, suffix, resourceParam string) (string, string) {
+	if !strings.HasPrefix(suffix, "distribution") {
+		return "", ""
+	}
+
+	if op, id := parseCFDistributionRoot(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	if strings.HasPrefix(suffix, "distribution-tenant/") {
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, "distribution-tenant/"), "/associate-web-acl")
+		if strings.HasSuffix(suffix, "/associate-web-acl") && method == http.MethodPut {
+			return opAssociateDistributionTenantWebACL, id
+		}
+
+		return "", ""
+	}
+
+	return parseCFDistributionSubPath(method, suffix)
+}
+
+// parseCFDistributionRoot handles the distribution collection and simple CRUD operations.
+func parseCFDistributionRoot(method, suffix, resourceParam string) (string, string) {
 	switch {
-	case suffix == sfxDistribution && method == http.MethodPost:
+	case suffix == sfxDistribution && method == http.MethodPost && resourceParam != "WithTags":
 		return opCreateDistribution, ""
 	case suffix == sfxDistribution && method == http.MethodGet:
 		return opListDistributions, ""
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/config")
-		switch method {
-		case http.MethodGet:
-			return opGetDistributionConfig, id
-		case http.MethodPut:
-			return opUpdateDistribution, id
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/invalidation"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/invalidation")
-		switch method {
-		case http.MethodPost:
-			return opCreateInvalidation, id
-		case http.MethodGet:
-			return opListInvalidations, id
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.Contains(suffix, "/invalidation/"):
-		// distribution/{distID}/invalidation/{invID}
-		inner := strings.TrimPrefix(suffix, "distribution/")
-		before, _, ok := strings.Cut(inner, "/invalidation/")
-		if ok && method == http.MethodGet {
-			return opGetInvalidation, before
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/associate-alias"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/associate-alias")
-		if method == http.MethodPut {
-			return opAssociateAlias, id
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/associate-web-acl"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/associate-web-acl")
-		if method == http.MethodPut {
-			return opAssociateDistributionWebACL, id
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/copy"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/copy")
-		if method == http.MethodPost {
-			return opCopyDistribution, id
-		}
-	case strings.HasPrefix(suffix, "distribution/") &&
-		!strings.Contains(strings.TrimPrefix(suffix, "distribution/"), "/"):
+	case strings.HasPrefix(suffix, "distribution/") && !strings.Contains(strings.TrimPrefix(suffix, "distribution/"), "/"):
 		id := strings.TrimPrefix(suffix, "distribution/")
 		switch method {
 		case http.MethodGet:
@@ -514,28 +529,95 @@ func parseCFPath(method, path, resourceParam string) (string, string) {
 		case http.MethodDelete:
 			return opDeleteDistribution, id
 		}
-	case strings.HasPrefix(suffix, "distribution-tenant/") && strings.HasSuffix(suffix, "/associate-web-acl"):
-		id := strings.TrimPrefix(suffix, "distribution-tenant/")
-		id = strings.TrimSuffix(id, "/associate-web-acl")
-		if method == http.MethodPut {
-			return opAssociateDistributionTenantWebACL, id
+	}
+
+	return "", ""
+}
+
+// parseCFDistributionSubPath handles distribution sub-path operations (config, invalidation, etc.).
+func parseCFDistributionSubPath(method, suffix string) (string, string) {
+	if !strings.HasPrefix(suffix, "distribution/") {
+		return "", ""
+	}
+
+	inner := strings.TrimPrefix(suffix, "distribution/")
+
+	if op, id := parseCFDistributionConfigAndInvalidation(method, inner); op != "" {
+		return op, id
+	}
+
+	return parseCFDistributionAssocAndAction(method, inner)
+}
+
+// parseCFDistributionConfigAndInvalidation handles config and invalidation sub-paths.
+func parseCFDistributionConfigAndInvalidation(method, inner string) (string, string) {
+	switch {
+	case strings.HasSuffix(inner, "/config"):
+		id := strings.TrimSuffix(inner, "/config")
+		switch method {
+		case http.MethodGet:
+			return opGetDistributionConfig, id
+		case http.MethodPut:
+			return opUpdateDistribution, id
 		}
-	case suffix == "origin-access-identity/cloudfront" && method == http.MethodPost:
+	case strings.HasSuffix(inner, "/invalidation"):
+		id := strings.TrimSuffix(inner, "/invalidation")
+		switch method {
+		case http.MethodPost:
+			return opCreateInvalidation, id
+		case http.MethodGet:
+			return opListInvalidations, id
+		}
+	case strings.Contains(inner, "/invalidation/"):
+		before, _, ok := strings.Cut(inner, "/invalidation/")
+		if ok && method == http.MethodGet {
+			return opGetInvalidation, before
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFDistributionAssocAndAction handles associate, copy, and other sub-paths.
+func parseCFDistributionAssocAndAction(method, inner string) (string, string) {
+	switch {
+	case strings.HasSuffix(inner, "/associate-alias"):
+		if method == http.MethodPut {
+			return opAssociateAlias, strings.TrimSuffix(inner, "/associate-alias")
+		}
+	case strings.HasSuffix(inner, "/associate-web-acl"):
+		if method == http.MethodPut {
+			return opAssociateDistributionWebACL, strings.TrimSuffix(inner, "/associate-web-acl")
+		}
+	case strings.HasSuffix(inner, "/copy"):
+		if method == http.MethodPost {
+			return opCopyDistribution, strings.TrimSuffix(inner, "/copy")
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFOAIPath routes CloudFront Origin Access Identity paths.
+func parseCFOAIPath(method, suffix string) (string, string) {
+	const oaiPrefix = "origin-access-identity/cloudfront/"
+	const oaiRoot = "origin-access-identity/cloudfront"
+
+	switch {
+	case suffix == oaiRoot && method == http.MethodPost:
 		return opCreateCloudFrontOriginAccessIdentity, ""
-	case suffix == "origin-access-identity/cloudfront" && method == http.MethodGet:
+	case suffix == oaiRoot && method == http.MethodGet:
 		return opListCloudFrontOriginAccessIdentities, ""
-	case strings.HasPrefix(suffix, "origin-access-identity/cloudfront/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "origin-access-identity/cloudfront/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
+	case strings.HasPrefix(suffix, oaiPrefix) && strings.HasSuffix(suffix, "/config"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, oaiPrefix), "/config")
+		switch method {
+		case http.MethodGet:
 			return opGetCloudFrontOriginAccessIdentityConfig, id
-		}
-		if method == http.MethodPut {
+		case http.MethodPut:
 			return opUpdateCloudFrontOAI, id
 		}
-	case strings.HasPrefix(suffix, "origin-access-identity/cloudfront/") &&
-		!strings.Contains(strings.TrimPrefix(suffix, "origin-access-identity/cloudfront/"), "/"):
-		id := strings.TrimPrefix(suffix, "origin-access-identity/cloudfront/")
+	case strings.HasPrefix(suffix, oaiPrefix) && !strings.Contains(strings.TrimPrefix(suffix, oaiPrefix), "/"):
+		id := strings.TrimPrefix(suffix, oaiPrefix)
 		switch method {
 		case http.MethodGet:
 			return opGetCloudFrontOriginAccessIdentity, id
@@ -544,140 +626,474 @@ func parseCFPath(method, path, resourceParam string) (string, string) {
 		case http.MethodDelete:
 			return opDeleteCloudFrontOriginAccessIdentity, id
 		}
-	case suffix == "anycast-ip-list" && method == http.MethodPost:
-		return opCreateAnycastIPList, ""
-	// --- Cache Policy ---
-	case suffix == "cache-policy" && method == http.MethodPost:
-		return opCreateCachePolicy, ""
-	case suffix == "cache-policy" && method == http.MethodGet:
-		return opListCachePolicies, ""
-	case strings.HasPrefix(suffix, "cache-policy/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "cache-policy/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetCachePolicyConfig, id
-		}
-	case strings.HasPrefix(suffix, "cache-policy/") &&
-		!strings.Contains(strings.TrimPrefix(suffix, "cache-policy/"), "/"):
-		id := strings.TrimPrefix(suffix, "cache-policy/")
-		switch method {
-		case http.MethodGet:
-			return opGetCachePolicy, id
-		case http.MethodPut:
-			return opUpdateCachePolicy, id
-		case http.MethodDelete:
-			return opDeleteCachePolicy, id
-		}
-	// --- Origin Access Control ---
-	case suffix == "origin-access-control" && method == http.MethodPost:
+	}
+
+	return "", ""
+}
+
+// parseCFPolicyPath routes cache policy, OAC, response headers policy, function, and origin request policy paths.
+func parseCFPolicyPath(method, suffix string) (string, string) {
+	if op, id := parseCFResourcePath(method, suffix, "cache-policy",
+		opCreateCachePolicy, opListCachePolicies, opGetCachePolicy, opUpdateCachePolicy, opDeleteCachePolicy,
+		opGetCachePolicyConfig, ""); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFOriginAccessControlPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFResourcePath(method, suffix, "response-headers-policy",
+		opCreateResponseHeadersPolicy, opListResponseHeadersPolicies, opGetResponseHeadersPolicy, opUpdateResponseHeadersPolicy, opDeleteResponseHeadersPolicy,
+		opGetResponseHeadersPolicyConfig, opUpdateResponseHeadersPolicy); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFOriginRequestPolicyPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	return parseCFFunctionPath(method, suffix)
+}
+
+// parseCFOriginAccessControlPath routes OAC paths.
+func parseCFOriginAccessControlPath(method, suffix string) (string, string) {
+	const prefix = "origin-access-control/"
+	const root = "origin-access-control"
+
+	switch {
+	case suffix == root && method == http.MethodPost:
 		return opCreateOriginAccessControl, ""
-	case suffix == "origin-access-control" && method == http.MethodGet:
+	case suffix == root && method == http.MethodGet:
 		return opListOriginAccessControls, ""
-	case strings.HasPrefix(suffix, "origin-access-control/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "origin-access-control/")
-		id = strings.TrimSuffix(id, "/config")
+	case strings.HasPrefix(suffix, prefix) && strings.HasSuffix(suffix, "/config"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, prefix), "/config")
 		switch method {
 		case http.MethodGet:
 			return opGetOriginAccessControlConfig, id
 		case http.MethodPut:
 			return opUpdateOriginAccessControl, id
 		}
-	case strings.HasPrefix(suffix, "origin-access-control/") &&
-		!strings.Contains(strings.TrimPrefix(suffix, "origin-access-control/"), "/"):
-		id := strings.TrimPrefix(suffix, "origin-access-control/")
+	case strings.HasPrefix(suffix, prefix) && !strings.Contains(strings.TrimPrefix(suffix, prefix), "/"):
+		id := strings.TrimPrefix(suffix, prefix)
 		switch method {
 		case http.MethodGet:
 			return opGetOriginAccessControl, id
 		case http.MethodDelete:
 			return opDeleteOriginAccessControl, id
 		}
-	// --- Response Headers Policy ---
-	case suffix == "response-headers-policy" && method == http.MethodPost:
-		return opCreateResponseHeadersPolicy, ""
-	case suffix == "response-headers-policy" && method == http.MethodGet:
-		return opListResponseHeadersPolicies, ""
-	case strings.HasPrefix(suffix, "response-headers-policy/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "response-headers-policy/")
-		id = strings.TrimSuffix(id, "/config")
-		switch method {
-		case http.MethodGet:
-			return opGetResponseHeadersPolicyConfig, id
-		case http.MethodPut:
-			return opUpdateResponseHeadersPolicy, id
-		}
-	case strings.HasPrefix(suffix, "response-headers-policy/") &&
-		!strings.Contains(strings.TrimPrefix(suffix, "response-headers-policy/"), "/"):
-		id := strings.TrimPrefix(suffix, "response-headers-policy/")
-		switch method {
-		case http.MethodGet:
-			return opGetResponseHeadersPolicy, id
-		case http.MethodDelete:
-			return opDeleteResponseHeadersPolicy, id
-		}
-	// --- CloudFront Function ---
-	case suffix == "function" && method == http.MethodPost:
-		return opCreateFunction, ""
-	case suffix == "function" && method == http.MethodGet:
-		return opListFunctions, ""
-	case strings.HasPrefix(suffix, "function/") && strings.HasSuffix(suffix, "/publish"):
-		name := strings.TrimPrefix(suffix, "function/")
-		name = strings.TrimSuffix(name, "/publish")
-		if method == http.MethodPost {
-			return opPublishFunction, name
-		}
-	case strings.HasPrefix(suffix, "function/") && strings.HasSuffix(suffix, "/describe"):
-		name := strings.TrimPrefix(suffix, "function/")
-		name = strings.TrimSuffix(name, "/describe")
-		if method == http.MethodGet {
-			return opDescribeFunction, name
-		}
-	case strings.HasPrefix(suffix, "function/") && strings.HasSuffix(suffix, "/test"):
-		name := strings.TrimPrefix(suffix, "function/")
-		name = strings.TrimSuffix(name, "/test")
-		if method == http.MethodPost {
-			return opTestFunction, name
-		}
-	case strings.HasPrefix(suffix, "function/") && !strings.Contains(strings.TrimPrefix(suffix, "function/"), "/"):
-		name := strings.TrimPrefix(suffix, "function/")
-		switch method {
-		case http.MethodGet:
-			return opGetFunction, name
-		case http.MethodPut:
-			return opUpdateFunction, name
-		case http.MethodDelete:
-			return opDeleteFunction, name
-		}
-	// --- Origin Request Policy ---
-	case suffix == "origin-request-policy" && method == http.MethodPost:
+	}
+
+	return "", ""
+}
+
+// parseCFOriginRequestPolicyPath routes origin request policy paths.
+func parseCFOriginRequestPolicyPath(method, suffix string) (string, string) {
+	const prefix = "origin-request-policy/"
+	const root = "origin-request-policy"
+
+	switch {
+	case suffix == root && method == http.MethodPost:
 		return opCreateOriginRequestPolicy, ""
-	case suffix == "origin-request-policy" && method == http.MethodGet:
+	case suffix == root && method == http.MethodGet:
 		return opListOriginRequestPolicies, ""
-	case strings.HasPrefix(suffix, "origin-request-policy/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "origin-request-policy/")
-		id = strings.TrimSuffix(id, "/config")
+	case strings.HasPrefix(suffix, prefix) && strings.HasSuffix(suffix, "/config"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, prefix), "/config")
 		switch method {
 		case http.MethodGet:
 			return opGetOriginRequestPolicyConfig, id
 		case http.MethodPut:
 			return opUpdateOriginRequestPolicy, id
 		}
-	case strings.HasPrefix(suffix, "origin-request-policy/") &&
-		!strings.Contains(strings.TrimPrefix(suffix, "origin-request-policy/"), "/"):
-		id := strings.TrimPrefix(suffix, "origin-request-policy/")
+	case strings.HasPrefix(suffix, prefix) && !strings.Contains(strings.TrimPrefix(suffix, prefix), "/"):
+		id := strings.TrimPrefix(suffix, prefix)
 		switch method {
 		case http.MethodGet:
 			return opGetOriginRequestPolicy, id
 		case http.MethodDelete:
 			return opDeleteOriginRequestPolicy, id
 		}
-	// --- Connection / ContinuousDeployment / Tags ---
-	case suffix == "connection-function" && method == http.MethodPost:
-		return opCreateConnectionFunction, ""
-	case suffix == "connection-group" && method == http.MethodPost:
-		return opCreateConnectionGroup, ""
-	case suffix == "continuous-deployment-policy" && method == http.MethodPost:
-		return opCreateContinuousDeploymentPolicy, ""
-	case suffix == "tagging":
+	}
+
+	return "", ""
+}
+
+// parseCFFunctionPath routes CloudFront function paths.
+func parseCFFunctionPath(method, suffix string) (string, string) {
+	const prefix = "function/"
+	const root = "function"
+
+	if suffix == root {
+		switch method {
+		case http.MethodPost:
+			return opCreateFunction, ""
+		case http.MethodGet:
+			return opListFunctions, ""
+		}
+
+		return "", ""
+	}
+
+	if !strings.HasPrefix(suffix, prefix) {
+		return "", ""
+	}
+
+	inner := strings.TrimPrefix(suffix, prefix)
+	switch {
+	case strings.HasSuffix(inner, "/publish"):
+		name := strings.TrimSuffix(inner, "/publish")
+		if method == http.MethodPost {
+			return opPublishFunction, name
+		}
+	case strings.HasSuffix(inner, "/describe"):
+		name := strings.TrimSuffix(inner, "/describe")
+		if method == http.MethodGet {
+			return opDescribeFunction, name
+		}
+	case strings.HasSuffix(inner, "/test"):
+		name := strings.TrimSuffix(inner, "/test")
+		if method == http.MethodPost {
+			return opTestFunction, name
+		}
+	case !strings.Contains(inner, "/"):
+		switch method {
+		case http.MethodGet:
+			return opGetFunction, inner
+		case http.MethodPut:
+			return opUpdateFunction, inner
+		case http.MethodDelete:
+			return opDeleteFunction, inner
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFEncryptionKeyPath routes field-level encryption, key group, key value store, public key,
+// realtime log config, streaming distribution, trust store, vpc origin, and anycast paths.
+func parseCFEncryptionKeyPath(method, suffix string) (string, string) {
+	if op, id := parseCFFieldLevelEncryptionPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFKeyAndLogPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	return parseCFStreamingTrustVPCPath(method, suffix)
+}
+
+// parseCFFieldLevelEncryptionPath routes field-level encryption and profile paths.
+func parseCFFieldLevelEncryptionPath(method, suffix string) (string, string) {
+	if op, id := parseCFResourcePath(method, suffix, "field-level-encryption",
+		opCreateFieldLevelEncryptionConfig, opListFieldLevelEncryptionConfigs,
+		opGetFieldLevelEncryption, opUpdateFieldLevelEncryptionConfig, opDeleteFieldLevelEncryptionConfig,
+		opGetFieldLevelEncryptionConfig, ""); op != "" {
+		return op, id
+	}
+
+	return parseCFResourcePath(method, suffix, "field-level-encryption-profile",
+		opCreateFieldLevelEncryptionProfile, opListFieldLevelEncryptionProfiles,
+		opGetFieldLevelEncryptionProfile, opUpdateFieldLevelEncryptionProfile, opDeleteFieldLevelEncryptionProfile,
+		opGetFieldLevelEncryptionProfileConfig, "")
+}
+
+// parseCFResourcePath is a generic helper for simple resource CRUD + optional config.
+func parseCFResourcePath(method, suffix, resourceType,
+	createOp, listOp, getOp, updateOp, deleteOp, getConfigOp, updateConfigOp string,
+) (string, string) {
+	prefix := resourceType + "/"
+
+	if suffix == resourceType {
+		switch method {
+		case http.MethodPost:
+			return createOp, ""
+		case http.MethodGet:
+			return listOp, ""
+		}
+
+		return "", ""
+	}
+
+	if !strings.HasPrefix(suffix, prefix) {
+		return "", ""
+	}
+
+	inner := strings.TrimPrefix(suffix, prefix)
+	if strings.HasSuffix(inner, "/config") {
+		id := strings.TrimSuffix(inner, "/config")
+		if method == http.MethodGet {
+			return getConfigOp, id
+		}
+
+		if method == http.MethodPut && updateConfigOp != "" {
+			return updateConfigOp, id
+		}
+
+		return "", ""
+	}
+
+	if !strings.Contains(inner, "/") {
+		switch method {
+		case http.MethodGet:
+			return getOp, inner
+		case http.MethodPut:
+			return updateOp, inner
+		case http.MethodDelete:
+			return deleteOp, inner
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFKeyAndLogPath routes key group, key value store, public key, and realtime log config paths.
+func parseCFKeyAndLogPath(method, suffix string) (string, string) {
+	if op, id := parseCFResourcePath(method, suffix, "key-group",
+		opCreateKeyGroup, opListKeyGroups, opGetKeyGroup, opUpdateKeyGroup, opDeleteKeyGroup,
+		opGetKeyGroupConfig, ""); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFResourcePath(method, suffix, "key-value-store",
+		opCreateKeyValueStore, opListKeyValueStores, opDescribeKeyValueStore, opUpdateKeyValueStore, opDeleteKeyValueStore,
+		"", ""); op != "" {
+		return op, id
+	}
+
+	return parseCFPublicKeyRealtimePath(method, suffix)
+}
+
+// parseCFPublicKeyRealtimePath routes public key and realtime log config paths.
+func parseCFPublicKeyRealtimePath(method, suffix string) (string, string) {
+	if op, id := parseCFResourcePath(method, suffix, "public-key",
+		opCreatePublicKey, opListPublicKeys, opGetPublicKey, opUpdatePublicKey, opDeletePublicKey,
+		opGetPublicKeyConfig, ""); op != "" {
+		return op, id
+	}
+
+	return parseCFResourcePath(method, suffix, "realtime-log-config",
+		opCreateRealtimeLogConfig, opListRealtimeLogConfigs, opGetRealtimeLogConfig, opUpdateRealtimeLogConfig, opDeleteRealtimeLogConfig,
+		"", "")
+}
+
+// parseCFStreamingTrustVPCPath routes streaming distribution, trust store, vpc origin, and anycast paths.
+func parseCFStreamingTrustVPCPath(method, suffix string) (string, string) {
+	if op, id := parseCFResourcePath(method, suffix, "streaming-distribution",
+		opCreateStreamingDistribution, opListStreamingDistributions,
+		opGetStreamingDistribution, opUpdateStreamingDistribution, opDeleteStreamingDistribution,
+		opGetStreamingDistributionConfig, ""); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFResourcePath(method, suffix, "trust-store",
+		opCreateTrustStore, opListTrustStores, opGetTrustStore, opUpdateTrustStore, opDeleteTrustStore,
+		"", ""); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFResourcePath(method, suffix, "vpc-origin",
+		opCreateVpcOrigin, opListVpcOrigins, opGetVpcOrigin, opUpdateVpcOrigin, opDeleteVpcOrigin,
+		"", ""); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFResourcePath(method, suffix, "anycast-ip-list",
+		"", opListAnycastIPLists, opGetAnycastIPList, opUpdateAnycastIPList, opDeleteAnycastIPList,
+		"", ""); op != "" {
+		return op, id
+	}
+
+	return "", ""
+}
+
+// parseCFConnectionPath routes connection function, group, and continuous deployment policy paths.
+func parseCFConnectionPath(method, suffix, resourceParam string) (string, string) {
+	if op, id := parseCFConnectionFunctionPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFConnectionGroupPath(method, suffix); op != "" {
+		return op, id
+	}
+
+	return parseCFContinuousDeploymentPath(method, suffix, resourceParam)
+}
+
+// parseCFConnectionFunctionPath routes connection function paths.
+func parseCFConnectionFunctionPath(method, suffix string) (string, string) {
+	const prefix = "connection-function/"
+	const root = "connection-function"
+
+	switch {
+	case suffix == root && method == http.MethodGet:
+		return opListConnectionFunctions, ""
+	case strings.HasPrefix(suffix, prefix) && strings.HasSuffix(suffix, "/describe"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, prefix), "/describe")
+
+		return opDescribeConnectionFunction, id
+	case strings.HasPrefix(suffix, prefix) && strings.HasSuffix(suffix, "/publish"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, prefix), "/publish")
+
+		return opPublishConnectionFunction, id
+	case strings.HasPrefix(suffix, prefix) && strings.HasSuffix(suffix, "/test"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, prefix), "/test")
+
+		return opTestConnectionFunction, id
+	case strings.HasPrefix(suffix, prefix) && !strings.Contains(strings.TrimPrefix(suffix, prefix), "/"):
+		id := strings.TrimPrefix(suffix, prefix)
+		switch method {
+		case http.MethodGet:
+			return opGetConnectionFunction, id
+		case http.MethodPut:
+			return opUpdateConnectionFunction, id
+		case http.MethodDelete:
+			return opDeleteConnectionFunction, id
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFConnectionGroupPath routes connection group paths.
+func parseCFConnectionGroupPath(method, suffix string) (string, string) {
+	const prefix = "connection-group/"
+	const root = "connection-group"
+
+	switch {
+	case suffix == root && method == http.MethodGet:
+		return opListConnectionGroups, ""
+	case suffix == "connection-group-by-routing-endpoint" && method == http.MethodGet:
+		return opGetConnectionGroupByRoutingEndpoint, ""
+	case strings.HasPrefix(suffix, prefix) && !strings.Contains(strings.TrimPrefix(suffix, prefix), "/"):
+		id := strings.TrimPrefix(suffix, prefix)
+		switch method {
+		case http.MethodGet:
+			return opGetConnectionGroup, id
+		case http.MethodPut:
+			return opUpdateConnectionGroup, id
+		case http.MethodDelete:
+			return opDeleteConnectionGroup, id
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFContinuousDeploymentPath routes continuous deployment policy and distribution-tenant extended paths.
+func parseCFContinuousDeploymentPath(method, suffix, resourceParam string) (string, string) {
+	const prefix = "continuous-deployment-policy/"
+	const root = "continuous-deployment-policy"
+
+	switch {
+	case suffix == root && method == http.MethodGet:
+		return opListContinuousDeploymentPolicies, ""
+	case strings.HasPrefix(suffix, prefix) && strings.HasSuffix(suffix, "/config"):
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, prefix), "/config")
+		if method == http.MethodGet {
+			return opGetContinuousDeploymentPolicyConfig, id
+		}
+	case strings.HasPrefix(suffix, prefix) && !strings.Contains(strings.TrimPrefix(suffix, prefix), "/"):
+		id := strings.TrimPrefix(suffix, prefix)
+		switch method {
+		case http.MethodGet:
+			return opGetContinuousDeploymentPolicy, id
+		case http.MethodPut:
+			return opUpdateContinuousDeploymentPolicy, id
+		case http.MethodDelete:
+			return opDeleteContinuousDeploymentPolicy, id
+		}
+	case suffix == "distribution-tenant-by-domain" && method == http.MethodGet:
+		return opGetDistributionTenantByDomain, ""
+	}
+
+	_ = resourceParam
+
+	return "", ""
+}
+
+// parseCFDistributionsByPath routes "distributions/by-*" paths.
+func parseCFDistributionsByPath(method, suffix string) (string, string) {
+	if method != http.MethodGet {
+		return "", ""
+	}
+
+	switch {
+	case strings.HasPrefix(suffix, "distributions/by-cache-policy-id/"):
+		return opListDistributionsByCachePolicyID, strings.TrimPrefix(suffix, "distributions/by-cache-policy-id/")
+	case strings.HasPrefix(suffix, "distributions/by-origin-request-policy-id/"):
+		return opListDistributionsByOriginRequestPol, strings.TrimPrefix(suffix, "distributions/by-origin-request-policy-id/")
+	case strings.HasPrefix(suffix, "distributions/by-response-headers-policy-id/"):
+		return opListDistributionsByResponseHeadersPol, strings.TrimPrefix(suffix, "distributions/by-response-headers-policy-id/")
+	case strings.HasPrefix(suffix, "distributions/by-web-acl-id/"):
+		return opListDistributionsByWebACLID, strings.TrimPrefix(suffix, "distributions/by-web-acl-id/")
+	case strings.HasPrefix(suffix, "distributions/by-key-group/"):
+		return opListDistributionsByKeyGroup, strings.TrimPrefix(suffix, "distributions/by-key-group/")
+	case strings.HasPrefix(suffix, "distributions/by-realtime-log-config"):
+		return opListDistributionsByRealtimeLogConfig, ""
+	case strings.HasPrefix(suffix, "distributions/by-vpc-origin-id/"):
+		return opListDistributionsByVpcOriginID, strings.TrimPrefix(suffix, "distributions/by-vpc-origin-id/")
+	case strings.HasPrefix(suffix, "distributions/by-anycast-ip-list-id/"):
+		return opListDistributionsByAnycastIPListID, strings.TrimPrefix(suffix, "distributions/by-anycast-ip-list-id/")
+	case strings.HasPrefix(suffix, "distributions/by-connection-function/"):
+		return opListDistributionsByConnectionFunction, strings.TrimPrefix(suffix, "distributions/by-connection-function/")
+	case suffix == "distributions/by-connection-mode":
+		return opListDistributionsByConnectionMode, ""
+	case suffix == "distribution-tenants/by-customization":
+		return opListDistributionTenantsByCustom, ""
+	case strings.HasPrefix(suffix, "trust-store/") && strings.Contains(suffix, "/by-trust-store/"):
+		return opListDistributionsByTrustStore, ""
+	}
+
+	return "", ""
+}
+
+// parseCFPathCore handles remaining distribution-tenant, create ops, tags, and resource policy paths.
+func parseCFPathCore(method, suffix, resourceParam string) (string, string) {
+	if op, id := parseCFCreateAndTagOps(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	if op, id := parseCFDistributionTenantOps(method, suffix); op != "" {
+		return op, id
+	}
+
+	return parseCFDistributionExtPath(method, suffix)
+}
+
+// parseCFCreateAndTagOps handles create operations and tagging.
+func parseCFCreateAndTagOps(method, suffix, resourceParam string) (string, string) {
+	if op, id := parseCFCreateAndTagCoreOps(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	if suffix == sfxResourcePolicy {
+		switch method {
+		case http.MethodGet:
+			return opGetResourcePolicy, resourceParam
+		case http.MethodPost:
+			return opPutResourcePolicy, resourceParam
+		case http.MethodDelete:
+			return opDeleteResourcePolicy, resourceParam
+		}
+	}
+
+	return "", ""
+}
+
+// parseCFCreateAndTagCoreOps handles create ops and tagging (without resource policy).
+// parseCFCreateAndTagCoreOps handles create ops and tagging (without resource policy).
+func parseCFCreateAndTagCoreOps(method, suffix, resourceParam string) (string, string) {
+	if op, id := parseCFTaggingOps(method, suffix, resourceParam); op != "" {
+		return op, id
+	}
+
+	return parseCFCreateOps(method, suffix, resourceParam)
+}
+
+// parseCFTaggingOps handles tagging and distribution-with-tags creation.
+func parseCFTaggingOps(method, suffix, resourceParam string) (string, string) {
+	if suffix == "tagging" {
 		switch method {
 		case http.MethodGet:
 			return opListTagsForResource, resourceParam
@@ -686,14 +1102,49 @@ func parseCFPath(method, path, resourceParam string) (string, string) {
 		case http.MethodDelete:
 			return opUntagResource, resourceParam
 		}
-	// --- Stub operation paths ---
-	case suffix == sfxDistribution && method == http.MethodPost && resourceParam == "WithTags":
+	}
+
+	if suffix == sfxDistribution && method == http.MethodPost && resourceParam == "WithTags" {
 		return opCreateDistributionWithTags, ""
-	case suffix == "distribution-tenant" && method == http.MethodPost:
-		return opCreateDistributionTenant, ""
-	case suffix == "distribution-tenant" && method == http.MethodGet:
-		return opListDistributionTenants, ""
-	case strings.HasPrefix(suffix, "distribution-tenant/") && !strings.Contains(strings.TrimPrefix(suffix, "distribution-tenant/"), "/"):
+	}
+
+	return "", ""
+}
+
+// parseCFCreateOps handles simple POST create operations.
+func parseCFCreateOps(method, suffix, _ string) (string, string) {
+	if method != http.MethodPost {
+		return "", ""
+	}
+
+	switch suffix {
+	case "anycast-ip-list":
+		return opCreateAnycastIPList, ""
+	case "connection-function":
+		return opCreateConnectionFunction, ""
+	case "connection-group":
+		return opCreateConnectionGroup, ""
+	case "continuous-deployment-policy":
+		return opCreateContinuousDeploymentPolicy, ""
+	}
+
+	return "", ""
+}
+
+// parseCFDistributionTenantOps handles distribution-tenant CRUD operations.
+func parseCFDistributionTenantOps(method, suffix string) (string, string) {
+	switch suffix {
+	case "distribution-tenant":
+		switch method {
+		case http.MethodPost:
+			return opCreateDistributionTenant, ""
+		case http.MethodGet:
+			return opListDistributionTenants, ""
+		}
+	}
+
+	if strings.HasPrefix(suffix, "distribution-tenant/") &&
+		!strings.Contains(strings.TrimPrefix(suffix, "distribution-tenant/"), "/") {
 		id := strings.TrimPrefix(suffix, "distribution-tenant/")
 		switch method {
 		case http.MethodGet:
@@ -703,237 +1154,35 @@ func parseCFPath(method, path, resourceParam string) (string, string) {
 		case http.MethodDelete:
 			return opDeleteDistributionTenant, id
 		}
-	case suffix == "field-level-encryption" && method == http.MethodPost:
-		return opCreateFieldLevelEncryptionConfig, ""
-	case suffix == "field-level-encryption" && method == http.MethodGet:
-		return opListFieldLevelEncryptionConfigs, ""
-	case strings.HasPrefix(suffix, "field-level-encryption/") && !strings.Contains(strings.TrimPrefix(suffix, "field-level-encryption/"), "/"):
-		id := strings.TrimPrefix(suffix, "field-level-encryption/")
-		switch method {
-		case http.MethodGet:
-			return opGetFieldLevelEncryption, id
-		case http.MethodPut:
-			return opUpdateFieldLevelEncryptionConfig, id
-		case http.MethodDelete:
-			return opDeleteFieldLevelEncryptionConfig, id
+	}
+
+	return "", ""
+}
+
+// parseCFDistributionExtPath handles extended distribution paths (monitoring, staging, tenant invalidations, etc.).
+func parseCFDistributionExtPath(method, suffix string) (string, string) {
+	if strings.HasPrefix(suffix, "distribution/") {
+		if op, id := parseCFDistributionMonitoringOps(method, suffix); op != "" {
+			return op, id
 		}
-	case strings.HasPrefix(suffix, "field-level-encryption/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "field-level-encryption/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetFieldLevelEncryptionConfig, id
+	}
+
+	if strings.HasPrefix(suffix, "distribution-tenant/") {
+		if op, id := parseCFDistributionTenantExtOps(method, suffix); op != "" {
+			return op, id
 		}
-	case suffix == "field-level-encryption-profile" && method == http.MethodPost:
-		return opCreateFieldLevelEncryptionProfile, ""
-	case suffix == "field-level-encryption-profile" && method == http.MethodGet:
-		return opListFieldLevelEncryptionProfiles, ""
-	case strings.HasPrefix(suffix, "field-level-encryption-profile/") && !strings.Contains(strings.TrimPrefix(suffix, "field-level-encryption-profile/"), "/"):
-		id := strings.TrimPrefix(suffix, "field-level-encryption-profile/")
-		switch method {
-		case http.MethodGet:
-			return opGetFieldLevelEncryptionProfile, id
-		case http.MethodPut:
-			return opUpdateFieldLevelEncryptionProfile, id
-		case http.MethodDelete:
-			return opDeleteFieldLevelEncryptionProfile, id
-		}
-	case strings.HasPrefix(suffix, "field-level-encryption-profile/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "field-level-encryption-profile/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetFieldLevelEncryptionProfileConfig, id
-		}
-	case suffix == "key-group" && method == http.MethodPost:
-		return opCreateKeyGroup, ""
-	case suffix == "key-group" && method == http.MethodGet:
-		return opListKeyGroups, ""
-	case strings.HasPrefix(suffix, "key-group/") && !strings.Contains(strings.TrimPrefix(suffix, "key-group/"), "/"):
-		id := strings.TrimPrefix(suffix, "key-group/")
-		switch method {
-		case http.MethodGet:
-			return opGetKeyGroup, id
-		case http.MethodPut:
-			return opUpdateKeyGroup, id
-		case http.MethodDelete:
-			return opDeleteKeyGroup, id
-		}
-	case strings.HasPrefix(suffix, "key-group/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "key-group/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetKeyGroupConfig, id
-		}
-	case suffix == "key-value-store" && method == http.MethodPost:
-		return opCreateKeyValueStore, ""
-	case suffix == "key-value-store" && method == http.MethodGet:
-		return opListKeyValueStores, ""
-	case strings.HasPrefix(suffix, "key-value-store/") && !strings.Contains(strings.TrimPrefix(suffix, "key-value-store/"), "/"):
-		id := strings.TrimPrefix(suffix, "key-value-store/")
-		switch method {
-		case http.MethodGet:
-			return opDescribeKeyValueStore, id
-		case http.MethodPut:
-			return opUpdateKeyValueStore, id
-		case http.MethodDelete:
-			return opDeleteKeyValueStore, id
-		}
-	case suffix == "public-key" && method == http.MethodPost:
-		return opCreatePublicKey, ""
-	case suffix == "public-key" && method == http.MethodGet:
-		return opListPublicKeys, ""
-	case strings.HasPrefix(suffix, "public-key/") && !strings.Contains(strings.TrimPrefix(suffix, "public-key/"), "/"):
-		id := strings.TrimPrefix(suffix, "public-key/")
-		switch method {
-		case http.MethodGet:
-			return opGetPublicKey, id
-		case http.MethodPut:
-			return opUpdatePublicKey, id
-		case http.MethodDelete:
-			return opDeletePublicKey, id
-		}
-	case strings.HasPrefix(suffix, "public-key/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "public-key/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetPublicKeyConfig, id
-		}
-	case suffix == "realtime-log-config" && method == http.MethodPost:
-		return opCreateRealtimeLogConfig, ""
-	case suffix == "realtime-log-config" && method == http.MethodGet:
-		return opListRealtimeLogConfigs, ""
-	case strings.HasPrefix(suffix, "realtime-log-config/") && !strings.Contains(strings.TrimPrefix(suffix, "realtime-log-config/"), "/"):
-		id := strings.TrimPrefix(suffix, "realtime-log-config/")
-		switch method {
-		case http.MethodGet:
-			return opGetRealtimeLogConfig, id
-		case http.MethodPut:
-			return opUpdateRealtimeLogConfig, id
-		case http.MethodDelete:
-			return opDeleteRealtimeLogConfig, id
-		}
-	case suffix == "streaming-distribution" && method == http.MethodPost:
-		return opCreateStreamingDistribution, ""
-	case suffix == "streaming-distribution" && method == http.MethodGet:
-		return opListStreamingDistributions, ""
-	case strings.HasPrefix(suffix, "streaming-distribution/") && !strings.Contains(strings.TrimPrefix(suffix, "streaming-distribution/"), "/"):
-		id := strings.TrimPrefix(suffix, "streaming-distribution/")
-		switch method {
-		case http.MethodGet:
-			return opGetStreamingDistribution, id
-		case http.MethodPut:
-			return opUpdateStreamingDistribution, id
-		case http.MethodDelete:
-			return opDeleteStreamingDistribution, id
-		}
-	case strings.HasPrefix(suffix, "streaming-distribution/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "streaming-distribution/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetStreamingDistributionConfig, id
-		}
-	case suffix == "trust-store" && method == http.MethodPost:
-		return opCreateTrustStore, ""
-	case suffix == "trust-store" && method == http.MethodGet:
-		return opListTrustStores, ""
-	case strings.HasPrefix(suffix, "trust-store/") && !strings.Contains(strings.TrimPrefix(suffix, "trust-store/"), "/"):
-		id := strings.TrimPrefix(suffix, "trust-store/")
-		switch method {
-		case http.MethodGet:
-			return opGetTrustStore, id
-		case http.MethodPut:
-			return opUpdateTrustStore, id
-		case http.MethodDelete:
-			return opDeleteTrustStore, id
-		}
-	case suffix == "vpc-origin" && method == http.MethodPost:
-		return opCreateVpcOrigin, ""
-	case suffix == "vpc-origin" && method == http.MethodGet:
-		return opListVpcOrigins, ""
-	case strings.HasPrefix(suffix, "vpc-origin/") && !strings.Contains(strings.TrimPrefix(suffix, "vpc-origin/"), "/"):
-		id := strings.TrimPrefix(suffix, "vpc-origin/")
-		switch method {
-		case http.MethodGet:
-			return opGetVpcOrigin, id
-		case http.MethodPut:
-			return opUpdateVpcOrigin, id
-		case http.MethodDelete:
-			return opDeleteVpcOrigin, id
-		}
-	case strings.HasPrefix(suffix, "anycast-ip-list/") && !strings.Contains(strings.TrimPrefix(suffix, "anycast-ip-list/"), "/"):
-		id := strings.TrimPrefix(suffix, "anycast-ip-list/")
-		switch method {
-		case http.MethodGet:
-			return opGetAnycastIPList, id
-		case http.MethodPut:
-			return opUpdateAnycastIPList, id
-		case http.MethodDelete:
-			return opDeleteAnycastIPList, id
-		}
-	case suffix == "anycast-ip-list" && method == http.MethodGet:
-		return opListAnycastIPLists, ""
-	case strings.HasPrefix(suffix, "connection-function/") && strings.HasSuffix(suffix, "/describe"):
-		id := strings.TrimPrefix(suffix, "connection-function/")
-		id = strings.TrimSuffix(id, "/describe")
-		return opDescribeConnectionFunction, id
-	case strings.HasPrefix(suffix, "connection-function/") && strings.HasSuffix(suffix, "/publish"):
-		id := strings.TrimPrefix(suffix, "connection-function/")
-		id = strings.TrimSuffix(id, "/publish")
-		return opPublishConnectionFunction, id
-	case strings.HasPrefix(suffix, "connection-function/") && strings.HasSuffix(suffix, "/test"):
-		id := strings.TrimPrefix(suffix, "connection-function/")
-		id = strings.TrimSuffix(id, "/test")
-		return opTestConnectionFunction, id
-	case strings.HasPrefix(suffix, "connection-function/") && !strings.Contains(strings.TrimPrefix(suffix, "connection-function/"), "/"):
-		id := strings.TrimPrefix(suffix, "connection-function/")
-		switch method {
-		case http.MethodGet:
-			return opGetConnectionFunction, id
-		case http.MethodPut:
-			return opUpdateConnectionFunction, id
-		case http.MethodDelete:
-			return opDeleteConnectionFunction, id
-		}
-	case suffix == "connection-function" && method == http.MethodGet:
-		return opListConnectionFunctions, ""
-	case suffix == "connection-group" && method == http.MethodGet:
-		return opListConnectionGroups, ""
-	case strings.HasPrefix(suffix, "connection-group/") && !strings.Contains(strings.TrimPrefix(suffix, "connection-group/"), "/"):
-		id := strings.TrimPrefix(suffix, "connection-group/")
-		switch method {
-		case http.MethodGet:
-			return opGetConnectionGroup, id
-		case http.MethodPut:
-			return opUpdateConnectionGroup, id
-		case http.MethodDelete:
-			return opDeleteConnectionGroup, id
-		}
-	case suffix == "continuous-deployment-policy" && method == http.MethodGet:
-		return opListContinuousDeploymentPolicies, ""
-	case strings.HasPrefix(suffix, "continuous-deployment-policy/") && strings.HasSuffix(suffix, "/config"):
-		id := strings.TrimPrefix(suffix, "continuous-deployment-policy/")
-		id = strings.TrimSuffix(id, "/config")
-		if method == http.MethodGet {
-			return opGetContinuousDeploymentPolicyConfig, id
-		}
-	case strings.HasPrefix(suffix, "continuous-deployment-policy/") && !strings.Contains(strings.TrimPrefix(suffix, "continuous-deployment-policy/"), "/"):
-		id := strings.TrimPrefix(suffix, "continuous-deployment-policy/")
-		switch method {
-		case http.MethodGet:
-			return opGetContinuousDeploymentPolicy, id
-		case http.MethodPut:
-			return opUpdateContinuousDeploymentPolicy, id
-		case http.MethodDelete:
-			return opDeleteContinuousDeploymentPolicy, id
-		}
-	case suffix == sfxResourcePolicy && method == http.MethodGet:
-		return opGetResourcePolicy, resourceParam
-	case suffix == sfxResourcePolicy && method == http.MethodPost:
-		return opPutResourcePolicy, resourceParam
-	case suffix == sfxResourcePolicy && method == http.MethodDelete:
-		return opDeleteResourcePolicy, resourceParam
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/monitoring-subscription"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/monitoring-subscription")
+	}
+
+	return parseCFMiscPath(method, suffix)
+}
+
+// parseCFDistributionMonitoringOps handles distribution monitoring, staging, and disassociate paths.
+func parseCFDistributionMonitoringOps(method, suffix string) (string, string) {
+	inner := strings.TrimPrefix(suffix, "distribution/")
+
+	switch {
+	case strings.HasSuffix(inner, "/monitoring-subscription"):
+		id := strings.TrimSuffix(inner, "/monitoring-subscription")
 		switch method {
 		case http.MethodPost:
 			return opCreateMonitoringSubscription, id
@@ -942,43 +1191,52 @@ func parseCFPath(method, path, resourceParam string) (string, string) {
 		case http.MethodDelete:
 			return opDeleteMonitoringSubscription, id
 		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/staging"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/staging")
-		if method == http.MethodPut {
-			return opUpdateDistributionWithStagingConfig, id
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.HasSuffix(suffix, "/disassociate-web-acl"):
-		id := strings.TrimPrefix(suffix, "distribution/")
-		id = strings.TrimSuffix(id, "/disassociate-web-acl")
-		if method == http.MethodPut {
-			return opDisassociateDistributionWebACL, id
-		}
-	case strings.HasPrefix(suffix, "distribution-tenant/") && strings.HasSuffix(suffix, "/disassociate-web-acl"):
-		id := strings.TrimPrefix(suffix, "distribution-tenant/")
-		id = strings.TrimSuffix(id, "/disassociate-web-acl")
-		if method == http.MethodPut {
-			return opDisassociateDistributionTenantWebACL, id
-		}
-	case strings.HasPrefix(suffix, "distribution-tenant/") && strings.Contains(suffix, "/invalidation"):
-		inner := strings.TrimPrefix(suffix, "distribution-tenant/")
-		if strings.HasSuffix(suffix, "/invalidation") && method == http.MethodPost {
-			id := strings.TrimSuffix(inner, "/invalidation")
-			return opCreateInvalidationForDistTenant, id
-		}
-		if strings.HasSuffix(suffix, "/invalidation") && method == http.MethodGet {
-			id := strings.TrimSuffix(inner, "/invalidation")
-			return opListInvalidationsForDistTenant, id
-		}
-		if before, after, ok := strings.Cut(inner, "/invalidation/"); ok &&
-			method == http.MethodGet {
-			_ = after
-			return opGetInvalidationForDistTenant, before
-		}
-	case strings.HasPrefix(suffix, "distribution/") && strings.Contains(suffix, "/list-by-"):
-		if method == http.MethodGet {
-			return opListDistributionsByOwnedResource, ""
-		}
+	case strings.HasSuffix(inner, "/staging") && method == http.MethodPut:
+		return opUpdateDistributionWithStagingConfig, strings.TrimSuffix(inner, "/staging")
+	case strings.HasSuffix(inner, "/disassociate-web-acl") && method == http.MethodPut:
+		return opDisassociateDistributionWebACL, strings.TrimSuffix(inner, "/disassociate-web-acl")
+	case strings.Contains(inner, "/list-by-") && method == http.MethodGet:
+		return opListDistributionsByOwnedResource, ""
+	}
+
+	return "", ""
+}
+
+// parseCFDistributionTenantExtOps handles distribution-tenant extended paths.
+func parseCFDistributionTenantExtOps(method, suffix string) (string, string) {
+	if strings.Contains(suffix, "/invalidation") {
+		return parseCFDistributionTenantInvalidation(method, suffix)
+	}
+
+	if strings.HasSuffix(suffix, "/managed-certificate-details") {
+		id := strings.TrimSuffix(strings.TrimPrefix(suffix, "distribution-tenant/"), "/managed-certificate-details")
+
+		return opGetManagedCertificateDetails, id
+	}
+
+	return "", ""
+}
+
+// parseCFDistributionTenantInvalidation handles distribution-tenant invalidation paths.
+func parseCFDistributionTenantInvalidation(method, suffix string) (string, string) {
+	inner := strings.TrimPrefix(suffix, "distribution-tenant/")
+	switch {
+	case strings.HasSuffix(suffix, "/invalidation") && method == http.MethodPost:
+		return opCreateInvalidationForDistTenant, strings.TrimSuffix(inner, "/invalidation")
+	case strings.HasSuffix(suffix, "/invalidation") && method == http.MethodGet:
+		return opListInvalidationsForDistTenant, strings.TrimSuffix(inner, "/invalidation")
+	}
+
+	if before, _, ok := strings.Cut(inner, "/invalidation/"); ok && method == http.MethodGet {
+		return opGetInvalidationForDistTenant, before
+	}
+
+	return "", ""
+}
+
+// parseCFMiscPath handles miscellaneous CloudFront paths.
+func parseCFMiscPath(method, suffix string) (string, string) {
+	switch {
 	case suffix == "conflicting-alias" && method == http.MethodGet:
 		return opListConflictingAliases, ""
 	case suffix == "domain-conflict" && method == http.MethodPost:
@@ -987,46 +1245,6 @@ func parseCFPath(method, path, resourceParam string) (string, string) {
 		return opUpdateDomainAssociation, ""
 	case suffix == "verify-dns-configuration" && method == http.MethodPost:
 		return opVerifyDNSConfiguration, ""
-	case strings.HasPrefix(suffix, "distributions/by-cache-policy-id/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-cache-policy-id/")
-		return opListDistributionsByCachePolicyID, id
-	case strings.HasPrefix(suffix, "distributions/by-origin-request-policy-id/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-origin-request-policy-id/")
-		return opListDistributionsByOriginRequestPol, id
-	case strings.HasPrefix(suffix, "distributions/by-response-headers-policy-id/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-response-headers-policy-id/")
-		return opListDistributionsByResponseHeadersPol, id
-	case strings.HasPrefix(suffix, "distributions/by-web-acl-id/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-web-acl-id/")
-		return opListDistributionsByWebACLID, id
-	case strings.HasPrefix(suffix, "distributions/by-key-group/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-key-group/")
-		return opListDistributionsByKeyGroup, id
-	case strings.HasPrefix(suffix, "distributions/by-realtime-log-config") && method == http.MethodGet:
-		return opListDistributionsByRealtimeLogConfig, ""
-	case strings.HasPrefix(suffix, "distributions/by-vpc-origin-id/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-vpc-origin-id/")
-		return opListDistributionsByVpcOriginID, id
-	case strings.HasPrefix(suffix, "distributions/by-anycast-ip-list-id/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-anycast-ip-list-id/")
-		return opListDistributionsByAnycastIPListID, id
-	case strings.HasPrefix(suffix, "distributions/by-connection-function/") && method == http.MethodGet:
-		id := strings.TrimPrefix(suffix, "distributions/by-connection-function/")
-		return opListDistributionsByConnectionFunction, id
-	case suffix == "distributions/by-connection-mode" && method == http.MethodGet:
-		return opListDistributionsByConnectionMode, ""
-	case suffix == "distribution-tenants/by-customization" && method == http.MethodGet:
-		return opListDistributionTenantsByCustom, ""
-	case strings.HasPrefix(suffix, "distribution-tenant/") && strings.HasSuffix(suffix, "/managed-certificate-details"):
-		id := strings.TrimPrefix(suffix, "distribution-tenant/")
-		id = strings.TrimSuffix(id, "/managed-certificate-details")
-		return opGetManagedCertificateDetails, id
-	case suffix == "connection-group-by-routing-endpoint" && method == http.MethodGet:
-		return opGetConnectionGroupByRoutingEndpoint, ""
-	case suffix == "distribution-tenant-by-domain" && method == http.MethodGet:
-		return opGetDistributionTenantByDomain, ""
-	case strings.HasPrefix(suffix, "trust-store/") && strings.Contains(suffix, "/by-trust-store/"):
-		return opListDistributionsByTrustStore, ""
 	}
 
 	return "Unknown", ""
@@ -1231,8 +1449,21 @@ func (h *Handler) dispatchCreateExtended(c *echo.Context, operation string) erro
 
 // dispatchGetOrMutate handles all GET, PUT, and DELETE operations.
 //
-//nolint:cyclop,funlen,gocyclo // combined GET/mutate dispatch table is inherently wide
+
 func (h *Handler) dispatchGetOrMutate(c *echo.Context, operation, resource string) error {
+	if err := h.dispatchGetOrMutateCoreOps(c, operation, resource); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	if err := h.dispatchGetOrMutateEncryptionOps(c, operation, resource); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	return h.dispatchGetOrMutateExtOps(c, operation, resource)
+}
+
+// dispatchGetOrMutateCoreOps handles core GET, DELETE, and UPDATE operations.
+func (h *Handler) dispatchGetOrMutateCoreOps(c *echo.Context, operation, resource string) error {
 	switch operation {
 	case opGetCachePolicy:
 		return h.handleGetCachePolicy(c, resource)
@@ -1270,6 +1501,14 @@ func (h *Handler) dispatchGetOrMutate(c *echo.Context, operation, resource strin
 		return h.handleDeleteFunction(c, resource)
 	case opDeleteOriginAccessControl:
 		return h.handleDeleteOriginAccessControl(c, resource)
+	}
+
+	return errNotDispatched
+}
+
+// dispatchGetOrMutateEncryptionOps handles OAI, policy, and encryption operations.
+func (h *Handler) dispatchGetOrMutateEncryptionOps(c *echo.Context, operation, resource string) error {
+	switch operation {
 	case opDeleteCloudFrontOriginAccessIdentity:
 		return h.handleDeleteOAI(c, resource)
 	case opDeleteOriginRequestPolicy:
@@ -1306,6 +1545,23 @@ func (h *Handler) dispatchGetOrMutate(c *echo.Context, operation, resource strin
 		return h.handleUpdateFieldLevelEncryptionProfile(c, resource)
 	case opDeleteFieldLevelEncryptionProfile:
 		return h.handleDeleteFieldLevelEncryptionProfile(c, resource)
+	}
+
+	return errNotDispatched
+}
+
+// dispatchGetOrMutateExtOps handles public key, key group, log config, key value store, and VPC origin operations.
+func (h *Handler) dispatchGetOrMutateExtOps(c *echo.Context, operation, resource string) error {
+	if err := h.dispatchPublicKeyAndGroupOps(c, operation, resource); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	return h.dispatchLogStoreVPCOps(c, operation, resource)
+}
+
+// dispatchPublicKeyAndGroupOps handles public key and key group operations.
+func (h *Handler) dispatchPublicKeyAndGroupOps(c *echo.Context, operation, resource string) error {
+	switch operation {
 	case opGetPublicKey:
 		return h.handleGetPublicKey(c, resource)
 	case opGetPublicKeyConfig:
@@ -1322,6 +1578,14 @@ func (h *Handler) dispatchGetOrMutate(c *echo.Context, operation, resource strin
 		return h.handleUpdateKeyGroup(c, resource)
 	case opDeleteKeyGroup:
 		return h.handleDeleteKeyGroup(c, resource)
+	}
+
+	return errNotDispatched
+}
+
+// dispatchLogStoreVPCOps handles realtime log config, key value store, and VPC origin operations.
+func (h *Handler) dispatchLogStoreVPCOps(c *echo.Context, operation, resource string) error {
+	switch operation {
 	case opGetRealtimeLogConfig:
 		return h.handleGetRealtimeLogConfig(c, resource)
 	case opUpdateRealtimeLogConfig:
@@ -1340,9 +1604,9 @@ func (h *Handler) dispatchGetOrMutate(c *echo.Context, operation, resource strin
 		return h.handleUpdateVpcOrigin(c, resource)
 	case opDeleteVpcOrigin:
 		return h.handleDeleteVpcOrigin(c, resource)
-	default:
-		return errNotDispatched
 	}
+
+	return errNotDispatched
 }
 
 func (h *Handler) dispatchList(c *echo.Context, operation, resource string) error {
@@ -1433,210 +1697,220 @@ func cfStubXMLList(ns, listTag string) string {
 		listTag, ns, listTag)
 }
 
+// cfStubHelpers holds helper closures for generating CloudFront stub responses.
+type cfStubHelpers struct {
+	noContent func() error
+	emptyList func(tag string) error
+	created   func(tag, id string) error
+	getStub   func(tag, id string) error
+	xmlResp   func(body string) error
+}
+
 // dispatchStubs handles all stub CloudFront operations with minimal valid responses.
 //
-//nolint:funlen,cyclop,gocyclo // large dispatch table for stub operations
+
 func (h *Handler) dispatchStubs(c *echo.Context, operation string) error {
-	emptyItems := `<?xml version="1.0" encoding="UTF-8"?><Items xmlns="` + cfNS + `"/>`
-	noContent := func() error { return c.NoContent(http.StatusNoContent) }
-	emptyList := func(tag string) error { return xmlResp(c, http.StatusOK, cfStubXMLList(cfNS, tag)) }
-	created := func(tag, id string) error {
-		return xmlResp(c, http.StatusCreated, fmt.Sprintf(
-			`<?xml version="1.0" encoding="UTF-8"?><%s xmlns="%s"><Id>%s</Id></%s>`,
-			tag, cfNS, id, tag))
+	helpers := cfStubHelpers{
+		noContent: func() error { return c.NoContent(http.StatusNoContent) },
+		emptyList: func(tag string) error { return xmlResp(c, http.StatusOK, cfStubXMLList(cfNS, tag)) },
+		created: func(tag, id string) error {
+			return xmlResp(c, http.StatusCreated, fmt.Sprintf(
+				`<?xml version="1.0" encoding="UTF-8"?><%s xmlns="%s"><Id>%s</Id></%s>`,
+				tag, cfNS, id, tag))
+		},
+		getStub: func(tag, id string) error {
+			return xmlResp(c, http.StatusOK, fmt.Sprintf(
+				`<?xml version="1.0" encoding="UTF-8"?><%s xmlns="%s"><Id>%s</Id></%s>`,
+				tag, cfNS, id, tag))
+		},
+		xmlResp: func(body string) error { return xmlResp(c, http.StatusOK, body) },
 	}
-	getStub := func(tag, id string) error {
-		return xmlResp(c, http.StatusOK, fmt.Sprintf(
-			`<?xml version="1.0" encoding="UTF-8"?><%s xmlns="%s"><Id>%s</Id></%s>`,
-			tag, cfNS, id, tag))
+
+	if err := h.dispatchStubsDistributions(c, helpers, operation); !errors.Is(err, errNotDispatched) {
+		return err
 	}
-	_ = emptyItems
+
+	if err := h.dispatchStubsTrustAndMisc(c, helpers, operation); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	return h.dispatchStubsConnectionAndPolicy(c, helpers, operation)
+}
+
+// dispatchStubsDistributions handles distribution tenant and monitoring stub responses.
+func (h *Handler) dispatchStubsDistributions(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	if err := h.dispatchStubsDistributionTenant(c, hlp, operation); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	return h.dispatchStubsMonitoringAndStreaming(c, hlp, operation)
+}
+
+// dispatchStubsDistributionTenant handles distribution tenant and web ACL stubs.
+func (h *Handler) dispatchStubsDistributionTenant(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	noContent, emptyList, created := hlp.noContent, hlp.emptyList, hlp.created
+	_ = noContent
 
 	switch operation {
-	// Distribution variants.
 	case opCreateDistributionTenant:
 		return created("DistributionTenant", "tenant-stub")
 	case opCreateDistributionWithTags:
 		return created("Distribution", "dist-stub")
 	case opUpdateDistributionTenant:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><DistributionTenant xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><DistributionTenant xmlns="`+cfNS+`"/>`)
 	case opDeleteDistributionTenant:
 		return noContent()
 	case opGetDistributionTenant, opGetDistributionTenantByDomain:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><DistributionTenant xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><DistributionTenant xmlns="`+cfNS+`"/>`)
 	case opListDistributionTenants, opListDistributionTenantsByCustom:
 		return emptyList("DistributionTenantList")
 	case opUpdateDistributionWithStagingConfig:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><Distribution xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><Distribution xmlns="`+cfNS+`"/>`)
 	case opUpdateDomainAssociation:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><DomainAssociation xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><DomainAssociation xmlns="`+cfNS+`"/>`)
 	case opVerifyDNSConfiguration:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><VerifyDnsConfigurationResponse xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><VerifyDnsConfigurationResponse xmlns="`+cfNS+`"/>`)
+	}
 
-	// Monitoring subscription.
+	return errNotDispatched
+}
+
+// dispatchStubsMonitoringAndStreaming handles monitoring subscription and streaming distribution stubs.
+func (h *Handler) dispatchStubsMonitoringAndStreaming(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	noContent, emptyList, created, getStub := hlp.noContent, hlp.emptyList, hlp.created, hlp.getStub
+	_ = created
+
+	switch operation {
 	case opCreateMonitoringSubscription:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`)
 	case opGetMonitoringSubscription:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`)
 	case opDeleteMonitoringSubscription:
 		return noContent()
-
-	// Disassociate WebACL.
 	case opDisassociateDistributionWebACL, opDisassociateDistributionTenantWebACL:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><Distribution xmlns="`+cfNS+`"/>`,
-		)
-
-	// Field level encryption, key group, key value store, public key,
-	// realtime log config — promoted to real handlers; stubs removed.
-
-	// Streaming distribution.
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><Distribution xmlns="`+cfNS+`"/>`)
 	case opCreateStreamingDistribution, opCreateStreamingDistributionWithTags:
 		return created("StreamingDistribution", "sdist-stub")
 	case opGetStreamingDistribution, opGetStreamingDistributionConfig:
 		return getStub("StreamingDistribution", "sdist-stub")
 	case opUpdateStreamingDistribution:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><StreamingDistribution xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><StreamingDistribution xmlns="`+cfNS+`"/>`)
 	case opDeleteStreamingDistribution:
 		return noContent()
 	case opListStreamingDistributions:
 		return emptyList("StreamingDistributionList")
+	}
 
-	// Trust store.
+	return errNotDispatched
+}
+
+// dispatchStubsTrustAndMisc handles trust store, anycast, and connection function stubs.
+func (h *Handler) dispatchStubsTrustAndMisc(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	if err := h.dispatchStubsTrustAnycast(c, hlp, operation); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	return h.dispatchStubsConnectionFunction(c, hlp, operation)
+}
+
+// dispatchStubsTrustAnycast handles trust store and anycast IP list stubs.
+func (h *Handler) dispatchStubsTrustAnycast(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	noContent, emptyList, created, getStub := hlp.noContent, hlp.emptyList, hlp.created, hlp.getStub
+	_ = created
+
+	switch operation {
 	case opCreateTrustStore:
 		return created("TrustStore", "ts-stub")
 	case opGetTrustStore:
 		return getStub("TrustStore", "ts-stub")
 	case opUpdateTrustStore:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><TrustStore xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><TrustStore xmlns="`+cfNS+`"/>`)
 	case opDeleteTrustStore:
 		return noContent()
 	case opListTrustStores:
 		return emptyList("TrustStoreList")
-
-	// VPC origin — promoted to real handlers; stubs removed.
-
-	// Anycast IP list.
 	case opGetAnycastIPList:
 		return getStub("AnycastIpList", "anycast-stub")
 	case opUpdateAnycastIPList:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><AnycastIpList xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><AnycastIpList xmlns="`+cfNS+`"/>`)
 	case opDeleteAnycastIPList:
 		return noContent()
 	case opListAnycastIPLists:
 		return emptyList("AnycastIpLists")
+	}
 
-	// Connection function.
-	case opDescribeConnectionFunction:
-		return getStub("ConnectionFunction", "cf-stub")
-	case opGetConnectionFunction:
+	return errNotDispatched
+}
+
+// dispatchStubsConnectionFunction handles connection function and connection group stubs.
+func (h *Handler) dispatchStubsConnectionFunction(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	noContent, emptyList, getStub := hlp.noContent, hlp.emptyList, hlp.getStub
+
+	switch operation {
+	case opDescribeConnectionFunction, opGetConnectionFunction:
 		return getStub("ConnectionFunction", "cf-stub")
 	case opUpdateConnectionFunction:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><ConnectionFunction xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ConnectionFunction xmlns="`+cfNS+`"/>`)
 	case opDeleteConnectionFunction:
 		return noContent()
 	case opListConnectionFunctions:
 		return emptyList("ConnectionFunctionList")
 	case opPublishConnectionFunction:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><ConnectionFunction xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ConnectionFunction xmlns="`+cfNS+`"/>`)
 	case opTestConnectionFunction:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><TestResult xmlns="`+cfNS+`"/>`,
-		)
-
-	// Connection group.
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><TestResult xmlns="`+cfNS+`"/>`)
 	case opGetConnectionGroup, opGetConnectionGroupByRoutingEndpoint:
 		return getStub("ConnectionGroup", "cg-stub")
+	}
+
+	return errNotDispatched
+}
+
+// dispatchStubsConnectionAndPolicy handles connection group, continuous deployment, resource policy, and misc stubs.
+func (h *Handler) dispatchStubsConnectionAndPolicy(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	if err := h.dispatchStubsConnectionGroupAndCDP(c, hlp, operation); !errors.Is(err, errNotDispatched) {
+		return err
+	}
+
+	return h.dispatchStubsResourcePolicyAndMisc(c, hlp, operation)
+}
+
+// dispatchStubsConnectionGroupAndCDP handles connection group and continuous deployment policy stubs.
+func (h *Handler) dispatchStubsConnectionGroupAndCDP(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	noContent, emptyList, getStub := hlp.noContent, hlp.emptyList, hlp.getStub
+
+	switch operation {
 	case opUpdateConnectionGroup:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><ConnectionGroup xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ConnectionGroup xmlns="`+cfNS+`"/>`)
 	case opDeleteConnectionGroup:
 		return noContent()
 	case opListConnectionGroups:
 		return emptyList("ConnectionGroupList")
-
-	// Continuous deployment policy.
 	case opGetContinuousDeploymentPolicy, opGetContinuousDeploymentPolicyConfig:
 		return getStub("ContinuousDeploymentPolicy", "cdp-stub")
 	case opUpdateContinuousDeploymentPolicy:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><ContinuousDeploymentPolicy xmlns="`+cfNS+`"/>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ContinuousDeploymentPolicy xmlns="`+cfNS+`"/>`)
 	case opDeleteContinuousDeploymentPolicy:
 		return noContent()
 	case opListContinuousDeploymentPolicies:
 		return emptyList("ContinuousDeploymentPolicyList")
-
-	// Resource policy.
 	case opGetResourcePolicy:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><ResourcePolicy xmlns="`+cfNS+`"><Policy>{}</Policy></ResourcePolicy>`,
-		)
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ResourcePolicy xmlns="`+cfNS+`"><Policy>{}</Policy></ResourcePolicy>`)
 	case opPutResourcePolicy:
 		return noContent()
 	case opDeleteResourcePolicy:
 		return noContent()
+	}
 
-	// List distributions by X.
+	return errNotDispatched
+}
+
+// dispatchStubsResourcePolicyAndMisc handles distribution list, invalidation, and managed certificate stubs.
+func (h *Handler) dispatchStubsResourcePolicyAndMisc(c *echo.Context, hlp cfStubHelpers, operation string) error {
+	noContent, emptyList, created, getStub := hlp.noContent, hlp.emptyList, hlp.created, hlp.getStub
+	_ = noContent
+
+	switch operation {
 	case opListDistributionsByCachePolicyID, opListDistributionsByOriginRequestPol,
 		opListDistributionsByResponseHeadersPol, opListDistributionsByWebACLID,
 		opListDistributionsByKeyGroup, opListDistributionsByRealtimeLogConfig,
@@ -1644,35 +1918,20 @@ func (h *Handler) dispatchStubs(c *echo.Context, operation string) error {
 		opListDistributionsByConnectionFunction, opListDistributionsByConnectionMode,
 		opListDistributionsByTrustStore, opListDistributionsByOwnedResource:
 		return emptyList("DistributionList")
-
-	// Misc list operations.
 	case opListConflictingAliases:
 		return emptyList("ConflictingAliasesList")
 	case opListDomainConflicts:
 		return emptyList("DomainConflictList")
-
-	// Invalidation for distribution tenant.
 	case opCreateInvalidationForDistTenant:
 		return created("Invalidation", "inv-stub")
 	case opGetInvalidationForDistTenant:
 		return getStub("Invalidation", "inv-stub")
 	case opListInvalidationsForDistTenant:
 		return emptyList("InvalidationList")
-
-	// Managed certificate details.
 	case opGetManagedCertificateDetails:
-		return xmlResp(
-			c,
-			http.StatusOK,
-			`<?xml version="1.0" encoding="UTF-8"?><ManagedCertificateDetails xmlns="`+cfNS+`"/>`,
-		)
-
+		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ManagedCertificateDetails xmlns="`+cfNS+`"/>`)
 	default:
-		return xmlResp(
-			c,
-			http.StatusNotFound,
-			cfErrorXML("NoSuchOperation", "unknown operation: "+operation),
-		)
+		return xmlResp(c, http.StatusNotFound, cfErrorXML("NoSuchOperation", "unknown operation: "+operation))
 	}
 }
 

--- a/services/codeartifact/handler.go
+++ b/services/codeartifact/handler.go
@@ -322,9 +322,16 @@ func parseDomainRepoPath(method, path string) codeartifactRoute {
 }
 
 // parsePackageOpPath handles package, package-group, and package-version routes.
-//
-//nolint:cyclop // large switch-case dispatch is inherently high cyclomatic complexity
 func parsePackageOpPath(method, path string) codeartifactRoute {
+	if r := parsePackageGroupVersionOps(method, path); r.operation != opUnknown {
+		return r
+	}
+
+	return parsePackageVersionAssetOps(path)
+}
+
+// parsePackageGroupVersionOps handles package group, package CRUD, and package version operations.
+func parsePackageGroupVersionOps(method, path string) codeartifactRoute {
 	switch path {
 	case pathV1PackageGroup:
 		return parsePackageGroupRoute(method)
@@ -348,6 +355,14 @@ func parsePackageOpPath(method, path string) codeartifactRoute {
 		return codeartifactRoute{operation: opUpdatePackageVersionsStatus}
 	case pathV1PackageVersionsPublish:
 		return codeartifactRoute{operation: opPublishPackageVersion}
+	}
+
+	return codeartifactRoute{operation: opUnknown}
+}
+
+// parsePackageVersionAssetOps handles package version asset and package-group association operations.
+func parsePackageVersionAssetOps(path string) codeartifactRoute {
+	switch path {
 	case pathV1PackageVersionAsset:
 		return codeartifactRoute{operation: opGetPackageVersionAsset}
 	case pathV1PackageVersionReadme:

--- a/services/dms/handler.go
+++ b/services/dms/handler.go
@@ -632,47 +632,76 @@ func (h *Handler) ExtractOperation(c *echo.Context) string {
 }
 
 // ExtractResource extracts the primary resource identifier from the request body.
-func (h *Handler) ExtractResource( //nolint:cyclop // switch covers many operations
-	c *echo.Context,
-) string {
+func (h *Handler) ExtractResource(c *echo.Context) string {
 	action := h.ExtractOperation(c)
+	if r := extractCoreResourceField(c, action); r != "" {
+		return r
+	}
 
+	return extractExtendedResourceField(c, action)
+}
+
+// extractCoreResourceField extracts resource identifiers for core DMS operations.
+func extractCoreResourceField(c *echo.Context, action string) string {
 	switch action {
 	case opCreateReplicationInstance, opDescribeReplicationInstances, opDeleteReplicationInstance,
 		opModifyReplicationInstance, opRebootReplicationInstance:
+
 		return extractField(c, "ReplicationInstanceIdentifier", "ReplicationInstanceArn")
 	case opCreateEndpoint, opDescribeEndpoints, opDeleteEndpoint, opModifyEndpoint:
+
 		return extractField(c, "EndpointIdentifier", "EndpointArn")
 	case opCreateReplicationTask, opDescribeReplicationTasks,
 		opStartReplicationTask, opStopReplicationTask, opDeleteReplicationTask,
 		opModifyReplicationTask, opMoveReplicationTask:
+
 		return extractField(c, "ReplicationTaskIdentifier", "ReplicationTaskArn")
 	case opAddTagsToResource, opListTagsForResource, opRemoveTagsFromResource:
+
 		return extractField(c, "ResourceArn")
 	case opApplyPendingMaintenanceAction:
+
 		return extractField(c, "ReplicationInstanceArn")
 	case opCreateDataMigration, opDeleteDataMigration, opModifyDataMigration,
 		opStartDataMigration, opStopDataMigration:
+
 		return extractField(c, "DataMigrationName", "DataMigrationArn")
 	case opCreateDataProvider, opDeleteDataProvider, opModifyDataProvider:
+
 		return extractField(c, "DataProviderName", "DataProviderArn")
 	case opCreateEventSubscription, opDeleteEventSubscription, opModifyEventSubscription:
+
 		return extractField(c, "SubscriptionName")
+	}
+
+	return ""
+}
+
+// extractExtendedResourceField extracts resource identifiers for extended DMS operations.
+func extractExtendedResourceField(c *echo.Context, action string) string {
+	switch action {
 	case opCreateFleetAdvisorCollector, opDeleteFleetAdvisorCollector:
+
 		return extractField(c, "CollectorName")
 	case opCreateInstanceProfile, opDeleteInstanceProfile, opModifyInstanceProfile:
+
 		return extractField(c, "InstanceProfileName", "InstanceProfileArn")
 	case opCreateMigrationProject, opDeleteMigrationProject, opModifyMigrationProject:
+
 		return extractField(c, "MigrationProjectName", "MigrationProjectArn")
 	case opCreateReplicationConfig, opDeleteReplicationConfig, opModifyReplicationConfig:
+
 		return extractField(c, "ReplicationConfigIdentifier", "ReplicationConfigArn")
 	case opCreateReplicationSubnetGroup,
 		opDeleteReplicationSubnetGroup,
 		opModifyReplicationSubnetGroup:
+
 		return extractField(c, "ReplicationSubnetGroupIdentifier")
 	case opDeleteCertificate, opImportCertificate:
+
 		return extractField(c, "CertificateIdentifier", "CertificateArn")
 	case opTestConnection:
+
 		return extractField(c, "EndpointArn")
 	}
 
@@ -734,26 +763,31 @@ func (h *Handler) dispatch(ctx context.Context, action string, body []byte) ([]b
 func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err error) error {
 	switch {
 	case errors.Is(err, ErrNotFound):
+
 		return c.JSON(http.StatusNotFound, service.JSONErrorResponse{
 			Type:    "ResourceNotFoundFault",
 			Message: err.Error(),
 		})
 	case errors.Is(err, ErrAlreadyExists):
+
 		return c.JSON(http.StatusConflict, service.JSONErrorResponse{
 			Type:    "ResourceAlreadyExistsFault",
 			Message: err.Error(),
 		})
 	case errors.Is(err, ErrInvalidState), errors.Is(err, ErrValidation):
+
 		return c.JSON(http.StatusBadRequest, service.JSONErrorResponse{
 			Type:    "InvalidResourceStateFault",
 			Message: err.Error(),
 		})
 	case errors.Is(err, errUnknownAction):
+
 		return c.JSON(http.StatusBadRequest, service.JSONErrorResponse{
 			Type:    "UnknownOperationException",
 			Message: err.Error(),
 		})
 	default:
+
 		return c.JSON(http.StatusInternalServerError, service.JSONErrorResponse{
 			Type:    "InternalFailure",
 			Message: err.Error(),

--- a/services/elasticsearch/handler.go
+++ b/services/elasticsearch/handler.go
@@ -112,31 +112,43 @@ func (h *Handler) Name() string { return "Elasticsearch" }
 func (h *Handler) MatchPriority() int { return service.PriorityPathSubdomain }
 
 // RouteMatcher returns a matcher that selects Elasticsearch requests by path prefix.
-func (h *Handler) RouteMatcher() service.Matcher { //nolint:cyclop // matches all Elasticsearch path prefixes
+func (h *Handler) RouteMatcher() service.Matcher {
 	return func(c *echo.Context) bool {
-		path := c.Request().URL.Path
-
-		return strings.HasPrefix(path, elasticsearchPathPrefix) ||
-			path == elasticsearchDomainInfo ||
-			path == elasticsearchTagsPath ||
-			path == elasticsearchTagsRemove ||
-			path == elasticsearchServiceRole ||
-			strings.HasPrefix(path, elasticsearchSoftwareUpdate) ||
-			strings.HasPrefix(path, elasticsearchCCSInbound) ||
-			path == elasticsearchCCSOutbound ||
-			path == elasticsearchVpcEndpoints ||
-			strings.HasPrefix(path, elasticsearchVpcEndpoints+"/") ||
-			strings.HasPrefix(path, elasticsearchPackages) ||
-			strings.HasPrefix(path, elasticsearchDomainPackages+"/") ||
-			strings.HasPrefix(path, elasticsearchUpgradeDomain) ||
-			path == elasticsearchCompatibleVersions ||
-			path == elasticsearchVersions ||
-			strings.HasPrefix(path, elasticsearchInstanceTypes) ||
-			strings.HasPrefix(path, elasticsearchInstanceTypeLimits) ||
-			path == elasticsearchReservedOfferings ||
-			path == elasticsearchReservedInstances ||
-			path == elasticsearchPurchaseReserved
+		return matchElasticsearchPath(c.Request().URL.Path)
 	}
+}
+
+// matchElasticsearchPath returns true if the path matches a known Elasticsearch API path.
+func matchElasticsearchPath(path string) bool {
+	return matchElasticsearchCorePaths(path) || matchElasticsearchExtPaths(path)
+}
+
+// matchElasticsearchCorePaths returns true if path matches core Elasticsearch paths.
+func matchElasticsearchCorePaths(path string) bool {
+	return strings.HasPrefix(path, elasticsearchPathPrefix) ||
+		path == elasticsearchDomainInfo ||
+		path == elasticsearchTagsPath ||
+		path == elasticsearchTagsRemove ||
+		path == elasticsearchServiceRole ||
+		strings.HasPrefix(path, elasticsearchSoftwareUpdate) ||
+		strings.HasPrefix(path, elasticsearchCCSInbound) ||
+		path == elasticsearchCCSOutbound ||
+		path == elasticsearchVpcEndpoints ||
+		strings.HasPrefix(path, elasticsearchVpcEndpoints+"/")
+}
+
+// matchElasticsearchExtPaths returns true if path matches extended Elasticsearch paths.
+func matchElasticsearchExtPaths(path string) bool {
+	return strings.HasPrefix(path, elasticsearchPackages) ||
+		strings.HasPrefix(path, elasticsearchDomainPackages+"/") ||
+		strings.HasPrefix(path, elasticsearchUpgradeDomain) ||
+		path == elasticsearchCompatibleVersions ||
+		path == elasticsearchVersions ||
+		strings.HasPrefix(path, elasticsearchInstanceTypes) ||
+		strings.HasPrefix(path, elasticsearchInstanceTypeLimits) ||
+		path == elasticsearchReservedOfferings ||
+		path == elasticsearchReservedInstances ||
+		path == elasticsearchPurchaseReserved
 }
 
 // GetSupportedOperations returns supported operations.
@@ -247,30 +259,69 @@ func extractTagAndServiceOperation(path, method string) string {
 }
 
 // extractCCSVpcPackageOperation handles CCS, VPC endpoint, and package paths.
-//
-//nolint:cyclop,gocognit,gocyclo,funlen // large switch covers all CCS/VPC/package routes
 func extractCCSVpcPackageOperation(path, method string) string {
+	if op := extractCCSOperation(path, method); op != "" {
+		return op
+	}
+
+	if op := extractVpcPackageOperation(path, method); op != "" {
+		return op
+	}
+
+	return extractUpgradeAndMiscOperation(path, method)
+}
+
+// extractCCSOperation handles Cross-Cluster Search operations.
+func extractCCSOperation(path, method string) string {
+	if strings.HasPrefix(path, elasticsearchCCSInbound+"/") {
+		return extractCCSInboundOp(path, method)
+	}
+
+	return extractCCSOutboundOp(path, method)
+}
+
+// extractCCSInboundOp handles inbound CCS operations.
+func extractCCSInboundOp(path, method string) string {
 	switch {
-	case strings.HasPrefix(path, elasticsearchCCSInbound+"/") &&
-		strings.HasSuffix(path, "/accept") &&
-		method == http.MethodPut:
+	case strings.HasSuffix(path, "/accept") && method == http.MethodPut:
 		return "AcceptInboundCrossClusterSearchConnection"
-	case strings.HasPrefix(path, elasticsearchCCSInbound+"/") &&
-		strings.HasSuffix(path, "/reject") &&
-		method == http.MethodPut:
+	case strings.HasSuffix(path, "/reject") && method == http.MethodPut:
 		return "RejectInboundCrossClusterSearchConnection"
-	case strings.HasPrefix(path, elasticsearchCCSInbound+"/") &&
-		method == http.MethodDelete:
+	case method == http.MethodDelete:
 		return "DeleteInboundCrossClusterSearchConnection"
+	}
+
+	return ""
+}
+
+// extractCCSOutboundOp handles outbound CCS operations.
+func extractCCSOutboundOp(path, method string) string {
+	switch {
 	case path == elasticsearchCCSInboundSearch && method == http.MethodPost:
 		return "DescribeInboundCrossClusterSearchConnections"
 	case path == elasticsearchCCSOutbound && method == http.MethodPost:
 		return "CreateOutboundCrossClusterSearchConnection"
-	case strings.HasPrefix(path, elasticsearchCCSOutbound+"/") &&
-		method == http.MethodDelete:
+	case strings.HasPrefix(path, elasticsearchCCSOutbound+"/") && method == http.MethodDelete:
 		return "DeleteOutboundCrossClusterSearchConnection"
 	case path == elasticsearchCCSOutboundSearch && method == http.MethodPost:
 		return "DescribeOutboundCrossClusterSearchConnections"
+	}
+
+	return ""
+}
+
+// extractVpcPackageOperation handles VPC endpoint and package operations.
+func extractVpcPackageOperation(path, method string) string {
+	if op := extractVpcEndpointOperation(path, method); op != "" {
+		return op
+	}
+
+	return extractPackageOperation(path, method)
+}
+
+// extractVpcEndpointOperation handles VPC endpoint operations.
+func extractVpcEndpointOperation(path, method string) string {
+	switch {
 	case path == elasticsearchVpcEndpoints && method == http.MethodPost:
 		return "CreateVpcEndpoint"
 	case path == elasticsearchVpcEndpoints && method == http.MethodGet:
@@ -279,9 +330,25 @@ func extractCCSVpcPackageOperation(path, method string) string {
 		return "DescribeVpcEndpoints"
 	case path == elasticsearchVpcEndpoints+"/update" && method == http.MethodPost:
 		return "UpdateVpcEndpoint"
-	case strings.HasPrefix(path, elasticsearchVpcEndpoints+"/") &&
-		method == http.MethodDelete:
+	case strings.HasPrefix(path, elasticsearchVpcEndpoints+"/") && method == http.MethodDelete:
 		return "DeleteVpcEndpoint"
+	}
+
+	return ""
+}
+
+// extractPackageOperation handles package operations.
+func extractPackageOperation(path, method string) string {
+	if op := extractPackageCRUDOp(path, method); op != "" {
+		return op
+	}
+
+	return extractPackageDomainOp(path, method)
+}
+
+// extractPackageCRUDOp handles package CRUD and association operations.
+func extractPackageCRUDOp(path, method string) string {
+	switch {
 	case strings.HasPrefix(path, elasticsearchPackages+"/associate/") && method == http.MethodPost:
 		return "AssociatePackage"
 	case strings.HasPrefix(path, elasticsearchPackages+"/dissociate/") && method == http.MethodPost:
@@ -292,6 +359,14 @@ func extractCCSVpcPackageOperation(path, method string) string {
 		return "DescribePackages"
 	case path == elasticsearchPackages+"/update" && method == http.MethodPost:
 		return "UpdatePackage"
+	}
+
+	return ""
+}
+
+// extractPackageDomainOp handles package history, domain listing, and domain-package operations.
+func extractPackageDomainOp(path, method string) string {
+	switch {
 	case strings.HasPrefix(path, elasticsearchPackages+"/") &&
 		strings.HasSuffix(path, "/history") &&
 		method == http.MethodGet:
@@ -300,13 +375,29 @@ func extractCCSVpcPackageOperation(path, method string) string {
 		strings.HasSuffix(path, "/domains") &&
 		method == http.MethodGet:
 		return "ListDomainsForPackage"
-	case strings.HasPrefix(path, elasticsearchPackages+"/") &&
-		method == http.MethodDelete:
+	case strings.HasPrefix(path, elasticsearchPackages+"/") && method == http.MethodDelete:
 		return "DeletePackage"
 	case strings.HasPrefix(path, elasticsearchDomainPackages+"/") &&
 		strings.HasSuffix(path, "/packages") &&
 		method == http.MethodGet:
 		return "ListPackagesForDomain"
+	}
+
+	return ""
+}
+
+// extractUpgradeAndMiscOperation handles upgrade, instance, reserved, and software update operations.
+func extractUpgradeAndMiscOperation(path, method string) string {
+	if op := extractVersionAndInstanceOp(path, method); op != "" {
+		return op
+	}
+
+	return extractUpgradeOp(path, method)
+}
+
+// extractVersionAndInstanceOp handles version, instance type, and reserved instance operations.
+func extractVersionAndInstanceOp(path, method string) string {
+	switch {
 	case path == elasticsearchCompatibleVersions && method == http.MethodGet:
 		return "GetCompatibleElasticsearchVersions"
 	case path == elasticsearchVersions && method == http.MethodGet:
@@ -321,6 +412,14 @@ func extractCCSVpcPackageOperation(path, method string) string {
 		return "DescribeReservedElasticsearchInstances"
 	case path == elasticsearchPurchaseReserved && method == http.MethodPost:
 		return "PurchaseReservedElasticsearchInstanceOffering"
+	}
+
+	return ""
+}
+
+// extractUpgradeOp handles upgrade and software update operations.
+func extractUpgradeOp(path, method string) string {
+	switch {
 	case path == elasticsearchUpgradeDomain && method == http.MethodPost:
 		return "UpgradeElasticsearchDomain"
 	case strings.HasPrefix(path, elasticsearchUpgradeDomain+"/") &&
@@ -353,7 +452,25 @@ func extractDomainOperation(rest, method string) string {
 }
 
 // extractSubDomainOperation resolves operations on specific domain paths (rest starts with "/").
-func extractSubDomainOperation(rest, method string) string { //nolint:cyclop // covers all domain sub-path operations
+func extractSubDomainOperation(rest, method string) string {
+	if op := extractSubDomainSuffixOp(rest, method); op != opUnknown {
+		return op
+	}
+
+	return extractSubDomainMethodOp(method)
+}
+
+// extractSubDomainSuffixOp matches sub-domain operations by path suffix.
+func extractSubDomainSuffixOp(rest, method string) string {
+	if op := extractSubDomainConfigOp(rest, method); op != opUnknown {
+		return op
+	}
+
+	return extractSubDomainListingOp(rest, method)
+}
+
+// extractSubDomainConfigOp handles config, cancel, and VPC authorization operations.
+func extractSubDomainConfigOp(rest, method string) string {
 	switch {
 	case strings.HasSuffix(rest, "/config/cancel") && method == http.MethodPost:
 		return "CancelDomainConfigChange"
@@ -365,6 +482,14 @@ func extractSubDomainOperation(rest, method string) string { //nolint:cyclop // 
 		return "UpdateElasticsearchDomainConfig"
 	case strings.HasSuffix(rest, "/config"):
 		return "DescribeElasticsearchDomainConfig"
+	}
+
+	return opUnknown
+}
+
+// extractSubDomainListingOp handles auto-tunes, progress, and VPC endpoint listing operations.
+func extractSubDomainListingOp(rest, method string) string {
+	switch {
 	case strings.HasSuffix(rest, "/autoTunes") && method == http.MethodGet:
 		return "DescribeDomainAutoTunes"
 	case strings.HasSuffix(rest, "/progress") && method == http.MethodGet:
@@ -373,9 +498,17 @@ func extractSubDomainOperation(rest, method string) string { //nolint:cyclop // 
 		return "ListVpcEndpointAccess"
 	case strings.HasSuffix(rest, "/vpcEndpoints") && method == http.MethodGet:
 		return "ListVpcEndpointsForDomain"
-	case method == http.MethodGet:
+	}
+
+	return opUnknown
+}
+
+// extractSubDomainMethodOp matches sub-domain operations by HTTP method alone.
+func extractSubDomainMethodOp(method string) string {
+	switch method {
+	case http.MethodGet:
 		return "DescribeElasticsearchDomain"
-	case method == http.MethodDelete:
+	case http.MethodDelete:
 		return "DeleteElasticsearchDomain"
 	}
 
@@ -511,11 +644,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // handlePrefixRoutes handles routes that require prefix matching with path params.
 // Returns true if the request was handled.
-//
-//nolint:cyclop,gocognit,gocyclo,funlen // large prefix router covers all dynamic routes
 func (h *Handler) handlePrefixRoutes(w http.ResponseWriter, r *http.Request) bool {
 	path := r.URL.Path
 
+	if h.handleCCSPrefixRoutes(w, r, path) {
+		return true
+	}
+
+	if h.handlePackagePrefixRoutes(w, r, path) {
+		return true
+	}
+
+	return h.handleInstanceUpgradePrefixRoutes(w, r, path)
+}
+
+// handleCCSPrefixRoutes handles CCS and VPC endpoint prefix routes.
+func (h *Handler) handleCCSPrefixRoutes(w http.ResponseWriter, r *http.Request, path string) bool {
 	// CCS inbound routes (ordered most-specific first)
 	if strings.HasPrefix(path, elasticsearchCCSInbound+"/") {
 		switch {
@@ -534,21 +678,32 @@ func (h *Handler) handlePrefixRoutes(w http.ResponseWriter, r *http.Request) boo
 		}
 	}
 
-	// CCS outbound dynamic routes
 	if strings.HasPrefix(path, elasticsearchCCSOutbound+"/") && r.Method == http.MethodDelete {
 		h.handleDeleteOutboundCrossClusterSearchConnection(w, r)
 
 		return true
 	}
 
-	// VPC endpoint dynamic routes (check prefix with "/" to avoid matching fixed paths)
 	if strings.HasPrefix(path, elasticsearchVpcEndpoints+"/") && r.Method == http.MethodDelete {
 		h.handleDeleteVpcEndpoint(w, r)
 
 		return true
 	}
 
-	// Package routes (most-specific first to avoid prefix conflicts)
+	return false
+}
+
+// handlePackagePrefixRoutes handles package and domain-package prefix routes.
+func (h *Handler) handlePackagePrefixRoutes(w http.ResponseWriter, r *http.Request, path string) bool {
+	if h.handlePackageAssocDisassoc(w, r, path) {
+		return true
+	}
+
+	return h.handlePackageHistoryAndDelete(w, r, path)
+}
+
+// handlePackageAssocDisassoc handles package association and history listing operations.
+func (h *Handler) handlePackageAssocDisassoc(w http.ResponseWriter, r *http.Request, path string) bool {
 	switch {
 	case strings.HasPrefix(path, elasticsearchPackages+"/associate/") && r.Method == http.MethodPost:
 		h.handleAssociatePackage(w, r)
@@ -570,8 +725,14 @@ func (h *Handler) handlePrefixRoutes(w http.ResponseWriter, r *http.Request) boo
 		h.handleListDomainsForPackage(w, r)
 
 		return true
-	case strings.HasPrefix(path, elasticsearchPackages+"/") && r.Method == http.MethodDelete:
-		// Only handle if not a fixed route (/describe, /update are handled in ops table)
+	}
+
+	return false
+}
+
+// handlePackageHistoryAndDelete handles package delete and domain-package listing.
+func (h *Handler) handlePackageHistoryAndDelete(w http.ResponseWriter, r *http.Request, path string) bool {
+	if strings.HasPrefix(path, elasticsearchPackages+"/") && r.Method == http.MethodDelete {
 		rest := strings.TrimPrefix(path, elasticsearchPackages+"/")
 		if !strings.Contains(rest, "/") {
 			h.handleDeletePackage(w, r)
@@ -580,7 +741,6 @@ func (h *Handler) handlePrefixRoutes(w http.ResponseWriter, r *http.Request) boo
 		}
 	}
 
-	// Domain-scoped package routes (path prefix /2015-01-01/domain, not /2015-01-01/es/domain)
 	if strings.HasPrefix(path, elasticsearchDomainPackages+"/") &&
 		strings.HasSuffix(path, "/packages") &&
 		r.Method == http.MethodGet {
@@ -589,7 +749,11 @@ func (h *Handler) handlePrefixRoutes(w http.ResponseWriter, r *http.Request) boo
 		return true
 	}
 
-	// Instance types / limits (dynamic version segment)
+	return false
+}
+
+// handleInstanceUpgradePrefixRoutes handles instance type and upgrade prefix routes.
+func (h *Handler) handleInstanceUpgradePrefixRoutes(w http.ResponseWriter, r *http.Request, path string) bool {
 	if strings.HasPrefix(path, elasticsearchInstanceTypes+"/") && r.Method == http.MethodGet {
 		h.handleListElasticsearchInstanceTypes(w, r)
 
@@ -602,7 +766,6 @@ func (h *Handler) handlePrefixRoutes(w http.ResponseWriter, r *http.Request) boo
 		return true
 	}
 
-	// Upgrade domain history/status (dynamic domain name)
 	if strings.HasPrefix(path, elasticsearchUpgradeDomain+"/") {
 		switch {
 		case strings.HasSuffix(path, "/history") && r.Method == http.MethodGet:

--- a/services/emrserverless/handler.go
+++ b/services/emrserverless/handler.go
@@ -157,12 +157,16 @@ func parseEMRPath(method, rawPath string) emrRoute {
 
 	switch len(parts) {
 	case pathPartsApplication:
+
 		return parseSingleAppRoute(method, parts[0])
 	case pathPartsWithSub:
+
 		return parseAppSubRoute(method, parts[0], parts[1])
 	case pathPartsWithJobRun:
+
 		return parseJobRunRoute(method, parts[0], parts[1], parts[2])
 	case pathPartsWithJobRunSub:
+
 		return parseJobRunSubRoute(method, parts[0], parts[1], parts[2], parts[3])
 	}
 
@@ -172,10 +176,13 @@ func parseEMRPath(method, rawPath string) emrRoute {
 func parseTagRoute(method, resourceARN string) emrRoute {
 	switch method {
 	case http.MethodGet:
+
 		return emrRoute{operation: opListTagsForResource, resourceARN: resourceARN}
 	case http.MethodPost:
+
 		return emrRoute{operation: opTagResource, resourceARN: resourceARN}
 	case http.MethodDelete:
+
 		return emrRoute{operation: opUntagResource, resourceARN: resourceARN}
 	}
 
@@ -185,8 +192,10 @@ func parseTagRoute(method, resourceARN string) emrRoute {
 func parseApplicationsCollection(method string) emrRoute {
 	switch method {
 	case http.MethodPost:
+
 		return emrRoute{operation: opCreateApplication}
 	case http.MethodGet:
+
 		return emrRoute{operation: opListApplications}
 	}
 
@@ -196,10 +205,13 @@ func parseApplicationsCollection(method string) emrRoute {
 func parseSingleAppRoute(method, appID string) emrRoute {
 	switch method {
 	case http.MethodGet:
+
 		return emrRoute{operation: opGetApplication, applicationID: appID}
 	case http.MethodPatch:
+
 		return emrRoute{operation: opUpdateApplication, applicationID: appID}
 	case http.MethodDelete:
+
 		return emrRoute{operation: opDeleteApplication, applicationID: appID}
 	}
 
@@ -219,8 +231,10 @@ func parseAppSubRoute(method, appID, sub string) emrRoute {
 	case pathJobRuns:
 		switch method {
 		case http.MethodPost:
+
 			return emrRoute{operation: opStartJobRun, applicationID: appID}
 		case http.MethodGet:
+
 			return emrRoute{operation: opListJobRuns, applicationID: appID}
 		}
 	}
@@ -235,8 +249,10 @@ func parseJobRunRoute(method, appID, sub, jobRunID string) emrRoute {
 
 	switch method {
 	case http.MethodGet:
+
 		return emrRoute{operation: opGetJobRun, applicationID: appID, jobRunID: jobRunID}
 	case http.MethodDelete:
+
 		return emrRoute{operation: opCancelJobRun, applicationID: appID, jobRunID: jobRunID}
 	}
 
@@ -254,8 +270,10 @@ func parseJobRunSubRoute(method, appID, sub, jobRunID, action string) emrRoute {
 
 	switch action {
 	case "dashboard":
+
 		return emrRoute{operation: opGetDashboardForJobRun, applicationID: appID, jobRunID: jobRunID}
 	case "attempts":
+
 		return emrRoute{operation: opListJobRunAttempts, applicationID: appID, jobRunID: jobRunID}
 	}
 
@@ -306,57 +324,98 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	}
 }
 
-//nolint:cyclop // dispatch table for 16 REST operations is inherently wide
+// dispatch routes to the appropriate handler based on the parsed route.
 func (h *Handler) dispatch(c *echo.Context, route emrRoute, body []byte) error {
+	if ok, err := h.dispatchApplicationOps(c, route, body); ok {
+		return err
+	}
+	if ok, err := h.dispatchJobRunOps(c, route, body); ok {
+		return err
+	}
+
+	return c.JSON(http.StatusNotFound, errResp("ResourceNotFoundException", "unknown operation: "+route.operation))
+}
+
+// dispatchApplicationOps handles application lifecycle operations.
+func (h *Handler) dispatchApplicationOps(c *echo.Context, route emrRoute, body []byte) (bool, error) {
 	switch route.operation {
 	case opCreateApplication:
-		return h.handleCreateApplication(c, body)
+
+		return true, h.handleCreateApplication(c, body)
 	case opGetApplication:
-		return h.handleGetApplication(c, route.applicationID)
+
+		return true, h.handleGetApplication(c, route.applicationID)
 	case opListApplications:
-		return h.handleListApplications(c)
+
+		return true, h.handleListApplications(c)
 	case opUpdateApplication:
-		return h.handleUpdateApplication(c, route.applicationID, body)
+
+		return true, h.handleUpdateApplication(c, route.applicationID, body)
 	case opDeleteApplication:
-		return h.handleDeleteApplication(c, route.applicationID)
+
+		return true, h.handleDeleteApplication(c, route.applicationID)
 	case opStartApplication:
-		return h.handleStartApplication(c, route.applicationID)
+
+		return true, h.handleStartApplication(c, route.applicationID)
 	case opStopApplication:
-		return h.handleStopApplication(c, route.applicationID)
-	case opStartJobRun:
-		return h.handleStartJobRun(c, route.applicationID, body)
-	case opGetJobRun:
-		return h.handleGetJobRun(c, route.applicationID, route.jobRunID)
-	case opListJobRuns:
-		return h.handleListJobRuns(c, route.applicationID)
-	case opCancelJobRun:
-		return h.handleCancelJobRun(c, route.applicationID, route.jobRunID)
-	case opGetDashboardForJobRun:
-		return h.handleGetDashboardForJobRun(c, route.applicationID, route.jobRunID)
-	case opListJobRunAttempts:
-		return h.handleListJobRunAttempts(c, route.applicationID, route.jobRunID)
-	case opListTagsForResource:
-		return h.handleListTagsForResource(c, route.resourceARN)
-	case opTagResource:
-		return h.handleTagResource(c, route.resourceARN, body)
-	case opUntagResource:
-		return h.handleUntagResource(c, route.resourceARN, c.Request().URL.Query())
-	default:
-		return c.JSON(http.StatusNotFound, errResp("ResourceNotFoundException", "unknown operation: "+route.operation))
+
+		return true, h.handleStopApplication(c, route.applicationID)
 	}
+
+	return false, nil
+}
+
+// dispatchJobRunOps handles job run and tagging operations.
+func (h *Handler) dispatchJobRunOps(c *echo.Context, route emrRoute, body []byte) (bool, error) {
+	switch route.operation {
+	case opStartJobRun:
+
+		return true, h.handleStartJobRun(c, route.applicationID, body)
+	case opGetJobRun:
+
+		return true, h.handleGetJobRun(c, route.applicationID, route.jobRunID)
+	case opListJobRuns:
+
+		return true, h.handleListJobRuns(c, route.applicationID)
+	case opCancelJobRun:
+
+		return true, h.handleCancelJobRun(c, route.applicationID, route.jobRunID)
+	case opGetDashboardForJobRun:
+
+		return true, h.handleGetDashboardForJobRun(c, route.applicationID, route.jobRunID)
+	case opListJobRunAttempts:
+
+		return true, h.handleListJobRunAttempts(c, route.applicationID, route.jobRunID)
+	case opListTagsForResource:
+
+		return true, h.handleListTagsForResource(c, route.resourceARN)
+	case opTagResource:
+
+		return true, h.handleTagResource(c, route.resourceARN, body)
+	case opUntagResource:
+
+		return true, h.handleUntagResource(c, route.resourceARN, c.Request().URL.Query())
+	}
+
+	return false, nil
 }
 
 func (h *Handler) handleError(c *echo.Context, err error) error {
 	switch {
 	case errors.Is(err, ErrNotFound):
+
 		return c.JSON(http.StatusNotFound, errResp("ResourceNotFoundException", err.Error()))
 	case errors.Is(err, ErrAlreadyExists):
+
 		return c.JSON(http.StatusConflict, errResp("ConflictException", err.Error()))
 	case errors.Is(err, ErrValidation):
+
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", err.Error()))
 	case errors.Is(err, ErrInvalidState):
+
 		return c.JSON(http.StatusBadRequest, errResp("RequestFailedException", err.Error()))
 	default:
+
 		return c.JSON(http.StatusInternalServerError, errResp("InternalFailure", err.Error()))
 	}
 }

--- a/services/fis/actions.go
+++ b/services/fis/actions.go
@@ -288,7 +288,8 @@ func parseOperations(s string) []string {
 // parseISODuration parses a subset of ISO 8601 duration strings (PTxHxMxS).
 // Returns 0 on empty or invalid input.
 //
-//nolint:cyclop,gocognit // ISO 8601 parsing inherently requires complex character-by-character logic
+// parseISODuration parses a subset of ISO 8601 duration strings (PTxHxMxS).
+// Returns 0 on empty or invalid input.
 func parseISODuration(s string) time.Duration {
 	if s == "" {
 		return 0
@@ -331,26 +332,32 @@ func parseISODuration(s string) time.Duration {
 				continue
 			}
 
-			switch ch {
-			case 'H':
-				total += time.Duration(val * float64(time.Hour))
-			case 'M':
-				if inTime {
-					total += time.Duration(val * float64(time.Minute))
-				} else {
-					// 'M' before 'T' means months — not representable as time.Duration;
-					// treat as 30 days for approximation.
-					total += time.Duration(val * daysPerMonth * float64(hoursPerDay*time.Hour))
-				}
-			case 'S':
-				total += time.Duration(val * float64(time.Second))
-			case 'D':
-				total += time.Duration(val * float64(hoursPerDay*time.Hour))
-			case 'W':
-				total += time.Duration(val * daysPerWeek * float64(hoursPerDay*time.Hour))
-			}
+			total += applyISOUnit(ch, val, inTime)
 		}
 	}
 
 	return total
+}
+
+// applyISOUnit converts an ISO 8601 duration unit character and value to a time.Duration.
+func applyISOUnit(ch rune, val float64, inTime bool) time.Duration {
+	switch ch {
+	case 'H':
+		return time.Duration(val * float64(time.Hour))
+	case 'M':
+		if inTime {
+			return time.Duration(val * float64(time.Minute))
+		}
+		// 'M' before 'T' means months — not representable as time.Duration;
+		// treat as 30 days for approximation.
+		return time.Duration(val * daysPerMonth * float64(hoursPerDay*time.Hour))
+	case 'S':
+		return time.Duration(val * float64(time.Second))
+	case 'D':
+		return time.Duration(val * float64(hoursPerDay*time.Hour))
+	case 'W':
+		return time.Duration(val * daysPerWeek * float64(hoursPerDay*time.Hour))
+	}
+
+	return 0
 }

--- a/services/fis/handler.go
+++ b/services/fis/handler.go
@@ -90,7 +90,10 @@ func NewHandler(backend StorageBackend) *Handler {
 // WithJanitor attaches a background janitor to the handler.
 // If the backend is not an *InMemoryBackend, this is a no-op.
 // The optional taskTimeout bounds each sweep; 0 means no per-task timeout.
-func (h *Handler) WithJanitor(interval, experimentTTL time.Duration, taskTimeout ...time.Duration) *Handler {
+func (h *Handler) WithJanitor(
+	interval, experimentTTL time.Duration,
+	taskTimeout ...time.Duration,
+) *Handler {
 	if mem, ok := h.Backend.(*InMemoryBackend); ok {
 		j := NewJanitor(mem, interval, experimentTTL)
 		if len(taskTimeout) > 0 {
@@ -238,7 +241,12 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		if err != nil {
 			log.ErrorContext(ctx, "fis: failed to read request body", "error", err)
 
-			return h.writeError(c, http.StatusInternalServerError, "failed to read request body", "")
+			return h.writeError(
+				c,
+				http.StatusInternalServerError,
+				"failed to read request body",
+				"",
+			)
 		}
 
 		log.DebugContext(ctx, "fis request", "op", op, "id", id)
@@ -248,62 +256,90 @@ func (h *Handler) Handler() echo.HandlerFunc {
 }
 
 // dispatch routes a parsed FIS operation to the appropriate backend call.
-//
-//nolint:cyclop // dispatch table has necessary branches for each operation
 func (h *Handler) dispatch(ctx context.Context, c *echo.Context, op, id string, body []byte) error {
 	if handled, err := h.dispatchTargetAccountOps(c, op, id, body); handled {
 		return err
 	}
 
-	switch op {
-	case opCreateExperimentTemplate:
-		return h.handleCreateExperimentTemplate(ctx, c, body)
-	case opGetExperimentTemplate:
-		return h.handleGetExperimentTemplate(c, id)
-	case opUpdateExperimentTemplate:
-		return h.handleUpdateExperimentTemplate(c, id, body)
-	case opDeleteExperimentTemplate:
-		return h.handleDeleteExperimentTemplate(c, id)
-	case opListExperimentTemplates:
-		return h.handleListExperimentTemplates(c)
-	case opStartExperiment:
-		return h.handleStartExperiment(ctx, c, body)
-	case opGetExperiment:
-		return h.handleGetExperiment(c, id)
-	case opStopExperiment:
-		return h.handleStopExperiment(c, id)
-	case opListExperiments:
-		return h.handleListExperiments(c)
-	case opListExperimentResolvedTargets:
-		return h.handleListExperimentResolvedTargets(c, id)
-	case opGetAction:
-		return h.handleGetAction(c, id)
-	case opListActions:
-		return h.handleListActions(c)
-	case opGetTargetResourceType:
-		rt, _ := url.PathUnescape(id)
+	if handled, err := h.dispatchExperimentOps(ctx, c, op, id, body); handled {
+		return err
+	}
 
-		return h.handleGetTargetResourceType(c, rt)
-	case opListTargetResourceTypes:
-		return h.handleListTargetResourceTypes(c)
-	case opTagResource:
-		return h.handleTagResource(c, id, body)
-	case opUntagResource:
-		return h.handleUntagResource(c, id, c.Request().URL.Query())
-	case opListTagsForResource:
-		return h.handleListTagsForResource(c, id)
-	case opGetSafetyLever:
-		return h.handleGetSafetyLever(c, id)
-	case opUpdateSafetyLeverState:
-		return h.handleUpdateSafetyLeverState(c, id, body)
+	if handled, err := h.dispatchActionTagOps(c, op, id, body); handled {
+		return err
 	}
 
 	return h.writeError(c, http.StatusNotFound, "unknown operation: "+op, "")
 }
 
+// dispatchExperimentOps handles experiment template and experiment operations.
+func (h *Handler) dispatchExperimentOps(
+	ctx context.Context,
+	c *echo.Context,
+	op, id string,
+	body []byte,
+) (bool, error) {
+	switch op {
+	case opCreateExperimentTemplate:
+		return true, h.handleCreateExperimentTemplate(ctx, c, body)
+	case opGetExperimentTemplate:
+		return true, h.handleGetExperimentTemplate(c, id)
+	case opUpdateExperimentTemplate:
+		return true, h.handleUpdateExperimentTemplate(c, id, body)
+	case opDeleteExperimentTemplate:
+		return true, h.handleDeleteExperimentTemplate(c, id)
+	case opListExperimentTemplates:
+		return true, h.handleListExperimentTemplates(c)
+	case opStartExperiment:
+		return true, h.handleStartExperiment(ctx, c, body)
+	case opGetExperiment:
+		return true, h.handleGetExperiment(c, id)
+	case opStopExperiment:
+		return true, h.handleStopExperiment(c, id)
+	case opListExperiments:
+		return true, h.handleListExperiments(c)
+	case opListExperimentResolvedTargets:
+		return true, h.handleListExperimentResolvedTargets(c, id)
+	}
+
+	return false, nil
+}
+
+// dispatchActionTagOps handles action, target resource type, tag, and safety lever operations.
+func (h *Handler) dispatchActionTagOps(c *echo.Context, op, id string, body []byte) (bool, error) {
+	switch op {
+	case opGetAction:
+		return true, h.handleGetAction(c, id)
+	case opListActions:
+		return true, h.handleListActions(c)
+	case opGetTargetResourceType:
+		rt, _ := url.PathUnescape(id)
+
+		return true, h.handleGetTargetResourceType(c, rt)
+	case opListTargetResourceTypes:
+		return true, h.handleListTargetResourceTypes(c)
+	case opTagResource:
+		return true, h.handleTagResource(c, id, body)
+	case opUntagResource:
+		return true, h.handleUntagResource(c, id, c.Request().URL.Query())
+	case opListTagsForResource:
+		return true, h.handleListTagsForResource(c, id)
+	case opGetSafetyLever:
+		return true, h.handleGetSafetyLever(c, id)
+	case opUpdateSafetyLeverState:
+		return true, h.handleUpdateSafetyLeverState(c, id, body)
+	}
+
+	return false, nil
+}
+
 // dispatchTargetAccountOps handles the target account configuration operations.
 // Returns (true, err) when the operation was handled, (false, nil) otherwise.
-func (h *Handler) dispatchTargetAccountOps(c *echo.Context, op, id string, body []byte) (bool, error) {
+func (h *Handler) dispatchTargetAccountOps(
+	c *echo.Context,
+	op, id string,
+	body []byte,
+) (bool, error) {
 	switch op {
 	case opCreateTargetAccountConfiguration:
 		return true, h.handleCreateTargetAccountConfiguration(c, id, body)
@@ -328,7 +364,11 @@ func (h *Handler) dispatchTargetAccountOps(c *echo.Context, op, id string, body 
 // ExperimentTemplate handlers
 // ----------------------------------------
 
-func (h *Handler) handleCreateExperimentTemplate(_ context.Context, c *echo.Context, body []byte) error {
+func (h *Handler) handleCreateExperimentTemplate(
+	_ context.Context,
+	c *echo.Context,
+	body []byte,
+) error {
 	var input createExperimentTemplateRequest
 	if err := json.Unmarshal(body, &input); err != nil {
 		return h.writeError(c, http.StatusBadRequest, "invalid request body: "+err.Error(), "")
@@ -621,15 +661,29 @@ func splitCompositeID(compositeID string) (string, string) {
 	return resourceID, accountID
 }
 
-func (h *Handler) handleCreateTargetAccountConfiguration(c *echo.Context, compositeID string, body []byte) error {
+func (h *Handler) handleCreateTargetAccountConfiguration(
+	c *echo.Context,
+	compositeID string,
+	body []byte,
+) error {
 	templateID, accountID := splitCompositeID(compositeID)
 
 	var input createTargetAccountConfigurationRequest
 	if err := json.Unmarshal(body, &input); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "invalid request body: "+err.Error(), compositeID)
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"invalid request body: "+err.Error(),
+			compositeID,
+		)
 	}
 
-	cfg, err := h.Backend.CreateTargetAccountConfiguration(templateID, accountID, input.RoleArn, input.Description)
+	cfg, err := h.Backend.CreateTargetAccountConfiguration(
+		templateID,
+		accountID,
+		input.RoleArn,
+		input.Description,
+	)
 	if err != nil {
 		return h.writeBackendError(c, err, compositeID)
 	}
@@ -639,7 +693,10 @@ func (h *Handler) handleCreateTargetAccountConfiguration(c *echo.Context, compos
 	})
 }
 
-func (h *Handler) handleDeleteTargetAccountConfiguration(c *echo.Context, compositeID string) error {
+func (h *Handler) handleDeleteTargetAccountConfiguration(
+	c *echo.Context,
+	compositeID string,
+) error {
 	templateID, accountID := splitCompositeID(compositeID)
 
 	cfg, err := h.Backend.DeleteTargetAccountConfiguration(templateID, accountID)
@@ -665,15 +722,29 @@ func (h *Handler) handleGetTargetAccountConfiguration(c *echo.Context, composite
 	})
 }
 
-func (h *Handler) handleUpdateTargetAccountConfiguration(c *echo.Context, compositeID string, body []byte) error {
+func (h *Handler) handleUpdateTargetAccountConfiguration(
+	c *echo.Context,
+	compositeID string,
+	body []byte,
+) error {
 	templateID, accountID := splitCompositeID(compositeID)
 
 	var input updateTargetAccountConfigurationRequest
 	if err := json.Unmarshal(body, &input); err != nil {
-		return h.writeError(c, http.StatusBadRequest, "invalid request body: "+err.Error(), compositeID)
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"invalid request body: "+err.Error(),
+			compositeID,
+		)
 	}
 
-	cfg, err := h.Backend.UpdateTargetAccountConfiguration(templateID, accountID, input.RoleArn, input.Description)
+	cfg, err := h.Backend.UpdateTargetAccountConfiguration(
+		templateID,
+		accountID,
+		input.RoleArn,
+		input.Description,
+	)
 	if err != nil {
 		return h.writeBackendError(c, err, compositeID)
 	}
@@ -699,7 +770,10 @@ func (h *Handler) handleListTargetAccountConfigurations(c *echo.Context, templat
 	})
 }
 
-func (h *Handler) handleGetExperimentTargetAccountConfiguration(c *echo.Context, compositeID string) error {
+func (h *Handler) handleGetExperimentTargetAccountConfiguration(
+	c *echo.Context,
+	compositeID string,
+) error {
 	experimentID, accountID := splitCompositeID(compositeID)
 
 	cfg, err := h.Backend.GetExperimentTargetAccountConfiguration(experimentID, accountID)
@@ -712,7 +786,10 @@ func (h *Handler) handleGetExperimentTargetAccountConfiguration(c *echo.Context,
 	})
 }
 
-func (h *Handler) handleListExperimentTargetAccountConfigurations(c *echo.Context, experimentID string) error {
+func (h *Handler) handleListExperimentTargetAccountConfigurations(
+	c *echo.Context,
+	experimentID string,
+) error {
 	cfgs, err := h.Backend.ListExperimentTargetAccountConfigurations(experimentID)
 	if err != nil {
 		return h.writeBackendError(c, err, experimentID)
@@ -769,8 +846,6 @@ func (h *Handler) writeBackendError(c *echo.Context, err error, id string) error
 
 // parseFISPath maps an HTTP method + URL path to a FIS operation name and optional resource ID.
 // Returns ("", "") when no pattern matches.
-//
-//nolint:cyclop,gocognit,gocyclo,funlen // routing table per HTTP method + resource
 func parseFISPath(method, path string) (string, string) {
 	segs := pathSegments(path)
 	if len(segs) == 0 {
@@ -782,102 +857,172 @@ func parseFISPath(method, path string) (string, string) {
 
 	switch root {
 	case pathExperimentTemplates:
-		switch {
-		case method == http.MethodPost && !hasID:
-			return opCreateExperimentTemplate, ""
-		case method == http.MethodGet && !hasID:
-			return opListExperimentTemplates, ""
-		// Must check 4-segment paths before 3-segment paths and generic 2-segment paths.
-		case len(segs) >= 4 && segs[2] == pathTargetAccountConfigurations:
-			// /experimentTemplates/{tplId}/targetAccountConfigurations/{accountId}
-			compositeID := segs[1] + "/" + segs[3]
-			switch method {
-			case http.MethodPost:
-				return opCreateTargetAccountConfiguration, compositeID
-			case http.MethodGet:
-				return opGetTargetAccountConfiguration, compositeID
-			case http.MethodPatch:
-				return opUpdateTargetAccountConfiguration, compositeID
-			case http.MethodDelete:
-				return opDeleteTargetAccountConfiguration, compositeID
-			}
-		case len(segs) >= 3 && segs[2] == pathTargetAccountConfigurations:
-			// /experimentTemplates/{tplId}/targetAccountConfigurations
-			if method == http.MethodGet {
-				return opListTargetAccountConfigurations, segs[1]
-			}
-		case method == http.MethodGet && hasID:
-			return opGetExperimentTemplate, segs[1]
-		case method == http.MethodPatch && hasID:
-			return opUpdateExperimentTemplate, segs[1]
-		case method == http.MethodDelete && hasID:
-			return opDeleteExperimentTemplate, segs[1]
-		}
-
+		return parseFISExperimentTemplatePath(method, segs, hasID)
 	case pathExperiments:
-		switch {
-		case method == http.MethodPost && !hasID:
-			return opStartExperiment, ""
-		case method == http.MethodGet && !hasID:
-			return opListExperiments, ""
-		// Must check 3+ segment paths before generic 2-segment GET.
-		case method == http.MethodGet && len(segs) >= 3 && segs[2] == subPathResolvedTargets:
-			return opListExperimentResolvedTargets, segs[1]
-		case len(segs) >= 4 && segs[2] == pathTargetAccountConfigurations:
-			// /experiments/{expId}/targetAccountConfigurations/{accountId}
-			if method == http.MethodGet {
-				return opGetExperimentTargetAccountConfiguration, segs[1] + "/" + segs[3]
-			}
-		case len(segs) >= 3 && segs[2] == pathTargetAccountConfigurations:
-			// /experiments/{expId}/targetAccountConfigurations
-			if method == http.MethodGet {
-				return opListExperimentTargetAccountConfigurations, segs[1]
-			}
-		case method == http.MethodGet && hasID:
-			return opGetExperiment, segs[1]
-		case method == http.MethodDelete && hasID:
-			return opStopExperiment, segs[1]
-		}
-
+		return parseFISExperimentPath(method, segs, hasID)
 	case pathActions:
-		switch {
-		case method == http.MethodGet && !hasID:
-			return opListActions, ""
-		case method == http.MethodGet && hasID:
-			return opGetAction, segs[1]
-		}
-
+		return parseFISActionPath(method, segs, hasID)
 	case pathTargetResourceTypes:
-		switch {
-		case method == http.MethodGet && !hasID:
-			return opListTargetResourceTypes, ""
-		case method == http.MethodGet && hasID:
-			// Resource type may be URL-encoded (e.g. aws%3Aec2%3Ainstance); the caller decodes.
-			return opGetTargetResourceType, segs[1]
-		}
-
+		return parseFISTargetResourceTypePath(method, segs, hasID)
 	case pathTags:
-		if hasID {
-			arnStr := strings.Join(segs[1:], "/")
-			switch method {
-			case http.MethodGet:
-				return opListTagsForResource, arnStr
-			case http.MethodPost:
-				return opTagResource, arnStr
-			case http.MethodDelete:
-				return opUntagResource, arnStr
-			}
+		return parseFISTagPath(method, segs, hasID)
+	case pathSafetyLevers:
+		return parseFISSafetyLeverPath(method, segs, hasID)
+	}
+
+	return "", ""
+}
+
+// parseFISExperimentTemplatePath routes experiment template paths.
+func parseFISExperimentTemplatePath(method string, segs []string, hasID bool) (string, string) {
+	if !hasID {
+		if method == http.MethodPost {
+			return opCreateExperimentTemplate, ""
+		}
+		if method == http.MethodGet {
+			return opListExperimentTemplates, ""
 		}
 
-	case pathSafetyLevers:
-		if hasID {
-			switch method {
-			case http.MethodGet:
-				return opGetSafetyLever, segs[1]
-			case http.MethodPatch:
-				return opUpdateSafetyLeverState, segs[1]
-			}
+		return "", ""
+	}
+
+	if op, id := parseFISTemplateSubPath(method, segs); op != "" {
+		return op, id
+	}
+
+	switch method {
+	case http.MethodGet:
+		return opGetExperimentTemplate, segs[1]
+	case http.MethodPatch:
+		return opUpdateExperimentTemplate, segs[1]
+	case http.MethodDelete:
+		return opDeleteExperimentTemplate, segs[1]
+	}
+
+	return "", ""
+}
+
+// parseFISTemplateSubPath routes sub-paths of experiment templates (target account configurations).
+func parseFISTemplateSubPath(method string, segs []string) (string, string) {
+	if len(segs) >= 4 && segs[2] == pathTargetAccountConfigurations {
+		compositeID := segs[1] + "/" + segs[3]
+		switch method {
+		case http.MethodPost:
+			return opCreateTargetAccountConfiguration, compositeID
+		case http.MethodGet:
+			return opGetTargetAccountConfiguration, compositeID
+		case http.MethodPatch:
+			return opUpdateTargetAccountConfiguration, compositeID
+		case http.MethodDelete:
+			return opDeleteTargetAccountConfiguration, compositeID
 		}
+	}
+
+	if len(segs) >= 3 && segs[2] == pathTargetAccountConfigurations && method == http.MethodGet {
+		return opListTargetAccountConfigurations, segs[1]
+	}
+
+	return "", ""
+}
+
+// parseFISExperimentPath routes experiment paths.
+func parseFISExperimentPath(method string, segs []string, hasID bool) (string, string) {
+	if !hasID {
+		if method == http.MethodPost {
+			return opStartExperiment, ""
+		}
+		if method == http.MethodGet {
+			return opListExperiments, ""
+		}
+
+		return "", ""
+	}
+
+	if op, id := parseFISExperimentSubPath(method, segs); op != "" {
+		return op, id
+	}
+
+	switch method {
+	case http.MethodGet:
+		return opGetExperiment, segs[1]
+	case http.MethodDelete:
+		return opStopExperiment, segs[1]
+	}
+
+	return "", ""
+}
+
+// parseFISExperimentSubPath routes sub-paths of experiments.
+func parseFISExperimentSubPath(method string, segs []string) (string, string) {
+	if method == http.MethodGet && len(segs) >= 3 && segs[2] == subPathResolvedTargets {
+		return opListExperimentResolvedTargets, segs[1]
+	}
+
+	if len(segs) >= 4 && segs[2] == pathTargetAccountConfigurations && method == http.MethodGet {
+		return opGetExperimentTargetAccountConfiguration, segs[1] + "/" + segs[3]
+	}
+
+	if len(segs) >= 3 && segs[2] == pathTargetAccountConfigurations && method == http.MethodGet {
+		return opListExperimentTargetAccountConfigurations, segs[1]
+	}
+
+	return "", ""
+}
+
+// parseFISActionPath routes action paths.
+func parseFISActionPath(method string, segs []string, hasID bool) (string, string) {
+	switch {
+	case method == http.MethodGet && !hasID:
+		return opListActions, ""
+	case method == http.MethodGet && hasID:
+		return opGetAction, segs[1]
+	}
+
+	return "", ""
+}
+
+// parseFISTargetResourceTypePath routes target resource type paths.
+func parseFISTargetResourceTypePath(method string, segs []string, hasID bool) (string, string) {
+	switch {
+	case method == http.MethodGet && !hasID:
+		return opListTargetResourceTypes, ""
+	case method == http.MethodGet && hasID:
+		return opGetTargetResourceType, segs[1]
+	}
+
+	return "", ""
+}
+
+// parseFISTagPath routes tag management paths.
+func parseFISTagPath(method string, segs []string, hasID bool) (string, string) {
+	if !hasID {
+		return "", ""
+	}
+
+	arnStr := strings.Join(segs[1:], "/")
+	switch method {
+	case http.MethodGet:
+		return opListTagsForResource, arnStr
+	case http.MethodPost:
+		return opTagResource, arnStr
+	case http.MethodDelete:
+		return opUntagResource, arnStr
+	}
+
+	return "", ""
+}
+
+// parseFISSafetyLeverPath routes safety lever paths.
+func parseFISSafetyLeverPath(method string, segs []string, hasID bool) (string, string) {
+	if !hasID {
+		return "", ""
+	}
+
+	switch method {
+	case http.MethodGet:
+		return opGetSafetyLever, segs[1]
+	case http.MethodPatch:
+		return opUpdateSafetyLeverState, segs[1]
 	}
 
 	return "", ""
@@ -1006,14 +1151,20 @@ func toExperimentDTO(exp *Experiment) experimentDTO {
 		Arn:                  exp.Arn,
 		ExperimentTemplateID: exp.ExperimentTemplateID,
 		RoleArn:              exp.RoleArn,
-		Status:               experimentStatusDTO{Status: exp.Status.Status, Reason: exp.Status.Reason},
-		State:                experimentStatusDTO{Status: exp.Status.Status, Reason: exp.Status.Reason},
-		Targets:              targets,
-		Actions:              actions,
-		StopConditions:       stopConditions,
-		Tags:                 exp.Tags,
-		StartTime:            toUnix(exp.StartTime),
-		EndTime:              toUnixPtr(exp.EndTime),
+		Status: experimentStatusDTO{
+			Status: exp.Status.Status,
+			Reason: exp.Status.Reason,
+		},
+		State: experimentStatusDTO{
+			Status: exp.Status.Status,
+			Reason: exp.Status.Reason,
+		},
+		Targets:        targets,
+		Actions:        actions,
+		StopConditions: stopConditions,
+		Tags:           exp.Tags,
+		StartTime:      toUnix(exp.StartTime),
+		EndTime:        toUnixPtr(exp.EndTime),
 	}
 
 	if exp.LogConfiguration != nil {

--- a/services/iam/conditions.go
+++ b/services/iam/conditions.go
@@ -50,6 +50,7 @@ func evalOperator(operator string, keyValues map[string]any, ctx ConditionContex
 func conditionValues(v any) []string {
 	switch val := v.(type) {
 	case string:
+
 		return []string{val}
 	case []any:
 		out := make([]string, 0, len(val))
@@ -72,10 +73,13 @@ func resolveContextKey(key string, ctx ConditionContext) string {
 
 	switch lower {
 	case "aws:sourceip":
+
 		return ctx.SourceIP
 	case "aws:username":
+
 		return ctx.Username
 	case "aws:userid":
+
 		return ctx.UserID
 	default:
 		if ctx.Extra != nil {
@@ -91,8 +95,6 @@ func resolveContextKey(key string, ctx ConditionContext) string {
 // evalSingleCondition evaluates one condition key against the resolved context
 // value and the required condition values, using the given IAM operator.
 // Returns true if the condition is satisfied.
-//
-//nolint:cyclop // operator dispatch is inherently branchy
 func evalSingleCondition(operator, ctxVal string, condVals []string) bool {
 	// IfExists suffix: if the key is missing (empty), condition is always true.
 	baseOp, ifExists := strings.CutSuffix(operator, "ifexists")
@@ -105,47 +107,81 @@ func evalSingleCondition(operator, ctxVal string, condVals []string) bool {
 		baseOp = operator
 	}
 
+	if result, ok := evalStringCondition(baseOp, ctxVal, condVals); ok {
+		return result
+	}
+	if result, ok := evalIPARNCondition(baseOp, ctxVal, condVals); ok {
+		return result
+	}
+	// Unknown operator — treat as not matching (conservative default).
+	return false
+}
+
+// evalStringCondition handles string and bool/null condition operators.
+func evalStringCondition(baseOp, ctxVal string, condVals []string) (bool, bool) {
 	switch baseOp {
 	case "stringequals":
-		return anyStringEquals(ctxVal, condVals)
+
+		return anyStringEquals(ctxVal, condVals), true
 	case "stringnotequals":
-		return !anyStringEquals(ctxVal, condVals)
+
+		return !anyStringEquals(ctxVal, condVals), true
 	case "stringequalsignorecase":
-		return anyStringEquals(strings.ToLower(ctxVal), toLower(condVals))
+
+		return anyStringEquals(strings.ToLower(ctxVal), toLower(condVals)), true
 	case "stringnotequalsignorecase":
-		return !anyStringEquals(strings.ToLower(ctxVal), toLower(condVals))
+
+		return !anyStringEquals(strings.ToLower(ctxVal), toLower(condVals)), true
 	case "stringlike":
-		return anyStringLike(ctxVal, condVals)
+
+		return anyStringLike(ctxVal, condVals), true
 	case "stringnotlike":
-		return !anyStringLike(ctxVal, condVals)
-	case "ipaddress":
-		return anyIPMatch(ctxVal, condVals)
-	case "notipaddress":
-		return !anyIPMatch(ctxVal, condVals)
-	case "arnequals", "arnlike":
-		return anyStringLike(strings.ToLower(ctxVal), toLower(condVals))
-	case "arnnotequals", "arnnotlike":
-		return !anyStringLike(strings.ToLower(ctxVal), toLower(condVals))
+
+		return !anyStringLike(ctxVal, condVals), true
 	case "bool":
-		return anyStringEquals(strings.ToLower(ctxVal), toLower(condVals))
+
+		return anyStringEquals(strings.ToLower(ctxVal), toLower(condVals)), true
 	case "null":
-		// Condition value is "true" (key must be absent) or "false" (key must be present).
-		isNull := ctxVal == ""
-		for _, v := range condVals {
-			if strings.EqualFold(v, "true") && isNull {
-				return true
-			}
 
-			if strings.EqualFold(v, "false") && !isNull {
-				return true
-			}
-		}
-
-		return false
-	default:
-		// Unknown operator — treat as not matching (conservative default).
-		return false
+		return evalNullCondition(ctxVal, condVals), true
 	}
+
+	return false, false
+}
+
+// evalNullCondition evaluates the "null" IAM condition operator.
+func evalNullCondition(ctxVal string, condVals []string) bool {
+	isNull := ctxVal == ""
+	for _, v := range condVals {
+		if strings.EqualFold(v, "true") && isNull {
+			return true
+		}
+		if strings.EqualFold(v, "false") && !isNull {
+			return true
+		}
+	}
+
+	return false
+}
+
+// evalIPARNCondition handles IP address and ARN condition operators.
+func evalIPARNCondition(baseOp, ctxVal string, condVals []string) (bool, bool) {
+	switch baseOp {
+	case "ipaddress":
+
+		return anyIPMatch(ctxVal, condVals), true
+	case "notipaddress":
+
+		return !anyIPMatch(ctxVal, condVals), true
+	case "arnequals", "arnlike":
+
+		return anyStringLike(strings.ToLower(ctxVal), toLower(condVals)), true
+	case "arnnotequals", "arnnotlike":
+
+		return !anyStringLike(strings.ToLower(ctxVal), toLower(condVals)), true
+	}
+
+	return false, false
 }
 
 // anyStringEquals returns true if ctxVal equals any value in condVals.

--- a/services/identitystore/handler.go
+++ b/services/identitystore/handler.go
@@ -304,56 +304,101 @@ type deleteGroupRequest struct {
 // Dispatch
 // ----------------------------------------
 
-//nolint:cyclop // dispatch table has necessary branches for each operation
+// dispatch routes to the appropriate handler based on the operation name.
 func (h *Handler) dispatch(c *echo.Context, op string, body []byte) error {
-	switch op {
-	// User operations
-	case "CreateUser":
-		return h.handleCreateUser(c, body)
-	case "DescribeUser":
-		return h.handleDescribeUser(c, body)
-	case "ListUsers":
-		return h.handleListUsers(c, body)
-	case "UpdateUser":
-		return h.handleUpdateUser(c, body)
-	case "DeleteUser":
-		return h.handleDeleteUser(c, body)
-	case "GetUserId":
-		return h.handleGetUserID(c, body)
-
-	// Group operations
-	case "CreateGroup":
-		return h.handleCreateGroup(c, body)
-	case "DescribeGroup":
-		return h.handleDescribeGroup(c, body)
-	case "ListGroups":
-		return h.handleListGroups(c, body)
-	case "UpdateGroup":
-		return h.handleUpdateGroup(c, body)
-	case "DeleteGroup":
-		return h.handleDeleteGroup(c, body)
-	case "GetGroupId":
-		return h.handleGetGroupID(c, body)
-
-	// Membership operations
-	case "CreateGroupMembership":
-		return h.handleCreateGroupMembership(c, body)
-	case "DescribeGroupMembership":
-		return h.handleDescribeGroupMembership(c, body)
-	case "ListGroupMemberships":
-		return h.handleListGroupMemberships(c, body)
-	case "DeleteGroupMembership":
-		return h.handleDeleteGroupMembership(c, body)
-	case "GetGroupMembershipId":
-		return h.handleGetGroupMembershipID(c, body)
-	case "ListGroupMembershipsForMember":
-		return h.handleListGroupMembershipsForMember(c, body)
-	case isMemberInGroupsOp:
-		return h.handleIsMemberInGroups(c, body)
+	if ok, err := h.dispatchUserOps(c, op, body); ok {
+		return err
+	}
+	if ok, err := h.dispatchGroupOps(c, op, body); ok {
+		return err
+	}
+	if ok, err := h.dispatchMembershipOps(c, op, body); ok {
+		return err
 	}
 
 	return h.writeError(c, http.StatusBadRequest, "UnrecognizedClientException",
 		"operation "+op+" is not supported")
+}
+
+// dispatchUserOps handles user operations.
+func (h *Handler) dispatchUserOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "CreateUser":
+
+		return true, h.handleCreateUser(c, body)
+	case "DescribeUser":
+
+		return true, h.handleDescribeUser(c, body)
+	case "ListUsers":
+
+		return true, h.handleListUsers(c, body)
+	case "UpdateUser":
+
+		return true, h.handleUpdateUser(c, body)
+	case "DeleteUser":
+
+		return true, h.handleDeleteUser(c, body)
+	case "GetUserId":
+
+		return true, h.handleGetUserID(c, body)
+	}
+
+	return false, nil
+}
+
+// dispatchGroupOps handles group operations.
+func (h *Handler) dispatchGroupOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "CreateGroup":
+
+		return true, h.handleCreateGroup(c, body)
+	case "DescribeGroup":
+
+		return true, h.handleDescribeGroup(c, body)
+	case "ListGroups":
+
+		return true, h.handleListGroups(c, body)
+	case "UpdateGroup":
+
+		return true, h.handleUpdateGroup(c, body)
+	case "DeleteGroup":
+
+		return true, h.handleDeleteGroup(c, body)
+	case "GetGroupId":
+
+		return true, h.handleGetGroupID(c, body)
+	}
+
+	return false, nil
+}
+
+// dispatchMembershipOps handles group membership operations.
+func (h *Handler) dispatchMembershipOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "CreateGroupMembership":
+
+		return true, h.handleCreateGroupMembership(c, body)
+	case "DescribeGroupMembership":
+
+		return true, h.handleDescribeGroupMembership(c, body)
+	case "ListGroupMemberships":
+
+		return true, h.handleListGroupMemberships(c, body)
+	case "DeleteGroupMembership":
+
+		return true, h.handleDeleteGroupMembership(c, body)
+	case "GetGroupMembershipId":
+
+		return true, h.handleGetGroupMembershipID(c, body)
+	case "ListGroupMembershipsForMember":
+
+		return true, h.handleListGroupMembershipsForMember(c, body)
+	case isMemberInGroupsOp:
+
+		return true, h.handleIsMemberInGroups(c, body)
+	}
+
+	return false, nil
 }
 
 // ----------------------------------------
@@ -835,14 +880,19 @@ func (h *Handler) handleIsMemberInGroups(c *echo.Context, body []byte) error {
 func (h *Handler) handleBackendError(c *echo.Context, err error) error {
 	switch {
 	case errors.Is(err, ErrUserNotFound):
+
 		return h.writeResourceError(c, "ResourceNotFoundException", err.Error(), "USER")
 	case errors.Is(err, ErrGroupNotFound):
+
 		return h.writeResourceError(c, "ResourceNotFoundException", err.Error(), "GROUP")
 	case errors.Is(err, ErrMembershipNotFound):
+
 		return h.writeResourceError(c, "ResourceNotFoundException", err.Error(), "GROUP_MEMBERSHIP")
 	case errors.Is(err, ErrConflict):
+
 		return h.writeError(c, http.StatusConflict, "ConflictException", err.Error())
 	case errors.Is(err, ErrValidation):
+
 		return h.writeError(c, http.StatusBadRequest, "ValidationException", err.Error())
 	}
 

--- a/services/iotwireless/handler.go
+++ b/services/iotwireless/handler.go
@@ -435,10 +435,17 @@ func parseIoTWirelessPath(method, path string) (string, string) {
 	return parseIoTWirelessBase(method, base, id, subPath, hasID)
 }
 
-// parseIoTWirelessBase routes path segments to their operation names.
-//
-//nolint:cyclop,gocognit,gocyclo,funlen // routes across many resource types
+// parseIoTWirelessBase dispatches path parsing based on the first path segment.
 func parseIoTWirelessBase(method, base, id, subPath string, hasID bool) (string, string) {
+	if op, resource := parseIoTWirelessCoreGroup(method, base, id, subPath, hasID); op != "" {
+		return op, resource
+	}
+
+	return parseIoTWirelessExtGroup(method, base, id, hasID)
+}
+
+// parseIoTWirelessCoreGroup handles core resource path segments.
+func parseIoTWirelessCoreGroup(method, base, id, subPath string, hasID bool) (string, string) {
 	switch base {
 	case pathBaseWirelessDevices:
 		return parseWirelessDevicePath(method, id, subPath, hasID)
@@ -464,28 +471,32 @@ func parseIoTWirelessBase(method, base, id, subPath string, hasID bool) (string,
 		return parseEventConfigsPath(method, id, hasID)
 	case pathBaseLogLevels:
 		return parseLogLevelsPath(method, id, hasID)
-	case pathBaseMetricConfiguration:
-		if method == http.MethodGet {
-			return opGetMetricConfiguration, ""
-		}
+	}
 
-		if method == http.MethodPut {
-			return opUpdateMetricConfiguration, ""
-		}
+	return "", ""
+}
+
+// parseIoTWirelessExtGroup handles extended path segments (metrics, position, tasks, etc.).
+// parseIoTWirelessExtGroup handles extended path segments (metrics, position, tasks, etc.).
+func parseIoTWirelessExtGroup(method, base, id string, hasID bool) (string, string) {
+	if op, res := parseIoTWirelessMetricsAndPosition(method, base, id, hasID); op != "" {
+		return op, res
+	}
+
+	return parseIoTWirelessTasksAndImport(method, base, id, hasID)
+}
+
+// parseIoTWirelessMetricsAndPosition handles metrics and position paths.
+func parseIoTWirelessMetricsAndPosition(method, base, id string, hasID bool) (string, string) {
+	switch base {
+	case pathBaseMetricConfiguration:
+		return parseMetricConfigPath(method)
 	case pathBaseMetrics:
 		if method == http.MethodPost {
 			return opGetMetrics, ""
 		}
 	case pathBasePositions:
-		if hasID {
-			if method == http.MethodGet {
-				return opGetPosition, id
-			}
-
-			if method == http.MethodPut {
-				return opUpdatePosition, id
-			}
-		}
+		return parsePositionsPath(method, id, hasID)
 	case pathBasePositionConfigurations:
 		return parsePositionConfigPath(method, id, hasID)
 	case pathBasePositionEstimate:
@@ -493,15 +504,15 @@ func parseIoTWirelessBase(method, base, id, subPath string, hasID bool) (string,
 			return opGetPositionEstimate, ""
 		}
 	case pathBaseResourcePositions:
-		if hasID {
-			if method == http.MethodGet {
-				return opGetResourcePosition, id
-			}
+		return parseResourcePositionsPath(method, id, hasID)
+	}
 
-			if method == http.MethodPut {
-				return opUpdateResourcePosition, id
-			}
-		}
+	return "", ""
+}
+
+// parseIoTWirelessTasksAndImport handles gateway task definitions, import tasks, and service endpoint.
+func parseIoTWirelessTasksAndImport(method, base, id string, hasID bool) (string, string) {
+	switch base {
 	case pathBaseWirelessGatewayTaskDefs:
 		return parseGatewayTaskDefPath(method, id, hasID)
 	case pathBaseWirelessDeviceImportTask:
@@ -518,6 +529,50 @@ func parseIoTWirelessBase(method, base, id, subPath string, hasID bool) (string,
 		if method == http.MethodGet {
 			return opGetServiceEndpoint, ""
 		}
+	}
+
+	return "", ""
+}
+
+// parseMetricConfigPath routes metric configuration paths.
+func parseMetricConfigPath(method string) (string, string) {
+	switch method {
+	case http.MethodGet:
+		return opGetMetricConfiguration, ""
+	case http.MethodPut:
+		return opUpdateMetricConfiguration, ""
+	}
+
+	return "", ""
+}
+
+// parsePositionsPath routes positions paths.
+func parsePositionsPath(method, id string, hasID bool) (string, string) {
+	if !hasID {
+		return "", ""
+	}
+
+	switch method {
+	case http.MethodGet:
+		return opGetPosition, id
+	case http.MethodPut:
+		return opUpdatePosition, id
+	}
+
+	return "", ""
+}
+
+// parseResourcePositionsPath routes resource positions paths.
+func parseResourcePositionsPath(method, id string, hasID bool) (string, string) {
+	if !hasID {
+		return "", ""
+	}
+
+	switch method {
+	case http.MethodGet:
+		return opGetResourcePosition, id
+	case http.MethodPut:
+		return opUpdateResourcePosition, id
 	}
 
 	return "", ""
@@ -725,140 +780,180 @@ func parseImportTaskPath(method, id string, hasID bool) (string, string) {
 }
 
 // parseWirelessDevicePath handles wireless-devices sub-path routing.
-//
-//nolint:cyclop,gocognit,nestif // routes across several sub-paths
 func parseWirelessDevicePath(method, id, subPath string, hasID bool) (string, string) {
 	if hasID {
-		switch subPath {
-		case "thing":
-			if method == http.MethodPut {
-				return opAssociateWirelessDeviceWithThing, id
-			}
-
-			if method == http.MethodDelete {
-				return opDisassociateWirelessDeviceFromThing, id
-			}
-		case "statistics":
-			if method == http.MethodGet {
-				return opGetWirelessDeviceStatistics, id
-			}
-		case "data":
-			if method == http.MethodPost {
-				return opSendDataToWirelessDevice, id
-			}
-
-			if method == http.MethodDelete {
-				return opDeleteQueuedMessages, id
-			}
-
-			if method == http.MethodGet {
-				return opListQueuedMessages, id
-			}
-		case "test":
-			if method == http.MethodPost {
-				return opTestWirelessDevice, id
-			}
-		case "deregister":
-			if method == http.MethodPatch {
-				return opDeregisterWirelessDevice, id
-			}
-		case "":
-			if method == http.MethodPatch {
-				return opUpdateWirelessDevice, id
-			}
+		if op := parseWirelessDeviceSubPath(method, subPath); op != "" {
+			return op, id
 		}
 	}
 
 	return parseCollectionPath(method, "WirelessDevice", hasID, id)
 }
 
+// parseWirelessDeviceSubPath routes sub-paths of a wireless device resource.
+func parseWirelessDeviceSubPath(method, subPath string) string {
+	switch subPath {
+	case "thing":
+		switch method {
+		case http.MethodPut:
+			return opAssociateWirelessDeviceWithThing
+		case http.MethodDelete:
+			return opDisassociateWirelessDeviceFromThing
+		}
+	case "statistics":
+		if method == http.MethodGet {
+			return opGetWirelessDeviceStatistics
+		}
+	case "data":
+		return parseWirelessDeviceDataPath(method)
+	case "test":
+		if method == http.MethodPost {
+			return opTestWirelessDevice
+		}
+	case "deregister":
+		if method == http.MethodPatch {
+			return opDeregisterWirelessDevice
+		}
+	case "":
+		if method == http.MethodPatch {
+			return opUpdateWirelessDevice
+		}
+	}
+
+	return ""
+}
+
+// parseWirelessDeviceDataPath routes data-related paths for a wireless device.
+func parseWirelessDeviceDataPath(method string) string {
+	switch method {
+	case http.MethodPost:
+		return opSendDataToWirelessDevice
+	case http.MethodDelete:
+		return opDeleteQueuedMessages
+	case http.MethodGet:
+		return opListQueuedMessages
+	}
+
+	return ""
+}
+
 // parseWirelessGatewayPath handles wireless-gateways sub-path routing.
 //
-//nolint:cyclop,gocognit,nestif // routes across several sub-paths
+// parseWirelessGatewayPath handles wireless-gateways sub-path routing.
 func parseWirelessGatewayPath(method, id, subPath string, hasID bool) (string, string) {
 	if hasID {
-		switch subPath {
-		case "certificate":
-			if method == http.MethodPut {
-				return opAssociateWirelessGatewayWithCertificate, id
-			}
-
-			if method == http.MethodGet {
-				return opGetWirelessGatewayCertificate, id
-			}
-
-			if method == http.MethodDelete {
-				return opDisassociateWirelessGatewayFromCertificate, id
-			}
-		case "thing":
-			if method == http.MethodPut {
-				return opAssociateWirelessGatewayWithThing, id
-			}
-
-			if method == http.MethodDelete {
-				return opDisassociateWirelessGatewayFromThing, id
-			}
-		case "firmware-information":
-			if method == http.MethodGet {
-				return opGetWirelessGatewayFirmwareInformation, id
-			}
-		case "statistics":
-			if method == http.MethodGet {
-				return opGetWirelessGatewayStatistics, id
-			}
-		case "tasks":
-			if method == http.MethodPost {
-				return opCreateWirelessGatewayTask, id
-			}
-
-			if method == http.MethodGet {
-				return opGetWirelessGatewayTask, id
-			}
-
-			if method == http.MethodDelete {
-				return opDeleteWirelessGatewayTask, id
-			}
-		case "":
-			if method == http.MethodPatch {
-				return opUpdateWirelessGateway, id
-			}
+		if op := parseWirelessGatewaySubPath(method, subPath); op != "" {
+			return op, id
 		}
 	}
 
 	return parseCollectionPath(method, "WirelessGateway", hasID, id)
 }
 
-// parseFuotaTaskPath handles fuota-tasks sub-path routing.
-//
-//nolint:cyclop // routes across several sub-paths
-func parseFuotaTaskPath(method, id, subPath string, hasID bool) (string, string) {
-	if hasID {
-		switch {
-		case subPath == pathBaseMulticastGroups && method == http.MethodPut:
-			// PUT /fuota-tasks/{id}/multicast-groups → associate
-			return opAssociateMulticastGroupWithFuotaTask, id
-		case subPath == pathBaseMulticastGroups && method == http.MethodGet:
-			// GET /fuota-tasks/{id}/multicast-groups → list
-			return opListMulticastGroupsByFuotaTask, id
-		case strings.HasPrefix(subPath, "multicast-groups/") && method == http.MethodDelete:
-			return opDisassociateMulticastGroupFromFuotaTask, id
-		case subPath == pathBaseWirelessDevices && method == http.MethodPut:
-			return opAssociateWirelessDeviceWithFuotaTask, id
-		case strings.HasPrefix(subPath, "wireless-devices/") && method == http.MethodDelete:
-			return opDisassociateWirelessDeviceFromFuotaTask, id
-		case subPath == "" && method == http.MethodPut:
-			return opStartFuotaTask, id
-		case subPath == "" && method == http.MethodPatch:
-			return opUpdateFuotaTask, id
+// parseWirelessGatewaySubPath routes sub-paths of a wireless gateway resource.
+func parseWirelessGatewaySubPath(method, subPath string) string {
+	switch subPath {
+	case "certificate":
+		return parseGatewayCertPath(method)
+	case "thing":
+		return parseGatewayThingPath(method)
+	case "firmware-information":
+		if method == http.MethodGet {
+			return opGetWirelessGatewayFirmwareInformation
 		}
+	case "statistics":
+		if method == http.MethodGet {
+			return opGetWirelessGatewayStatistics
+		}
+	case "tasks":
+		return parseGatewayTasksPath(method)
+	case "":
+		if method == http.MethodPatch {
+			return opUpdateWirelessGateway
+		}
+	}
+
+	return ""
+}
+
+// parseGatewayCertPath routes gateway certificate paths.
+func parseGatewayCertPath(method string) string {
+	switch method {
+	case http.MethodPut:
+		return opAssociateWirelessGatewayWithCertificate
+	case http.MethodGet:
+		return opGetWirelessGatewayCertificate
+	case http.MethodDelete:
+		return opDisassociateWirelessGatewayFromCertificate
+	}
+
+	return ""
+}
+
+// parseGatewayThingPath routes gateway thing paths.
+func parseGatewayThingPath(method string) string {
+	switch method {
+	case http.MethodPut:
+		return opAssociateWirelessGatewayWithThing
+	case http.MethodDelete:
+		return opDisassociateWirelessGatewayFromThing
+	}
+
+	return ""
+}
+
+// parseGatewayTasksPath routes gateway tasks paths.
+func parseGatewayTasksPath(method string) string {
+	switch method {
+	case http.MethodPost:
+		return opCreateWirelessGatewayTask
+	case http.MethodGet:
+		return opGetWirelessGatewayTask
+	case http.MethodDelete:
+		return opDeleteWirelessGatewayTask
+	}
+
+	return ""
+}
+
+// parseFuotaTaskPath handles fuota-tasks sub-path routing.
+func parseFuotaTaskPath(method, id, subPath string, hasID bool) (string, string) {
+	if !hasID {
+		return parseCollectionPath(method, "FuotaTask", hasID, id)
+	}
+
+	if op := parseFuotaTaskSubPath(method, id, subPath); op != "" {
+		return op, id
 	}
 
 	return parseCollectionPath(method, "FuotaTask", hasID, id)
 }
 
+// parseFuotaTaskSubPath routes sub-paths of a FUOTA task resource.
+func parseFuotaTaskSubPath(method, id, subPath string) string {
+	switch {
+	case subPath == pathBaseMulticastGroups && method == http.MethodPut:
+		return opAssociateMulticastGroupWithFuotaTask
+	case subPath == pathBaseMulticastGroups && method == http.MethodGet:
+		return opListMulticastGroupsByFuotaTask
+	case strings.HasPrefix(subPath, "multicast-groups/") && method == http.MethodDelete:
+		return opDisassociateMulticastGroupFromFuotaTask
+	case subPath == pathBaseWirelessDevices && method == http.MethodPut:
+		return opAssociateWirelessDeviceWithFuotaTask
+	case strings.HasPrefix(subPath, "wireless-devices/") && method == http.MethodDelete:
+		return opDisassociateWirelessDeviceFromFuotaTask
+	case subPath == "" && method == http.MethodPut:
+		return opStartFuotaTask
+	case subPath == "" && method == http.MethodPatch:
+		return opUpdateFuotaTask
+	}
+
+	_ = id // suppress unused warning
+
+	return ""
+}
+
 // parseMulticastGroupPath handles multicast-groups sub-path routing.
-//
-//nolint:cyclop // routes across several sub-paths
 func parseMulticastGroupPath(method, id, subPath string, hasID bool) (string, string) {
 	if !hasID {
 		switch method {
@@ -871,32 +966,64 @@ func parseMulticastGroupPath(method, id, subPath string, hasID bool) (string, st
 		return "", ""
 	}
 
-	switch {
-	case subPath == pathBaseWirelessDevices && method == http.MethodPut:
-		return opAssociateWirelessDeviceWithMulticastGroup, id
-	case strings.HasPrefix(subPath, "wireless-devices/") && method == http.MethodDelete:
-		return opDisassociateWirelessDeviceFromMulticastGroup, id
-	case subPath == pathSubSession && method == http.MethodDelete:
-		return opCancelMulticastGroupSession, id
-	case subPath == pathSubSession && method == http.MethodPut:
-		return opStartMulticastGroupSession, id
-	case subPath == pathSubSession && method == http.MethodGet:
-		return opGetMulticastGroupSession, id
-	case subPath == "data" && method == http.MethodPost:
-		return opSendDataToMulticastGroup, id
-	case subPath == "bulk" && method == http.MethodPatch:
-		return opStartBulkAssociateWirelessDeviceWithMulticastGroup, id
-	case subPath == "bulk" && method == http.MethodPost:
-		return opStartBulkDisassociateWirelessDeviceFromMulticastGroup, id
-	case subPath == "" && method == http.MethodGet:
-		return opGetMulticastGroup, id
-	case subPath == "" && method == http.MethodDelete:
-		return opDeleteMulticastGroup, id
-	case subPath == "" && method == http.MethodPatch:
-		return opUpdateMulticastGroup, id
+	if op := parseMulticastGroupSubPath(method, subPath); op != "" {
+		return op, id
+	}
+
+	// Use parseCollectionPath for default CRUD on the resource itself.
+	if subPath == "" {
+		switch method {
+		case http.MethodGet:
+			return opGetMulticastGroup, id
+		case http.MethodDelete:
+			return opDeleteMulticastGroup, id
+		case http.MethodPatch:
+			return opUpdateMulticastGroup, id
+		}
 	}
 
 	return "", ""
+}
+
+// parseMulticastGroupSubPath routes sub-paths of a multicast group resource.
+func parseMulticastGroupSubPath(method, subPath string) string {
+	if op := parseMulticastWirelessDeviceSubPath(method, subPath); op != "" {
+		return op
+	}
+
+	return parseMulticastSessionBulkSubPath(method, subPath)
+}
+
+// parseMulticastWirelessDeviceSubPath routes wireless device association sub-paths.
+func parseMulticastWirelessDeviceSubPath(method, subPath string) string {
+	switch {
+	case subPath == pathBaseWirelessDevices && method == http.MethodPut:
+		return opAssociateWirelessDeviceWithMulticastGroup
+	case strings.HasPrefix(subPath, "wireless-devices/") && method == http.MethodDelete:
+		return opDisassociateWirelessDeviceFromMulticastGroup
+	case subPath == "data" && method == http.MethodPost:
+		return opSendDataToMulticastGroup
+	}
+
+	return ""
+}
+
+// parseMulticastSessionBulkSubPath routes session and bulk operation sub-paths.
+func parseMulticastSessionBulkSubPath(method, subPath string) string {
+	switch {
+	case subPath == pathSubSession && method == http.MethodDelete:
+		return opCancelMulticastGroupSession
+	case subPath == pathSubSession && method == http.MethodPut:
+		return opStartMulticastGroupSession
+	case subPath == pathSubSession && method == http.MethodGet:
+		return opGetMulticastGroupSession
+	case subPath == "bulk" && method == http.MethodPatch:
+		return opStartBulkAssociateWirelessDeviceWithMulticastGroup
+	case subPath == "bulk" && method == http.MethodPost:
+		return opStartBulkDisassociateWirelessDeviceFromMulticastGroup
+	}
+
+	return ""
 }
 
 // parseCollectionPath handles standard CRUD routing for a resource collection.
@@ -923,73 +1050,97 @@ func parseCollectionPath(method, resourceType string, hasID bool, id string) (st
 }
 
 // dispatch routes to the appropriate handler based on the operation name.
-//
-//nolint:cyclop // routes across many resource types
 func (h *Handler) dispatch(c *echo.Context, op, resource string, body []byte, query url.Values) error {
-	if handled, result := h.dispatchWirelessDevice(c, op, resource, body); handled {
+	if handled, result := h.dispatchCoreOps(c, op, resource, body); handled {
 		return result
 	}
 
-	if handled, result := h.dispatchWirelessGateway(c, op, resource, body); handled {
+	if handled, result := h.dispatchTagOps(c, op, resource, body, query); handled {
 		return result
-	}
-
-	if handled, result := h.dispatchServiceProfile(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchDestination(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchNewOps(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchMulticastOps(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchNetworkAnalyzerOps(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchMetricsAndLogOps(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchPositionOps(c, op, resource); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchGatewayTaskOps(c, op, resource, body); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchImportTaskOps(c, op, resource); handled {
-		return result
-	}
-
-	if handled, result := h.dispatchPartnerAndMiscOps(c, op, resource, body); handled {
-		return result
-	}
-
-	switch op {
-	case opListTagsForResource:
-		return h.listTagsForResource(c, resource)
-	case opTagResource:
-		return h.tagResource(c, resource, body)
-	case opUntagResource:
-		return h.untagResource(c, resource, query)
 	}
 
 	return writeError(c, http.StatusNotFound, "unknown operation")
 }
 
+// dispatchCoreOps routes all non-tag operations.
+func (h *Handler) dispatchCoreOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if handled, result := h.dispatchWirelessDevice(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchWirelessGateway(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchServiceProfile(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchDestination(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchNewOps(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchMulticastOps(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchNetworkAnalyzerOps(c, op, resource, body); handled {
+		return true, result
+	}
+
+	return h.dispatchExtendedOpsGroup(c, op, resource, body)
+}
+
+// dispatchExtendedOpsGroup routes metrics, position, gateway task, import task, and partner ops.
+func (h *Handler) dispatchExtendedOpsGroup(c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if handled, result := h.dispatchMetricsAndLogOps(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchPositionOps(c, op, resource); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchGatewayTaskOps(c, op, resource, body); handled {
+		return true, result
+	}
+
+	if handled, result := h.dispatchImportTaskOps(c, op, resource); handled {
+		return true, result
+	}
+
+	return h.dispatchPartnerAndMiscOps(c, op, resource, body)
+}
+
+// dispatchTagOps handles resource tagging operations.
+func (h *Handler) dispatchTagOps(c *echo.Context, op, resource string, body []byte, query url.Values) (bool, error) {
+	switch op {
+	case opListTagsForResource:
+		return true, h.listTagsForResource(c, resource)
+	case opTagResource:
+		return true, h.tagResource(c, resource, body)
+	case opUntagResource:
+		return true, h.untagResource(c, resource, query)
+	}
+
+	return false, nil
+}
+
 // dispatchMulticastOps handles multicast group operations.
-//
-//nolint:cyclop // routes across many resource types
-func (h *Handler) dispatchMulticastOps(c *echo.Context, op, resource string, _ []byte) (bool, error) {
+func (h *Handler) dispatchMulticastOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if handled, result := h.dispatchMulticastGroupCRUDOps(c, op, resource); handled {
+		return true, result
+	}
+
+	return h.dispatchMulticastAssocOps(c, op, resource, body)
+}
+
+// dispatchMulticastGroupCRUDOps handles multicast group CRUD and session operations.
+func (h *Handler) dispatchMulticastGroupCRUDOps(c *echo.Context, op, resource string) (bool, error) {
 	switch op {
 	case opCreateMulticastGroup:
 		return true, h.createMulticastGroup(c)
@@ -1009,6 +1160,14 @@ func (h *Handler) dispatchMulticastOps(c *echo.Context, op, resource string, _ [
 		return true, h.listMulticastGroupsByFuotaTask(c, resource)
 	case opSendDataToMulticastGroup:
 		return true, h.sendDataToMulticastGroup(c, resource)
+	}
+
+	return false, nil
+}
+
+// dispatchMulticastAssocOps handles multicast group association/disassociation and FUOTA task operations.
+func (h *Handler) dispatchMulticastAssocOps(c *echo.Context, op, resource string, _ []byte) (bool, error) {
+	switch op {
 	case opStartBulkAssociateWirelessDeviceWithMulticastGroup:
 		return true, h.startBulkAssociateWirelessDeviceWithMulticastGroup(c, resource)
 	case opStartBulkDisassociateWirelessDeviceFromMulticastGroup:
@@ -1151,9 +1310,16 @@ func (h *Handler) dispatchImportTaskOps(c *echo.Context, op, resource string) (b
 }
 
 // dispatchPartnerAndMiscOps handles partner account, destination update, and misc operations.
-//
-//nolint:cyclop // routes across many resource types
-func (h *Handler) dispatchPartnerAndMiscOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+func (h *Handler) dispatchPartnerAndMiscOps(c *echo.Context, op, resource string, _ []byte) (bool, error) {
+	if handled, result := h.dispatchPartnerOps(c, op, resource); handled {
+		return true, result
+	}
+
+	return h.dispatchGatewayDeviceMiscOps(c, op, resource)
+}
+
+// dispatchPartnerOps handles partner account and destination operations.
+func (h *Handler) dispatchPartnerOps(c *echo.Context, op, resource string) (bool, error) {
 	switch op {
 	case opGetPartnerAccount:
 		return true, h.getPartnerAccount(c, resource)
@@ -1175,6 +1341,14 @@ func (h *Handler) dispatchPartnerAndMiscOps(c *echo.Context, op, resource string
 		return true, h.getWirelessGatewayStatistics(c, resource)
 	case opDisassociateWirelessGatewayFromCertificate:
 		return true, h.disassociateWirelessGatewayFromCertificate(c, resource)
+	}
+
+	return false, nil
+}
+
+// dispatchGatewayDeviceMiscOps handles wireless gateway and device miscellaneous operations.
+func (h *Handler) dispatchGatewayDeviceMiscOps(c *echo.Context, op, resource string) (bool, error) {
+	switch op {
 	case opDisassociateWirelessGatewayFromThing:
 		return true, h.disassociateWirelessGatewayFromThing(c, resource)
 	case opUpdateWirelessGateway:
@@ -1196,8 +1370,6 @@ func (h *Handler) dispatchPartnerAndMiscOps(c *echo.Context, op, resource string
 	case opListQueuedMessages:
 		return true, h.listQueuedMessages(c, resource)
 	}
-
-	_ = body
 
 	return false, nil
 }

--- a/services/kafka/handler.go
+++ b/services/kafka/handler.go
@@ -374,10 +374,30 @@ func parseClusterRootV1(method string) (string, string) {
 	return "", ""
 }
 
-//nolint:cyclop,gocognit,gocyclo,funlen // complexity is inherent to the number of path sub-patterns handled
+// parseClusterResourceV1 routes V1 cluster resource paths.
 func parseClusterResourceV1(method, remainder string) (string, string) {
 	decoded, _ := url.PathUnescape(remainder)
 
+	if op, id := parseClusterResourceV1Topics(method, decoded); op != "" {
+		return op, id
+	}
+
+	if op, id := parseClusterResourceV1Config(method, decoded); op != "" {
+		return op, id
+	}
+
+	switch method {
+	case http.MethodGet:
+		return opDescribeCluster, decoded
+	case http.MethodDelete:
+		return opDeleteCluster, decoded
+	}
+
+	return "", ""
+}
+
+// parseClusterResourceV1Topics handles topic and scram secret sub-paths.
+func parseClusterResourceV1Topics(method, decoded string) (string, string) {
 	// /topic-partitions/{topicName}: must be checked before /topics suffix.
 	if idx := strings.Index(decoded, topicPartitionsSuffix+"/"); idx != -1 {
 		arnStr := decoded[:idx]
@@ -437,6 +457,11 @@ func parseClusterResourceV1(method, remainder string) (string, string) {
 		return "", ""
 	}
 
+	return "", ""
+}
+
+// parseClusterResourceV1Config handles policy, broker, VPC, and operations sub-paths.
+func parseClusterResourceV1Config(method, decoded string) (string, string) {
 	// /policy: DeleteClusterPolicy (DELETE), GetClusterPolicy (GET), PutClusterPolicy (PUT).
 	if strings.HasSuffix(decoded, policySuffix) {
 		arnStr := decoded[:len(decoded)-len(policySuffix)]
@@ -464,6 +489,15 @@ func parseClusterResourceV1(method, remainder string) (string, string) {
 		return "", ""
 	}
 
+	if op, id := parseClusterResourceV1Misc(method, decoded); op != "" {
+		return op, id
+	}
+
+	return "", ""
+}
+
+// parseClusterResourceV1Misc handles compatible versions, nodes, reboot, VPC, and operations paths.
+func parseClusterResourceV1Misc(method, decoded string) (string, string) {
 	// /compatible-kafka-versions: GetCompatibleKafkaVersions.
 	if strings.HasSuffix(decoded, compatibleVersionsSuffix) {
 		arnStr := decoded[:len(decoded)-len(compatibleVersionsSuffix)]
@@ -528,16 +562,6 @@ func parseClusterResourceV1(method, remainder string) (string, string) {
 		}
 
 		return "", ""
-	}
-
-	switch method {
-	case http.MethodGet:
-		return opDescribeCluster, decoded
-	case http.MethodDelete:
-		return opDeleteCluster, decoded
-	case http.MethodPut:
-		// PUT on a cluster ARN with update sub-ops handled inline — distinguish by query/body not path.
-		// These specific update endpoints use dedicated paths, so fallthrough to empty.
 	}
 
 	return "", ""
@@ -749,9 +773,16 @@ func (h *Handler) dispatch(c *echo.Context, op, resource string, body []byte) er
 
 // dispatchCoreOps handles cluster, configuration, and tag operations.
 // Returns (true, err) if the operation was handled, (false, nil) otherwise.
-//
-//nolint:cyclop // dispatch switch complexity is inherent to the number of operations
 func (h *Handler) dispatchCoreOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if ok, err := h.dispatchClusterOps(c, op, resource, body); ok {
+		return true, err
+	}
+
+	return h.dispatchConfigTagOps(c, op, resource, body)
+}
+
+// dispatchClusterOps handles cluster CRUD and bootstrap operations.
+func (h *Handler) dispatchClusterOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
 	switch op {
 	case opCreateCluster:
 		return true, h.handleCreateCluster(c, body)
@@ -769,6 +800,14 @@ func (h *Handler) dispatchCoreOps(c *echo.Context, op, resource string, body []b
 		return true, h.handleDeleteCluster(c, resource)
 	case opGetBootstrapBrokers:
 		return true, h.handleGetBootstrapBrokers(c, resource)
+	}
+
+	return false, nil
+}
+
+// dispatchConfigTagOps handles configuration and tag operations.
+func (h *Handler) dispatchConfigTagOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+	switch op {
 	case opCreateConfiguration:
 		return true, h.handleCreateConfiguration(c, body)
 	case opListConfigurations:

--- a/services/mediastore/handler.go
+++ b/services/mediastore/handler.go
@@ -156,55 +156,105 @@ func (h *Handler) Handler() echo.HandlerFunc {
 }
 
 // dispatch routes to the appropriate handler based on the operation name.
-//
-//nolint:cyclop // switch-based operation dispatch; each case is a single delegation.
 func (h *Handler) dispatch(c *echo.Context, op string, body []byte) error {
-	switch op {
-	case "CreateContainer":
-		return h.handleCreateContainer(c, body)
-	case "DeleteContainer":
-		return h.handleDeleteContainer(c, body)
-	case "DescribeContainer":
-		return h.handleDescribeContainer(c, body)
-	case "ListContainers":
-		return h.handleListContainers(c, body)
-	case "PutContainerPolicy":
-		return h.handlePutContainerPolicy(c, body)
-	case "GetContainerPolicy":
-		return h.handleGetContainerPolicy(c, body)
-	case "DeleteContainerPolicy":
-		return h.handleDeleteContainerPolicy(c, body)
-	case "PutCorsPolicy":
-		return h.handlePutCorsPolicy(c, body)
-	case "GetCorsPolicy":
-		return h.handleGetCorsPolicy(c, body)
-	case "DeleteCorsPolicy":
-		return h.handleDeleteCorsPolicy(c, body)
-	case "PutLifecyclePolicy":
-		return h.handlePutLifecyclePolicy(c, body)
-	case "GetLifecyclePolicy":
-		return h.handleGetLifecyclePolicy(c, body)
-	case "DeleteLifecyclePolicy":
-		return h.handleDeleteLifecyclePolicy(c, body)
-	case "PutMetricPolicy":
-		return h.handlePutMetricPolicy(c, body)
-	case "GetMetricPolicy":
-		return h.handleGetMetricPolicy(c, body)
-	case "DeleteMetricPolicy":
-		return h.handleDeleteMetricPolicy(c, body)
-	case "StartAccessLogging":
-		return h.handleStartAccessLogging(c, body)
-	case "StopAccessLogging":
-		return h.handleStopAccessLogging(c, body)
-	case "TagResource":
-		return h.handleTagResource(c, body)
-	case "UntagResource":
-		return h.handleUntagResource(c, body)
-	case "ListTagsForResource":
-		return h.handleListTagsForResource(c, body)
+	if ok, err := h.dispatchContainerOps(c, op, body); ok {
+		return err
+	}
+	if ok, err := h.dispatchPolicyOps(c, op, body); ok {
+		return err
+	}
+	if ok, err := h.dispatchLoggingTagOps(c, op, body); ok {
+		return err
 	}
 
 	return writeError(c, http.StatusBadRequest, "UnknownOperationException", "unknown operation: "+op)
+}
+
+// dispatchContainerOps handles container lifecycle operations.
+func (h *Handler) dispatchContainerOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "CreateContainer":
+
+		return true, h.handleCreateContainer(c, body)
+	case "DeleteContainer":
+
+		return true, h.handleDeleteContainer(c, body)
+	case "DescribeContainer":
+
+		return true, h.handleDescribeContainer(c, body)
+	case "ListContainers":
+
+		return true, h.handleListContainers(c, body)
+	}
+
+	return false, nil
+}
+
+// dispatchPolicyOps handles container policy operations.
+func (h *Handler) dispatchPolicyOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "PutContainerPolicy":
+
+		return true, h.handlePutContainerPolicy(c, body)
+	case "GetContainerPolicy":
+
+		return true, h.handleGetContainerPolicy(c, body)
+	case "DeleteContainerPolicy":
+
+		return true, h.handleDeleteContainerPolicy(c, body)
+	case "PutCorsPolicy":
+
+		return true, h.handlePutCorsPolicy(c, body)
+	case "GetCorsPolicy":
+
+		return true, h.handleGetCorsPolicy(c, body)
+	case "DeleteCorsPolicy":
+
+		return true, h.handleDeleteCorsPolicy(c, body)
+	case "PutLifecyclePolicy":
+
+		return true, h.handlePutLifecyclePolicy(c, body)
+	case "GetLifecyclePolicy":
+
+		return true, h.handleGetLifecyclePolicy(c, body)
+	case "DeleteLifecyclePolicy":
+
+		return true, h.handleDeleteLifecyclePolicy(c, body)
+	case "PutMetricPolicy":
+
+		return true, h.handlePutMetricPolicy(c, body)
+	case "GetMetricPolicy":
+
+		return true, h.handleGetMetricPolicy(c, body)
+	case "DeleteMetricPolicy":
+
+		return true, h.handleDeleteMetricPolicy(c, body)
+	}
+
+	return false, nil
+}
+
+// dispatchLoggingTagOps handles access logging and tagging operations.
+func (h *Handler) dispatchLoggingTagOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "StartAccessLogging":
+
+		return true, h.handleStartAccessLogging(c, body)
+	case "StopAccessLogging":
+
+		return true, h.handleStopAccessLogging(c, body)
+	case "TagResource":
+
+		return true, h.handleTagResource(c, body)
+	case "UntagResource":
+
+		return true, h.handleUntagResource(c, body)
+	case "ListTagsForResource":
+
+		return true, h.handleListTagsForResource(c, body)
+	}
+
+	return false, nil
 }
 
 func (h *Handler) handleCreateContainer(c *echo.Context, body []byte) error {
@@ -612,8 +662,10 @@ func (h *Handler) handleListTagsForResource(c *echo.Context, body []byte) error 
 func (h *Handler) writeBackendError(c *echo.Context, err error) error {
 	switch {
 	case errors.Is(err, awserr.ErrNotFound):
+
 		return writeError(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
 	case errors.Is(err, awserr.ErrAlreadyExists):
+
 		return writeError(c, http.StatusConflict, "ContainerInUseException", err.Error())
 	case errors.Is(err, ErrInvalidContainerName),
 		errors.Is(err, ErrInvalidPolicy),
@@ -621,8 +673,10 @@ func (h *Handler) writeBackendError(c *echo.Context, err error) error {
 		errors.Is(err, ErrInvalidMetricPolicy),
 		errors.Is(err, ErrTooManyMetricRules),
 		errors.Is(err, ErrEmptyTagKey):
+
 		return writeError(c, http.StatusBadRequest, "ValidationException", err.Error())
 	default:
+
 		return writeError(c, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}
 }

--- a/services/memorydb/handler.go
+++ b/services/memorydb/handler.go
@@ -207,55 +207,104 @@ func (h *Handler) dispatch(c *echo.Context, op string, body []byte) error {
 }
 
 // dispatchCoreOps handles the original core operations.
-//
-//nolint:cyclop // switch-based operation dispatch; each case is a single delegation.
 func (h *Handler) dispatchCoreOps(c *echo.Context, op string, body []byte) (bool, error) {
+	if ok, err := h.dispatchClusterACLOps(c, op, body); ok {
+		return true, err
+	}
+	if ok, err := h.dispatchSubnetUserOps(c, op, body); ok {
+		return true, err
+	}
+
+	return h.dispatchParamTagOps(c, op, body)
+}
+
+// dispatchClusterACLOps handles cluster and ACL operations.
+func (h *Handler) dispatchClusterACLOps(c *echo.Context, op string, body []byte) (bool, error) {
 	switch op {
 	case "CreateCluster":
+
 		return true, h.handleCreateCluster(c, body)
 	case "DescribeClusters":
+
 		return true, h.handleDescribeClusters(c, body)
 	case "DeleteCluster":
+
 		return true, h.handleDeleteCluster(c, body)
 	case "UpdateCluster":
+
 		return true, h.handleUpdateCluster(c, body)
 	case "CreateACL":
+
 		return true, h.handleCreateACL(c, body)
 	case "DescribeACLs":
+
 		return true, h.handleDescribeACLs(c, body)
 	case "DeleteACL":
+
 		return true, h.handleDeleteACL(c, body)
 	case "UpdateACL":
+
 		return true, h.handleUpdateACL(c, body)
+	}
+
+	return false, nil
+}
+
+// dispatchSubnetUserOps handles subnet group and user operations.
+func (h *Handler) dispatchSubnetUserOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
 	case "CreateSubnetGroup":
+
 		return true, h.handleCreateSubnetGroup(c, body)
 	case "DescribeSubnetGroups":
+
 		return true, h.handleDescribeSubnetGroups(c, body)
 	case "DeleteSubnetGroup":
+
 		return true, h.handleDeleteSubnetGroup(c, body)
 	case "UpdateSubnetGroup":
+
 		return true, h.handleUpdateSubnetGroup(c, body)
 	case "CreateUser":
+
 		return true, h.handleCreateUser(c, body)
 	case "DescribeUsers":
+
 		return true, h.handleDescribeUsers(c, body)
 	case "DeleteUser":
+
 		return true, h.handleDeleteUser(c, body)
 	case "UpdateUser":
+
 		return true, h.handleUpdateUser(c, body)
+	}
+
+	return false, nil
+}
+
+// dispatchParamTagOps handles parameter group and tag operations.
+func (h *Handler) dispatchParamTagOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
 	case "CreateParameterGroup":
+
 		return true, h.handleCreateParameterGroup(c, body)
 	case "DescribeParameterGroups":
+
 		return true, h.handleDescribeParameterGroups(c, body)
 	case "DeleteParameterGroup":
+
 		return true, h.handleDeleteParameterGroup(c, body)
 	case "UpdateParameterGroup":
+
 		return true, h.handleUpdateParameterGroup(c, body)
 	case "ListTags":
+
 		return true, h.handleListTags(c, body)
 	case "TagResource":
+
 		return true, h.handleTagResource(c, body)
 	case "UntagResource":
+
 		return true, h.handleUntagResource(c, body)
 	}
 
@@ -279,20 +328,28 @@ func (h *Handler) dispatchNewOps(c *echo.Context, op string, body []byte) (bool,
 func (h *Handler) dispatchSnapshotAndEngineOps(c *echo.Context, op string, body []byte) (bool, error) {
 	switch op {
 	case "CreateSnapshot":
+
 		return true, h.handleCreateSnapshot(c, body)
 	case "DescribeSnapshots":
+
 		return true, h.handleDescribeSnapshots(c, body)
 	case "CopySnapshot":
+
 		return true, h.handleCopySnapshot(c, body)
 	case "DeleteSnapshot":
+
 		return true, h.handleDeleteSnapshot(c, body)
 	case "DescribeEngineVersions":
+
 		return true, h.handleDescribeEngineVersions(c, body)
 	case "DescribeEvents":
+
 		return true, h.handleDescribeEvents(c, body)
 	case "BatchUpdateCluster":
+
 		return true, h.handleBatchUpdateCluster(c, body)
 	case "DescribeServiceUpdates":
+
 		return true, h.handleDescribeServiceUpdates(c, body)
 	}
 
@@ -303,16 +360,22 @@ func (h *Handler) dispatchSnapshotAndEngineOps(c *echo.Context, op string, body 
 func (h *Handler) dispatchMultiRegionOps(c *echo.Context, op string, body []byte) (bool, error) {
 	switch op {
 	case "CreateMultiRegionCluster":
+
 		return true, h.handleCreateMultiRegionCluster(c, body)
 	case "DeleteMultiRegionCluster":
+
 		return true, h.handleDeleteMultiRegionCluster(c, body)
 	case "DescribeMultiRegionClusters":
+
 		return true, h.handleDescribeMultiRegionClusters(c, body)
 	case "DescribeMultiRegionParameterGroups":
+
 		return true, h.handleDescribeMultiRegionParameterGroups(c, body)
 	case "UpdateMultiRegionCluster":
+
 		return true, h.handleUpdateMultiRegionCluster(c, body)
 	case "ListAllowedMultiRegionClusterUpdates":
+
 		return true, h.handleListAllowedMultiRegionClusterUpdates(c, body)
 	}
 
@@ -323,20 +386,28 @@ func (h *Handler) dispatchMultiRegionOps(c *echo.Context, op string, body []byte
 func (h *Handler) dispatchParameterAndShardOps(c *echo.Context, op string, body []byte) (bool, error) {
 	switch op {
 	case "DescribeParameters":
+
 		return true, h.handleDescribeParameters(c, body)
 	case "ResetParameterGroup":
+
 		return true, h.handleResetParameterGroup(c, body)
 	case "FailoverShard":
+
 		return true, h.handleFailoverShard(c, body)
 	case "ListAllowedNodeTypeUpdates":
+
 		return true, h.handleListAllowedNodeTypeUpdates(c, body)
 	case "DescribeReservedNodes":
+
 		return true, h.handleDescribeReservedNodes(c, body)
 	case "DescribeReservedNodesOfferings":
+
 		return true, h.handleDescribeReservedNodesOfferings(c, body)
 	case "PurchaseReservedNodesOffering":
+
 		return true, h.handlePurchaseReservedNodesOffering(c, body)
 	case "DescribeMultiRegionParameters":
+
 		return true, h.handleDescribeMultiRegionParameters(c, body)
 	}
 
@@ -1427,14 +1498,19 @@ func findStartIndex[T any](items []T, token string, getName func(T) string) int 
 func (h *Handler) writeBackendError(c *echo.Context, err error) error {
 	switch {
 	case errors.Is(err, awserr.ErrNotFound):
+
 		return writeError(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
 	case errors.Is(err, awserr.ErrAlreadyExists):
+
 		return writeError(c, http.StatusConflict, "ResourceInUseException", err.Error())
 	case errors.Is(err, awserr.ErrInvalidParameter):
+
 		return writeError(c, http.StatusBadRequest, "InvalidParameterValueException", err.Error())
 	case errors.Is(err, awserr.ErrConflict):
+
 		return writeError(c, http.StatusConflict, "InvalidRequestException", err.Error())
 	default:
+
 		return writeError(c, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}
 }

--- a/services/pinpoint/handler.go
+++ b/services/pinpoint/handler.go
@@ -249,62 +249,104 @@ func (h *Handler) RouteMatcher() service.Matcher {
 func (h *Handler) MatchPriority() int { return pinpointMatchPriority }
 
 // ExtractOperation extracts the operation name from the request path and method.
-//
-//nolint:cyclop,gocognit // Many op variants mapped from path/method; inevitable complexity.
 func (h *Handler) ExtractOperation(c *echo.Context) string {
 	method := c.Request().Method
 	path := c.Request().URL.Path
 
+	if op := extractTagOrAppsOp(h, method, path); op != unknownOperation {
+		return op
+	}
+
+	return extractRecommenderTemplateOp(h, method, path)
+}
+
+// extractTagOrAppsOp handles tag and app operations.
+func extractTagOrAppsOp(h *Handler, method, path string) string {
 	switch {
 	case strings.HasPrefix(path, "/v1/tags/"):
 		return extractTagOperation(method)
 	case path == "/v1/apps" || path == "/v1/apps/":
-		if method == http.MethodPost {
-			return "CreateApp"
-		}
-
-		if method == http.MethodGet {
-			return "GetApps"
-		}
+		return extractAppsCollectionOp(method)
 	case strings.HasPrefix(path, "/v1/apps/"):
-		suffix := strings.TrimPrefix(path, "/v1/apps/")
-		if strings.Contains(suffix, "/") {
-			return h.extractAppSubOperation(method, suffix)
-		}
+		return extractAppsResourceOp(h, method, path)
+	}
 
-		switch method {
-		case http.MethodGet:
-			return "GetApp"
-		case http.MethodDelete:
-			return "DeleteApp"
-		}
+	return unknownOperation
+}
+
+// extractAppsCollectionOp returns the operation for the apps collection.
+func extractAppsCollectionOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateApp"
+	case http.MethodGet:
+		return "GetApps"
+	}
+
+	return unknownOperation
+}
+
+// extractAppsResourceOp returns the operation for a specific app resource.
+func extractAppsResourceOp(h *Handler, method, path string) string {
+	suffix := strings.TrimPrefix(path, "/v1/apps/")
+	if strings.Contains(suffix, "/") {
+		return h.extractAppSubOperation(method, suffix)
+	}
+
+	switch method {
+	case http.MethodGet:
+		return "GetApp"
+	case http.MethodDelete:
+		return "DeleteApp"
+	}
+
+	return unknownOperation
+}
+
+// extractRecommenderTemplateOp handles recommender and template operations.
+func extractRecommenderTemplateOp(h *Handler, method, path string) string {
+	switch {
 	case path == "/v1/recommenders" || path == "/v1/recommenders/":
-		if method == http.MethodPost {
-			return "CreateRecommenderConfiguration"
-		}
-
-		if method == http.MethodGet {
-			return "GetRecommenderConfigurations"
-		}
+		return extractRecommendersCollectionOp(method)
 	case strings.HasPrefix(path, "/v1/recommenders/"):
-		recommenderID := strings.TrimPrefix(path, "/v1/recommenders/")
-
-		if recommenderID != "" {
-			switch method {
-			case http.MethodGet:
-				return "GetRecommenderConfiguration"
-			case http.MethodPut:
-				return "UpdateRecommenderConfiguration"
-			case http.MethodDelete:
-				return "DeleteRecommenderConfiguration"
-			}
-		}
+		return extractRecommenderResourceOp(method, path)
 	case path == "/v1/templates" || path == "/v1/templates/":
 		return "ListTemplates"
 	case strings.HasPrefix(path, "/v1/templates/"):
 		return h.extractTemplateOperation(method, path)
 	case path == phoneValidatePath:
 		return "PhoneNumberValidate"
+	}
+
+	return unknownOperation
+}
+
+// extractRecommendersCollectionOp returns the operation for the recommenders collection.
+func extractRecommendersCollectionOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateRecommenderConfiguration"
+	case http.MethodGet:
+		return "GetRecommenderConfigurations"
+	}
+
+	return unknownOperation
+}
+
+// extractRecommenderResourceOp returns the operation for a specific recommender resource.
+func extractRecommenderResourceOp(method, path string) string {
+	recommenderID := strings.TrimPrefix(path, "/v1/recommenders/")
+	if recommenderID == "" {
+		return unknownOperation
+	}
+
+	switch method {
+	case http.MethodGet:
+		return "GetRecommenderConfiguration"
+	case http.MethodPut:
+		return "UpdateRecommenderConfiguration"
+	case http.MethodDelete:
+		return "DeleteRecommenderConfiguration"
 	}
 
 	return unknownOperation
@@ -326,7 +368,7 @@ func extractTagOperation(method string) string {
 
 // extractAppSubOperation resolves the operation name for paths under /v1/apps/{id}/.
 //
-//nolint:cyclop,gocognit,gocyclo,funlen // Fan-out over many sub-path patterns is inherently complex.
+
 func (h *Handler) extractAppSubOperation(method, suffix string) string {
 	parts := strings.SplitN(suffix, "/", appSubPathParts)
 	if len(parts) != appSubPathParts {
@@ -335,68 +377,120 @@ func (h *Handler) extractAppSubOperation(method, suffix string) string {
 
 	subPath := parts[1]
 
+	if op := h.extractAppCoreSubOp(method, subPath); op != unknownOperation {
+		return op
+	}
+
+	return h.extractAppExtSubOp(method, subPath)
+}
+
+// extractAppCoreSubOp resolves settings, campaign, journey, segment, and job operations.
+func (h *Handler) extractAppCoreSubOp(method, subPath string) string {
 	switch {
 	case subPath == "settings":
-		switch method {
-		case http.MethodGet:
-			return "GetApplicationSettings"
-		case http.MethodPut:
-			return "UpdateApplicationSettings"
-		}
+		return extractSettingsOp(method)
 	case subPath == "campaigns":
-		switch method {
-		case http.MethodPost:
-			return "CreateCampaign"
-		case http.MethodGet:
-			return "GetCampaigns"
-		}
+		return extractCampaignsOp(method)
 	case strings.HasPrefix(subPath, "campaigns/"):
 		return h.extractCampaignSubOp(method, strings.TrimPrefix(subPath, "campaigns/"))
 	case subPath == "journeys":
-		switch method {
-		case http.MethodPost:
-			return "CreateJourney"
-		case http.MethodGet:
-			return "ListJourneys"
-		}
+		return extractJourneysOp(method)
 	case strings.HasPrefix(subPath, "journeys/"):
 		return h.extractJourneySubOp(method, strings.TrimPrefix(subPath, "journeys/"))
 	case subPath == "segments":
-		switch method {
-		case http.MethodPost:
-			return "CreateSegment"
-		case http.MethodGet:
-			return "GetSegments"
-		}
+		return extractSegmentsOp(method)
 	case strings.HasPrefix(subPath, "segments/"):
 		return h.extractSegmentSubOp(method, strings.TrimPrefix(subPath, "segments/"))
 	case subPath == subPathJobsExport:
-		switch method {
-		case http.MethodPost:
-			return "CreateExportJob"
-		case http.MethodGet:
-			return "GetExportJobs"
-		}
+		return extractExportJobsOp(method)
 	case strings.HasPrefix(subPath, subPathJobsExport+"/"):
 		return "GetExportJob"
 	case subPath == subPathJobsImport:
-		switch method {
-		case http.MethodPost:
-			return "CreateImportJob"
-		case http.MethodGet:
-			return "GetImportJobs"
-		}
+		return extractImportJobsOp(method)
 	case strings.HasPrefix(subPath, subPathJobsImport+"/"):
 		return "GetImportJob"
+	}
+
+	return unknownOperation
+}
+
+// extractSettingsOp returns the settings operation name.
+func extractSettingsOp(method string) string {
+	switch method {
+	case http.MethodGet:
+		return "GetApplicationSettings"
+	case http.MethodPut:
+		return "UpdateApplicationSettings"
+	}
+
+	return unknownOperation
+}
+
+// extractCampaignsOp returns the campaigns collection operation name.
+func extractCampaignsOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateCampaign"
+	case http.MethodGet:
+		return "GetCampaigns"
+	}
+
+	return unknownOperation
+}
+
+// extractJourneysOp returns the journeys collection operation name.
+func extractJourneysOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateJourney"
+	case http.MethodGet:
+		return "ListJourneys"
+	}
+
+	return unknownOperation
+}
+
+// extractSegmentsOp returns the segments collection operation name.
+func extractSegmentsOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateSegment"
+	case http.MethodGet:
+		return "GetSegments"
+	}
+
+	return unknownOperation
+}
+
+// extractExportJobsOp returns the export jobs collection operation name.
+func extractExportJobsOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateExportJob"
+	case http.MethodGet:
+		return "GetExportJobs"
+	}
+
+	return unknownOperation
+}
+
+// extractImportJobsOp returns the import jobs collection operation name.
+func extractImportJobsOp(method string) string {
+	switch method {
+	case http.MethodPost:
+		return "CreateImportJob"
+	case http.MethodGet:
+		return "GetImportJobs"
+	}
+
+	return unknownOperation
+}
+
+// extractAppExtSubOp resolves messaging, KPI, channel, endpoint, and user operations.
+func (h *Handler) extractAppExtSubOp(method, subPath string) string {
+	switch {
 	case subPath == "eventstream":
-		switch method {
-		case http.MethodGet:
-			return "GetEventStream"
-		case http.MethodPost:
-			return "PutEventStream"
-		case http.MethodDelete:
-			return "DeleteEventStream"
-		}
+		return extractEventStreamOp(method)
 	case subPath == "messages":
 		return "SendMessages"
 	case subPath == "users-messages":
@@ -420,15 +514,36 @@ func (h *Handler) extractAppSubOperation(method, suffix string) string {
 	case strings.HasPrefix(subPath, "users/"):
 		userID := strings.TrimPrefix(subPath, "users/")
 		if userID != "" {
-			switch method {
-			case http.MethodGet:
-				return "GetUserEndpoints"
-			case http.MethodDelete:
-				return "DeleteUserEndpoints"
-			}
+			return extractUserEndpointsOp(method)
 		}
 	case strings.HasPrefix(subPath, "attributes/"):
 		return "RemoveAttributes"
+	}
+
+	return unknownOperation
+}
+
+// extractEventStreamOp returns the event stream operation name.
+func extractEventStreamOp(method string) string {
+	switch method {
+	case http.MethodGet:
+		return "GetEventStream"
+	case http.MethodPost:
+		return "PutEventStream"
+	case http.MethodDelete:
+		return "DeleteEventStream"
+	}
+
+	return unknownOperation
+}
+
+// extractUserEndpointsOp returns the user endpoints operation name.
+func extractUserEndpointsOp(method string) string {
+	switch method {
+	case http.MethodGet:
+		return "GetUserEndpoints"
+	case http.MethodDelete:
+		return "DeleteUserEndpoints"
 	}
 
 	return unknownOperation
@@ -820,7 +935,7 @@ func (h *Handler) dispatchApp(c *echo.Context, appID string) error {
 
 // dispatchAppSubPath handles paths under /v1/apps/{appId}/ (e.g. settings).
 //
-//nolint:cyclop,funlen // Fan-out over many sub-path patterns; inevitable cyclomatic complexity.
+
 func (h *Handler) dispatchAppSubPath(c *echo.Context, suffix string) error {
 	parts := strings.SplitN(suffix, "/", appSubPathParts)
 	if len(parts) != appSubPathParts {
@@ -829,65 +944,86 @@ func (h *Handler) dispatchAppSubPath(c *echo.Context, suffix string) error {
 
 	appID, subPath := parts[0], parts[1]
 
-	switch {
-	case subPath == "settings":
-		return h.dispatchAppSettings(c, appID)
-	case subPath == "campaigns":
-		return h.dispatchCampaigns(c, appID)
-	case strings.HasPrefix(subPath, "campaigns/"):
-		return h.dispatchCampaignByID(c, appID, strings.TrimPrefix(subPath, "campaigns/"))
-	case subPath == "journeys":
-		return h.dispatchJourneys(c, appID)
-	case strings.HasPrefix(subPath, "journeys/"):
-		return h.dispatchJourneyByID(c, appID, strings.TrimPrefix(subPath, "journeys/"))
-	case subPath == "segments":
-		return h.dispatchSegments(c, appID)
-	case strings.HasPrefix(subPath, "segments/"):
-		return h.dispatchSegmentByID(c, appID, strings.TrimPrefix(subPath, "segments/"))
-	case subPath == subPathJobsExport:
-		return h.dispatchExportJobs(c, appID, "")
-	case strings.HasPrefix(subPath, subPathJobsExport+"/"):
-		return h.handleGetExportJob(c, appID, strings.TrimPrefix(subPath, "jobs/export/"))
-	case subPath == subPathJobsImport:
-		return h.dispatchImportJobs(c, appID, "")
-	case strings.HasPrefix(subPath, subPathJobsImport+"/"):
-		return h.handleGetImportJob(c, appID, strings.TrimPrefix(subPath, "jobs/import/"))
-	case subPath == "eventstream":
-		return h.dispatchEventStream(c, appID)
-	case subPath == "messages":
-		return h.handleSendMessages(c, appID)
-	case subPath == "users-messages":
-		return h.handleSendUsersMessages(c, appID)
-	case subPath == "otp":
-		return h.handleSendOTPMessage(c, appID)
-	case subPath == "verify-otp":
-		return h.handleVerifyOTPMessage(c, appID)
-	case subPath == "events":
-		return h.handlePutEvents(c, appID)
-	case strings.HasPrefix(subPath, "kpis/daterange/"):
-		return h.handleGetApplicationDateRangeKpi(c, appID, strings.TrimPrefix(subPath, "kpis/daterange/"))
-	case strings.HasPrefix(subPath, "channels/"):
-		channelType := strings.TrimPrefix(subPath, "channels/")
+	if handled, err := h.tryAppCoreSubPath(c, appID, subPath); handled {
+		return err
+	}
 
-		return h.dispatchChannelByType(c, appID, channelType)
-	case subPath == "channels":
-		return h.handleGetChannels(c, appID)
-	case strings.HasPrefix(subPath, "endpoints/"):
-		return h.dispatchEndpointByID(c, appID, strings.TrimPrefix(subPath, "endpoints/"))
-	case subPath == "endpoints":
-		if c.Request().Method == http.MethodPut {
-			return h.handleUpdateEndpointsBatch(c, appID)
-		}
-	case strings.HasPrefix(subPath, "users/"):
-		return h.dispatchUserByID(c, appID, strings.TrimPrefix(subPath, "users/"))
-	case strings.HasPrefix(subPath, "attributes/"):
-		attrType := strings.TrimPrefix(subPath, "attributes/")
-		if c.Request().Method == http.MethodPut {
-			return h.handleRemoveAttributes(c, appID, attrType)
-		}
+	if handled, err := h.tryAppExtSubPath(c, appID, subPath); handled {
+		return err
 	}
 
 	return writeErrorResponse(c, http.StatusNotFound, "NotFoundException", "resource not found")
+}
+
+// tryAppCoreSubPath handles settings, campaigns, journeys, segments, and job paths.
+// Returns (true, err) if the path was handled.
+func (h *Handler) tryAppCoreSubPath(c *echo.Context, appID, subPath string) (bool, error) {
+	switch {
+	case subPath == "settings":
+		return true, h.dispatchAppSettings(c, appID)
+	case subPath == "campaigns":
+		return true, h.dispatchCampaigns(c, appID)
+	case strings.HasPrefix(subPath, "campaigns/"):
+		return true, h.dispatchCampaignByID(c, appID, strings.TrimPrefix(subPath, "campaigns/"))
+	case subPath == "journeys":
+		return true, h.dispatchJourneys(c, appID)
+	case strings.HasPrefix(subPath, "journeys/"):
+		return true, h.dispatchJourneyByID(c, appID, strings.TrimPrefix(subPath, "journeys/"))
+	case subPath == "segments":
+		return true, h.dispatchSegments(c, appID)
+	case strings.HasPrefix(subPath, "segments/"):
+		return true, h.dispatchSegmentByID(c, appID, strings.TrimPrefix(subPath, "segments/"))
+	case subPath == subPathJobsExport:
+		return true, h.dispatchExportJobs(c, appID, "")
+	case strings.HasPrefix(subPath, subPathJobsExport+"/"):
+		return true, h.handleGetExportJob(c, appID, strings.TrimPrefix(subPath, "jobs/export/"))
+	case subPath == subPathJobsImport:
+		return true, h.dispatchImportJobs(c, appID, "")
+	case strings.HasPrefix(subPath, subPathJobsImport+"/"):
+		return true, h.handleGetImportJob(c, appID, strings.TrimPrefix(subPath, "jobs/import/"))
+	case subPath == "eventstream":
+		return true, h.dispatchEventStream(c, appID)
+	}
+
+	return false, nil
+}
+
+// tryAppExtSubPath handles messaging, KPI, channel, endpoint, and user paths.
+// Returns (true, err) if the path was handled.
+func (h *Handler) tryAppExtSubPath(c *echo.Context, appID, subPath string) (bool, error) {
+	switch {
+	case subPath == "messages":
+		return true, h.handleSendMessages(c, appID)
+	case subPath == "users-messages":
+		return true, h.handleSendUsersMessages(c, appID)
+	case subPath == "otp":
+		return true, h.handleSendOTPMessage(c, appID)
+	case subPath == "verify-otp":
+		return true, h.handleVerifyOTPMessage(c, appID)
+	case subPath == "events":
+		return true, h.handlePutEvents(c, appID)
+	case strings.HasPrefix(subPath, "kpis/daterange/"):
+		return true, h.handleGetApplicationDateRangeKpi(c, appID, strings.TrimPrefix(subPath, "kpis/daterange/"))
+	case strings.HasPrefix(subPath, "channels/"):
+		return true, h.dispatchChannelByType(c, appID, strings.TrimPrefix(subPath, "channels/"))
+	case subPath == "channels":
+		return true, h.handleGetChannels(c, appID)
+	case strings.HasPrefix(subPath, "endpoints/"):
+		return true, h.dispatchEndpointByID(c, appID, strings.TrimPrefix(subPath, "endpoints/"))
+	case subPath == "endpoints":
+		if c.Request().Method == http.MethodPut {
+			return true, h.handleUpdateEndpointsBatch(c, appID)
+		}
+	case strings.HasPrefix(subPath, "users/"):
+		return true, h.dispatchUserByID(c, appID, strings.TrimPrefix(subPath, "users/"))
+	case strings.HasPrefix(subPath, "attributes/"):
+		attrType := strings.TrimPrefix(subPath, "attributes/")
+		if c.Request().Method == http.MethodPut {
+			return true, h.handleRemoveAttributes(c, appID, attrType)
+		}
+	}
+
+	return false, nil
 }
 
 // dispatchAppSettings handles GET/PUT /v1/apps/{appId}/settings.

--- a/services/pinpoint/handler_ops.go
+++ b/services/pinpoint/handler_ops.go
@@ -671,62 +671,14 @@ func (h *Handler) handleGetTemplate(c *echo.Context, templateName, templateType 
 }
 
 // handleUpdateTemplate handles PUT for any template type.
-//
-//nolint:cyclop,gocognit // Fan-out by template type is inherently complex; each case is independent.
 func (h *Handler) handleUpdateTemplate(c *echo.Context, templateName, templateType string) error {
 	body, err := httputils.ReadBody(c.Request())
 	if err != nil {
 		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "failed to read request body")
 	}
 
-	switch templateType {
-	case templateTypeEmail:
-		var req createEmailTemplateRequest
-		if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
-		}
-
-		if _, updateErr := h.Backend.UpdateEmailTemplate(templateName, req); updateErr != nil {
-			return writeNotFoundOrInternal(c, updateErr)
-		}
-	case templateTypeInApp:
-		var req createInAppTemplateRequest
-		if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
-		}
-
-		if _, updateErr := h.Backend.UpdateInAppTemplate(templateName, req); updateErr != nil {
-			return writeNotFoundOrInternal(c, updateErr)
-		}
-	case templateTypePush:
-		var req createPushTemplateRequest
-		if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
-		}
-
-		if _, updateErr := h.Backend.UpdatePushTemplate(templateName, req); updateErr != nil {
-			return writeNotFoundOrInternal(c, updateErr)
-		}
-	case templateTypeSMS:
-		var req createSmsTemplateRequest
-		if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
-		}
-
-		if _, updateErr := h.Backend.UpdateSmsTemplate(templateName, req); updateErr != nil {
-			return writeNotFoundOrInternal(c, updateErr)
-		}
-	case templateTypeVoice:
-		var req createVoiceTemplateRequest
-		if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
-		}
-
-		if _, updateErr := h.Backend.UpdateVoiceTemplate(templateName, req); updateErr != nil {
-			return writeNotFoundOrInternal(c, updateErr)
-		}
-	default:
-		return writeErrorResponse(c, http.StatusNotFound, "NotFoundException", "unknown template type")
+	if updateErr := h.applyTemplateUpdate(c, body, templateName, templateType); updateErr != nil {
+		return updateErr
 	}
 
 	httputils.WriteJSON(
@@ -735,6 +687,94 @@ func (h *Handler) handleUpdateTemplate(c *echo.Context, templateName, templateTy
 		http.StatusAccepted,
 		messageBodyResponse{Message: acceptedMessage},
 	)
+
+	return nil
+}
+
+// applyTemplateUpdate applies the update for the given template type.
+func (h *Handler) applyTemplateUpdate(c *echo.Context, body []byte, templateName, templateType string) error {
+	switch templateType {
+	case templateTypeEmail:
+		return h.updateEmailTemplateFromBody(c, body, templateName)
+	case templateTypeInApp:
+		return h.updateInAppTemplateFromBody(c, body, templateName)
+	case templateTypePush:
+		return h.updatePushTemplateFromBody(c, body, templateName)
+	case templateTypeSMS:
+		return h.updateSMSTemplateFromBody(c, body, templateName)
+	case templateTypeVoice:
+		return h.updateVoiceTemplateFromBody(c, body, templateName)
+	}
+
+	return writeErrorResponse(c, http.StatusNotFound, "NotFoundException", "unknown template type")
+}
+
+// updateEmailTemplateFromBody parses and applies an email template update.
+func (h *Handler) updateEmailTemplateFromBody(c *echo.Context, body []byte, name string) error {
+	var req createEmailTemplateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+	}
+
+	if _, err := h.Backend.UpdateEmailTemplate(name, req); err != nil {
+		return writeNotFoundOrInternal(c, err)
+	}
+
+	return nil
+}
+
+// updateInAppTemplateFromBody parses and applies an in-app template update.
+func (h *Handler) updateInAppTemplateFromBody(c *echo.Context, body []byte, name string) error {
+	var req createInAppTemplateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+	}
+
+	if _, err := h.Backend.UpdateInAppTemplate(name, req); err != nil {
+		return writeNotFoundOrInternal(c, err)
+	}
+
+	return nil
+}
+
+// updatePushTemplateFromBody parses and applies a push template update.
+func (h *Handler) updatePushTemplateFromBody(c *echo.Context, body []byte, name string) error {
+	var req createPushTemplateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+	}
+
+	if _, err := h.Backend.UpdatePushTemplate(name, req); err != nil {
+		return writeNotFoundOrInternal(c, err)
+	}
+
+	return nil
+}
+
+// updateSMSTemplateFromBody parses and applies an SMS template update.
+func (h *Handler) updateSMSTemplateFromBody(c *echo.Context, body []byte, name string) error {
+	var req createSmsTemplateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+	}
+
+	if _, err := h.Backend.UpdateSmsTemplate(name, req); err != nil {
+		return writeNotFoundOrInternal(c, err)
+	}
+
+	return nil
+}
+
+// updateVoiceTemplateFromBody parses and applies a voice template update.
+func (h *Handler) updateVoiceTemplateFromBody(c *echo.Context, body []byte, name string) error {
+	var req createVoiceTemplateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+	}
+
+	if _, err := h.Backend.UpdateVoiceTemplate(name, req); err != nil {
+		return writeNotFoundOrInternal(c, err)
+	}
 
 	return nil
 }

--- a/services/pipes/handler.go
+++ b/services/pipes/handler.go
@@ -139,49 +139,97 @@ func (h *Handler) RouteMatcher() service.Matcher {
 
 func (h *Handler) MatchPriority() int { return pipesMatchPriority }
 
-//nolint:cyclop // function routes HTTP requests by method and path segments
+// ExtractOperation determines the operation name from the HTTP request.
 func (h *Handler) ExtractOperation(c *echo.Context) string {
 	method := c.Request().Method
 	path := c.Request().URL.Path
 
-	if strings.HasPrefix(path, pipesTagsPrefix) {
-		switch method {
-		case http.MethodGet:
-			return opListTagsForResource
-		case http.MethodPost:
-			return opTagResource
-		case http.MethodDelete:
-			return opUntagResource
-		}
+	if op := extractTagsOp(path, method); op != "" {
+		return op
 	}
 
 	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
-
-	switch {
-	case method == http.MethodGet && len(segments) >= 2 && segments[1] == pipeNameSegment &&
-		(len(segments) == 2 || (len(segments) == 3 && segments[2] == "")):
-		return opListPipes
-	case len(segments) == pipePathMinSegments && segments[0] == "v1" && segments[1] == pipeNameSegment:
-		switch method {
-		case http.MethodPost:
-			return opCreatePipe
-		case http.MethodGet:
-			return opDescribePipe
-		case http.MethodDelete:
-			return opDeletePipe
-		case http.MethodPut:
-			return opUpdatePipe
-		}
-	case len(segments) == 4 && segments[0] == "v1" && segments[1] == pipeNameSegment && method == http.MethodPost:
-		switch segments[3] {
-		case "start":
-			return opStartPipe
-		case "stop":
-			return opStopPipe
-		}
+	if op := extractPipeListOp(segments, method); op != "" {
+		return op
+	}
+	if op := extractPipeCRUDOp(segments, method); op != "" {
+		return op
+	}
+	if op := extractPipeActionOp(segments, method); op != "" {
+		return op
 	}
 
 	return "Unknown"
+}
+
+// extractTagsOp returns the tag operation for tags-prefix paths.
+func extractTagsOp(path, method string) string {
+	if !strings.HasPrefix(path, pipesTagsPrefix) {
+		return ""
+	}
+	switch method {
+	case http.MethodGet:
+
+		return opListTagsForResource
+	case http.MethodPost:
+
+		return opTagResource
+	case http.MethodDelete:
+
+		return opUntagResource
+	}
+
+	return ""
+}
+
+// extractPipeListOp returns the list-pipes operation when applicable.
+func extractPipeListOp(segments []string, method string) string {
+	if method == http.MethodGet && len(segments) >= 2 && segments[1] == pipeNameSegment &&
+		(len(segments) == 2 || (len(segments) == 3 && segments[2] == "")) {
+		return opListPipes
+	}
+
+	return ""
+}
+
+// extractPipeCRUDOp returns CRUD operations for /v1/pipes/{name} paths.
+func extractPipeCRUDOp(segments []string, method string) string {
+	if len(segments) != pipePathMinSegments || segments[0] != "v1" || segments[1] != pipeNameSegment {
+		return ""
+	}
+	switch method {
+	case http.MethodPost:
+
+		return opCreatePipe
+	case http.MethodGet:
+
+		return opDescribePipe
+	case http.MethodDelete:
+
+		return opDeletePipe
+	case http.MethodPut:
+
+		return opUpdatePipe
+	}
+
+	return ""
+}
+
+// extractPipeActionOp returns start/stop operations for /v1/pipes/{name}/{action} paths.
+func extractPipeActionOp(segments []string, method string) string {
+	if len(segments) != 4 || segments[0] != "v1" || segments[1] != pipeNameSegment || method != http.MethodPost {
+		return ""
+	}
+	switch segments[3] {
+	case "start":
+
+		return opStartPipe
+	case "stop":
+
+		return opStopPipe
+	}
+
+	return ""
 }
 
 func (h *Handler) ExtractResource(c *echo.Context) string {
@@ -234,26 +282,37 @@ func (h *Handler) dispatch(
 ) ([]byte, error) {
 	switch op {
 	case opCreatePipe:
+
 		return h.handleCreatePipe(ctx, path, body)
 	case opDescribePipe:
+
 		return h.handleDescribePipe(ctx, path)
 	case opListPipes:
+
 		return h.handleListPipes(ctx, query)
 	case opDeletePipe:
+
 		return h.handleDeletePipe(ctx, path)
 	case opUpdatePipe:
+
 		return h.handleUpdatePipe(ctx, path, body)
 	case opStartPipe:
+
 		return h.handleStartPipe(ctx, path)
 	case opStopPipe:
+
 		return h.handleStopPipe(ctx, path)
 	case opTagResource:
+
 		return h.handleTagResource(ctx, path, body)
 	case opUntagResource:
+
 		return h.handleUntagResource(ctx, path, query)
 	case opListTagsForResource:
+
 		return h.handleListTagsForResource(ctx, path)
 	default:
+
 		return nil, fmt.Errorf("%w: %s", errUnknownAction, op)
 	}
 }
@@ -286,8 +345,10 @@ func (h *Handler) handleError(c *echo.Context, err error) error {
 		return c.JSONBlob(http.StatusBadRequest, payload)
 	case errors.Is(err, errInvalidRequest), errors.Is(err, errUnknownAction),
 		errors.As(err, &syntaxErr), errors.As(err, &typeErr):
+
 		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: err.Error()})
 	default:
+
 		return c.JSON(
 			http.StatusInternalServerError,
 			map[string]string{keyMessageField: err.Error()},

--- a/services/ram/handler.go
+++ b/services/ram/handler.go
@@ -280,11 +280,16 @@ func extractCreateDeleteOp(path string) string {
 }
 
 // extractGetListOp maps get/list paths to operation names.
-//
-//nolint:cyclop // large switch needed to map all RAM list/get paths to op names
-func extractGetListOp(
-	path string,
-) string {
+func extractGetListOp(path string) string {
+	if op := extractGetOps(path); op != "" {
+		return op
+	}
+
+	return extractListOps(path)
+}
+
+// extractGetOps maps GET-style paths to operation names.
+func extractGetOps(path string) string {
 	switch {
 	case strings.HasPrefix(path, "/getpermission"):
 		return opGetPermission
@@ -306,6 +311,14 @@ func extractGetListOp(
 		return opListPermissions
 	case strings.HasPrefix(path, "/listprincipals"):
 		return opListPrincipals
+	}
+
+	return ""
+}
+
+// extractListOps maps list/promote/replace/tag paths to operation names.
+func extractListOps(path string) string {
+	switch {
 	case strings.HasPrefix(path, "/listreplacepermissionassociationswork"):
 		return opListReplacePermissionAssociationsWork
 	case strings.HasPrefix(path, "/listresourcesharepermissions"):
@@ -328,9 +341,9 @@ func extractGetListOp(
 		return opTagResource
 	case strings.HasPrefix(path, "/untagresource"):
 		return opUntagResource
-	default:
-		return ""
 	}
+
+	return ""
 }
 
 // extractAssociationOperation maps associate/disassociate RAM paths to their operation names.

--- a/services/rds/handler_stubs.go
+++ b/services/rds/handler_stubs.go
@@ -6,6 +6,7 @@ package rds
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/url"
 )
@@ -29,66 +30,118 @@ const (
 	backupStatusReplicating = "replicating"
 )
 
+// errRDSStubNotHandled is a sentinel used internally to signal that a dispatch
+// helper did not recognise the action. It is never returned to callers.
+var errRDSStubNotHandled = errors.New("rds: action not handled by this dispatcher")
+
 // dispatchExtended14 routes the stub RDS operations added for SDK completeness.
-//
-//nolint:cyclop // dispatches many stub operations in one function
 func (h *Handler) dispatchExtended14(action string, vals url.Values) (any, error) {
+	if r, err := h.dispatchEngineShardOps(action, vals); !errors.Is(err, errRDSStubNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchIntegrationTenantOps(action, vals); !errors.Is(err, errRDSStubNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchAutomatedBackupOps(action, vals); !errors.Is(err, errRDSStubNotHandled) {
+		return r, err
+	}
+
+	return nil, fmt.Errorf("%w: %s is not a valid RDS action", ErrUnknownAction, action)
+}
+
+// dispatchEngineShardOps handles custom engine version and shard group operations.
+func (h *Handler) dispatchEngineShardOps(action string, vals url.Values) (any, error) {
 	switch action {
-	// Custom DB Engine Versions
 	case "CreateCustomDBEngineVersion":
+
 		return h.handleCreateCustomDBEngineVersion(vals)
 	case "DeleteCustomDBEngineVersion":
+
 		return h.handleDeleteCustomDBEngineVersion(vals)
 	case "ModifyCustomDBEngineVersion":
+
 		return h.handleModifyCustomDBEngineVersion(vals)
-	// DB Shard Groups
 	case "CreateDBShardGroup":
+
 		return h.handleCreateDBShardGroup(vals)
 	case "DeleteDBShardGroup":
+
 		return h.handleDeleteDBShardGroup(vals)
 	case "DescribeDBShardGroups":
+
 		return h.handleDescribeDBShardGroups(vals)
 	case "ModifyDBShardGroup":
+
 		return h.handleModifyDBShardGroup(vals)
 	case "RebootDBShardGroup":
+
 		return h.handleRebootDBShardGroup(vals)
-	// Integrations
+	}
+
+	return nil, errRDSStubNotHandled
+}
+
+// dispatchIntegrationTenantOps handles integration and tenant database operations.
+func (h *Handler) dispatchIntegrationTenantOps(action string, vals url.Values) (any, error) {
+	switch action {
 	case "CreateIntegration":
+
 		return h.handleCreateIntegration(vals)
 	case "DeleteIntegration":
+
 		return h.handleDeleteIntegration(vals)
 	case "DescribeIntegrations":
+
 		return h.handleDescribeIntegrations(vals)
 	case "ModifyIntegration":
+
 		return h.handleModifyIntegration(vals)
-	// Tenant Databases
 	case "CreateTenantDatabase":
+
 		return h.handleCreateTenantDatabase(vals)
 	case "DeleteTenantDatabase":
+
 		return h.handleDeleteTenantDatabase(vals)
 	case "DescribeTenantDatabases":
+
 		return h.handleDescribeTenantDatabases(vals)
 	case "ModifyTenantDatabase":
+
 		return h.handleModifyTenantDatabase(vals)
-	// Automated Backups
+	}
+
+	return nil, errRDSStubNotHandled
+}
+
+// dispatchAutomatedBackupOps handles automated backup and snapshot tenant database operations.
+func (h *Handler) dispatchAutomatedBackupOps(action string, vals url.Values) (any, error) {
+	switch action {
 	case "DeleteDBClusterAutomatedBackup":
+
 		return h.handleDeleteDBClusterAutomatedBackup(vals)
 	case "DeleteDBInstanceAutomatedBackup":
+
 		return h.handleDeleteDBInstanceAutomatedBackup(vals)
 	case "DescribeDBClusterAutomatedBackups":
+
 		return h.handleDescribeDBClusterAutomatedBackups(vals)
 	case "DescribeDBInstanceAutomatedBackups":
+
 		return h.handleDescribeDBInstanceAutomatedBackups(vals)
 	case "StartDBInstanceAutomatedBackupsReplication":
+
 		return h.handleStartDBInstanceAutomatedBackupsReplication(vals)
 	case "StopDBInstanceAutomatedBackupsReplication":
+
 		return h.handleStopDBInstanceAutomatedBackupsReplication(vals)
-	// Snapshot Tenant Databases
 	case "DescribeDBSnapshotTenantDatabases":
+
 		return h.handleDescribeDBSnapshotTenantDatabases(vals)
-	default:
-		return nil, fmt.Errorf("%w: %s is not a valid RDS action", ErrUnknownAction, action)
 	}
+
+	return nil, errRDSStubNotHandled
 }
 
 // ---- XML response types ----

--- a/services/route53/handler.go
+++ b/services/route53/handler.go
@@ -636,42 +636,10 @@ func (h *Handler) routeHostedZoneRoot(c *echo.Context, method string) error {
 	}
 }
 
-//nolint:cyclop // routes many hosted zone sub-paths
+// routeHostedZone routes requests for a specific hosted zone by path suffix.
 func (h *Handler) routeHostedZone(c *echo.Context, path, method string) error {
-	if strings.HasSuffix(path, route53RRSetSuffix) {
-		switch method {
-		case http.MethodPost:
-			return h.changeResourceRecordSets(c)
-		case http.MethodGet:
-			return h.listResourceRecordSets(c)
-		default:
-			return xmlError(c, http.StatusNotFound, "NoSuchOperation",
-				"unsupported method on rrset")
-		}
-	}
-
-	if strings.HasSuffix(path, route53AssociateVPCSuffix) {
-		switch method {
-		case http.MethodPost:
-			return h.associateVPCWithHostedZone(c, path)
-		case http.MethodGet:
-			return h.listVPCAssociationAuthorizations(c, path)
-		default:
-			return xmlError(c, http.StatusNotFound, "NoSuchOperation",
-				"unsupported method on associatevpc")
-		}
-	}
-
-	if strings.HasSuffix(path, route53DeauthorizeVPCSuffix) && method == http.MethodPost {
-		return h.deleteVPCAssociationAuthorization(c, path)
-	}
-
-	if strings.HasSuffix(path, route53DisassociateVPCSuffix) && method == http.MethodPost {
-		return h.disassociateVPCFromHostedZone(c, path)
-	}
-
-	if strings.HasSuffix(path, route53FeaturesSuffix) && method == http.MethodPost {
-		return h.updateHostedZoneFeatures(c, path)
+	if ok, err := h.routeHostedZoneSuffix(c, path, method); ok {
+		return err
 	}
 
 	if ok, err := h.routeHostedZoneDNSSEC(c, path, method); ok {
@@ -684,11 +652,61 @@ func (h *Handler) routeHostedZone(c *echo.Context, path, method string) error {
 	case http.MethodGet:
 		return h.getHostedZone(c)
 	case http.MethodPost:
-		// UpdateHostedZoneComment — POST /2013-04-01/hostedzone/{Id}
 		return h.updateHostedZoneComment(c, path)
 	default:
 		return xmlError(c, http.StatusNotFound, "NoSuchOperation",
 			"unsupported method on hosted zone")
+	}
+}
+
+// routeHostedZoneSuffix handles suffix-based sub-paths for a hosted zone.
+func (h *Handler) routeHostedZoneSuffix(c *echo.Context, path, method string) (bool, error) {
+	if strings.HasSuffix(path, route53RRSetSuffix) {
+		return true, h.routeRRSet(c, method)
+	}
+
+	if strings.HasSuffix(path, route53AssociateVPCSuffix) {
+		return true, h.routeAssociateVPC(c, path, method)
+	}
+
+	if strings.HasSuffix(path, route53DeauthorizeVPCSuffix) && method == http.MethodPost {
+		return true, h.deleteVPCAssociationAuthorization(c, path)
+	}
+
+	if strings.HasSuffix(path, route53DisassociateVPCSuffix) && method == http.MethodPost {
+		return true, h.disassociateVPCFromHostedZone(c, path)
+	}
+
+	if strings.HasSuffix(path, route53FeaturesSuffix) && method == http.MethodPost {
+		return true, h.updateHostedZoneFeatures(c, path)
+	}
+
+	return false, nil
+}
+
+// routeRRSet routes resource record set requests.
+func (h *Handler) routeRRSet(c *echo.Context, method string) error {
+	switch method {
+	case http.MethodPost:
+		return h.changeResourceRecordSets(c)
+	case http.MethodGet:
+		return h.listResourceRecordSets(c)
+	default:
+		return xmlError(c, http.StatusNotFound, "NoSuchOperation",
+			"unsupported method on rrset")
+	}
+}
+
+// routeAssociateVPC routes VPC association requests.
+func (h *Handler) routeAssociateVPC(c *echo.Context, path, method string) error {
+	switch method {
+	case http.MethodPost:
+		return h.associateVPCWithHostedZone(c, path)
+	case http.MethodGet:
+		return h.listVPCAssociationAuthorizations(c, path)
+	default:
+		return xmlError(c, http.StatusNotFound, "NoSuchOperation",
+			"unsupported method on associatevpc")
 	}
 }
 

--- a/services/route53/handler_completeness.go
+++ b/services/route53/handler_completeness.go
@@ -44,48 +44,13 @@ const (
 
 // routeCompleteness handles previously-notImplemented Route53 paths.
 // Returns (true, err) if the path was handled, (false, nil) if not.
-//
-//nolint:gocognit,gocyclo,cyclop // routes many completeness sub-paths
 func (h *Handler) routeCompleteness(c *echo.Context, path, method string) (bool, error) {
-	switch {
-	case path == route53TestDNSAnswerPath && method == http.MethodGet:
-		return true, h.testDNSAnswer(c)
-	case path == route53CheckerIPRangesPath && method == http.MethodGet:
-		return true, h.getCheckerIPRanges(c)
-	case path == route53GeoLocationPath && method == http.MethodGet:
-		return true, h.getGeoLocation(c)
-	case path == route53GeoLocationsPath && method == http.MethodGet:
-		return true, h.listGeoLocations(c)
-	case path == route53HealthCheckCountPath && method == http.MethodGet:
-		return true, h.getHealthCheckCount(c)
-	case path == route53HostedZoneCountPath && method == http.MethodGet:
-		return true, h.getHostedZoneCount(c)
-	case path == route53HostedZonesByNamePath && method == http.MethodGet:
-		return true, h.listHostedZonesByName(c)
-	case path == route53HostedZonesByVPCPath && method == http.MethodGet:
-		return true, h.listHostedZonesByVPC(c)
-	case path == route53TPInstancesByHZPath && method == http.MethodGet:
-		return true, h.listTrafficPolicyInstancesByHostedZone(c)
-	case path == route53TPInstancesByPolicyPath && method == http.MethodGet:
-		return true, h.listTrafficPolicyInstancesByPolicy(c)
-	case strings.HasPrefix(path, route53AccountLimitPrefix) && method == http.MethodGet:
-		return true, h.getAccountLimit(c, path)
-	case strings.HasPrefix(path, route53HostedZoneLimitPrefix) && method == http.MethodGet:
-		return true, h.getHostedZoneLimit(c, path)
-	case strings.HasPrefix(path, route53ReusableDSLimitPrefix) && method == http.MethodGet:
-		return true, h.getReusableDelegationSetLimit(c, path)
-	case strings.HasSuffix(path, route53AuthorizeVPCSuffix) && method == http.MethodGet:
-		return true, h.listVPCAssociationAuthorizations(c, path)
-	case strings.HasSuffix(path, route53AuthorizeVPCSuffix) && method == http.MethodPost:
-		return true, h.createVPCAssociationAuthorization(c, path)
-	case strings.HasSuffix(path, route53DeauthorizeVPCSuffix) && method == http.MethodPost:
-		return true, h.deleteVPCAssociationAuthorization(c, path)
-	case strings.HasSuffix(path, route53DisassociateVPCSuffix) && method == http.MethodPost:
-		return true, h.disassociateVPCFromHostedZone(c, path)
-	case strings.HasSuffix(path, route53FeaturesSuffix) && method == http.MethodPost:
-		return true, h.updateHostedZoneFeatures(c, path)
-	case strings.HasSuffix(path, route53LastFailureReasonSuffix) && method == http.MethodGet:
-		return true, h.getHealthCheckLastFailureReason(c, path)
+	if ok, err := h.routeCompletenessCore(c, path, method); ok {
+		return true, err
+	}
+
+	if ok, err := h.routeCompletenessVPC(c, path, method); ok {
+		return true, err
 	}
 
 	if ok, err := h.routeCompletenessTP(c, path, method); ok {
@@ -98,6 +63,81 @@ func (h *Handler) routeCompleteness(c *echo.Context, path, method string) (bool,
 
 	if ok, err := h.routeCompletenessQueryLogging(c, path, method); ok {
 		return true, err
+	}
+
+	return false, nil
+}
+
+// routeCompletenessCore handles basic info and limit endpoints.
+func (h *Handler) routeCompletenessCore(c *echo.Context, path, method string) (bool, error) {
+	if ok, err := h.routeCompletenessInfo(c, path, method); ok {
+		return true, err
+	}
+
+	return h.routeCompletenessLimits(c, path, method)
+}
+
+// routeCompletenessInfo handles DNS answer, geo, health-check, and hosted-zone info endpoints.
+func (h *Handler) routeCompletenessInfo(c *echo.Context, path, method string) (bool, error) {
+	if method != http.MethodGet {
+		return false, nil
+	}
+
+	switch path {
+	case route53TestDNSAnswerPath:
+		return true, h.testDNSAnswer(c)
+	case route53CheckerIPRangesPath:
+		return true, h.getCheckerIPRanges(c)
+	case route53GeoLocationPath:
+		return true, h.getGeoLocation(c)
+	case route53GeoLocationsPath:
+		return true, h.listGeoLocations(c)
+	case route53HealthCheckCountPath:
+		return true, h.getHealthCheckCount(c)
+	case route53HostedZoneCountPath:
+		return true, h.getHostedZoneCount(c)
+	case route53HostedZonesByNamePath:
+		return true, h.listHostedZonesByName(c)
+	case route53HostedZonesByVPCPath:
+		return true, h.listHostedZonesByVPC(c)
+	case route53TPInstancesByHZPath:
+		return true, h.listTrafficPolicyInstancesByHostedZone(c)
+	case route53TPInstancesByPolicyPath:
+		return true, h.listTrafficPolicyInstancesByPolicy(c)
+	}
+
+	return false, nil
+}
+
+// routeCompletenessLimits handles limit and last-failure-reason endpoints.
+func (h *Handler) routeCompletenessLimits(c *echo.Context, path, method string) (bool, error) {
+	switch {
+	case strings.HasPrefix(path, route53AccountLimitPrefix) && method == http.MethodGet:
+		return true, h.getAccountLimit(c, path)
+	case strings.HasPrefix(path, route53HostedZoneLimitPrefix) && method == http.MethodGet:
+		return true, h.getHostedZoneLimit(c, path)
+	case strings.HasPrefix(path, route53ReusableDSLimitPrefix) && method == http.MethodGet:
+		return true, h.getReusableDelegationSetLimit(c, path)
+	case strings.HasSuffix(path, route53LastFailureReasonSuffix) && method == http.MethodGet:
+		return true, h.getHealthCheckLastFailureReason(c, path)
+	}
+
+	return false, nil
+}
+
+// routeCompletenessVPC handles VPC association and disassociation endpoints.
+func (h *Handler) routeCompletenessVPC(c *echo.Context, path, method string) (bool, error) {
+	switch {
+	case strings.HasSuffix(path, route53AuthorizeVPCSuffix) && method == http.MethodGet:
+		return true, h.listVPCAssociationAuthorizations(c, path)
+	case strings.HasSuffix(path, route53AuthorizeVPCSuffix) && method == http.MethodPost:
+		return true, h.createVPCAssociationAuthorization(c, path)
+	case strings.HasSuffix(path, route53DeauthorizeVPCSuffix) && method == http.MethodPost:
+		return true, h.deleteVPCAssociationAuthorization(c, path)
+	case strings.HasSuffix(path, route53DisassociateVPCSuffix) && method == http.MethodPost:
+		return true, h.disassociateVPCFromHostedZone(c, path)
+	case strings.HasSuffix(path, route53FeaturesSuffix) && method == http.MethodPost:
+		return true, h.updateHostedZoneFeatures(c, path)
 	}
 
 	return false, nil

--- a/services/s3/bucket_ops.go
+++ b/services/s3/bucket_ops.go
@@ -157,9 +157,21 @@ func (h *S3Handler) routeBucketPut(
 
 // routeBucketPutExtra handles PUT sub-resources that are not in the primary switch.
 // Returns true if the request was handled.
-//
-//nolint:cyclop // dispatches many bucket PUT sub-resources; complexity is unavoidable
 func (h *S3Handler) routeBucketPutExtra(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) bool {
+	if h.routeBucketPutStorage(ctx, w, r, bucket) {
+		return true
+	}
+
+	return h.routeBucketPutConfig(ctx, w, r, bucket)
+}
+
+// routeBucketPutStorage handles replication, encryption, access-control, and analytics PUT sub-resources.
+func (h *S3Handler) routeBucketPutStorage(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
@@ -184,6 +196,23 @@ func (h *S3Handler) routeBucketPutExtra(
 		h.putBucketAnalyticsConfiguration(ctx, w, r, bucket)
 	case q.Has("intelligent-tiering"):
 		h.putBucketIntelligentTieringConfiguration(ctx, w, r, bucket)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeBucketPutConfig handles inventory, metrics, and miscellaneous PUT sub-resources.
+func (h *S3Handler) routeBucketPutConfig(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) bool {
+	q := r.URL.Query()
+
+	switch {
 	case q.Has("inventory"):
 		h.putBucketInventoryConfiguration(ctx, w, r, bucket)
 	case q.Has("metrics"):

--- a/services/s3/select_sql.go
+++ b/services/s3/select_sql.go
@@ -76,7 +76,7 @@ func (t *sqlTokeniser) peek() (sqlToken, error) {
 }
 
 // next returns the next token.
-func (t *sqlTokeniser) next() (sqlToken, error) { //nolint:cyclop // tokeniser switch inherently broad
+func (t *sqlTokeniser) next() (sqlToken, error) {
 	t.skipWhitespace()
 
 	if t.pos >= len(t.src) {
@@ -85,42 +85,65 @@ func (t *sqlTokeniser) next() (sqlToken, error) { //nolint:cyclop // tokeniser s
 
 	ch := t.src[t.pos]
 
-	switch {
-	case ch == '\'':
-		return t.readString()
-	case ch == '"':
-		return t.readQuotedIdent()
-	case ch == '*':
-		t.pos++
+	if ok, tok, err := t.nextQuoteOrPunct(ch); ok {
+		return tok, err
+	}
 
-		return sqlToken{typ: tokStar, val: "*"}, nil
-	case ch == ',':
-		t.pos++
-
-		return sqlToken{typ: tokComma, val: ","}, nil
-	case ch == '.':
-		t.pos++
-
-		return sqlToken{typ: tokDot, val: "."}, nil
-	case ch == '(':
-		t.pos++
-
-		return sqlToken{typ: tokLParen, val: "("}, nil
-	case ch == ')':
-		t.pos++
-
-		return sqlToken{typ: tokRParen, val: ")"}, nil
-	case ch == '=':
-		t.pos++
-
-		return sqlToken{typ: tokEq, val: "="}, nil
-	case unicode.IsDigit(rune(ch)) || (ch == '-' && t.pos+1 < len(t.src) && unicode.IsDigit(rune(t.src[t.pos+1]))):
+	if t.isNumberStart(ch) {
 		return t.readNumber()
-	case unicode.IsLetter(rune(ch)) || ch == '_':
+	}
+
+	if unicode.IsLetter(rune(ch)) || ch == '_' {
 		return t.readIdent()
 	}
 
 	return t.readOperator(ch)
+}
+
+// isNumberStart returns true if ch starts a numeric token.
+func (t *sqlTokeniser) isNumberStart(ch byte) bool {
+	return unicode.IsDigit(rune(ch)) ||
+		(ch == '-' && t.pos+1 < len(t.src) && unicode.IsDigit(rune(t.src[t.pos+1])))
+}
+
+// nextQuoteOrPunct handles quote characters and single-character punctuation tokens.
+func (t *sqlTokeniser) nextQuoteOrPunct(ch byte) (bool, sqlToken, error) {
+	switch ch {
+	case '\'':
+		tok, err := t.readString()
+
+		return true, tok, err
+	case '"':
+		tok, err := t.readQuotedIdent()
+
+		return true, tok, err
+	case '*':
+		t.pos++
+
+		return true, sqlToken{typ: tokStar, val: "*"}, nil
+	case ',':
+		t.pos++
+
+		return true, sqlToken{typ: tokComma, val: ","}, nil
+	case '.':
+		t.pos++
+
+		return true, sqlToken{typ: tokDot, val: "."}, nil
+	case '(':
+		t.pos++
+
+		return true, sqlToken{typ: tokLParen, val: "("}, nil
+	case ')':
+		t.pos++
+
+		return true, sqlToken{typ: tokRParen, val: ")"}, nil
+	case '=':
+		t.pos++
+
+		return true, sqlToken{typ: tokEq, val: "="}, nil
+	}
+
+	return false, sqlToken{}, nil
 }
 
 func (t *sqlTokeniser) skipWhitespace() {
@@ -264,7 +287,7 @@ func parseSQL(src string) (*sqlQuery, error) {
 	return newSQLParser(src).parse()
 }
 
-func (p *sqlParser) parse() (*sqlQuery, error) { //nolint:cyclop // SQL parsing inherently has many branches
+func (p *sqlParser) parse() (*sqlQuery, error) {
 	q := &sqlQuery{}
 
 	if err := p.expectKeyword("SELECT"); err != nil {
@@ -279,47 +302,70 @@ func (p *sqlParser) parse() (*sqlQuery, error) { //nolint:cyclop // SQL parsing 
 	q.columns = cols
 	q.selectAll = selectAll
 
-	if fromErr := p.expectKeyword("FROM"); fromErr != nil {
-		return nil, fromErr
-	}
-
-	// consume table name (s3object or similar)
-	if _, err = p.tok.next(); err != nil {
+	if err = p.parseFromClause(q); err != nil {
 		return nil, err
 	}
 
+	if err = p.parseWhereLimit(q); err != nil {
+		return nil, err
+	}
+
+	return q, nil
+}
+
+// parseFromClause consumes the FROM clause, table name, and optional alias.
+func (p *sqlParser) parseFromClause(q *sqlQuery) error {
+	if err := p.expectKeyword("FROM"); err != nil {
+		return err
+	}
+
+	// consume table name (s3object or similar)
+	if _, err := p.tok.next(); err != nil {
+		return err
+	}
+
 	// optional alias
-	if tok, peekErr := p.tok.peek(); peekErr == nil && tok.typ == tokIdent && !isKeyword(tok.val) {
+	tok, peekErr := p.tok.peek()
+	if peekErr == nil && tok.typ == tokIdent && !isKeyword(tok.val) {
 		if _, peekErr = p.tok.next(); peekErr != nil {
-			return nil, peekErr
+			return peekErr
 		}
 
 		q.tableAlias = tok.val
 	}
 
+	return nil
+}
+
+// parseWhereLimit consumes the optional WHERE and LIMIT clauses.
+func (p *sqlParser) parseWhereLimit(q *sqlQuery) error {
 	// optional WHERE
-	if tok, peekErr := p.tok.peek(); peekErr == nil && tok.typ == tokIdent && strings.EqualFold(tok.val, "WHERE") {
+	tok, peekErr := p.tok.peek()
+	if peekErr == nil && tok.typ == tokIdent && strings.EqualFold(tok.val, "WHERE") {
 		if _, peekErr = p.tok.next(); peekErr != nil {
-			return nil, peekErr
+			return peekErr
 		}
 
+		var err error
 		if q.condition, err = p.parseOr(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	// optional LIMIT
-	if tok, peekErr := p.tok.peek(); peekErr == nil && tok.typ == tokIdent && strings.EqualFold(tok.val, "LIMIT") {
+	tok, peekErr = p.tok.peek()
+	if peekErr == nil && tok.typ == tokIdent && strings.EqualFold(tok.val, "LIMIT") {
 		if _, peekErr = p.tok.next(); peekErr != nil {
-			return nil, peekErr
+			return peekErr
 		}
 
+		var err error
 		if q.limit, err = p.parseLimit(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return q, nil
+	return nil
 }
 
 func (p *sqlParser) parseLimit() (int, error) {

--- a/services/s3control/handler.go
+++ b/services/s3control/handler.go
@@ -254,36 +254,94 @@ func isPrefixSuffix(prefix, path, suffix string) bool {
 	return strings.HasPrefix(path, prefix) && strings.HasSuffix(path, suffix)
 }
 
-func extractNewOpsOperation(path, method string) string { //nolint:cyclop,gocognit,gocyclo // path dispatch table
+// extractNewOpsOperation routes access grants and access point operations.
+func extractNewOpsOperation(path, method string) string {
+	if op := extractAccessGrantsInstanceOp(path, method); op != "" {
+		return op
+	}
+
+	if op := extractAccessGrantsOp(path, method); op != "" {
+		return op
+	}
+
+	return extractAccessPointOpsOperation(path, method)
+}
+
+// extractAccessGrantsInstanceOp handles access grants instance and identity center operations.
+func extractAccessGrantsInstanceOp(path, method string) string {
+	switch path {
+	case pathAccessGrantsInstance:
+		switch method {
+		case http.MethodPost:
+			return "CreateAccessGrantsInstance"
+		case http.MethodGet:
+			return "GetAccessGrantsInstance"
+		case http.MethodDelete:
+			return "DeleteAccessGrantsInstance"
+		}
+	case pathAccessGrantsInstanceResourcePolicy:
+		switch method {
+		case http.MethodGet:
+			return "GetAccessGrantsInstanceResourcePolicy"
+		case http.MethodPut:
+			return "PutAccessGrantsInstanceResourcePolicy"
+		case http.MethodDelete:
+			return "DeleteAccessGrantsInstanceResourcePolicy"
+		}
+	case pathIdentityCenter:
+		switch method {
+		case http.MethodPost:
+			return "AssociateAccessGrantsIdentityCenter"
+		case http.MethodDelete:
+			return "DissociateAccessGrantsIdentityCenter"
+		}
+	}
+
+	return ""
+}
+
+// extractAccessGrantsOp handles access grants, locations, and data access operations.
+func extractAccessGrantsOp(path, method string) string {
+	if op := extractAccessGrantsExactOp(path, method); op != "" {
+		return op
+	}
+
+	return extractAccessGrantsPrefixOp(path, method)
+}
+
+// extractAccessGrantsExactOp handles exact-path access grants operations.
+func extractAccessGrantsExactOp(path, method string) string {
+	switch path {
+	case pathAccessGrant:
+		switch method {
+		case http.MethodPost:
+			return "CreateAccessGrant"
+		case http.MethodGet:
+			return "ListAccessGrants"
+		}
+	case pathCallerAccessGrants:
+		if method == http.MethodGet {
+			return "ListCallerAccessGrants"
+		}
+	case pathDataAccess:
+		if method == http.MethodGet {
+			return "GetDataAccess"
+		}
+	case pathAccessGrantsLocation:
+		switch method {
+		case http.MethodPost:
+			return "CreateAccessGrantsLocation"
+		case http.MethodGet:
+			return "ListAccessGrantsLocations"
+		}
+	}
+
+	return ""
+}
+
+// extractAccessGrantsPrefixOp handles prefix-based access grants operations.
+func extractAccessGrantsPrefixOp(path, method string) string {
 	switch {
-	case path == pathAccessGrantsInstance && method == http.MethodPost:
-		return "CreateAccessGrantsInstance"
-	case path == pathAccessGrantsInstance && method == http.MethodGet:
-		return "GetAccessGrantsInstance"
-	case path == pathAccessGrantsInstance && method == http.MethodDelete:
-		return "DeleteAccessGrantsInstance"
-	case path == pathAccessGrantsInstanceResourcePolicy && method == http.MethodGet:
-		return "GetAccessGrantsInstanceResourcePolicy"
-	case path == pathAccessGrantsInstanceResourcePolicy && method == http.MethodPut:
-		return "PutAccessGrantsInstanceResourcePolicy"
-	case path == pathAccessGrantsInstanceResourcePolicy && method == http.MethodDelete:
-		return "DeleteAccessGrantsInstanceResourcePolicy"
-	case path == pathIdentityCenter && method == http.MethodPost:
-		return "AssociateAccessGrantsIdentityCenter"
-	case path == pathIdentityCenter && method == http.MethodDelete:
-		return "DissociateAccessGrantsIdentityCenter"
-	case path == pathAccessGrant && method == http.MethodPost:
-		return "CreateAccessGrant"
-	case path == pathAccessGrant && method == http.MethodGet:
-		return "ListAccessGrants"
-	case path == pathCallerAccessGrants && method == http.MethodGet:
-		return "ListCallerAccessGrants"
-	case path == pathDataAccess && method == http.MethodGet:
-		return "GetDataAccess"
-	case path == pathAccessGrantsLocation && method == http.MethodPost:
-		return "CreateAccessGrantsLocation"
-	case path == pathAccessGrantsLocation && method == http.MethodGet:
-		return "ListAccessGrantsLocations"
 	case strings.HasPrefix(path, pathAccessGrantsInstancePrefix+"prefix") && method == http.MethodGet:
 		return "GetAccessGrantsInstanceForPrefix"
 	case strings.HasPrefix(path, pathAccessGrantPrefix) && method == http.MethodGet:
@@ -298,18 +356,67 @@ func extractNewOpsOperation(path, method string) string { //nolint:cyclop,gocogn
 		return "UpdateAccessGrantsLocation"
 	}
 
-	return extractAccessPointOpsOperation(path, method)
+	return ""
 }
 
-//nolint:cyclop,gocognit,gocyclo // path dispatch table for access point and object lambda ops
+// extractAccessPointOpsOperation routes access point and object lambda operations.
 func extractAccessPointOpsOperation(path, method string) string {
+	if op := extractAccessPointCRUDOp(path, method); op != "" {
+		return op
+	}
+
+	if op := extractObjectLambdaOp(path, method); op != "" {
+		return op
+	}
+
+	return extractBucketOpsOperation(path, method)
+}
+
+// extractAccessPointCRUDOp handles standard access point CRUD and listing.
+func extractAccessPointCRUDOp(path, method string) string {
+	if op := extractAccessPointBasicOp(path, method); op != "" {
+		return op
+	}
+
+	return extractAccessPointSubResourceOp(path, method)
+}
+
+// extractAccessPointBasicOp handles access point CRUD and list operations.
+func extractAccessPointBasicOp(path, method string) string {
+	if isSimplePath(pathAccessPointPrefix, path) {
+		switch method {
+		case http.MethodPut:
+			return "CreateAccessPoint"
+		case http.MethodGet:
+			return "GetAccessPoint"
+		case http.MethodDelete:
+			return "DeleteAccessPoint"
+		}
+
+		return ""
+	}
+
+	switch path {
+	case "/v20180820/accesspoint":
+		if method == http.MethodGet {
+			return "ListAccessPoints"
+		}
+	case pathAccessPointsDirectoryBuckets:
+		if method == http.MethodGet {
+			return "ListAccessPointsForDirectoryBuckets"
+		}
+	case pathAccessPointsForObjectLambdaList:
+		if method == http.MethodGet {
+			return "ListAccessPointsForObjectLambda"
+		}
+	}
+
+	return ""
+}
+
+// extractAccessPointSubResourceOp handles access point policy, status, and scope operations.
+func extractAccessPointSubResourceOp(path, method string) string {
 	switch {
-	case isSimplePath(pathAccessPointPrefix, path) && method == http.MethodPut:
-		return "CreateAccessPoint"
-	case isSimplePath(pathAccessPointPrefix, path) && method == http.MethodGet:
-		return "GetAccessPoint"
-	case isSimplePath(pathAccessPointPrefix, path) && method == http.MethodDelete:
-		return "DeleteAccessPoint"
 	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodGet:
 		return "GetAccessPointPolicy"
 	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodPut:
@@ -324,12 +431,32 @@ func extractAccessPointOpsOperation(path, method string) string {
 		return "PutAccessPointScope"
 	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodDelete:
 		return "DeleteAccessPointScope"
-	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodPut:
-		return "CreateAccessPointForObjectLambda"
-	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodGet:
-		return "GetAccessPointForObjectLambda"
-	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodDelete:
-		return "DeleteAccessPointForObjectLambda"
+	}
+
+	return ""
+}
+
+// extractObjectLambdaOp handles object lambda access point operations.
+func extractObjectLambdaOp(path, method string) string {
+	if isSimplePath(pathObjectLambdaPrefix, path) {
+		switch method {
+		case http.MethodPut:
+			return "CreateAccessPointForObjectLambda"
+		case http.MethodGet:
+			return "GetAccessPointForObjectLambda"
+		case http.MethodDelete:
+			return "DeleteAccessPointForObjectLambda"
+		}
+
+		return ""
+	}
+
+	return extractObjectLambdaPolicyOp(path, method)
+}
+
+// extractObjectLambdaPolicyOp handles object lambda policy and configuration operations.
+func extractObjectLambdaPolicyOp(path, method string) string {
+	switch {
 	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodGet:
 		return "GetAccessPointPolicyForObjectLambda"
 	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodPut:
@@ -342,37 +469,91 @@ func extractAccessPointOpsOperation(path, method string) string {
 		return "GetAccessPointConfigurationForObjectLambda"
 	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/configuration") && method == http.MethodPut:
 		return "PutAccessPointConfigurationForObjectLambda"
-	case path == "/v20180820/accesspoint" && method == http.MethodGet:
-		return "ListAccessPoints"
-	case path == pathAccessPointsDirectoryBuckets && method == http.MethodGet:
-		return "ListAccessPointsForDirectoryBuckets"
-	case path == pathAccessPointsForObjectLambdaList && method == http.MethodGet:
-		return "ListAccessPointsForObjectLambda"
 	}
 
-	return extractBucketOpsOperation(path, method)
+	return ""
 }
 
-func extractBucketOpsOperation(path, method string) string { //nolint:cyclop,gocyclo // path dispatch table
+// extractBucketOpsOperation routes bucket and sub-resource operations.
+func extractBucketOpsOperation(path, method string) string {
+	if op := extractBucketCRUDOps(path, method); op != "" {
+		return op
+	}
+
+	if op := extractBucketSubResourceOps(path, method); op != "" {
+		return op
+	}
+
+	return extractJobMRAPStorageLensOps(path, method)
+}
+
+// extractBucketCRUDOps handles bucket CRUD, lifecycle, and policy operations.
+func extractBucketCRUDOps(path, method string) string {
+	if isSimplePath(pathBucketPrefix, path) {
+		switch method {
+		case http.MethodPut:
+			return "CreateBucket"
+		case http.MethodGet:
+			return "GetBucket"
+		case http.MethodDelete:
+			return "DeleteBucket"
+		}
+
+		return ""
+	}
+
+	if isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") {
+		switch method {
+		case http.MethodGet:
+			return "GetBucketLifecycleConfiguration"
+		case http.MethodPut:
+			return "PutBucketLifecycleConfiguration"
+		case http.MethodDelete:
+			return "DeleteBucketLifecycleConfiguration"
+		}
+
+		return ""
+	}
+
+	if isPrefixSuffix(pathBucketPrefix, path, "/policy") {
+		switch method {
+		case http.MethodGet:
+			return "GetBucketPolicy"
+		case http.MethodPut:
+			return "PutBucketPolicy"
+		case http.MethodDelete:
+			return "DeleteBucketPolicy"
+		}
+	}
+
+	return ""
+}
+
+// extractBucketSubResourceOps handles bucket replication, tagging, versioning, and listing.
+func extractBucketSubResourceOps(path, method string) string {
+	if op := extractBucketReplicationTaggingOp(path, method); op != "" {
+		return op
+	}
+
+	if isPrefixSuffix(pathBucketPrefix, path, "/versioning") {
+		switch method {
+		case http.MethodGet:
+			return "GetBucketVersioning"
+		case http.MethodPut:
+			return "PutBucketVersioning"
+		}
+	}
+
+	if path == pathRegionalBuckets && method == http.MethodGet {
+		return "ListRegionalBuckets"
+	}
+
+	return ""
+}
+
+// extractBucketReplicationTaggingOp handles bucket replication and tagging operations.
+func extractBucketReplicationTaggingOp(path, method string) string {
 	switch {
-	case isSimplePath(pathBucketPrefix, path) && method == http.MethodPut:
-		return "CreateBucket"
-	case isSimplePath(pathBucketPrefix, path) && method == http.MethodGet:
-		return "GetBucket"
-	case isSimplePath(pathBucketPrefix, path) && method == http.MethodDelete:
-		return "DeleteBucket"
-	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodGet:
-		return "GetBucketLifecycleConfiguration"
-	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodPut:
-		return "PutBucketLifecycleConfiguration"
-	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodDelete:
-		return "DeleteBucketLifecycleConfiguration"
-	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodGet:
-		return "GetBucketPolicy"
-	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodPut:
-		return "PutBucketPolicy"
-	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodDelete:
-		return "DeleteBucketPolicy"
 	case isPrefixSuffix(pathBucketPrefix, path, "/replication") && method == http.MethodGet:
 		return "GetBucketReplication"
 	case isPrefixSuffix(pathBucketPrefix, path, "/replication") && method == http.MethodPut:
@@ -385,35 +566,82 @@ func extractBucketOpsOperation(path, method string) string { //nolint:cyclop,goc
 		return "PutBucketTagging"
 	case isPrefixSuffix(pathBucketPrefix, path, "/tagging") && method == http.MethodDelete:
 		return "DeleteBucketTagging"
-	case isPrefixSuffix(pathBucketPrefix, path, "/versioning") && method == http.MethodGet:
-		return "GetBucketVersioning"
-	case isPrefixSuffix(pathBucketPrefix, path, "/versioning") && method == http.MethodPut:
-		return "PutBucketVersioning"
-	case path == pathRegionalBuckets && method == http.MethodGet:
-		return "ListRegionalBuckets"
 	}
 
-	return extractJobMRAPStorageLensOps(path, method)
+	return ""
 }
 
-func extractJobMRAPStorageLensOps(path, method string) string { //nolint:cyclop,gocyclo // path dispatch table
-	switch {
-	case path == pathJobs && method == http.MethodPost:
-		return "CreateJob"
-	case path == pathJobs && method == http.MethodGet:
-		return "ListJobs"
-	case isSimplePath(pathJobPrefix, path) && method == http.MethodGet:
+// extractJobMRAPStorageLensOps routes job, MRAP, and storage lens operations.
+func extractJobMRAPStorageLensOps(path, method string) string {
+	if op := extractJobOps(path, method); op != "" {
+		return op
+	}
+
+	if op := extractMRAPOps(path, method); op != "" {
+		return op
+	}
+
+	return extractStorageLensTagOps(path, method)
+}
+
+// extractJobOps handles S3 Batch Operations job operations.
+func extractJobOps(path, method string) string {
+	if path == pathJobs {
+		switch method {
+		case http.MethodPost:
+			return "CreateJob"
+		case http.MethodGet:
+			return "ListJobs"
+		}
+
+		return ""
+	}
+
+	if isSimplePath(pathJobPrefix, path) && method == http.MethodGet {
 		return "DescribeJob"
-	case isPrefixSuffix(pathJobPrefix, path, "/tagging") && method == http.MethodGet:
-		return "GetJobTagging"
-	case isPrefixSuffix(pathJobPrefix, path, "/tagging") && method == http.MethodPut:
-		return "PutJobTagging"
-	case isPrefixSuffix(pathJobPrefix, path, "/tagging") && method == http.MethodDelete:
-		return "DeleteJobTagging"
-	case isPrefixSuffix(pathJobPrefix, path, "/priority") && method == http.MethodPut:
+	}
+
+	return extractJobSubResourceOp(path, method)
+}
+
+// extractJobSubResourceOp handles job tagging, priority, and status operations.
+func extractJobSubResourceOp(path, method string) string {
+	if isPrefixSuffix(pathJobPrefix, path, "/tagging") {
+		switch method {
+		case http.MethodGet:
+			return "GetJobTagging"
+		case http.MethodPut:
+			return "PutJobTagging"
+		case http.MethodDelete:
+			return "DeleteJobTagging"
+		}
+
+		return ""
+	}
+
+	if isPrefixSuffix(pathJobPrefix, path, "/priority") && method == http.MethodPut {
 		return "UpdateJobPriority"
-	case isPrefixSuffix(pathJobPrefix, path, "/status") && method == http.MethodPut:
+	}
+
+	if isPrefixSuffix(pathJobPrefix, path, "/status") && method == http.MethodPut {
 		return "UpdateJobStatus"
+	}
+
+	return ""
+}
+
+// extractMRAPOps handles Multi-Region Access Point operations.
+func extractMRAPOps(path, method string) string {
+	if op := extractMRAPCreateListOp(path, method); op != "" {
+		return op
+	}
+
+	return extractMRAPInstanceOp(path, method)
+}
+
+// extractMRAPCreateListOp handles MRAP create, delete, policy, and list operations.
+func extractMRAPCreateListOp(path, method string) string {
+	switch {
 	case path == pathMRAPCreate && method == http.MethodPost:
 		return "CreateMultiRegionAccessPoint"
 	case strings.HasPrefix(path, pathMRAPDeletePrefix) && method == http.MethodPost:
@@ -424,10 +652,25 @@ func extractJobMRAPStorageLensOps(path, method string) string { //nolint:cyclop,
 		return "DescribeMultiRegionAccessPointOperation"
 	case path == pathMRAPList && method == http.MethodGet:
 		return "ListMultiRegionAccessPoints"
-	case isSimplePath(pathMRAPInstancePrefix, path) && method == http.MethodGet:
-		return "GetMultiRegionAccessPoint"
-	case isSimplePath(pathMRAPInstancePrefix, path) && method == http.MethodDelete:
-		return opDeleteMRAP
+	}
+
+	return ""
+}
+
+// extractMRAPInstanceOp handles MRAP instance CRUD and sub-resource operations.
+func extractMRAPInstanceOp(path, method string) string {
+	if isSimplePath(pathMRAPInstancePrefix, path) {
+		switch method {
+		case http.MethodGet:
+			return "GetMultiRegionAccessPoint"
+		case http.MethodDelete:
+			return opDeleteMRAP
+		}
+
+		return ""
+	}
+
+	switch {
 	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/policy") && method == http.MethodGet:
 		return "GetMultiRegionAccessPointPolicy"
 	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/policyStatus") && method == http.MethodGet:
@@ -438,17 +681,43 @@ func extractJobMRAPStorageLensOps(path, method string) string { //nolint:cyclop,
 		return "SubmitMultiRegionAccessPointRoutes"
 	}
 
-	return extractStorageLensTagOps(path, method)
+	return ""
 }
 
-func extractStorageLensTagOps(path, method string) string { //nolint:cyclop,gocyclo // path dispatch table
+// extractStorageLensTagOps routes storage lens and tagging operations.
+func extractStorageLensTagOps(path, method string) string {
+	if op := extractStorageLensOps(path, method); op != "" {
+		return op
+	}
+
+	return extractTagOps(path, method)
+}
+
+// extractStorageLensOps handles storage lens configuration and group operations.
+func extractStorageLensOps(path, method string) string {
+	if op := extractStorageLensConfigOp(path, method); op != "" {
+		return op
+	}
+
+	return extractStorageLensGroupOp(path, method)
+}
+
+// extractStorageLensConfigOp handles storage lens configuration operations.
+func extractStorageLensConfigOp(path, method string) string {
+	if isSimplePath(pathStorageLensPrefix, path) {
+		switch method {
+		case http.MethodGet:
+			return "GetStorageLensConfiguration"
+		case http.MethodPut:
+			return "PutStorageLensConfiguration"
+		case http.MethodDelete:
+			return "DeleteStorageLensConfiguration"
+		}
+
+		return ""
+	}
+
 	switch {
-	case isSimplePath(pathStorageLensPrefix, path) && method == http.MethodGet:
-		return "GetStorageLensConfiguration"
-	case isSimplePath(pathStorageLensPrefix, path) && method == http.MethodPut:
-		return "PutStorageLensConfiguration"
-	case isSimplePath(pathStorageLensPrefix, path) && method == http.MethodDelete:
-		return "DeleteStorageLensConfiguration"
 	case isPrefixSuffix(pathStorageLensPrefix, path, "/tagging") && method == http.MethodGet:
 		return "GetStorageLensConfigurationTagging"
 	case isPrefixSuffix(pathStorageLensPrefix, path, "/tagging") && method == http.MethodPut:
@@ -457,16 +726,38 @@ func extractStorageLensTagOps(path, method string) string { //nolint:cyclop,gocy
 		return "DeleteStorageLensConfigurationTagging"
 	case path == pathStorageLensList && method == http.MethodGet:
 		return "ListStorageLensConfigurations"
-	case path == pathStorageLensGroup && method == http.MethodPost:
-		return "CreateStorageLensGroup"
-	case path == pathStorageLensGroup && method == http.MethodGet:
-		return "ListStorageLensGroups"
+	}
+
+	return ""
+}
+
+// extractStorageLensGroupOp handles storage lens group operations.
+func extractStorageLensGroupOp(path, method string) string {
+	switch path {
+	case pathStorageLensGroup:
+		switch method {
+		case http.MethodPost:
+			return "CreateStorageLensGroup"
+		case http.MethodGet:
+			return "ListStorageLensGroups"
+		}
+	}
+
+	switch {
 	case strings.HasPrefix(path, pathStorageLensGroupPrefix) && method == http.MethodGet:
 		return "GetStorageLensGroup"
 	case strings.HasPrefix(path, pathStorageLensGroupPrefix) && method == http.MethodPut:
 		return "UpdateStorageLensGroup"
 	case strings.HasPrefix(path, pathStorageLensGroupPrefix) && method == http.MethodDelete:
 		return "DeleteStorageLensGroup"
+	}
+
+	return ""
+}
+
+// extractTagOps handles resource tagging operations.
+func extractTagOps(path, method string) string {
+	switch {
 	case strings.HasPrefix(path, pathTagsPrefix) && method == http.MethodGet:
 		return "ListTagsForResource"
 	case strings.HasPrefix(path, pathTagsPrefix) && method == http.MethodPost:
@@ -511,223 +802,497 @@ func (h *Handler) dispatchPublicAccessBlock(c *echo.Context, method string) erro
 	return c.String(http.StatusNotFound, "not found")
 }
 
-//nolint:cyclop,gocognit,gocyclo // dispatch table for access grants ops
+// dispatchNewOps handles access grants instance and access point operations.
 func (h *Handler) dispatchNewOps(c *echo.Context, path, method string) error {
-	switch {
-	case path == pathAccessGrantsInstance && method == http.MethodPost:
-		return h.handleCreateAccessGrantsInstance(c)
-	case path == pathAccessGrantsInstance && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessGrantsInstance")
-	case path == pathAccessGrantsInstance && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessGrantsInstance")
-	case path == pathAccessGrantsInstanceResourcePolicy && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessGrantsInstanceResourcePolicy")
-	case path == pathAccessGrantsInstanceResourcePolicy && method == http.MethodPut:
-		return h.handleStub(c, "PutAccessGrantsInstanceResourcePolicy")
-	case path == pathAccessGrantsInstanceResourcePolicy && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessGrantsInstanceResourcePolicy")
-	case path == pathIdentityCenter && method == http.MethodPost:
-		return h.handleAssociateAccessGrantsIdentityCenter(c)
-	case path == pathIdentityCenter && method == http.MethodDelete:
-		return h.handleStub(c, "DissociateAccessGrantsIdentityCenter")
-	case path == pathAccessGrant && method == http.MethodPost:
-		return h.handleCreateAccessGrant(c)
-	case path == pathAccessGrant && method == http.MethodGet:
-		return h.handleStub(c, "ListAccessGrants")
-	case path == pathCallerAccessGrants && method == http.MethodGet:
-		return h.handleStub(c, "ListCallerAccessGrants")
-	case path == pathDataAccess && method == http.MethodGet:
-		return h.handleStub(c, "GetDataAccess")
-	case path == pathAccessGrantsLocation && method == http.MethodPost:
-		return h.handleCreateAccessGrantsLocation(c)
-	case path == pathAccessGrantsLocation && method == http.MethodGet:
-		return h.handleStub(c, "ListAccessGrantsLocations")
-	case strings.HasPrefix(path, pathAccessGrantsInstancePrefix+"prefix") && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessGrantsInstanceForPrefix")
-	case strings.HasPrefix(path, pathAccessGrantPrefix) && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessGrant")
-	case strings.HasPrefix(path, pathAccessGrantPrefix) && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessGrant")
-	case isGrantsLocationPath(path) && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessGrantsLocation")
-	case isGrantsLocationPath(path) && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessGrantsLocation")
-	case isGrantsLocationPath(path) && method == http.MethodPut:
-		return h.handleStub(c, "UpdateAccessGrantsLocation")
+	if handled, err := h.dispatchAccessGrantsInstanceOps(c, path, method); handled {
+		return err
+	}
+
+	if handled, err := h.dispatchAccessGrantsOps(c, path, method); handled {
+		return err
 	}
 
 	return h.dispatchAccessPointOps(c, path, method)
 }
 
-//nolint:cyclop,gocognit,gocyclo // dispatch table for access point ops
-func (h *Handler) dispatchAccessPointOps(c *echo.Context, path, method string) error {
+// dispatchAccessGrantsInstanceOps handles access grants instance and identity center operations.
+func (h *Handler) dispatchAccessGrantsInstanceOps(c *echo.Context, path, method string) (bool, error) {
+	switch path {
+	case pathAccessGrantsInstance:
+		switch method {
+		case http.MethodPost:
+			return true, h.handleCreateAccessGrantsInstance(c)
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetAccessGrantsInstance")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteAccessGrantsInstance")
+		}
+	case pathAccessGrantsInstanceResourcePolicy:
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetAccessGrantsInstanceResourcePolicy")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutAccessGrantsInstanceResourcePolicy")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteAccessGrantsInstanceResourcePolicy")
+		}
+	case pathIdentityCenter:
+		switch method {
+		case http.MethodPost:
+			return true, h.handleAssociateAccessGrantsIdentityCenter(c)
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DissociateAccessGrantsIdentityCenter")
+		}
+	}
+
+	return false, nil
+}
+
+// dispatchAccessGrantsOps handles access grants, locations, and data access operations.
+func (h *Handler) dispatchAccessGrantsOps(c *echo.Context, path, method string) (bool, error) {
+	if handled, err := h.dispatchAccessGrantsExactOps(c, path, method); handled {
+		return true, err
+	}
+
+	return h.dispatchAccessGrantsPrefixOps(c, path, method)
+}
+
+// dispatchAccessGrantsExactOps handles exact-path access grants dispatch.
+func (h *Handler) dispatchAccessGrantsExactOps(c *echo.Context, path, method string) (bool, error) {
+	switch path {
+	case pathAccessGrant:
+		switch method {
+		case http.MethodPost:
+			return true, h.handleCreateAccessGrant(c)
+		case http.MethodGet:
+			return true, h.handleStub(c, "ListAccessGrants")
+		}
+	case pathCallerAccessGrants:
+		if method == http.MethodGet {
+			return true, h.handleStub(c, "ListCallerAccessGrants")
+		}
+	case pathDataAccess:
+		if method == http.MethodGet {
+			return true, h.handleStub(c, "GetDataAccess")
+		}
+	case pathAccessGrantsLocation:
+		switch method {
+		case http.MethodPost:
+			return true, h.handleCreateAccessGrantsLocation(c)
+		case http.MethodGet:
+			return true, h.handleStub(c, "ListAccessGrantsLocations")
+		}
+	}
+
+	return false, nil
+}
+
+// dispatchAccessGrantsPrefixOps handles prefix-based access grants dispatch.
+func (h *Handler) dispatchAccessGrantsPrefixOps(c *echo.Context, path, method string) (bool, error) {
 	switch {
-	case isSimplePath(pathAccessPointPrefix, path) && method == http.MethodPut:
-		return h.handleCreateAccessPoint(c)
-	case isSimplePath(pathAccessPointPrefix, path) && method == http.MethodGet:
-		return h.handleGetAccessPoint(c)
-	case isSimplePath(pathAccessPointPrefix, path) && method == http.MethodDelete:
-		return h.handleDeleteAccessPoint(c)
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodGet:
-		return h.handleGetAccessPointPolicy(c)
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodPut:
-		return h.handlePutAccessPointPolicy(c)
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodDelete:
-		return h.handleDeleteAccessPointPolicy(c)
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/policyStatus") && method == http.MethodGet:
-		return h.handleGetAccessPointPolicyStatus(c)
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessPointScope")
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodPut:
-		return h.handleStub(c, "PutAccessPointScope")
-	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessPointScope")
-	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodPut:
-		return h.handleCreateAccessPointForObjectLambda(c)
-	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessPointForObjectLambda")
-	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessPointForObjectLambda")
-	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessPointPolicyForObjectLambda")
-	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodPut:
-		return h.handleStub(c, "PutAccessPointPolicyForObjectLambda")
-	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteAccessPointPolicyForObjectLambda")
-	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policyStatus") && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessPointPolicyStatusForObjectLambda")
-	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/configuration") && method == http.MethodGet:
-		return h.handleStub(c, "GetAccessPointConfigurationForObjectLambda")
-	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/configuration") && method == http.MethodPut:
-		return h.handleStub(c, "PutAccessPointConfigurationForObjectLambda")
-	case path == "/v20180820/accesspoint" && method == http.MethodGet:
-		return h.handleListAccessPoints(c)
-	case path == pathAccessPointsDirectoryBuckets && method == http.MethodGet:
-		return h.handleStub(c, "ListAccessPointsForDirectoryBuckets")
-	case path == pathAccessPointsForObjectLambdaList && method == http.MethodGet:
-		return h.handleStub(c, "ListAccessPointsForObjectLambda")
+	case strings.HasPrefix(path, pathAccessGrantsInstancePrefix+"prefix") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessGrantsInstanceForPrefix")
+	case strings.HasPrefix(path, pathAccessGrantPrefix) && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessGrant")
+	case strings.HasPrefix(path, pathAccessGrantPrefix) && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteAccessGrant")
+	case isGrantsLocationPath(path) && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessGrantsLocation")
+	case isGrantsLocationPath(path) && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteAccessGrantsLocation")
+	case isGrantsLocationPath(path) && method == http.MethodPut:
+		return true, h.handleStub(c, "UpdateAccessGrantsLocation")
+	}
+
+	return false, nil
+}
+
+// dispatchAccessPointOps handles access point and object lambda operations.
+func (h *Handler) dispatchAccessPointOps(c *echo.Context, path, method string) error {
+	if handled, err := h.dispatchAccessPointCRUDOps(c, path, method); handled {
+		return err
+	}
+
+	if handled, err := h.dispatchObjectLambdaOps(c, path, method); handled {
+		return err
 	}
 
 	return h.dispatchBucketOps(c, path, method)
 }
 
-//nolint:cyclop,gocyclo // dispatch table for outposts bucket ops
-func (h *Handler) dispatchBucketOps(c *echo.Context, path, method string) error {
+// dispatchAccessPointCRUDOps handles standard access point CRUD and listing.
+func (h *Handler) dispatchAccessPointCRUDOps(c *echo.Context, path, method string) (bool, error) {
+	if handled, err := h.dispatchAccessPointBasicOps(c, path, method); handled {
+		return true, err
+	}
+
+	return h.dispatchAccessPointSubResourceOps(c, path, method)
+}
+
+// dispatchAccessPointBasicOps handles access point CRUD and list dispatch.
+func (h *Handler) dispatchAccessPointBasicOps(c *echo.Context, path, method string) (bool, error) {
+	if isSimplePath(pathAccessPointPrefix, path) {
+		switch method {
+		case http.MethodPut:
+			return true, h.handleCreateAccessPoint(c)
+		case http.MethodGet:
+			return true, h.handleGetAccessPoint(c)
+		case http.MethodDelete:
+			return true, h.handleDeleteAccessPoint(c)
+		}
+
+		return false, nil
+	}
+
+	switch path {
+	case "/v20180820/accesspoint":
+		if method == http.MethodGet {
+			return true, h.handleListAccessPoints(c)
+		}
+	case pathAccessPointsDirectoryBuckets:
+		if method == http.MethodGet {
+			return true, h.handleStub(c, "ListAccessPointsForDirectoryBuckets")
+		}
+	case pathAccessPointsForObjectLambdaList:
+		if method == http.MethodGet {
+			return true, h.handleStub(c, "ListAccessPointsForObjectLambda")
+		}
+	}
+
+	return false, nil
+}
+
+// dispatchAccessPointSubResourceOps handles access point policy, status, and scope dispatch.
+func (h *Handler) dispatchAccessPointSubResourceOps(c *echo.Context, path, method string) (bool, error) {
 	switch {
-	case isSimplePath(pathBucketPrefix, path) && method == http.MethodPut:
-		return h.handleCreateBucket(c)
-	case isSimplePath(pathBucketPrefix, path) && method == http.MethodGet:
-		return h.handleStub(c, "GetBucket")
-	case isSimplePath(pathBucketPrefix, path) && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteBucket")
-	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodGet:
-		return h.handleStub(c, "GetBucketLifecycleConfiguration")
-	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodPut:
-		return h.handleStub(c, "PutBucketLifecycleConfiguration")
-	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteBucketLifecycleConfiguration")
-	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodGet:
-		return h.handleStub(c, "GetBucketPolicy")
-	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodPut:
-		return h.handleStub(c, "PutBucketPolicy")
-	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteBucketPolicy")
-	case isPrefixSuffix(pathBucketPrefix, path, "/replication") && method == http.MethodGet:
-		return h.handleStub(c, "GetBucketReplication")
-	case isPrefixSuffix(pathBucketPrefix, path, "/replication") && method == http.MethodPut:
-		return h.handleStub(c, "PutBucketReplication")
-	case isPrefixSuffix(pathBucketPrefix, path, "/replication") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteBucketReplication")
-	case isPrefixSuffix(pathBucketPrefix, path, "/tagging") && method == http.MethodGet:
-		return h.handleStub(c, "GetBucketTagging")
-	case isPrefixSuffix(pathBucketPrefix, path, "/tagging") && method == http.MethodPut:
-		return h.handleStub(c, "PutBucketTagging")
-	case isPrefixSuffix(pathBucketPrefix, path, "/tagging") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteBucketTagging")
-	case isPrefixSuffix(pathBucketPrefix, path, "/versioning") && method == http.MethodGet:
-		return h.handleStub(c, "GetBucketVersioning")
-	case isPrefixSuffix(pathBucketPrefix, path, "/versioning") && method == http.MethodPut:
-		return h.handleStub(c, "PutBucketVersioning")
-	case path == pathRegionalBuckets && method == http.MethodGet:
-		return h.handleStub(c, "ListRegionalBuckets")
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodGet:
+		return true, h.handleGetAccessPointPolicy(c)
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodPut:
+		return true, h.handlePutAccessPointPolicy(c)
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/policy") && method == http.MethodDelete:
+		return true, h.handleDeleteAccessPointPolicy(c)
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/policyStatus") && method == http.MethodGet:
+		return true, h.handleGetAccessPointPolicyStatus(c)
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessPointScope")
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodPut:
+		return true, h.handleStub(c, "PutAccessPointScope")
+	case isPrefixSuffix(pathAccessPointPrefix, path, "/scope") && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteAccessPointScope")
+	}
+
+	return false, nil
+}
+
+// dispatchObjectLambdaOps handles object lambda access point operations.
+func (h *Handler) dispatchObjectLambdaOps(c *echo.Context, path, method string) (bool, error) {
+	switch {
+	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodPut:
+		return true, h.handleCreateAccessPointForObjectLambda(c)
+	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessPointForObjectLambda")
+	case isSimplePath(pathObjectLambdaPrefix, path) && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteAccessPointForObjectLambda")
+	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessPointPolicyForObjectLambda")
+	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodPut:
+		return true, h.handleStub(c, "PutAccessPointPolicyForObjectLambda")
+	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policy") && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteAccessPointPolicyForObjectLambda")
+	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/policyStatus") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessPointPolicyStatusForObjectLambda")
+	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/configuration") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetAccessPointConfigurationForObjectLambda")
+	case isPrefixSuffix(pathObjectLambdaPrefix, path, "/configuration") && method == http.MethodPut:
+		return true, h.handleStub(c, "PutAccessPointConfigurationForObjectLambda")
+	}
+
+	return false, nil
+}
+
+// dispatchBucketOps handles bucket CRUD and sub-resource operations.
+func (h *Handler) dispatchBucketOps(c *echo.Context, path, method string) error {
+	if handled, err := h.dispatchBucketCRUDStubs(c, path, method); handled {
+		return err
+	}
+
+	if handled, err := h.dispatchBucketSubResourceStubs(c, path, method); handled {
+		return err
 	}
 
 	return h.dispatchJobMRAPStorageLensOps(c, path, method)
 }
 
-//nolint:cyclop,gocyclo // dispatch table for job and MRAP ops
-func (h *Handler) dispatchJobMRAPStorageLensOps(c *echo.Context, path, method string) error {
+// dispatchBucketCRUDStubs handles bucket CRUD, lifecycle, and policy stub operations.
+func (h *Handler) dispatchBucketCRUDStubs(c *echo.Context, path, method string) (bool, error) {
 	switch {
-	case path == pathJobs && method == http.MethodPost:
-		return h.handleCreateJob(c)
-	case path == pathJobs && method == http.MethodGet:
-		return h.handleListJobs(c)
-	case isSimplePath(pathJobPrefix, path) && method == http.MethodGet:
-		return h.handleDescribeJob(c)
-	case isPrefixSuffix(pathJobPrefix, path, "/tagging") && method == http.MethodGet:
-		return h.handleStub(c, "GetJobTagging")
-	case isPrefixSuffix(pathJobPrefix, path, "/tagging") && method == http.MethodPut:
-		return h.handleStub(c, "PutJobTagging")
-	case isPrefixSuffix(pathJobPrefix, path, "/tagging") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteJobTagging")
-	case isPrefixSuffix(pathJobPrefix, path, "/priority") && method == http.MethodPut:
-		return h.handleUpdateJobPriority(c)
-	case isPrefixSuffix(pathJobPrefix, path, "/status") && method == http.MethodPut:
-		return h.handleUpdateJobStatus(c)
-	case path == pathMRAPCreate && method == http.MethodPost:
-		return h.handleCreateMultiRegionAccessPoint(c)
-	case strings.HasPrefix(path, pathMRAPDeletePrefix) && method == http.MethodPost:
-		return h.handleDeleteMultiRegionAccessPointAsync(c)
-	case strings.HasPrefix(path, pathMRAPPutPolicyPrefix) && method == http.MethodPost:
-		return h.handlePutMultiRegionAccessPointPolicy(c)
-	case strings.HasPrefix(path, pathMRAPPrefix) && method == http.MethodGet:
-		return h.handleStub(c, "DescribeMultiRegionAccessPointOperation")
-	case path == pathMRAPList && method == http.MethodGet:
-		return h.handleListMultiRegionAccessPoints(c)
-	case isSimplePath(pathMRAPInstancePrefix, path) && method == http.MethodGet:
-		return h.handleGetMultiRegionAccessPoint(c)
-	case isSimplePath(pathMRAPInstancePrefix, path) && method == http.MethodDelete:
-		return h.handleDeleteMultiRegionAccessPoint(c)
-	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/policy") && method == http.MethodGet:
-		return h.handleStub(c, "GetMultiRegionAccessPointPolicy")
-	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/policyStatus") && method == http.MethodGet:
-		return h.handleStub(c, "GetMultiRegionAccessPointPolicyStatus")
-	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/routes") && method == http.MethodGet:
-		return h.handleStub(c, "GetMultiRegionAccessPointRoutes")
-	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/routes") && method == http.MethodPatch:
-		return h.handleStub(c, "SubmitMultiRegionAccessPointRoutes")
+	case isSimplePath(pathBucketPrefix, path) && method == http.MethodPut:
+		return true, h.handleCreateBucket(c)
+	case isSimplePath(pathBucketPrefix, path) && method == http.MethodGet:
+		return true, h.handleStub(c, "GetBucket")
+	case isSimplePath(pathBucketPrefix, path) && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteBucket")
+	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetBucketLifecycleConfiguration")
+	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodPut:
+		return true, h.handleStub(c, "PutBucketLifecycleConfiguration")
+	case isPrefixSuffix(pathBucketPrefix, path, "/lifecycle") && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteBucketLifecycleConfiguration")
+	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetBucketPolicy")
+	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodPut:
+		return true, h.handleStub(c, "PutBucketPolicy")
+	case isPrefixSuffix(pathBucketPrefix, path, "/policy") && method == http.MethodDelete:
+		return true, h.handleStub(c, "DeleteBucketPolicy")
+	}
+
+	return false, nil
+}
+
+// dispatchBucketSubResourceStubs handles bucket replication, tagging, versioning, and listing stubs.
+func (h *Handler) dispatchBucketSubResourceStubs(c *echo.Context, path, method string) (bool, error) {
+	if isPrefixSuffix(pathBucketPrefix, path, "/replication") {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetBucketReplication")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutBucketReplication")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteBucketReplication")
+		}
+
+		return false, nil
+	}
+
+	return h.dispatchBucketTagVersionStubs(c, path, method)
+}
+
+// dispatchBucketTagVersionStubs handles bucket tagging, versioning, and listing stubs.
+func (h *Handler) dispatchBucketTagVersionStubs(c *echo.Context, path, method string) (bool, error) {
+	if isPrefixSuffix(pathBucketPrefix, path, "/tagging") {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetBucketTagging")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutBucketTagging")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteBucketTagging")
+		}
+
+		return false, nil
+	}
+
+	if isPrefixSuffix(pathBucketPrefix, path, "/versioning") {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetBucketVersioning")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutBucketVersioning")
+		}
+
+		return false, nil
+	}
+
+	if path == pathRegionalBuckets && method == http.MethodGet {
+		return true, h.handleStub(c, "ListRegionalBuckets")
+	}
+
+	return false, nil
+}
+
+// dispatchJobMRAPStorageLensOps handles job, MRAP, and storage lens dispatch.
+func (h *Handler) dispatchJobMRAPStorageLensOps(c *echo.Context, path, method string) error {
+	if handled, err := h.dispatchJobOps(c, path, method); handled {
+		return err
+	}
+
+	if handled, err := h.dispatchMRAPDispatchOps(c, path, method); handled {
+		return err
 	}
 
 	return h.dispatchStorageLensTagOps(c, path, method)
 }
 
-//nolint:cyclop,gocyclo // dispatch table for storage lens and tag ops
-func (h *Handler) dispatchStorageLensTagOps(c *echo.Context, path, method string) error {
+// dispatchJobOps handles S3 Batch Operations job dispatch.
+func (h *Handler) dispatchJobOps(c *echo.Context, path, method string) (bool, error) {
+	if path == pathJobs {
+		switch method {
+		case http.MethodPost:
+			return true, h.handleCreateJob(c)
+		case http.MethodGet:
+			return true, h.handleListJobs(c)
+		}
+
+		return false, nil
+	}
+
+	if isSimplePath(pathJobPrefix, path) && method == http.MethodGet {
+		return true, h.handleDescribeJob(c)
+	}
+
+	return h.dispatchJobSubResourceOps(c, path, method)
+}
+
+// dispatchJobSubResourceOps handles job tagging, priority, and status dispatch.
+func (h *Handler) dispatchJobSubResourceOps(c *echo.Context, path, method string) (bool, error) {
+	if isPrefixSuffix(pathJobPrefix, path, "/tagging") {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetJobTagging")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutJobTagging")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteJobTagging")
+		}
+
+		return false, nil
+	}
+
+	if isPrefixSuffix(pathJobPrefix, path, "/priority") && method == http.MethodPut {
+		return true, h.handleUpdateJobPriority(c)
+	}
+
+	if isPrefixSuffix(pathJobPrefix, path, "/status") && method == http.MethodPut {
+		return true, h.handleUpdateJobStatus(c)
+	}
+
+	return false, nil
+}
+
+// dispatchMRAPDispatchOps handles Multi-Region Access Point dispatch.
+func (h *Handler) dispatchMRAPDispatchOps(c *echo.Context, path, method string) (bool, error) {
+	if handled, err := h.dispatchMRAPCreateListOps(c, path, method); handled {
+		return true, err
+	}
+
+	return h.dispatchMRAPInstanceDispatch(c, path, method)
+}
+
+// dispatchMRAPCreateListOps handles MRAP create, delete, policy, and list dispatch.
+func (h *Handler) dispatchMRAPCreateListOps(c *echo.Context, path, method string) (bool, error) {
 	switch {
-	case isSimplePath(pathStorageLensPrefix, path) && method == http.MethodGet:
-		return h.handleStub(c, "GetStorageLensConfiguration")
-	case isSimplePath(pathStorageLensPrefix, path) && method == http.MethodPut:
-		return h.handleStub(c, "PutStorageLensConfiguration")
-	case isSimplePath(pathStorageLensPrefix, path) && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteStorageLensConfiguration")
-	case isPrefixSuffix(pathStorageLensPrefix, path, "/tagging") && method == http.MethodGet:
-		return h.handleStub(c, "GetStorageLensConfigurationTagging")
-	case isPrefixSuffix(pathStorageLensPrefix, path, "/tagging") && method == http.MethodPut:
-		return h.handleStub(c, "PutStorageLensConfigurationTagging")
-	case isPrefixSuffix(pathStorageLensPrefix, path, "/tagging") && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteStorageLensConfigurationTagging")
-	case path == pathStorageLensList && method == http.MethodGet:
-		return h.handleStub(c, "ListStorageLensConfigurations")
-	case path == pathStorageLensGroup && method == http.MethodPost:
-		return h.handleCreateStorageLensGroup(c)
-	case path == pathStorageLensGroup && method == http.MethodGet:
-		return h.handleStub(c, "ListStorageLensGroups")
+	case path == pathMRAPCreate && method == http.MethodPost:
+		return true, h.handleCreateMultiRegionAccessPoint(c)
+	case strings.HasPrefix(path, pathMRAPDeletePrefix) && method == http.MethodPost:
+		return true, h.handleDeleteMultiRegionAccessPointAsync(c)
+	case strings.HasPrefix(path, pathMRAPPutPolicyPrefix) && method == http.MethodPost:
+		return true, h.handlePutMultiRegionAccessPointPolicy(c)
+	case strings.HasPrefix(path, pathMRAPPrefix) && method == http.MethodGet:
+		return true, h.handleStub(c, "DescribeMultiRegionAccessPointOperation")
+	case path == pathMRAPList && method == http.MethodGet:
+		return true, h.handleListMultiRegionAccessPoints(c)
+	}
+
+	return false, nil
+}
+
+// dispatchMRAPInstanceDispatch handles MRAP instance CRUD and sub-resource dispatch.
+func (h *Handler) dispatchMRAPInstanceDispatch(c *echo.Context, path, method string) (bool, error) {
+	if isSimplePath(pathMRAPInstancePrefix, path) {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleGetMultiRegionAccessPoint(c)
+		case http.MethodDelete:
+			return true, h.handleDeleteMultiRegionAccessPoint(c)
+		}
+
+		return false, nil
+	}
+
+	switch {
+	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/policy") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetMultiRegionAccessPointPolicy")
+	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/policyStatus") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetMultiRegionAccessPointPolicyStatus")
+	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/routes") && method == http.MethodGet:
+		return true, h.handleStub(c, "GetMultiRegionAccessPointRoutes")
+	case isPrefixSuffix(pathMRAPInstancePrefix, path, "/routes") && method == http.MethodPatch:
+		return true, h.handleStub(c, "SubmitMultiRegionAccessPointRoutes")
+	}
+
+	return false, nil
+}
+
+// dispatchStorageLensTagOps handles storage lens and tagging dispatch.
+func (h *Handler) dispatchStorageLensTagOps(c *echo.Context, path, method string) error {
+	if handled, err := h.dispatchStorageLensDispatch(c, path, method); handled {
+		return err
+	}
+
+	return h.dispatchTagDispatch(c, path, method)
+}
+
+// dispatchStorageLensDispatch handles storage lens configuration and group operations.
+func (h *Handler) dispatchStorageLensDispatch(c *echo.Context, path, method string) (bool, error) {
+	if handled, err := h.dispatchStorageLensConfigDispatch(c, path, method); handled {
+		return true, err
+	}
+
+	return h.dispatchStorageLensGroupDispatch(c, path, method)
+}
+
+// dispatchStorageLensConfigDispatch handles storage lens configuration dispatch.
+func (h *Handler) dispatchStorageLensConfigDispatch(c *echo.Context, path, method string) (bool, error) {
+	if isSimplePath(pathStorageLensPrefix, path) {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetStorageLensConfiguration")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutStorageLensConfiguration")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteStorageLensConfiguration")
+		}
+
+		return false, nil
+	}
+
+	if isPrefixSuffix(pathStorageLensPrefix, path, "/tagging") {
+		switch method {
+		case http.MethodGet:
+			return true, h.handleStub(c, "GetStorageLensConfigurationTagging")
+		case http.MethodPut:
+			return true, h.handleStub(c, "PutStorageLensConfigurationTagging")
+		case http.MethodDelete:
+			return true, h.handleStub(c, "DeleteStorageLensConfigurationTagging")
+		}
+
+		return false, nil
+	}
+
+	if path == pathStorageLensList && method == http.MethodGet {
+		return true, h.handleStub(c, "ListStorageLensConfigurations")
+	}
+
+	return false, nil
+}
+
+// dispatchStorageLensGroupDispatch handles storage lens group dispatch.
+func (h *Handler) dispatchStorageLensGroupDispatch(c *echo.Context, path, method string) (bool, error) {
+	switch path {
+	case pathStorageLensGroup:
+		switch method {
+		case http.MethodPost:
+			return true, h.handleCreateStorageLensGroup(c)
+		case http.MethodGet:
+			return true, h.handleStub(c, "ListStorageLensGroups")
+		}
+	}
+
+	switch {
 	case strings.HasPrefix(path, pathStorageLensGroupPrefix) && method == http.MethodGet:
-		return h.handleStub(c, "GetStorageLensGroup")
+		return true, h.handleStub(c, "GetStorageLensGroup")
 	case strings.HasPrefix(path, pathStorageLensGroupPrefix) && method == http.MethodPut:
-		return h.handleStub(c, "UpdateStorageLensGroup")
+		return true, h.handleStub(c, "UpdateStorageLensGroup")
 	case strings.HasPrefix(path, pathStorageLensGroupPrefix) && method == http.MethodDelete:
-		return h.handleStub(c, "DeleteStorageLensGroup")
+		return true, h.handleStub(c, "DeleteStorageLensGroup")
+	}
+
+	return false, nil
+}
+
+// dispatchTagDispatch handles resource tagging dispatch.
+func (h *Handler) dispatchTagDispatch(c *echo.Context, path, method string) error {
+	switch {
 	case strings.HasPrefix(path, pathTagsPrefix) && method == http.MethodGet:
 		return h.handleStub(c, "ListTagsForResource")
 	case strings.HasPrefix(path, pathTagsPrefix) && method == http.MethodPost:

--- a/services/s3tables/handler.go
+++ b/services/s3tables/handler.go
@@ -272,7 +272,7 @@ func (h *Handler) routeRequest(r *http.Request) (string, dispatchFunc) {
 	return "", nil
 }
 
-//nolint:cyclop,gocognit,funlen // routing table is inherently switch-heavy
+// routeBuckets routes bucket-level operations.
 func (h *Handler) routeBuckets(segs []string, method string, r *http.Request) (string, dispatchFunc) {
 	switch len(segs) {
 	case 1:
@@ -290,52 +290,75 @@ func (h *Handler) routeBuckets(segs []string, method string, r *http.Request) (s
 			return "DeleteTableBucket", h.handleDeleteTableBucket
 		}
 	case 3: //nolint:mnd // bucket ARN + sub-resource
-		sub := segs[2]
-		switch sub {
-		case segMaintenance:
-			if method == http.MethodGet {
-				return "GetTableBucketMaintenanceConfiguration", h.handleGetTableBucketMaintenanceConfiguration
-			}
-		case segEncryption:
-			switch method {
-			case http.MethodGet:
-				return "GetTableBucketEncryption", h.handleGetTableBucketEncryption
-			case http.MethodPut:
-				return "PutTableBucketEncryption", h.handlePutTableBucketEncryption
-			case http.MethodDelete:
-				return "DeleteTableBucketEncryption", h.handleDeleteTableBucketEncryption
-			}
-		case segMetrics:
-			switch method {
-			case http.MethodGet:
-				return "GetTableBucketMetricsConfiguration", h.handleGetTableBucketMetricsConfiguration
-			case http.MethodPut:
-				return "PutTableBucketMetricsConfiguration", h.handlePutTableBucketMetricsConfiguration
-			case http.MethodDelete:
-				return "DeleteTableBucketMetricsConfiguration", h.handleDeleteTableBucketMetricsConfiguration
-			}
-		case segStorageClass:
-			switch method {
-			case http.MethodGet:
-				return "GetTableBucketStorageClass", h.handleGetTableBucketStorageClass
-			case http.MethodPut:
-				return "PutTableBucketStorageClass", h.handlePutTableBucketStorageClass
-			}
-		case "policy":
-			switch method {
-			case http.MethodGet:
-				return "GetTableBucketPolicy", h.handleGetTableBucketPolicy
-			case http.MethodPut:
-				return "PutTableBucketPolicy", h.handlePutTableBucketPolicy
-			case http.MethodDelete:
-				return "DeleteTableBucketPolicy", h.handleDeleteTableBucketPolicy
-			}
-		}
-
 		_ = r
+
+		return h.routeBucketSubResource(segs[2], method)
 	case 4: //nolint:mnd // bucket ARN + maintenance + config type
 		if segs[2] == segMaintenance && method == http.MethodPut {
 			return "PutTableBucketMaintenanceConfiguration", h.handlePutTableBucketMaintenanceConfiguration
+		}
+	}
+
+	return "", nil
+}
+
+// routeBucketSubResource routes bucket sub-resource operations.
+func (h *Handler) routeBucketSubResource(sub, method string) (string, dispatchFunc) {
+	if op, fn := h.routeBucketStorageOps(sub, method); op != "" {
+		return op, fn
+	}
+
+	return h.routeBucketPolicyOps(sub, method)
+}
+
+// routeBucketStorageOps handles bucket maintenance, encryption, and metrics sub-resources.
+func (h *Handler) routeBucketStorageOps(sub, method string) (string, dispatchFunc) {
+	switch sub {
+	case segMaintenance:
+		if method == http.MethodGet {
+			return "GetTableBucketMaintenanceConfiguration", h.handleGetTableBucketMaintenanceConfiguration
+		}
+	case segEncryption:
+		switch method {
+		case http.MethodGet:
+			return "GetTableBucketEncryption", h.handleGetTableBucketEncryption
+		case http.MethodPut:
+			return "PutTableBucketEncryption", h.handlePutTableBucketEncryption
+		case http.MethodDelete:
+			return "DeleteTableBucketEncryption", h.handleDeleteTableBucketEncryption
+		}
+	case segMetrics:
+		switch method {
+		case http.MethodGet:
+			return "GetTableBucketMetricsConfiguration", h.handleGetTableBucketMetricsConfiguration
+		case http.MethodPut:
+			return "PutTableBucketMetricsConfiguration", h.handlePutTableBucketMetricsConfiguration
+		case http.MethodDelete:
+			return "DeleteTableBucketMetricsConfiguration", h.handleDeleteTableBucketMetricsConfiguration
+		}
+	}
+
+	return "", nil
+}
+
+// routeBucketPolicyOps handles bucket storage class and policy sub-resources.
+func (h *Handler) routeBucketPolicyOps(sub, method string) (string, dispatchFunc) {
+	switch sub {
+	case segStorageClass:
+		switch method {
+		case http.MethodGet:
+			return "GetTableBucketStorageClass", h.handleGetTableBucketStorageClass
+		case http.MethodPut:
+			return "PutTableBucketStorageClass", h.handlePutTableBucketStorageClass
+		}
+	case "policy":
+		switch method {
+		case http.MethodGet:
+			return "GetTableBucketPolicy", h.handleGetTableBucketPolicy
+		case http.MethodPut:
+			return "PutTableBucketPolicy", h.handlePutTableBucketPolicy
+		case http.MethodDelete:
+			return "DeleteTableBucketPolicy", h.handleDeleteTableBucketPolicy
 		}
 	}
 
@@ -388,8 +411,17 @@ func (h *Handler) routeTables(segs []string, method string, r *http.Request) (st
 	return "", nil
 }
 
-//nolint:cyclop // routing table is inherently switch-heavy
+// routeTableSubResource routes table sub-resource operations.
 func (h *Handler) routeTableSubResource(sub, method string, _ *http.Request) (string, dispatchFunc) {
+	if op, fn := h.routeTableMetaOps(sub, method); op != "" {
+		return op, fn
+	}
+
+	return h.routeTableConfigOps(sub, method)
+}
+
+// routeTableMetaOps handles table rename, metadata location, and maintenance operations.
+func (h *Handler) routeTableMetaOps(sub, method string) (string, dispatchFunc) {
 	switch sub {
 	case "rename":
 		if method == http.MethodPut {
@@ -410,6 +442,14 @@ func (h *Handler) routeTableSubResource(sub, method string, _ *http.Request) (st
 		if method == http.MethodGet {
 			return "GetTableMaintenanceJobStatus", h.handleGetTableMaintenanceJobStatus
 		}
+	}
+
+	return "", nil
+}
+
+// routeTableConfigOps handles table encryption, storage class, and policy operations.
+func (h *Handler) routeTableConfigOps(sub, method string) (string, dispatchFunc) {
+	switch sub {
 	case segEncryption:
 		if method == http.MethodGet {
 			return "GetTableEncryption", h.handleGetTableEncryption

--- a/services/sesv2/handler.go
+++ b/services/sesv2/handler.go
@@ -382,55 +382,53 @@ func parseSESv2Path(method, path string) (string, string) {
 }
 
 // parseMiscPaths handles the newer SES v2 path prefixes.
-//
-//nolint:cyclop // routes many sub-path categories
-func parseMiscPaths(
-	method string,
-	segments []string,
-) (string, string) {
+func parseMiscPaths(method string, segments []string) (string, string) {
+	if op, id := parseMiscPathsSpecial(method, segments); op != unknownAction {
+		return op, id
+	}
+
+	return parseExtendedPaths(method, segments)
+}
+
+// parseMiscPathsSpecial handles paths with special POST-create logic before extended dispatch.
+func parseMiscPathsSpecial(method string, segments []string) (string, string) {
 	switch segments[0] {
 	case "metrics":
 		return parseMetricsPath(method, segments)
 	case "export-jobs":
-		// POST /v2/email/export-jobs handled by extended parser; legacy cancel path handled below
-		if op, res := parseExportJobsPath(method, segments); op != unknownAction {
-			return op, res
-		}
-
-		return parseExtendedPaths(method, segments)
+		return parseExportJobsPath(method, segments)
 	case "contact-lists":
-		if method == http.MethodPost && len(segments) == 1 {
-			return opCreateContactList, ""
-		}
-
-		if method == http.MethodPost && len(segments) == 3 && segments[2] == segContacts {
-			return opCreateContact, segments[1]
-		}
-
-		return parseExtendedPaths(method, segments)
+		return parseContactListSpecialPath(method, segments)
 	case "custom-verification-email-templates":
 		if method == http.MethodPost && len(segments) == 1 {
 			return opCreateCustomVerificationEmailTemplate, ""
 		}
-
-		return parseExtendedPaths(method, segments)
 	case "dedicated-ip-pools":
 		if method == http.MethodPost && len(segments) == 1 {
 			return opCreateDedicatedIPPool, ""
 		}
-
-		return parseExtendedPaths(method, segments)
 	case "deliverability-dashboard":
 		return parseDeliverabilityDashboardPath(method, segments)
 	case "templates":
 		if method == http.MethodPost && len(segments) == 1 {
 			return opCreateEmailTemplate, ""
 		}
-
-		return parseExtendedPaths(method, segments)
-	default:
-		return parseExtendedPaths(method, segments)
 	}
+
+	return unknownAction, ""
+}
+
+// parseContactListSpecialPath handles contact list POST-create paths.
+func parseContactListSpecialPath(method string, segments []string) (string, string) {
+	if method == http.MethodPost && len(segments) == 1 {
+		return opCreateContactList, ""
+	}
+
+	if method == http.MethodPost && len(segments) == 3 && segments[2] == segContacts {
+		return opCreateContact, segments[1]
+	}
+
+	return unknownAction, ""
 }
 
 const metricsPathSegments = 2

--- a/services/sesv2/handler_ops.go
+++ b/services/sesv2/handler_ops.go
@@ -2,6 +2,7 @@ package sesv2
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,14 +29,33 @@ const (
 )
 
 // dispatchExtendedOps handles all 89 newly-added SES v2 operations.
-//
-//nolint:cyclop,gocyclo,funlen // large switch dispatch for all 89 new ops
-func (h *Handler) dispatchExtendedOps(
-	c *echo.Context,
-	op, resource string,
-) (any, error) {
+func (h *Handler) dispatchExtendedOps(c *echo.Context, op, resource string) (any, error) {
+	if r, err := h.dispatchAccountAndSuppressionOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchContactAndVerificationOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchDedicatedIPAndDeliverabilityOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchTemplateAndJobOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	if r, err := h.dispatchIdentityAndConfigSetOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	return h.dispatchEndpointAndTenantOps(c, op, resource)
+}
+
+// dispatchAccountAndSuppressionOps handles account and suppression operations.
+func (h *Handler) dispatchAccountAndSuppressionOps(c *echo.Context, op, resource string) (any, error) {
 	switch op {
-	// account
 	case opGetAccount:
 		return h.handleGetAccount()
 	case opGetBlacklistReports:
@@ -50,7 +70,6 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handlePutAccountSuppressionAttributes()
 	case opPutAccountVdmAttributes:
 		return h.handlePutAccountVdmAttributes()
-	// suppressed destinations
 	case opPutSuppressedDestination:
 		return h.handlePutSuppressedDestination(c)
 	case opGetSuppressedDestination:
@@ -59,7 +78,14 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleDeleteSuppressedDestination(resource)
 	case opListSuppressedDestinations:
 		return h.handleListSuppressedDestinations(c)
-	// contact lists / contacts
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchContactAndVerificationOps handles contact list, contact, and verification template operations.
+func (h *Handler) dispatchContactAndVerificationOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opGetContactList:
 		return h.handleGetContactList(resource)
 	case opDeleteContactList:
@@ -76,7 +102,6 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleUpdateContact(c, resource)
 	case opListContacts:
 		return h.handleListContacts(c, resource)
-	// custom verification templates
 	case opGetCustomVerificationEmailTemplate:
 		return h.handleGetCustomVerificationEmailTemplate(resource)
 	case opDeleteCustomVerificationEmailTemplate:
@@ -87,7 +112,23 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleListCustomVerificationEmailTemplates(c)
 	case opSendCustomVerificationEmail:
 		return h.handleSendCustomVerificationEmail(c)
-	// dedicated IP pools
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchDedicatedIPAndDeliverabilityOps handles dedicated IP pool and deliverability operations.
+func (h *Handler) dispatchDedicatedIPAndDeliverabilityOps(c *echo.Context, op, resource string) (any, error) {
+	if r, err := h.dispatchDedicatedIPOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	return h.dispatchDeliverabilityOps(c, op, resource)
+}
+
+// dispatchDedicatedIPOps handles dedicated IP pool operations.
+func (h *Handler) dispatchDedicatedIPOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opGetDedicatedIPPool:
 		return h.handleGetDedicatedIPPool(resource)
 	case opDeleteDedicatedIPPool:
@@ -104,7 +145,14 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handlePutDedicatedIPPoolScalingAttributes(c, resource)
 	case opPutDedicatedIPWarmupAttributes:
 		return h.handlePutDedicatedIPWarmupAttributes(resource)
-	// deliverability
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchDeliverabilityOps handles deliverability and insights operations.
+func (h *Handler) dispatchDeliverabilityOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opGetDeliverabilityDashboardOptions:
 		return h.handleGetDeliverabilityDashboardOptions()
 	case opPutDeliverabilityDashboardOption:
@@ -125,7 +173,14 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleGetMessageInsights(resource)
 	case opListRecommendations:
 		return h.handleListRecommendations(c)
-	// email templates
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchTemplateAndJobOps handles email template, export/import job operations.
+func (h *Handler) dispatchTemplateAndJobOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opGetEmailTemplate:
 		return h.handleGetEmailTemplate(resource)
 	case opDeleteEmailTemplate:
@@ -136,7 +191,6 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleListEmailTemplates(c)
 	case opTestRenderEmailTemplate:
 		return h.handleTestRenderEmailTemplate(c, resource)
-	// export / import jobs
 	case opCreateExportJob:
 		return h.handleCreateExportJob(c)
 	case opGetExportJob:
@@ -149,14 +203,31 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleGetImportJob(resource)
 	case opListImportJobs:
 		return h.handleListImportJobs(c)
-	// email identity policies
+	case opSendBulkEmail:
+		return h.handleSendBulkEmail(c)
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchIdentityAndConfigSetOps handles email identity and config set operations.
+func (h *Handler) dispatchIdentityAndConfigSetOps(c *echo.Context, op, resource string) (any, error) {
+	if r, err := h.dispatchEmailIdentityOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	return h.dispatchConfigSetAttrOps(c, op, resource)
+}
+
+// dispatchEmailIdentityOps handles email identity policy and attribute operations.
+func (h *Handler) dispatchEmailIdentityOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opGetEmailIdentityPolicies:
 		return h.handleGetEmailIdentityPolicies(resource)
 	case opDeleteEmailIdentityPolicy:
 		return h.handleDeleteEmailIdentityPolicy(c, resource)
 	case opUpdateEmailIdentityPolicy:
 		return h.handleUpdateEmailIdentityPolicy(c, resource)
-	// email identity attributes
 	case opPutEmailIdentityConfigurationSetAttributes:
 		return h.handlePutEmailIdentityConfigurationSetAttributes()
 	case opPutEmailIdentityDkimAttributes:
@@ -167,14 +238,20 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handlePutEmailIdentityFeedbackAttributes()
 	case opPutEmailIdentityMailFromAttributes:
 		return h.handlePutEmailIdentityMailFromAttributes()
-	// configuration set event destinations
 	case opGetConfigurationSetEventDestinations:
 		return h.handleGetConfigurationSetEventDestinations(resource)
 	case opDeleteConfigurationSetEventDestination:
 		return h.handleDeleteConfigurationSetEventDestination(c, resource)
 	case opUpdateConfigurationSetEventDestination:
 		return h.handleUpdateConfigurationSetEventDestination(c, resource)
-	// configuration set attributes
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchConfigSetAttrOps handles configuration set attribute put operations.
+func (h *Handler) dispatchConfigSetAttrOps(_ *echo.Context, op, _ string) (any, error) {
+	switch op {
 	case opPutConfigurationSetArchivingOptions:
 		return h.handlePutConfigurationSetArchivingOptions()
 	case opPutConfigurationSetDeliveryOptions:
@@ -189,10 +266,23 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handlePutConfigurationSetTrackingOptions()
 	case opPutConfigurationSetVdmOptions:
 		return h.handlePutConfigurationSetVdmOptions()
-	// bulk email
-	case opSendBulkEmail:
-		return h.handleSendBulkEmail(c)
-	// multi-region endpoints
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchEndpointAndTenantOps handles multi-region endpoint, tenant, and reputation entity operations.
+func (h *Handler) dispatchEndpointAndTenantOps(c *echo.Context, op, resource string) (any, error) {
+	if r, err := h.dispatchEndpointTenantCRUDOps(c, op, resource); !errors.Is(err, errOpNotHandled) {
+		return r, err
+	}
+
+	return h.dispatchReputationEntityOps(c, op, resource)
+}
+
+// dispatchEndpointTenantCRUDOps handles multi-region endpoint and tenant operations.
+func (h *Handler) dispatchEndpointTenantCRUDOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opCreateMultiRegionEndpoint:
 		return h.handleCreateMultiRegionEndpoint(c)
 	case opGetMultiRegionEndpoint:
@@ -201,7 +291,6 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleDeleteMultiRegionEndpoint(resource)
 	case opListMultiRegionEndpoints:
 		return h.handleListMultiRegionEndpoints(c)
-	// tenants
 	case opCreateTenant:
 		return h.handleCreateTenant(c)
 	case opGetTenant:
@@ -218,7 +307,14 @@ func (h *Handler) dispatchExtendedOps(
 		return h.handleListResourceTenants(c)
 	case opListTenantResources:
 		return h.handleListTenantResources(c, resource)
-	// reputation entities
+	}
+
+	return nil, errOpNotHandled
+}
+
+// dispatchReputationEntityOps handles reputation entity operations.
+func (h *Handler) dispatchReputationEntityOps(c *echo.Context, op, resource string) (any, error) {
+	switch op {
 	case opGetReputationEntity:
 		return h.handleGetReputationEntity(resource)
 	case opListReputationEntities:
@@ -238,11 +334,19 @@ func (h *Handler) dispatchExtendedOps(
 // It is called from parseMiscPaths when the first segment is not handled by the
 // original set of patterns.
 //
-//nolint:cyclop,gocyclo // top-level path router for all new paths
-func parseExtendedPaths(
-	method string,
-	segments []string,
-) (string, string) {
+
+// parseExtendedPaths parses paths for newly-added operations.
+func parseExtendedPaths(method string, segments []string) (string, string) {
+	if op, id := parseExtendedPathsCoreGroup(method, segments); op != unknownAction {
+		return op, id
+	}
+
+	return parseExtendedPathsExtGroup(method, segments)
+}
+
+// parseExtendedPathsCoreGroup handles core extended paths (account through recommendations).
+// parseExtendedPathsCoreGroup handles core extended paths (account through recommendations).
+func parseExtendedPathsCoreGroup(method string, segments []string) (string, string) {
 	switch segments[0] {
 	case "account":
 		return parseAccountPath(method, segments)
@@ -258,6 +362,14 @@ func parseExtendedPaths(
 		return parseDedicatedIPsPath(method, segments)
 	case "deliverability-dashboard":
 		return parseDeliverabilityExtPath(method, segments)
+	}
+
+	return parseExtendedInsightsPath(method, segments)
+}
+
+// parseExtendedInsightsPath handles insights and recommendations paths.
+func parseExtendedInsightsPath(method string, segments []string) (string, string) {
+	switch segments[0] {
 	case "email-insights":
 		if method == http.MethodGet && len(segments) == 2 {
 			return opGetEmailAddressInsights, segments[1]
@@ -270,6 +382,14 @@ func parseExtendedPaths(
 		if method == http.MethodGet && len(segments) == 1 {
 			return opListRecommendations, ""
 		}
+	}
+
+	return unknownAction, ""
+}
+
+// parseExtendedPathsExtGroup handles extended paths (templates through reputation entities).
+func parseExtendedPathsExtGroup(method string, segments []string) (string, string) {
+	switch segments[0] {
 	case "templates":
 		return parseTemplateExtPath(method, segments)
 	case "export-jobs":
@@ -277,24 +397,15 @@ func parseExtendedPaths(
 	case "import-jobs":
 		return parseImportJobPath(method, segments)
 	case "vdm-attributes":
-		if method == http.MethodGet {
-			return opGetAccount, ""
-		}
-		if method == http.MethodPut {
-			return opPutAccountVdmAttributes, ""
-		}
+		return parseVdmAttributesPath(method)
 	case "outbound-bulk-emails":
-		if method == http.MethodPost && len(segments) == 1 {
-			return opSendBulkEmail, ""
-		}
+		return parseOutboundBulkEmailsPath(method, segments)
 	case "multi-region-endpoints":
 		return parseMultiRegionEndpointPath(method, segments)
 	case "tenants":
 		return parseTenantPath(method, segments)
 	case "resource-tenants":
-		if method == http.MethodGet && len(segments) == 1 {
-			return opListResourceTenants, ""
-		}
+		return parseResourceTenantsPath(method, segments)
 	case "reputation-entities":
 		return parseReputationEntityPath(method, segments)
 	}
@@ -302,39 +413,71 @@ func parseExtendedPaths(
 	return unknownAction, ""
 }
 
-//nolint:gocognit // path branching inherently complex
-func parseAccountPath(
-	method string,
-	segments []string,
-) (string, string) {
-	if len(segments) == 1 {
-		if method == http.MethodGet {
-			return opGetAccount, ""
-		}
+// parseVdmAttributesPath routes VDM attributes paths.
+func parseVdmAttributesPath(method string) (string, string) {
+	switch method {
+	case http.MethodGet:
+		return opGetAccount, ""
+	case http.MethodPut:
+		return opPutAccountVdmAttributes, ""
 	}
 
-	if len(segments) == pathDepth2 { //nolint:nestif // URL path segment dispatching requires nested if
-		switch segments[1] {
-		case "dedicated-ip-warmup-attributes":
-			if method == http.MethodPut {
-				return opPutAccountDedicatedIPWarmupAttributes, ""
-			}
-		case "details":
-			if method == http.MethodPost {
-				return opPutAccountDetails, ""
-			}
-		case "sending-attributes":
-			if method == http.MethodPut {
-				return opPutAccountSendingAttributes, ""
-			}
-		case "suppression-attributes":
-			if method == http.MethodPut {
-				return opPutAccountSuppressionAttributes, ""
-			}
-		case "vdm-attributes":
-			if method == http.MethodPut {
-				return opPutAccountVdmAttributes, ""
-			}
+	return unknownAction, ""
+}
+
+// parseOutboundBulkEmailsPath routes outbound bulk email paths.
+func parseOutboundBulkEmailsPath(method string, segments []string) (string, string) {
+	if method == http.MethodPost && len(segments) == 1 {
+		return opSendBulkEmail, ""
+	}
+
+	return unknownAction, ""
+}
+
+// parseResourceTenantsPath routes resource-tenants paths.
+func parseResourceTenantsPath(method string, segments []string) (string, string) {
+	if method == http.MethodGet && len(segments) == 1 {
+		return opListResourceTenants, ""
+	}
+
+	return unknownAction, ""
+}
+
+// parseAccountPath routes account and account attribute paths.
+func parseAccountPath(method string, segments []string) (string, string) {
+	if len(segments) == 1 && method == http.MethodGet {
+		return opGetAccount, ""
+	}
+
+	if len(segments) != pathDepth2 {
+		return unknownAction, ""
+	}
+
+	return parseAccountAttrPath(method, segments[1])
+}
+
+// parseAccountAttrPath routes account attribute sub-paths.
+func parseAccountAttrPath(method, sub string) (string, string) {
+	switch sub {
+	case "dedicated-ip-warmup-attributes":
+		if method == http.MethodPut {
+			return opPutAccountDedicatedIPWarmupAttributes, ""
+		}
+	case "details":
+		if method == http.MethodPost {
+			return opPutAccountDetails, ""
+		}
+	case "sending-attributes":
+		if method == http.MethodPut {
+			return opPutAccountSendingAttributes, ""
+		}
+	case "suppression-attributes":
+		if method == http.MethodPut {
+			return opPutAccountSuppressionAttributes, ""
+		}
+	case "vdm-attributes":
+		if method == http.MethodPut {
+			return opPutAccountVdmAttributes, ""
 		}
 	}
 
@@ -356,28 +499,37 @@ func parseSuppressedDestinationPath(method string, segments []string) (string, s
 	return unknownAction, ""
 }
 
-//nolint:cyclop // path branching inherently complex
-func parseContactListExtPath(
-	method string,
-	segments []string,
-) (string, string) {
-	switch {
-	case len(segments) == 1 && method == http.MethodGet:
-		return opListContactLists, ""
-	case len(segments) == 2 && method == http.MethodGet:
-		return opGetContactList, segments[1]
-	case len(segments) == 2 && method == http.MethodDelete:
-		return opDeleteContactList, segments[1]
-	case len(segments) == 2 && method == http.MethodPut:
-		return opUpdateContactList, segments[1]
-	case len(segments) == 3 && segments[2] == segContacts && method == http.MethodGet:
-		return opListContacts, segments[1]
-	case len(segments) == 4 && segments[2] == segContacts && method == http.MethodGet:
-		return opGetContact, segments[1]
-	case len(segments) == 4 && segments[2] == segContacts && method == http.MethodDelete:
-		return opDeleteContact, segments[1]
-	case len(segments) == 4 && segments[2] == segContacts && method == http.MethodPut:
-		return opUpdateContact, segments[1]
+// parseContactListExtPath routes contact list and contact paths.
+func parseContactListExtPath(method string, segments []string) (string, string) {
+	switch len(segments) {
+	case 1:
+		if method == http.MethodGet {
+			return opListContactLists, ""
+		}
+	case 2:
+		switch method {
+		case http.MethodGet:
+			return opGetContactList, segments[1]
+		case http.MethodDelete:
+			return opDeleteContactList, segments[1]
+		case http.MethodPut:
+			return opUpdateContactList, segments[1]
+		}
+	case 3:
+		if segments[2] == segContacts && method == http.MethodGet {
+			return opListContacts, segments[1]
+		}
+	case 4:
+		if segments[2] == segContacts {
+			switch method {
+			case http.MethodGet:
+				return opGetContact, segments[1]
+			case http.MethodDelete:
+				return opDeleteContact, segments[1]
+			case http.MethodPut:
+				return opUpdateContact, segments[1]
+			}
+		}
 	}
 
 	return unknownAction, ""
@@ -428,11 +580,8 @@ func parseDedicatedIPsPath(method string, segments []string) (string, string) {
 	return unknownAction, ""
 }
 
-//nolint:cyclop,gocognit // path branching inherently complex
-func parseDeliverabilityExtPath(
-	method string,
-	segments []string,
-) (string, string) {
+// parseDeliverabilityExtPath routes deliverability dashboard paths.
+func parseDeliverabilityExtPath(method string, segments []string) (string, string) {
 	if len(segments) == 1 {
 		switch method {
 		case http.MethodGet:
@@ -440,42 +589,68 @@ func parseDeliverabilityExtPath(
 		case http.MethodPut:
 			return opPutDeliverabilityDashboardOption, ""
 		}
+
+		return unknownAction, ""
 	}
 
-	if len(segments) == metricsPathSegments && segments[1] == "test" && method == http.MethodPost {
+	if segments[1] == "test" && method == http.MethodPost {
 		return opCreateDeliverabilityTestReport, ""
 	}
 
-	if len(segments) >= pathDepth2 { //nolint:nestif // URL path segment dispatching requires nested if
-		switch segments[1] {
-		case "reports":
-			if len(segments) == 2 && method == http.MethodGet {
-				return opListDeliverabilityTestReports, ""
-			}
+	return parseDeliverabilitySubPath(method, segments)
+}
 
-			if len(segments) == 3 && method == http.MethodGet {
-				return opGetDeliverabilityTestReport, segments[2]
-			}
+// parseDeliverabilitySubPath routes deliverability report and campaign sub-paths.
+func parseDeliverabilitySubPath(method string, segments []string) (string, string) {
+	if len(segments) < 2 {
+		return unknownAction, ""
+	}
 
-		case "blacklist-report":
-			if method == http.MethodGet {
-				return opGetBlacklistReports, ""
-			}
-
-		case "statistics":
-			if method == http.MethodGet && len(segments) == 3 {
-				return opGetDomainStatisticsReport, segments[2]
-			}
-
-		case "campaigns":
-			if method == http.MethodGet && len(segments) == 3 {
-				return opListDomainDeliverabilityCampaigns, segments[2]
-			}
-
-			if method == http.MethodGet && len(segments) == 4 {
-				return opGetDomainDeliverabilityCampaign, segments[2]
-			}
+	switch segments[1] {
+	case "reports":
+		return parseDeliverabilityReportsPath(method, segments)
+	case "blacklist-report":
+		if method == http.MethodGet {
+			return opGetBlacklistReports, ""
 		}
+	case "statistics":
+		if method == http.MethodGet && len(segments) == 3 {
+			return opGetDomainStatisticsReport, segments[2]
+		}
+	case "campaigns":
+		return parseDeliverabilityDomainCampaignsPath(method, segments)
+	}
+
+	return unknownAction, ""
+}
+
+// parseDeliverabilityReportsPath routes deliverability test report paths.
+func parseDeliverabilityReportsPath(method string, segments []string) (string, string) {
+	if method != http.MethodGet {
+		return unknownAction, ""
+	}
+
+	switch len(segments) {
+	case 2:
+		return opListDeliverabilityTestReports, ""
+	case 3:
+		return opGetDeliverabilityTestReport, segments[2]
+	}
+
+	return unknownAction, ""
+}
+
+// parseDeliverabilityDomainCampaignsPath routes domain deliverability campaign paths.
+func parseDeliverabilityDomainCampaignsPath(method string, segments []string) (string, string) {
+	if method != http.MethodGet {
+		return unknownAction, ""
+	}
+
+	switch len(segments) {
+	case 3:
+		return opListDomainDeliverabilityCampaigns, segments[2]
+	case 4:
+		return opGetDomainDeliverabilityCampaign, segments[2]
 	}
 
 	return unknownAction, ""
@@ -541,26 +716,36 @@ func parseMultiRegionEndpointPath(method string, segments []string) (string, str
 	return unknownAction, ""
 }
 
-//nolint:cyclop // path branching inherently complex
-func parseTenantPath(
-	method string,
-	segments []string,
-) (string, string) {
-	switch {
-	case len(segments) == 1 && method == http.MethodGet:
-		return opListTenants, ""
-	case len(segments) == 1 && method == http.MethodPost:
-		return opCreateTenant, ""
-	case len(segments) == 2 && method == http.MethodGet:
-		return opGetTenant, segments[1]
-	case len(segments) == 2 && method == http.MethodDelete:
-		return opDeleteTenant, segments[1]
-	case len(segments) == 3 && segments[2] == segResources && method == http.MethodGet:
-		return opListTenantResources, segments[1]
-	case len(segments) == 3 && segments[2] == segResources && method == http.MethodPost:
-		return opCreateTenantResourceAssociation, segments[1]
-	case len(segments) == 4 && segments[2] == segResources && method == http.MethodDelete:
-		return opDeleteTenantResourceAssociation, segments[1]
+// parseTenantPath routes tenant paths.
+func parseTenantPath(method string, segments []string) (string, string) {
+	switch len(segments) {
+	case 1:
+		switch method {
+		case http.MethodGet:
+			return opListTenants, ""
+		case http.MethodPost:
+			return opCreateTenant, ""
+		}
+	case 2:
+		switch method {
+		case http.MethodGet:
+			return opGetTenant, segments[1]
+		case http.MethodDelete:
+			return opDeleteTenant, segments[1]
+		}
+	case 3:
+		if segments[2] == segResources {
+			switch method {
+			case http.MethodGet:
+				return opListTenantResources, segments[1]
+			case http.MethodPost:
+				return opCreateTenantResourceAssociation, segments[1]
+			}
+		}
+	case 4:
+		if segments[2] == segResources && method == http.MethodDelete {
+			return opDeleteTenantResourceAssociation, segments[1]
+		}
 	}
 
 	return unknownAction, ""
@@ -582,116 +767,141 @@ func parseReputationEntityPath(method string, segments []string) (string, string
 }
 
 // parseIdentityExtPath handles additional identity paths.
-//
-//nolint:cyclop // path branching inherently complex
-func parseIdentityExtPath(
-	method string,
-	segments []string,
-) (string, string) {
-	// /v2/email/identities/{identity}/policies — GET returns all policies
-	if len(segments) == 3 && segments[2] == segPolicies {
-		if method == http.MethodGet {
-			return opGetEmailIdentityPolicies, segments[1]
-		}
+func parseIdentityExtPath(method string, segments []string) (string, string) {
+	if len(segments) < 3 {
+		return unknownAction, ""
 	}
 
-	// /v2/email/identities/{identity}/policies/{policyName}
-	if len(segments) == 4 && segments[2] == segPolicies {
+	identity := segments[1]
+	sub := segments[2]
+
+	if op, id := parseIdentityPoliciesPath(method, segments, identity, sub); op != unknownAction {
+		return op, id
+	}
+
+	return parseIdentityAttributesPath(method, segments, identity, sub)
+}
+
+// parseIdentityPoliciesPath routes identity policy sub-paths.
+func parseIdentityPoliciesPath(method string, segments []string, identity, sub string) (string, string) {
+	if sub != segPolicies {
+		return unknownAction, ""
+	}
+
+	switch len(segments) {
+	case 3:
+		if method == http.MethodGet {
+			return opGetEmailIdentityPolicies, identity
+		}
+	case 4:
 		switch method {
 		case http.MethodDelete:
-			return opDeleteEmailIdentityPolicy, segments[1]
+			return opDeleteEmailIdentityPolicy, identity
 		case http.MethodPut:
-			return opUpdateEmailIdentityPolicy, segments[1]
+			return opUpdateEmailIdentityPolicy, identity
 		}
 	}
 
-	// /v2/email/identities/{identity}/configuration-set
-	if len(segments) == 3 && segments[2] == "configuration-set" && method == http.MethodPut {
-		return opPutEmailIdentityConfigurationSetAttributes, segments[1]
+	return unknownAction, ""
+}
+
+// parseIdentityAttributesPath routes identity attribute sub-paths.
+func parseIdentityAttributesPath(method string, segments []string, identity, sub string) (string, string) {
+	if method != http.MethodPut {
+		return unknownAction, ""
 	}
 
-	// /v2/email/identities/{identity}/dkim
-	if len(segments) == 3 && segments[2] == "dkim" {
-		if method == http.MethodPut {
-			return opPutEmailIdentityDkimAttributes, segments[1]
+	switch sub {
+	case "configuration-set":
+		if len(segments) == 3 {
+			return opPutEmailIdentityConfigurationSetAttributes, identity
 		}
-	}
-
-	// /v2/email/identities/{identity}/dkim/signing
-	if len(segments) == 4 && segments[2] == "dkim" && segments[3] == "signing" &&
-		method == http.MethodPut {
-		return opPutEmailIdentityDkimSigningAttributes, segments[1]
-	}
-
-	// /v2/email/identities/{identity}/feedback
-	if len(segments) == 3 && segments[2] == "feedback" && method == http.MethodPut {
-		return opPutEmailIdentityFeedbackAttributes, segments[1]
-	}
-
-	// /v2/email/identities/{identity}/mail-from
-	if len(segments) == 3 && segments[2] == "mail-from" && method == http.MethodPut {
-		return opPutEmailIdentityMailFromAttributes, segments[1]
+	case "dkim":
+		switch len(segments) {
+		case 3:
+			return opPutEmailIdentityDkimAttributes, identity
+		case 4:
+			if segments[3] == "signing" {
+				return opPutEmailIdentityDkimSigningAttributes, identity
+			}
+		}
+	case "feedback":
+		if len(segments) == 3 {
+			return opPutEmailIdentityFeedbackAttributes, identity
+		}
+	case "mail-from":
+		if len(segments) == 3 {
+			return opPutEmailIdentityMailFromAttributes, identity
+		}
 	}
 
 	return unknownAction, ""
 }
 
 // parseConfigSetExtPath handles additional configuration set paths.
-//
-//nolint:cyclop,gocognit // path branching inherently complex
-func parseConfigSetExtPath(
-	method string,
-	segments []string,
-) (string, string) {
-	// /v2/email/configuration-sets/{name}/event-destinations
-	if len(segments) == 3 && segments[2] == segEventDestinations {
-		if method == http.MethodGet {
-			return opGetConfigurationSetEventDestinations, segments[1]
-		}
+func parseConfigSetExtPath(method string, segments []string) (string, string) {
+	if len(segments) < 3 {
+		return unknownAction, ""
 	}
 
-	// /v2/email/configuration-sets/{name}/event-destinations/{destName}
-	if len(segments) == 4 && segments[2] == segEventDestinations {
+	name := segments[1]
+	sub := segments[2]
+
+	if op, id := parseConfigSetEventDestPath(method, segments, name, sub); op != unknownAction {
+		return op, id
+	}
+
+	if len(segments) == pathDepth3 {
+		return parseConfigSetAttrPath(method, name, sub)
+	}
+
+	return unknownAction, ""
+}
+
+// parseConfigSetEventDestPath routes configuration set event destination paths.
+func parseConfigSetEventDestPath(method string, segments []string, name, sub string) (string, string) {
+	if sub != segEventDestinations {
+		return unknownAction, ""
+	}
+
+	switch len(segments) {
+	case 3:
+		if method == http.MethodGet {
+			return opGetConfigurationSetEventDestinations, name
+		}
+	case 4:
 		switch method {
 		case http.MethodDelete:
-			return opDeleteConfigurationSetEventDestination, segments[1]
+			return opDeleteConfigurationSetEventDestination, name
 		case http.MethodPut:
-			return opUpdateConfigurationSetEventDestination, segments[1]
+			return opUpdateConfigurationSetEventDestination, name
 		}
 	}
 
-	// /v2/email/configuration-sets/{name}/{attribute}
-	if len(segments) == pathDepth3 { //nolint:nestif // URL path segment dispatching requires nested if
-		switch segments[2] {
-		case "archiving-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetArchivingOptions, segments[1]
-			}
-		case "delivery-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetDeliveryOptions, segments[1]
-			}
-		case "reputation-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetReputationOptions, segments[1]
-			}
-		case "sending-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetSendingOptions, segments[1]
-			}
-		case "suppression-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetSuppressionOptions, segments[1]
-			}
-		case "tracking-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetTrackingOptions, segments[1]
-			}
-		case "vdm-options":
-			if method == http.MethodPut {
-				return opPutConfigurationSetVdmOptions, segments[1]
-			}
-		}
+	return unknownAction, ""
+}
+
+// parseConfigSetAttrPath routes configuration set attribute put paths.
+func parseConfigSetAttrPath(method, name, sub string) (string, string) {
+	if method != http.MethodPut {
+		return unknownAction, ""
+	}
+
+	switch sub {
+	case "archiving-options":
+		return opPutConfigurationSetArchivingOptions, name
+	case "delivery-options":
+		return opPutConfigurationSetDeliveryOptions, name
+	case "reputation-options":
+		return opPutConfigurationSetReputationOptions, name
+	case "sending-options":
+		return opPutConfigurationSetSendingOptions, name
+	case "suppression-options":
+		return opPutConfigurationSetSuppressionOptions, name
+	case "tracking-options":
+		return opPutConfigurationSetTrackingOptions, name
+	case "vdm-options":
+		return opPutConfigurationSetVdmOptions, name
 	}
 
 	return unknownAction, ""

--- a/services/ssoadmin/handler.go
+++ b/services/ssoadmin/handler.go
@@ -207,93 +207,151 @@ func (h *Handler) Handler() echo.HandlerFunc {
 func (h *Handler) dispatch(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "ListInstances":
+
 		return h.handleListInstances(c, body)
 	case "CreateInstance":
+
 		return h.handleCreateInstance(c, body)
 	case "DescribeInstance":
+
 		return h.handleDescribeInstance(c, body)
 	case "DeleteInstance":
+
 		return h.handleDeleteInstance(c, body)
 	case "CreatePermissionSet":
+
 		return h.handleCreatePermissionSet(c, body)
 	case "DescribePermissionSet":
+
 		return h.handleDescribePermissionSet(c, body)
 	case "ListPermissionSets":
+
 		return h.handleListPermissionSets(c, body)
 	case "DeletePermissionSet":
+
 		return h.handleDeletePermissionSet(c, body)
 	case "UpdatePermissionSet":
+
 		return h.handleUpdatePermissionSet(c, body)
 	default:
+
 		return h.dispatchAssignmentAndPolicy(c, op, body)
 	}
 }
 
-//nolint:cyclop // intentional large switch for assignment and policy operations
+// dispatchAssignmentAndPolicy routes assignment and policy operations.
 func (h *Handler) dispatchAssignmentAndPolicy(c *echo.Context, op string, body []byte) error {
+	if ok, err := h.dispatchAssignmentOps(c, op, body); ok {
+		return err
+	}
+	if ok, err := h.dispatchPolicyTagOps(c, op, body); ok {
+		return err
+	}
+
+	return h.dispatchNewOps(c, op, body)
+}
+
+// dispatchAssignmentOps handles account assignment operations.
+func (h *Handler) dispatchAssignmentOps(c *echo.Context, op string, body []byte) (bool, error) {
 	switch op {
 	case "CreateAccountAssignment":
-		return h.handleCreateAccountAssignment(c, body)
+
+		return true, h.handleCreateAccountAssignment(c, body)
 	case "DescribeAccountAssignmentCreationStatus":
-		return h.handleDescribeAccountAssignmentCreationStatus(c, body)
+
+		return true, h.handleDescribeAccountAssignmentCreationStatus(c, body)
 	case "DeleteAccountAssignment":
-		return h.handleDeleteAccountAssignment(c, body)
+
+		return true, h.handleDeleteAccountAssignment(c, body)
 	case "DescribeAccountAssignmentDeletionStatus":
-		return h.handleDescribeAccountAssignmentDeletionStatus(c, body)
+
+		return true, h.handleDescribeAccountAssignmentDeletionStatus(c, body)
 	case "ListAccountAssignments":
-		return h.handleListAccountAssignments(c, body)
-	case "AttachManagedPolicyToPermissionSet":
-		return h.handleAttachManagedPolicyToPermissionSet(c, body)
-	case "DetachManagedPolicyFromPermissionSet":
-		return h.handleDetachManagedPolicyFromPermissionSet(c, body)
-	case "ListManagedPoliciesInPermissionSet":
-		return h.handleListManagedPoliciesInPermissionSet(c, body)
-	case "PutInlinePolicyToPermissionSet":
-		return h.handlePutInlinePolicyToPermissionSet(c, body)
-	case "GetInlinePolicyForPermissionSet":
-		return h.handleGetInlinePolicyForPermissionSet(c, body)
-	case "DeleteInlinePolicyFromPermissionSet":
-		return h.handleDeleteInlinePolicyFromPermissionSet(c, body)
-	case "ProvisionPermissionSet":
-		return h.handleProvisionPermissionSet(c, body)
-	case "DescribePermissionSetProvisioningStatus":
-		return h.handleDescribePermissionSetProvisioningStatus(c, body)
-	case "TagResource":
-		return h.handleTagResource(c, body)
-	case "UntagResource":
-		return h.handleUntagResource(c, body)
-	case "ListTagsForResource":
-		return h.handleListTagsForResource(c, body)
-	default:
-		return h.dispatchNewOps(c, op, body)
+
+		return true, h.handleListAccountAssignments(c, body)
 	}
+
+	return false, nil
+}
+
+// dispatchPolicyTagOps handles policy management and tagging operations.
+func (h *Handler) dispatchPolicyTagOps(c *echo.Context, op string, body []byte) (bool, error) {
+	switch op {
+	case "AttachManagedPolicyToPermissionSet":
+
+		return true, h.handleAttachManagedPolicyToPermissionSet(c, body)
+	case "DetachManagedPolicyFromPermissionSet":
+
+		return true, h.handleDetachManagedPolicyFromPermissionSet(c, body)
+	case "ListManagedPoliciesInPermissionSet":
+
+		return true, h.handleListManagedPoliciesInPermissionSet(c, body)
+	case "PutInlinePolicyToPermissionSet":
+
+		return true, h.handlePutInlinePolicyToPermissionSet(c, body)
+	case "GetInlinePolicyForPermissionSet":
+
+		return true, h.handleGetInlinePolicyForPermissionSet(c, body)
+	case "DeleteInlinePolicyFromPermissionSet":
+
+		return true, h.handleDeleteInlinePolicyFromPermissionSet(c, body)
+	case "ProvisionPermissionSet":
+
+		return true, h.handleProvisionPermissionSet(c, body)
+	case "DescribePermissionSetProvisioningStatus":
+
+		return true, h.handleDescribePermissionSetProvisioningStatus(c, body)
+	case "TagResource":
+
+		return true, h.handleTagResource(c, body)
+	case "UntagResource":
+
+		return true, h.handleUntagResource(c, body)
+	case "ListTagsForResource":
+
+		return true, h.handleListTagsForResource(c, body)
+	}
+
+	return false, nil
 }
 
 func (h *Handler) dispatchNewOps(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "AddRegion":
+
 		return h.handleAddRegion(c, body)
 	case "AttachCustomerManagedPolicyReferenceToPermissionSet":
+
 		return h.handleAttachCustomerManagedPolicyReferenceToPermissionSet(c, body)
 	case "CreateApplication":
+
 		return h.handleCreateApplication(c, body)
 	case "CreateApplicationAssignment":
+
 		return h.handleCreateApplicationAssignment(c, body)
 	case "CreateInstanceAccessControlAttributeConfiguration":
+
 		return h.handleCreateInstanceAccessControlAttributeConfiguration(c, body)
 	case "CreateTrustedTokenIssuer":
+
 		return h.handleCreateTrustedTokenIssuer(c, body)
 	case "DeleteApplication":
+
 		return h.handleDeleteApplication(c, body)
 	case "DeleteApplicationAccessScope":
+
 		return h.handleDeleteApplicationAccessScope(c, body)
 	case "DeleteApplicationAssignment":
+
 		return h.handleDeleteApplicationAssignment(c, body)
 	case "DeleteApplicationAuthenticationMethod":
+
 		return h.handleDeleteApplicationAuthenticationMethod(c, body)
 	case "DetachCustomerManagedPolicyReferenceFromPermissionSet":
+
 		return h.handleDetachCustomerManagedPolicyReferenceFromPermissionSet(c, body)
 	default:
+
 		return h.dispatchNewestOps(c, op, body)
 	}
 }
@@ -301,32 +359,46 @@ func (h *Handler) dispatchNewOps(c *echo.Context, op string, body []byte) error 
 func (h *Handler) dispatchNewestOps(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "DeleteApplicationGrant":
+
 		return h.handleDeleteApplicationGrant(c, body)
 	case "DeleteInstanceAccessControlAttributeConfiguration":
+
 		return h.handleDeleteInstanceAccessControlAttributeConfiguration(c, body)
 	case "DeleteTrustedTokenIssuer":
+
 		return h.handleDeleteTrustedTokenIssuer(c, body)
 	case "DescribeApplication":
+
 		return h.handleDescribeApplication(c, body)
 	case "DescribeApplicationAssignment":
+
 		return h.handleDescribeApplicationAssignment(c, body)
 	case "DescribeApplicationProvider":
+
 		return h.handleDescribeApplicationProvider(c, body)
 	case "DescribeInstanceAccessControlAttributeConfiguration":
+
 		return h.handleDescribeInstanceAccessControlAttributeConfiguration(c, body)
 	case "DescribeTrustedTokenIssuer":
+
 		return h.handleDescribeTrustedTokenIssuer(c, body)
 	case "GetPermissionsBoundaryForPermissionSet":
+
 		return h.handleGetPermissionsBoundaryForPermissionSet(c, body)
 	case "ListAccountAssignmentCreationStatus":
+
 		return h.handleListAccountAssignmentCreationStatus(c, body)
 	case "ListAccountAssignmentDeletionStatus":
+
 		return h.handleListAccountAssignmentDeletionStatus(c, body)
 	case "ListAccountAssignmentsForPrincipal":
+
 		return h.handleListAccountAssignmentsForPrincipal(c, body)
 	case "ListPermissionSetsProvisionedToAccount":
+
 		return h.handleListPermissionSetsProvisionedToAccount(c, body)
 	default:
+
 		return h.dispatchNewestAppOps(c, op, body)
 	}
 }
@@ -334,18 +406,25 @@ func (h *Handler) dispatchNewestOps(c *echo.Context, op string, body []byte) err
 func (h *Handler) dispatchNewestAppOps(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "ListApplicationAccessScopes":
+
 		return h.handleListApplicationAccessScopes(c, body)
 	case "ListApplicationAssignments":
+
 		return h.handleListApplicationAssignments(c, body)
 	case "ListApplicationAuthenticationMethods":
+
 		return h.handleListApplicationAuthenticationMethods(c, body)
 	case "ListApplicationGrants":
+
 		return h.handleListApplicationGrants(c, body)
 	case "ListApplicationProviders":
+
 		return h.handleListApplicationProviders(c, body)
 	case "ListApplications":
+
 		return h.handleListApplications(c, body)
 	default:
+
 		return h.dispatchNewestConfigOps(c, op, body)
 	}
 }
@@ -353,24 +432,34 @@ func (h *Handler) dispatchNewestAppOps(c *echo.Context, op string, body []byte) 
 func (h *Handler) dispatchNewestConfigOps(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "DeletePermissionsBoundaryFromPermissionSet":
+
 		return h.handleDeletePermissionsBoundaryFromPermissionSet(c, body)
 	case "GetApplicationAssignmentConfiguration":
+
 		return h.handleGetApplicationAssignmentConfiguration(c, body)
 	case "GetApplicationSessionConfiguration":
+
 		return h.handleGetApplicationSessionConfiguration(c, body)
 	case "ListCustomerManagedPolicyReferencesInPermissionSet":
+
 		return h.handleListCustomerManagedPolicyReferencesInPermissionSet(c, body)
 	case "ListPermissionSetProvisioningStatus":
+
 		return h.handleListPermissionSetProvisioningStatus(c, body)
 	case "ListRegions":
+
 		return h.handleListRegions(c, body)
 	case "ListTrustedTokenIssuers":
+
 		return h.handleListTrustedTokenIssuers(c, body)
 	case "PutApplicationAccessScope":
+
 		return h.handlePutApplicationAccessScope(c, body)
 	case "PutApplicationAssignmentConfiguration":
+
 		return h.handlePutApplicationAssignmentConfiguration(c, body)
 	default:
+
 		return h.dispatchUpdateOps(c, op, body)
 	}
 }
@@ -378,24 +467,34 @@ func (h *Handler) dispatchNewestConfigOps(c *echo.Context, op string, body []byt
 func (h *Handler) dispatchUpdateOps(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "PutApplicationAuthenticationMethod":
+
 		return h.handlePutApplicationAuthenticationMethod(c, body)
 	case "PutApplicationGrant":
+
 		return h.handlePutApplicationGrant(c, body)
 	case "PutApplicationSessionConfiguration":
+
 		return h.handlePutApplicationSessionConfiguration(c, body)
 	case "PutPermissionsBoundaryToPermissionSet":
+
 		return h.handlePutPermissionsBoundaryToPermissionSet(c, body)
 	case "RemoveRegion":
+
 		return h.handleRemoveRegion(c, body)
 	case "UpdateApplication":
+
 		return h.handleUpdateApplication(c, body)
 	case "UpdateInstance":
+
 		return h.handleUpdateInstance(c, body)
 	case "UpdateInstanceAccessControlAttributeConfiguration":
+
 		return h.handleUpdateInstanceAccessControlAttributeConfiguration(c, body)
 	case "UpdateTrustedTokenIssuer":
+
 		return h.handleUpdateTrustedTokenIssuer(c, body)
 	default:
+
 		return h.dispatchRefinement3Ops(c, op, body)
 	}
 }
@@ -403,18 +502,25 @@ func (h *Handler) dispatchUpdateOps(c *echo.Context, op string, body []byte) err
 func (h *Handler) dispatchRefinement3Ops(c *echo.Context, op string, body []byte) error {
 	switch op {
 	case "GetApplicationAccessScope":
+
 		return h.handleGetApplicationAccessScope(c, body)
 	case "GetApplicationAuthenticationMethod":
+
 		return h.handleGetApplicationAuthenticationMethod(c, body)
 	case "GetApplicationGrant":
+
 		return h.handleGetApplicationGrant(c, body)
 	case "ListAccountsForProvisionedPermissionSet":
+
 		return h.handleListAccountsForProvisionedPermissionSet(c, body)
 	case "ListApplicationAssignmentsForPrincipal":
+
 		return h.handleListApplicationAssignmentsForPrincipal(c, body)
 	case "DescribeRegion":
+
 		return h.handleDescribeRegion(c, body)
 	default:
+
 		return writeError(c, http.StatusBadRequest, "UnknownOperationException", "unknown operation: "+op)
 	}
 }
@@ -1153,10 +1259,13 @@ func handleBackendError(c *echo.Context, err error, notFoundMsg string) error {
 
 	switch err.Error() {
 	case "ResourceNotFoundException":
+
 		return writeError(c, http.StatusNotFound, "ResourceNotFoundException", notFoundMsg)
 	case "ConflictException":
+
 		return writeError(c, http.StatusConflict, "ConflictException", notFoundMsg)
 	default:
+
 		return writeError(c, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}
 }

--- a/services/stepfunctions/asl/executor.go
+++ b/services/stepfunctions/asl/executor.go
@@ -333,79 +333,117 @@ func (e *Executor) executePass(state *State, input any) (string, any, error) {
 
 // executeWait handles Wait state.
 //
-//nolint:cyclop,gocognit // inherently complex due to multiple wait modes
+
+// executeWait handles Wait state.
 func (e *Executor) executeWait(ctx context.Context, state *State, input any) (string, any, error) {
-	var waitDuration time.Duration
-
-	switch {
-	case state.Seconds > 0:
-		waitDuration = time.Duration(state.Seconds) * time.Second
-
-	case state.SecondsPath != "":
-		val, err := applyPath(state.SecondsPath, input, e.jsonPathCache)
-		if err != nil {
-			return "", nil, fmt.Errorf("SecondsPath error: %w", err)
-		}
-
-		secs, ok := toFloat(val)
-		if !ok {
-			return "", nil, ErrSecondsPathNotNumber
-		}
-
-		if secs > 0 {
-			waitDuration = time.Duration(secs * float64(time.Second))
-		}
-
-	case state.Timestamp != "":
-		t, err := time.Parse(time.RFC3339, state.Timestamp)
-		if err != nil {
-			return "", nil, fmt.Errorf("timestamp parse error: %w", err)
-		}
-
-		if d := time.Until(t); d > 0 {
-			waitDuration = d
-		}
-
-	case state.TimestampPath != "":
-		val, err := applyPath(state.TimestampPath, input, e.jsonPathCache)
-		if err != nil {
-			return "", nil, fmt.Errorf("TimestampPath error: %w", err)
-		}
-
-		tsStr, ok := val.(string)
-		if !ok {
-			return "", nil, ErrTimestampPathNotString
-		}
-
-		t, err := time.Parse(time.RFC3339, tsStr)
-		if err != nil {
-			return "", nil, fmt.Errorf("TimestampPath value parse error: %w", err)
-		}
-
-		if d := time.Until(t); d > 0 {
-			waitDuration = d
-		}
+	waitDuration, err := e.resolveWaitDuration(state, input)
+	if err != nil {
+		return "", nil, err
 	}
 
 	if waitDuration > 0 {
-		timer := time.NewTimer(waitDuration)
-		defer func() {
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-		}()
-
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			return "", nil, ctx.Err()
+		if err := e.waitForDuration(ctx, waitDuration); err != nil {
+			return "", nil, err
 		}
 	}
 
 	return state.Next, input, nil
+}
+
+// resolveWaitDuration determines the wait duration from the state configuration.
+func (e *Executor) resolveWaitDuration(state *State, input any) (time.Duration, error) {
+	switch {
+	case state.Seconds > 0:
+		return time.Duration(state.Seconds) * time.Second, nil
+
+	case state.SecondsPath != "":
+		return e.resolveSecondsPath(state.SecondsPath, input)
+
+	case state.Timestamp != "":
+		return resolveTimestampDuration(state.Timestamp)
+
+	case state.TimestampPath != "":
+		return e.resolveTimestampPath(state.TimestampPath, input)
+	}
+
+	return 0, nil
+}
+
+// resolveSecondsPath resolves the wait duration from a path to a numeric value.
+func (e *Executor) resolveSecondsPath(path string, input any) (time.Duration, error) {
+	val, err := applyPath(path, input, e.jsonPathCache)
+	if err != nil {
+		return 0, fmt.Errorf("SecondsPath error: %w", err)
+	}
+
+	secs, ok := toFloat(val)
+	if !ok {
+		return 0, ErrSecondsPathNotNumber
+	}
+
+	if secs > 0 {
+		return time.Duration(secs * float64(time.Second)), nil
+	}
+
+	return 0, nil
+}
+
+// resolveTimestampDuration resolves the wait duration from a timestamp string.
+func resolveTimestampDuration(timestamp string) (time.Duration, error) {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return 0, fmt.Errorf("timestamp parse error: %w", err)
+	}
+
+	if d := time.Until(t); d > 0 {
+		return d, nil
+	}
+
+	return 0, nil
+}
+
+// resolveTimestampPath resolves the wait duration from a path to a timestamp string.
+func (e *Executor) resolveTimestampPath(path string, input any) (time.Duration, error) {
+	val, err := applyPath(path, input, e.jsonPathCache)
+	if err != nil {
+		return 0, fmt.Errorf("TimestampPath error: %w", err)
+	}
+
+	tsStr, ok := val.(string)
+	if !ok {
+		return 0, ErrTimestampPathNotString
+	}
+
+	t, err := time.Parse(time.RFC3339, tsStr)
+	if err != nil {
+		return 0, fmt.Errorf("TimestampPath value parse error: %w", err)
+	}
+
+	if d := time.Until(t); d > 0 {
+		return d, nil
+	}
+
+	return 0, nil
+}
+
+// waitForDuration waits for the specified duration or context cancellation.
+func (e *Executor) waitForDuration(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // executeChoice handles Choice state.
@@ -1405,41 +1443,42 @@ func matchVariableCondition(rule *ChoiceRule, varVal, input any, pathCache *sync
 }
 
 // matchStringCondition checks string comparison conditions.
-//
-//nolint:gocyclo,cyclop,gocognit,funlen // many string comparison operators
 func matchStringCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.Map) (bool, bool) {
-	if rule.StringEquals != nil {
-		s, ok := varVal.(string)
+	if result, matched := matchStringLiteralCondition(rule, varVal); matched {
+		return result, matched
+	}
 
+	return matchStringPathCondition(rule, varVal, input, pathCache)
+}
+
+// matchStringLiteralCondition checks direct string comparison conditions.
+func matchStringLiteralCondition(rule *ChoiceRule, varVal any) (bool, bool) {
+	s, ok := varVal.(string)
+
+	switch {
+	case rule.StringEquals != nil:
 		return ok && s == *rule.StringEquals, true
-	}
-
-	if rule.StringLessThan != nil {
-		s, ok := varVal.(string)
-
+	case rule.StringLessThan != nil:
 		return ok && s < *rule.StringLessThan, true
-	}
-
-	if rule.StringGreaterThan != nil {
-		s, ok := varVal.(string)
-
+	case rule.StringGreaterThan != nil:
 		return ok && s > *rule.StringGreaterThan, true
-	}
-
-	if rule.StringLessThanEquals != nil {
-		s, ok := varVal.(string)
-
+	case rule.StringLessThanEquals != nil:
 		return ok && s <= *rule.StringLessThanEquals, true
-	}
-
-	if rule.StringGreaterThanEquals != nil {
-		s, ok := varVal.(string)
-
+	case rule.StringGreaterThanEquals != nil:
 		return ok && s >= *rule.StringGreaterThanEquals, true
 	}
 
-	if rule.StringEqualsPath != nil {
-		ref, err := applyPath(*rule.StringEqualsPath, input, pathCache)
+	return false, false
+}
+
+// matchStringPathCondition checks path-based string comparison conditions.
+func matchStringPathCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.Map) (bool, bool) {
+	comparePath := func(path *string, cmp func(s1, s2 string) bool) (bool, bool) {
+		if path == nil {
+			return false, false
+		}
+
+		ref, err := applyPath(*path, input, pathCache)
 		if err != nil {
 			return false, true
 		}
@@ -1447,96 +1486,69 @@ func matchStringCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.M
 		s1, ok1 := varVal.(string)
 		s2, ok2 := ref.(string)
 
-		return ok1 && ok2 && s1 == s2, true
+		return ok1 && ok2 && cmp(s1, s2), true
 	}
 
-	if rule.StringLessThanPath != nil {
-		ref, err := applyPath(*rule.StringLessThanPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
-
-		s1, ok1 := varVal.(string)
-		s2, ok2 := ref.(string)
-
-		return ok1 && ok2 && s1 < s2, true
+	if r, m := comparePath(rule.StringEqualsPath, func(a, b string) bool { return a == b }); m {
+		return r, m
 	}
 
-	if rule.StringGreaterThanPath != nil {
-		ref, err := applyPath(*rule.StringGreaterThanPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
-
-		s1, ok1 := varVal.(string)
-		s2, ok2 := ref.(string)
-
-		return ok1 && ok2 && s1 > s2, true
+	if r, m := comparePath(rule.StringLessThanPath, func(a, b string) bool { return a < b }); m {
+		return r, m
 	}
 
-	if rule.StringLessThanEqualsPath != nil {
-		ref, err := applyPath(*rule.StringLessThanEqualsPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
-
-		s1, ok1 := varVal.(string)
-		s2, ok2 := ref.(string)
-
-		return ok1 && ok2 && s1 <= s2, true
+	if r, m := comparePath(rule.StringGreaterThanPath, func(a, b string) bool { return a > b }); m {
+		return r, m
 	}
 
-	if rule.StringGreaterThanEqualsPath != nil {
-		ref, err := applyPath(*rule.StringGreaterThanEqualsPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
+	if r, m := comparePath(rule.StringLessThanEqualsPath, func(a, b string) bool { return a <= b }); m {
+		return r, m
+	}
 
-		s1, ok1 := varVal.(string)
-		s2, ok2 := ref.(string)
-
-		return ok1 && ok2 && s1 >= s2, true
+	if r, m := comparePath(rule.StringGreaterThanEqualsPath, func(a, b string) bool { return a >= b }); m {
+		return r, m
 	}
 
 	return false, false
 }
 
 // matchNumericCondition checks numeric comparison conditions.
-//
-//nolint:gocyclo,cyclop,gocognit,funlen // many numeric comparison operators
 func matchNumericCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.Map) (bool, bool) {
-	if rule.NumericEquals != nil {
-		n, ok := toFloat(varVal)
+	if result, matched := matchNumericLiteralCondition(rule, varVal); matched {
+		return result, matched
+	}
 
+	return matchNumericPathCondition(rule, varVal, input, pathCache)
+}
+
+// matchNumericLiteralCondition checks direct numeric comparison conditions.
+func matchNumericLiteralCondition(rule *ChoiceRule, varVal any) (bool, bool) {
+	n, ok := toFloat(varVal)
+
+	switch {
+	case rule.NumericEquals != nil:
 		return ok && n == *rule.NumericEquals, true
-	}
-
-	if rule.NumericLessThan != nil {
-		n, ok := toFloat(varVal)
-
+	case rule.NumericLessThan != nil:
 		return ok && n < *rule.NumericLessThan, true
-	}
-
-	if rule.NumericGreaterThan != nil {
-		n, ok := toFloat(varVal)
-
+	case rule.NumericGreaterThan != nil:
 		return ok && n > *rule.NumericGreaterThan, true
-	}
-
-	if rule.NumericLessThanEquals != nil {
-		n, ok := toFloat(varVal)
-
+	case rule.NumericLessThanEquals != nil:
 		return ok && n <= *rule.NumericLessThanEquals, true
-	}
-
-	if rule.NumericGreaterThanEquals != nil {
-		n, ok := toFloat(varVal)
-
+	case rule.NumericGreaterThanEquals != nil:
 		return ok && n >= *rule.NumericGreaterThanEquals, true
 	}
 
-	if rule.NumericEqualsPath != nil {
-		ref, err := applyPath(*rule.NumericEqualsPath, input, pathCache)
+	return false, false
+}
+
+// matchNumericPathCondition checks path-based numeric comparison conditions.
+func matchNumericPathCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.Map) (bool, bool) {
+	compareNumPath := func(path *string, cmp func(n1, n2 float64) bool) (bool, bool) {
+		if path == nil {
+			return false, false
+		}
+
+		ref, err := applyPath(*path, input, pathCache)
 		if err != nil {
 			return false, true
 		}
@@ -1544,55 +1556,27 @@ func matchNumericCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.
 		n1, ok1 := toFloat(varVal)
 		n2, ok2 := toFloat(ref)
 
-		return ok1 && ok2 && n1 == n2, true
+		return ok1 && ok2 && cmp(n1, n2), true
 	}
 
-	if rule.NumericLessThanPath != nil {
-		ref, err := applyPath(*rule.NumericLessThanPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
-
-		n1, ok1 := toFloat(varVal)
-		n2, ok2 := toFloat(ref)
-
-		return ok1 && ok2 && n1 < n2, true
+	if r, m := compareNumPath(rule.NumericEqualsPath, func(a, b float64) bool { return a == b }); m {
+		return r, m
 	}
 
-	if rule.NumericGreaterThanPath != nil {
-		ref, err := applyPath(*rule.NumericGreaterThanPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
-
-		n1, ok1 := toFloat(varVal)
-		n2, ok2 := toFloat(ref)
-
-		return ok1 && ok2 && n1 > n2, true
+	if r, m := compareNumPath(rule.NumericLessThanPath, func(a, b float64) bool { return a < b }); m {
+		return r, m
 	}
 
-	if rule.NumericLessThanEqualsPath != nil {
-		ref, err := applyPath(*rule.NumericLessThanEqualsPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
-
-		n1, ok1 := toFloat(varVal)
-		n2, ok2 := toFloat(ref)
-
-		return ok1 && ok2 && n1 <= n2, true
+	if r, m := compareNumPath(rule.NumericGreaterThanPath, func(a, b float64) bool { return a > b }); m {
+		return r, m
 	}
 
-	if rule.NumericGreaterThanEqualsPath != nil {
-		ref, err := applyPath(*rule.NumericGreaterThanEqualsPath, input, pathCache)
-		if err != nil {
-			return false, true
-		}
+	if r, m := compareNumPath(rule.NumericLessThanEqualsPath, func(a, b float64) bool { return a <= b }); m {
+		return r, m
+	}
 
-		n1, ok1 := toFloat(varVal)
-		n2, ok2 := toFloat(ref)
-
-		return ok1 && ok2 && n1 >= n2, true
+	if r, m := compareNumPath(rule.NumericGreaterThanEqualsPath, func(a, b float64) bool { return a >= b }); m {
+		return r, m
 	}
 
 	return false, false
@@ -1622,72 +1606,80 @@ func matchBooleanCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.
 }
 
 // matchTimestampCondition checks timestamp comparison conditions.
-//
-//nolint:cyclop // many timestamp comparison operators
 func matchTimestampCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.Map) (bool, bool) {
-	if rule.TimestampEquals != nil {
+	if result, matched := matchTimestampLiteralCondition(rule, varVal); matched {
+		return result, matched
+	}
+
+	return matchTimestampPathCondition(rule, varVal, input, pathCache)
+}
+
+// matchTimestampLiteralCondition checks direct timestamp comparison conditions.
+func matchTimestampLiteralCondition(rule *ChoiceRule, varVal any) (bool, bool) {
+	compareLiteral := func(tsPtr *string, cmp func(t1, t2 time.Time) bool) (bool, bool) {
+		if tsPtr == nil {
+			return false, false
+		}
+
 		t1, err1 := parseTimestamp(varVal)
-		t2, err2 := time.Parse(time.RFC3339, *rule.TimestampEquals)
+		t2, err2 := time.Parse(time.RFC3339, *tsPtr)
 
-		return err1 == nil && err2 == nil && t1.Equal(t2), true
+		return err1 == nil && err2 == nil && cmp(t1, t2), true
 	}
 
-	if rule.TimestampLessThan != nil {
-		t1, err1 := parseTimestamp(varVal)
-		t2, err2 := time.Parse(time.RFC3339, *rule.TimestampLessThan)
-
-		return err1 == nil && err2 == nil && t1.Before(t2), true
+	if r, m := compareLiteral(rule.TimestampEquals, time.Time.Equal); m {
+		return r, m
 	}
 
-	if rule.TimestampGreaterThan != nil {
-		t1, err1 := parseTimestamp(varVal)
-		t2, err2 := time.Parse(time.RFC3339, *rule.TimestampGreaterThan)
-
-		return err1 == nil && err2 == nil && t1.After(t2), true
+	if r, m := compareLiteral(rule.TimestampLessThan, time.Time.Before); m {
+		return r, m
 	}
 
-	if rule.TimestampLessThanEquals != nil {
-		t1, err1 := parseTimestamp(varVal)
-		t2, err2 := time.Parse(time.RFC3339, *rule.TimestampLessThanEquals)
-
-		return err1 == nil && err2 == nil && !t1.After(t2), true
+	if r, m := compareLiteral(rule.TimestampGreaterThan, time.Time.After); m {
+		return r, m
 	}
 
-	if rule.TimestampGreaterThanEquals != nil {
-		t1, err1 := parseTimestamp(varVal)
-		t2, err2 := time.Parse(time.RFC3339, *rule.TimestampGreaterThanEquals)
-
-		return err1 == nil && err2 == nil && !t1.Before(t2), true
+	if r, m := compareLiteral(rule.TimestampLessThanEquals, func(t1, t2 time.Time) bool { return !t1.After(t2) }); m {
+		return r, m
 	}
 
-	if rule.TimestampEqualsPath != nil {
-		t1, t2, err := resolveTimestampPath(varVal, *rule.TimestampEqualsPath, input, pathCache)
-
-		return err == nil && t1.Equal(t2), true
+	if r, m := compareLiteral(rule.TimestampGreaterThanEquals, func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
+		return r, m
 	}
 
-	if rule.TimestampLessThanPath != nil {
-		t1, t2, err := resolveTimestampPath(varVal, *rule.TimestampLessThanPath, input, pathCache)
+	return false, false
+}
 
-		return err == nil && t1.Before(t2), true
+// matchTimestampPathCondition checks path-based timestamp comparison conditions.
+func matchTimestampPathCondition(rule *ChoiceRule, varVal, input any, pathCache *sync.Map) (bool, bool) {
+	comparePath := func(path *string, cmp func(t1, t2 time.Time) bool) (bool, bool) {
+		if path == nil {
+			return false, false
+		}
+
+		t1, t2, err := resolveTimestampPath(varVal, *path, input, pathCache)
+
+		return err == nil && cmp(t1, t2), true
 	}
 
-	if rule.TimestampGreaterThanPath != nil {
-		t1, t2, err := resolveTimestampPath(varVal, *rule.TimestampGreaterThanPath, input, pathCache)
-
-		return err == nil && t1.After(t2), true
+	if r, m := comparePath(rule.TimestampEqualsPath, time.Time.Equal); m {
+		return r, m
 	}
 
-	if rule.TimestampLessThanEqualsPath != nil {
-		t1, t2, err := resolveTimestampPath(varVal, *rule.TimestampLessThanEqualsPath, input, pathCache)
-
-		return err == nil && !t1.After(t2), true
+	if r, m := comparePath(rule.TimestampLessThanPath, time.Time.Before); m {
+		return r, m
 	}
 
-	if rule.TimestampGreaterThanEqualsPath != nil {
-		t1, t2, err := resolveTimestampPath(varVal, *rule.TimestampGreaterThanEqualsPath, input, pathCache)
+	if r, m := comparePath(rule.TimestampGreaterThanPath, time.Time.After); m {
+		return r, m
+	}
 
-		return err == nil && !t1.Before(t2), true
+	if r, m := comparePath(rule.TimestampLessThanEqualsPath, func(t1, t2 time.Time) bool { return !t1.After(t2) }); m {
+		return r, m
+	}
+
+	if r, m := comparePath(rule.TimestampGreaterThanEqualsPath, func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
+		return r, m
 	}
 
 	return false, false
@@ -1849,56 +1841,73 @@ func applyParametersTemplate(template json.RawMessage, input any) (any, error) {
 
 // evalTemplate recursively evaluates a template structure against the input context.
 //
-//nolint:gocognit // recursive template evaluation handles explicit type branches.
+
+// evalTemplate recursively evaluates a template against input.
 func evalTemplate(tmpl, input any) (any, error) {
 	switch v := tmpl.(type) {
 	case map[string]any:
-		result := make(map[string]any, len(v))
-
-		for key, val := range v {
-			if strings.HasSuffix(key, ".$") {
-				actualKey := key[:len(key)-2]
-
-				strVal, ok := val.(string)
-				if !ok {
-					return nil, fmt.Errorf("%w: %q", ErrReferenceKeyNotString, key)
-				}
-
-				evaluated, err := evaluateReference(strVal, input)
-				if err != nil {
-					return nil, fmt.Errorf("evaluating reference %q: %w", key, err)
-				}
-
-				result[actualKey] = evaluated
-			} else {
-				sub, err := evalTemplate(val, input)
-				if err != nil {
-					return nil, err
-				}
-
-				result[key] = sub
-			}
-		}
-
-		return result, nil
-
+		return evalTemplateMap(v, input)
 	case []any:
-		result := make([]any, len(v))
+		return evalTemplateSlice(v, input)
+	default:
+		return tmpl, nil
+	}
+}
 
-		for i, item := range v {
-			sub, err := evalTemplate(item, input)
+// evalTemplateMap evaluates a map template, resolving reference keys (ending in ".$").
+func evalTemplateMap(v map[string]any, input any) (map[string]any, error) {
+	result := make(map[string]any, len(v))
+
+	for key, val := range v {
+		if strings.HasSuffix(key, ".$") {
+			evaluated, err := evalTemplateRefKey(key, val, input)
 			if err != nil {
 				return nil, err
 			}
 
-			result[i] = sub
+			result[key[:len(key)-2]] = evaluated
+		} else {
+			sub, err := evalTemplate(val, input)
+			if err != nil {
+				return nil, err
+			}
+
+			result[key] = sub
+		}
+	}
+
+	return result, nil
+}
+
+// evalTemplateRefKey evaluates a reference key (ending in ".$").
+func evalTemplateRefKey(key string, val, input any) (any, error) {
+	strVal, ok := val.(string)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrReferenceKeyNotString, key)
+	}
+
+	evaluated, err := evaluateReference(strVal, input)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating reference %q: %w", key, err)
+	}
+
+	return evaluated, nil
+}
+
+// evalTemplateSlice evaluates a slice template.
+func evalTemplateSlice(v []any, input any) ([]any, error) {
+	result := make([]any, len(v))
+
+	for i, item := range v {
+		sub, err := evalTemplate(item, input)
+		if err != nil {
+			return nil, err
 		}
 
-		return result, nil
-
-	default:
-		return tmpl, nil
+		result[i] = sub
 	}
+
+	return result, nil
 }
 
 // evaluateReference resolves a JSONPath expression or intrinsic function call.

--- a/services/stepfunctions/asl/intrinsics.go
+++ b/services/stepfunctions/asl/intrinsics.go
@@ -54,8 +54,6 @@ const intrinsicTwoArgs = 2
 
 // evaluateIntrinsicFunction evaluates an ASL intrinsic function call such as
 // States.Format, States.StringToJson, etc.
-//
-//nolint:cyclop // dispatches to 11 ASL intrinsic functions
 func evaluateIntrinsicFunction(expr string, input any) (any, error) {
 	parenIdx := strings.IndexByte(expr, '(')
 	if parenIdx < 0 || !strings.HasSuffix(strings.TrimSpace(expr), ")") {
@@ -71,6 +69,23 @@ func evaluateIntrinsicFunction(expr string, input any) (any, error) {
 		return nil, fmt.Errorf("%s: %w", fnName, err)
 	}
 
+	if r, dispErr := evalStringArrayIntrinsic(fnName, args); !errors.Is(dispErr, errIntrinsicNotHandled) {
+		return r, dispErr
+	}
+
+	if r, dispErr := evalMathEncodingIntrinsic(fnName, args); !errors.Is(dispErr, errIntrinsicNotHandled) {
+		return r, dispErr
+	}
+
+	return nil, fmt.Errorf("%w: %q", ErrUnknownIntrinsicFunction, fnName)
+}
+
+// errIntrinsicNotHandled is a sentinel used internally to signal that a dispatch
+// helper did not recognise the function name. It is never returned to callers.
+var errIntrinsicNotHandled = errors.New("asl: intrinsic not handled by this dispatcher")
+
+// evalStringArrayIntrinsic handles string formatting and array intrinsic functions.
+func evalStringArrayIntrinsic(fnName string, args []any) (any, error) {
 	switch fnName {
 	case "States.Format":
 		return intrinsicFormat(args)
@@ -86,6 +101,14 @@ func evaluateIntrinsicFunction(expr string, input any) (any, error) {
 		return intrinsicArrayContains(args)
 	case "States.ArrayPartition":
 		return intrinsicArrayPartition(args)
+	}
+
+	return nil, errIntrinsicNotHandled
+}
+
+// evalMathEncodingIntrinsic handles math, base64, and hash intrinsic functions.
+func evalMathEncodingIntrinsic(fnName string, args []any) (any, error) {
+	switch fnName {
 	case "States.MathRandom":
 		return intrinsicMathRandom(args)
 	case "States.Base64Encode":
@@ -94,9 +117,9 @@ func evaluateIntrinsicFunction(expr string, input any) (any, error) {
 		return intrinsicBase64Decode(args)
 	case "States.Hash":
 		return intrinsicHash(args)
-	default:
-		return nil, fmt.Errorf("%w: %q", ErrUnknownIntrinsicFunction, fnName)
 	}
+
+	return nil, errIntrinsicNotHandled
 }
 
 // parseIntrinsicArgs tokenizes a comma-separated argument list, respecting

--- a/services/transfer/persistence.go
+++ b/services/transfer/persistence.go
@@ -25,114 +25,11 @@ type backendSnapshot struct {
 
 // Snapshot serialises the backend state to JSON.
 // It implements persistence.Persistable.
-//
-//nolint:gocognit,cyclop,funlen // function copies independent map collections
 func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	snap := backendSnapshot{
-		Servers:       make(map[string]*Server, len(b.servers)),
-		Users:         make(map[string]map[string]*User, len(b.users)),
-		Accesses:      make(map[string]map[string]*Access, len(b.accesses)),
-		Agreements:    make(map[string]map[string]*Agreement, len(b.agreements)),
-		Connectors:    make(map[string]*Connector, len(b.connectors)),
-		Profiles:      make(map[string]*Profile, len(b.profiles)),
-		WebApps:       make(map[string]*WebApp, len(b.webApps)),
-		Workflows:     make(map[string]*Workflow, len(b.workflows)),
-		Certificates:  make(map[string]*Certificate, len(b.certificates)),
-		HostKeys:      make(map[string]map[string]*HostKey, len(b.hostKeys)),
-		SSHPublicKeys: make(map[string]map[string]map[string]*SSHPublicKey, len(b.sshPublicKeys)),
-		Executions:    make(map[string]map[string]*Execution, len(b.executions)),
-		TagsStore:     make(map[string]map[string]string, len(b.tagsStore)),
-	}
-
-	for k, v := range b.servers {
-		snap.Servers[k] = cloneServer(v)
-	}
-
-	for sid, userMap := range b.users {
-		m := make(map[string]*User, len(userMap))
-		for k, v := range userMap {
-			m[k] = cloneUser(v)
-		}
-		snap.Users[sid] = m
-	}
-
-	for sid, accessMap := range b.accesses {
-		m := make(map[string]*Access, len(accessMap))
-		for k, v := range accessMap {
-			m[k] = cloneAccess(v)
-		}
-		snap.Accesses[sid] = m
-	}
-
-	for sid, agMap := range b.agreements {
-		m := make(map[string]*Agreement, len(agMap))
-		for k, v := range agMap {
-			m[k] = cloneAgreement(v)
-		}
-		snap.Agreements[sid] = m
-	}
-
-	for k, v := range b.connectors {
-		snap.Connectors[k] = cloneConnector(v)
-	}
-
-	for k, v := range b.profiles {
-		snap.Profiles[k] = cloneProfile(v)
-	}
-
-	for k, v := range b.webApps {
-		snap.WebApps[k] = cloneWebApp(v)
-	}
-
-	for k, v := range b.workflows {
-		snap.Workflows[k] = cloneWorkflow(v)
-	}
-
-	for k, v := range b.certificates {
-		cp := *v
-		cp.Tags = make(map[string]string, len(v.Tags))
-		maps.Copy(cp.Tags, v.Tags)
-		snap.Certificates[k] = &cp
-	}
-
-	for sid, keyMap := range b.hostKeys {
-		m := make(map[string]*HostKey, len(keyMap))
-		for k, v := range keyMap {
-			m[k] = cloneHostKey(v)
-		}
-		snap.HostKeys[sid] = m
-	}
-
-	for sid, userMap := range b.sshPublicKeys {
-		um := make(map[string]map[string]*SSHPublicKey, len(userMap))
-		for userName, keyMap := range userMap {
-			km := make(map[string]*SSHPublicKey, len(keyMap))
-			for k, v := range keyMap {
-				cp := *v
-				km[k] = &cp
-			}
-			um[userName] = km
-		}
-		snap.SSHPublicKeys[sid] = um
-	}
-
-	for wid, execMap := range b.executions {
-		em := make(map[string]*Execution, len(execMap))
-		for k, v := range execMap {
-			cp := *v
-			em[k] = &cp
-		}
-		snap.Executions[wid] = em
-	}
-
-	for arn, tagMap := range b.tagsStore {
-		m := make(map[string]string, len(tagMap))
-		maps.Copy(m, tagMap)
-		snap.TagsStore[arn] = m
-	}
+	snap := b.buildSnapshot()
 
 	data, err := json.Marshal(snap)
 	if err != nil {
@@ -142,6 +39,125 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	}
 
 	return data
+}
+
+// buildSnapshot constructs the serialisable snapshot from backend state.
+func (b *InMemoryBackend) buildSnapshot() backendSnapshot {
+	snap := backendSnapshot{
+		Servers:       snapshotServers(b.servers),
+		Users:         snapshotNestedMap(b.users, cloneUser),
+		Accesses:      snapshotNestedMap(b.accesses, cloneAccess),
+		Agreements:    snapshotNestedMap(b.agreements, cloneAgreement),
+		Connectors:    snapshotFlatMap(b.connectors, cloneConnector),
+		Profiles:      snapshotFlatMap(b.profiles, cloneProfile),
+		WebApps:       snapshotFlatMap(b.webApps, cloneWebApp),
+		Workflows:     snapshotFlatMap(b.workflows, cloneWorkflow),
+		Certificates:  snapshotCertificates(b.certificates),
+		HostKeys:      snapshotNestedMap(b.hostKeys, cloneHostKey),
+		SSHPublicKeys: snapshotSSHPublicKeys(b.sshPublicKeys),
+		Executions:    snapshotExecutions(b.executions),
+		TagsStore:     snapshotTagsStore(b.tagsStore),
+	}
+
+	return snap
+}
+
+// snapshotServers clones the servers map.
+func snapshotServers(src map[string]*Server) map[string]*Server {
+	dst := make(map[string]*Server, len(src))
+	for k, v := range src {
+		dst[k] = cloneServer(v)
+	}
+
+	return dst
+}
+
+// snapshotFlatMap clones a flat map using the provided clone function.
+func snapshotFlatMap[V any](src map[string]*V, clone func(*V) *V) map[string]*V {
+	dst := make(map[string]*V, len(src))
+	for k, v := range src {
+		dst[k] = clone(v)
+	}
+
+	return dst
+}
+
+// snapshotNestedMap clones a two-level nested map using the provided clone function.
+func snapshotNestedMap[V any](
+	src map[string]map[string]*V,
+	clone func(*V) *V,
+) map[string]map[string]*V {
+	dst := make(map[string]map[string]*V, len(src))
+	for sid, inner := range src {
+		m := make(map[string]*V, len(inner))
+		for k, v := range inner {
+			m[k] = clone(v)
+		}
+		dst[sid] = m
+	}
+
+	return dst
+}
+
+// snapshotCertificates clones the certificates map including tag maps.
+func snapshotCertificates(src map[string]*Certificate) map[string]*Certificate {
+	dst := make(map[string]*Certificate, len(src))
+	for k, v := range src {
+		cp := *v
+		cp.Tags = make(map[string]string, len(v.Tags))
+		maps.Copy(cp.Tags, v.Tags)
+		dst[k] = &cp
+	}
+
+	return dst
+}
+
+// snapshotSSHPublicKeys clones the three-level SSH public key map.
+func snapshotSSHPublicKeys(
+	src map[string]map[string]map[string]*SSHPublicKey,
+) map[string]map[string]map[string]*SSHPublicKey {
+	dst := make(map[string]map[string]map[string]*SSHPublicKey, len(src))
+	for sid, userMap := range src {
+		um := make(map[string]map[string]*SSHPublicKey, len(userMap))
+		for userName, keyMap := range userMap {
+			km := make(map[string]*SSHPublicKey, len(keyMap))
+			for k, v := range keyMap {
+				cp := *v
+				km[k] = &cp
+			}
+			um[userName] = km
+		}
+		dst[sid] = um
+	}
+
+	return dst
+}
+
+// snapshotExecutions clones the two-level executions map.
+func snapshotExecutions(src map[string]map[string]*Execution) map[string]map[string]*Execution {
+	dst := make(map[string]map[string]*Execution, len(src))
+	for wid, execMap := range src {
+		em := make(map[string]*Execution, len(execMap))
+		for k, v := range execMap {
+			cp := *v
+			em[k] = &cp
+		}
+		dst[wid] = em
+	}
+
+	return dst
+}
+
+// snapshotTagsStore clones the tags store map.
+func snapshotTagsStore(src map[string]map[string]string) map[string]map[string]string {
+	dst := make(map[string]map[string]string, len(src))
+	for arn, tagMap := range src {
+		m := make(map[string]string, len(tagMap))
+		maps.Copy(m, tagMap)
+		dst[arn] = m
+	}
+
+	return dst
 }
 
 // Restore loads backend state from a JSON snapshot.


### PR DESCRIPTION
## Summary

- Removed all 86 `//nolint:cyclop`, `//nolint:gocognit`, and `//nolint:gocyclo` directives from `services/` by refactoring the underlying functions
- Split large dispatch functions (switches with >14 cases) into sub-dispatchers of ≤14 cases each
- Extracted deeply nested logic into named helpers to reduce cognitive complexity
- Covered 30+ service packages: acm, apigateway, appconfig, backup, bedrock, cloudformation, cloudfront, codeartifact, dms, elasticsearch, emrserverless, fis, iam, identitystore, iotwireless, kafka, mediastore, memorydb, pinpoint, pipes, ram, rds, route53, s3, s3control, s3tables, sesv2, ssoadmin, stepfunctions/asl, transfer, and more
- Used `//nolint:funlen` and `//nolint:dupl` where appropriate per task rules (acceptable linters)
- All 0 cyclop/gocognit/gocyclo violations; pre-existing unrelated lint issues (mnd, dupl, etc.) unchanged

## Test plan

- [ ] `golangci-lint run ./... | grep -E "cyclop|gocognit|gocyclo"` returns empty
- [ ] `go test ./... | grep FAIL` returns only the 3 pre-existing failures (ec2, ssoadmin, textract)
- [ ] CI passes

Closes #1563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->