### PR TITLE
fix: post-PR-1638 lint errors in bedrock, cloudfront, stepfunctions

### DIFF
--- a/services/bedrock/handler_agents.go
+++ b/services/bedrock/handler_agents.go
@@ -123,7 +123,6 @@ const (
 
 	// JSON response key constants.
 	keyAgentID         = "agentId"
-	keyStatus          = "status"
 	keyKnowledgeBaseID = "knowledgeBaseId"
 )
 

--- a/services/cloudfront/handler.go
+++ b/services/cloudfront/handler.go
@@ -651,9 +651,13 @@ func parseCFPolicyPath(method, suffix string) (string, string) {
 		return op, id
 	}
 
-	if op, id := parseCFResourcePath(method, suffix, "response-headers-policy",
-		opCreateResponseHeadersPolicy, opListResponseHeadersPolicies, opGetResponseHeadersPolicy, opUpdateResponseHeadersPolicy, opDeleteResponseHeadersPolicy,
-		opGetResponseHeadersPolicyConfig, opUpdateResponseHeadersPolicy); op != "" {
+	if op, id := parseCFResourcePath(
+		method, suffix, "response-headers-policy",
+		opCreateResponseHeadersPolicy, opListResponseHeadersPolicies,
+		opGetResponseHeadersPolicy, opUpdateResponseHeadersPolicy,
+		opDeleteResponseHeadersPolicy, opGetResponseHeadersPolicyConfig,
+		opUpdateResponseHeadersPolicy,
+	); op != "" {
 		return op, id
 	}
 
@@ -863,9 +867,12 @@ func parseCFKeyAndLogPath(method, suffix string) (string, string) {
 		return op, id
 	}
 
-	if op, id := parseCFResourcePath(method, suffix, "key-value-store",
-		opCreateKeyValueStore, opListKeyValueStores, opDescribeKeyValueStore, opUpdateKeyValueStore, opDeleteKeyValueStore,
-		"", ""); op != "" {
+	if op, id := parseCFResourcePath(
+		method, suffix, "key-value-store",
+		opCreateKeyValueStore, opListKeyValueStores,
+		opDescribeKeyValueStore, opUpdateKeyValueStore,
+		opDeleteKeyValueStore, "", "",
+	); op != "" {
 		return op, id
 	}
 
@@ -880,9 +887,18 @@ func parseCFPublicKeyRealtimePath(method, suffix string) (string, string) {
 		return op, id
 	}
 
-	return parseCFResourcePath(method, suffix, "realtime-log-config",
-		opCreateRealtimeLogConfig, opListRealtimeLogConfigs, opGetRealtimeLogConfig, opUpdateRealtimeLogConfig, opDeleteRealtimeLogConfig,
-		"", "")
+	return parseCFResourcePath(
+		method,
+		suffix,
+		"realtime-log-config",
+		opCreateRealtimeLogConfig,
+		opListRealtimeLogConfigs,
+		opGetRealtimeLogConfig,
+		opUpdateRealtimeLogConfig,
+		opDeleteRealtimeLogConfig,
+		"",
+		"",
+	)
 }
 
 // parseCFStreamingTrustVPCPath routes streaming distribution, trust store, vpc origin, and anycast paths.
@@ -1030,9 +1046,15 @@ func parseCFDistributionsByPath(method, suffix string) (string, string) {
 	case strings.HasPrefix(suffix, "distributions/by-cache-policy-id/"):
 		return opListDistributionsByCachePolicyID, strings.TrimPrefix(suffix, "distributions/by-cache-policy-id/")
 	case strings.HasPrefix(suffix, "distributions/by-origin-request-policy-id/"):
-		return opListDistributionsByOriginRequestPol, strings.TrimPrefix(suffix, "distributions/by-origin-request-policy-id/")
+		return opListDistributionsByOriginRequestPol, strings.TrimPrefix(
+			suffix,
+			"distributions/by-origin-request-policy-id/",
+		)
 	case strings.HasPrefix(suffix, "distributions/by-response-headers-policy-id/"):
-		return opListDistributionsByResponseHeadersPol, strings.TrimPrefix(suffix, "distributions/by-response-headers-policy-id/")
+		return opListDistributionsByResponseHeadersPol, strings.TrimPrefix(
+			suffix,
+			"distributions/by-response-headers-policy-id/",
+		)
 	case strings.HasPrefix(suffix, "distributions/by-web-acl-id/"):
 		return opListDistributionsByWebACLID, strings.TrimPrefix(suffix, "distributions/by-web-acl-id/")
 	case strings.HasPrefix(suffix, "distributions/by-key-group/"):
@@ -1044,7 +1066,10 @@ func parseCFDistributionsByPath(method, suffix string) (string, string) {
 	case strings.HasPrefix(suffix, "distributions/by-anycast-ip-list-id/"):
 		return opListDistributionsByAnycastIPListID, strings.TrimPrefix(suffix, "distributions/by-anycast-ip-list-id/")
 	case strings.HasPrefix(suffix, "distributions/by-connection-function/"):
-		return opListDistributionsByConnectionFunction, strings.TrimPrefix(suffix, "distributions/by-connection-function/")
+		return opListDistributionsByConnectionFunction, strings.TrimPrefix(
+			suffix,
+			"distributions/by-connection-function/",
+		)
 	case suffix == "distributions/by-connection-mode":
 		return opListDistributionsByConnectionMode, ""
 	case suffix == "distribution-tenants/by-customization":
@@ -1697,8 +1722,6 @@ func (h *Handler) dispatchLogStoreVPCOps(c *echo.Context, operation, resource st
 	default:
 		return errNotDispatched
 	}
-
-	return errNotDispatched
 }
 
 func (h *Handler) dispatchList(c *echo.Context, operation, resource string) error {
@@ -1867,7 +1890,11 @@ func (h *Handler) dispatchStubsDistributionTenant(c *echo.Context, hlp cfStubHel
 	case opUpdateDomainAssociation:
 		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><DomainAssociation xmlns="`+cfNS+`"/>`)
 	case opVerifyDNSConfiguration:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><VerifyDnsConfigurationResponse xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><VerifyDnsConfigurationResponse xmlns="`+cfNS+`"/>`,
+		)
 	}
 
 	return errNotDispatched
@@ -1880,9 +1907,17 @@ func (h *Handler) dispatchStubsMonitoringAndStreaming(c *echo.Context, hlp cfStu
 
 	switch operation {
 	case opCreateMonitoringSubscription:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`,
+		)
 	case opGetMonitoringSubscription:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`,
+		)
 	case opDeleteMonitoringSubscription:
 		return noContent()
 	case opDisassociateDistributionWebACL, opDisassociateDistributionTenantWebACL:
@@ -1892,7 +1927,11 @@ func (h *Handler) dispatchStubsMonitoringAndStreaming(c *echo.Context, hlp cfStu
 	case opGetStreamingDistribution, opGetStreamingDistributionConfig:
 		return getStub("StreamingDistribution", "sdist-stub")
 	case opUpdateStreamingDistribution:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><StreamingDistribution xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><StreamingDistribution xmlns="`+cfNS+`"/>`,
+		)
 	case opDeleteStreamingDistribution:
 		return noContent()
 	case opListStreamingDistributions:
@@ -1989,7 +2028,11 @@ func (h *Handler) dispatchStubsConnectionGroupAndCDP(c *echo.Context, hlp cfStub
 
 	// Resource policy.
 	case opGetResourcePolicy:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ResourcePolicy xmlns="`+cfNS+`"><Policy>{}</Policy></ResourcePolicy>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><ResourcePolicy xmlns="`+cfNS+`"><Policy>{}</Policy></ResourcePolicy>`,
+		)
 	case opPutResourcePolicy:
 		return noContent()
 	case opDeleteResourcePolicy:
@@ -2023,7 +2066,11 @@ func (h *Handler) dispatchStubsResourcePolicyAndMisc(c *echo.Context, hlp cfStub
 	case opListInvalidationsForDistTenant:
 		return emptyList("InvalidationList")
 	case opGetManagedCertificateDetails:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ManagedCertificateDetails xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><ManagedCertificateDetails xmlns="`+cfNS+`"/>`,
+		)
 	default:
 		return xmlResp(c, http.StatusNotFound, cfErrorXML("NoSuchOperation", "unknown operation: "+operation))
 	}

--- a/services/stepfunctions/asl/executor.go
+++ b/services/stepfunctions/asl/executor.go
@@ -342,8 +342,8 @@ func (e *Executor) executeWait(ctx context.Context, state *State, input any) (st
 	}
 
 	if waitDuration > 0 {
-		if err := e.waitForDuration(ctx, waitDuration); err != nil {
-			return "", nil, err
+		if waitErr := e.waitForDuration(ctx, waitDuration); waitErr != nil {
+			return "", nil, waitErr
 		}
 	}
 
@@ -1657,7 +1657,8 @@ func matchTimestampLiteralCondition(rule *ChoiceRule, varVal any) (bool, bool) {
 		return r, m
 	}
 
-	if r, m := compareLiteral(rule.TimestampGreaterThanEquals, func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
+	if r, m := compareLiteral(rule.TimestampGreaterThanEquals,
+		func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
 		return r, m
 	}
 
@@ -1692,7 +1693,8 @@ func matchTimestampPathCondition(rule *ChoiceRule, varVal, input any, pathCache 
 		return r, m
 	}
 
-	if r, m := comparePath(rule.TimestampGreaterThanEqualsPath, func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
+	if r, m := comparePath(rule.TimestampGreaterThanEqualsPath,
+		func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
 		return r, m
 	}
 


### PR DESCRIPTION
Fixes issues introduced by PR #1638 merge: bedrock keyStatus redeclared across files, cloudfront golines/unreachable, stepfunctions shadow variable and golines.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blackbirdworks/gopherstack/pull/1647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->