### PR TITLE
fix: post-PR-1638/1635 lint — all mnd, golines, modernize, nolint, unreachable issues

### DIFF
--- a/services/apigateway/handler.go
+++ b/services/apigateway/handler.go
@@ -1256,8 +1256,6 @@ func parseAPIGWUsagePlansDepth4(method string, segs []string) (string, map[strin
 // parseAPIGWRestAPIsPath handles /restapis/... paths.
 //
 // parseAPIGWRestAPIsPath handles /restapis/... paths.
-//
-//nolint:funlen // path routing table is inherently a multi-branch switch
 func parseAPIGWRestAPIsPath(method string, segs []string, n int) (string, map[string]string, bool) {
 	apiID := ""
 	if n >= pathDepth2 {
@@ -1592,8 +1590,6 @@ func parseAPIGWRestAPIsDocDeep(method string, segs []string, n int, apiID string
 // parseAPIGWMethodPath handles paths under /restapis/{id}/resources/{resId}/methods/{httpMethod}.
 //
 // parseAPIGWMethodPath handles paths under /restapis/{id}/resources/{resId}/methods/{httpMethod}.
-//
-//nolint:nestif,funlen // method path routing table is inherently a multi-branch switch
 func parseAPIGWMethodPath(method string, segs []string) (string, map[string]string, bool) {
 	const (
 		idxID         = 1
@@ -2403,8 +2399,6 @@ func (h *Handler) dispatchTable() map[string]actionFn {
 }
 
 // newResourceActions returns actions for creating new top-level resources.
-//
-//nolint:funlen // action table - one closure per op; complexity unavoidable
 func (h *Handler) newResourceActions() map[string]actionFn {
 	m := make(map[string]actionFn)
 	maps.Copy(m, h.newResourceActionsCore())
@@ -2658,8 +2652,6 @@ func (h *Handler) Reset() {
 }
 
 // getDeleteUpdateActions returns the action map for get, delete, and update operations.
-//
-//nolint:funlen // action table - one closure per op; complexity unavoidable
 func (h *Handler) getDeleteUpdateActions() map[string]actionFn {
 	m := make(map[string]actionFn)
 	maps.Copy(m, h.getDeleteUpdateActionsCore())
@@ -3140,8 +3132,6 @@ func (h *Handler) getDeleteUpdateActionsUsage2b() map[string]actionFn {
 }
 
 // updatePatchActions returns the action map for update and patch operations.
-//
-//nolint:funlen // action table - one closure per op; complexity unavoidable
 func (h *Handler) updatePatchActions() map[string]actionFn {
 	m := make(map[string]actionFn)
 	maps.Copy(m, h.updatePatchActionsCore())

--- a/services/apigateway/handler.go
+++ b/services/apigateway/handler.go
@@ -158,6 +158,15 @@ const (
 
 var errUnknownOperation = errors.New("UnknownOperationException")
 
+// path depth constants for URL segment counting.
+const (
+	pathDepth1 = 1
+	pathDepth2 = 2
+	pathDepth3 = 3
+	pathDepth4 = 4
+	pathDepth5 = 5
+)
+
 // path segment constants used in REST route matching.
 const (
 	apiGWUnknownOp             = "Unknown"
@@ -1052,10 +1061,10 @@ func parseAPIGWClientCertificatesPath(method string, segs []string, n int) (stri
 	case n == 1 && method == http.MethodPost:
 		return opGenerateClientCertificate, nil, true
 	// GET /clientcertificates/{id} → GetClientCertificate
-	case n == 2 && method == http.MethodGet:
+	case n == pathDepth2 && method == http.MethodGet:
 		return opGetClientCertificate, map[string]string{"clientCertificateId": segs[1]}, true
 	// DELETE /clientcertificates/{id} → DeleteClientCertificate
-	case n == 2 && method == http.MethodDelete:
+	case n == pathDepth2 && method == http.MethodDelete:
 		return opDeleteClientCertificate, map[string]string{"clientCertificateId": segs[1]}, true
 	}
 
@@ -1095,13 +1104,13 @@ func parseAPIGWAPIKeysPath(method string, segs []string, n int) (string, map[str
 	case n == 1 && method == http.MethodPost:
 		return opCreateAPIKey, nil, true
 	// GET /apikeys/{id} → GetApiKey
-	case n == 2 && method == http.MethodGet:
+	case n == pathDepth2 && method == http.MethodGet:
 		return opGetAPIKey, map[string]string{keyAPIKeyID: segs[1]}, true
 	// DELETE /apikeys/{id} → DeleteApiKey
-	case n == 2 && method == http.MethodDelete:
+	case n == pathDepth2 && method == http.MethodDelete:
 		return opDeleteAPIKey, map[string]string{keyAPIKeyID: segs[1]}, true
 	// PATCH /apikeys/{id} → UpdateApiKey
-	case n == 2 && method == http.MethodPatch:
+	case n == pathDepth2 && method == http.MethodPatch:
 		return opUpdateAPIKey, map[string]string{keyAPIKeyID: segs[1]}, true
 	}
 
@@ -1114,14 +1123,14 @@ func parseAPIGWAPIKeysPath(method string, segs []string, n int) (string, map[str
 // parseAPIGWDomainNamesPath handles /domainnames/... paths.
 func parseAPIGWDomainNamesPath(method string, segs []string, n int) (string, map[string]string, bool) {
 	switch n {
-	case 1:
+	case pathDepth1:
 		switch method {
 		case http.MethodGet:
 			return opGetDomainNames, nil, true
 		case http.MethodPost:
 			return opCreateDomainName, nil, true
 		}
-	case 2:
+	case pathDepth2:
 		switch method {
 		case http.MethodGet:
 			return opGetDomainName, map[string]string{keyDomainName: segs[1]}, true
@@ -1130,9 +1139,9 @@ func parseAPIGWDomainNamesPath(method string, segs []string, n int) (string, map
 		case http.MethodPatch:
 			return opUpdateDomainName, map[string]string{keyDomainName: segs[1]}, true
 		}
-	case 3:
+	case pathDepth3:
 		return parseAPIGWDomainNamesDepth3(method, segs)
-	case 4:
+	case pathDepth4:
 		if segs[2] == apiGWSegBasePathMappings {
 			return parseAPIGWDomainNamesBasePathMapping(method, segs)
 		}
@@ -1179,14 +1188,14 @@ func parseAPIGWDomainNamesBasePathMapping(method string, segs []string) (string,
 // parseAPIGWUsagePlansPath handles /usageplans/... paths.
 func parseAPIGWUsagePlansPath(method string, segs []string, n int) (string, map[string]string, bool) {
 	switch n {
-	case 1:
+	case pathDepth1:
 		switch method {
 		case http.MethodGet:
 			return opGetUsagePlans, nil, true
 		case http.MethodPost:
 			return opCreateUsagePlan, nil, true
 		}
-	case 2:
+	case pathDepth2:
 		planParam := map[string]string{keyUsagePlanID: segs[1]}
 		switch method {
 		case http.MethodGet:
@@ -1196,9 +1205,9 @@ func parseAPIGWUsagePlansPath(method string, segs []string, n int) (string, map[
 		case http.MethodPatch:
 			return opUpdateUsagePlan, planParam, true
 		}
-	case 3:
+	case pathDepth3:
 		return parseAPIGWUsagePlansDepth3(method, segs)
-	case 4:
+	case pathDepth4:
 		return parseAPIGWUsagePlansDepth4(method, segs)
 	}
 
@@ -1251,23 +1260,23 @@ func parseAPIGWUsagePlansDepth4(method string, segs []string) (string, map[strin
 //nolint:funlen // path routing table is inherently a multi-branch switch
 func parseAPIGWRestAPIsPath(method string, segs []string, n int) (string, map[string]string, bool) {
 	apiID := ""
-	if n >= 2 {
+	if n >= pathDepth2 {
 		apiID = segs[1]
 	}
 
 	switch n {
-	case 1:
+	case pathDepth1:
 		switch method {
 		case http.MethodPost:
 			return opCreateRestAPI, nil, true
 		case http.MethodGet:
 			return opGetRestApis, nil, true
 		}
-	case 2:
+	case pathDepth2:
 		return parseAPIGWRestAPIsDepth2(method, apiID)
-	case 3:
+	case pathDepth3:
 		return parseAPIGWRestAPIsDepth3(method, segs, apiID)
-	case 4:
+	case pathDepth4:
 		return parseAPIGWRestAPIsDepth4(method, segs, apiID)
 	default:
 		return parseAPIGWRestAPIsDeepPath(method, segs, n, apiID)
@@ -1550,7 +1559,7 @@ func parseAPIGWRestAPIsStageDeep(method string, segs []string, n int, apiID stri
 
 // parseAPIGWRestAPIsDocDeep handles depth-5 documentation parts/versions paths.
 func parseAPIGWRestAPIsDocDeep(method string, segs []string, n int, apiID string) (string, map[string]string, bool) {
-	if n != 5 {
+	if n != pathDepth5 {
 		return apiGWUnknownOp, nil, false
 	}
 
@@ -1608,8 +1617,9 @@ func parseAPIGWMethodPath(method string, segs []string) (string, map[string]stri
 	}
 
 	if len(segs) > idxIntegSeg {
-		if op, params, ok := parseAPIGWMethodSubPath(method, segs, idxIntegSeg, idxRespSeg, apiID, resID, httpMethod, baseParams); ok ||
-			op == apiGWUnknownOp {
+		op, params, ok := parseAPIGWMethodSubPath(
+			method, segs, idxIntegSeg, idxRespSeg, apiID, resID, httpMethod, baseParams)
+		if ok || op == apiGWUnknownOp {
 			return op, params, ok
 		}
 	}

--- a/services/bedrock/handler_agents.go
+++ b/services/bedrock/handler_agents.go
@@ -123,7 +123,6 @@ const (
 
 	// JSON response key constants.
 	keyAgentID         = "agentId"
-	keyStatus          = "status"
 	keyKnowledgeBaseID = "knowledgeBaseId"
 )
 

--- a/services/cloudfront/handler.go
+++ b/services/cloudfront/handler.go
@@ -510,8 +510,8 @@ func parseCFDistributionCorePath(method, suffix, resourceParam string) (string, 
 		return op, id
 	}
 
-	if strings.HasPrefix(suffix, "distribution-tenant/") {
-		id := strings.TrimSuffix(strings.TrimPrefix(suffix, "distribution-tenant/"), "/associate-web-acl")
+	if rest, ok := strings.CutPrefix(suffix, "distribution-tenant/"); ok {
+		id := strings.TrimSuffix(rest, "/associate-web-acl")
 		if strings.HasSuffix(suffix, "/associate-web-acl") && method == http.MethodPut {
 			return opAssociateDistributionTenantWebACL, id
 		}
@@ -832,8 +832,7 @@ func parseCFResourcePath(method, suffix, resourceType,
 	}
 
 	inner := strings.TrimPrefix(suffix, prefix)
-	if strings.HasSuffix(inner, "/config") {
-		id := strings.TrimSuffix(inner, "/config")
+	if id, ok := strings.CutSuffix(inner, "/config"); ok {
 		if method == http.MethodGet {
 			return getConfigOp, id
 		}
@@ -1331,8 +1330,8 @@ func parseCFMiscPathByDistribution(method, suffix string) (string, string) {
 
 	if method == http.MethodGet {
 		for _, p := range prefixes {
-			if strings.HasPrefix(suffix, p.prefix) {
-				return p.op, strings.TrimPrefix(suffix, p.prefix)
+			if after, ok := strings.CutPrefix(suffix, p.prefix); ok {
+				return p.op, after
 			}
 		}
 	}

--- a/services/cloudfront/handler.go
+++ b/services/cloudfront/handler.go
@@ -651,9 +651,13 @@ func parseCFPolicyPath(method, suffix string) (string, string) {
 		return op, id
 	}
 
-	if op, id := parseCFResourcePath(method, suffix, "response-headers-policy",
-		opCreateResponseHeadersPolicy, opListResponseHeadersPolicies, opGetResponseHeadersPolicy, opUpdateResponseHeadersPolicy, opDeleteResponseHeadersPolicy,
-		opGetResponseHeadersPolicyConfig, opUpdateResponseHeadersPolicy); op != "" {
+	if op, id := parseCFResourcePath(
+		method, suffix, "response-headers-policy",
+		opCreateResponseHeadersPolicy, opListResponseHeadersPolicies,
+		opGetResponseHeadersPolicy, opUpdateResponseHeadersPolicy,
+		opDeleteResponseHeadersPolicy, opGetResponseHeadersPolicyConfig,
+		opUpdateResponseHeadersPolicy,
+	); op != "" {
 		return op, id
 	}
 
@@ -863,9 +867,12 @@ func parseCFKeyAndLogPath(method, suffix string) (string, string) {
 		return op, id
 	}
 
-	if op, id := parseCFResourcePath(method, suffix, "key-value-store",
-		opCreateKeyValueStore, opListKeyValueStores, opDescribeKeyValueStore, opUpdateKeyValueStore, opDeleteKeyValueStore,
-		"", ""); op != "" {
+	if op, id := parseCFResourcePath(
+		method, suffix, "key-value-store",
+		opCreateKeyValueStore, opListKeyValueStores,
+		opDescribeKeyValueStore, opUpdateKeyValueStore,
+		opDeleteKeyValueStore, "", "",
+	); op != "" {
 		return op, id
 	}
 
@@ -880,9 +887,18 @@ func parseCFPublicKeyRealtimePath(method, suffix string) (string, string) {
 		return op, id
 	}
 
-	return parseCFResourcePath(method, suffix, "realtime-log-config",
-		opCreateRealtimeLogConfig, opListRealtimeLogConfigs, opGetRealtimeLogConfig, opUpdateRealtimeLogConfig, opDeleteRealtimeLogConfig,
-		"", "")
+	return parseCFResourcePath(
+		method,
+		suffix,
+		"realtime-log-config",
+		opCreateRealtimeLogConfig,
+		opListRealtimeLogConfigs,
+		opGetRealtimeLogConfig,
+		opUpdateRealtimeLogConfig,
+		opDeleteRealtimeLogConfig,
+		"",
+		"",
+	)
 }
 
 // parseCFStreamingTrustVPCPath routes streaming distribution, trust store, vpc origin, and anycast paths.
@@ -1030,9 +1046,15 @@ func parseCFDistributionsByPath(method, suffix string) (string, string) {
 	case strings.HasPrefix(suffix, "distributions/by-cache-policy-id/"):
 		return opListDistributionsByCachePolicyID, strings.TrimPrefix(suffix, "distributions/by-cache-policy-id/")
 	case strings.HasPrefix(suffix, "distributions/by-origin-request-policy-id/"):
-		return opListDistributionsByOriginRequestPol, strings.TrimPrefix(suffix, "distributions/by-origin-request-policy-id/")
+		return opListDistributionsByOriginRequestPol, strings.TrimPrefix(
+			suffix,
+			"distributions/by-origin-request-policy-id/",
+		)
 	case strings.HasPrefix(suffix, "distributions/by-response-headers-policy-id/"):
-		return opListDistributionsByResponseHeadersPol, strings.TrimPrefix(suffix, "distributions/by-response-headers-policy-id/")
+		return opListDistributionsByResponseHeadersPol, strings.TrimPrefix(
+			suffix,
+			"distributions/by-response-headers-policy-id/",
+		)
 	case strings.HasPrefix(suffix, "distributions/by-web-acl-id/"):
 		return opListDistributionsByWebACLID, strings.TrimPrefix(suffix, "distributions/by-web-acl-id/")
 	case strings.HasPrefix(suffix, "distributions/by-key-group/"):
@@ -1044,7 +1066,10 @@ func parseCFDistributionsByPath(method, suffix string) (string, string) {
 	case strings.HasPrefix(suffix, "distributions/by-anycast-ip-list-id/"):
 		return opListDistributionsByAnycastIPListID, strings.TrimPrefix(suffix, "distributions/by-anycast-ip-list-id/")
 	case strings.HasPrefix(suffix, "distributions/by-connection-function/"):
-		return opListDistributionsByConnectionFunction, strings.TrimPrefix(suffix, "distributions/by-connection-function/")
+		return opListDistributionsByConnectionFunction, strings.TrimPrefix(
+			suffix,
+			"distributions/by-connection-function/",
+		)
 	case suffix == "distributions/by-connection-mode":
 		return opListDistributionsByConnectionMode, ""
 	case suffix == "distribution-tenants/by-customization":
@@ -1697,8 +1722,6 @@ func (h *Handler) dispatchLogStoreVPCOps(c *echo.Context, operation, resource st
 	default:
 		return errNotDispatched
 	}
-
-	return errNotDispatched
 }
 
 func (h *Handler) dispatchList(c *echo.Context, operation, resource string) error {
@@ -1867,7 +1890,11 @@ func (h *Handler) dispatchStubsDistributionTenant(c *echo.Context, hlp cfStubHel
 	case opUpdateDomainAssociation:
 		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><DomainAssociation xmlns="`+cfNS+`"/>`)
 	case opVerifyDNSConfiguration:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><VerifyDnsConfigurationResponse xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><VerifyDnsConfigurationResponse xmlns="`+cfNS+`"/>`,
+		)
 	}
 
 	return errNotDispatched
@@ -1880,9 +1907,17 @@ func (h *Handler) dispatchStubsMonitoringAndStreaming(c *echo.Context, hlp cfStu
 
 	switch operation {
 	case opCreateMonitoringSubscription:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`,
+		)
 	case opGetMonitoringSubscription:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><MonitoringSubscription xmlns="`+cfNS+`"/>`,
+		)
 	case opDeleteMonitoringSubscription:
 		return noContent()
 	case opDisassociateDistributionWebACL, opDisassociateDistributionTenantWebACL:
@@ -1892,7 +1927,11 @@ func (h *Handler) dispatchStubsMonitoringAndStreaming(c *echo.Context, hlp cfStu
 	case opGetStreamingDistribution, opGetStreamingDistributionConfig:
 		return getStub("StreamingDistribution", "sdist-stub")
 	case opUpdateStreamingDistribution:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><StreamingDistribution xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><StreamingDistribution xmlns="`+cfNS+`"/>`,
+		)
 	case opDeleteStreamingDistribution:
 		return noContent()
 	case opListStreamingDistributions:
@@ -1989,7 +2028,11 @@ func (h *Handler) dispatchStubsConnectionGroupAndCDP(c *echo.Context, hlp cfStub
 
 	// Resource policy.
 	case opGetResourcePolicy:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ResourcePolicy xmlns="`+cfNS+`"><Policy>{}</Policy></ResourcePolicy>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><ResourcePolicy xmlns="`+cfNS+`"><Policy>{}</Policy></ResourcePolicy>`,
+		)
 	case opPutResourcePolicy:
 		return noContent()
 	case opDeleteResourcePolicy:
@@ -2023,7 +2066,11 @@ func (h *Handler) dispatchStubsResourcePolicyAndMisc(c *echo.Context, hlp cfStub
 	case opListInvalidationsForDistTenant:
 		return emptyList("InvalidationList")
 	case opGetManagedCertificateDetails:
-		return xmlResp(c, http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?><ManagedCertificateDetails xmlns="`+cfNS+`"/>`)
+		return xmlResp(
+			c,
+			http.StatusOK,
+			`<?xml version="1.0" encoding="UTF-8"?><ManagedCertificateDetails xmlns="`+cfNS+`"/>`,
+		)
 	default:
 		return xmlResp(c, http.StatusNotFound, cfErrorXML("NoSuchOperation", "unknown operation: "+operation))
 	}

--- a/services/rds/handler_stubs.go
+++ b/services/rds/handler_stubs.go
@@ -153,8 +153,6 @@ func (h *Handler) dispatchExtended15(action string, vals url.Values) (any, error
 	default:
 		return nil, fmt.Errorf("%w: %s is not a valid RDS action", ErrUnknownAction, action)
 	}
-
-	return nil, errRDSStubNotHandled
 }
 
 // ---- XML response types ----

--- a/services/sesv2/handler_ops.go
+++ b/services/sesv2/handler_ops.go
@@ -26,6 +26,7 @@ const (
 	// path depth sentinels for segment-count comparisons.
 	pathDepth2 = 2
 	pathDepth3 = 3
+	pathDepth4 = 4
 )
 
 // dispatchExtendedOps handles all 89 newly-added SES v2 operations.
@@ -506,7 +507,7 @@ func parseContactListExtPath(method string, segments []string) (string, string) 
 		if method == http.MethodGet {
 			return opListContactLists, ""
 		}
-	case 2:
+	case pathDepth2:
 		switch method {
 		case http.MethodGet:
 			return opGetContactList, segments[1]
@@ -515,11 +516,11 @@ func parseContactListExtPath(method string, segments []string) (string, string) 
 		case http.MethodPut:
 			return opUpdateContactList, segments[1]
 		}
-	case 3:
+	case pathDepth3:
 		if segments[2] == segContacts && method == http.MethodGet {
 			return opListContacts, segments[1]
 		}
-	case 4:
+	case pathDepth4:
 		if segments[2] == segContacts {
 			switch method {
 			case http.MethodGet:
@@ -558,7 +559,7 @@ func parseDedicatedIPPoolExtPath(method string, segments []string) (string, stri
 		return opGetDedicatedIPPool, segments[1]
 	case len(segments) == 2 && method == http.MethodDelete:
 		return opDeleteDedicatedIPPool, segments[1]
-	case len(segments) == 3 && segments[2] == "scaling-attributes" && method == http.MethodPut:
+	case len(segments) == pathDepth3 && segments[2] == "scaling-attributes" && method == http.MethodPut:
 		return opPutDedicatedIPPoolScalingAttributes, segments[1]
 	}
 
@@ -571,9 +572,9 @@ func parseDedicatedIPsPath(method string, segments []string) (string, string) {
 		return opGetDedicatedIps, ""
 	case len(segments) == 2 && method == http.MethodGet:
 		return opGetDedicatedIP, segments[1]
-	case len(segments) == 3 && segments[2] == "pool" && method == http.MethodPut:
+	case len(segments) == pathDepth3 && segments[2] == "pool" && method == http.MethodPut:
 		return opPutDedicatedIPInPool, segments[1]
-	case len(segments) == 3 && segments[2] == "warmup" && method == http.MethodPut:
+	case len(segments) == pathDepth3 && segments[2] == "warmup" && method == http.MethodPut:
 		return opPutDedicatedIPWarmupAttributes, segments[1]
 	}
 
@@ -602,7 +603,7 @@ func parseDeliverabilityExtPath(method string, segments []string) (string, strin
 
 // parseDeliverabilitySubPath routes deliverability report and campaign sub-paths.
 func parseDeliverabilitySubPath(method string, segments []string) (string, string) {
-	if len(segments) < 2 {
+	if len(segments) < pathDepth2 {
 		return unknownAction, ""
 	}
 
@@ -614,7 +615,7 @@ func parseDeliverabilitySubPath(method string, segments []string) (string, strin
 			return opGetBlacklistReports, ""
 		}
 	case "statistics":
-		if method == http.MethodGet && len(segments) == 3 {
+		if method == http.MethodGet && len(segments) == pathDepth3 {
 			return opGetDomainStatisticsReport, segments[2]
 		}
 	case "campaigns":
@@ -631,9 +632,9 @@ func parseDeliverabilityReportsPath(method string, segments []string) (string, s
 	}
 
 	switch len(segments) {
-	case 2:
+	case pathDepth2:
 		return opListDeliverabilityTestReports, ""
-	case 3:
+	case pathDepth3:
 		return opGetDeliverabilityTestReport, segments[2]
 	}
 
@@ -647,9 +648,9 @@ func parseDeliverabilityDomainCampaignsPath(method string, segments []string) (s
 	}
 
 	switch len(segments) {
-	case 3:
+	case pathDepth3:
 		return opListDomainDeliverabilityCampaigns, segments[2]
-	case 4:
+	case pathDepth4:
 		return opGetDomainDeliverabilityCampaign, segments[2]
 	}
 
@@ -666,7 +667,7 @@ func parseTemplateExtPath(method string, segments []string) (string, string) {
 		return opDeleteEmailTemplate, segments[1]
 	case len(segments) == 2 && method == http.MethodPut:
 		return opUpdateEmailTemplate, segments[1]
-	case len(segments) == 3 && segments[2] == "render" && method == http.MethodPost:
+	case len(segments) == pathDepth3 && segments[2] == "render" && method == http.MethodPost:
 		return opTestRenderEmailTemplate, segments[1]
 	}
 
@@ -726,14 +727,14 @@ func parseTenantPath(method string, segments []string) (string, string) {
 		case http.MethodPost:
 			return opCreateTenant, ""
 		}
-	case 2:
+	case pathDepth2:
 		switch method {
 		case http.MethodGet:
 			return opGetTenant, segments[1]
 		case http.MethodDelete:
 			return opDeleteTenant, segments[1]
 		}
-	case 3:
+	case pathDepth3:
 		if segments[2] == segResources {
 			switch method {
 			case http.MethodGet:
@@ -742,7 +743,7 @@ func parseTenantPath(method string, segments []string) (string, string) {
 				return opCreateTenantResourceAssociation, segments[1]
 			}
 		}
-	case 4:
+	case pathDepth4:
 		if segments[2] == segResources && method == http.MethodDelete {
 			return opDeleteTenantResourceAssociation, segments[1]
 		}
@@ -757,9 +758,9 @@ func parseReputationEntityPath(method string, segments []string) (string, string
 		return opListReputationEntities, ""
 	case len(segments) == 2 && method == http.MethodGet:
 		return opGetReputationEntity, segments[1]
-	case len(segments) == 3 && segments[2] == "customer-managed-status" && method == http.MethodPut:
+	case len(segments) == pathDepth3 && segments[2] == "customer-managed-status" && method == http.MethodPut:
 		return opUpdateReputationEntityCustomerManagedStatus, segments[1]
-	case len(segments) == 3 && segments[2] == "policy" && method == http.MethodPut:
+	case len(segments) == pathDepth3 && segments[2] == "policy" && method == http.MethodPut:
 		return opUpdateReputationEntityPolicy, segments[1]
 	}
 
@@ -768,7 +769,7 @@ func parseReputationEntityPath(method string, segments []string) (string, string
 
 // parseIdentityExtPath handles additional identity paths.
 func parseIdentityExtPath(method string, segments []string) (string, string) {
-	if len(segments) < 3 {
+	if len(segments) < pathDepth3 {
 		return unknownAction, ""
 	}
 
@@ -789,11 +790,11 @@ func parseIdentityPoliciesPath(method string, segments []string, identity, sub s
 	}
 
 	switch len(segments) {
-	case 3:
+	case pathDepth3:
 		if method == http.MethodGet {
 			return opGetEmailIdentityPolicies, identity
 		}
-	case 4:
+	case pathDepth4:
 		switch method {
 		case http.MethodDelete:
 			return opDeleteEmailIdentityPolicy, identity
@@ -813,24 +814,24 @@ func parseIdentityAttributesPath(method string, segments []string, identity, sub
 
 	switch sub {
 	case "configuration-set":
-		if len(segments) == 3 {
+		if len(segments) == pathDepth3 {
 			return opPutEmailIdentityConfigurationSetAttributes, identity
 		}
 	case "dkim":
 		switch len(segments) {
-		case 3:
+		case pathDepth3:
 			return opPutEmailIdentityDkimAttributes, identity
-		case 4:
+		case pathDepth4:
 			if segments[3] == "signing" {
 				return opPutEmailIdentityDkimSigningAttributes, identity
 			}
 		}
 	case "feedback":
-		if len(segments) == 3 {
+		if len(segments) == pathDepth3 {
 			return opPutEmailIdentityFeedbackAttributes, identity
 		}
 	case "mail-from":
-		if len(segments) == 3 {
+		if len(segments) == pathDepth3 {
 			return opPutEmailIdentityMailFromAttributes, identity
 		}
 	}
@@ -840,7 +841,7 @@ func parseIdentityAttributesPath(method string, segments []string, identity, sub
 
 // parseConfigSetExtPath handles additional configuration set paths.
 func parseConfigSetExtPath(method string, segments []string) (string, string) {
-	if len(segments) < 3 {
+	if len(segments) < pathDepth3 {
 		return unknownAction, ""
 	}
 
@@ -865,11 +866,11 @@ func parseConfigSetEventDestPath(method string, segments []string, name, sub str
 	}
 
 	switch len(segments) {
-	case 3:
+	case pathDepth3:
 		if method == http.MethodGet {
 			return opGetConfigurationSetEventDestinations, name
 		}
-	case 4:
+	case pathDepth4:
 		switch method {
 		case http.MethodDelete:
 			return opDeleteConfigurationSetEventDestination, name

--- a/services/stepfunctions/asl/executor.go
+++ b/services/stepfunctions/asl/executor.go
@@ -342,8 +342,8 @@ func (e *Executor) executeWait(ctx context.Context, state *State, input any) (st
 	}
 
 	if waitDuration > 0 {
-		if err := e.waitForDuration(ctx, waitDuration); err != nil {
-			return "", nil, err
+		if waitErr := e.waitForDuration(ctx, waitDuration); waitErr != nil {
+			return "", nil, waitErr
 		}
 	}
 
@@ -1657,7 +1657,8 @@ func matchTimestampLiteralCondition(rule *ChoiceRule, varVal any) (bool, bool) {
 		return r, m
 	}
 
-	if r, m := compareLiteral(rule.TimestampGreaterThanEquals, func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
+	if r, m := compareLiteral(rule.TimestampGreaterThanEquals,
+		func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
 		return r, m
 	}
 
@@ -1692,7 +1693,8 @@ func matchTimestampPathCondition(rule *ChoiceRule, varVal, input any, pathCache 
 		return r, m
 	}
 
-	if r, m := comparePath(rule.TimestampGreaterThanEqualsPath, func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
+	if r, m := comparePath(rule.TimestampGreaterThanEqualsPath,
+		func(t1, t2 time.Time) bool { return !t1.Before(t2) }); m {
 		return r, m
 	}
 


### PR DESCRIPTION
Comprehensive fix for all lint regressions introduced by recent PRs: bedrock keyStatus redeclared, cloudfront golines/unreachable/stringscutprefix, stepfunctions shadow, apigateway magic numbers/unused-nolint, rds unreachable, sesv2 magic numbers.