### PR TITLE
feat(mega-batch-3): DataBrew service, Glue Schema Registry, OpenSearch advanced features

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -93,6 +93,7 @@ import (
 	codestarconnectionsbackend "github.com/blackbirdworks/gopherstack/services/codestarconnections"
 	cognitoidentitybackend "github.com/blackbirdworks/gopherstack/services/cognitoidentity"
 	cognitoidpbackend "github.com/blackbirdworks/gopherstack/services/cognitoidp"
+	databrewbackend "github.com/blackbirdworks/gopherstack/services/databrew"
 	dmsbackend "github.com/blackbirdworks/gopherstack/services/dms"
 	docdbbackend "github.com/blackbirdworks/gopherstack/services/docdb"
 	ddbbackend "github.com/blackbirdworks/gopherstack/services/dynamodb"
@@ -2605,6 +2606,7 @@ func getMostRecentServiceProviders() []service.Provider {
 		&wafv2backend.Provider{},
 		&xraybackend.Provider{},
 		&s3tablesbackend.Provider{},
+		&databrewbackend.Provider{},
 	}
 }
 

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -942,7 +942,7 @@ func (rc *ResourceCreator) createMSKCluster(
 		brokerInfo.InstanceType = "kafka.m5.large"
 	}
 
-	cluster, err := rc.backends.Kafka.Backend.CreateCluster(name, kafkaVersion, numBrokers, brokerInfo, nil)
+	cluster, err := rc.backends.Kafka.Backend.CreateCluster(name, kafkaVersion, numBrokers, brokerInfo, nil, nil)
 	if err != nil {
 		return "", fmt.Errorf("create MSK cluster %s: %w", name, err)
 	}

--- a/services/databrew/backend.go
+++ b/services/databrew/backend.go
@@ -1,0 +1,622 @@
+// Package databrew implements an in-memory AWS Glue DataBrew service backend.
+package databrew
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/arn"
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrNotFound is returned when a requested resource does not exist.
+	ErrNotFound = awserr.New("ResourceNotFoundException", awserr.ErrNotFound)
+	// ErrAlreadyExists is returned when a resource already exists.
+	ErrAlreadyExists = awserr.New("ConflictException", awserr.ErrAlreadyExists)
+	// ErrValidation is returned when input validation fails.
+	ErrValidation = awserr.New("ValidationException", awserr.ErrInvalidParameter)
+)
+
+// DatasetFormatOptions holds format-specific options for a dataset.
+type DatasetFormatOptions struct {
+	Csv   map[string]any `json:"Csv,omitempty"`
+	Excel map[string]any `json:"Excel,omitempty"`
+	JSON  map[string]any `json:"JSON,omitempty"`
+}
+
+// DatasetInput holds the data source for a dataset.
+type DatasetInput struct {
+	S3InputDefinition          *S3Location       `json:"S3InputDefinition,omitempty"`
+	DataCatalogInputDefinition *DataCatalogInput `json:"DataCatalogInputDefinition,omitempty"`
+}
+
+// S3Location references an S3 path.
+type S3Location struct {
+	Bucket string `json:"Bucket"`
+	Key    string `json:"Key,omitempty"`
+}
+
+// DataCatalogInput references a Glue Data Catalog table.
+type DataCatalogInput struct {
+	DatabaseName string `json:"DatabaseName"`
+	TableName    string `json:"TableName"`
+}
+
+// Dataset represents a DataBrew dataset.
+type Dataset struct {
+	FormatOptions    DatasetFormatOptions `json:"FormatOptions,omitzero"`
+	Input            DatasetInput         `json:"Input,omitzero"`
+	Tags             map[string]string    `json:"Tags,omitempty"`
+	Name             string               `json:"Name"`
+	Arn              string               `json:"ResourceArn"`
+	Format           string               `json:"Format,omitempty"`
+	Source           string               `json:"Source,omitempty"`
+	CreatedBy        string               `json:"CreatedBy,omitempty"`
+	LastModifiedBy   string               `json:"LastModifiedBy,omitempty"`
+	CreateDate       float64              `json:"CreateDate,omitempty"`
+	LastModifiedDate float64              `json:"LastModifiedDate,omitempty"`
+}
+
+// RecipeStep is one transformation step in a recipe.
+type RecipeStep struct {
+	Action               map[string]any   `json:"Action,omitempty"`
+	ConditionExpressions []map[string]any `json:"ConditionExpressions,omitempty"`
+}
+
+// Recipe represents a DataBrew recipe.
+type Recipe struct {
+	Tags             map[string]string `json:"Tags,omitempty"`
+	Name             string            `json:"Name"`
+	Arn              string            `json:"ResourceArn"`
+	Description      string            `json:"Description,omitempty"`
+	PublishedBy      string            `json:"PublishedBy,omitempty"`
+	RecipeVersion    string            `json:"RecipeVersion,omitempty"`
+	CreatedBy        string            `json:"CreatedBy,omitempty"`
+	LastModifiedBy   string            `json:"LastModifiedBy,omitempty"`
+	Steps            []RecipeStep      `json:"Steps,omitempty"`
+	PublishedDate    float64           `json:"PublishedDate,omitempty"`
+	CreateDate       float64           `json:"CreateDate,omitempty"`
+	LastModifiedDate float64           `json:"LastModifiedDate,omitempty"`
+}
+
+// Sample describes a data sample for a project.
+type Sample struct {
+	Type string `json:"Type,omitempty"`
+	Size int    `json:"Size,omitempty"`
+}
+
+// Project represents a DataBrew project.
+type Project struct {
+	Tags             map[string]string `json:"Tags,omitempty"`
+	Name             string            `json:"Name"`
+	Arn              string            `json:"ResourceArn"`
+	DatasetName      string            `json:"DatasetName,omitempty"`
+	RecipeName       string            `json:"RecipeName"`
+	RoleArn          string            `json:"RoleArn,omitempty"`
+	SessionStatus    string            `json:"SessionStatus,omitempty"`
+	CreatedBy        string            `json:"CreatedBy,omitempty"`
+	LastModifiedBy   string            `json:"LastModifiedBy,omitempty"`
+	Sample           Sample            `json:"Sample,omitzero"`
+	CreateDate       float64           `json:"CreateDate,omitempty"`
+	LastModifiedDate float64           `json:"LastModifiedDate,omitempty"`
+}
+
+// Output describes a DataBrew job output destination.
+type Output struct {
+	FormatOptions     map[string]any `json:"FormatOptions,omitempty"`
+	Location          S3Location     `json:"Location,omitzero"`
+	Format            string         `json:"Format,omitempty"`
+	CompressionFormat string         `json:"CompressionFormat,omitempty"`
+	Overwrite         bool           `json:"Overwrite,omitempty"`
+}
+
+// Job represents a DataBrew job.
+type Job struct {
+	Tags             map[string]string `json:"Tags,omitempty"`
+	RoleArn          string            `json:"RoleArn,omitempty"`
+	LastModifiedBy   string            `json:"LastModifiedBy,omitempty"`
+	Arn              string            `json:"ResourceArn"`
+	Type             string            `json:"Type,omitempty"`
+	DatasetName      string            `json:"DatasetName,omitempty"`
+	ProjectName      string            `json:"ProjectName,omitempty"`
+	Name             string            `json:"Name"`
+	CreatedBy        string            `json:"CreatedBy,omitempty"`
+	RecipeName       string            `json:"RecipeName,omitempty"`
+	Outputs          []Output          `json:"Outputs,omitempty"`
+	CreateDate       float64           `json:"CreateDate,omitempty"`
+	LastModifiedDate float64           `json:"LastModifiedDate,omitempty"`
+	MaxCapacity      int               `json:"MaxCapacity,omitempty"`
+	MaxRetries       int               `json:"MaxRetries,omitempty"`
+	Timeout          int               `json:"Timeout,omitempty"`
+}
+
+// JobRun represents a single execution of a DataBrew job.
+type JobRun struct {
+	DatasetName   string  `json:"DatasetName,omitempty"`
+	JobName       string  `json:"JobName"`
+	RunID         string  `json:"RunID"`
+	State         string  `json:"State"`
+	LogGroupName  string  `json:"LogGroupName,omitempty"`
+	StartedOn     float64 `json:"StartedOn,omitempty"`
+	CompletedOn   float64 `json:"CompletedOn,omitempty"`
+	ExecutionTime int     `json:"ExecutionTime,omitempty"`
+}
+
+// InMemoryBackend stores DataBrew state in memory.
+type InMemoryBackend struct {
+	datasets  map[string]*Dataset
+	recipes   map[string]*Recipe
+	projects  map[string]*Project
+	jobs      map[string]*Job
+	jobRuns   map[string][]*JobRun
+	mu        *lockmetrics.RWMutex
+	accountID string
+	region    string
+}
+
+// NewInMemoryBackend creates a new in-memory DataBrew backend.
+func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
+	return &InMemoryBackend{
+		datasets:  make(map[string]*Dataset),
+		recipes:   make(map[string]*Recipe),
+		projects:  make(map[string]*Project),
+		jobs:      make(map[string]*Job),
+		jobRuns:   make(map[string][]*JobRun),
+		mu:        lockmetrics.New("databrew"),
+		accountID: accountID,
+		region:    region,
+	}
+}
+
+func (b *InMemoryBackend) Region() string    { return b.region }
+func (b *InMemoryBackend) AccountID() string { return b.accountID }
+
+func (b *InMemoryBackend) Reset() {
+	b.mu.Lock("Reset")
+	defer b.mu.Unlock()
+	b.datasets = make(map[string]*Dataset)
+	b.recipes = make(map[string]*Recipe)
+	b.projects = make(map[string]*Project)
+	b.jobs = make(map[string]*Job)
+	b.jobRuns = make(map[string][]*JobRun)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
+func (b *InMemoryBackend) datasetARN(name string) string {
+	return arn.Build("databrew", b.region, b.accountID, "dataset/"+name)
+}
+
+func (b *InMemoryBackend) recipeARN(name string) string {
+	return arn.Build("databrew", b.region, b.accountID, "recipe/"+name)
+}
+
+func (b *InMemoryBackend) projectARN(name string) string {
+	return arn.Build("databrew", b.region, b.accountID, "project/"+name)
+}
+
+func (b *InMemoryBackend) jobARN(name string) string {
+	return arn.Build("databrew", b.region, b.accountID, "job/"+name)
+}
+
+func (b *InMemoryBackend) CreateDataset(
+	name, format string,
+	input DatasetInput,
+	formatOpts DatasetFormatOptions,
+	tags map[string]string,
+) (*Dataset, error) {
+	b.mu.Lock("CreateDataset")
+	defer b.mu.Unlock()
+	if name == "" {
+		return nil, ErrValidation
+	}
+	if _, ok := b.datasets[name]; ok {
+		return nil, ErrAlreadyExists
+	}
+	source := "S3"
+	if input.DataCatalogInputDefinition != nil {
+		source = "DATA_CATALOG"
+	}
+	ds := &Dataset{
+		Name: name, Arn: b.datasetARN(name), Format: format,
+		Input: input, FormatOptions: formatOpts, Tags: maps.Clone(tags),
+		Source: source, CreateDate: float64(time.Now().Unix()),
+		LastModifiedDate: float64(time.Now().Unix()),
+	}
+	b.datasets[name] = ds
+
+	return ds, nil
+}
+
+func (b *InMemoryBackend) DescribeDataset(name string) (*Dataset, error) {
+	b.mu.RLock("DescribeDataset")
+	defer b.mu.RUnlock()
+	ds, ok := b.datasets[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	cp := *ds
+	cp.Tags = maps.Clone(ds.Tags)
+
+	return &cp, nil
+}
+
+func (b *InMemoryBackend) ListDatasets() []*Dataset {
+	b.mu.RLock("ListDatasets")
+	defer b.mu.RUnlock()
+	out := make([]*Dataset, 0, len(b.datasets))
+	for _, k := range sortedKeys(b.datasets) {
+		cp := *b.datasets[k]
+		cp.Tags = maps.Clone(b.datasets[k].Tags)
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+func (b *InMemoryBackend) UpdateDataset(
+	name, format string,
+	input DatasetInput,
+	formatOpts DatasetFormatOptions,
+) error {
+	b.mu.Lock("UpdateDataset")
+	defer b.mu.Unlock()
+	ds, ok := b.datasets[name]
+	if !ok {
+		return ErrNotFound
+	}
+	ds.Format = format
+	ds.Input = input
+	ds.FormatOptions = formatOpts
+	ds.LastModifiedDate = float64(time.Now().Unix())
+
+	return nil
+}
+
+func (b *InMemoryBackend) DeleteDataset(name string) error {
+	b.mu.Lock("DeleteDataset")
+	defer b.mu.Unlock()
+	if _, ok := b.datasets[name]; !ok {
+		return ErrNotFound
+	}
+	delete(b.datasets, name)
+
+	return nil
+}
+
+func (b *InMemoryBackend) CreateRecipe(
+	name, description string,
+	steps []RecipeStep,
+	tags map[string]string,
+) (*Recipe, error) {
+	b.mu.Lock("CreateRecipe")
+	defer b.mu.Unlock()
+	if name == "" {
+		return nil, ErrValidation
+	}
+	if _, ok := b.recipes[name]; ok {
+		return nil, ErrAlreadyExists
+	}
+	r := &Recipe{
+		Name: name, Arn: b.recipeARN(name), Description: description,
+		Steps: steps, Tags: maps.Clone(tags), RecipeVersion: "0.1",
+		CreateDate: float64(time.Now().Unix()), LastModifiedDate: float64(time.Now().Unix()),
+	}
+	b.recipes[name] = r
+
+	return r, nil
+}
+
+func (b *InMemoryBackend) DescribeRecipe(name string) (*Recipe, error) {
+	b.mu.RLock("DescribeRecipe")
+	defer b.mu.RUnlock()
+	r, ok := b.recipes[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	cp := *r
+	cp.Tags = maps.Clone(r.Tags)
+	cp.Steps = append([]RecipeStep(nil), r.Steps...)
+
+	return &cp, nil
+}
+
+func (b *InMemoryBackend) ListRecipes() []*Recipe {
+	b.mu.RLock("ListRecipes")
+	defer b.mu.RUnlock()
+	out := make([]*Recipe, 0, len(b.recipes))
+	for _, k := range sortedKeys(b.recipes) {
+		cp := *b.recipes[k]
+		cp.Tags = maps.Clone(b.recipes[k].Tags)
+		cp.Steps = append([]RecipeStep(nil), b.recipes[k].Steps...)
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+func (b *InMemoryBackend) PublishRecipe(name, description string) error {
+	b.mu.Lock("PublishRecipe")
+	defer b.mu.Unlock()
+	r, ok := b.recipes[name]
+	if !ok {
+		return ErrNotFound
+	}
+	r.RecipeVersion = "1.0"
+	r.PublishedDate = float64(time.Now().Unix())
+	r.PublishedBy = "admin"
+	if description != "" {
+		r.Description = description
+	}
+
+	return nil
+}
+
+func (b *InMemoryBackend) UpdateRecipe(name, description string, steps []RecipeStep) error {
+	b.mu.Lock("UpdateRecipe")
+	defer b.mu.Unlock()
+	r, ok := b.recipes[name]
+	if !ok {
+		return ErrNotFound
+	}
+	if description != "" {
+		r.Description = description
+	}
+	r.Steps = steps
+	r.LastModifiedDate = float64(time.Now().Unix())
+
+	return nil
+}
+
+func (b *InMemoryBackend) DeleteRecipe(name string) error {
+	b.mu.Lock("DeleteRecipe")
+	defer b.mu.Unlock()
+	if _, ok := b.recipes[name]; !ok {
+		return ErrNotFound
+	}
+	delete(b.recipes, name)
+
+	return nil
+}
+
+func (b *InMemoryBackend) CreateProject(
+	name, datasetName, recipeName, roleArn string,
+	sample Sample,
+	tags map[string]string,
+) (*Project, error) {
+	b.mu.Lock("CreateProject")
+	defer b.mu.Unlock()
+	if name == "" {
+		return nil, ErrValidation
+	}
+	if _, ok := b.projects[name]; ok {
+		return nil, ErrAlreadyExists
+	}
+	p := &Project{
+		Name: name, Arn: b.projectARN(name), DatasetName: datasetName,
+		RecipeName: recipeName, RoleArn: roleArn, Sample: sample,
+		Tags: maps.Clone(tags), SessionStatus: "READY",
+		CreateDate: float64(time.Now().Unix()), LastModifiedDate: float64(time.Now().Unix()),
+	}
+	b.projects[name] = p
+
+	return p, nil
+}
+
+func (b *InMemoryBackend) DescribeProject(name string) (*Project, error) {
+	b.mu.RLock("DescribeProject")
+	defer b.mu.RUnlock()
+	p, ok := b.projects[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	cp := *p
+	cp.Tags = maps.Clone(p.Tags)
+
+	return &cp, nil
+}
+
+func (b *InMemoryBackend) ListProjects() []*Project {
+	b.mu.RLock("ListProjects")
+	defer b.mu.RUnlock()
+	out := make([]*Project, 0, len(b.projects))
+	for _, k := range sortedKeys(b.projects) {
+		cp := *b.projects[k]
+		cp.Tags = maps.Clone(b.projects[k].Tags)
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+func (b *InMemoryBackend) UpdateProject(name, datasetName, roleArn string, sample Sample) error {
+	b.mu.Lock("UpdateProject")
+	defer b.mu.Unlock()
+	p, ok := b.projects[name]
+	if !ok {
+		return ErrNotFound
+	}
+	if datasetName != "" {
+		p.DatasetName = datasetName
+	}
+	if roleArn != "" {
+		p.RoleArn = roleArn
+	}
+	p.Sample = sample
+	p.LastModifiedDate = float64(time.Now().Unix())
+
+	return nil
+}
+
+func (b *InMemoryBackend) DeleteProject(name string) error {
+	b.mu.Lock("DeleteProject")
+	defer b.mu.Unlock()
+	if _, ok := b.projects[name]; !ok {
+		return ErrNotFound
+	}
+	delete(b.projects, name)
+
+	return nil
+}
+
+func (b *InMemoryBackend) CreateJob(
+	name, jobType, datasetName, projectName, recipeName, roleArn string,
+	outputs []Output,
+	tags map[string]string,
+) (*Job, error) {
+	b.mu.Lock("CreateJob")
+	defer b.mu.Unlock()
+	if name == "" {
+		return nil, ErrValidation
+	}
+	if _, ok := b.jobs[name]; ok {
+		return nil, ErrAlreadyExists
+	}
+	j := &Job{
+		Name: name, Arn: b.jobARN(name), Type: jobType,
+		DatasetName: datasetName, ProjectName: projectName,
+		RecipeName: recipeName, RoleArn: roleArn, Outputs: outputs,
+		Tags: maps.Clone(tags), CreateDate: float64(time.Now().Unix()),
+		LastModifiedDate: float64(time.Now().Unix()),
+	}
+	b.jobs[name] = j
+
+	return j, nil
+}
+
+func (b *InMemoryBackend) DescribeJob(name string) (*Job, error) {
+	b.mu.RLock("DescribeJob")
+	defer b.mu.RUnlock()
+	j, ok := b.jobs[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	cp := *j
+	cp.Tags = maps.Clone(j.Tags)
+	cp.Outputs = append([]Output(nil), j.Outputs...)
+
+	return &cp, nil
+}
+
+func (b *InMemoryBackend) ListJobs() []*Job {
+	b.mu.RLock("ListJobs")
+	defer b.mu.RUnlock()
+	out := make([]*Job, 0, len(b.jobs))
+	for _, k := range sortedKeys(b.jobs) {
+		cp := *b.jobs[k]
+		cp.Tags = maps.Clone(b.jobs[k].Tags)
+		cp.Outputs = append([]Output(nil), b.jobs[k].Outputs...)
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+func (b *InMemoryBackend) UpdateJob(
+	name, roleArn string,
+	outputs []Output,
+	maxCapacity, maxRetries, timeout int,
+) error {
+	b.mu.Lock("UpdateJob")
+	defer b.mu.Unlock()
+	j, ok := b.jobs[name]
+	if !ok {
+		return ErrNotFound
+	}
+	if roleArn != "" {
+		j.RoleArn = roleArn
+	}
+	if len(outputs) > 0 {
+		j.Outputs = outputs
+	}
+	if maxCapacity > 0 {
+		j.MaxCapacity = maxCapacity
+	}
+	if maxRetries >= 0 {
+		j.MaxRetries = maxRetries
+	}
+	if timeout > 0 {
+		j.Timeout = timeout
+	}
+	j.LastModifiedDate = float64(time.Now().Unix())
+
+	return nil
+}
+
+func (b *InMemoryBackend) DeleteJob(name string) error {
+	b.mu.Lock("DeleteJob")
+	defer b.mu.Unlock()
+	if _, ok := b.jobs[name]; !ok {
+		return ErrNotFound
+	}
+	delete(b.jobs, name)
+	delete(b.jobRuns, name)
+
+	return nil
+}
+
+const (
+	// jobRunTransitionDelay is how long to wait before transitioning a job run to SUCCEEDED.
+	jobRunTransitionDelay = 100 * time.Millisecond
+	// jobRunDefaultExecTime is the simulated execution time returned in a completed job run.
+	jobRunDefaultExecTime = 30
+)
+
+// StartJobRun creates a new job run with STARTING state, transitioning to SUCCEEDED asynchronously.
+func (b *InMemoryBackend) StartJobRun(jobName string) (*JobRun, error) {
+	b.mu.Lock("StartJobRun")
+	defer b.mu.Unlock()
+
+	if _, ok := b.jobs[jobName]; !ok {
+		return nil, fmt.Errorf("%w: job %q not found", ErrNotFound, jobName)
+	}
+
+	run := &JobRun{
+		JobName:   jobName,
+		RunID:     uuid.New().String(),
+		State:     "STARTING",
+		StartedOn: float64(time.Now().Unix()),
+	}
+
+	b.jobRuns[jobName] = append(b.jobRuns[jobName], run)
+
+	go func() {
+		time.Sleep(jobRunTransitionDelay)
+		b.mu.Lock("StartJobRun.transition")
+		defer b.mu.Unlock()
+		run.State = "SUCCEEDED"
+		run.CompletedOn = float64(time.Now().Unix())
+		run.ExecutionTime = jobRunDefaultExecTime
+	}()
+
+	return run, nil
+}
+
+func (b *InMemoryBackend) ListJobRuns(jobName string) ([]*JobRun, error) {
+	b.mu.RLock("ListJobRuns")
+	defer b.mu.RUnlock()
+	if _, ok := b.jobs[jobName]; !ok {
+		return nil, fmt.Errorf("%w: job %q not found", ErrNotFound, jobName)
+	}
+	src := b.jobRuns[jobName]
+	out := make([]*JobRun, len(src))
+	for i, r := range src {
+		cp := *r
+		out[len(src)-1-i] = &cp
+	}
+
+	return out, nil
+}

--- a/services/databrew/handler.go
+++ b/services/databrew/handler.go
@@ -1,0 +1,879 @@
+package databrew
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
+	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/service"
+)
+
+const (
+	databrewPathPrefix = "/databrew/v1/"
+
+	segDatasets    = "datasets"
+	segRecipes     = "recipes"
+	segProjects    = "projects"
+	segProfileJobs = "profileJobs"
+	segRecipeJobs  = "recipeJobs"
+	segJobs        = "jobs"
+
+	opCreateDataset    = "CreateDataset"
+	opDescribeDataset  = "DescribeDataset"
+	opListDatasets     = "ListDatasets"
+	opUpdateDataset    = "UpdateDataset"
+	opDeleteDataset    = "DeleteDataset"
+	opCreateRecipe     = "CreateRecipe"
+	opDescribeRecipe   = "DescribeRecipe"
+	opListRecipes      = "ListRecipes"
+	opPublishRecipe    = "PublishRecipe"
+	opUpdateRecipe     = "UpdateRecipe"
+	opDeleteRecipe     = "DeleteRecipe"
+	opCreateProject    = "CreateProject"
+	opDescribeProject  = "DescribeProject"
+	opListProjects     = "ListProjects"
+	opUpdateProject    = "UpdateProject"
+	opDeleteProject    = "DeleteProject"
+	opCreateProfileJob = "CreateProfileJob"
+	opCreateRecipeJob  = "CreateRecipeJob"
+	opDescribeJob      = "DescribeJob"
+	opListJobs         = "ListJobs"
+	opUpdateProfileJob = "UpdateProfileJob"
+	opUpdateRecipeJob  = "UpdateRecipeJob"
+	opDeleteJob        = "DeleteJob"
+	opStartJobRun      = "StartJobRun"
+	opListJobRuns      = "ListJobRuns"
+	opUnknown          = "Unknown"
+
+	minPathSegments = 2
+
+	keyName    = "Name"
+	keyMessage = "Message"
+)
+
+var (
+	errUnknownAction  = errors.New("unknown action")
+	errInvalidRequest = errors.New("invalid request body")
+)
+
+// Handler is the HTTP handler for AWS Glue DataBrew operations.
+type Handler struct {
+	Backend   StorageBackend
+	AccountID string
+	Region    string
+}
+
+// NewHandler creates a new DataBrew handler.
+func NewHandler(backend StorageBackend) *Handler {
+	return &Handler{
+		Backend:   backend,
+		AccountID: backend.AccountID(),
+		Region:    backend.Region(),
+	}
+}
+
+func (h *Handler) Name() string                        { return "DataBrew" }
+func (h *Handler) Reset()                              { h.Backend.Reset() }
+func (h *Handler) StartWorker(_ context.Context) error { return nil }
+
+func (h *Handler) GetSupportedOperations() []string {
+	return []string{
+		opCreateDataset, opDescribeDataset, opListDatasets, opUpdateDataset, opDeleteDataset,
+		opCreateRecipe, opDescribeRecipe, opListRecipes, opPublishRecipe, opUpdateRecipe, opDeleteRecipe,
+		opCreateProject, opDescribeProject, opListProjects, opUpdateProject, opDeleteProject,
+		opCreateProfileJob, opCreateRecipeJob, opDescribeJob, opListJobs,
+		opUpdateProfileJob, opUpdateRecipeJob, opDeleteJob, opStartJobRun, opListJobRuns,
+	}
+}
+
+func (h *Handler) RouteMatcher() service.Matcher {
+	return func(c *echo.Context) bool {
+		path := c.Request().URL.Path
+
+		return strings.HasPrefix(path, databrewPathPrefix) || path == "/databrew/v1"
+	}
+}
+
+func (h *Handler) MatchPriority() int { return service.PriorityPathVersioned }
+
+func (h *Handler) ExtractOperation(c *echo.Context) string {
+	op, _ := parseDataBrewRESTPath(c.Request().Method, c.Request().URL.Path)
+
+	return op
+}
+
+func (h *Handler) ExtractResource(c *echo.Context) string {
+	_, name := parseDataBrewRESTPath(c.Request().Method, c.Request().URL.Path)
+
+	return name
+}
+
+func (h *Handler) Handler() echo.HandlerFunc {
+	return func(c *echo.Context) error {
+		ctx := c.Request().Context()
+		log := logger.Load(ctx)
+
+		action, name := parseDataBrewRESTPath(c.Request().Method, c.Request().URL.Path)
+		if action == opUnknown {
+			return c.String(http.StatusNotFound, "not found")
+		}
+
+		body, err := httputils.ReadBody(c.Request())
+		if err != nil {
+			log.ErrorContext(ctx, "databrew: failed to read request body", "error", err)
+
+			return c.String(http.StatusInternalServerError, "internal server error")
+		}
+
+		body = enrichDataBrewBody(action, name, body)
+
+		result, dispErr := h.dispatch(ctx, action, body)
+		if dispErr != nil {
+			return h.handleError(c, dispErr)
+		}
+
+		if result == nil {
+			return c.JSON(http.StatusOK, map[string]any{})
+		}
+
+		return c.JSONBlob(http.StatusOK, result)
+	}
+}
+
+func (h *Handler) handleError(c *echo.Context, err error) error {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return c.JSON(http.StatusNotFound, map[string]string{keyMessage: err.Error()})
+	case errors.Is(err, ErrAlreadyExists):
+		return c.JSON(http.StatusConflict, map[string]string{keyMessage: err.Error()})
+	case errors.Is(err, ErrValidation):
+		return c.JSON(http.StatusBadRequest, map[string]string{keyMessage: err.Error()})
+	case errors.Is(err, errUnknownAction):
+		return c.JSON(http.StatusNotFound, map[string]string{keyMessage: err.Error()})
+	case errors.Is(err, errInvalidRequest):
+		return c.JSON(http.StatusBadRequest, map[string]string{keyMessage: err.Error()})
+	}
+
+	return c.JSON(http.StatusInternalServerError, map[string]string{keyMessage: err.Error()})
+}
+
+func parseDataBrewRESTPath(method, path string) (string, string) {
+	after, ok := strings.CutPrefix(path, databrewPathPrefix)
+	if !ok {
+		return opUnknown, ""
+	}
+
+	segments := strings.SplitN(after, "/", minPathSegments+1)
+	if len(segments) == 0 || segments[0] == "" {
+		return opUnknown, ""
+	}
+
+	resource := segments[0]
+	name := ""
+	if len(segments) >= minPathSegments {
+		name = segments[1]
+	}
+
+	var subOp string
+	if len(segments) >= 3 { //nolint:mnd // 3 segments: resource/name/subOp
+		subOp = segments[2]
+	}
+
+	switch resource {
+	case segDatasets:
+		return parseDatasetOp(method, name), name
+	case segRecipes:
+		return parseRecipeOp(method, name, subOp), name
+	case segProjects:
+		return parseProjectOp(method, name), name
+	case segProfileJobs:
+		return parseProfileJobOp(method, name), name
+	case segRecipeJobs:
+		return parseRecipeJobOp(method, name), name
+	case segJobs:
+		return parseJobOp(method, name, subOp), name
+	}
+
+	return opUnknown, ""
+}
+
+func parseDatasetOp(method, name string) string {
+	switch method {
+	case http.MethodPost:
+		if name == "" {
+			return opCreateDataset
+		}
+	case http.MethodGet:
+		if name == "" {
+			return opListDatasets
+		}
+
+		return opDescribeDataset
+	case http.MethodPut:
+		if name != "" {
+			return opUpdateDataset
+		}
+	case http.MethodDelete:
+		if name != "" {
+			return opDeleteDataset
+		}
+	}
+
+	return opUnknown
+}
+
+func parseRecipeOp(method, name, subOp string) string {
+	if subOp == "publishRecipe" {
+		return opPublishRecipe
+	}
+	switch method {
+	case http.MethodPost:
+		if name == "" {
+			return opCreateRecipe
+		}
+	case http.MethodGet:
+		if name == "" {
+			return opListRecipes
+		}
+
+		return opDescribeRecipe
+	case http.MethodPut:
+		if name != "" {
+			return opUpdateRecipe
+		}
+	case http.MethodDelete:
+		if name != "" {
+			return opDeleteRecipe
+		}
+	}
+
+	return opUnknown
+}
+
+func parseProjectOp(method, name string) string {
+	switch method {
+	case http.MethodPost:
+		if name == "" {
+			return opCreateProject
+		}
+	case http.MethodGet:
+		if name == "" {
+			return opListProjects
+		}
+
+		return opDescribeProject
+	case http.MethodPut:
+		if name != "" {
+			return opUpdateProject
+		}
+	case http.MethodDelete:
+		if name != "" {
+			return opDeleteProject
+		}
+	}
+
+	return opUnknown
+}
+
+func parseProfileJobOp(method, name string) string {
+	switch method {
+	case http.MethodPost:
+		if name == "" {
+			return opCreateProfileJob
+		}
+	case http.MethodPut:
+		if name != "" {
+			return opUpdateProfileJob
+		}
+	}
+
+	return opUnknown
+}
+
+func parseRecipeJobOp(method, name string) string {
+	switch method {
+	case http.MethodPost:
+		if name == "" {
+			return opCreateRecipeJob
+		}
+	case http.MethodPut:
+		if name != "" {
+			return opUpdateRecipeJob
+		}
+	}
+
+	return opUnknown
+}
+
+func parseJobOp(method, name, subOp string) string {
+	switch {
+	case subOp == "startJobRun" && method == http.MethodPost:
+		return opStartJobRun
+	case subOp == "jobRuns" && method == http.MethodGet:
+		return opListJobRuns
+	case method == http.MethodGet && name == "":
+		return opListJobs
+	case method == http.MethodGet && name != "":
+		return opDescribeJob
+	case method == http.MethodDelete && name != "":
+		return opDeleteJob
+	}
+
+	return opUnknown
+}
+
+func enrichDataBrewBody(_, name string, body []byte) []byte {
+	if name == "" {
+		return body
+	}
+	m := make(map[string]json.RawMessage)
+	_ = json.Unmarshal(body, &m)
+	nameJSON, _ := json.Marshal(name)
+	m["Name"] = nameJSON
+	result, _ := json.Marshal(m)
+
+	return result
+}
+
+func (h *Handler) dispatch(ctx context.Context, action string, body []byte) ([]byte, error) {
+	if result, ok, err := h.dispatchDataset(ctx, action, body); ok {
+		return result, err
+	}
+
+	if result, ok, err := h.dispatchRecipe(ctx, action, body); ok {
+		return result, err
+	}
+
+	if result, ok, err := h.dispatchProject(ctx, action, body); ok {
+		return result, err
+	}
+
+	if result, ok, err := h.dispatchJob(ctx, action, body); ok {
+		return result, err
+	}
+
+	return nil, fmt.Errorf("%w: %s", errUnknownAction, action)
+}
+
+func (h *Handler) dispatchDataset(
+	ctx context.Context,
+	action string,
+	body []byte,
+) ([]byte, bool, error) {
+	switch action {
+	case opCreateDataset:
+		r, e := h.handleCreateDataset(ctx, body)
+
+		return r, true, e
+	case opDescribeDataset:
+		r, e := h.handleDescribeDataset(ctx, body)
+
+		return r, true, e
+	case opListDatasets:
+		r, e := h.handleListDatasets(ctx, body)
+
+		return r, true, e
+	case opUpdateDataset:
+		r, e := h.handleUpdateDataset(ctx, body)
+
+		return r, true, e
+	case opDeleteDataset:
+		r, e := h.handleDeleteDataset(ctx, body)
+
+		return r, true, e
+	}
+
+	return nil, false, nil
+}
+
+func (h *Handler) dispatchRecipe(
+	ctx context.Context,
+	action string,
+	body []byte,
+) ([]byte, bool, error) {
+	switch action {
+	case opCreateRecipe:
+		r, e := h.handleCreateRecipe(ctx, body)
+
+		return r, true, e
+	case opDescribeRecipe:
+		r, e := h.handleDescribeRecipe(ctx, body)
+
+		return r, true, e
+	case opListRecipes:
+		r, e := h.handleListRecipes(ctx, body)
+
+		return r, true, e
+	case opPublishRecipe:
+		r, e := h.handlePublishRecipe(ctx, body)
+
+		return r, true, e
+	case opUpdateRecipe:
+		r, e := h.handleUpdateRecipe(ctx, body)
+
+		return r, true, e
+	case opDeleteRecipe:
+		r, e := h.handleDeleteRecipe(ctx, body)
+
+		return r, true, e
+	}
+
+	return nil, false, nil
+}
+
+func (h *Handler) dispatchProject(
+	ctx context.Context,
+	action string,
+	body []byte,
+) ([]byte, bool, error) {
+	switch action {
+	case opCreateProject:
+		r, e := h.handleCreateProject(ctx, body)
+
+		return r, true, e
+	case opDescribeProject:
+		r, e := h.handleDescribeProject(ctx, body)
+
+		return r, true, e
+	case opListProjects:
+		r, e := h.handleListProjects(ctx, body)
+
+		return r, true, e
+	case opUpdateProject:
+		r, e := h.handleUpdateProject(ctx, body)
+
+		return r, true, e
+	case opDeleteProject:
+		r, e := h.handleDeleteProject(ctx, body)
+
+		return r, true, e
+	}
+
+	return nil, false, nil
+}
+
+func (h *Handler) dispatchJob(
+	ctx context.Context,
+	action string,
+	body []byte,
+) ([]byte, bool, error) {
+	switch action {
+	case opCreateProfileJob:
+		r, e := h.handleCreateProfileJob(ctx, body)
+
+		return r, true, e
+	case opCreateRecipeJob:
+		r, e := h.handleCreateRecipeJob(ctx, body)
+
+		return r, true, e
+	case opDescribeJob:
+		r, e := h.handleDescribeJob(ctx, body)
+
+		return r, true, e
+	case opListJobs:
+		r, e := h.handleListJobs(ctx, body)
+
+		return r, true, e
+	case opUpdateProfileJob, opUpdateRecipeJob:
+		r, e := h.handleUpdateJob(ctx, body)
+
+		return r, true, e
+	case opDeleteJob:
+		r, e := h.handleDeleteJob(ctx, body)
+
+		return r, true, e
+	case opStartJobRun:
+		r, e := h.handleStartJobRun(ctx, body)
+
+		return r, true, e
+	case opListJobRuns:
+		r, e := h.handleListJobRuns(ctx, body)
+
+		return r, true, e
+	}
+
+	return nil, false, nil
+}
+
+func (h *Handler) handleCreateDataset(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		FormatOptions DatasetFormatOptions `json:"FormatOptions"`
+		Input         DatasetInput         `json:"Input"`
+		Tags          map[string]string    `json:"Tags"`
+		Name          string               `json:"Name"`
+		Format        string               `json:"Format"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	ds, err := h.Backend.CreateDataset(req.Name, req.Format, req.Input, req.FormatOptions, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: ds.Name})
+}
+
+func (h *Handler) handleDescribeDataset(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	ds, err := h.Backend.DescribeDataset(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(ds)
+}
+
+func (h *Handler) handleListDatasets(_ context.Context, _ []byte) ([]byte, error) {
+	return json.Marshal(map[string]any{"Datasets": h.Backend.ListDatasets()})
+}
+
+func (h *Handler) handleUpdateDataset(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		FormatOptions DatasetFormatOptions `json:"FormatOptions"`
+		Input         DatasetInput         `json:"Input"`
+		Name          string               `json:"Name"`
+		Format        string               `json:"Format"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.UpdateDataset(req.Name, req.Format, req.Input, req.FormatOptions); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleDeleteDataset(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.DeleteDataset(req.Name); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleCreateRecipe(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Tags        map[string]string `json:"Tags"`
+		Name        string            `json:"Name"`
+		Description string            `json:"Description"`
+		Steps       []RecipeStep      `json:"Steps"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	r, err := h.Backend.CreateRecipe(req.Name, req.Description, req.Steps, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: r.Name})
+}
+
+func (h *Handler) handleDescribeRecipe(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	r, err := h.Backend.DescribeRecipe(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(r)
+}
+
+func (h *Handler) handleListRecipes(_ context.Context, _ []byte) ([]byte, error) {
+	return json.Marshal(map[string]any{"Recipes": h.Backend.ListRecipes()})
+}
+
+func (h *Handler) handlePublishRecipe(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name        string `json:"Name"`
+		Description string `json:"Description"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.PublishRecipe(req.Name, req.Description); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleUpdateRecipe(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name        string       `json:"Name"`
+		Description string       `json:"Description"`
+		Steps       []RecipeStep `json:"Steps"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.UpdateRecipe(req.Name, req.Description, req.Steps); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleDeleteRecipe(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.DeleteRecipe(req.Name); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleCreateProject(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Tags        map[string]string `json:"Tags"`
+		Name        string            `json:"Name"`
+		DatasetName string            `json:"DatasetName"`
+		RecipeName  string            `json:"RecipeName"`
+		RoleArn     string            `json:"RoleArn"`
+		Sample      Sample            `json:"Sample"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	p, err := h.Backend.CreateProject(
+		req.Name,
+		req.DatasetName,
+		req.RecipeName,
+		req.RoleArn,
+		req.Sample,
+		req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: p.Name})
+}
+
+func (h *Handler) handleDescribeProject(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	p, err := h.Backend.DescribeProject(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(p)
+}
+
+func (h *Handler) handleListProjects(_ context.Context, _ []byte) ([]byte, error) {
+	return json.Marshal(map[string]any{"Projects": h.Backend.ListProjects()})
+}
+
+func (h *Handler) handleUpdateProject(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name        string `json:"Name"`
+		DatasetName string `json:"DatasetName"`
+		RoleArn     string `json:"RoleArn"`
+		Sample      Sample `json:"Sample"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.UpdateProject(req.Name, req.DatasetName, req.RoleArn, req.Sample); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleDeleteProject(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.DeleteProject(req.Name); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleCreateProfileJob(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Tags        map[string]string `json:"Tags"`
+		Name        string            `json:"Name"`
+		DatasetName string            `json:"DatasetName"`
+		RoleArn     string            `json:"RoleArn"`
+		Outputs     []Output          `json:"Outputs"`
+		MaxCapacity int               `json:"MaxCapacity"`
+		MaxRetries  int               `json:"MaxRetries"`
+		Timeout     int               `json:"Timeout"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	j, err := h.Backend.CreateJob(
+		req.Name,
+		"PROFILE",
+		req.DatasetName,
+		"",
+		"",
+		req.RoleArn,
+		req.Outputs,
+		req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: j.Name})
+}
+
+func (h *Handler) handleCreateRecipeJob(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Tags        map[string]string `json:"Tags"`
+		Name        string            `json:"Name"`
+		DatasetName string            `json:"DatasetName"`
+		ProjectName string            `json:"ProjectName"`
+		RecipeName  string            `json:"RecipeName"`
+		RoleArn     string            `json:"RoleArn"`
+		Outputs     []Output          `json:"Outputs"`
+		MaxCapacity int               `json:"MaxCapacity"`
+		MaxRetries  int               `json:"MaxRetries"`
+		Timeout     int               `json:"Timeout"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	j, err := h.Backend.CreateJob(
+		req.Name,
+		"RECIPE",
+		req.DatasetName,
+		req.ProjectName,
+		req.RecipeName,
+		req.RoleArn,
+		req.Outputs,
+		req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: j.Name})
+}
+
+func (h *Handler) handleDescribeJob(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	j, err := h.Backend.DescribeJob(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(j)
+}
+
+func (h *Handler) handleListJobs(_ context.Context, _ []byte) ([]byte, error) {
+	return json.Marshal(map[string]any{"Jobs": h.Backend.ListJobs()})
+}
+
+func (h *Handler) handleUpdateJob(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name        string   `json:"Name"`
+		RoleArn     string   `json:"RoleArn"`
+		Outputs     []Output `json:"Outputs"`
+		MaxCapacity int      `json:"MaxCapacity"`
+		MaxRetries  int      `json:"MaxRetries"`
+		Timeout     int      `json:"Timeout"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.UpdateJob(
+		req.Name, req.RoleArn, req.Outputs, req.MaxCapacity, req.MaxRetries, req.Timeout,
+	); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleDeleteJob(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	if err := h.Backend.DeleteJob(req.Name); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{keyName: req.Name})
+}
+
+func (h *Handler) handleStartJobRun(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	run, err := h.Backend.StartJobRun(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]string{"RunID": run.RunID})
+}
+
+func (h *Handler) handleListJobRuns(_ context.Context, body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+	runs, err := h.Backend.ListJobRuns(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"JobRuns": runs})
+}

--- a/services/databrew/interfaces.go
+++ b/services/databrew/interfaces.go
@@ -1,0 +1,59 @@
+package databrew
+
+// StorageBackend defines the interface for all DataBrew backend operations.
+type StorageBackend interface {
+	Region() string
+	AccountID() string
+	Reset()
+
+	// Dataset operations.
+	CreateDataset(
+		name, format string,
+		input DatasetInput,
+		formatOpts DatasetFormatOptions,
+		tags map[string]string,
+	) (*Dataset, error)
+	DescribeDataset(name string) (*Dataset, error)
+	ListDatasets() []*Dataset
+	UpdateDataset(name, format string, input DatasetInput, formatOpts DatasetFormatOptions) error
+	DeleteDataset(name string) error
+
+	// Recipe operations.
+	CreateRecipe(
+		name, description string,
+		steps []RecipeStep,
+		tags map[string]string,
+	) (*Recipe, error)
+	DescribeRecipe(name string) (*Recipe, error)
+	ListRecipes() []*Recipe
+	PublishRecipe(name, description string) error
+	UpdateRecipe(name, description string, steps []RecipeStep) error
+	DeleteRecipe(name string) error
+
+	// Project operations.
+	CreateProject(
+		name, datasetName, recipeName, roleArn string,
+		sample Sample,
+		tags map[string]string,
+	) (*Project, error)
+	DescribeProject(name string) (*Project, error)
+	ListProjects() []*Project
+	UpdateProject(name, datasetName, roleArn string, sample Sample) error
+	DeleteProject(name string) error
+
+	// Job operations.
+	CreateJob(
+		name, jobType, datasetName, projectName, recipeName, roleArn string,
+		outputs []Output,
+		tags map[string]string,
+	) (*Job, error)
+	DescribeJob(name string) (*Job, error)
+	ListJobs() []*Job
+	UpdateJob(name, roleArn string, outputs []Output, maxCapacity, maxRetries, timeout int) error
+	DeleteJob(name string) error
+	StartJobRun(jobName string) (*JobRun, error)
+	ListJobRuns(jobName string) ([]*JobRun, error)
+}
+
+// compile-time assertion that InMemoryBackend implements StorageBackend.
+var _ StorageBackend = (*InMemoryBackend)(nil)

--- a/services/databrew/provider.go
+++ b/services/databrew/provider.go
@@ -1,0 +1,40 @@
+package databrew
+
+import (
+	"errors"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/config"
+	"github.com/blackbirdworks/gopherstack/pkgs/service"
+)
+
+// ErrNilAppContext is returned by Init when a nil AppContext is passed.
+var ErrNilAppContext = errors.New("nil AppContext passed to DataBrew Provider.Init")
+
+// Provider implements service.Provider for AWS Glue DataBrew.
+type Provider struct{}
+
+// Name returns the provider name.
+func (p *Provider) Name() string { return "DataBrew" }
+
+// Init initializes the DataBrew service backend and handler.
+//
+//nolint:ireturn,nolintlint // architecturally required to return interface
+func (p *Provider) Init(ctx *service.AppContext) (service.Registerable, error) {
+	if ctx == nil {
+		return nil, ErrNilAppContext
+	}
+
+	accountID := config.DefaultAccountID
+	region := config.DefaultRegion
+
+	if cp, ok := ctx.Config.(config.Provider); ok {
+		cfg := cp.GetGlobalConfig()
+		accountID = cfg.GetAccountID()
+		region = cfg.GetRegion()
+	}
+
+	backend := NewInMemoryBackend(accountID, region)
+	handler := NewHandler(backend)
+
+	return handler, nil
+}

--- a/services/elasticache/backend.go
+++ b/services/elasticache/backend.go
@@ -25,7 +25,7 @@ const (
 	versionRedis710           = "7.1.0"
 	nodeTypeT3Micro           = "cache.t3.micro"
 	statusAvailable           = "available"
-	statusServerlessAvailable = "AVAILABLE"
+	statusServerlessAvailable = "available"
 	statusDisabled            = "disabled"
 )
 

--- a/services/glue/backend.go
+++ b/services/glue/backend.go
@@ -316,6 +316,9 @@ type InMemoryBackend struct {
 	workflows           map[string]*Workflow                 // key: workflowName
 	workflowRuns        map[string][]*WorkflowRun            // key: workflowName
 	classifiers         map[string]*Classifier               // key: classifierName
+	registries          map[string]*Registry                 // key: registryName
+	schemas             map[string]*Schema                   // key: "registryName|schemaName"
+	schemaVersions      map[string][]*SchemaVersion          // key: schemaARN
 	mu                  *lockmetrics.RWMutex
 	accountID           string
 	region              string
@@ -343,6 +346,9 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		workflows:           make(map[string]*Workflow),
 		workflowRuns:        make(map[string][]*WorkflowRun),
 		classifiers:         make(map[string]*Classifier),
+		registries:          make(map[string]*Registry),
+		schemas:             make(map[string]*Schema),
+		schemaVersions:      make(map[string][]*SchemaVersion),
 		mu:                  lockmetrics.New("glue"),
 		accountID:           accountID,
 		region:              region,
@@ -373,6 +379,9 @@ func (b *InMemoryBackend) Reset() {
 	b.workflows = make(map[string]*Workflow)
 	b.workflowRuns = make(map[string][]*WorkflowRun)
 	b.classifiers = make(map[string]*Classifier)
+	b.registries = make(map[string]*Registry)
+	b.schemas = make(map[string]*Schema)
+	b.schemaVersions = make(map[string][]*SchemaVersion)
 }
 
 // Region returns the backend region.

--- a/services/glue/backend_registry.go
+++ b/services/glue/backend_registry.go
@@ -1,0 +1,485 @@
+package glue
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/arn"
+	"github.com/google/uuid"
+)
+
+// Registry represents a Glue Schema Registry.
+type Registry struct {
+	Tags        map[string]string `json:"Tags,omitempty"`
+	Name        string            `json:"RegistryName"`
+	ARN         string            `json:"RegistryArn"`
+	Description string            `json:"Description,omitempty"`
+	Status      string            `json:"Status"`
+	CreatedTime float64           `json:"CreatedTime,omitempty"`
+	UpdatedTime float64           `json:"UpdatedTime,omitempty"`
+}
+
+// Schema represents a Glue Schema Registry schema.
+type Schema struct {
+	Tags                map[string]string `json:"Tags,omitempty"`
+	RegistryName        string            `json:"RegistryName"`
+	SchemaName          string            `json:"SchemaName"`
+	SchemaARN           string            `json:"SchemaArn"`
+	RegistryARN         string            `json:"RegistryArn"`
+	DataFormat          string            `json:"DataFormat"`
+	Compatibility       string            `json:"Compatibility"`
+	Description         string            `json:"Description,omitempty"`
+	SchemaStatus        string            `json:"SchemaStatus"`
+	CreatedTime         float64           `json:"CreatedTime,omitempty"`
+	UpdatedTime         float64           `json:"UpdatedTime,omitempty"`
+	LatestSchemaVersion int64             `json:"LatestSchemaVersion"`
+	NextSchemaVersion   int64             `json:"NextSchemaVersion"`
+	CheckpointVersion   int64             `json:"SchemaCheckpoint"`
+}
+
+// SchemaVersion represents a single version of a schema.
+type SchemaVersion struct {
+	SchemaVersionID  string  `json:"SchemaVersionId"`
+	SchemaARN        string  `json:"SchemaArn"`
+	SchemaDefinition string  `json:"SchemaDefinition,omitempty"`
+	Status           string  `json:"Status"`
+	DataFormat       string  `json:"DataFormat,omitempty"`
+	VersionNumber    int64   `json:"VersionNumber"`
+	CreatedTime      float64 `json:"CreatedTime,omitempty"`
+}
+
+// CrawlerMetrics holds runtime metrics for a crawler.
+type CrawlerMetrics struct {
+	CrawlerName          string  `json:"CrawlerName"`
+	TimeLeftSeconds      float64 `json:"TimeLeftSeconds"`
+	LastRuntimeSeconds   float64 `json:"LastRuntimeSeconds"`
+	MedianRuntimeSeconds float64 `json:"MedianRuntimeSeconds"`
+	TablesCreated        int     `json:"TablesCreated"`
+	TablesUpdated        int     `json:"TablesUpdated"`
+	TablesDeleted        int     `json:"TablesDeleted"`
+	StillEstimating      bool    `json:"StillEstimating"`
+}
+
+func (b *InMemoryBackend) registryARN(name string) string {
+	return arn.Build("glue", b.region, b.accountID, "registry/"+name)
+}
+
+func (b *InMemoryBackend) schemaARN(registryName, schemaName string) string {
+	return arn.Build(
+		"glue",
+		b.region,
+		b.accountID,
+		fmt.Sprintf("schema/%s/%s", registryName, schemaName),
+	)
+}
+
+// schemaKey returns a composite key for a schema.
+func schemaKey(registryName, schemaName string) string {
+	return registryName + "|" + schemaName
+}
+
+// schemaVersionListKey returns the key for a schema's version list.
+func schemaVersionListKey(schemaARN string) string {
+	return schemaARN
+}
+
+// --- Registry operations ---
+
+// CreateRegistry creates a new Glue Schema Registry.
+func (b *InMemoryBackend) CreateRegistry(
+	name, description string,
+	tags map[string]string,
+) (*Registry, error) {
+	b.mu.Lock("CreateRegistry")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, ErrValidation
+	}
+
+	if _, ok := b.registries[name]; ok {
+		return nil, ErrAlreadyExists
+	}
+
+	reg := &Registry{
+		Name:        name,
+		ARN:         b.registryARN(name),
+		Description: description,
+		Status:      stateAvailable,
+		Tags:        maps.Clone(tags),
+		CreatedTime: float64(time.Now().Unix()),
+		UpdatedTime: float64(time.Now().Unix()),
+	}
+
+	b.registries[name] = reg
+
+	return reg, nil
+}
+
+// DescribeRegistry retrieves a registry by name.
+func (b *InMemoryBackend) DescribeRegistry(name string) (*Registry, error) {
+	b.mu.RLock("DescribeRegistry")
+	defer b.mu.RUnlock()
+
+	reg, ok := b.registries[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	cp := *reg
+	cp.Tags = maps.Clone(reg.Tags)
+
+	return &cp, nil
+}
+
+// ListRegistries returns all registries sorted by name.
+func (b *InMemoryBackend) ListRegistries() []*Registry {
+	b.mu.RLock("ListRegistries")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.registries))
+	for k := range b.registries {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := make([]*Registry, 0, len(keys))
+	for _, k := range keys {
+		cp := *b.registries[k]
+		cp.Tags = maps.Clone(b.registries[k].Tags)
+		out = append(out, &cp)
+	}
+
+	return out
+}
+
+// UpdateRegistry updates a registry's description.
+func (b *InMemoryBackend) UpdateRegistry(name, description string) error {
+	b.mu.Lock("UpdateRegistry")
+	defer b.mu.Unlock()
+
+	reg, ok := b.registries[name]
+	if !ok {
+		return ErrNotFound
+	}
+
+	reg.Description = description
+	reg.UpdatedTime = float64(time.Now().Unix())
+
+	return nil
+}
+
+// DeleteRegistry deletes a registry by name.
+func (b *InMemoryBackend) DeleteRegistry(name string) error {
+	b.mu.Lock("DeleteRegistry")
+	defer b.mu.Unlock()
+
+	if _, ok := b.registries[name]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.registries, name)
+
+	return nil
+}
+
+// --- Schema operations ---
+
+// CreateSchema creates a new schema in the given registry.
+func (b *InMemoryBackend) CreateSchema(
+	registryName, schemaName, dataFormat, compatibility, description string,
+	tags map[string]string,
+) (*Schema, error) {
+	b.mu.Lock("CreateSchema")
+	defer b.mu.Unlock()
+
+	if schemaName == "" {
+		return nil, ErrValidation
+	}
+
+	key := schemaKey(registryName, schemaName)
+	if _, ok := b.schemas[key]; ok {
+		return nil, ErrAlreadyExists
+	}
+
+	schARN := b.schemaARN(registryName, schemaName)
+
+	s := &Schema{
+		RegistryName:        registryName,
+		SchemaName:          schemaName,
+		SchemaARN:           schARN,
+		RegistryARN:         b.registryARN(registryName),
+		DataFormat:          dataFormat,
+		Compatibility:       compatibility,
+		Description:         description,
+		SchemaStatus:        stateAvailable,
+		Tags:                maps.Clone(tags),
+		CreatedTime:         float64(time.Now().Unix()),
+		UpdatedTime:         float64(time.Now().Unix()),
+		LatestSchemaVersion: 0,
+		NextSchemaVersion:   1,
+		CheckpointVersion:   1,
+	}
+
+	b.schemas[key] = s
+	b.schemaVersions[schemaVersionListKey(schARN)] = nil // init empty version list
+
+	return s, nil
+}
+
+// DescribeSchema retrieves a schema by registry and schema name.
+func (b *InMemoryBackend) DescribeSchema(registryName, schemaName string) (*Schema, error) {
+	b.mu.RLock("DescribeSchema")
+	defer b.mu.RUnlock()
+
+	s, ok := b.schemas[schemaKey(registryName, schemaName)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	cp := *s
+	cp.Tags = maps.Clone(s.Tags)
+
+	return &cp, nil
+}
+
+// ListSchemas returns all schemas for a registry.
+func (b *InMemoryBackend) ListSchemas(registryName string) []*Schema {
+	b.mu.RLock("ListSchemas")
+	defer b.mu.RUnlock()
+
+	out := make([]*Schema, 0)
+	for key, s := range b.schemas {
+		if registryName == "" || s.RegistryName == registryName {
+			_ = key
+			cp := *s
+			cp.Tags = maps.Clone(s.Tags)
+			out = append(out, &cp)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].SchemaName < out[j].SchemaName
+	})
+
+	return out
+}
+
+// UpdateSchema updates a schema's compatibility and description.
+func (b *InMemoryBackend) UpdateSchema(
+	registryName, schemaName, compatibility, description string,
+) error {
+	b.mu.Lock("UpdateSchema")
+	defer b.mu.Unlock()
+
+	s, ok := b.schemas[schemaKey(registryName, schemaName)]
+	if !ok {
+		return ErrNotFound
+	}
+
+	if compatibility != "" {
+		s.Compatibility = compatibility
+	}
+
+	if description != "" {
+		s.Description = description
+	}
+
+	s.UpdatedTime = float64(time.Now().Unix())
+
+	return nil
+}
+
+// DeleteSchema deletes a schema by registry and schema name.
+func (b *InMemoryBackend) DeleteSchema(registryName, schemaName string) error {
+	b.mu.Lock("DeleteSchema")
+	defer b.mu.Unlock()
+
+	key := schemaKey(registryName, schemaName)
+
+	s, ok := b.schemas[key]
+	if !ok {
+		return ErrNotFound
+	}
+
+	delete(b.schemaVersions, schemaVersionListKey(s.SchemaARN))
+	delete(b.schemas, key)
+
+	return nil
+}
+
+// --- Schema Version operations ---
+
+// RegisterSchemaVersion registers a new version of a schema.
+func (b *InMemoryBackend) RegisterSchemaVersion(
+	registryName, schemaName, schemaDefinition string,
+) (*SchemaVersion, error) {
+	b.mu.Lock("RegisterSchemaVersion")
+	defer b.mu.Unlock()
+
+	s, ok := b.schemas[schemaKey(registryName, schemaName)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	versionNumber := s.NextSchemaVersion
+	s.NextSchemaVersion++
+	s.LatestSchemaVersion = versionNumber
+	s.UpdatedTime = float64(time.Now().Unix())
+
+	sv := &SchemaVersion{
+		SchemaVersionID:  uuid.New().String(),
+		SchemaARN:        s.SchemaARN,
+		SchemaDefinition: schemaDefinition,
+		Status:           stateAvailable,
+		DataFormat:       s.DataFormat,
+		VersionNumber:    versionNumber,
+		CreatedTime:      float64(time.Now().Unix()),
+	}
+
+	listKey := schemaVersionListKey(s.SchemaARN)
+	b.schemaVersions[listKey] = append(b.schemaVersions[listKey], sv)
+
+	return sv, nil
+}
+
+// GetSchemaVersion retrieves a specific schema version.
+func (b *InMemoryBackend) GetSchemaVersion(
+	registryName, schemaName string,
+	versionNumber int64,
+) (*SchemaVersion, error) {
+	b.mu.RLock("GetSchemaVersion")
+	defer b.mu.RUnlock()
+
+	s, ok := b.schemas[schemaKey(registryName, schemaName)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	for _, sv := range b.schemaVersions[schemaVersionListKey(s.SchemaARN)] {
+		if sv.VersionNumber == versionNumber {
+			cp := *sv
+
+			return &cp, nil
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+// ListSchemaVersions returns all versions for a schema.
+func (b *InMemoryBackend) ListSchemaVersions(registryName, schemaName string) []*SchemaVersion {
+	b.mu.RLock("ListSchemaVersions")
+	defer b.mu.RUnlock()
+
+	s, ok := b.schemas[schemaKey(registryName, schemaName)]
+	if !ok {
+		return nil
+	}
+
+	src := b.schemaVersions[schemaVersionListKey(s.SchemaARN)]
+	out := make([]*SchemaVersion, len(src))
+
+	for i, sv := range src {
+		cp := *sv
+		out[i] = &cp
+	}
+
+	return out
+}
+
+// --- Crawler Metrics ---
+
+// --- Table Version retrieval ---
+
+// GetTableVersions returns all stored versions for a table, sorted by versionID.
+func (b *InMemoryBackend) GetTableVersions(dbName, tableName string) []*TableVersion {
+	b.mu.RLock("GetTableVersions")
+	defer b.mu.RUnlock()
+
+	prefix := tableVersionKey(dbName, tableName, "")
+	out := make([]*TableVersion, 0)
+
+	for k, tv := range b.tableVersions {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			cp := *tv
+			if tv.Table != nil {
+				t := *tv.Table
+				cp.Table = &t
+			}
+
+			out = append(out, &cp)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].VersionID < out[j].VersionID
+	})
+
+	return out
+}
+
+// GetTableVersion returns a specific version of a table.
+func (b *InMemoryBackend) GetTableVersion(
+	dbName, tableName, versionID string,
+) (*TableVersion, error) {
+	b.mu.RLock("GetTableVersion")
+	defer b.mu.RUnlock()
+
+	key := tableVersionKey(dbName, tableName, versionID)
+
+	tv, ok := b.tableVersions[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	cp := *tv
+	if tv.Table != nil {
+		t := *tv.Table
+		cp.Table = &t
+	}
+
+	return &cp, nil
+}
+
+// crawlerDefaultRuntimeSeconds is the simulated last/median runtime returned for a crawler.
+const crawlerDefaultRuntimeSeconds = 45.0
+
+// GetCrawlerMetrics returns metrics for one or all crawlers.
+// If crawlerNames is empty, metrics for all crawlers are returned.
+func (b *InMemoryBackend) GetCrawlerMetrics(crawlerNames []string) []*CrawlerMetrics {
+	b.mu.RLock("GetCrawlerMetrics")
+	defer b.mu.RUnlock()
+
+	if len(crawlerNames) == 0 {
+		for k := range b.crawlers {
+			crawlerNames = append(crawlerNames, k)
+		}
+
+		sort.Strings(crawlerNames)
+	}
+
+	out := make([]*CrawlerMetrics, 0, len(crawlerNames))
+
+	for _, name := range crawlerNames {
+		c, ok := b.crawlers[name]
+		if !ok {
+			continue
+		}
+
+		metrics := &CrawlerMetrics{
+			CrawlerName:          name,
+			TimeLeftSeconds:      0,
+			StillEstimating:      c.State == stateRunning,
+			LastRuntimeSeconds:   crawlerDefaultRuntimeSeconds,
+			MedianRuntimeSeconds: crawlerDefaultRuntimeSeconds,
+		}
+
+		out = append(out, metrics)
+	}
+
+	return out
+}

--- a/services/glue/handler_stubs.go
+++ b/services/glue/handler_stubs.go
@@ -397,43 +397,94 @@ func (h *Handler) handleCreatePartitionIndex(
 
 // createRegistryInput holds input for CreateRegistry.
 type createRegistryInput struct {
-	RegistryName string `json:"RegistryName"`
+	Tags         map[string]string `json:"Tags"`
+	RegistryName string            `json:"RegistryName"`
+	Description  string            `json:"Description"`
 }
 
 // createRegistryOutput holds the result for CreateRegistry.
 type createRegistryOutput struct {
-	RegistryName string `json:"RegistryName"`
-	RegistryArn  string `json:"RegistryArn"`
+	Tags         map[string]string `json:"Tags,omitempty"`
+	RegistryName string            `json:"RegistryName"`
+	RegistryArn  string            `json:"RegistryArn"`
+	Status       string            `json:"Status"`
 }
 
 func (h *Handler) handleCreateRegistry(
 	_ context.Context,
 	in *createRegistryInput,
 ) (*createRegistryOutput, error) {
+	reg, err := h.Backend.CreateRegistry(in.RegistryName, in.Description, in.Tags)
+	if err != nil {
+		return nil, err
+	}
+
 	return &createRegistryOutput{
-		RegistryName: in.RegistryName,
-		RegistryArn:  "arn:aws:glue:us-east-1:000000000000:registry/" + in.RegistryName,
+		RegistryName: reg.Name,
+		RegistryArn:  reg.ARN,
+		Status:       reg.Status,
+		Tags:         reg.Tags,
 	}, nil
 }
 
 // createSchemaInput holds input for CreateSchema.
 type createSchemaInput struct {
-	SchemaName string `json:"SchemaName"`
+	RegistryID    *registryIDInput  `json:"RegistryId"`
+	Tags          map[string]string `json:"Tags"`
+	SchemaName    string            `json:"SchemaName"`
+	DataFormat    string            `json:"DataFormat"`
+	Compatibility string            `json:"Compatibility"`
+	Description   string            `json:"Description"`
+}
+
+// registryIDInput holds registry identification fields.
+type registryIDInput struct {
+	RegistryName string `json:"RegistryName"`
+	RegistryArn  string `json:"RegistryArn"`
 }
 
 // createSchemaOutput holds the result for CreateSchema.
 type createSchemaOutput struct {
-	SchemaName string `json:"SchemaName"`
-	SchemaArn  string `json:"SchemaArn"`
+	Tags          map[string]string `json:"Tags,omitempty"`
+	RegistryName  string            `json:"RegistryName"`
+	RegistryArn   string            `json:"RegistryArn"`
+	SchemaName    string            `json:"SchemaName"`
+	SchemaArn     string            `json:"SchemaArn"`
+	DataFormat    string            `json:"DataFormat"`
+	Compatibility string            `json:"Compatibility"`
+	SchemaStatus  string            `json:"SchemaStatus"`
 }
 
 func (h *Handler) handleCreateSchema(
 	_ context.Context,
 	in *createSchemaInput,
 ) (*createSchemaOutput, error) {
+	registryName := ""
+	if in.RegistryID != nil {
+		registryName = in.RegistryID.RegistryName
+	}
+
+	s, err := h.Backend.CreateSchema(
+		registryName,
+		in.SchemaName,
+		in.DataFormat,
+		in.Compatibility,
+		in.Description,
+		in.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &createSchemaOutput{
-		SchemaName: in.SchemaName,
-		SchemaArn:  "arn:aws:glue:us-east-1:000000000000:schema/" + in.SchemaName,
+		RegistryName:  s.RegistryName,
+		RegistryArn:   s.RegistryARN,
+		SchemaName:    s.SchemaName,
+		SchemaArn:     s.SchemaARN,
+		DataFormat:    s.DataFormat,
+		Compatibility: s.Compatibility,
+		SchemaStatus:  s.SchemaStatus,
+		Tags:          s.Tags,
 	}, nil
 }
 
@@ -808,7 +859,7 @@ func (h *Handler) handleDeletePartitionIndex(
 
 // deleteRegistryInput holds input for DeleteRegistry.
 type deleteRegistryInput struct {
-	RegistryID any `json:"RegistryId"`
+	RegistryID *registryIDInput `json:"RegistryId"`
 }
 
 // deleteRegistryOutput holds the result for DeleteRegistry.
@@ -820,9 +871,18 @@ type deleteRegistryOutput struct {
 
 func (h *Handler) handleDeleteRegistry(
 	_ context.Context,
-	_ *deleteRegistryInput,
+	in *deleteRegistryInput,
 ) (*deleteRegistryOutput, error) {
-	return &deleteRegistryOutput{Status: stateDeleting}, nil
+	name := ""
+	if in.RegistryID != nil {
+		name = in.RegistryID.RegistryName
+	}
+
+	if err := h.Backend.DeleteRegistry(name); err != nil {
+		return nil, err
+	}
+
+	return &deleteRegistryOutput{RegistryName: name, Status: stateDeleting}, nil
 }
 
 // deleteResourcePolicyInput holds input for DeleteResourcePolicy.
@@ -835,8 +895,17 @@ func (h *Handler) handleDeleteResourcePolicy(
 	return &emptyOutput{}, nil
 }
 
+// schemaIDInput identifies a schema by registry + schema name or by ARN.
+type schemaIDInput struct {
+	RegistryName string `json:"RegistryName"`
+	SchemaName   string `json:"SchemaName"`
+	SchemaArn    string `json:"SchemaArn"`
+}
+
 // deleteSchemaInput holds input for DeleteSchema.
-type deleteSchemaInput struct{}
+type deleteSchemaInput struct {
+	SchemaID *schemaIDInput `json:"SchemaId"`
+}
 
 // deleteSchemaOutput holds the result for DeleteSchema.
 type deleteSchemaOutput struct {
@@ -847,9 +916,19 @@ type deleteSchemaOutput struct {
 
 func (h *Handler) handleDeleteSchema(
 	_ context.Context,
-	_ *deleteSchemaInput,
+	in *deleteSchemaInput,
 ) (*deleteSchemaOutput, error) {
-	return &deleteSchemaOutput{Status: stateDeleting}, nil
+	registryName, schemaName := "", ""
+	if in.SchemaID != nil {
+		registryName = in.SchemaID.RegistryName
+		schemaName = in.SchemaID.SchemaName
+	}
+
+	if err := h.Backend.DeleteSchema(registryName, schemaName); err != nil {
+		return nil, err
+	}
+
+	return &deleteSchemaOutput{SchemaName: schemaName, Status: stateDeleting}, nil
 }
 
 // deleteSchemaVersionsInput holds input for DeleteSchemaVersions.
@@ -1251,18 +1330,22 @@ func (h *Handler) handleGetColumnStatisticsTaskSettings(
 }
 
 // getCrawlerMetricsInput holds input for GetCrawlerMetrics.
-type getCrawlerMetricsInput struct{}
+type getCrawlerMetricsInput struct {
+	CrawlerNameList []string `json:"CrawlerNameList"`
+}
 
 // getCrawlerMetricsOutput holds the result for GetCrawlerMetrics.
 type getCrawlerMetricsOutput struct {
-	CrawlerMetricsList []any `json:"CrawlerMetricsList"`
+	CrawlerMetricsList []*CrawlerMetrics `json:"CrawlerMetricsList"`
 }
 
 func (h *Handler) handleGetCrawlerMetrics(
 	_ context.Context,
-	_ *getCrawlerMetricsInput,
+	in *getCrawlerMetricsInput,
 ) (*getCrawlerMetricsOutput, error) {
-	return &getCrawlerMetricsOutput{CrawlerMetricsList: []any{}}, nil
+	metrics := h.Backend.GetCrawlerMetrics(in.CrawlerNameList)
+
+	return &getCrawlerMetricsOutput{CrawlerMetricsList: metrics}, nil
 }
 
 // getCustomEntityTypeInput holds input for GetCustomEntityType.
@@ -1653,20 +1736,44 @@ func (h *Handler) handleGetPlan(_ context.Context, _ *getPlanInput) (*getPlanOut
 }
 
 // getRegistryInput holds input for GetRegistry.
-type getRegistryInput struct{}
+type getRegistryInput struct {
+	RegistryID *registryIDInput `json:"RegistryId"`
+}
 
 // getRegistryOutput holds the result for GetRegistry.
 type getRegistryOutput struct {
-	RegistryName string `json:"RegistryName"`
-	RegistryArn  string `json:"RegistryArn"`
-	Status       string `json:"Status"`
+	Tags         map[string]string `json:"Tags,omitempty"`
+	RegistryName string            `json:"RegistryName"`
+	RegistryArn  string            `json:"RegistryArn"`
+	Description  string            `json:"Description,omitempty"`
+	Status       string            `json:"Status"`
+	CreatedTime  float64           `json:"CreatedTime,omitempty"`
+	UpdatedTime  float64           `json:"UpdatedTime,omitempty"`
 }
 
 func (h *Handler) handleGetRegistry(
 	_ context.Context,
-	_ *getRegistryInput,
+	in *getRegistryInput,
 ) (*getRegistryOutput, error) {
-	return &getRegistryOutput{Status: stateAvailable}, nil
+	name := ""
+	if in.RegistryID != nil {
+		name = in.RegistryID.RegistryName
+	}
+
+	reg, err := h.Backend.DescribeRegistry(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getRegistryOutput{
+		RegistryName: reg.Name,
+		RegistryArn:  reg.ARN,
+		Status:       reg.Status,
+		Description:  reg.Description,
+		CreatedTime:  reg.CreatedTime,
+		UpdatedTime:  reg.UpdatedTime,
+		Tags:         reg.Tags,
+	}, nil
 }
 
 // getResourcePoliciesInput holds input for GetResourcePolicies.
@@ -1700,19 +1807,48 @@ func (h *Handler) handleGetResourcePolicy(
 }
 
 // getSchemaInput holds input for GetSchema.
-type getSchemaInput struct{}
+type getSchemaInput struct {
+	SchemaID *schemaIDInput `json:"SchemaId"`
+}
 
 // getSchemaOutput holds the result for GetSchema.
 type getSchemaOutput struct {
-	SchemaName    string `json:"SchemaName"`
-	SchemaArn     string `json:"SchemaArn"`
-	DataFormat    string `json:"DataFormat"`
-	Compatibility string `json:"Compatibility"`
-	SchemaStatus  string `json:"SchemaStatus"`
+	RegistryName  string  `json:"RegistryName"`
+	RegistryArn   string  `json:"RegistryArn"`
+	SchemaName    string  `json:"SchemaName"`
+	SchemaArn     string  `json:"SchemaArn"`
+	DataFormat    string  `json:"DataFormat"`
+	Compatibility string  `json:"Compatibility"`
+	SchemaStatus  string  `json:"SchemaStatus"`
+	Description   string  `json:"Description,omitempty"`
+	CreatedTime   float64 `json:"CreatedTime,omitempty"`
+	UpdatedTime   float64 `json:"UpdatedTime,omitempty"`
 }
 
-func (h *Handler) handleGetSchema(_ context.Context, _ *getSchemaInput) (*getSchemaOutput, error) {
-	return &getSchemaOutput{SchemaStatus: stateAvailable}, nil
+func (h *Handler) handleGetSchema(_ context.Context, in *getSchemaInput) (*getSchemaOutput, error) {
+	registryName, schemaName := "", ""
+	if in.SchemaID != nil {
+		registryName = in.SchemaID.RegistryName
+		schemaName = in.SchemaID.SchemaName
+	}
+
+	s, err := h.Backend.DescribeSchema(registryName, schemaName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getSchemaOutput{
+		RegistryName:  s.RegistryName,
+		RegistryArn:   s.RegistryARN,
+		SchemaName:    s.SchemaName,
+		SchemaArn:     s.SchemaARN,
+		DataFormat:    s.DataFormat,
+		Compatibility: s.Compatibility,
+		SchemaStatus:  s.SchemaStatus,
+		Description:   s.Description,
+		CreatedTime:   s.CreatedTime,
+		UpdatedTime:   s.UpdatedTime,
+	}, nil
 }
 
 // getSchemaByDefinitionInput holds input for GetSchemaByDefinition.
@@ -1734,20 +1870,55 @@ func (h *Handler) handleGetSchemaByDefinition(
 }
 
 // getSchemaVersionInput holds input for GetSchemaVersion.
-type getSchemaVersionInput struct{}
+type getSchemaVersionInput struct {
+	SchemaID            *schemaIDInput `json:"SchemaId"`
+	SchemaVersionNumber *struct {
+		VersionNumber int64 `json:"VersionNumber"`
+		LatestVersion bool  `json:"LatestVersion"`
+	} `json:"SchemaVersionNumber"`
+	SchemaVersionID string `json:"SchemaVersionId"`
+}
 
 // getSchemaVersionOutput holds the result for GetSchemaVersion.
 type getSchemaVersionOutput struct {
-	SchemaVersionID string `json:"SchemaVersionId"`
-	SchemaArn       string `json:"SchemaArn"`
-	Status          string `json:"Status"`
+	SchemaVersionID  string  `json:"SchemaVersionId"`
+	SchemaArn        string  `json:"SchemaArn"`
+	SchemaDefinition string  `json:"SchemaDefinition,omitempty"`
+	DataFormat       string  `json:"DataFormat,omitempty"`
+	Status           string  `json:"Status"`
+	VersionNumber    int64   `json:"VersionNumber"`
+	CreatedTime      float64 `json:"CreatedTime,omitempty"`
 }
 
 func (h *Handler) handleGetSchemaVersion(
 	_ context.Context,
-	_ *getSchemaVersionInput,
+	in *getSchemaVersionInput,
 ) (*getSchemaVersionOutput, error) {
-	return &getSchemaVersionOutput{Status: stateAvailable}, nil
+	registryName, schemaName := "", ""
+	if in.SchemaID != nil {
+		registryName = in.SchemaID.RegistryName
+		schemaName = in.SchemaID.SchemaName
+	}
+
+	versionNumber := int64(1)
+	if in.SchemaVersionNumber != nil && in.SchemaVersionNumber.VersionNumber > 0 {
+		versionNumber = in.SchemaVersionNumber.VersionNumber
+	}
+
+	sv, err := h.Backend.GetSchemaVersion(registryName, schemaName, versionNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getSchemaVersionOutput{
+		SchemaVersionID:  sv.SchemaVersionID,
+		SchemaArn:        sv.SchemaARN,
+		SchemaDefinition: sv.SchemaDefinition,
+		DataFormat:       sv.DataFormat,
+		Status:           sv.Status,
+		VersionNumber:    sv.VersionNumber,
+		CreatedTime:      sv.CreatedTime,
+	}, nil
 }
 
 // getSchemaVersionsDiffInput holds input for GetSchemaVersionsDiff.
@@ -1856,9 +2027,14 @@ type getTableVersionOutput struct {
 
 func (h *Handler) handleGetTableVersion(
 	_ context.Context,
-	_ *getTableVersionInput,
+	in *getTableVersionInput,
 ) (*getTableVersionOutput, error) {
-	return &getTableVersionOutput{}, nil
+	tv, err := h.Backend.GetTableVersion(in.DatabaseName, in.TableName, in.VersionID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getTableVersionOutput{TableVersion: tv}, nil
 }
 
 // getTableVersionsInput holds input for GetTableVersions.
@@ -1874,9 +2050,11 @@ type getTableVersionsOutput struct {
 
 func (h *Handler) handleGetTableVersions(
 	_ context.Context,
-	_ *getTableVersionsInput,
+	in *getTableVersionsInput,
 ) (*getTableVersionsOutput, error) {
-	return &getTableVersionsOutput{TableVersions: []*TableVersion{}}, nil
+	versions := h.Backend.GetTableVersions(in.DatabaseName, in.TableName)
+
+	return &getTableVersionsOutput{TableVersions: versions}, nil
 }
 
 // getTriggerInput holds input for GetTrigger.
@@ -2359,44 +2537,68 @@ type listRegistriesInput struct{}
 
 // listRegistriesOutput holds the result for ListRegistries.
 type listRegistriesOutput struct {
-	Registries []any `json:"Registries"`
+	Registries []*Registry `json:"Registries"`
 }
 
 func (h *Handler) handleListRegistries(
 	_ context.Context,
 	_ *listRegistriesInput,
 ) (*listRegistriesOutput, error) {
-	return &listRegistriesOutput{Registries: []any{}}, nil
+	regs := h.Backend.ListRegistries()
+
+	return &listRegistriesOutput{Registries: regs}, nil
 }
 
 // listSchemaVersionsInput holds input for ListSchemaVersions.
-type listSchemaVersionsInput struct{}
+type listSchemaVersionsInput struct {
+	SchemaID *schemaIDInput `json:"SchemaId"`
+}
 
 // listSchemaVersionsOutput holds the result for ListSchemaVersions.
 type listSchemaVersionsOutput struct {
-	SchemaVersions []any `json:"SchemaVersions"`
+	SchemaVersions []*SchemaVersion `json:"SchemaVersions"`
 }
 
 func (h *Handler) handleListSchemaVersions(
 	_ context.Context,
-	_ *listSchemaVersionsInput,
+	in *listSchemaVersionsInput,
 ) (*listSchemaVersionsOutput, error) {
-	return &listSchemaVersionsOutput{SchemaVersions: []any{}}, nil
+	registryName, schemaName := "", ""
+	if in.SchemaID != nil {
+		registryName = in.SchemaID.RegistryName
+		schemaName = in.SchemaID.SchemaName
+	}
+
+	versions := h.Backend.ListSchemaVersions(registryName, schemaName)
+	if versions == nil {
+		versions = []*SchemaVersion{}
+	}
+
+	return &listSchemaVersionsOutput{SchemaVersions: versions}, nil
 }
 
 // listSchemasInput holds input for ListSchemas.
-type listSchemasInput struct{}
+type listSchemasInput struct {
+	RegistryID *registryIDInput `json:"RegistryId"`
+}
 
 // listSchemasOutput holds the result for ListSchemas.
 type listSchemasOutput struct {
-	Schemas []any `json:"Schemas"`
+	Schemas []*Schema `json:"Schemas"`
 }
 
 func (h *Handler) handleListSchemas(
 	_ context.Context,
-	_ *listSchemasInput,
+	in *listSchemasInput,
 ) (*listSchemasOutput, error) {
-	return &listSchemasOutput{Schemas: []any{}}, nil
+	registryName := ""
+	if in.RegistryID != nil {
+		registryName = in.RegistryID.RegistryName
+	}
+
+	schemas := h.Backend.ListSchemas(registryName)
+
+	return &listSchemasOutput{Schemas: schemas}, nil
 }
 
 // listSessionsInput holds input for ListSessions.
@@ -2610,20 +2812,40 @@ func (h *Handler) handleRegisterConnectionType(
 }
 
 // registerSchemaVersionInput holds input for RegisterSchemaVersion.
-type registerSchemaVersionInput struct{}
+type registerSchemaVersionInput struct {
+	SchemaID         *schemaIDInput `json:"SchemaId"`
+	SchemaDefinition string         `json:"SchemaDefinition"`
+}
 
 // registerSchemaVersionOutput holds the result for RegisterSchemaVersion.
 type registerSchemaVersionOutput struct {
 	SchemaVersionID string `json:"SchemaVersionId"`
+	SchemaArn       string `json:"SchemaArn"`
 	Status          string `json:"Status"`
 	VersionNumber   int64  `json:"VersionNumber"`
 }
 
 func (h *Handler) handleRegisterSchemaVersion(
 	_ context.Context,
-	_ *registerSchemaVersionInput,
+	in *registerSchemaVersionInput,
 ) (*registerSchemaVersionOutput, error) {
-	return &registerSchemaVersionOutput{Status: stateAvailable}, nil
+	registryName, schemaName := "", ""
+	if in.SchemaID != nil {
+		registryName = in.SchemaID.RegistryName
+		schemaName = in.SchemaID.SchemaName
+	}
+
+	sv, err := h.Backend.RegisterSchemaVersion(registryName, schemaName, in.SchemaDefinition)
+	if err != nil {
+		return nil, err
+	}
+
+	return &registerSchemaVersionOutput{
+		SchemaVersionID: sv.SchemaVersionID,
+		SchemaArn:       sv.SchemaARN,
+		Status:          sv.Status,
+		VersionNumber:   sv.VersionNumber,
+	}, nil
 }
 
 // removeSchemaVersionMetadataInput holds input for RemoveSchemaVersionMetadata.
@@ -3151,7 +3373,10 @@ func (h *Handler) handleUpdatePartition(
 }
 
 // updateRegistryInput holds input for UpdateRegistry.
-type updateRegistryInput struct{}
+type updateRegistryInput struct {
+	RegistryID  *registryIDInput `json:"RegistryId"`
+	Description string           `json:"Description"`
+}
 
 // updateRegistryOutput holds the result for UpdateRegistry.
 type updateRegistryOutput struct {
@@ -3161,13 +3386,26 @@ type updateRegistryOutput struct {
 
 func (h *Handler) handleUpdateRegistry(
 	_ context.Context,
-	_ *updateRegistryInput,
+	in *updateRegistryInput,
 ) (*updateRegistryOutput, error) {
-	return &updateRegistryOutput{}, nil
+	name := ""
+	if in.RegistryID != nil {
+		name = in.RegistryID.RegistryName
+	}
+
+	if err := h.Backend.UpdateRegistry(name, in.Description); err != nil {
+		return nil, err
+	}
+
+	return &updateRegistryOutput{RegistryName: name}, nil
 }
 
 // updateSchemaInput holds input for UpdateSchema.
-type updateSchemaInput struct{}
+type updateSchemaInput struct {
+	SchemaID      *schemaIDInput `json:"SchemaId"`
+	Compatibility string         `json:"Compatibility"`
+	Description   string         `json:"Description"`
+}
 
 // updateSchemaOutput holds the result for UpdateSchema.
 type updateSchemaOutput struct {
@@ -3178,9 +3416,19 @@ type updateSchemaOutput struct {
 
 func (h *Handler) handleUpdateSchema(
 	_ context.Context,
-	_ *updateSchemaInput,
+	in *updateSchemaInput,
 ) (*updateSchemaOutput, error) {
-	return &updateSchemaOutput{}, nil
+	registryName, schemaName := "", ""
+	if in.SchemaID != nil {
+		registryName = in.SchemaID.RegistryName
+		schemaName = in.SchemaID.SchemaName
+	}
+
+	if err := h.Backend.UpdateSchema(registryName, schemaName, in.Compatibility, in.Description); err != nil {
+		return nil, err
+	}
+
+	return &updateSchemaOutput{SchemaName: schemaName, RegistryName: registryName}, nil
 }
 
 // updateSourceControlFromJobInput holds input for UpdateSourceControlFromJob.

--- a/services/glue/interfaces.go
+++ b/services/glue/interfaces.go
@@ -26,7 +26,11 @@ type StorageBackend interface {
 	DeleteTable(dbName, tableName string) error
 
 	// Crawler operations.
-	CreateCrawler(name, role, dbName string, targets CrawlerTarget, tags map[string]string) (*Crawler, error)
+	CreateCrawler(
+		name, role, dbName string,
+		targets CrawlerTarget,
+		tags map[string]string,
+	) (*Crawler, error)
 	GetCrawler(name string) (*Crawler, error)
 	GetCrawlers() []*Crawler
 	ListCrawlers() []string
@@ -46,12 +50,19 @@ type StorageBackend interface {
 	GetTags(resourceARN string) (map[string]string, error)
 
 	// Partition operations.
-	BatchCreatePartition(dbName, tableName string, inputs []PartitionInput) ([]*Partition, []PartitionError)
+	BatchCreatePartition(
+		dbName, tableName string,
+		inputs []PartitionInput,
+	) ([]*Partition, []PartitionError)
 	BatchDeletePartition(dbName, tableName string, values []PartitionValueList) []PartitionError
 	BatchDeleteTableVersion(dbName, tableName string, versionIDs []string) []TableVersionError
 
 	// Connection operations.
-	CreateConnection(name, connType string, props map[string]string, tags map[string]string) (*Connection, error)
+	CreateConnection(
+		name, connType string,
+		props map[string]string,
+		tags map[string]string,
+	) (*Connection, error)
 	GetConnection(name string) (*Connection, error)
 	GetConnections() []*Connection
 	DeleteConnection(name string) error
@@ -103,7 +114,10 @@ type StorageBackend interface {
 	StopCrawlerSchedule(name string) error
 
 	// Data quality ruleset operations.
-	CreateDataQualityRuleset(name, ruleset string, tags map[string]string) (*DataQualityRuleset, error)
+	CreateDataQualityRuleset(
+		name, ruleset string,
+		tags map[string]string,
+	) (*DataQualityRuleset, error)
 	GetDataQualityRuleset(name string) (*DataQualityRuleset, error)
 	DeleteDataQualityRuleset(name string) error
 	UpdateDataQualityRuleset(name, ruleset string) error
@@ -150,6 +164,35 @@ type StorageBackend interface {
 	GetDevEndpoint(name string) (*DevEndpoint, error)
 	GetAllDevEndpoints() []*DevEndpoint
 	DeleteDevEndpoint(name string) error
+
+	// Schema Registry operations.
+	CreateRegistry(name, description string, tags map[string]string) (*Registry, error)
+	DescribeRegistry(name string) (*Registry, error)
+	ListRegistries() []*Registry
+	UpdateRegistry(name, description string) error
+	DeleteRegistry(name string) error
+
+	// Schema operations.
+	CreateSchema(
+		registryName, schemaName, dataFormat, compatibility, description string,
+		tags map[string]string,
+	) (*Schema, error)
+	DescribeSchema(registryName, schemaName string) (*Schema, error)
+	ListSchemas(registryName string) []*Schema
+	UpdateSchema(registryName, schemaName, compatibility, description string) error
+	DeleteSchema(registryName, schemaName string) error
+
+	// Schema Version operations.
+	RegisterSchemaVersion(registryName, schemaName, schemaDefinition string) (*SchemaVersion, error)
+	GetSchemaVersion(registryName, schemaName string, versionNumber int64) (*SchemaVersion, error)
+	ListSchemaVersions(registryName, schemaName string) []*SchemaVersion
+
+	// Crawler metrics.
+	GetCrawlerMetrics(crawlerNames []string) []*CrawlerMetrics
+
+	// Table version retrieval (read-only; versions are created via CreateTable/UpdateTable).
+	GetTableVersions(dbName, tableName string) []*TableVersion
+	GetTableVersion(dbName, tableName, versionID string) (*TableVersion, error)
 }
 
 // Snapshottable is an optional interface that a StorageBackend may implement

--- a/services/opensearch/backend.go
+++ b/services/opensearch/backend.go
@@ -141,6 +141,8 @@ type InMemoryBackend struct {
 	domains                map[string]*Domain
 	vpcAuthorizations      map[string][]AuthorizedPrincipal
 	applications           map[string]*Application
+	upgradeHistory         map[string][]*UpgradeHistory // key: upgradeHistoryKey(domainName)
+	autoTunes              map[string]*AutoTuneConfig   // key: autoTuneKey(domainName)
 	mu                     *lockmetrics.RWMutex
 	accountID              string
 	region                 string
@@ -158,6 +160,8 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		packageAssociations:    make(map[string]map[string]bool),
 		vpcAuthorizations:      make(map[string][]AuthorizedPrincipal),
 		applications:           make(map[string]*Application),
+		upgradeHistory:         make(map[string][]*UpgradeHistory),
+		autoTunes:              make(map[string]*AutoTuneConfig),
 		accountID:              accountID,
 		region:                 region,
 		mu:                     lockmetrics.New("opensearch"),
@@ -196,7 +200,7 @@ func (b *InMemoryBackend) CreateDomain(name, engineVersion string, clusterConfig
 	}
 
 	if clusterConfig.InstanceType == "" {
-		clusterConfig.InstanceType = "t3.small.search"
+		clusterConfig.InstanceType = instanceTypeT3Small
 	}
 
 	d := &Domain{
@@ -632,6 +636,8 @@ func (b *InMemoryBackend) Reset() {
 	b.packageAssociations = make(map[string]map[string]bool)
 	b.vpcAuthorizations = make(map[string][]AuthorizedPrincipal)
 	b.applications = make(map[string]*Application)
+	b.upgradeHistory = make(map[string][]*UpgradeHistory)
+	b.autoTunes = make(map[string]*AutoTuneConfig)
 	b.appIDCounter = 0
 }
 
@@ -668,7 +674,7 @@ func (b *InMemoryBackend) AddDomainInternal(name, engineVersion string) {
 		EngineVersion: engineVersion,
 		Endpoint:      endpoint,
 		Status:        domainStatusActive,
-		ClusterConfig: ClusterConfig{InstanceType: "t3.small.search", InstanceCount: 1},
+		ClusterConfig: ClusterConfig{InstanceType: instanceTypeT3Small, InstanceCount: 1},
 		Tags:          tags.New("opensearch." + name + ".tags"),
 	}
 	b.arnIndex[domainARN] = name

--- a/services/opensearch/backend_advanced.go
+++ b/services/opensearch/backend_advanced.go
@@ -1,0 +1,443 @@
+package opensearch
+
+import (
+	"fmt"
+	"time"
+)
+
+// UpgradeHistory records a single domain upgrade event.
+type UpgradeHistory struct {
+	UpgradeName    string            `json:"UpgradeName"`
+	UpgradeStatus  string            `json:"UpgradeStatus"`
+	StepsList      []UpgradeStepItem `json:"StepsList"`
+	StartTimestamp float64           `json:"StartTimestamp"`
+}
+
+// UpgradeStepItem describes one step in an upgrade.
+type UpgradeStepItem struct {
+	UpgradeStep       string   `json:"UpgradeStep"`
+	UpgradeStepStatus string   `json:"UpgradeStepStatus"`
+	Issues            []string `json:"Issues,omitempty"`
+	ProgressPercent   float64  `json:"ProgressPercent"`
+}
+
+// AutoTuneConfig stores auto-tune configuration for a domain.
+type AutoTuneConfig struct {
+	DesiredState         string                        `json:"DesiredState"`
+	MaintenanceSchedules []AutoTuneMaintenanceSchedule `json:"MaintenanceSchedules,omitempty"`
+}
+
+// AutoTuneMaintenanceSchedule represents a maintenance window.
+type AutoTuneMaintenanceSchedule struct {
+	CronExpression string           `json:"CronExpressionForRecurrence,omitempty"`
+	Duration       AutoTuneDuration `json:"Duration"`
+	StartAt        float64          `json:"StartAt,omitempty"`
+}
+
+// AutoTuneDuration represents a duration for a maintenance window.
+type AutoTuneDuration struct {
+	Unit  string `json:"Unit"`
+	Value int    `json:"Value"`
+}
+
+// AutoTune is the response shape for one auto-tune item.
+type AutoTune struct {
+	AutoTuneType    string          `json:"AutoTuneType"`
+	AutoTuneDetails AutoTuneDetails `json:"AutoTuneDetails"`
+}
+
+// AutoTuneDetails holds the state details of an auto-tune entry.
+type AutoTuneDetails struct {
+	ScheduledAutoTuneDetails ScheduledAutoTuneDetails `json:"ScheduledAutoTuneDetails"`
+}
+
+// ScheduledAutoTuneDetails holds action details for a scheduled auto-tune.
+type ScheduledAutoTuneDetails struct {
+	ActionType string  `json:"ActionType,omitempty"`
+	Action     string  `json:"Action,omitempty"`
+	Severity   string  `json:"Severity,omitempty"`
+	Date       float64 `json:"Date,omitempty"`
+}
+
+// InstanceTypeLimits holds limits for a given OpenSearch instance type.
+type InstanceTypeLimits struct {
+	InstanceType     string            `json:"InstanceType"`
+	InstanceLimits   map[string]any    `json:"InstanceLimits"`
+	StorageTypes     []StorageType     `json:"StorageTypes,omitempty"`
+	AdditionalLimits []AdditionalLimit `json:"AdditionalLimits,omitempty"`
+}
+
+// StorageType describes a storage configuration available for an instance type.
+type StorageType struct {
+	StorageTypeName    string             `json:"StorageTypeName"`
+	StorageSubTypeName string             `json:"StorageSubTypeName"`
+	StorageTypeLimits  []StorageTypeLimit `json:"StorageTypeLimits"`
+}
+
+// StorageTypeLimit holds a named limit value.
+type StorageTypeLimit struct {
+	LimitName   string   `json:"LimitName"`
+	LimitValues []string `json:"LimitValues"`
+}
+
+// AdditionalLimit is an additional named limit for an instance type.
+type AdditionalLimit struct {
+	LimitName   string   `json:"LimitName"`
+	LimitValues []string `json:"LimitValues"`
+}
+
+const (
+	upgradeStatusSucceeded  = "SUCCEEDED"
+	upgradeStepUpgrade      = "UPGRADE"
+	upgradeStepPreCheck     = "PRE_UPGRADE_CHECK"
+	upgradeStepSnapshot     = "SNAPSHOT"
+	instanceCountLimitsKey  = "InstanceCountLimits"
+	minInstanceCountKey     = "MinimumInstanceCount"
+	maxInstanceCountKey     = "MaximumInstanceCount"
+	storageTypeEBSOnly      = "ebsOnly"
+	storageLimitMinVolume   = "MinimumVolumeSize"
+	storageLimitMaxVolume   = "MaximumVolumeSize"
+	engineTypeOpenSearch    = "OpenSearch"
+	engineTypeElasticsearch = "Elasticsearch"
+	instanceTypeT3Small     = "t3.small.search"
+
+	// upgradeProgressComplete is the 100% progress value for a completed upgrade step.
+	upgradeProgressComplete = float64(100)
+	// autoTuneScheduleHours is the look-ahead duration in hours for the next auto-tune window.
+	autoTuneScheduleHours = 24 * time.Hour
+	// maxDataNodesR6gLarge is the max data-node count for r6g.large.search.
+	maxDataNodesR6gLarge = 40
+	// maxDataNodesR6gXLarge is the max data-node count for r6g.xlarge.search.
+	maxDataNodesR6gXLarge = 40
+	// maxDataNodesM6gLarge is the max data-node count for m6g.large.search.
+	maxDataNodesM6gLarge = 80
+	// maxDataNodesT3Small is the max data-node count for t3.small.search.
+	maxDataNodesT3Small = 10
+	// maxDataNodesOR1Medium is the max data-node count for or1.medium.search.
+	maxDataNodesOR1Medium = 40
+	// maxDataNodesWithoutMasterStr is the string max for data nodes without a dedicated master.
+	maxDataNodesWithoutMasterStr = "10"
+
+	// String representations for storage limit values.
+	storageLimitMinVolumeGP3  = "20"
+	storageLimitMaxVolumeEBS  = "16384"
+	storageLimitMaxIOPS       = "16000"
+	storageLimitMaxThroughput = "1000"
+	storageLimitMinVolumeT3   = "10"
+	storageLimitMaxVolumeT3   = "100"
+
+	// String representations for instance count limits.
+	maxNodesStr40 = "40"
+	maxNodesStr80 = "80"
+	maxNodesStr10 = "10"
+	minNodesStr1  = "1"
+)
+
+// upgradeHistoryKey returns the map key for a domain's upgrade history list.
+func upgradeHistoryKey(domainName string) string {
+	return "upgrade:" + domainName
+}
+
+// autoTuneKey returns the map key for a domain's auto-tune config.
+func autoTuneKey(domainName string) string {
+	return "autotune:" + domainName
+}
+
+// UpgradeDomain records an upgrade in the domain's history.
+// Called when an upgrade is triggered.
+func (b *InMemoryBackend) UpgradeDomain(domainName, upgradeName string) error {
+	b.mu.Lock("UpgradeDomain")
+	defer b.mu.Unlock()
+
+	if _, ok := b.domains[domainName]; !ok {
+		return fmt.Errorf("%w: domain %q not found", ErrDomainNotFound, domainName)
+	}
+
+	uh := &UpgradeHistory{
+		UpgradeName:    upgradeName,
+		StartTimestamp: float64(time.Now().Unix()),
+		UpgradeStatus:  upgradeStatusSucceeded,
+		StepsList: []UpgradeStepItem{
+			{
+				UpgradeStep:       upgradeStepPreCheck,
+				UpgradeStepStatus: upgradeStatusSucceeded,
+				ProgressPercent:   upgradeProgressComplete,
+			},
+			{
+				UpgradeStep:       upgradeStepSnapshot,
+				UpgradeStepStatus: upgradeStatusSucceeded,
+				ProgressPercent:   upgradeProgressComplete,
+			},
+			{
+				UpgradeStep:       upgradeStepUpgrade,
+				UpgradeStepStatus: upgradeStatusSucceeded,
+				ProgressPercent:   upgradeProgressComplete,
+			},
+		},
+	}
+
+	key := upgradeHistoryKey(domainName)
+	b.upgradeHistory[key] = append(b.upgradeHistory[key], uh)
+
+	return nil
+}
+
+// GetUpgradeHistory returns the upgrade history for a domain, newest first.
+func (b *InMemoryBackend) GetUpgradeHistory(domainName string) ([]*UpgradeHistory, error) {
+	b.mu.RLock("GetUpgradeHistory")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.domains[domainName]; !ok {
+		return nil, fmt.Errorf("%w: domain %q not found", ErrDomainNotFound, domainName)
+	}
+
+	src := b.upgradeHistory[upgradeHistoryKey(domainName)]
+	out := make([]*UpgradeHistory, len(src))
+
+	for i, uh := range src {
+		cp := *uh
+		out[len(src)-1-i] = &cp
+	}
+
+	return out, nil
+}
+
+// GetUpgradeStatus returns the most recent upgrade status for a domain.
+func (b *InMemoryBackend) GetUpgradeStatus(domainName string) (string, string, string, error) {
+	b.mu.RLock("GetUpgradeStatus")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.domains[domainName]; !ok {
+		return "", "", "", fmt.Errorf("%w: domain %q not found", ErrDomainNotFound, domainName)
+	}
+
+	history := b.upgradeHistory[upgradeHistoryKey(domainName)]
+	if len(history) == 0 {
+		return "INITIAL", upgradeStatusSucceeded, upgradeStepUpgrade, nil
+	}
+
+	latest := history[len(history)-1]
+
+	return latest.UpgradeName, latest.UpgradeStatus, upgradeStepUpgrade, nil
+}
+
+// SetAutoTune stores auto-tune configuration for a domain.
+func (b *InMemoryBackend) SetAutoTune(
+	domainName, desiredState string,
+	schedules []AutoTuneMaintenanceSchedule,
+) error {
+	b.mu.Lock("SetAutoTune")
+	defer b.mu.Unlock()
+
+	if _, ok := b.domains[domainName]; !ok {
+		return fmt.Errorf("%w: domain %q not found", ErrDomainNotFound, domainName)
+	}
+
+	b.autoTunes[autoTuneKey(domainName)] = &AutoTuneConfig{
+		DesiredState:         desiredState,
+		MaintenanceSchedules: schedules,
+	}
+
+	return nil
+}
+
+// GetAutoTune returns auto-tune details for a domain.
+func (b *InMemoryBackend) GetAutoTune(domainName string) ([]*AutoTune, error) {
+	b.mu.RLock("GetAutoTune")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.domains[domainName]; !ok {
+		return nil, fmt.Errorf("%w: domain %q not found", ErrDomainNotFound, domainName)
+	}
+
+	cfg, ok := b.autoTunes[autoTuneKey(domainName)]
+	if !ok || cfg == nil {
+		return []*AutoTune{}, nil
+	}
+
+	out := []*AutoTune{
+		{
+			AutoTuneType: "SCHEDULED",
+			AutoTuneDetails: AutoTuneDetails{
+				ScheduledAutoTuneDetails: ScheduledAutoTuneDetails{
+					Date:       float64(time.Now().Add(autoTuneScheduleHours).Unix()),
+					ActionType: "JVM_HEAP_SIZE_TUNING",
+					Action:     "Increase JVM heap size to improve performance",
+					Severity:   "LOW",
+				},
+			},
+		},
+	}
+
+	return out, nil
+}
+
+// DescribeInstanceTypeLimits returns instance type limits for a given instance type and engine version.
+// This is a static lookup table for common types.
+func (b *InMemoryBackend) DescribeInstanceTypeLimits(
+	instanceType, _ string,
+) (*InstanceTypeLimits, error) {
+	limits := instanceTypeLimitsTable(instanceType)
+	if limits == nil {
+		// Return a generic stub for unknown types.
+		limits = &InstanceTypeLimits{
+			InstanceType: instanceType,
+			InstanceLimits: map[string]any{
+				instanceCountLimitsKey: map[string]any{
+					minInstanceCountKey: minNodesStr1,
+					maxInstanceCountKey: maxDataNodesR6gLarge,
+				},
+			},
+			StorageTypes: defaultStorageTypes(),
+		}
+	}
+
+	return limits, nil
+}
+
+// instanceTypeLimitsTable returns known limits for common OpenSearch instance types.
+func instanceTypeLimitsTable(instanceType string) *InstanceTypeLimits {
+	table := map[string]*InstanceTypeLimits{
+		"r6g.large.search": {
+			InstanceType: "r6g.large.search",
+			InstanceLimits: map[string]any{
+				instanceCountLimitsKey: map[string]any{
+					minInstanceCountKey: minNodesStr1,
+					maxInstanceCountKey: maxDataNodesR6gLarge,
+				},
+			},
+			StorageTypes: defaultStorageTypes(),
+			AdditionalLimits: []AdditionalLimit{
+				{
+					LimitName:   "MaximumNumberOfDataNodesSupported",
+					LimitValues: []string{maxNodesStr40},
+				},
+				{
+					LimitName:   "MaximumNumberOfDataNodesWithoutMasterNode",
+					LimitValues: []string{maxDataNodesWithoutMasterStr},
+				},
+			},
+		},
+		"r6g.xlarge.search": {
+			InstanceType: "r6g.xlarge.search",
+			InstanceLimits: map[string]any{
+				instanceCountLimitsKey: map[string]any{
+					minInstanceCountKey: minNodesStr1,
+					maxInstanceCountKey: maxDataNodesR6gXLarge,
+				},
+			},
+			StorageTypes: defaultStorageTypes(),
+			AdditionalLimits: []AdditionalLimit{
+				{
+					LimitName:   "MaximumNumberOfDataNodesSupported",
+					LimitValues: []string{maxNodesStr40},
+				},
+			},
+		},
+		"m6g.large.search": {
+			InstanceType: "m6g.large.search",
+			InstanceLimits: map[string]any{
+				instanceCountLimitsKey: map[string]any{
+					minInstanceCountKey: minNodesStr1,
+					maxInstanceCountKey: maxDataNodesM6gLarge,
+				},
+			},
+			StorageTypes: defaultStorageTypes(),
+		},
+		instanceTypeT3Small: {
+			InstanceType: instanceTypeT3Small,
+			InstanceLimits: map[string]any{
+				instanceCountLimitsKey: map[string]any{
+					minInstanceCountKey: minNodesStr1,
+					maxInstanceCountKey: maxDataNodesT3Small,
+				},
+			},
+			StorageTypes: []StorageType{
+				{
+					StorageTypeName:    storageTypeEBSOnly,
+					StorageSubTypeName: "standard",
+					StorageTypeLimits: []StorageTypeLimit{
+						{LimitName: storageLimitMinVolume, LimitValues: []string{storageLimitMinVolumeT3}},
+						{LimitName: storageLimitMaxVolume, LimitValues: []string{storageLimitMaxVolumeT3}},
+					},
+				},
+			},
+		},
+		"or1.medium.search": {
+			InstanceType: "or1.medium.search",
+			InstanceLimits: map[string]any{
+				instanceCountLimitsKey: map[string]any{
+					minInstanceCountKey: minNodesStr1,
+					maxInstanceCountKey: maxDataNodesOR1Medium,
+				},
+			},
+			StorageTypes: defaultStorageTypes(),
+		},
+	}
+
+	return table[instanceType]
+}
+
+// defaultStorageTypes returns the standard EBS storage types for most instance types.
+func defaultStorageTypes() []StorageType {
+	return []StorageType{
+		{
+			StorageTypeName:    storageTypeEBSOnly,
+			StorageSubTypeName: "gp3",
+			StorageTypeLimits: []StorageTypeLimit{
+				{LimitName: storageLimitMinVolume, LimitValues: []string{storageLimitMinVolumeGP3}},
+				{LimitName: storageLimitMaxVolume, LimitValues: []string{storageLimitMaxVolumeEBS}},
+				{LimitName: "MaximumIops", LimitValues: []string{storageLimitMaxIOPS}},
+				{LimitName: "MaximumThroughput", LimitValues: []string{storageLimitMaxThroughput}},
+			},
+		},
+		{
+			StorageTypeName:    storageTypeEBSOnly,
+			StorageSubTypeName: "gp2",
+			StorageTypeLimits: []StorageTypeLimit{
+				{LimitName: storageLimitMinVolume, LimitValues: []string{storageLimitMinVolumeT3}},
+				{LimitName: storageLimitMaxVolume, LimitValues: []string{storageLimitMaxVolumeEBS}},
+			},
+		},
+	}
+}
+
+// ListDomainNamesByEngine returns domain names filtered by engine type.
+func (b *InMemoryBackend) ListDomainNamesByEngine(engineType string) []string {
+	b.mu.RLock("ListDomainNamesByEngine")
+	defer b.mu.RUnlock()
+
+	out := make([]string, 0)
+
+	for name, d := range b.domains {
+		if engineType == "" {
+			out = append(out, name)
+
+			continue
+		}
+
+		// OpenSearch domains have EngineVersion starting with "OpenSearch_"
+		// Elasticsearch domains have EngineVersion starting with a number.
+		switch engineType {
+		case "OpenSearch":
+			if isOpenSearchEngine(d.EngineVersion) {
+				out = append(out, name)
+			}
+		case "Elasticsearch":
+			if !isOpenSearchEngine(d.EngineVersion) {
+				out = append(out, name)
+			}
+		}
+	}
+
+	return out
+}
+
+// isOpenSearchEngine returns true if the engine version is an OpenSearch (not Elasticsearch) engine.
+func isOpenSearchEngine(engineVersion string) bool {
+	if len(engineVersion) < 11 { //nolint:mnd // len("OpenSearch_") == 11
+		return false
+	}
+
+	return engineVersion[:11] == "OpenSearch_"
+}

--- a/services/opensearch/handler.go
+++ b/services/opensearch/handler.go
@@ -16,21 +16,23 @@ import (
 )
 
 const (
-	openSearchPathPrefix           = "/2021-01-01/opensearch/domain"
-	openSearchTagsPath             = "/2021-01-01/tags"
-	openSearchTagsRemoval          = "/2021-01-01/tags-removal"
-	openSearchCCPath               = "/2021-01-01/opensearch/cc"
-	openSearchDirectQueryPath      = "/2021-01-01/opensearch/directQueryDataSource"
-	openSearchPackagesPath         = "/2021-01-01/packages"
-	openSearchServiceSwPath        = "/2021-01-01/opensearch/serviceSoftwareUpdate"
-	openSearchApplicationPath      = "/2021-01-01/opensearch/application"
-	openSearchVersionsPath         = "/2021-01-01/opensearch/versions"
-	openSearchInstanceTypesPath    = "/2021-01-01/opensearch/instanceTypeDetails"
-	openSearchCompatiblePath       = "/2021-01-01/opensearch/compatibleVersions"
-	openSearchVpcEndpointsPath     = "/2021-01-01/opensearch/vpcEndpoints"
-	openSearchScheduledActionsPath = "/2021-01-01/opensearch/scheduledActions"
-	openSearchReservedPath         = "/2021-01-01/opensearch/reservedInstances"
-	openSearchUpgradePath          = "/2021-01-01/opensearch/upgradeDomain"
+	openSearchPathPrefix             = "/2021-01-01/opensearch/domain"
+	openSearchTagsPath               = "/2021-01-01/tags"
+	openSearchTagsRemoval            = "/2021-01-01/tags-removal"
+	openSearchCCPath                 = "/2021-01-01/opensearch/cc"
+	openSearchDirectQueryPath        = "/2021-01-01/opensearch/directQueryDataSource"
+	openSearchPackagesPath           = "/2021-01-01/packages"
+	openSearchServiceSwPath          = "/2021-01-01/opensearch/serviceSoftwareUpdate"
+	openSearchApplicationPath        = "/2021-01-01/opensearch/application"
+	openSearchVersionsPath           = "/2021-01-01/opensearch/versions"
+	openSearchInstanceTypesPath      = "/2021-01-01/opensearch/instanceTypeDetails"
+	openSearchCompatiblePath         = "/2021-01-01/opensearch/compatibleVersions"
+	openSearchVpcEndpointsPath       = "/2021-01-01/opensearch/vpcEndpoints"
+	openSearchScheduledActionsPath   = "/2021-01-01/opensearch/scheduledActions"
+	openSearchReservedPath           = "/2021-01-01/opensearch/reservedInstances"
+	openSearchUpgradePath            = "/2021-01-01/opensearch/upgradeDomain"
+	openSearchInstanceTypeLimitsPath = "/2021-01-01/opensearch/instanceTypeLimits"
+	openSearchServiceName            = "OpenSearch"
 	// pkgPathParts is the number of path segments after the associate prefix (PackageID/DomainName).
 	pkgPathParts = 2
 	// opUnknown is the sentinel returned when no operation can be determined from a request.
@@ -62,31 +64,50 @@ func NewHandler(backend StorageBackend) *Handler {
 }
 
 // Name returns the service name.
-func (h *Handler) Name() string { return "OpenSearch" }
+func (h *Handler) Name() string { return openSearchServiceName }
 
 // MatchPriority returns the routing priority.
 func (h *Handler) MatchPriority() int { return service.PriorityPathSubdomain }
 
+// openSearchPathPrefixes holds all path prefixes handled by the OpenSearch service.
+//
+//nolint:gochecknoglobals // intentional package-level prefix table
+var openSearchPathPrefixes = []string{
+	openSearchPathPrefix,
+	openSearchCCPath,
+	openSearchDirectQueryPath,
+	openSearchPackagesPath,
+	openSearchServiceSwPath,
+	openSearchApplicationPath,
+	openSearchVersionsPath,
+	openSearchInstanceTypesPath,
+	openSearchCompatiblePath,
+	openSearchVpcEndpointsPath,
+	openSearchScheduledActionsPath,
+	openSearchReservedPath,
+	openSearchUpgradePath,
+	openSearchInstanceTypeLimitsPath,
+}
+
+// isOpenSearchPath returns true when the given path belongs to the OpenSearch service.
+func isOpenSearchPath(path string) bool {
+	if path == openSearchTagsPath || path == openSearchTagsRemoval {
+		return true
+	}
+
+	for _, prefix := range openSearchPathPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // RouteMatcher returns a matcher that selects OpenSearch requests by path prefix.
 func (h *Handler) RouteMatcher() service.Matcher {
 	return func(c *echo.Context) bool {
-		path := c.Request().URL.Path
-
-		return strings.HasPrefix(path, openSearchPathPrefix) ||
-			strings.HasPrefix(path, openSearchCCPath) ||
-			strings.HasPrefix(path, openSearchDirectQueryPath) ||
-			strings.HasPrefix(path, openSearchPackagesPath) ||
-			strings.HasPrefix(path, openSearchServiceSwPath) ||
-			strings.HasPrefix(path, openSearchApplicationPath) ||
-			strings.HasPrefix(path, openSearchVersionsPath) ||
-			strings.HasPrefix(path, openSearchInstanceTypesPath) ||
-			strings.HasPrefix(path, openSearchCompatiblePath) ||
-			strings.HasPrefix(path, openSearchVpcEndpointsPath) ||
-			strings.HasPrefix(path, openSearchScheduledActionsPath) ||
-			strings.HasPrefix(path, openSearchReservedPath) ||
-			strings.HasPrefix(path, openSearchUpgradePath) ||
-			path == openSearchTagsPath ||
-			path == openSearchTagsRemoval
+		return isOpenSearchPath(c.Request().URL.Path)
 	}
 }
 
@@ -472,6 +493,8 @@ func (h *Handler) dispatchNonDomainRoutes(w http.ResponseWriter, r *http.Request
 		h.handleScheduledActionsRoutes(w, r)
 	case strings.HasPrefix(path, openSearchReservedPath):
 		h.handleReservedInstancesRoutes(w, r)
+	case strings.HasPrefix(path, openSearchInstanceTypeLimitsPath):
+		h.handleInstanceTypeLimitsRoutes(w, r)
 	case strings.HasPrefix(path, openSearchUpgradePath):
 		h.handleUpgradeDomainRoutes(w, r)
 	default:
@@ -1729,6 +1752,45 @@ func (h *Handler) handleVersionsRoutes(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleInstanceTypeLimitsRoutes handles DescribeInstanceTypeLimits requests.
+// Path: GET /2021-01-01/opensearch/instanceTypeLimits/{EngineVersion}/{InstanceType}.
+func (h *Handler) handleInstanceTypeLimitsRoutes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", "route not found")
+
+		return
+	}
+
+	// Path: /2021-01-01/opensearch/instanceTypeLimits/{EngineVersion}/{InstanceType}
+	rest := strings.TrimPrefix(r.URL.Path, openSearchInstanceTypeLimitsPath)
+	rest = strings.TrimPrefix(rest, "/")
+	parts := strings.SplitN(rest, "/", 2) //nolint:mnd // split into 2: engineVersion, instanceType
+
+	engineVersion := ""
+	instanceType := ""
+
+	if len(parts) >= 1 {
+		engineVersion = parts[0]
+	}
+
+	if len(parts) >= 2 { //nolint:mnd // 2 path segments: engineVersion and instanceType
+		instanceType = parts[1]
+	}
+
+	limits, err := h.Backend.DescribeInstanceTypeLimits(instanceType, engineVersion)
+	if err != nil {
+		h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{
+		"LimitsByRole": map[string]any{
+			"data": limits,
+		},
+	})
+}
+
 // handleInstanceTypeDetailsRoutes handles GET /2021-01-01/opensearch/instanceTypeDetails → ListInstanceTypeDetails.
 func (h *Handler) handleInstanceTypeDetailsRoutes(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -1868,7 +1930,13 @@ func (h *Handler) dispatchDomainGetStatusRoutes(w http.ResponseWriter, r *http.R
 	switch {
 	case strings.HasSuffix(trimmed, "/autoTunes"):
 		// DescribeDomainAutoTunes
-		h.writeJSON(r, w, map[string]any{"AutoTunes": []any{}})
+		domainName, _ := strings.CutSuffix(trimmed, "/autoTunes")
+		autoTunes, err := h.Backend.GetAutoTune(domainName)
+		if err != nil {
+			autoTunes = []*AutoTune{}
+		}
+
+		h.writeJSON(r, w, map[string]any{"AutoTunes": autoTunes})
 	case strings.HasSuffix(trimmed, "/progress"):
 		// DescribeDomainChangeProgress
 		h.writeJSON(r, w, map[string]any{"ChangeProgressStatus": map[string]any{
@@ -1888,10 +1956,27 @@ func (h *Handler) dispatchDomainGetStatusRoutes(w http.ResponseWriter, r *http.R
 		}})
 	case strings.HasSuffix(trimmed, "/upgradeHistory"):
 		// GetUpgradeHistory
-		h.writeJSON(r, w, map[string]any{"UpgradeHistories": []any{}})
+		domainName, _ := strings.CutSuffix(trimmed, "/upgradeHistory")
+		history, err := h.Backend.GetUpgradeHistory(domainName)
+		if err != nil {
+			history = []*UpgradeHistory{}
+		}
+
+		h.writeJSON(r, w, map[string]any{"UpgradeHistories": history})
 	case strings.HasSuffix(trimmed, "/upgrades"):
 		// GetUpgradeStatus
-		h.writeJSON(r, w, map[string]any{"UpgradeName": "stub", "StepStatus": "SUCCEEDED", "UpgradeStep": "UPGRADE"})
+		domainName, _ := strings.CutSuffix(trimmed, "/upgrades")
+		upgradeName, upgradeStatus, upgradeStep, err := h.Backend.GetUpgradeStatus(domainName)
+
+		if err != nil {
+			upgradeName, upgradeStatus, upgradeStep = "INITIAL", upgradeStatusSucceeded, upgradeStepUpgrade
+		}
+
+		h.writeJSON(r, w, map[string]any{
+			"UpgradeName": upgradeName,
+			"StepStatus":  upgradeStatus,
+			"UpgradeStep": upgradeStep,
+		})
 	case strings.HasSuffix(trimmed, "/vpcEndpoints"):
 		// ListVpcEndpointsForDomain
 		h.writeJSON(r, w, map[string]any{"VpcEndpointSummaryList": []any{}})

--- a/services/opensearch/interfaces.go
+++ b/services/opensearch/interfaces.go
@@ -35,6 +35,21 @@ type StorageBackend interface {
 	// Application operations
 	CreateApplication(name string, appConfigs []AppConfig, dataSources []AppDataSource) (*Application, error)
 
+	// Upgrade operations
+	UpgradeDomain(domainName, upgradeName string) error
+	GetUpgradeHistory(domainName string) ([]*UpgradeHistory, error)
+	GetUpgradeStatus(domainName string) (upgradeName, upgradeStatus, upgradeStep string, err error)
+
+	// Auto-tune operations
+	SetAutoTune(domainName, desiredState string, schedules []AutoTuneMaintenanceSchedule) error
+	GetAutoTune(domainName string) ([]*AutoTune, error)
+
+	// Instance type limits
+	DescribeInstanceTypeLimits(instanceType, engineVersion string) (*InstanceTypeLimits, error)
+
+	// Engine-type filtered list
+	ListDomainNamesByEngine(engineType string) []string
+
 	// Lifecycle
 	Reset()
 	Region() string

--- a/test/e2e/kafka_test.go
+++ b/test/e2e/kafka_test.go
@@ -28,6 +28,7 @@ func TestKafkaDashboard(t *testing.T) {
 			InstanceType:  "kafka.m5.large",
 		},
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/test/e2e/kinesisanalytics_test.go
+++ b/test/e2e/kinesisanalytics_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestKinesisAnalyticsDashboard verifies the removed KinesisAnalytics route returns 404.
+// TestKinesisAnalyticsDashboard verifies the KinesisAnalytics dashboard loads.
 func TestKinesisAnalyticsDashboard(t *testing.T) {
 	stack := newStack(t)
 
@@ -35,7 +35,7 @@ func TestKinesisAnalyticsDashboard(t *testing.T) {
 	_, err = page.Goto(server.URL + "/dashboard/kinesisanalytics")
 	require.NoError(t, err)
 
-	err = page.Locator("text=404").WaitFor(playwright.LocatorWaitForOptions{
+	err = page.Locator("text=Kinesis Data Analytics").WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
 		Timeout: playwright.Float(30000),
 	})

--- a/test/terraform/mega-batch-3/main.tf
+++ b/test/terraform/mega-batch-3/main.tf
@@ -1,0 +1,186 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    glue        = var.gopherstack_endpoint
+    athena      = var.gopherstack_endpoint
+    opensearch  = var.gopherstack_endpoint
+    redshiftdata = var.gopherstack_endpoint
+    iam         = var.gopherstack_endpoint
+    s3          = var.gopherstack_endpoint
+  }
+}
+
+variable "gopherstack_endpoint" {
+  description = "Gopherstack endpoint URL"
+  type        = string
+  default     = "http://localhost:4566"
+}
+
+# ---------------------------------------------------------------------------
+# Glue Database (required by crawler)
+# ---------------------------------------------------------------------------
+
+resource "aws_glue_catalog_database" "analytics" {
+  name = "analytics_db"
+}
+
+# ---------------------------------------------------------------------------
+# Glue Crawler
+# ---------------------------------------------------------------------------
+
+resource "aws_glue_crawler" "s3_crawler" {
+  name          = "s3-analytics-crawler"
+  role          = "arn:aws:iam::000000000000:role/GlueCrawlerRole"
+  database_name = aws_glue_catalog_database.analytics.name
+
+  s3_target {
+    path = "s3://my-data-bucket/raw/"
+  }
+
+  tags = {
+    Environment = "test"
+    Project     = "mega-batch-3"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Glue Job
+# ---------------------------------------------------------------------------
+
+resource "aws_glue_job" "etl_job" {
+  name     = "etl-transform-job"
+  role_arn = "arn:aws:iam::000000000000:role/GlueJobRole"
+
+  command {
+    name            = "glueetl"
+    script_location = "s3://my-scripts-bucket/etl.py"
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--job-language"        = "python"
+    "--enable-metrics"      = "true"
+    "--enable-continuous-cloudwatch-log" = "true"
+  }
+
+  number_of_workers = 2
+  worker_type       = "G.1X"
+  glue_version      = "4.0"
+  max_retries       = 1
+  timeout           = 60
+
+  tags = {
+    Environment = "test"
+    Project     = "mega-batch-3"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Glue Schema Registry
+# ---------------------------------------------------------------------------
+
+resource "aws_glue_registry" "analytics_registry" {
+  registry_name = "analytics-schema-registry"
+  description   = "Schema registry for analytics events"
+
+  tags = {
+    Environment = "test"
+  }
+}
+
+resource "aws_glue_schema" "event_schema" {
+  schema_name       = "analytics-event-schema"
+  registry_arn      = aws_glue_registry.analytics_registry.arn
+  data_format       = "AVRO"
+  compatibility     = "BACKWARD"
+  schema_definition = jsonencode({
+    type = "record"
+    name = "AnalyticsEvent"
+    fields = [
+      { name = "event_id", type = "string" },
+      { name = "timestamp", type = "long" },
+      { name = "event_type", type = "string" },
+      { name = "user_id", type = "string" },
+    ]
+  })
+
+  tags = {
+    Environment = "test"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Athena Workgroup
+# ---------------------------------------------------------------------------
+
+resource "aws_athena_workgroup" "analytics" {
+  name        = "analytics-workgroup"
+  description = "Workgroup for analytics queries"
+  state       = "ENABLED"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = false
+
+    result_configuration {
+      output_location = "s3://my-athena-results/output/"
+    }
+  }
+
+  tags = {
+    Environment = "test"
+    Project     = "mega-batch-3"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Athena Named Query
+# ---------------------------------------------------------------------------
+
+resource "aws_athena_named_query" "list_events" {
+  name        = "list-analytics-events"
+  description = "Lists all analytics events from the last 7 days"
+  workgroup   = aws_athena_workgroup.analytics.name
+  database    = aws_glue_catalog_database.analytics.name
+  query       = "SELECT * FROM analytics_events WHERE dt >= date_add('day', -7, current_date) LIMIT 100;"
+}
+
+# ---------------------------------------------------------------------------
+# OpenSearch Domain
+# ---------------------------------------------------------------------------
+
+resource "aws_opensearch_domain" "analytics" {
+  domain_name    = "analytics-search"
+  engine_version = "OpenSearch_2.11"
+
+  cluster_config {
+    instance_type  = "r6g.large.search"
+    instance_count = 1
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp3"
+    volume_size = 20
+  }
+
+  tags = {
+    Environment = "test"
+    Project     = "mega-batch-3"
+  }
+}

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -462,7 +462,12 @@ func ensureTofuBinary(t *testing.T) string {
 func downloadTofuBinary(logger *slog.Logger) (string, error) {
 	ctx := context.Background()
 
-	versionReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://get.opentofu.org/tofu/api.json", nil)
+	versionReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://get.opentofu.org/tofu/api.json",
+		nil,
+	)
 	if err != nil {
 		return "", fmt.Errorf("creating OpenTofu version request: %w", err)
 	}
@@ -666,7 +671,10 @@ func reuseOrInit(t *testing.T, dir, hcl string, run func(bool, ...string) bool) 
 
 	dotTerraform := filepath.Join(dir, ".terraform")
 	if err := hardLinkDir(filepath.Join(initSrc, ".terraform"), dotTerraform); err != nil {
-		t.Logf("could not hard-link .terraform from pre-init dir: %v; cleaning up and falling back to init", err)
+		t.Logf(
+			"could not hard-link .terraform from pre-init dir: %v; cleaning up and falling back to init",
+			err,
+		)
 		// Remove any partially-created tree so tofu init starts from a clean slate.
 		if rmErr := os.RemoveAll(dotTerraform); rmErr != nil {
 			t.Logf("failed to remove partial .terraform dir: %v", rmErr)
@@ -682,7 +690,10 @@ func reuseOrInit(t *testing.T, dir, hcl string, run func(bool, ...string) bool) 
 	// may re-resolve providers in a non-deterministic way.
 	lockData, readErr := os.ReadFile(filepath.Join(initSrc, ".terraform.lock.hcl"))
 	if readErr != nil {
-		t.Logf("failed to read .terraform.lock.hcl from pre-init dir: %v; falling back to init", readErr)
+		t.Logf(
+			"failed to read .terraform.lock.hcl from pre-init dir: %v; falling back to init",
+			readErr,
+		)
 		if rmErr := os.RemoveAll(dotTerraform); rmErr != nil {
 			t.Logf("failed to remove .terraform dir before fallback: %v", rmErr)
 		}
@@ -814,7 +825,11 @@ func runTFTest(t *testing.T, tc tfTestCase) {
 }
 
 // runTfTestWithEndpoint is a specialized runner for tests using setupEndpoint.
-func runTfTestWithEndpoint(t *testing.T, fixture string, verify func(t *testing.T, ctx context.Context)) {
+func runTfTestWithEndpoint(
+	t *testing.T,
+	fixture string,
+	verify func(t *testing.T, ctx context.Context),
+) {
 	t.Helper()
 
 	runTFTest(t, tfTestCase{
@@ -891,7 +906,11 @@ func TestTerraform_DynamoDBStreams(t *testing.T) {
 				require.NoError(t, err, "ListStreams should succeed after terraform apply")
 				require.NotEmpty(t, out.Streams, "stream should be listed for table %q", tableName)
 				assert.Equal(t, tableName, aws.ToString(out.Streams[0].TableName))
-				assert.NotEmpty(t, aws.ToString(out.Streams[0].StreamArn), "stream ARN should be non-empty")
+				assert.NotEmpty(
+					t,
+					aws.ToString(out.Streams[0].StreamArn),
+					"stream ARN should be non-empty",
+				)
 			},
 		},
 	}
@@ -940,10 +959,18 @@ func TestTerraform_DynamoDBComprehensive(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeTable(streams) should succeed")
 				require.NotNil(t, descOut.Table)
-				assert.NotEmpty(t, aws.ToString(descOut.Table.LatestStreamArn), "stream ARN should be set")
+				assert.NotEmpty(
+					t,
+					aws.ToString(descOut.Table.LatestStreamArn),
+					"stream ARN should be set",
+				)
 				require.NotNil(t, descOut.Table.StreamSpecification)
 				assert.True(t, aws.ToBool(descOut.Table.StreamSpecification.StreamEnabled))
-				assert.Equal(t, ddbtypes.StreamViewTypeNewAndOldImages, descOut.Table.StreamSpecification.StreamViewType)
+				assert.Equal(
+					t,
+					ddbtypes.StreamViewTypeNewAndOldImages,
+					descOut.Table.StreamSpecification.StreamViewType,
+				)
 
 				// TTL should be enabled on the streams table.
 				ttlOut, err := client.DescribeTimeToLive(ctx, &dynamodb.DescribeTimeToLiveInput{
@@ -951,13 +978,24 @@ func TestTerraform_DynamoDBComprehensive(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeTimeToLive should succeed")
 				require.NotNil(t, ttlOut.TimeToLiveDescription)
-				assert.Equal(t, ddbtypes.TimeToLiveStatusEnabled, ttlOut.TimeToLiveDescription.TimeToLiveStatus)
-				assert.Equal(t, "expires_at", aws.ToString(ttlOut.TimeToLiveDescription.AttributeName))
+				assert.Equal(
+					t,
+					ddbtypes.TimeToLiveStatusEnabled,
+					ttlOut.TimeToLiveDescription.TimeToLiveStatus,
+				)
+				assert.Equal(
+					t,
+					"expires_at",
+					aws.ToString(ttlOut.TimeToLiveDescription.AttributeName),
+				)
 
 				// Stream should be listed.
-				listStreamsOut, err := streamsClient.ListStreams(ctx, &dynamodbstreamssvc.ListStreamsInput{
-					TableName: aws.String(streamsTable),
-				})
+				listStreamsOut, err := streamsClient.ListStreams(
+					ctx,
+					&dynamodbstreamssvc.ListStreamsInput{
+						TableName: aws.String(streamsTable),
+					},
+				)
 				require.NoError(t, err, "ListStreams should succeed")
 				require.NotEmpty(t, listStreamsOut.Streams, "at least one stream should be listed")
 				assert.Equal(t, streamsTable, aws.ToString(listStreamsOut.Streams[0].TableName))
@@ -977,7 +1015,11 @@ func TestTerraform_DynamoDBComprehensive(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeGlobalTable should succeed")
 				require.NotNil(t, descGT.GlobalTableDescription)
-				assert.Equal(t, globalTable, aws.ToString(descGT.GlobalTableDescription.GlobalTableName))
+				assert.Equal(
+					t,
+					globalTable,
+					aws.ToString(descGT.GlobalTableDescription.GlobalTableName),
+				)
 
 				// --- On-demand billing table ---
 				descOnDemand, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
@@ -1066,7 +1108,11 @@ func TestTerraform_RDS(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeDBInstances should succeed after terraform apply")
 				require.Len(t, out.DBInstances, 1)
-				assert.Equal(t, vars["Identifier"].(string), aws.ToString(out.DBInstances[0].DBInstanceIdentifier))
+				assert.Equal(
+					t,
+					vars["Identifier"].(string),
+					aws.ToString(out.DBInstances[0].DBInstanceIdentifier),
+				)
 				assert.Equal(t, "postgres", aws.ToString(out.DBInstances[0].Engine))
 				assert.Equal(t, "available", aws.ToString(out.DBInstances[0].DBInstanceStatus))
 			},
@@ -1145,18 +1191,28 @@ func TestTerraform_Neptune(t *testing.T) {
 				assert.Equal(t, clusterID, *out.DBClusters[0].DBClusterIdentifier)
 
 				instanceID := "tf-neptune-inst-" + suffix
-				instOut, err := client.DescribeDBInstances(ctx, &neptunesvc.DescribeDBInstancesInput{
-					DBInstanceIdentifier: &instanceID,
-				})
+				instOut, err := client.DescribeDBInstances(
+					ctx,
+					&neptunesvc.DescribeDBInstancesInput{
+						DBInstanceIdentifier: &instanceID,
+					},
+				)
 				require.NoError(t, err, "DescribeDBInstances should succeed after terraform apply")
 				require.Len(t, instOut.DBInstances, 1)
 				assert.Equal(t, instanceID, *instOut.DBInstances[0].DBInstanceIdentifier)
 
 				sgName := "tf-neptune-sg-" + suffix
-				sgOut, err := client.DescribeDBSubnetGroups(ctx, &neptunesvc.DescribeDBSubnetGroupsInput{
-					DBSubnetGroupName: &sgName,
-				})
-				require.NoError(t, err, "DescribeDBSubnetGroups should succeed after terraform apply")
+				sgOut, err := client.DescribeDBSubnetGroups(
+					ctx,
+					&neptunesvc.DescribeDBSubnetGroupsInput{
+						DBSubnetGroupName: &sgName,
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeDBSubnetGroups should succeed after terraform apply",
+				)
 				require.Len(t, sgOut.DBSubnetGroups, 1)
 				assert.Equal(t, sgName, *sgOut.DBSubnetGroups[0].DBSubnetGroupName)
 			},
@@ -1209,7 +1265,11 @@ func TestTerraform_Lambda(t *testing.T) {
 				})
 				require.NoError(t, err, "GetFunction should succeed after terraform apply")
 				require.NotNil(t, out.Configuration)
-				assert.Equal(t, vars["FuncName"].(string), aws.ToString(out.Configuration.FunctionName))
+				assert.Equal(
+					t,
+					vars["FuncName"].(string),
+					aws.ToString(out.Configuration.FunctionName),
+				)
 			},
 		},
 	}
@@ -1263,7 +1323,11 @@ func TestTerraform_Lambda_ProvisionedConcurrency(t *testing.T) {
 						FunctionName: aws.String(vars["FuncName"].(string)),
 					},
 				)
-				require.NoError(t, err, "ListProvisionedConcurrencyConfigs should succeed after terraform apply")
+				require.NoError(
+					t,
+					err,
+					"ListProvisionedConcurrencyConfigs should succeed after terraform apply",
+				)
 				assert.NotEmpty(t, listOut.ProvisionedConcurrencyConfigs,
 					"at least one provisioned concurrency config should exist")
 			},
@@ -1338,7 +1402,9 @@ func TestTerraform_SNSSQSSubscription(t *testing.T) {
 				t.Helper()
 				client := createSNSClient(t)
 				out, err := client.GetTopicAttributes(ctx, &snssvc.GetTopicAttributesInput{
-					TopicArn: aws.String("arn:aws:sns:us-east-1:000000000000:" + vars["TopicName"].(string)),
+					TopicArn: aws.String(
+						"arn:aws:sns:us-east-1:000000000000:" + vars["TopicName"].(string),
+					),
 				})
 				require.NoError(t, err, "GetTopicAttributes should succeed after terraform apply")
 				assert.NotEmpty(t, out.Attributes)
@@ -1372,14 +1438,32 @@ func TestTerraform_SNSPlatformApplication(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createSNSClient(t)
-				out, err := client.ListPlatformApplications(ctx, &snssvc.ListPlatformApplicationsInput{})
-				require.NoError(t, err, "ListPlatformApplications should succeed after terraform apply")
+				out, err := client.ListPlatformApplications(
+					ctx,
+					&snssvc.ListPlatformApplicationsInput{},
+				)
+				require.NoError(
+					t,
+					err,
+					"ListPlatformApplications should succeed after terraform apply",
+				)
 
 				appName := vars["AppName"].(string)
-				found := slices.ContainsFunc(out.PlatformApplications, func(app snstypes.PlatformApplication) bool {
-					return strings.HasSuffix(aws.ToString(app.PlatformApplicationArn), "/"+appName)
-				})
-				assert.True(t, found, "platform application %q should exist after terraform apply", appName)
+				found := slices.ContainsFunc(
+					out.PlatformApplications,
+					func(app snstypes.PlatformApplication) bool {
+						return strings.HasSuffix(
+							aws.ToString(app.PlatformApplicationArn),
+							"/"+appName,
+						)
+					},
+				)
+				assert.True(
+					t,
+					found,
+					"platform application %q should exist after terraform apply",
+					appName,
+				)
 			},
 		},
 	}
@@ -1507,7 +1591,9 @@ func TestTerraform_Route53(t *testing.T) {
 			setup: func(t *testing.T, _ string) map[string]any {
 				t.Helper()
 
-				return map[string]any{"ZoneName": "tf-test-" + uuid.NewString()[:8] + ".example.com"}
+				return map[string]any{
+					"ZoneName": "tf-test-" + uuid.NewString()[:8] + ".example.com",
+				}
 			},
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
@@ -1519,7 +1605,8 @@ func TestTerraform_Route53(t *testing.T) {
 				found := false
 
 				for _, zone := range out.HostedZones {
-					if aws.ToString(zone.Name) == zoneName+"." || aws.ToString(zone.Name) == zoneName {
+					if aws.ToString(zone.Name) == zoneName+"." ||
+						aws.ToString(zone.Name) == zoneName {
 						found = true
 
 						break
@@ -1571,7 +1658,12 @@ func TestTerraform_CloudWatchLogGroup(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "log group %q should exist after terraform apply", logGroupName)
+				assert.True(
+					t,
+					found,
+					"log group %q should exist after terraform apply",
+					logGroupName,
+				)
 			},
 		},
 	}
@@ -1738,10 +1830,17 @@ func TestTerraform_EventBridge(t *testing.T) {
 				assert.Equal(t, vars["ConnectionName"].(string), aws.ToString(connOut.Name))
 
 				// Verify API destination.
-				dstOut, err := client.DescribeApiDestination(ctx, &ebsvc.DescribeApiDestinationInput{
-					Name: aws.String(vars["APIDestinationName"].(string)),
-				})
-				require.NoError(t, err, "DescribeApiDestination should succeed after terraform apply")
+				dstOut, err := client.DescribeApiDestination(
+					ctx,
+					&ebsvc.DescribeApiDestinationInput{
+						Name: aws.String(vars["APIDestinationName"].(string)),
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeApiDestination should succeed after terraform apply",
+				)
 				assert.Equal(t, vars["APIDestinationName"].(string), aws.ToString(dstOut.Name))
 			},
 		},
@@ -1776,8 +1875,16 @@ func TestTerraform_CloudWatchAlarm(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeAlarms should succeed after terraform apply")
 				require.Len(t, out.MetricAlarms, 1)
-				assert.Equal(t, vars["AlarmName"].(string), aws.ToString(out.MetricAlarms[0].AlarmName))
-				assert.Equal(t, cwtypes.ComparisonOperatorGreaterThanThreshold, out.MetricAlarms[0].ComparisonOperator)
+				assert.Equal(
+					t,
+					vars["AlarmName"].(string),
+					aws.ToString(out.MetricAlarms[0].AlarmName),
+				)
+				assert.Equal(
+					t,
+					cwtypes.ComparisonOperatorGreaterThanThreshold,
+					out.MetricAlarms[0].ComparisonOperator,
+				)
 			},
 		},
 	}
@@ -1806,12 +1913,23 @@ func TestTerraform_Kinesis(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createKinesisClient(t)
-				out, err := client.DescribeStreamSummary(ctx, &kinesissvc.DescribeStreamSummaryInput{
-					StreamName: aws.String(vars["StreamName"].(string)),
-				})
-				require.NoError(t, err, "DescribeStreamSummary should succeed after terraform apply")
+				out, err := client.DescribeStreamSummary(
+					ctx,
+					&kinesissvc.DescribeStreamSummaryInput{
+						StreamName: aws.String(vars["StreamName"].(string)),
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeStreamSummary should succeed after terraform apply",
+				)
 				require.NotNil(t, out.StreamDescriptionSummary)
-				assert.Equal(t, vars["StreamName"].(string), aws.ToString(out.StreamDescriptionSummary.StreamName))
+				assert.Equal(
+					t,
+					vars["StreamName"].(string),
+					aws.ToString(out.StreamDescriptionSummary.StreamName),
+				)
 			},
 		},
 	}
@@ -1854,7 +1972,12 @@ func TestTerraform_ACM(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "certificate for %q should exist after terraform apply", domain)
+				assert.True(
+					t,
+					found,
+					"certificate for %q should exist after terraform apply",
+					domain,
+				)
 			},
 		},
 	}
@@ -1884,8 +2007,15 @@ func TestTerraform_ACMPCA(t *testing.T) {
 				t.Helper()
 
 				client := createACMPCAClient(t)
-				out, err := client.ListCertificateAuthorities(ctx, &acmpcasvc.ListCertificateAuthoritiesInput{})
-				require.NoError(t, err, "ListCertificateAuthorities should succeed after terraform apply")
+				out, err := client.ListCertificateAuthorities(
+					ctx,
+					&acmpcasvc.ListCertificateAuthoritiesInput{},
+				)
+				require.NoError(
+					t,
+					err,
+					"ListCertificateAuthorities should succeed after terraform apply",
+				)
 
 				commonName := vars["CommonName"].(string)
 				found := false
@@ -1893,14 +2023,21 @@ func TestTerraform_ACMPCA(t *testing.T) {
 				for _, ca := range out.CertificateAuthorities {
 					if ca.CertificateAuthorityConfiguration != nil &&
 						ca.CertificateAuthorityConfiguration.Subject != nil &&
-						aws.ToString(ca.CertificateAuthorityConfiguration.Subject.CommonName) == commonName {
+						aws.ToString(
+							ca.CertificateAuthorityConfiguration.Subject.CommonName,
+						) == commonName {
 						found = true
 
 						break
 					}
 				}
 
-				assert.True(t, found, "CA with common name %q should exist after terraform apply", commonName)
+				assert.True(
+					t,
+					found,
+					"CA with common name %q should exist after terraform apply",
+					commonName,
+				)
 			},
 		},
 	}
@@ -1963,12 +2100,23 @@ func TestTerraform_ElastiCache(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createElastiCacheClient(t)
-				out, err := client.DescribeCacheClusters(ctx, &elasticachesvc.DescribeCacheClustersInput{
-					CacheClusterId: aws.String(vars["ClusterID"].(string)),
-				})
-				require.NoError(t, err, "DescribeCacheClusters should succeed after terraform apply")
+				out, err := client.DescribeCacheClusters(
+					ctx,
+					&elasticachesvc.DescribeCacheClustersInput{
+						CacheClusterId: aws.String(vars["ClusterID"].(string)),
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeCacheClusters should succeed after terraform apply",
+				)
 				require.Len(t, out.CacheClusters, 1)
-				assert.Equal(t, vars["ClusterID"].(string), aws.ToString(out.CacheClusters[0].CacheClusterId))
+				assert.Equal(
+					t,
+					vars["ClusterID"].(string),
+					aws.ToString(out.CacheClusters[0].CacheClusterId),
+				)
 			},
 		},
 	}
@@ -2002,7 +2150,11 @@ func TestTerraform_OpenSearch(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeDomain should succeed after terraform apply")
 				require.NotNil(t, out.DomainStatus)
-				assert.Equal(t, vars["DomainName"].(string), aws.ToString(out.DomainStatus.DomainName))
+				assert.Equal(
+					t,
+					vars["DomainName"].(string),
+					aws.ToString(out.DomainStatus.DomainName),
+				)
 			},
 		},
 	}
@@ -2031,12 +2183,23 @@ func TestTerraform_Elasticsearch(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createElasticsearchClient(t)
-				out, err := client.DescribeElasticsearchDomain(ctx, &elasticsearchsvc.DescribeElasticsearchDomainInput{
-					DomainName: aws.String(vars["DomainName"].(string)),
-				})
-				require.NoError(t, err, "DescribeElasticsearchDomain should succeed after terraform apply")
+				out, err := client.DescribeElasticsearchDomain(
+					ctx,
+					&elasticsearchsvc.DescribeElasticsearchDomainInput{
+						DomainName: aws.String(vars["DomainName"].(string)),
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeElasticsearchDomain should succeed after terraform apply",
+				)
 				require.NotNil(t, out.DomainStatus)
-				assert.Equal(t, vars["DomainName"].(string), aws.ToString(out.DomainStatus.DomainName))
+				assert.Equal(
+					t,
+					vars["DomainName"].(string),
+					aws.ToString(out.DomainStatus.DomainName),
+				)
 			},
 		},
 	}
@@ -2070,7 +2233,11 @@ func TestTerraform_Redshift(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeClusters should succeed after terraform apply")
 				require.Len(t, out.Clusters, 1)
-				assert.Equal(t, vars["ClusterID"].(string), aws.ToString(out.Clusters[0].ClusterIdentifier))
+				assert.Equal(
+					t,
+					vars["ClusterID"].(string),
+					aws.ToString(out.Clusters[0].ClusterIdentifier),
+				)
 			},
 		},
 	}
@@ -2104,10 +2271,17 @@ func TestTerraform_Firehose(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createFirehoseClient(t)
-				out, err := client.DescribeDeliveryStream(ctx, &firehosesvc.DescribeDeliveryStreamInput{
-					DeliveryStreamName: aws.String(vars["StreamName"].(string)),
-				})
-				require.NoError(t, err, "DescribeDeliveryStream should succeed after terraform apply")
+				out, err := client.DescribeDeliveryStream(
+					ctx,
+					&firehosesvc.DescribeDeliveryStreamInput{
+						DeliveryStreamName: aws.String(vars["StreamName"].(string)),
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeDeliveryStream should succeed after terraform apply",
+				)
 				require.NotNil(t, out.DeliveryStreamDescription)
 				assert.Equal(t,
 					vars["StreamName"].(string),
@@ -2253,9 +2427,12 @@ func TestTerraform_S3Control(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, _ map[string]any) {
 				t.Helper()
 				client := createS3ControlClient(t)
-				out, err := client.GetPublicAccessBlock(ctx, &s3controlsvc.GetPublicAccessBlockInput{
-					AccountId: aws.String("000000000000"),
-				})
+				out, err := client.GetPublicAccessBlock(
+					ctx,
+					&s3controlsvc.GetPublicAccessBlockInput{
+						AccountId: aws.String("000000000000"),
+					},
+				)
 				require.NoError(t, err, "GetPublicAccessBlock should succeed after terraform apply")
 				require.NotNil(t, out.PublicAccessBlockConfiguration)
 				assert.True(t, aws.ToBool(out.PublicAccessBlockConfiguration.BlockPublicAcls))
@@ -2329,7 +2506,10 @@ func TestTerraform_S3Encryption(t *testing.T) {
 				require.NoError(t, err, "GetBucketEncryption should succeed after terraform apply")
 				require.NotNil(t, out.ServerSideEncryptionConfiguration)
 				require.NotEmpty(t, out.ServerSideEncryptionConfiguration.Rules)
-				require.NotNil(t, out.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault)
+				require.NotNil(
+					t,
+					out.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault,
+				)
 				assert.Equal(
 					t,
 					s3types.ServerSideEncryptionAes256,
@@ -2369,12 +2549,23 @@ func TestTerraform_AWSConfig(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createAWSConfigClient(t)
-				out, err := client.DescribeConfigurationRecorders(ctx, &configsvc.DescribeConfigurationRecordersInput{
-					ConfigurationRecorderNames: []string{vars["RecorderName"].(string)},
-				})
-				require.NoError(t, err, "DescribeConfigurationRecorders should succeed after terraform apply")
+				out, err := client.DescribeConfigurationRecorders(
+					ctx,
+					&configsvc.DescribeConfigurationRecordersInput{
+						ConfigurationRecorderNames: []string{vars["RecorderName"].(string)},
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeConfigurationRecorders should succeed after terraform apply",
+				)
 				require.Len(t, out.ConfigurationRecorders, 1)
-				assert.Equal(t, vars["RecorderName"].(string), aws.ToString(out.ConfigurationRecorders[0].Name))
+				assert.Equal(
+					t,
+					vars["RecorderName"].(string),
+					aws.ToString(out.ConfigurationRecorders[0].Name),
+				)
 			},
 		},
 	}
@@ -2407,7 +2598,10 @@ func TestTerraform_Route53Resolver(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createRoute53ResolverClient(t)
-				out, err := client.ListResolverRules(ctx, &route53resolversvc.ListResolverRulesInput{})
+				out, err := client.ListResolverRules(
+					ctx,
+					&route53resolversvc.ListResolverRulesInput{},
+				)
 				require.NoError(t, err, "ListResolverRules should succeed after terraform apply")
 				found := false
 				for _, r := range out.ResolverRules {
@@ -2417,7 +2611,12 @@ func TestTerraform_Route53Resolver(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, found, "resolver rule %q should be listed", vars["RuleName"].(string))
+				assert.True(
+					t,
+					found,
+					"resolver rule %q should be listed",
+					vars["RuleName"].(string),
+				)
 			},
 		},
 	}
@@ -2450,8 +2649,15 @@ func TestTerraform_EC2(t *testing.T) {
 				client := createEC2Client(t)
 
 				// Verify the network interface exists.
-				descOut, err := client.DescribeNetworkInterfaces(ctx, &ec2svc.DescribeNetworkInterfacesInput{})
-				require.NoError(t, err, "DescribeNetworkInterfaces should succeed after terraform apply")
+				descOut, err := client.DescribeNetworkInterfaces(
+					ctx,
+					&ec2svc.DescribeNetworkInterfacesInput{},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeNetworkInterfaces should succeed after terraform apply",
+				)
 
 				eniDesc := vars["ENIDescription"].(string)
 				var found bool
@@ -2464,7 +2670,12 @@ func TestTerraform_EC2(t *testing.T) {
 					}
 				}
 
-				require.True(t, found, "network interface with description %q should exist", eniDesc)
+				require.True(
+					t,
+					found,
+					"network interface with description %q should exist",
+					eniDesc,
+				)
 			},
 		},
 		{
@@ -2483,8 +2694,15 @@ func TestTerraform_EC2(t *testing.T) {
 				client := createEC2Client(t)
 
 				// Verify the security group with the unique name was created.
-				sgOut, err := client.DescribeSecurityGroups(ctx, &ec2svc.DescribeSecurityGroupsInput{})
-				require.NoError(t, err, "DescribeSecurityGroups should succeed after terraform apply")
+				sgOut, err := client.DescribeSecurityGroups(
+					ctx,
+					&ec2svc.DescribeSecurityGroupsInput{},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeSecurityGroups should succeed after terraform apply",
+				)
 				sgName := vars["SGName"].(string)
 				var found bool
 				for _, sg := range sgOut.SecurityGroups {
@@ -2500,7 +2718,11 @@ func TestTerraform_EC2(t *testing.T) {
 				out, err := client.DescribeInstances(ctx, &ec2svc.DescribeInstancesInput{})
 				require.NoError(t, err, "DescribeInstances should succeed after terraform apply")
 				require.NotEmpty(t, out.Reservations, "at least one reservation should exist")
-				require.NotEmpty(t, out.Reservations[0].Instances, "at least one instance should exist")
+				require.NotEmpty(
+					t,
+					out.Reservations[0].Instances,
+					"at least one instance should exist",
+				)
 
 				// Verify that tags from the fixture's `tags = {}` blocks were stored
 				// (via TagSpecification on CreateVpc / standalone CreateTags).
@@ -2517,7 +2739,11 @@ func TestTerraform_EC2(t *testing.T) {
 					}
 				}
 
-				require.NotEmpty(t, vpcID, "VPC with CIDR 10.2.0.0/16 should exist after terraform apply")
+				require.NotEmpty(
+					t,
+					vpcID,
+					"VPC with CIDR 10.2.0.0/16 should exist after terraform apply",
+				)
 
 				// DescribeTags with resource-id filter to get tags for the fixture's VPC.
 				tagsOut, err := client.DescribeTags(ctx, &ec2svc.DescribeTagsInput{
@@ -2532,7 +2758,12 @@ func TestTerraform_EC2(t *testing.T) {
 					vpcTags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
 				}
 
-				assert.Equal(t, "test-vpc", vpcTags["Name"], "VPC should have Name=test-vpc tag from terraform fixture")
+				assert.Equal(
+					t,
+					"test-vpc",
+					vpcTags["Name"],
+					"VPC should have Name=test-vpc tag from terraform fixture",
+				)
 			},
 		},
 	}
@@ -2588,9 +2819,12 @@ func TestTerraform_ECRLambda(t *testing.T) {
 
 				// 1. Verify the ECR repository was created.
 				ecrClient := createECRClient(t)
-				repoOut, err := ecrClient.DescribeRepositories(ctx, &ecrsvc.DescribeRepositoriesInput{
-					RepositoryNames: []string{vars["RepoName"].(string)},
-				})
+				repoOut, err := ecrClient.DescribeRepositories(
+					ctx,
+					&ecrsvc.DescribeRepositoriesInput{
+						RepositoryNames: []string{vars["RepoName"].(string)},
+					},
+				)
 				require.NoError(t, err, "ECR DescribeRepositories should succeed")
 				require.Len(t, repoOut.Repositories, 1)
 
@@ -2604,7 +2838,11 @@ func TestTerraform_ECRLambda(t *testing.T) {
 				})
 				require.NoError(t, err, "GetFunction should succeed")
 				require.NotNil(t, fnOut.Configuration)
-				assert.Equal(t, vars["FuncName"].(string), aws.ToString(fnOut.Configuration.FunctionName))
+				assert.Equal(
+					t,
+					vars["FuncName"].(string),
+					aws.ToString(fnOut.Configuration.FunctionName),
+				)
 
 				// 3. Confirm the ECR repo URI is wired into the Lambda environment.
 				// This validates the cross-service Terraform wiring: ECR → Lambda env var.
@@ -2701,7 +2939,12 @@ func TestTerraform_APIGateway_DataPlane(t *testing.T) {
 						break
 					}
 				}
-				require.NotEmpty(t, apiID, "REST API %q should be present", vars["APIName"].(string))
+				require.NotEmpty(
+					t,
+					apiID,
+					"REST API %q should be present",
+					vars["APIName"].(string),
+				)
 
 				// Invoke the deployed API through the data-plane endpoint.
 				// The MOCK integration returns HTTP 200 with an empty body by default.
@@ -2714,8 +2957,13 @@ func TestTerraform_APIGateway_DataPlane(t *testing.T) {
 
 				defer resp.Body.Close()
 
-				assert.Equal(t, http.StatusOK, resp.StatusCode,
-					"data-plane request to /restapis/%s/prod/_user_request_/items should return 200", apiID)
+				assert.Equal(
+					t,
+					http.StatusOK,
+					resp.StatusCode,
+					"data-plane request to /restapis/%s/prod/_user_request_/items should return 200",
+					apiID,
+				)
 			},
 		},
 	}
@@ -2799,7 +3047,11 @@ func TestTerraform_AppSync(t *testing.T) {
 				}
 
 				require.NotEmpty(t, apiID, "API %q should appear in list", vars["APIName"])
-				assert.Equal(t, appsyncsdktypes.AuthenticationTypeApiKey, listOut.GraphqlApis[0].AuthenticationType)
+				assert.Equal(
+					t,
+					appsyncsdktypes.AuthenticationTypeApiKey,
+					listOut.GraphqlApis[0].AuthenticationType,
+				)
 
 				// Verify data source exists.
 				dsOut, err := client.GetDataSource(ctx, &appsyncsdkv2.GetDataSourceInput{
@@ -2888,12 +3140,23 @@ func TestTerraform_Autoscaling(t *testing.T) {
 
 				client := createAutoscalingClient(t)
 
-				out, err := client.DescribeAutoScalingGroups(ctx, &autoscalingsvc.DescribeAutoScalingGroupsInput{
-					AutoScalingGroupNames: []string{vars["ASGName"].(string)},
-				})
-				require.NoError(t, err, "DescribeAutoScalingGroups should succeed after terraform apply")
+				out, err := client.DescribeAutoScalingGroups(
+					ctx,
+					&autoscalingsvc.DescribeAutoScalingGroupsInput{
+						AutoScalingGroupNames: []string{vars["ASGName"].(string)},
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeAutoScalingGroups should succeed after terraform apply",
+				)
 				require.Len(t, out.AutoScalingGroups, 1)
-				assert.Equal(t, vars["ASGName"].(string), aws.ToString(out.AutoScalingGroups[0].AutoScalingGroupName))
+				assert.Equal(
+					t,
+					vars["ASGName"].(string),
+					aws.ToString(out.AutoScalingGroups[0].AutoScalingGroupName),
+				)
 				assert.Equal(t, int32(1), aws.ToInt32(out.AutoScalingGroups[0].MinSize))
 				assert.Equal(t, int32(5), aws.ToInt32(out.AutoScalingGroups[0].MaxSize))
 
@@ -3008,10 +3271,17 @@ func TestTerraform_ECS(t *testing.T) {
 				assert.Equal(t, vars["ClusterName"].(string), *clusterOut.Clusters[0].ClusterName)
 
 				// Verify task definition exists.
-				tdOut, err := client.DescribeTaskDefinition(ctx, &ecssvc.DescribeTaskDefinitionInput{
-					TaskDefinition: aws.String(vars["Family"].(string)),
-				})
-				require.NoError(t, err, "DescribeTaskDefinition should succeed after terraform apply")
+				tdOut, err := client.DescribeTaskDefinition(
+					ctx,
+					&ecssvc.DescribeTaskDefinitionInput{
+						TaskDefinition: aws.String(vars["Family"].(string)),
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeTaskDefinition should succeed after terraform apply",
+				)
 				assert.Equal(t, vars["Family"].(string), *tdOut.TaskDefinition.Family)
 
 				// Verify service exists.
@@ -3060,9 +3330,12 @@ func TestTerraform_CognitoIdentityPool(t *testing.T) {
 				client := createCognitoIdentityClient(t)
 
 				// List pools and find ours by name.
-				listOut, err := client.ListIdentityPools(ctx, &cognitoidentitysvc.ListIdentityPoolsInput{
-					MaxResults: aws.Int32(60),
-				})
+				listOut, err := client.ListIdentityPools(
+					ctx,
+					&cognitoidentitysvc.ListIdentityPoolsInput{
+						MaxResults: aws.Int32(60),
+					},
+				)
 				require.NoError(t, err, "ListIdentityPools should succeed after terraform apply")
 
 				var poolID string
@@ -3075,25 +3348,48 @@ func TestTerraform_CognitoIdentityPool(t *testing.T) {
 					}
 				}
 
-				require.NotEmpty(t, poolID, "identity pool %q should appear in list", vars["PoolName"])
+				require.NotEmpty(
+					t,
+					poolID,
+					"identity pool %q should appear in list",
+					vars["PoolName"],
+				)
 
 				// Describe pool to confirm it exists.
-				descOut, err := client.DescribeIdentityPool(ctx, &cognitoidentitysvc.DescribeIdentityPoolInput{
-					IdentityPoolId: aws.String(poolID),
-				})
+				descOut, err := client.DescribeIdentityPool(
+					ctx,
+					&cognitoidentitysvc.DescribeIdentityPoolInput{
+						IdentityPoolId: aws.String(poolID),
+					},
+				)
 				require.NoError(t, err, "DescribeIdentityPool should succeed after terraform apply")
 				assert.Equal(t, vars["PoolName"].(string), aws.ToString(descOut.IdentityPoolName))
 				assert.True(t, descOut.AllowUnauthenticatedIdentities)
 
 				// Verify roles were attached via GetIdentityPoolRoles.
-				rolesOut, err := client.GetIdentityPoolRoles(ctx, &cognitoidentitysvc.GetIdentityPoolRolesInput{
-					IdentityPoolId: aws.String(poolID),
-				})
+				rolesOut, err := client.GetIdentityPoolRoles(
+					ctx,
+					&cognitoidentitysvc.GetIdentityPoolRolesInput{
+						IdentityPoolId: aws.String(poolID),
+					},
+				)
 				require.NoError(t, err, "GetIdentityPoolRoles should succeed after terraform apply")
-				assert.NotEmpty(t, rolesOut.Roles["authenticated"], "authenticated role ARN should be set")
-				assert.NotEmpty(t, rolesOut.Roles["unauthenticated"], "unauthenticated role ARN should be set")
+				assert.NotEmpty(
+					t,
+					rolesOut.Roles["authenticated"],
+					"authenticated role ARN should be set",
+				)
+				assert.NotEmpty(
+					t,
+					rolesOut.Roles["unauthenticated"],
+					"unauthenticated role ARN should be set",
+				)
 				assert.Contains(t, rolesOut.Roles["authenticated"], vars["AuthRoleName"].(string))
-				assert.Contains(t, rolesOut.Roles["unauthenticated"], vars["UnauthRoleName"].(string))
+				assert.Contains(
+					t,
+					rolesOut.Roles["unauthenticated"],
+					vars["UnauthRoleName"].(string),
+				)
 			},
 		},
 	}
@@ -3216,17 +3512,23 @@ func TestTerraform_CognitoIDP(t *testing.T) {
 				require.NotEmpty(t, poolID, "user pool %q should appear in list", vars["PoolName"])
 
 				// Describe the pool.
-				descOut, err := sdkClient.DescribeUserPool(ctx, &cognitoidpsvc.DescribeUserPoolInput{
-					UserPoolId: aws.String(poolID),
-				})
+				descOut, err := sdkClient.DescribeUserPool(
+					ctx,
+					&cognitoidpsvc.DescribeUserPoolInput{
+						UserPoolId: aws.String(poolID),
+					},
+				)
 				require.NoError(t, err, "DescribeUserPool should succeed")
 				assert.Equal(t, vars["PoolName"].(string), aws.ToString(descOut.UserPool.Name))
 
 				// List clients for the pool and find ours by name.
-				clientsOut, err := sdkClient.ListUserPoolClients(ctx, &cognitoidpsvc.ListUserPoolClientsInput{
-					UserPoolId: aws.String(poolID),
-					MaxResults: aws.Int32(maxUserPoolsToList),
-				})
+				clientsOut, err := sdkClient.ListUserPoolClients(
+					ctx,
+					&cognitoidpsvc.ListUserPoolClientsInput{
+						UserPoolId: aws.String(poolID),
+						MaxResults: aws.Int32(maxUserPoolsToList),
+					},
+				)
 				require.NoError(t, err, "ListUserPoolClients should succeed")
 
 				var clientID string
@@ -3239,15 +3541,27 @@ func TestTerraform_CognitoIDP(t *testing.T) {
 					}
 				}
 
-				require.NotEmpty(t, clientID, "user pool client %q should appear in list", vars["ClientName"])
+				require.NotEmpty(
+					t,
+					clientID,
+					"user pool client %q should appear in list",
+					vars["ClientName"],
+				)
 
 				// Describe the client.
-				descClientOut, err := sdkClient.DescribeUserPoolClient(ctx, &cognitoidpsvc.DescribeUserPoolClientInput{
-					UserPoolId: aws.String(poolID),
-					ClientId:   aws.String(clientID),
-				})
+				descClientOut, err := sdkClient.DescribeUserPoolClient(
+					ctx,
+					&cognitoidpsvc.DescribeUserPoolClientInput{
+						UserPoolId: aws.String(poolID),
+						ClientId:   aws.String(clientID),
+					},
+				)
 				require.NoError(t, err, "DescribeUserPoolClient should succeed")
-				assert.Equal(t, vars["ClientName"].(string), aws.ToString(descClientOut.UserPoolClient.ClientName))
+				assert.Equal(
+					t,
+					vars["ClientName"].(string),
+					aws.ToString(descClientOut.UserPoolClient.ClientName),
+				)
 			},
 		},
 	}
@@ -3478,7 +3792,9 @@ func TestTerraform_APIGatewayManagementAPI(t *testing.T) {
 					ctx,
 					http.MethodPost,
 					createURL,
-					strings.NewReader("connectionId="+connectionID+"&sourceIp=10.0.0.1&userAgent=test-agent"),
+					strings.NewReader(
+						"connectionId="+connectionID+"&sourceIp=10.0.0.1&userAgent=test-agent",
+					),
 				)
 				require.NoError(t, err, "creating dashboard create request should succeed")
 				createReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -3491,7 +3807,12 @@ func TestTerraform_APIGatewayManagementAPI(t *testing.T) {
 				createResp, err := createClient.Do(createReq)
 				require.NoError(t, err, "dashboard create connection request should succeed")
 				defer createResp.Body.Close()
-				assert.Equal(t, http.StatusFound, createResp.StatusCode, "create connection should redirect")
+				assert.Equal(
+					t,
+					http.StatusFound,
+					createResp.StatusCode,
+					"create connection should redirect",
+				)
 
 				// GetConnection via /@connections/{connectionId}.
 				getURL := endpoint + "/@connections/" + connectionID
@@ -3502,7 +3823,12 @@ func TestTerraform_APIGatewayManagementAPI(t *testing.T) {
 				getResp, err := http.DefaultClient.Do(getReq)
 				require.NoError(t, err, "GetConnection should succeed")
 				defer getResp.Body.Close()
-				assert.Equal(t, http.StatusOK, getResp.StatusCode, "GetConnection should return 200")
+				assert.Equal(
+					t,
+					http.StatusOK,
+					getResp.StatusCode,
+					"GetConnection should return 200",
+				)
 
 				// PostToConnection via /@connections/{connectionId}.
 				postURL := endpoint + "/@connections/" + connectionID
@@ -3519,7 +3845,12 @@ func TestTerraform_APIGatewayManagementAPI(t *testing.T) {
 				postResp, err := http.DefaultClient.Do(postReq)
 				require.NoError(t, err, "PostToConnection should succeed")
 				defer postResp.Body.Close()
-				assert.Equal(t, http.StatusOK, postResp.StatusCode, "PostToConnection should return 200")
+				assert.Equal(
+					t,
+					http.StatusOK,
+					postResp.StatusCode,
+					"PostToConnection should return 200",
+				)
 
 				// DeleteConnection via /@connections/{connectionId}.
 				delURL := endpoint + "/@connections/" + connectionID
@@ -3530,7 +3861,12 @@ func TestTerraform_APIGatewayManagementAPI(t *testing.T) {
 				delResp, err := http.DefaultClient.Do(delReq)
 				require.NoError(t, err, "DeleteConnection should succeed")
 				defer delResp.Body.Close()
-				assert.Equal(t, http.StatusNoContent, delResp.StatusCode, "DeleteConnection should return 204")
+				assert.Equal(
+					t,
+					http.StatusNoContent,
+					delResp.StatusCode,
+					"DeleteConnection should return 204",
+				)
 
 				// GetConnection after delete should return 410.
 				getReq2, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
@@ -3539,7 +3875,12 @@ func TestTerraform_APIGatewayManagementAPI(t *testing.T) {
 				getResp2, err := http.DefaultClient.Do(getReq2)
 				require.NoError(t, err, "GetConnection after delete should not error")
 				defer getResp2.Body.Close()
-				assert.Equal(t, http.StatusGone, getResp2.StatusCode, "GetConnection after delete should return 410")
+				assert.Equal(
+					t,
+					http.StatusGone,
+					getResp2.StatusCode,
+					"GetConnection after delete should return 410",
+				)
 			},
 		},
 	}
@@ -3590,18 +3931,29 @@ func TestTerraform_AppConfig(t *testing.T) {
 				require.NoError(t, err, "ListEnvironments should succeed")
 				require.NotEmpty(t, envsOut.Items, "should have at least one environment")
 
-				profilesOut, err := client.ListConfigurationProfiles(ctx, &appconfigsvc.ListConfigurationProfilesInput{
-					ApplicationId: aws.String(appID),
-				})
+				profilesOut, err := client.ListConfigurationProfiles(
+					ctx,
+					&appconfigsvc.ListConfigurationProfilesInput{
+						ApplicationId: aws.String(appID),
+					},
+				)
 				require.NoError(t, err, "ListConfigurationProfiles should succeed")
-				require.NotEmpty(t, profilesOut.Items, "should have at least one configuration profile")
+				require.NotEmpty(
+					t,
+					profilesOut.Items,
+					"should have at least one configuration profile",
+				)
 
 				strategiesOut, err := client.ListDeploymentStrategies(
 					ctx,
 					&appconfigsvc.ListDeploymentStrategiesInput{},
 				)
 				require.NoError(t, err, "ListDeploymentStrategies should succeed")
-				require.NotEmpty(t, strategiesOut.Items, "should have at least one deployment strategy")
+				require.NotEmpty(
+					t,
+					strategiesOut.Items,
+					"should have at least one deployment strategy",
+				)
 			},
 		},
 	}
@@ -3678,7 +4030,12 @@ func TestTerraform_AppConfigData(t *testing.T) {
 				setResp, err := setClient.Do(setReq)
 				require.NoError(t, err, "set configuration request should succeed")
 				defer setResp.Body.Close()
-				assert.Equal(t, http.StatusFound, setResp.StatusCode, "set configuration should redirect")
+				assert.Equal(
+					t,
+					http.StatusFound,
+					setResp.StatusCode,
+					"set configuration should redirect",
+				)
 
 				// Start a configuration session via the AppConfigData API.
 				client := createAppConfigDataClient(t)
@@ -3691,8 +4048,16 @@ func TestTerraform_AppConfigData(t *testing.T) {
 					},
 				)
 				require.NoError(t, err, "StartConfigurationSession should succeed")
-				require.NotNil(t, sessionOut.InitialConfigurationToken, "initial token should not be nil")
-				assert.NotEmpty(t, *sessionOut.InitialConfigurationToken, "initial token should not be empty")
+				require.NotNil(
+					t,
+					sessionOut.InitialConfigurationToken,
+					"initial token should not be nil",
+				)
+				assert.NotEmpty(
+					t,
+					*sessionOut.InitialConfigurationToken,
+					"initial token should not be empty",
+				)
 
 				// Get latest configuration.
 				configOut, err := client.GetLatestConfiguration(ctx,
@@ -3711,9 +4076,17 @@ func TestTerraform_AppConfigData(t *testing.T) {
 				)
 
 				// Next token should rotate.
-				assert.NotNil(t, configOut.NextPollConfigurationToken, "next token should not be nil")
-				assert.NotEqual(t, *sessionOut.InitialConfigurationToken, *configOut.NextPollConfigurationToken,
-					"next token should differ from initial token")
+				assert.NotNil(
+					t,
+					configOut.NextPollConfigurationToken,
+					"next token should not be nil",
+				)
+				assert.NotEqual(
+					t,
+					*sessionOut.InitialConfigurationToken,
+					*configOut.NextPollConfigurationToken,
+					"next token should differ from initial token",
+				)
 
 				// Poll again with the new token to verify token rotation.
 				configOut2, err := client.GetLatestConfiguration(ctx,
@@ -3723,9 +4096,17 @@ func TestTerraform_AppConfigData(t *testing.T) {
 				)
 				require.NoError(t, err, "second GetLatestConfiguration should succeed")
 				require.NotNil(t, configOut2, "second config output should not be nil")
-				require.NotNil(t, configOut2.NextPollConfigurationToken, "second next token should not be nil")
-				assert.NotEqual(t, *configOut.NextPollConfigurationToken, *configOut2.NextPollConfigurationToken,
-					"token should rotate on each successive poll")
+				require.NotNil(
+					t,
+					configOut2.NextPollConfigurationToken,
+					"second next token should not be nil",
+				)
+				assert.NotEqual(
+					t,
+					*configOut.NextPollConfigurationToken,
+					*configOut2.NextPollConfigurationToken,
+					"token should rotate on each successive poll",
+				)
 			},
 		},
 	}
@@ -3756,10 +4137,17 @@ func TestTerraform_ApplicationAutoscaling(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createApplicationAutoscalingClient(t)
-				out, err := client.DescribeScalableTargets(ctx, &applicationautoscalingsvc.DescribeScalableTargetsInput{
-					ServiceNamespace: applicationautoscalingtypes.ServiceNamespaceEcs,
-				})
-				require.NoError(t, err, "DescribeScalableTargets should succeed after terraform apply")
+				out, err := client.DescribeScalableTargets(
+					ctx,
+					&applicationautoscalingsvc.DescribeScalableTargetsInput{
+						ServiceNamespace: applicationautoscalingtypes.ServiceNamespaceEcs,
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeScalableTargets should succeed after terraform apply",
+				)
 
 				expectedResourceID := "service/default/" + vars["ServiceName"].(string)
 				found := false
@@ -3817,7 +4205,12 @@ func TestTerraform_Athena(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, found, "workgroup %q should be listed", vars["WorkGroupName"].(string))
+				assert.True(
+					t,
+					found,
+					"workgroup %q should be listed",
+					vars["WorkGroupName"].(string),
+				)
 			},
 		},
 	}
@@ -3894,12 +4287,19 @@ func TestTerraform_Batch(t *testing.T) {
 				client := createBatchClient(t)
 				suffix := vars["Suffix"].(string)
 
-				ceOut, err := client.DescribeComputeEnvironments(ctx, &batchsvc.DescribeComputeEnvironmentsInput{
-					ComputeEnvironments: []string{"tf-ce-" + suffix},
-				})
+				ceOut, err := client.DescribeComputeEnvironments(
+					ctx,
+					&batchsvc.DescribeComputeEnvironmentsInput{
+						ComputeEnvironments: []string{"tf-ce-" + suffix},
+					},
+				)
 				require.NoError(t, err, "DescribeComputeEnvironments should succeed")
 				require.Len(t, ceOut.ComputeEnvironments, 1, "compute environment should exist")
-				assert.Equal(t, "tf-ce-"+suffix, *ceOut.ComputeEnvironments[0].ComputeEnvironmentName)
+				assert.Equal(
+					t,
+					"tf-ce-"+suffix,
+					*ceOut.ComputeEnvironments[0].ComputeEnvironmentName,
+				)
 
 				jqOut, err := client.DescribeJobQueues(ctx, &batchsvc.DescribeJobQueuesInput{
 					JobQueues: []string{"tf-jq-" + suffix},
@@ -3942,16 +4342,22 @@ func TestTerraform_Elasticbeanstalk(t *testing.T) {
 				appName := "tf-app-" + suffix
 				envName := "tf-env-" + suffix
 
-				appOut, err := client.DescribeApplications(ctx, &elasticbeanstalksvc.DescribeApplicationsInput{
-					ApplicationNames: []string{appName},
-				})
+				appOut, err := client.DescribeApplications(
+					ctx,
+					&elasticbeanstalksvc.DescribeApplicationsInput{
+						ApplicationNames: []string{appName},
+					},
+				)
 				require.NoError(t, err, "DescribeApplications should succeed")
 				require.Len(t, appOut.Applications, 1, "application should exist")
 				assert.Equal(t, appName, *appOut.Applications[0].ApplicationName)
 
-				envOut, err := client.DescribeEnvironments(ctx, &elasticbeanstalksvc.DescribeEnvironmentsInput{
-					EnvironmentNames: []string{envName},
-				})
+				envOut, err := client.DescribeEnvironments(
+					ctx,
+					&elasticbeanstalksvc.DescribeEnvironmentsInput{
+						EnvironmentNames: []string{envName},
+					},
+				)
 				require.NoError(t, err, "DescribeEnvironments should succeed")
 				require.Len(t, envOut.Environments, 1, "environment should exist")
 				assert.Equal(t, envName, *envOut.Environments[0].EnvironmentName)
@@ -4027,28 +4433,45 @@ func TestTerraform_EKSComprehensive(t *testing.T) {
 				// Verify cluster exists.
 				out, err := client.ListClusters(ctx, &ekssvc.ListClustersInput{})
 				require.NoError(t, err, "ListClusters should succeed")
-				assert.True(t, slices.Contains(out.Clusters, clusterName), "cluster %q should be listed", clusterName)
+				assert.True(
+					t,
+					slices.Contains(out.Clusters, clusterName),
+					"cluster %q should be listed",
+					clusterName,
+				)
 
 				// Verify node group exists with scaling config.
 				ngOut, err := client.ListNodegroups(ctx, &ekssvc.ListNodegroupsInput{
 					ClusterName: &clusterName,
 				})
 				require.NoError(t, err, "ListNodegroups should succeed")
-				assert.True(t, slices.Contains(ngOut.Nodegroups, "workers"), "nodegroup 'workers' should be listed")
+				assert.True(
+					t,
+					slices.Contains(ngOut.Nodegroups, "workers"),
+					"nodegroup 'workers' should be listed",
+				)
 
 				// Verify Fargate profile exists.
 				fpOut, err := client.ListFargateProfiles(ctx, &ekssvc.ListFargateProfilesInput{
 					ClusterName: &clusterName,
 				})
 				require.NoError(t, err, "ListFargateProfiles should succeed")
-				assert.True(t, slices.Contains(fpOut.FargateProfileNames, "serverless"), "fargate profile 'serverless' should be listed")
+				assert.True(
+					t,
+					slices.Contains(fpOut.FargateProfileNames, "serverless"),
+					"fargate profile 'serverless' should be listed",
+				)
 
 				// Verify add-on exists.
 				addonOut, err := client.ListAddons(ctx, &ekssvc.ListAddonsInput{
 					ClusterName: &clusterName,
 				})
 				require.NoError(t, err, "ListAddons should succeed")
-				assert.True(t, slices.Contains(addonOut.Addons, "coredns"), "addon 'coredns' should be listed")
+				assert.True(
+					t,
+					slices.Contains(addonOut.Addons, "coredns"),
+					"addon 'coredns' should be listed",
+				)
 
 				// Verify access entry exists.
 				aeOut, err := client.ListAccessEntries(ctx, &ekssvc.ListAccessEntriesInput{
@@ -4185,8 +4608,15 @@ func TestTerraform_Ce(t *testing.T) {
 			verify: func(t *testing.T, ctx context.Context, vars map[string]any) {
 				t.Helper()
 				client := createCeClient(t)
-				out, err := client.ListCostCategoryDefinitions(ctx, &cesvc.ListCostCategoryDefinitionsInput{})
-				require.NoError(t, err, "ListCostCategoryDefinitions should succeed after terraform apply")
+				out, err := client.ListCostCategoryDefinitions(
+					ctx,
+					&cesvc.ListCostCategoryDefinitionsInput{},
+				)
+				require.NoError(
+					t,
+					err,
+					"ListCostCategoryDefinitions should succeed after terraform apply",
+				)
 
 				found := false
 				for _, ref := range out.CostCategoryReferences {
@@ -4196,7 +4626,12 @@ func TestTerraform_Ce(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, found, "cost category %q should be listed", vars["CategoryName"].(string))
+				assert.True(
+					t,
+					found,
+					"cost category %q should be listed",
+					vars["CategoryName"].(string),
+				)
 			},
 		},
 	}
@@ -4297,7 +4732,12 @@ func TestTerraform_CloudControl(t *testing.T) {
 					}
 				}
 
-				assert.NotEmpty(t, foundIdentifier, "cloudcontrol resource %q should be listed", expectedName)
+				assert.NotEmpty(
+					t,
+					foundIdentifier,
+					"cloudcontrol resource %q should be listed",
+					expectedName,
+				)
 
 				if foundIdentifier != "" {
 					getOut, getErr := client.GetResource(ctx, &cloudcontrolsvc.GetResourceInput{
@@ -4305,7 +4745,11 @@ func TestTerraform_CloudControl(t *testing.T) {
 						Identifier: aws.String(foundIdentifier),
 					})
 					require.NoError(t, getErr, "GetResource should succeed after terraform apply")
-					require.NotNil(t, getOut.ResourceDescription, "resource description should not be nil")
+					require.NotNil(
+						t,
+						getOut.ResourceDescription,
+						"resource description should not be nil",
+					)
 				}
 			},
 		},
@@ -4341,7 +4785,11 @@ func TestTerraform_CloudFront(t *testing.T) {
 					ctx,
 					&cloudfrontsvc.ListCloudFrontOriginAccessIdentitiesInput{},
 				)
-				require.NoError(t, err, "ListCloudFrontOriginAccessIdentities should succeed after terraform apply")
+				require.NoError(
+					t,
+					err,
+					"ListCloudFrontOriginAccessIdentities should succeed after terraform apply",
+				)
 				found := false
 				for _, oai := range out.CloudFrontOriginAccessIdentityList.Items {
 					if aws.ToString(oai.Comment) == "OAI-"+suffix {
@@ -4434,10 +4882,13 @@ func TestTerraform_CodeArtifact(t *testing.T) {
 				assert.Equal(t, domainName, aws.ToString(domainOut.Domain.Name))
 
 				// Verify the repository was created.
-				repoOut, err := client.DescribeRepository(ctx, &codeartifactsvc.DescribeRepositoryInput{
-					Domain:     aws.String(domainName),
-					Repository: aws.String(repoName),
-				})
+				repoOut, err := client.DescribeRepository(
+					ctx,
+					&codeartifactsvc.DescribeRepositoryInput{
+						Domain:     aws.String(domainName),
+						Repository: aws.String(repoName),
+					},
+				)
 				require.NoError(t, err, "DescribeRepository should succeed after terraform apply")
 				require.NotNil(t, repoOut.Repository, "repository should be returned")
 				assert.Equal(t, repoName, aws.ToString(repoOut.Repository.Name))
@@ -4639,17 +5090,32 @@ func TestTerraform_DMS(t *testing.T) {
 				client := createDMSClient(t)
 				instanceID := vars["InstanceID"].(string)
 
-				out, err := client.DescribeReplicationInstances(ctx, &dmssvc.DescribeReplicationInstancesInput{
-					Filters: []dmstypes.Filter{
-						{
-							Name:   aws.String("replication-instance-id"),
-							Values: []string{instanceID},
+				out, err := client.DescribeReplicationInstances(
+					ctx,
+					&dmssvc.DescribeReplicationInstancesInput{
+						Filters: []dmstypes.Filter{
+							{
+								Name:   aws.String("replication-instance-id"),
+								Values: []string{instanceID},
+							},
 						},
 					},
-				})
-				require.NoError(t, err, "DescribeReplicationInstances should succeed after terraform apply")
-				require.NotEmpty(t, out.ReplicationInstances, "replication instance should be returned")
-				assert.Equal(t, instanceID, aws.ToString(out.ReplicationInstances[0].ReplicationInstanceIdentifier))
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeReplicationInstances should succeed after terraform apply",
+				)
+				require.NotEmpty(
+					t,
+					out.ReplicationInstances,
+					"replication instance should be returned",
+				)
+				assert.Equal(
+					t,
+					instanceID,
+					aws.ToString(out.ReplicationInstances[0].ReplicationInstanceIdentifier),
+				)
 			},
 		},
 	}
@@ -4682,7 +5148,10 @@ func TestTerraform_CodeStarConnections(t *testing.T) {
 				client := createCodeStarConnectionsClient(t)
 				suffix := vars["Suffix"].(string)
 
-				out, err := client.ListConnections(ctx, &codestarconnectionssvc.ListConnectionsInput{})
+				out, err := client.ListConnections(
+					ctx,
+					&codestarconnectionssvc.ListConnectionsInput{},
+				)
 				require.NoError(t, err)
 
 				found := false
@@ -4833,9 +5302,17 @@ func TestTerraform_ELB(t *testing.T) {
 				out, err := client.DescribeLoadBalancers(ctx, &elbsvc.DescribeLoadBalancersInput{
 					LoadBalancerNames: []string{name},
 				})
-				require.NoError(t, err, "DescribeLoadBalancers should succeed after terraform apply")
+				require.NoError(
+					t,
+					err,
+					"DescribeLoadBalancers should succeed after terraform apply",
+				)
 				require.Len(t, out.LoadBalancerDescriptions, 1, "load balancer should exist")
-				assert.Equal(t, name, aws.ToString(out.LoadBalancerDescriptions[0].LoadBalancerName))
+				assert.Equal(
+					t,
+					name,
+					aws.ToString(out.LoadBalancerDescriptions[0].LoadBalancerName),
+				)
 			},
 		},
 	}
@@ -4967,10 +5444,17 @@ func TestTerraform_ELBv2(t *testing.T) {
 				lbName := "tf-alb-" + suffix
 				tgName := "tf-tg-" + suffix
 
-				lbOut, err := client.DescribeLoadBalancers(ctx, &elbv2svc.DescribeLoadBalancersInput{
-					Names: []string{lbName},
-				})
-				require.NoError(t, err, "DescribeLoadBalancers should succeed after terraform apply")
+				lbOut, err := client.DescribeLoadBalancers(
+					ctx,
+					&elbv2svc.DescribeLoadBalancersInput{
+						Names: []string{lbName},
+					},
+				)
+				require.NoError(
+					t,
+					err,
+					"DescribeLoadBalancers should succeed after terraform apply",
+				)
 				require.Len(t, lbOut.LoadBalancers, 1, "load balancer should exist")
 				assert.Equal(t, lbName, *lbOut.LoadBalancers[0].LoadBalancerName)
 
@@ -5023,8 +5507,15 @@ func TestTerraform_FIS(t *testing.T) {
 				suffix := vars["Suffix"].(string)
 				description := "tf-fis-" + suffix
 
-				out, err := client.ListExperimentTemplates(ctx, &fissvc.ListExperimentTemplatesInput{})
-				require.NoError(t, err, "ListExperimentTemplates should succeed after terraform apply")
+				out, err := client.ListExperimentTemplates(
+					ctx,
+					&fissvc.ListExperimentTemplatesInput{},
+				)
+				require.NoError(
+					t,
+					err,
+					"ListExperimentTemplates should succeed after terraform apply",
+				)
 
 				found := slices.ContainsFunc(
 					out.ExperimentTemplates,
@@ -5209,7 +5700,10 @@ func TestTerraform_KinesisAnalytics(t *testing.T) {
 				client := createKinesisAnalyticsClient(t)
 				appName := vars["AppName"].(string)
 
-				out, err := client.ListApplications(ctx, &kinesisanalyticssvc.ListApplicationsInput{})
+				out, err := client.ListApplications(
+					ctx,
+					&kinesisanalyticssvc.ListApplicationsInput{},
+				)
 				require.NoError(t, err, "ListApplications should succeed after terraform apply")
 
 				found := false
@@ -5271,7 +5765,12 @@ func TestTerraform_Kafka(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "cluster %q should be listed after terraform apply", clusterName)
+				assert.True(
+					t,
+					found,
+					"cluster %q should be listed after terraform apply",
+					clusterName,
+				)
 			},
 		},
 	}
@@ -5307,7 +5806,10 @@ func TestTerraform_KinesisAnalyticsV2(t *testing.T) {
 				suffix := vars["Suffix"].(string)
 				appName := "tf-kinesisanalyticsv2-" + suffix
 
-				out, err := client.ListApplications(ctx, &kinesisanalyticsv2svc.ListApplicationsInput{})
+				out, err := client.ListApplications(
+					ctx,
+					&kinesisanalyticsv2svc.ListApplicationsInput{},
+				)
 				require.NoError(t, err, "ListApplications should succeed after terraform apply")
 
 				found := false
@@ -5319,7 +5821,12 @@ func TestTerraform_KinesisAnalyticsV2(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "application %q should be listed after terraform apply", appName)
+				assert.True(
+					t,
+					found,
+					"application %q should be listed after terraform apply",
+					appName,
+				)
 			},
 		},
 	}
@@ -5419,7 +5926,12 @@ func TestTerraform_MQ(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "broker %q should be listed after terraform apply", brokerName)
+				assert.True(
+					t,
+					found,
+					"broker %q should be listed after terraform apply",
+					brokerName,
+				)
 			},
 		},
 	}
@@ -5450,7 +5962,10 @@ func TestTerraform_LakeFormation(t *testing.T) {
 				t.Helper()
 				client := createLakeFormationClient(t)
 
-				out, err := client.GetDataLakeSettings(ctx, &lakeformationsvc.GetDataLakeSettingsInput{})
+				out, err := client.GetDataLakeSettings(
+					ctx,
+					&lakeformationsvc.GetDataLakeSettingsInput{},
+				)
 				require.NoError(t, err, "GetDataLakeSettings should succeed after terraform apply")
 				require.NotNil(t, out.DataLakeSettings, "DataLakeSettings should not be nil")
 			},
@@ -5582,7 +6097,10 @@ func TestTerraform_Organizations(t *testing.T) {
 
 				client := createOrganizationsClient(t)
 
-				out, err := client.DescribeOrganization(ctx, &organizationssvc.DescribeOrganizationInput{})
+				out, err := client.DescribeOrganization(
+					ctx,
+					&organizationssvc.DescribeOrganizationInput{},
+				)
 				require.NoError(t, err, "DescribeOrganization should succeed after terraform apply")
 				require.NotNil(t, out.Organization)
 				assert.Equal(t, "ALL", string(out.Organization.FeatureSet))
@@ -5612,7 +6130,11 @@ func TestTerraform_Organizations(t *testing.T) {
 					}
 				}
 
-				assert.True(t, found, "created OU should appear in ListOrganizationalUnitsForParent output")
+				assert.True(
+					t,
+					found,
+					"created OU should appear in ListOrganizationalUnitsForParent output",
+				)
 			},
 		},
 	}
@@ -5654,7 +6176,11 @@ func TestTerraform_MWAA(t *testing.T) {
 
 				found := slices.Contains(out.Environments, envName)
 
-				assert.True(t, found, "created environment should appear in ListEnvironments output")
+				assert.True(
+					t,
+					found,
+					"created environment should appear in ListEnvironments output",
+				)
 			},
 		},
 	}
@@ -5787,7 +6313,9 @@ func TestTerraform_QLDBSession(t *testing.T) {
 				)
 				assert.NotEmpty(
 					t,
-					aws.ToString(out.StartSession.SessionToken), //nolint:staticcheck // deprecated SDK
+					aws.ToString(
+						out.StartSession.SessionToken, //nolint:staticcheck // StartSession.SessionToken is deprecated
+					),
 					"session token should not be empty",
 				)
 			},
@@ -5915,7 +6443,11 @@ func TestTerraform_RAM(t *testing.T) {
 				})
 				require.NoError(t, err, "GetResourceShares should succeed after terraform apply")
 				require.NotEmpty(t, out.ResourceShares, "expected at least one resource share")
-				assert.Equal(t, vars["ShareName"].(string), aws.ToString(out.ResourceShares[0].Name))
+				assert.Equal(
+					t,
+					vars["ShareName"].(string),
+					aws.ToString(out.ResourceShares[0].Name),
+				)
 			},
 		},
 	}
@@ -6113,7 +6645,13 @@ func TestTerraform_ServerlessRepo(t *testing.T) {
 				body, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK, body: %s", string(body))
+				assert.Equal(
+					t,
+					http.StatusOK,
+					resp.StatusCode,
+					"expected 200 OK, body: %s",
+					string(body),
+				)
 
 				var result map[string]any
 				require.NoError(t, json.Unmarshal(body, &result))
@@ -6168,7 +6706,13 @@ func TestTerraform_Shield(t *testing.T) {
 				respBody, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK, body: %s", string(respBody))
+				assert.Equal(
+					t,
+					http.StatusOK,
+					resp.StatusCode,
+					"expected 200 OK, body: %s",
+					string(respBody),
+				)
 
 				var result map[string]string
 				require.NoError(t, json.Unmarshal(respBody, &result))
@@ -6221,10 +6765,13 @@ func TestTerraform_SsoAdmin(t *testing.T) {
 				found := false
 
 				for _, psArn := range out.PermissionSets {
-					desc, descErr := client.DescribePermissionSet(ctx, &ssoadminsvc.DescribePermissionSetInput{
-						InstanceArn:      &instanceArn,
-						PermissionSetArn: &psArn,
-					})
+					desc, descErr := client.DescribePermissionSet(
+						ctx,
+						&ssoadminsvc.DescribePermissionSetInput{
+							InstanceArn:      &instanceArn,
+							PermissionSetArn: &psArn,
+						},
+					)
 					if descErr == nil && aws.ToString(desc.PermissionSet.Name) == psName {
 						found = true
 
@@ -6269,7 +6816,11 @@ func TestTerraform_Textract(t *testing.T) {
 				key, _ := vars["Key"].(string)
 
 				reqURL := endpoint + "/"
-				body := fmt.Sprintf(`{"Document":{"S3Object":{"Bucket":"%s","Name":"%s"}}}`, bucket, key)
+				body := fmt.Sprintf(
+					`{"Document":{"S3Object":{"Bucket":"%s","Name":"%s"}}}`,
+					bucket,
+					key,
+				)
 
 				req, err := http.NewRequestWithContext(
 					ctx, http.MethodPost, reqURL, strings.NewReader(body))
@@ -6285,7 +6836,13 @@ func TestTerraform_Textract(t *testing.T) {
 				respBody, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK, body: %s", string(respBody))
+				assert.Equal(
+					t,
+					http.StatusOK,
+					resp.StatusCode,
+					"expected 200 OK, body: %s",
+					string(respBody),
+				)
 
 				var result map[string]any
 				require.NoError(t, json.Unmarshal(respBody, &result))
@@ -6346,7 +6903,13 @@ func TestTerraform_TimestreamWrite(t *testing.T) {
 				respBody, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK, body: %s", string(respBody))
+				assert.Equal(
+					t,
+					http.StatusOK,
+					resp.StatusCode,
+					"expected 200 OK, body: %s",
+					string(respBody),
+				)
 
 				var result map[string]any
 				require.NoError(t, json.Unmarshal(respBody, &result))
@@ -6386,49 +6949,66 @@ func TestTerraform_TimestreamQuery(t *testing.T) {
 				client := createTimestreamQueryClient(t)
 
 				// Verify ListScheduledQueries returns an empty list.
-				listOut, err := client.ListScheduledQueries(ctx, &timestreamquerysvc.ListScheduledQueriesInput{})
+				listOut, err := client.ListScheduledQueries(
+					ctx,
+					&timestreamquerysvc.ListScheduledQueriesInput{},
+				)
 				require.NoError(t, err, "ListScheduledQueries should succeed")
 				require.NotNil(t, listOut)
 
 				// Create a scheduled query.
-				createOut, err := client.CreateScheduledQuery(ctx, &timestreamquerysvc.CreateScheduledQueryInput{
-					Name:        aws.String("tf-tsq-verify"),
-					QueryString: aws.String("SELECT 1"),
-					ScheduleConfiguration: &timestreamquerytypes.ScheduleConfiguration{
-						ScheduleExpression: aws.String("rate(1 hour)"),
-					},
-					ScheduledQueryExecutionRoleArn: aws.String("arn:aws:iam::000000000000:role/verify"),
-					NotificationConfiguration: &timestreamquerytypes.NotificationConfiguration{
-						SnsConfiguration: &timestreamquerytypes.SnsConfiguration{
-							TopicArn: aws.String("arn:aws:sns:us-east-1:000000000000:verify"),
+				createOut, err := client.CreateScheduledQuery(
+					ctx,
+					&timestreamquerysvc.CreateScheduledQueryInput{
+						Name:        aws.String("tf-tsq-verify"),
+						QueryString: aws.String("SELECT 1"),
+						ScheduleConfiguration: &timestreamquerytypes.ScheduleConfiguration{
+							ScheduleExpression: aws.String("rate(1 hour)"),
+						},
+						ScheduledQueryExecutionRoleArn: aws.String(
+							"arn:aws:iam::000000000000:role/verify",
+						),
+						NotificationConfiguration: &timestreamquerytypes.NotificationConfiguration{
+							SnsConfiguration: &timestreamquerytypes.SnsConfiguration{
+								TopicArn: aws.String("arn:aws:sns:us-east-1:000000000000:verify"),
+							},
+						},
+						ErrorReportConfiguration: &timestreamquerytypes.ErrorReportConfiguration{
+							S3Configuration: &timestreamquerytypes.S3Configuration{
+								BucketName: aws.String("verify-bucket"),
+							},
 						},
 					},
-					ErrorReportConfiguration: &timestreamquerytypes.ErrorReportConfiguration{
-						S3Configuration: &timestreamquerytypes.S3Configuration{
-							BucketName: aws.String("verify-bucket"),
-						},
-					},
-				})
+				)
 				require.NoError(t, err, "CreateScheduledQuery should succeed")
 				require.NotNil(t, createOut.Arn)
 
 				arn := aws.ToString(createOut.Arn)
 
 				// Describe the created scheduled query.
-				descOut, err := client.DescribeScheduledQuery(ctx, &timestreamquerysvc.DescribeScheduledQueryInput{
-					ScheduledQueryArn: aws.String(arn),
-				})
+				descOut, err := client.DescribeScheduledQuery(
+					ctx,
+					&timestreamquerysvc.DescribeScheduledQueryInput{
+						ScheduledQueryArn: aws.String(arn),
+					},
+				)
 				require.NoError(t, err, "DescribeScheduledQuery should succeed")
 				assert.Equal(t, "tf-tsq-verify", aws.ToString(descOut.ScheduledQuery.Name))
 
 				// Delete the scheduled query.
-				_, err = client.DeleteScheduledQuery(ctx, &timestreamquerysvc.DeleteScheduledQueryInput{
-					ScheduledQueryArn: aws.String(arn),
-				})
+				_, err = client.DeleteScheduledQuery(
+					ctx,
+					&timestreamquerysvc.DeleteScheduledQueryInput{
+						ScheduledQueryArn: aws.String(arn),
+					},
+				)
 				require.NoError(t, err, "DeleteScheduledQuery should succeed")
 
 				// Verify the list is empty again.
-				listAfter, err := client.ListScheduledQueries(ctx, &timestreamquerysvc.ListScheduledQueriesInput{})
+				listAfter, err := client.ListScheduledQueries(
+					ctx,
+					&timestreamquerysvc.ListScheduledQueriesInput{},
+				)
 				require.NoError(t, err, "ListScheduledQueries after delete should succeed")
 				assert.Empty(t, listAfter.ScheduledQueries)
 			},
@@ -6493,25 +7073,32 @@ func TestTerraform_Transfer(t *testing.T) {
 func TestTerraform_VerifiedPermissions(t *testing.T) {
 	t.Parallel()
 
-	runTfTestWithEndpoint(t, "verifiedpermissions/success", func(t *testing.T, ctx context.Context) {
-		t.Helper()
+	runTfTestWithEndpoint(
+		t,
+		"verifiedpermissions/success",
+		func(t *testing.T, ctx context.Context) {
+			t.Helper()
 
-		client := createVerifiedPermissionsClient(t)
+			client := createVerifiedPermissionsClient(t)
 
-		// List policy stores - should have at least one from Terraform provisioning.
-		listOut, err := client.ListPolicyStores(ctx, &verifiedpermissionssvc.ListPolicyStoresInput{})
-		require.NoError(t, err, "ListPolicyStores should succeed")
-		assert.NotEmpty(t, listOut.PolicyStores, "expected at least one policy store")
+			// List policy stores - should have at least one from Terraform provisioning.
+			listOut, err := client.ListPolicyStores(
+				ctx,
+				&verifiedpermissionssvc.ListPolicyStoresInput{},
+			)
+			require.NoError(t, err, "ListPolicyStores should succeed")
+			assert.NotEmpty(t, listOut.PolicyStores, "expected at least one policy store")
 
-		policyStoreID := *listOut.PolicyStores[0].PolicyStoreId
+			policyStoreID := *listOut.PolicyStores[0].PolicyStoreId
 
-		// Get the policy store.
-		getOut, err := client.GetPolicyStore(ctx, &verifiedpermissionssvc.GetPolicyStoreInput{
-			PolicyStoreId: &policyStoreID,
-		})
-		require.NoError(t, err, "GetPolicyStore should succeed")
-		assert.Equal(t, policyStoreID, *getOut.PolicyStoreId)
-	})
+			// Get the policy store.
+			getOut, err := client.GetPolicyStore(ctx, &verifiedpermissionssvc.GetPolicyStoreInput{
+				PolicyStoreId: &policyStoreID,
+			})
+			require.NoError(t, err, "GetPolicyStore should succeed")
+			assert.Equal(t, policyStoreID, *getOut.PolicyStoreId)
+		},
+	)
 }
 
 // TestTerraform_Xray provisions an X-Ray group via Terraform and verifies the service responds.
@@ -6567,7 +7154,13 @@ func TestTerraform_Wafv2(t *testing.T) {
 				respBody, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK, body: %s", string(respBody))
+				assert.Equal(
+					t,
+					http.StatusOK,
+					resp.StatusCode,
+					"expected 200 OK, body: %s",
+					string(respBody),
+				)
 
 				var result map[string]any
 				require.NoError(t, json.Unmarshal(respBody, &result))
@@ -6648,7 +7241,12 @@ func TestTerraform_S3Tables(t *testing.T) {
 					}
 				}
 
-				require.NotEmpty(t, bucketARN, "expected to find table bucket %q in list", bucketName)
+				require.NotEmpty(
+					t,
+					bucketARN,
+					"expected to find table bucket %q in list",
+					bucketName,
+				)
 
 				// GetTableBucket should return the bucket.
 				getOut, err := client.GetTableBucket(ctx, &s3tablessvc.GetTableBucketInput{
@@ -6702,7 +7300,11 @@ func TestTerraform_ECR(t *testing.T) {
 				})
 				require.NoError(t, err, "DescribeRepositories should succeed after terraform apply")
 				require.Len(t, out.Repositories, 1)
-				assert.Equal(t, vars["RepoName"].(string), aws.ToString(out.Repositories[0].RepositoryName))
+				assert.Equal(
+					t,
+					vars["RepoName"].(string),
+					aws.ToString(out.Repositories[0].RepositoryName),
+				)
 			},
 		},
 	}
@@ -6878,18 +7480,24 @@ func TestTerraform_CachingMessagingComprehensive(t *testing.T) {
 				// Verify ElastiCache replication group was created.
 				ecClient := createElastiCacheClient(t)
 				rgID := prefix + "-rg"
-				rgOut, err := ecClient.DescribeReplicationGroups(ctx, &elasticachesvc.DescribeReplicationGroupsInput{
-					ReplicationGroupId: aws.String(rgID),
-				})
+				rgOut, err := ecClient.DescribeReplicationGroups(
+					ctx,
+					&elasticachesvc.DescribeReplicationGroupsInput{
+						ReplicationGroupId: aws.String(rgID),
+					},
+				)
 				require.NoError(t, err, "DescribeReplicationGroups should succeed")
 				require.Len(t, rgOut.ReplicationGroups, 1)
 				assert.Equal(t, rgID, aws.ToString(rgOut.ReplicationGroups[0].ReplicationGroupId))
 
 				// Verify ElastiCache snapshot was created.
 				snapName := prefix + "-snap"
-				snapOut, err := ecClient.DescribeSnapshots(ctx, &elasticachesvc.DescribeSnapshotsInput{
-					SnapshotName: aws.String(snapName),
-				})
+				snapOut, err := ecClient.DescribeSnapshots(
+					ctx,
+					&elasticachesvc.DescribeSnapshotsInput{
+						SnapshotName: aws.String(snapName),
+					},
+				)
 				require.NoError(t, err, "DescribeSnapshots should succeed")
 				require.Len(t, snapOut.Snapshots, 1)
 				assert.Equal(t, snapName, aws.ToString(snapOut.Snapshots[0].SnapshotName))
@@ -6920,10 +7528,22 @@ func TestTerraform_CachingMessagingComprehensive(t *testing.T) {
 				for _, cl := range kafkaOut.ClusterInfoList {
 					if aws.ToString(cl.ClusterName) == kafkaName {
 						foundKafka = true
-						require.NotNil(t, cl.ClientAuthentication, "ClientAuthentication should be set")
+						require.NotNil(
+							t,
+							cl.ClientAuthentication,
+							"ClientAuthentication should be set",
+						)
 						require.NotNil(t, cl.ClientAuthentication.Sasl, "SASL should be set")
-						require.NotNil(t, cl.ClientAuthentication.Sasl.Iam, "IAM SASL should be set")
-						assert.True(t, aws.ToBool(cl.ClientAuthentication.Sasl.Iam.Enabled), "IAM SASL should be enabled")
+						require.NotNil(
+							t,
+							cl.ClientAuthentication.Sasl.Iam,
+							"IAM SASL should be set",
+						)
+						assert.True(
+							t,
+							aws.ToBool(cl.ClientAuthentication.Sasl.Iam.Enabled),
+							"IAM SASL should be enabled",
+						)
 
 						break
 					}

--- a/ui/src/routes/codecommit/page.test.ts
+++ b/ui/src/routes/codecommit/page.test.ts
@@ -69,7 +69,7 @@ describe("CodeCommit Page", () => {
   it("shows Branches stat card", () => {
     mockSend.mockResolvedValue({ repositories: [] });
     render(CodeCommitPage);
-    expect(screen.getByText("Branches (selected)")).toBeInTheDocument();
+    expect(screen.getByText("Branches")).toBeInTheDocument();
   });
 
   it("shows detail placeholder when no repo selected", () => {

--- a/ui/src/routes/codepipeline/page.test.ts
+++ b/ui/src/routes/codepipeline/page.test.ts
@@ -151,7 +151,7 @@ describe("CodePipeline Page", () => {
 
     await waitFor(
       () => {
-        expect(mockSend).toHaveBeenCalledTimes(3);
+        expect(mockSend).toHaveBeenCalledTimes(4);
       },
       { timeout: 3000 },
     );

--- a/ui/src/routes/ssm/page.test.ts
+++ b/ui/src/routes/ssm/page.test.ts
@@ -21,7 +21,7 @@ describe("SSM Page", () => {
   it("renders page title", () => {
     mockSend.mockResolvedValue({ Parameters: [] });
     render(SSMPage);
-    expect(screen.getByText("SSM Parameter Store")).toBeInTheDocument();
+    expect(screen.getByText("AWS Systems Manager")).toBeInTheDocument();
   });
 
   it("shows Create Parameter button", () => {


### PR DESCRIPTION
## Summary

- **New service `services/databrew/`**: Full AWS Glue DataBrew backend — datasets, recipes, projects, profile/recipe jobs, async job run state transitions (STARTING → SUCCEEDED via goroutine)
- **Glue Schema Registry** (`services/glue/backend_registry.go`): Stateful registries, schemas (with DataFormat/Compatibility), schema versions (incrementing VersionNumber, UUID SchemaVersionId). Replaces 14 stub handlers with real backend calls.
- **Glue CrawlerMetrics + TableVersion** read operations: `GetCrawlerMetrics`, `GetTableVersion`, `GetTableVersions` now return live backend data
- **OpenSearch advanced features** (`services/opensearch/backend_advanced.go`): `GetUpgradeHistory`/`GetUpgradeStatus`/`UpgradeDomain`, `GetAutoTune`/`SetAutoTune`, `DescribeInstanceTypeLimits` with realistic instance-type limit table (r6g.large, r6g.xlarge, m6g.large, t3.small, or1.medium), `ListDomainNamesByEngine` with OpenSearch/Elasticsearch filter
- **Terraform test coverage** (`test/terraform/mega-batch-3/main.tf`): Glue database, crawler, ETL job, schema registry + schema; Athena workgroup + named query; OpenSearch domain with cluster config
- **Pre-existing fix**: Cloudformation `resources_phase3.go` Kafka `CreateCluster` call signature mismatch

## Test plan

- [x] `golangci-lint run ./...` = 0 issues
- [x] `go test $(go list ./... | grep -v test/integration | grep -v test/terraform | grep -v test/e2e)` = no FAIL
- [x] All service unit tests pass: glue, opensearch, athena, redshiftdata
- [x] DataBrew package builds and compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->