### PR TITLE
fix: remove duplicate wireCWLogsMetricEmitter calls in cli.go

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2393,14 +2393,8 @@ func initializeServices(appCtx *service.AppContext) ([]service.Registerable, err
 		byName["Firehose"],
 	)
 
-	t // Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
-	twireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
-
-	t // Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
-	twireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
-
-	t // Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
-	twireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
+	// Wire CloudWatch Logs metric filters to emit CloudWatch metric data points.
+	wireCWLogsMetricEmitter(byName["CloudWatchLogs"], byName["CloudWatch"])
 
 	// Wire Firehose → S3 and Lambda for actual record delivery and transformation.
 	wireFirehoseDelivery(byName["Firehose"], byName["S3"], byName["Lambda"])


### PR DESCRIPTION
The batch branch fixes added the wireCWLogs call multiple times. Deduplicates to one.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->