### PR TITLE
feat(ecs): AWS accuracy audit per #1681

### DIFF
--- a/services/ecs/backend.go
+++ b/services/ecs/backend.go
@@ -64,13 +64,33 @@ type Cluster struct {
 
 // ContainerDefinition represents a container definition in a task definition.
 type ContainerDefinition struct {
-	Image        string         `json:"image"`
-	Name         string         `json:"name"`
-	Environment  []KeyValuePair `json:"environment,omitempty"`
-	PortMappings []PortMapping  `json:"portMappings,omitempty"`
-	Essential    bool           `json:"essential"`
-	Memory       int            `json:"memory,omitempty"`
-	CPU          int            `json:"cpu,omitempty"`
+	LogConfiguration      *LogConfiguration      `json:"logConfiguration,omitempty"`
+	FirelensConfiguration *FirelensConfiguration `json:"firelensConfiguration,omitempty"`
+	HealthCheck           *HealthCheck           `json:"healthCheck,omitempty"`
+	RepositoryCredentials *RepositoryCredentials `json:"repositoryCredentials,omitempty"`
+	Image                 string                 `json:"image"`
+	Name                  string                 `json:"name"`
+	EntryPoint            []string               `json:"entryPoint,omitempty"`
+	Command               []string               `json:"command,omitempty"`
+	Environment           []KeyValuePair         `json:"environment,omitempty"`
+	Secrets               []SecretReference      `json:"secrets,omitempty"`
+	PortMappings          []PortMapping          `json:"portMappings,omitempty"`
+	MountPoints           []MountPoint           `json:"mountPoints,omitempty"`
+	VolumesFrom           []VolumeFrom           `json:"volumesFrom,omitempty"`
+	DependsOn             []ContainerDependency  `json:"dependsOn,omitempty"`
+	Memory                int                    `json:"memory,omitempty"`
+	MemoryReservation     int                    `json:"memoryReservation,omitempty"`
+	CPU                   int                    `json:"cpu,omitempty"`
+	Essential             bool                   `json:"essential"`
+	DisableNetworking     bool                   `json:"disableNetworking,omitempty"`
+	Privileged            bool                   `json:"privileged,omitempty"`
+	ReadonlyRootFilesystem bool                  `json:"readonlyRootFilesystem,omitempty"`
+}
+
+// ContainerDependency specifies a start/stop dependency between containers.
+type ContainerDependency struct {
+	ContainerName string `json:"containerName"`
+	Condition     string `json:"condition"`
 }
 
 // KeyValuePair is a name/value pair.
@@ -81,24 +101,31 @@ type KeyValuePair struct {
 
 // PortMapping maps a container port to a host port.
 type PortMapping struct {
-	Protocol      string `json:"protocol,omitempty"`
-	ContainerPort int    `json:"containerPort"`
-	HostPort      int    `json:"hostPort,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Protocol            string `json:"protocol,omitempty"`
+	AppProtocol         string `json:"appProtocol,omitempty"`
+	ContainerPortRange  string `json:"containerPortRange,omitempty"`
+	ContainerPort       int    `json:"containerPort,omitempty"`
+	HostPort            int    `json:"hostPort,omitempty"`
 }
 
 // TaskDefinition represents an ECS task definition.
 type TaskDefinition struct {
-	RegisteredAt         time.Time             `json:"registeredAt"`
-	TaskDefinitionArn    string                `json:"taskDefinitionArn"`
-	Family               string                `json:"family"`
-	NetworkMode          string                `json:"networkMode,omitempty"`
-	Status               string                `json:"status"`
-	PlatformFamily       string                `json:"platformFamily,omitempty"`
-	CPU                  string                `json:"cpu,omitempty"`
-	Memory               string                `json:"memory,omitempty"`
-	ContainerDefinitions []ContainerDefinition `json:"containerDefinitions"`
-	PlacementConstraints []PlacementConstraint `json:"placementConstraints,omitempty"`
-	Revision             int                   `json:"revision"`
+	RegisteredAt            time.Time             `json:"registeredAt"`
+	TaskDefinitionArn       string                `json:"taskDefinitionArn"`
+	Family                  string                `json:"family"`
+	TaskRoleArn             string                `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn        string                `json:"executionRoleArn,omitempty"`
+	NetworkMode             string                `json:"networkMode,omitempty"`
+	Status                  string                `json:"status"`
+	PlatformFamily          string                `json:"platformFamily,omitempty"`
+	CPU                     string                `json:"cpu,omitempty"`
+	Memory                  string                `json:"memory,omitempty"`
+	ContainerDefinitions    []ContainerDefinition `json:"containerDefinitions"`
+	Volumes                 []Volume              `json:"volumes,omitempty"`
+	PlacementConstraints    []PlacementConstraint `json:"placementConstraints,omitempty"`
+	RequiresCompatibilities []string              `json:"requiresCompatibilities,omitempty"`
+	Revision                int                   `json:"revision"`
 }
 
 // Service represents an ECS service.
@@ -106,6 +133,8 @@ type Service struct {
 	CreatedAt                   time.Time                      `json:"createdAt"`
 	ServiceConnectConfiguration *ServiceConnectConfiguration   `json:"serviceConnectConfiguration,omitempty"`
 	DeploymentConfiguration     *DeploymentConfiguration       `json:"deploymentConfiguration,omitempty"`
+	DeploymentController        *DeploymentController          `json:"deploymentController,omitempty"`
+	NetworkConfiguration        *NetworkConfiguration          `json:"networkConfiguration,omitempty"`
 	ServiceArn                  string                         `json:"serviceArn"`
 	ServiceName                 string                         `json:"serviceName"`
 	ClusterArn                  string                         `json:"clusterArn"`
@@ -113,7 +142,10 @@ type Service struct {
 	Status                      string                         `json:"status"`
 	LaunchType                  string                         `json:"launchType,omitempty"`
 	SchedulingStrategy          string                         `json:"schedulingStrategy,omitempty"`
+	PropagateTags               string                         `json:"propagateTags,omitempty"`
 	Tags                        []Tag                          `json:"tags,omitempty"`
+	LoadBalancers               []LoadBalancer                 `json:"loadBalancers,omitempty"`
+	ServiceRegistries           []ServiceRegistry              `json:"serviceRegistries,omitempty"`
 	PlacementConstraints        []PlacementConstraint          `json:"placementConstraints,omitempty"`
 	PlacementStrategy           []PlacementStrategy            `json:"placementStrategy,omitempty"`
 	CapacityProviderStrategy    []CapacityProviderStrategyItem `json:"capacityProviderStrategy,omitempty"`
@@ -124,26 +156,28 @@ type Service struct {
 
 // Task represents an ECS task.
 type Task struct {
-	StartedAt            *time.Time       `json:"startedAt,omitempty"`
-	StoppedAt            *time.Time       `json:"stoppedAt,omitempty"`
-	ConnectivityAt       *time.Time       `json:"connectivityAt,omitempty"`
-	Overrides            *TaskOverride    `json:"overrides,omitempty"`
-	TaskArn              string           `json:"taskArn"`
-	ClusterArn           string           `json:"clusterArn"`
-	TaskDefinitionArn    string           `json:"taskDefinitionArn"`
-	LastStatus           string           `json:"lastStatus"`
-	DesiredStatus        string           `json:"desiredStatus"`
-	Connectivity         string           `json:"connectivity,omitempty"`
-	StoppedReason        string           `json:"stoppedReason,omitempty"`
-	Group                string           `json:"group,omitempty"`
-	LaunchType           string           `json:"launchType,omitempty"`
-	ContainerInstanceArn string           `json:"containerInstanceArn,omitempty"`
-	StartedBy            string           `json:"startedBy,omitempty"`
-	PlatformVersion      string           `json:"platformVersion,omitempty"`
-	PlatformFamily       string           `json:"platformFamily,omitempty"`
-	RuntimeID            string           `json:"runtimeId,omitempty"`
-	Tags                 []Tag            `json:"tags,omitempty"`
-	Attachments          []TaskAttachment `json:"attachments,omitempty"`
+	StartedAt            *time.Time            `json:"startedAt,omitempty"`
+	StoppedAt            *time.Time            `json:"stoppedAt,omitempty"`
+	ConnectivityAt       *time.Time            `json:"connectivityAt,omitempty"`
+	Overrides            *TaskOverride         `json:"overrides,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	TaskArn              string                `json:"taskArn"`
+	ClusterArn           string                `json:"clusterArn"`
+	TaskDefinitionArn    string                `json:"taskDefinitionArn"`
+	LastStatus           string                `json:"lastStatus"`
+	DesiredStatus        string                `json:"desiredStatus"`
+	Connectivity         string                `json:"connectivity,omitempty"`
+	StoppedReason        string                `json:"stoppedReason,omitempty"`
+	Group                string                `json:"group,omitempty"`
+	LaunchType           string                `json:"launchType,omitempty"`
+	ContainerInstanceArn string                `json:"containerInstanceArn,omitempty"`
+	StartedBy            string                `json:"startedBy,omitempty"`
+	PlatformVersion      string                `json:"platformVersion,omitempty"`
+	PlatformFamily       string                `json:"platformFamily,omitempty"`
+	RuntimeID            string                `json:"runtimeId,omitempty"`
+	PropagateTags        string                `json:"propagateTags,omitempty"`
+	Tags                 []Tag                 `json:"tags,omitempty"`
+	Attachments          []TaskAttachment      `json:"attachments,omitempty"`
 }
 
 // CreateClusterInput holds input for CreateCluster.
@@ -153,26 +187,35 @@ type CreateClusterInput struct {
 
 // RegisterTaskDefinitionInput holds input for RegisterTaskDefinition.
 type RegisterTaskDefinitionInput struct {
-	Family               string                `json:"family"`
-	NetworkMode          string                `json:"networkMode,omitempty"`
-	CPU                  string                `json:"cpu,omitempty"`
-	Memory               string                `json:"memory,omitempty"`
-	PlatformFamily       string                `json:"platformFamily,omitempty"`
-	ContainerDefinitions []ContainerDefinition `json:"containerDefinitions"`
-	PlacementConstraints []PlacementConstraint `json:"placementConstraints,omitempty"`
-	Tags                 []Tag                 `json:"tags,omitempty"`
+	Family                  string                `json:"family"`
+	TaskRoleArn             string                `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn        string                `json:"executionRoleArn,omitempty"`
+	NetworkMode             string                `json:"networkMode,omitempty"`
+	CPU                     string                `json:"cpu,omitempty"`
+	Memory                  string                `json:"memory,omitempty"`
+	PlatformFamily          string                `json:"platformFamily,omitempty"`
+	ContainerDefinitions    []ContainerDefinition `json:"containerDefinitions"`
+	Volumes                 []Volume              `json:"volumes,omitempty"`
+	PlacementConstraints    []PlacementConstraint `json:"placementConstraints,omitempty"`
+	RequiresCompatibilities []string              `json:"requiresCompatibilities,omitempty"`
+	Tags                    []Tag                 `json:"tags,omitempty"`
 }
 
 // CreateServiceInput holds input for CreateService.
 type CreateServiceInput struct {
 	DeploymentConfiguration     *DeploymentConfiguration       `json:"deploymentConfiguration,omitempty"`
+	DeploymentController        *DeploymentController          `json:"deploymentController,omitempty"`
+	NetworkConfiguration        *NetworkConfiguration          `json:"networkConfiguration,omitempty"`
 	ServiceConnectConfiguration *ServiceConnectConfiguration   `json:"serviceConnectConfiguration,omitempty"`
 	ServiceName                 string                         `json:"serviceName"`
 	Cluster                     string                         `json:"cluster,omitempty"`
 	TaskDefinition              string                         `json:"taskDefinition"`
 	LaunchType                  string                         `json:"launchType,omitempty"`
 	SchedulingStrategy          string                         `json:"schedulingStrategy,omitempty"`
+	PropagateTags               string                         `json:"propagateTags,omitempty"`
 	Tags                        []Tag                          `json:"tags,omitempty"`
+	LoadBalancers               []LoadBalancer                 `json:"loadBalancers,omitempty"`
+	ServiceRegistries           []ServiceRegistry              `json:"serviceRegistries,omitempty"`
 	CapacityProviderStrategy    []CapacityProviderStrategyItem `json:"capacityProviderStrategy,omitempty"`
 	PlacementConstraints        []PlacementConstraint          `json:"placementConstraints,omitempty"`
 	PlacementStrategy           []PlacementStrategy            `json:"placementStrategy,omitempty"`
@@ -183,10 +226,13 @@ type CreateServiceInput struct {
 type UpdateServiceInput struct {
 	DesiredCount                *int                           `json:"desiredCount,omitempty"`
 	DeploymentConfiguration     *DeploymentConfiguration       `json:"deploymentConfiguration,omitempty"`
+	NetworkConfiguration        *NetworkConfiguration          `json:"networkConfiguration,omitempty"`
 	ServiceConnectConfiguration *ServiceConnectConfiguration   `json:"serviceConnectConfiguration,omitempty"`
 	Cluster                     string                         `json:"cluster,omitempty"`
 	Service                     string                         `json:"service"`
 	TaskDefinition              string                         `json:"taskDefinition,omitempty"`
+	PropagateTags               string                         `json:"propagateTags,omitempty"`
+	LoadBalancers               []LoadBalancer                 `json:"loadBalancers,omitempty"`
 	CapacityProviderStrategy    []CapacityProviderStrategyItem `json:"capacityProviderStrategy,omitempty"`
 	PlacementConstraints        []PlacementConstraint          `json:"placementConstraints,omitempty"`
 	PlacementStrategy           []PlacementStrategy            `json:"placementStrategy,omitempty"`
@@ -194,16 +240,18 @@ type UpdateServiceInput struct {
 
 // RunTaskInput holds input for RunTask.
 type RunTaskInput struct {
-	Overrides            *TaskOverride `json:"overrides,omitempty"`
-	Cluster              string        `json:"cluster,omitempty"`
-	TaskDefinition       string        `json:"taskDefinition"`
-	LaunchType           string        `json:"launchType,omitempty"`
-	Group                string        `json:"group,omitempty"`
-	StartedBy            string        `json:"startedBy,omitempty"`
-	PlatformVersion      string        `json:"platformVersion,omitempty"`
-	Tags                 []Tag         `json:"tags,omitempty"`
-	Count                int           `json:"count,omitempty"`
-	EnableECSManagedTags bool          `json:"enableECSManagedTags,omitempty"`
+	Overrides            *TaskOverride         `json:"overrides,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"networkConfiguration,omitempty"`
+	Cluster              string                `json:"cluster,omitempty"`
+	TaskDefinition       string                `json:"taskDefinition"`
+	LaunchType           string                `json:"launchType,omitempty"`
+	Group                string                `json:"group,omitempty"`
+	StartedBy            string                `json:"startedBy,omitempty"`
+	PlatformVersion      string                `json:"platformVersion,omitempty"`
+	PropagateTags        string                `json:"propagateTags,omitempty"`
+	Tags                 []Tag                 `json:"tags,omitempty"`
+	Count                int                   `json:"count,omitempty"`
+	EnableECSManagedTags bool                  `json:"enableECSManagedTags,omitempty"`
 }
 
 // compile-time assertion.
@@ -457,11 +505,12 @@ func (b *InMemoryBackend) DeleteCluster(clusterName string) (*Cluster, error) {
 		}
 	}
 
-	// Delete task sets for all services in this cluster before removing the services map,
-	// preventing stale task set entries on cluster recreation.
+	// Delete task sets and service deployments for all services in this cluster
+	// before removing the services map, preventing stale entries on cluster recreation.
 	if svcs, exists := b.services[key]; exists {
 		for _, svc := range svcs {
 			delete(b.taskSets, svc.ServiceArn)
+			delete(b.serviceDeployments, svc.ServiceArn)
 		}
 	}
 
@@ -494,6 +543,20 @@ func (b *InMemoryBackend) RegisterTaskDefinition(input RegisterTaskDefinitionInp
 		return nil, fmt.Errorf("%w: family is required", ErrInvalidParameter)
 	}
 
+	isFargate := false
+	for _, rc := range input.RequiresCompatibilities {
+		if strings.EqualFold(rc, launchTypeFargate) {
+			isFargate = true
+			break
+		}
+	}
+
+	if isFargate {
+		if err := validateFargateCPUMemory(input.CPU, input.Memory); err != nil {
+			return nil, err
+		}
+	}
+
 	b.mu.Lock("RegisterTaskDefinition")
 	defer b.mu.Unlock()
 
@@ -515,15 +578,19 @@ func (b *InMemoryBackend) RegisterTaskDefinition(input RegisterTaskDefinitionInp
 			input.Family,
 			revision,
 		),
-		Family:               input.Family,
-		NetworkMode:          input.NetworkMode,
-		CPU:                  input.CPU,
-		Memory:               input.Memory,
-		PlatformFamily:       input.PlatformFamily,
-		Status:               statusActive,
-		ContainerDefinitions: input.ContainerDefinitions,
-		PlacementConstraints: input.PlacementConstraints,
-		Revision:             revision,
+		Family:                  input.Family,
+		TaskRoleArn:             input.TaskRoleArn,
+		ExecutionRoleArn:        input.ExecutionRoleArn,
+		NetworkMode:             input.NetworkMode,
+		CPU:                     input.CPU,
+		Memory:                  input.Memory,
+		PlatformFamily:          input.PlatformFamily,
+		Status:                  statusActive,
+		ContainerDefinitions:    input.ContainerDefinitions,
+		Volumes:                 input.Volumes,
+		PlacementConstraints:    input.PlacementConstraints,
+		RequiresCompatibilities: input.RequiresCompatibilities,
+		Revision:                revision,
 	}
 
 	revisions = append(revisions, td)
@@ -654,21 +721,39 @@ func (b *InMemoryBackend) DeregisterTaskDefinition(taskDefinitionArn string) (*T
 	return nil, fmt.Errorf("%w: %s", ErrTaskDefinitionNotFound, taskDefinitionArn)
 }
 
+// ListTaskDefinitionsInput holds optional filters for ListTaskDefinitions.
+type ListTaskDefinitionsInput struct {
+	FamilyPrefix string
+	// Status filters by task definition status: "ACTIVE", "INACTIVE", or
+	// "DELETE_IN_PROGRESS". Empty string matches only ACTIVE (AWS default).
+	Status string
+}
+
 // ListTaskDefinitions returns ARNs of task definitions, optionally filtered by family prefix.
 // ARNs are returned sorted for deterministic output.
 func (b *InMemoryBackend) ListTaskDefinitions(familyPrefix string) ([]string, error) {
-	b.mu.RLock("ListTaskDefinitions")
+	return b.ListTaskDefinitionsFiltered(ListTaskDefinitionsInput{FamilyPrefix: familyPrefix})
+}
+
+// ListTaskDefinitionsFiltered returns task definition ARNs with status filtering.
+func (b *InMemoryBackend) ListTaskDefinitionsFiltered(input ListTaskDefinitionsInput) ([]string, error) {
+	b.mu.RLock("ListTaskDefinitionsFiltered")
 	defer b.mu.RUnlock()
+
+	wantStatus := strings.ToUpper(input.Status)
+	if wantStatus == "" {
+		wantStatus = statusActive
+	}
 
 	var arns []string
 
 	for family, revs := range b.taskDefinitions {
-		if familyPrefix != "" && !strings.HasPrefix(family, familyPrefix) {
+		if input.FamilyPrefix != "" && !strings.HasPrefix(family, input.FamilyPrefix) {
 			continue
 		}
 
 		for _, td := range revs {
-			if td.Status == statusActive {
+			if strings.EqualFold(td.Status, wantStatus) {
 				arns = append(arns, td.TaskDefinitionArn)
 			}
 		}
@@ -707,6 +792,10 @@ func (b *InMemoryBackend) CreateService(input CreateServiceInput) (*Service, err
 
 	clusterName := clusterKey(b.resolveCluster(input.Cluster))
 
+	if err := validateDeploymentController(input.DeploymentController); err != nil {
+		return nil, err
+	}
+
 	b.mu.Lock("CreateService")
 	defer b.mu.Unlock()
 
@@ -731,6 +820,11 @@ func (b *InMemoryBackend) CreateService(input CreateServiceInput) (*Service, err
 		schedulingStrategy = "REPLICA"
 	}
 
+	propagateTags := input.PropagateTags
+	if propagateTags == "" {
+		propagateTags = propagateTagsNone
+	}
+
 	svc := &Service{
 		CreatedAt: time.Now(),
 		ServiceArn: fmt.Sprintf(
@@ -746,8 +840,13 @@ func (b *InMemoryBackend) CreateService(input CreateServiceInput) (*Service, err
 		Status:                      statusActive,
 		LaunchType:                  launchType,
 		SchedulingStrategy:          schedulingStrategy,
+		PropagateTags:               propagateTags,
 		Tags:                        input.Tags,
-		DeploymentConfiguration:     input.DeploymentConfiguration,
+		LoadBalancers:               input.LoadBalancers,
+		ServiceRegistries:           input.ServiceRegistries,
+		DeploymentConfiguration:     input.DeploymentConfiguration.withAWSDefaults(),
+		DeploymentController:        input.DeploymentController,
+		NetworkConfiguration:        input.NetworkConfiguration,
 		CapacityProviderStrategy:    input.CapacityProviderStrategy,
 		PlacementConstraints:        input.PlacementConstraints,
 		PlacementStrategy:           input.PlacementStrategy,
@@ -891,6 +990,18 @@ func (b *InMemoryBackend) UpdateService(input UpdateServiceInput) (*Service, err
 		svc.ServiceConnectConfiguration = input.ServiceConnectConfiguration
 	}
 
+	if input.NetworkConfiguration != nil {
+		svc.NetworkConfiguration = input.NetworkConfiguration
+	}
+
+	if input.PropagateTags != "" {
+		svc.PropagateTags = input.PropagateTags
+	}
+
+	if len(input.LoadBalancers) > 0 {
+		svc.LoadBalancers = input.LoadBalancers
+	}
+
 	cp := *svc
 
 	return &cp, nil
@@ -935,6 +1046,10 @@ func (b *InMemoryBackend) RunTask(input RunTaskInput) ([]Task, error) {
 		return nil, fmt.Errorf("%w: taskDefinition is required", ErrInvalidParameter)
 	}
 
+	if err := validatePlatformVersion(input.PlatformVersion); err != nil {
+		return nil, err
+	}
+
 	count := input.Count
 	if count <= 0 {
 		count = 1
@@ -970,20 +1085,22 @@ func (b *InMemoryBackend) RunTask(input RunTaskInput) ([]Task, error) {
 
 		now := time.Now()
 		task := &Task{
-			TaskArn:           taskArn,
-			ClusterArn:        clusterArn,
-			TaskDefinitionArn: td.TaskDefinitionArn,
-			LastStatus:        statusProvisioning,
-			DesiredStatus:     statusRunning,
-			Group:             input.Group,
-			LaunchType:        launchType,
-			StartedBy:         input.StartedBy,
-			PlatformVersion:   input.PlatformVersion,
-			Tags:              input.Tags,
-			StartedAt:         &now,
-			Connectivity:      connectivityConnected,
-			ConnectivityAt:    &now,
-			Overrides:         input.Overrides,
+			TaskArn:              taskArn,
+			ClusterArn:           clusterArn,
+			TaskDefinitionArn:    td.TaskDefinitionArn,
+			LastStatus:           statusProvisioning,
+			DesiredStatus:        statusRunning,
+			Group:                input.Group,
+			LaunchType:           launchType,
+			StartedBy:            input.StartedBy,
+			PlatformVersion:      input.PlatformVersion,
+			PropagateTags:        input.PropagateTags,
+			Tags:                 input.Tags,
+			StartedAt:            &now,
+			Connectivity:         connectivityConnected,
+			ConnectivityAt:       &now,
+			Overrides:            input.Overrides,
+			NetworkConfiguration: input.NetworkConfiguration,
 		}
 
 		if launchType == launchTypeFargate {

--- a/services/ecs/backend.go
+++ b/services/ecs/backend.go
@@ -64,27 +64,27 @@ type Cluster struct {
 
 // ContainerDefinition represents a container definition in a task definition.
 type ContainerDefinition struct {
-	LogConfiguration      *LogConfiguration      `json:"logConfiguration,omitempty"`
-	FirelensConfiguration *FirelensConfiguration `json:"firelensConfiguration,omitempty"`
-	HealthCheck           *HealthCheck           `json:"healthCheck,omitempty"`
-	RepositoryCredentials *RepositoryCredentials `json:"repositoryCredentials,omitempty"`
-	Image                 string                 `json:"image"`
-	Name                  string                 `json:"name"`
-	EntryPoint            []string               `json:"entryPoint,omitempty"`
-	Command               []string               `json:"command,omitempty"`
-	Environment           []KeyValuePair         `json:"environment,omitempty"`
-	Secrets               []SecretReference      `json:"secrets,omitempty"`
-	PortMappings          []PortMapping          `json:"portMappings,omitempty"`
-	MountPoints           []MountPoint           `json:"mountPoints,omitempty"`
-	VolumesFrom           []VolumeFrom           `json:"volumesFrom,omitempty"`
-	DependsOn             []ContainerDependency  `json:"dependsOn,omitempty"`
-	Memory                int                    `json:"memory,omitempty"`
-	MemoryReservation     int                    `json:"memoryReservation,omitempty"`
-	CPU                   int                    `json:"cpu,omitempty"`
-	Essential             bool                   `json:"essential"`
-	DisableNetworking     bool                   `json:"disableNetworking,omitempty"`
-	Privileged            bool                   `json:"privileged,omitempty"`
-	ReadonlyRootFilesystem bool                  `json:"readonlyRootFilesystem,omitempty"`
+	LogConfiguration       *LogConfiguration      `json:"logConfiguration,omitempty"`
+	FirelensConfiguration  *FirelensConfiguration `json:"firelensConfiguration,omitempty"`
+	HealthCheck            *HealthCheck           `json:"healthCheck,omitempty"`
+	RepositoryCredentials  *RepositoryCredentials `json:"repositoryCredentials,omitempty"`
+	Image                  string                 `json:"image"`
+	Name                   string                 `json:"name"`
+	EntryPoint             []string               `json:"entryPoint,omitempty"`
+	Command                []string               `json:"command,omitempty"`
+	Environment            []KeyValuePair         `json:"environment,omitempty"`
+	Secrets                []SecretReference      `json:"secrets,omitempty"`
+	PortMappings           []PortMapping          `json:"portMappings,omitempty"`
+	MountPoints            []MountPoint           `json:"mountPoints,omitempty"`
+	VolumesFrom            []VolumeFrom           `json:"volumesFrom,omitempty"`
+	DependsOn              []ContainerDependency  `json:"dependsOn,omitempty"`
+	Memory                 int                    `json:"memory,omitempty"`
+	MemoryReservation      int                    `json:"memoryReservation,omitempty"`
+	CPU                    int                    `json:"cpu,omitempty"`
+	Essential              bool                   `json:"essential"`
+	DisableNetworking      bool                   `json:"disableNetworking,omitempty"`
+	Privileged             bool                   `json:"privileged,omitempty"`
+	ReadonlyRootFilesystem bool                   `json:"readonlyRootFilesystem,omitempty"`
 }
 
 // ContainerDependency specifies a start/stop dependency between containers.
@@ -101,12 +101,12 @@ type KeyValuePair struct {
 
 // PortMapping maps a container port to a host port.
 type PortMapping struct {
-	Name                string `json:"name,omitempty"`
-	Protocol            string `json:"protocol,omitempty"`
-	AppProtocol         string `json:"appProtocol,omitempty"`
-	ContainerPortRange  string `json:"containerPortRange,omitempty"`
-	ContainerPort       int    `json:"containerPort,omitempty"`
-	HostPort            int    `json:"hostPort,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Protocol           string `json:"protocol,omitempty"`
+	AppProtocol        string `json:"appProtocol,omitempty"`
+	ContainerPortRange string `json:"containerPortRange,omitempty"`
+	ContainerPort      int    `json:"containerPort,omitempty"`
+	HostPort           int    `json:"hostPort,omitempty"`
 }
 
 // TaskDefinition represents an ECS task definition.
@@ -544,9 +544,11 @@ func (b *InMemoryBackend) RegisterTaskDefinition(input RegisterTaskDefinitionInp
 	}
 
 	isFargate := false
+
 	for _, rc := range input.RequiresCompatibilities {
 		if strings.EqualFold(rc, launchTypeFargate) {
 			isFargate = true
+
 			break
 		}
 	}

--- a/services/ecs/backend_comprehensive.go
+++ b/services/ecs/backend_comprehensive.go
@@ -22,11 +22,11 @@ type ServiceConnectConfiguration struct {
 
 // ContainerOverride represents a container override for a task.
 type ContainerOverride struct {
-	CPU         *int           `json:"cpu,omitempty"`
-	Memory      *int           `json:"memory,omitempty"`
-	Name        string         `json:"name"`
-	Command     []string       `json:"command,omitempty"`
-	Environment []KeyValuePair `json:"environment,omitempty"`
+	CPU         *int              `json:"cpu,omitempty"`
+	Memory      *int              `json:"memory,omitempty"`
+	Name        string            `json:"name"`
+	Command     []string          `json:"command,omitempty"`
+	Environment []KeyValuePair    `json:"environment,omitempty"`
 	Secrets     []SecretReference `json:"secrets,omitempty"`
 }
 

--- a/services/ecs/backend_comprehensive.go
+++ b/services/ecs/backend_comprehensive.go
@@ -27,6 +27,7 @@ type ContainerOverride struct {
 	Name        string         `json:"name"`
 	Command     []string       `json:"command,omitempty"`
 	Environment []KeyValuePair `json:"environment,omitempty"`
+	Secrets     []SecretReference `json:"secrets,omitempty"`
 }
 
 // TaskOverride represents overrides for a task run.

--- a/services/ecs/backend_ext.go
+++ b/services/ecs/backend_ext.go
@@ -327,7 +327,7 @@ func (b *InMemoryBackend) CreateTaskSet(input CreateTaskSetInput) (*TaskSet, err
 
 	platformVersion := input.PlatformVersion
 	if platformVersion == "" {
-		platformVersion = "LATEST"
+		platformVersion = platformVersionLatest
 	}
 
 	scale := TaskSetScale{Unit: "PERCENT", Value: defaultTaskSetScaleValue}

--- a/services/ecs/backend_iface.go
+++ b/services/ecs/backend_iface.go
@@ -17,6 +17,7 @@ type Backend interface {
 	DescribeTaskDefinition(family string) (*TaskDefinition, error)
 	DeregisterTaskDefinition(taskDefinitionArn string) (*TaskDefinition, error)
 	ListTaskDefinitions(familyPrefix string) ([]string, error)
+	ListTaskDefinitionsFiltered(input ListTaskDefinitionsInput) ([]string, error)
 	DeleteTaskDefinitions(taskDefinitionArns []string) ([]TaskDefinition, []Failure, error)
 
 	// Services

--- a/services/ecs/backend_parity.go
+++ b/services/ecs/backend_parity.go
@@ -109,7 +109,7 @@ const (
 
 // AwsvpcConfiguration holds awsvpc mode network settings.
 type AwsvpcConfiguration struct {
-	AssignPublicIp string   `json:"assignPublicIp,omitempty"` //nolint:revive,stylecheck // AWS API field name
+	AssignPublicIP string   `json:"assignPublicIp,omitempty"`
 	Subnets        []string `json:"subnets"`
 	SecurityGroups []string `json:"securityGroups,omitempty"`
 }

--- a/services/ecs/backend_parity.go
+++ b/services/ecs/backend_parity.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -45,8 +46,8 @@ type SecretOption struct {
 
 // FirelensConfiguration specifies FireLens routing for container logs.
 type FirelensConfiguration struct {
-	Type    string            `json:"type"`
 	Options map[string]string `json:"options,omitempty"`
+	Type    string            `json:"type"`
 }
 
 // ---- Issue #6: Secrets ----
@@ -61,10 +62,10 @@ type SecretReference struct {
 
 // EFSVolumeConfiguration holds EFS-specific volume options.
 type EFSVolumeConfiguration struct {
-	FileSystemID          string `json:"fileSystemId"`
-	RootDirectory         string `json:"rootDirectory,omitempty"`
-	TransitEncryption     string `json:"transitEncryption,omitempty"`
-	AuthorizationConfig   *EFSAuthorizationConfig `json:"authorizationConfig,omitempty"`
+	AuthorizationConfig *EFSAuthorizationConfig `json:"authorizationConfig,omitempty"`
+	FileSystemID        string                  `json:"fileSystemId"`
+	RootDirectory       string                  `json:"rootDirectory,omitempty"`
+	TransitEncryption   string                  `json:"transitEncryption,omitempty"`
 }
 
 // EFSAuthorizationConfig holds EFS authorization settings.
@@ -80,9 +81,9 @@ type HostVolumeProperties struct {
 
 // Volume defines a storage volume for a task definition.
 type Volume struct {
-	Name                   string                  `json:"name"`
 	Host                   *HostVolumeProperties   `json:"host,omitempty"`
 	EFSVolumeConfiguration *EFSVolumeConfiguration `json:"efsVolumeConfiguration,omitempty"`
+	Name                   string                  `json:"name"`
 	ConfiguredAtLaunch     bool                    `json:"configuredAtLaunch,omitempty"`
 }
 
@@ -108,9 +109,9 @@ const (
 
 // AwsvpcConfiguration holds awsvpc mode network settings.
 type AwsvpcConfiguration struct {
+	AssignPublicIp string   `json:"assignPublicIp,omitempty"` //nolint:revive,stylecheck // AWS API field name
 	Subnets        []string `json:"subnets"`
 	SecurityGroups []string `json:"securityGroups,omitempty"`
-	AssignPublicIp string   `json:"assignPublicIp,omitempty"`
 }
 
 // NetworkConfiguration holds the network settings for a task or service.
@@ -141,33 +142,38 @@ type RepositoryCredentials struct {
 // ServiceRegistry wires tasks into a CloudMap namespace for service discovery.
 type ServiceRegistry struct {
 	RegistryArn   string `json:"registryArn,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
 	Port          int    `json:"port,omitempty"`
 	ContainerPort int    `json:"containerPort,omitempty"`
-	ContainerName string `json:"containerName,omitempty"`
 }
 
 // ---- Issue #9: Fargate CPU/memory validation ----
 
-// fargateCPUMemoryPairs maps valid Fargate CPU values (vCPU units as strings) to
-// the set of valid memory values (MiB as strings) per the AWS documentation.
-var fargateCPUMemoryPairs = map[string][]string{
-	"256":  {"512", "1024", "2048"},
-	"512":  {"1024", "2048", "3072", "4096"},
-	"1024": {"2048", "3072", "4096", "5120", "6144", "7168", "8192"},
-	"2048": {"4096", "5120", "6144", "7168", "8192", "9216", "10240", "11264", "12288", "13312", "14336", "15360", "16384"},
-	"4096": {
-		"8192", "9216", "10240", "11264", "12288", "13312", "14336", "15360",
-		"16384", "17408", "18432", "19456", "20480", "21504", "22528", "23552",
-		"24576", "25600", "26624", "27648", "28672", "29696", "30720",
-	},
-	"8192": {
-		"16384", "20480", "24576", "28672", "32768", "36864", "40960", "45056",
-		"49152", "53248", "57344", "61440",
-	},
-	"16384": {
-		"32768", "40960", "49152", "57344", "65536", "73728", "81920", "90112",
-		"98304", "106496", "114688", "122880",
-	},
+// fargateCPUMemoryPairs returns valid Fargate CPU/memory combinations per the AWS docs.
+// Keys are CPU values (vCPU units as strings); values are allowed memory values (MiB as strings).
+func fargateCPUMemoryPairs() map[string][]string {
+	return map[string][]string{
+		"256":  {"512", "1024", "2048"},
+		"512":  {"1024", "2048", "3072", "4096"},
+		"1024": {"2048", "3072", "4096", "5120", "6144", "7168", "8192"},
+		"2048": {
+			"4096", "5120", "6144", "7168", "8192", "9216", "10240", "11264",
+			"12288", "13312", "14336", "15360", "16384",
+		},
+		"4096": {
+			"8192", "9216", "10240", "11264", "12288", "13312", "14336", "15360",
+			"16384", "17408", "18432", "19456", "20480", "21504", "22528", "23552",
+			"24576", "25600", "26624", "27648", "28672", "29696", "30720",
+		},
+		"8192": {
+			"16384", "20480", "24576", "28672", "32768", "36864", "40960", "45056",
+			"49152", "53248", "57344", "61440",
+		},
+		"16384": {
+			"32768", "40960", "49152", "57344", "65536", "73728", "81920", "90112",
+			"98304", "106496", "114688", "122880",
+		},
+	}
 }
 
 // validateFargateCPUMemory returns an error if the cpu/memory combination is
@@ -177,7 +183,9 @@ func validateFargateCPUMemory(cpu, memory string) error {
 		return nil
 	}
 
-	validMemories, ok := fargateCPUMemoryPairs[cpu]
+	pairs := fargateCPUMemoryPairs()
+	validMemories, ok := pairs[cpu]
+
 	if !ok {
 		return fmt.Errorf(
 			"%w: invalid Fargate CPU value %q; valid values: 256, 512, 1024, 2048, 4096, 8192, 16384",
@@ -185,10 +193,8 @@ func validateFargateCPUMemory(cpu, memory string) error {
 		)
 	}
 
-	for _, m := range validMemories {
-		if m == memory {
-			return nil
-		}
+	if slices.Contains(validMemories, memory) {
+		return nil
 	}
 
 	return fmt.Errorf(
@@ -199,14 +205,28 @@ func validateFargateCPUMemory(cpu, memory string) error {
 
 // ---- Issue #16: PlatformVersion validation ----
 
-// validFargatePlatformVersions is the set of recognized Fargate platform versions.
-var validFargatePlatformVersions = map[string]bool{
-	"LATEST": true,
-	"1.4.0":  true,
-	"1.3.0":  true,
-	"1.2.0":  true,
-	"1.1.0":  true,
-	"1.0.0":  true,
+const (
+	platformVersionLatest = "LATEST"
+	platformVersion140    = "1.4.0"
+	platformVersion130    = "1.3.0"
+	platformVersion120    = "1.2.0"
+	platformVersion110    = "1.1.0"
+	platformVersion100    = "1.0.0"
+)
+
+// isValidFargatePlatformVersion reports whether pv is a known Fargate platform version.
+func isValidFargatePlatformVersion(pv string) bool {
+	switch pv {
+	case platformVersionLatest,
+		platformVersion140,
+		platformVersion130,
+		platformVersion120,
+		platformVersion110,
+		platformVersion100:
+		return true
+	}
+
+	return false
 }
 
 // validatePlatformVersion returns an error if the platform version is non-empty
@@ -216,7 +236,8 @@ func validatePlatformVersion(pv string) error {
 		return nil
 	}
 
-	if validFargatePlatformVersions[strings.ToUpper(pv)] || validFargatePlatformVersions[pv] {
+	upper := strings.ToUpper(pv)
+	if isValidFargatePlatformVersion(upper) || isValidFargatePlatformVersion(pv) {
 		return nil
 	}
 

--- a/services/ecs/backend_parity.go
+++ b/services/ecs/backend_parity.go
@@ -1,0 +1,261 @@
+package ecs
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ---- Issue #1: LoadBalancer ----
+
+// LoadBalancer wires ECS tasks to ALB/NLB target groups.
+type LoadBalancer struct {
+	TargetGroupArn   string `json:"targetGroupArn,omitempty"`
+	LoadBalancerName string `json:"loadBalancerName,omitempty"`
+	ContainerName    string `json:"containerName,omitempty"`
+	ContainerPort    int    `json:"containerPort,omitempty"`
+}
+
+// ---- Issue #3: DeploymentController ----
+
+const (
+	deploymentControllerRolling    = "ROLLING"
+	deploymentControllerExternal   = "EXTERNAL"
+	deploymentControllerCodeDeploy = "CODE_DEPLOY"
+)
+
+// DeploymentController specifies the deployment controller type for a service.
+type DeploymentController struct {
+	Type string `json:"type"`
+}
+
+// ---- Issue #4: LogConfiguration ----
+
+// LogConfiguration specifies the logging driver and options for a container.
+type LogConfiguration struct {
+	LogDriver     string            `json:"logDriver"`
+	Options       map[string]string `json:"options,omitempty"`
+	SecretOptions []SecretOption    `json:"secretOptions,omitempty"`
+}
+
+// SecretOption is a secret key/value pair for log driver authentication.
+type SecretOption struct {
+	Name      string `json:"name"`
+	ValueFrom string `json:"valueFrom"`
+}
+
+// FirelensConfiguration specifies FireLens routing for container logs.
+type FirelensConfiguration struct {
+	Type    string            `json:"type"`
+	Options map[string]string `json:"options,omitempty"`
+}
+
+// ---- Issue #6: Secrets ----
+
+// SecretReference resolves a SecretsManager ARN or SSM path into an env var.
+type SecretReference struct {
+	Name      string `json:"name"`
+	ValueFrom string `json:"valueFrom"`
+}
+
+// ---- Issue #7: Volumes ----
+
+// EFSVolumeConfiguration holds EFS-specific volume options.
+type EFSVolumeConfiguration struct {
+	FileSystemID          string `json:"fileSystemId"`
+	RootDirectory         string `json:"rootDirectory,omitempty"`
+	TransitEncryption     string `json:"transitEncryption,omitempty"`
+	AuthorizationConfig   *EFSAuthorizationConfig `json:"authorizationConfig,omitempty"`
+}
+
+// EFSAuthorizationConfig holds EFS authorization settings.
+type EFSAuthorizationConfig struct {
+	AccessPointID string `json:"accessPointId,omitempty"`
+	IAM           string `json:"iam,omitempty"`
+}
+
+// HostVolumeProperties holds host-bind volume path.
+type HostVolumeProperties struct {
+	SourcePath string `json:"sourcePath,omitempty"`
+}
+
+// Volume defines a storage volume for a task definition.
+type Volume struct {
+	Name                   string                  `json:"name"`
+	Host                   *HostVolumeProperties   `json:"host,omitempty"`
+	EFSVolumeConfiguration *EFSVolumeConfiguration `json:"efsVolumeConfiguration,omitempty"`
+	ConfiguredAtLaunch     bool                    `json:"configuredAtLaunch,omitempty"`
+}
+
+// MountPoint maps a volume into a container.
+type MountPoint struct {
+	SourceVolume  string `json:"sourceVolume,omitempty"`
+	ContainerPath string `json:"containerPath,omitempty"`
+	ReadOnly      bool   `json:"readOnly,omitempty"`
+}
+
+// VolumeFrom specifies a container whose volumes to mount.
+type VolumeFrom struct {
+	SourceContainer string `json:"sourceContainer,omitempty"`
+	ReadOnly        bool   `json:"readOnly,omitempty"`
+}
+
+// ---- Issue #8: NetworkConfiguration ----
+
+const (
+	assignPublicIPEnabled  = "ENABLED"
+	assignPublicIPDisabled = "DISABLED"
+)
+
+// AwsvpcConfiguration holds awsvpc mode network settings.
+type AwsvpcConfiguration struct {
+	Subnets        []string `json:"subnets"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+	AssignPublicIp string   `json:"assignPublicIp,omitempty"`
+}
+
+// NetworkConfiguration holds the network settings for a task or service.
+type NetworkConfiguration struct {
+	AwsvpcConfiguration *AwsvpcConfiguration `json:"awsvpcConfiguration,omitempty"`
+}
+
+// ---- Issue #10: HealthCheck ----
+
+// HealthCheck configures the container health check.
+type HealthCheck struct {
+	Command     []string `json:"command"`
+	Interval    int      `json:"interval,omitempty"`
+	Timeout     int      `json:"timeout,omitempty"`
+	Retries     int      `json:"retries,omitempty"`
+	StartPeriod int      `json:"startPeriod,omitempty"`
+}
+
+// ---- Issue #11: RepositoryCredentials ----
+
+// RepositoryCredentials references a SecretsManager secret for private registry pulls.
+type RepositoryCredentials struct {
+	CredentialsParameter string `json:"credentialsParameter"`
+}
+
+// ---- Issue #13: ServiceRegistry ----
+
+// ServiceRegistry wires tasks into a CloudMap namespace for service discovery.
+type ServiceRegistry struct {
+	RegistryArn   string `json:"registryArn,omitempty"`
+	Port          int    `json:"port,omitempty"`
+	ContainerPort int    `json:"containerPort,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+}
+
+// ---- Issue #9: Fargate CPU/memory validation ----
+
+// fargateCPUMemoryPairs maps valid Fargate CPU values (vCPU units as strings) to
+// the set of valid memory values (MiB as strings) per the AWS documentation.
+var fargateCPUMemoryPairs = map[string][]string{
+	"256":  {"512", "1024", "2048"},
+	"512":  {"1024", "2048", "3072", "4096"},
+	"1024": {"2048", "3072", "4096", "5120", "6144", "7168", "8192"},
+	"2048": {"4096", "5120", "6144", "7168", "8192", "9216", "10240", "11264", "12288", "13312", "14336", "15360", "16384"},
+	"4096": {
+		"8192", "9216", "10240", "11264", "12288", "13312", "14336", "15360",
+		"16384", "17408", "18432", "19456", "20480", "21504", "22528", "23552",
+		"24576", "25600", "26624", "27648", "28672", "29696", "30720",
+	},
+	"8192": {
+		"16384", "20480", "24576", "28672", "32768", "36864", "40960", "45056",
+		"49152", "53248", "57344", "61440",
+	},
+	"16384": {
+		"32768", "40960", "49152", "57344", "65536", "73728", "81920", "90112",
+		"98304", "106496", "114688", "122880",
+	},
+}
+
+// validateFargateCPUMemory returns an error if the cpu/memory combination is
+// invalid for Fargate. It is a no-op when either value is empty (EC2 launch type).
+func validateFargateCPUMemory(cpu, memory string) error {
+	if cpu == "" || memory == "" {
+		return nil
+	}
+
+	validMemories, ok := fargateCPUMemoryPairs[cpu]
+	if !ok {
+		return fmt.Errorf(
+			"%w: invalid Fargate CPU value %q; valid values: 256, 512, 1024, 2048, 4096, 8192, 16384",
+			ErrInvalidParameter, cpu,
+		)
+	}
+
+	for _, m := range validMemories {
+		if m == memory {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"%w: invalid Fargate memory %q for CPU %q; valid values: %s",
+		ErrInvalidParameter, memory, cpu, strings.Join(validMemories, ", "),
+	)
+}
+
+// ---- Issue #16: PlatformVersion validation ----
+
+// validFargatePlatformVersions is the set of recognized Fargate platform versions.
+var validFargatePlatformVersions = map[string]bool{
+	"LATEST": true,
+	"1.4.0":  true,
+	"1.3.0":  true,
+	"1.2.0":  true,
+	"1.1.0":  true,
+	"1.0.0":  true,
+}
+
+// validatePlatformVersion returns an error if the platform version is non-empty
+// and not recognized.
+func validatePlatformVersion(pv string) error {
+	if pv == "" {
+		return nil
+	}
+
+	if validFargatePlatformVersions[strings.ToUpper(pv)] || validFargatePlatformVersions[pv] {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: unknown Fargate platform version %q; valid values: LATEST, 1.4.0, 1.3.0, 1.2.0, 1.1.0, 1.0.0",
+		ErrInvalidParameter, pv,
+	)
+}
+
+// ---- Issue #12: PropagateTags constants ----
+
+const (
+	propagateTagsTaskDefinition = "TASK_DEFINITION"
+	propagateTagsService        = "SERVICE"
+	propagateTagsNone           = "NONE"
+)
+
+// ---- Issue #3: DeploymentController validation ----
+
+// validateDeploymentController returns an error for unsupported controller types.
+func validateDeploymentController(dc *DeploymentController) error {
+	if dc == nil {
+		return nil
+	}
+
+	switch strings.ToUpper(dc.Type) {
+	case deploymentControllerRolling, "":
+		return nil
+	case deploymentControllerExternal:
+		return nil
+	case deploymentControllerCodeDeploy:
+		return fmt.Errorf(
+			"%w: CODE_DEPLOY deployment controller is not supported; use ROLLING or EXTERNAL",
+			ErrInvalidParameter,
+		)
+	default:
+		return fmt.Errorf(
+			"%w: unknown deployment controller type %q; valid values: ROLLING, EXTERNAL",
+			ErrInvalidParameter, dc.Type,
+		)
+	}
+}

--- a/services/ecs/backend_parity_internal_test.go
+++ b/services/ecs/backend_parity_internal_test.go
@@ -36,6 +36,7 @@ func TestValidateFargateCPUMemory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := validateFargateCPUMemory(tt.cpu, tt.memory)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateFargateCPUMemory(%q, %q) error = %v, wantErr %v", tt.cpu, tt.memory, err, tt.wantErr)
@@ -47,6 +48,7 @@ func TestValidateFargateCPUMemory(t *testing.T) {
 // ---- validatePlatformVersion tests ----
 
 func TestValidatePlatformVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		pv      string
@@ -64,6 +66,7 @@ func TestValidatePlatformVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := validatePlatformVersion(tt.pv)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validatePlatformVersion(%q) error = %v, wantErr %v", tt.pv, err, tt.wantErr)
@@ -75,22 +78,24 @@ func TestValidatePlatformVersion(t *testing.T) {
 // ---- validateDeploymentController tests ----
 
 func TestValidateDeploymentController(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name    string
 		dc      *DeploymentController
+		name    string
 		wantErr bool
 	}{
-		{"nil", nil, false},
-		{"ROLLING", &DeploymentController{Type: "ROLLING"}, false},
-		{"rolling lowercase", &DeploymentController{Type: "rolling"}, false},
-		{"EXTERNAL", &DeploymentController{Type: "EXTERNAL"}, false},
-		{"CODE_DEPLOY", &DeploymentController{Type: "CODE_DEPLOY"}, true},
-		{"code_deploy lowercase", &DeploymentController{Type: "code_deploy"}, true},
-		{"unknown", &DeploymentController{Type: "UNKNOWN"}, true},
+		{nil, "nil", false},
+		{&DeploymentController{Type: "ROLLING"}, "ROLLING", false},
+		{&DeploymentController{Type: "rolling"}, "rolling lowercase", false},
+		{&DeploymentController{Type: "EXTERNAL"}, "EXTERNAL", false},
+		{&DeploymentController{Type: "CODE_DEPLOY"}, "CODE_DEPLOY", true},
+		{&DeploymentController{Type: "code_deploy"}, "code_deploy lowercase", true},
+		{&DeploymentController{Type: "UNKNOWN"}, "unknown", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := validateDeploymentController(tt.dc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateDeploymentController(%v) error = %v, wantErr %v", tt.dc, err, tt.wantErr)
@@ -102,7 +107,9 @@ func TestValidateDeploymentController(t *testing.T) {
 // ---- DeploymentConfiguration.withAWSDefaults tests ----
 
 func TestDeploymentConfigurationWithAWSDefaults(t *testing.T) {
+	t.Parallel()
 	t.Run("nil returns defaults", func(t *testing.T) {
+		t.Parallel()
 		var dc *DeploymentConfiguration
 		out := dc.withAWSDefaults()
 		if out == nil {
@@ -117,26 +124,28 @@ func TestDeploymentConfigurationWithAWSDefaults(t *testing.T) {
 	})
 
 	t.Run("existing values preserved", func(t *testing.T) {
-		min := 50
-		max := 150
+		t.Parallel()
+		minPct := 50
+		maxPct := 150
 		dc := &DeploymentConfiguration{
-			MinimumHealthyPercent: &min,
-			MaximumPercent:        &max,
+			MinimumHealthyPercent: &minPct,
+			MaximumPercent:        &maxPct,
 		}
 		out := dc.withAWSDefaults()
-		if *out.MinimumHealthyPercent != 50 {
+		if *out.MinimumHealthyPercent != minPct {
 			t.Errorf("MinimumHealthyPercent = %d, want 50", *out.MinimumHealthyPercent)
 		}
-		if *out.MaximumPercent != 150 {
+		if *out.MaximumPercent != maxPct {
 			t.Errorf("MaximumPercent = %d, want 150", *out.MaximumPercent)
 		}
 	})
 
 	t.Run("partial fill", func(t *testing.T) {
-		min := 75
-		dc := &DeploymentConfiguration{MinimumHealthyPercent: &min}
+		t.Parallel()
+		minPct := 75
+		dc := &DeploymentConfiguration{MinimumHealthyPercent: &minPct}
 		out := dc.withAWSDefaults()
-		if *out.MinimumHealthyPercent != 75 {
+		if *out.MinimumHealthyPercent != minPct {
 			t.Errorf("MinimumHealthyPercent = %d, want 75", *out.MinimumHealthyPercent)
 		}
 		if out.MaximumPercent == nil || *out.MaximumPercent != defaultMaximumPercent {
@@ -152,6 +161,7 @@ func newTestBackend() *InMemoryBackend {
 }
 
 func TestRegisterTaskDefinition_RequiresCompatibilities(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -172,6 +182,7 @@ func TestRegisterTaskDefinition_RequiresCompatibilities(t *testing.T) {
 }
 
 func TestRegisterTaskDefinition_FargateValidation_InvalidCPU(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -190,6 +201,7 @@ func TestRegisterTaskDefinition_FargateValidation_InvalidCPU(t *testing.T) {
 }
 
 func TestRegisterTaskDefinition_FargateValidation_InvalidMemory(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -208,6 +220,7 @@ func TestRegisterTaskDefinition_FargateValidation_InvalidMemory(t *testing.T) {
 }
 
 func TestRegisterTaskDefinition_EC2_NoFargateValidation(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	// EC2 does not require valid Fargate CPU/memory pairs
@@ -224,6 +237,7 @@ func TestRegisterTaskDefinition_EC2_NoFargateValidation(t *testing.T) {
 }
 
 func TestRegisterTaskDefinition_TaskRoleArn(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -246,6 +260,7 @@ func TestRegisterTaskDefinition_TaskRoleArn(t *testing.T) {
 }
 
 func TestRegisterTaskDefinition_Volumes(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	vols := []Volume{
@@ -281,6 +296,7 @@ func TestRegisterTaskDefinition_Volumes(t *testing.T) {
 }
 
 func TestCreateService_DeploymentConfigurationDefaults(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -316,6 +332,7 @@ func TestCreateService_DeploymentConfigurationDefaults(t *testing.T) {
 }
 
 func TestCreateService_DeploymentController_Valid(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -341,6 +358,7 @@ func TestCreateService_DeploymentController_Valid(t *testing.T) {
 }
 
 func TestCreateService_DeploymentController_CodeDeploy_Rejected(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -366,6 +384,7 @@ func TestCreateService_DeploymentController_CodeDeploy_Rejected(t *testing.T) {
 }
 
 func TestCreateService_LoadBalancers(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -402,6 +421,7 @@ func TestCreateService_LoadBalancers(t *testing.T) {
 }
 
 func TestCreateService_ServiceRegistries(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -435,6 +455,7 @@ func TestCreateService_ServiceRegistries(t *testing.T) {
 }
 
 func TestCreateService_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -449,7 +470,7 @@ func TestCreateService_NetworkConfiguration(t *testing.T) {
 		AwsvpcConfiguration: &AwsvpcConfiguration{
 			Subnets:        []string{"subnet-abc123", "subnet-def456"},
 			SecurityGroups: []string{"sg-12345678"},
-			AssignPublicIp: assignPublicIPEnabled,
+			AssignPublicIP: assignPublicIPEnabled,
 		},
 	}
 
@@ -471,6 +492,7 @@ func TestCreateService_NetworkConfiguration(t *testing.T) {
 }
 
 func TestCreateService_PropagateTags(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -496,6 +518,7 @@ func TestCreateService_PropagateTags(t *testing.T) {
 }
 
 func TestCreateService_PropagateTags_DefaultNone(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -520,6 +543,7 @@ func TestCreateService_PropagateTags_DefaultNone(t *testing.T) {
 }
 
 func TestRunTask_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -533,7 +557,7 @@ func TestRunTask_NetworkConfiguration(t *testing.T) {
 	nc := &NetworkConfiguration{
 		AwsvpcConfiguration: &AwsvpcConfiguration{
 			Subnets:        []string{"subnet-abc123"},
-			AssignPublicIp: assignPublicIPDisabled,
+			AssignPublicIP: assignPublicIPDisabled,
 		},
 	}
 
@@ -559,6 +583,7 @@ func TestRunTask_NetworkConfiguration(t *testing.T) {
 }
 
 func TestRunTask_PlatformVersionValidation(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -582,6 +607,7 @@ func TestRunTask_PlatformVersionValidation(t *testing.T) {
 }
 
 func TestRunTask_PlatformVersionLatest(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -605,6 +631,7 @@ func TestRunTask_PlatformVersionLatest(t *testing.T) {
 }
 
 func TestRunTask_PropagateTags(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -628,6 +655,7 @@ func TestRunTask_PropagateTags(t *testing.T) {
 }
 
 func TestListTaskDefinitionsFiltered_Status(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	// Register two definitions in the same family.
@@ -688,6 +716,7 @@ func TestListTaskDefinitionsFiltered_Status(t *testing.T) {
 }
 
 func TestDeleteCluster_CascadesServiceDeployments(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.CreateCluster(CreateClusterInput{ClusterName: "test-cluster"})
@@ -736,6 +765,7 @@ func TestDeleteCluster_CascadesServiceDeployments(t *testing.T) {
 }
 
 func TestContainerDefinition_NewFields(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	logCfg := &LogConfiguration{
@@ -796,6 +826,7 @@ func TestContainerDefinition_NewFields(t *testing.T) {
 }
 
 func TestPortMapping_ExtendedFields(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	pm := PortMapping{
@@ -831,6 +862,7 @@ func TestPortMapping_ExtendedFields(t *testing.T) {
 }
 
 func TestUpdateService_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -853,7 +885,7 @@ func TestUpdateService_NetworkConfiguration(t *testing.T) {
 	newNC := &NetworkConfiguration{
 		AwsvpcConfiguration: &AwsvpcConfiguration{
 			Subnets:        []string{"subnet-new123"},
-			AssignPublicIp: assignPublicIPEnabled,
+			AssignPublicIP: assignPublicIPEnabled,
 		},
 	}
 
@@ -872,6 +904,7 @@ func TestUpdateService_NetworkConfiguration(t *testing.T) {
 }
 
 func TestUpdateService_LoadBalancers(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -906,6 +939,7 @@ func TestUpdateService_LoadBalancers(t *testing.T) {
 }
 
 func TestDeploymentConfiguration_MinMaxPercent_Stored(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -943,6 +977,7 @@ func TestDeploymentConfiguration_MinMaxPercent_Stored(t *testing.T) {
 }
 
 func TestMountPoints_VolumeFrom(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
@@ -983,6 +1018,7 @@ func TestMountPoints_VolumeFrom(t *testing.T) {
 }
 
 func TestFirelensConfiguration(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	fls := &FirelensConfiguration{
@@ -1020,6 +1056,7 @@ func TestFirelensConfiguration(t *testing.T) {
 }
 
 func TestContainerDependency(t *testing.T) {
+	t.Parallel()
 	b := newTestBackend()
 
 	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{

--- a/services/ecs/backend_parity_test.go
+++ b/services/ecs/backend_parity_test.go
@@ -1,0 +1,1048 @@
+package ecs
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---- validateFargateCPUMemory tests ----
+
+func TestValidateFargateCPUMemory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cpu     string
+		memory  string
+		wantErr bool
+	}{
+		{"empty both", "", "", false},
+		{"empty cpu", "", "512", false},
+		{"empty memory", "256", "", false},
+		{"valid 256/512", "256", "512", false},
+		{"valid 256/1024", "256", "1024", false},
+		{"valid 256/2048", "256", "2048", false},
+		{"valid 512/1024", "512", "1024", false},
+		{"valid 1024/2048", "1024", "2048", false},
+		{"valid 2048/4096", "2048", "4096", false},
+		{"valid 4096/8192", "4096", "8192", false},
+		{"valid 8192/16384", "8192", "16384", false},
+		{"valid 16384/32768", "16384", "32768", false},
+		{"invalid cpu", "128", "512", true},
+		{"invalid memory for cpu", "256", "8192", true},
+		{"invalid memory 256/512+1", "256", "513", true},
+		{"unknown cpu string", "notanumber", "512", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFargateCPUMemory(tt.cpu, tt.memory)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateFargateCPUMemory(%q, %q) error = %v, wantErr %v", tt.cpu, tt.memory, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---- validatePlatformVersion tests ----
+
+func TestValidatePlatformVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		pv      string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"LATEST", "LATEST", false},
+		{"latest lowercase", "latest", false},
+		{"1.4.0", "1.4.0", false},
+		{"1.3.0", "1.3.0", false},
+		{"1.0.0", "1.0.0", false},
+		{"unknown", "2.0.0", true},
+		{"garbage", "notaversion", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePlatformVersion(tt.pv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePlatformVersion(%q) error = %v, wantErr %v", tt.pv, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---- validateDeploymentController tests ----
+
+func TestValidateDeploymentController(t *testing.T) {
+	tests := []struct {
+		name    string
+		dc      *DeploymentController
+		wantErr bool
+	}{
+		{"nil", nil, false},
+		{"ROLLING", &DeploymentController{Type: "ROLLING"}, false},
+		{"rolling lowercase", &DeploymentController{Type: "rolling"}, false},
+		{"EXTERNAL", &DeploymentController{Type: "EXTERNAL"}, false},
+		{"CODE_DEPLOY", &DeploymentController{Type: "CODE_DEPLOY"}, true},
+		{"code_deploy lowercase", &DeploymentController{Type: "code_deploy"}, true},
+		{"unknown", &DeploymentController{Type: "UNKNOWN"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDeploymentController(tt.dc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateDeploymentController(%v) error = %v, wantErr %v", tt.dc, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---- DeploymentConfiguration.withAWSDefaults tests ----
+
+func TestDeploymentConfigurationWithAWSDefaults(t *testing.T) {
+	t.Run("nil returns defaults", func(t *testing.T) {
+		var dc *DeploymentConfiguration
+		out := dc.withAWSDefaults()
+		if out == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if out.MinimumHealthyPercent == nil || *out.MinimumHealthyPercent != defaultMinimumHealthyPercent {
+			t.Errorf("MinimumHealthyPercent = %v, want %d", out.MinimumHealthyPercent, defaultMinimumHealthyPercent)
+		}
+		if out.MaximumPercent == nil || *out.MaximumPercent != defaultMaximumPercent {
+			t.Errorf("MaximumPercent = %v, want %d", out.MaximumPercent, defaultMaximumPercent)
+		}
+	})
+
+	t.Run("existing values preserved", func(t *testing.T) {
+		min := 50
+		max := 150
+		dc := &DeploymentConfiguration{
+			MinimumHealthyPercent: &min,
+			MaximumPercent:        &max,
+		}
+		out := dc.withAWSDefaults()
+		if *out.MinimumHealthyPercent != 50 {
+			t.Errorf("MinimumHealthyPercent = %d, want 50", *out.MinimumHealthyPercent)
+		}
+		if *out.MaximumPercent != 150 {
+			t.Errorf("MaximumPercent = %d, want 150", *out.MaximumPercent)
+		}
+	})
+
+	t.Run("partial fill", func(t *testing.T) {
+		min := 75
+		dc := &DeploymentConfiguration{MinimumHealthyPercent: &min}
+		out := dc.withAWSDefaults()
+		if *out.MinimumHealthyPercent != 75 {
+			t.Errorf("MinimumHealthyPercent = %d, want 75", *out.MinimumHealthyPercent)
+		}
+		if out.MaximumPercent == nil || *out.MaximumPercent != defaultMaximumPercent {
+			t.Errorf("MaximumPercent = %v, want %d", out.MaximumPercent, defaultMaximumPercent)
+		}
+	})
+}
+
+// ---- Backend integration tests for new fields ----
+
+func newTestBackend() *InMemoryBackend {
+	return NewInMemoryBackend("123456789012", "us-east-1", NewNoopRunner())
+}
+
+func TestRegisterTaskDefinition_RequiresCompatibilities(t *testing.T) {
+	b := newTestBackend()
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:                  "myapp",
+		RequiresCompatibilities: []string{"FARGATE"},
+		CPU:                     "256",
+		Memory:                  "512",
+		ContainerDefinitions: []ContainerDefinition{
+			{Name: "app", Image: "nginx"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(td.RequiresCompatibilities) != 1 || td.RequiresCompatibilities[0] != "FARGATE" {
+		t.Errorf("RequiresCompatibilities = %v, want [FARGATE]", td.RequiresCompatibilities)
+	}
+}
+
+func TestRegisterTaskDefinition_FargateValidation_InvalidCPU(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:                  "myapp",
+		RequiresCompatibilities: []string{"FARGATE"},
+		CPU:                     "128",
+		Memory:                  "512",
+		ContainerDefinitions:    []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid Fargate CPU")
+	}
+	if !strings.Contains(err.Error(), "invalid Fargate CPU") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRegisterTaskDefinition_FargateValidation_InvalidMemory(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:                  "myapp",
+		RequiresCompatibilities: []string{"FARGATE"},
+		CPU:                     "256",
+		Memory:                  "9999",
+		ContainerDefinitions:    []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid Fargate memory")
+	}
+	if !strings.Contains(err.Error(), "invalid Fargate memory") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRegisterTaskDefinition_EC2_NoFargateValidation(t *testing.T) {
+	b := newTestBackend()
+
+	// EC2 does not require valid Fargate CPU/memory pairs
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:                  "myapp",
+		RequiresCompatibilities: []string{"EC2"},
+		CPU:                     "128",
+		Memory:                  "256",
+		ContainerDefinitions:    []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for EC2 task definition: %v", err)
+	}
+}
+
+func TestRegisterTaskDefinition_TaskRoleArn(t *testing.T) {
+	b := newTestBackend()
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:           "myapp",
+		TaskRoleArn:      "arn:aws:iam::123456789012:role/task-role",
+		ExecutionRoleArn: "arn:aws:iam::123456789012:role/exec-role",
+		ContainerDefinitions: []ContainerDefinition{
+			{Name: "app", Image: "nginx"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if td.TaskRoleArn != "arn:aws:iam::123456789012:role/task-role" {
+		t.Errorf("TaskRoleArn = %q, want task-role ARN", td.TaskRoleArn)
+	}
+	if td.ExecutionRoleArn != "arn:aws:iam::123456789012:role/exec-role" {
+		t.Errorf("ExecutionRoleArn = %q, want exec-role ARN", td.ExecutionRoleArn)
+	}
+}
+
+func TestRegisterTaskDefinition_Volumes(t *testing.T) {
+	b := newTestBackend()
+
+	vols := []Volume{
+		{Name: "data", Host: &HostVolumeProperties{SourcePath: "/tmp/data"}},
+		{Name: "efs", EFSVolumeConfiguration: &EFSVolumeConfiguration{
+			FileSystemID:      "fs-12345678",
+			RootDirectory:     "/data",
+			TransitEncryption: "ENABLED",
+		}},
+	}
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:  "myapp",
+		Volumes: vols,
+		ContainerDefinitions: []ContainerDefinition{
+			{Name: "app", Image: "nginx", MountPoints: []MountPoint{
+				{SourceVolume: "data", ContainerPath: "/data"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(td.Volumes) != 2 {
+		t.Fatalf("len(Volumes) = %d, want 2", len(td.Volumes))
+	}
+	if td.Volumes[0].Name != "data" {
+		t.Errorf("Volumes[0].Name = %q, want data", td.Volumes[0].Name)
+	}
+	if td.Volumes[1].EFSVolumeConfiguration == nil {
+		t.Fatal("EFSVolumeConfiguration is nil")
+	}
+}
+
+func TestCreateService_DeploymentConfigurationDefaults(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   1,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if svc.DeploymentConfiguration == nil {
+		t.Fatal("DeploymentConfiguration should not be nil")
+	}
+	if svc.DeploymentConfiguration.MinimumHealthyPercent == nil ||
+		*svc.DeploymentConfiguration.MinimumHealthyPercent != defaultMinimumHealthyPercent {
+		t.Errorf("MinimumHealthyPercent = %v, want %d",
+			svc.DeploymentConfiguration.MinimumHealthyPercent, defaultMinimumHealthyPercent)
+	}
+	if svc.DeploymentConfiguration.MaximumPercent == nil ||
+		*svc.DeploymentConfiguration.MaximumPercent != defaultMaximumPercent {
+		t.Errorf("MaximumPercent = %v, want %d",
+			svc.DeploymentConfiguration.MaximumPercent, defaultMaximumPercent)
+	}
+}
+
+func TestCreateService_DeploymentController_Valid(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:          "my-svc",
+		TaskDefinition:       "myapp",
+		DesiredCount:         1,
+		DeploymentController: &DeploymentController{Type: "ROLLING"},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	if svc.DeploymentController == nil || svc.DeploymentController.Type != "ROLLING" {
+		t.Errorf("DeploymentController = %v, want ROLLING", svc.DeploymentController)
+	}
+}
+
+func TestCreateService_DeploymentController_CodeDeploy_Rejected(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	_, err = b.CreateService(CreateServiceInput{
+		ServiceName:          "my-svc",
+		TaskDefinition:       "myapp",
+		DesiredCount:         1,
+		DeploymentController: &DeploymentController{Type: "CODE_DEPLOY"},
+	})
+	if err == nil {
+		t.Fatal("expected error for CODE_DEPLOY controller")
+	}
+	if !strings.Contains(err.Error(), "CODE_DEPLOY") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateService_LoadBalancers(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	lbs := []LoadBalancer{
+		{
+			TargetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/abcd1234",
+			ContainerName:  "app",
+			ContainerPort:  8080,
+		},
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   1,
+		LoadBalancers:  lbs,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	if len(svc.LoadBalancers) != 1 {
+		t.Fatalf("len(LoadBalancers) = %d, want 1", len(svc.LoadBalancers))
+	}
+	if svc.LoadBalancers[0].ContainerPort != 8080 {
+		t.Errorf("ContainerPort = %d, want 8080", svc.LoadBalancers[0].ContainerPort)
+	}
+}
+
+func TestCreateService_ServiceRegistries(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	regs := []ServiceRegistry{
+		{
+			RegistryArn:   "arn:aws:servicediscovery:us-east-1:123456789012:service/srv-abc123",
+			ContainerName: "app",
+			ContainerPort: 80,
+		},
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:       "my-svc",
+		TaskDefinition:    "myapp",
+		DesiredCount:      1,
+		ServiceRegistries: regs,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	if len(svc.ServiceRegistries) != 1 {
+		t.Fatalf("len(ServiceRegistries) = %d, want 1", len(svc.ServiceRegistries))
+	}
+}
+
+func TestCreateService_NetworkConfiguration(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	nc := &NetworkConfiguration{
+		AwsvpcConfiguration: &AwsvpcConfiguration{
+			Subnets:        []string{"subnet-abc123", "subnet-def456"},
+			SecurityGroups: []string{"sg-12345678"},
+			AssignPublicIp: assignPublicIPEnabled,
+		},
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:          "my-svc",
+		TaskDefinition:       "myapp",
+		DesiredCount:         1,
+		NetworkConfiguration: nc,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	if svc.NetworkConfiguration == nil || svc.NetworkConfiguration.AwsvpcConfiguration == nil {
+		t.Fatal("NetworkConfiguration not stored")
+	}
+	if len(svc.NetworkConfiguration.AwsvpcConfiguration.Subnets) != 2 {
+		t.Errorf("Subnets = %v, want 2 subnets", svc.NetworkConfiguration.AwsvpcConfiguration.Subnets)
+	}
+}
+
+func TestCreateService_PropagateTags(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   1,
+		PropagateTags:  propagateTagsService,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	if svc.PropagateTags != propagateTagsService {
+		t.Errorf("PropagateTags = %q, want SERVICE", svc.PropagateTags)
+	}
+}
+
+func TestCreateService_PropagateTags_DefaultNone(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   1,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	if svc.PropagateTags != propagateTagsNone {
+		t.Errorf("PropagateTags = %q, want NONE (default)", svc.PropagateTags)
+	}
+}
+
+func TestRunTask_NetworkConfiguration(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	nc := &NetworkConfiguration{
+		AwsvpcConfiguration: &AwsvpcConfiguration{
+			Subnets:        []string{"subnet-abc123"},
+			AssignPublicIp: assignPublicIPDisabled,
+		},
+	}
+
+	tasks, err := b.RunTask(RunTaskInput{
+		TaskDefinition:       "myapp",
+		NetworkConfiguration: nc,
+		Count:                1,
+	})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1", len(tasks))
+	}
+	if tasks[0].NetworkConfiguration == nil ||
+		tasks[0].NetworkConfiguration.AwsvpcConfiguration == nil {
+		t.Fatal("task NetworkConfiguration not stored")
+	}
+	if tasks[0].NetworkConfiguration.AwsvpcConfiguration.Subnets[0] != "subnet-abc123" {
+		t.Errorf("subnet = %q, want subnet-abc123",
+			tasks[0].NetworkConfiguration.AwsvpcConfiguration.Subnets[0])
+	}
+}
+
+func TestRunTask_PlatformVersionValidation(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	_, err = b.RunTask(RunTaskInput{
+		TaskDefinition:  "myapp",
+		PlatformVersion: "9.9.9",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown platform version")
+	}
+	if !strings.Contains(err.Error(), "platform version") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunTask_PlatformVersionLatest(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	tasks, err := b.RunTask(RunTaskInput{
+		TaskDefinition:  "myapp",
+		PlatformVersion: "LATEST",
+	})
+	if err != nil {
+		t.Fatalf("RunTask with LATEST: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("expected at least 1 task")
+	}
+}
+
+func TestRunTask_PropagateTags(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	tasks, err := b.RunTask(RunTaskInput{
+		TaskDefinition: "myapp",
+		PropagateTags:  propagateTagsTaskDefinition,
+	})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+	if tasks[0].PropagateTags != propagateTagsTaskDefinition {
+		t.Errorf("PropagateTags = %q, want TASK_DEFINITION", tasks[0].PropagateTags)
+	}
+}
+
+func TestListTaskDefinitionsFiltered_Status(t *testing.T) {
+	b := newTestBackend()
+
+	// Register two definitions in the same family.
+	td1, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx:1"}},
+	})
+	if err != nil {
+		t.Fatalf("register td1: %v", err)
+	}
+
+	td2, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx:2"}},
+	})
+	if err != nil {
+		t.Fatalf("register td2: %v", err)
+	}
+
+	// Deregister td1.
+	_, err = b.DeregisterTaskDefinition(td1.TaskDefinitionArn)
+	if err != nil {
+		t.Fatalf("deregister td1: %v", err)
+	}
+
+	// Default (ACTIVE only).
+	arns, err := b.ListTaskDefinitionsFiltered(ListTaskDefinitionsInput{FamilyPrefix: "myapp"})
+	if err != nil {
+		t.Fatalf("ListTaskDefinitionsFiltered: %v", err)
+	}
+	if len(arns) != 1 || arns[0] != td2.TaskDefinitionArn {
+		t.Errorf("active arns = %v, want [%s]", arns, td2.TaskDefinitionArn)
+	}
+
+	// Explicit ACTIVE.
+	arns, err = b.ListTaskDefinitionsFiltered(ListTaskDefinitionsInput{
+		FamilyPrefix: "myapp",
+		Status:       "ACTIVE",
+	})
+	if err != nil {
+		t.Fatalf("ListTaskDefinitionsFiltered ACTIVE: %v", err)
+	}
+	if len(arns) != 1 {
+		t.Errorf("ACTIVE arns = %v, want 1", arns)
+	}
+
+	// INACTIVE.
+	arns, err = b.ListTaskDefinitionsFiltered(ListTaskDefinitionsInput{
+		FamilyPrefix: "myapp",
+		Status:       "INACTIVE",
+	})
+	if err != nil {
+		t.Fatalf("ListTaskDefinitionsFiltered INACTIVE: %v", err)
+	}
+	if len(arns) != 1 || arns[0] != td1.TaskDefinitionArn {
+		t.Errorf("inactive arns = %v, want [%s]", arns, td1.TaskDefinitionArn)
+	}
+}
+
+func TestDeleteCluster_CascadesServiceDeployments(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.CreateCluster(CreateClusterInput{ClusterName: "test-cluster"})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	_, err = b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	svc, err := b.CreateService(CreateServiceInput{
+		Cluster:        "test-cluster",
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   0,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	// Inject a fake service deployment entry to test cascade deletion.
+	b.mu.Lock("test-inject")
+	b.serviceDeployments[svc.ServiceArn] = &ServiceDeployment{
+		ServiceDeploymentArn: "arn:aws:ecs:us-east-1:123456789012:service-deployment/test-cluster/my-svc/abc",
+	}
+	b.mu.Unlock()
+
+	_, err = b.DeleteCluster("test-cluster")
+	if err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	// Service deployment should be gone.
+	b.mu.RLock("test-verify")
+	_, stillExists := b.serviceDeployments[svc.ServiceArn]
+	b.mu.RUnlock()
+
+	if stillExists {
+		t.Error("service deployment not cascade-deleted with cluster")
+	}
+}
+
+func TestContainerDefinition_NewFields(t *testing.T) {
+	b := newTestBackend()
+
+	logCfg := &LogConfiguration{
+		LogDriver: "awslogs",
+		Options: map[string]string{
+			"awslogs-group":  "/ecs/myapp",
+			"awslogs-region": "us-east-1",
+		},
+	}
+
+	hc := &HealthCheck{
+		Command:     []string{"CMD", "curl", "-f", "http://localhost/health"},
+		Interval:    30,
+		Timeout:     5,
+		Retries:     3,
+		StartPeriod: 10,
+	}
+
+	repoCreds := &RepositoryCredentials{
+		CredentialsParameter: "arn:aws:secretsmanager:us-east-1:123456789012:secret:registry-creds",
+	}
+
+	secrets := []SecretReference{
+		{Name: "DB_PASSWORD", ValueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass"},
+	}
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family: "myapp",
+		ContainerDefinitions: []ContainerDefinition{
+			{
+				Name:                  "app",
+				Image:                 "myregistry.example.com/myapp:latest",
+				LogConfiguration:      logCfg,
+				HealthCheck:           hc,
+				RepositoryCredentials: repoCreds,
+				Secrets:               secrets,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	cd := td.ContainerDefinitions[0]
+
+	if cd.LogConfiguration == nil || cd.LogConfiguration.LogDriver != "awslogs" {
+		t.Errorf("LogConfiguration = %v, want awslogs driver", cd.LogConfiguration)
+	}
+	if cd.HealthCheck == nil || cd.HealthCheck.Interval != 30 {
+		t.Errorf("HealthCheck = %v, want interval=30", cd.HealthCheck)
+	}
+	if cd.RepositoryCredentials == nil || cd.RepositoryCredentials.CredentialsParameter == "" {
+		t.Errorf("RepositoryCredentials = %v, want credentials", cd.RepositoryCredentials)
+	}
+	if len(cd.Secrets) != 1 || cd.Secrets[0].Name != "DB_PASSWORD" {
+		t.Errorf("Secrets = %v, want DB_PASSWORD", cd.Secrets)
+	}
+}
+
+func TestPortMapping_ExtendedFields(t *testing.T) {
+	b := newTestBackend()
+
+	pm := PortMapping{
+		ContainerPort:      8080,
+		HostPort:           0,
+		Protocol:           "tcp",
+		AppProtocol:        "http",
+		ContainerPortRange: "8080-8090",
+		Name:               "web",
+	}
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family: "myapp",
+		ContainerDefinitions: []ContainerDefinition{
+			{Name: "app", Image: "nginx", PortMappings: []PortMapping{pm}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	got := td.ContainerDefinitions[0].PortMappings[0]
+
+	if got.AppProtocol != "http" {
+		t.Errorf("AppProtocol = %q, want http", got.AppProtocol)
+	}
+	if got.ContainerPortRange != "8080-8090" {
+		t.Errorf("ContainerPortRange = %q, want 8080-8090", got.ContainerPortRange)
+	}
+	if got.Name != "web" {
+		t.Errorf("Name = %q, want web", got.Name)
+	}
+}
+
+func TestUpdateService_NetworkConfiguration(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	_, err = b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   0,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	newNC := &NetworkConfiguration{
+		AwsvpcConfiguration: &AwsvpcConfiguration{
+			Subnets:        []string{"subnet-new123"},
+			AssignPublicIp: assignPublicIPEnabled,
+		},
+	}
+
+	updated, err := b.UpdateService(UpdateServiceInput{
+		Service:              "my-svc",
+		NetworkConfiguration: newNC,
+	})
+	if err != nil {
+		t.Fatalf("UpdateService: %v", err)
+	}
+	if updated.NetworkConfiguration == nil ||
+		len(updated.NetworkConfiguration.AwsvpcConfiguration.Subnets) == 0 ||
+		updated.NetworkConfiguration.AwsvpcConfiguration.Subnets[0] != "subnet-new123" {
+		t.Errorf("NetworkConfiguration not updated: %v", updated.NetworkConfiguration)
+	}
+}
+
+func TestUpdateService_LoadBalancers(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	_, err = b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   0,
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	updated, err := b.UpdateService(UpdateServiceInput{
+		Service: "my-svc",
+		LoadBalancers: []LoadBalancer{
+			{TargetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/new-tg/abc"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateService: %v", err)
+	}
+	if len(updated.LoadBalancers) != 1 {
+		t.Errorf("LoadBalancers = %v, want 1", updated.LoadBalancers)
+	}
+}
+
+func TestDeploymentConfiguration_MinMaxPercent_Stored(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family:               "myapp",
+		ContainerDefinitions: []ContainerDefinition{{Name: "app", Image: "nginx"}},
+	})
+	if err != nil {
+		t.Fatalf("register task def: %v", err)
+	}
+
+	minPct := 75
+	maxPct := 150
+
+	svc, err := b.CreateService(CreateServiceInput{
+		ServiceName:    "my-svc",
+		TaskDefinition: "myapp",
+		DesiredCount:   1,
+		DeploymentConfiguration: &DeploymentConfiguration{
+			MinimumHealthyPercent: &minPct,
+			MaximumPercent:        &maxPct,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if svc.DeploymentConfiguration.MinimumHealthyPercent == nil ||
+		*svc.DeploymentConfiguration.MinimumHealthyPercent != 75 {
+		t.Errorf("MinimumHealthyPercent = %v, want 75", svc.DeploymentConfiguration.MinimumHealthyPercent)
+	}
+	if svc.DeploymentConfiguration.MaximumPercent == nil ||
+		*svc.DeploymentConfiguration.MaximumPercent != 150 {
+		t.Errorf("MaximumPercent = %v, want 150", svc.DeploymentConfiguration.MaximumPercent)
+	}
+}
+
+func TestMountPoints_VolumeFrom(t *testing.T) {
+	b := newTestBackend()
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family: "myapp",
+		Volumes: []Volume{
+			{Name: "shared", Host: &HostVolumeProperties{SourcePath: "/tmp/shared"}},
+		},
+		ContainerDefinitions: []ContainerDefinition{
+			{
+				Name:  "app",
+				Image: "nginx",
+				MountPoints: []MountPoint{
+					{SourceVolume: "shared", ContainerPath: "/shared", ReadOnly: false},
+				},
+			},
+			{
+				Name:  "sidecar",
+				Image: "busybox",
+				VolumesFrom: []VolumeFrom{
+					{SourceContainer: "app", ReadOnly: true},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	if len(td.ContainerDefinitions[0].MountPoints) != 1 {
+		t.Errorf("MountPoints = %v, want 1", td.ContainerDefinitions[0].MountPoints)
+	}
+	if len(td.ContainerDefinitions[1].VolumesFrom) != 1 {
+		t.Errorf("VolumesFrom = %v, want 1", td.ContainerDefinitions[1].VolumesFrom)
+	}
+	if td.ContainerDefinitions[1].VolumesFrom[0].SourceContainer != "app" {
+		t.Errorf("SourceContainer = %q, want app", td.ContainerDefinitions[1].VolumesFrom[0].SourceContainer)
+	}
+}
+
+func TestFirelensConfiguration(t *testing.T) {
+	b := newTestBackend()
+
+	fls := &FirelensConfiguration{
+		Type: "fluentbit",
+		Options: map[string]string{
+			"enable-ecs-log-metadata": "true",
+		},
+	}
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family: "myapp",
+		ContainerDefinitions: []ContainerDefinition{
+			{
+				Name:                  "log_router",
+				Image:                 "amazon/aws-for-fluent-bit:latest",
+				Essential:             true,
+				FirelensConfiguration: fls,
+			},
+			{Name: "app", Image: "nginx", LogConfiguration: &LogConfiguration{
+				LogDriver: "awsfirelens",
+				Options: map[string]string{
+					"Name": "firehose",
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	router := td.ContainerDefinitions[0]
+	if router.FirelensConfiguration == nil || router.FirelensConfiguration.Type != "fluentbit" {
+		t.Errorf("FirelensConfiguration = %v, want fluentbit", router.FirelensConfiguration)
+	}
+}
+
+func TestContainerDependency(t *testing.T) {
+	b := newTestBackend()
+
+	td, err := b.RegisterTaskDefinition(RegisterTaskDefinitionInput{
+		Family: "myapp",
+		ContainerDefinitions: []ContainerDefinition{
+			{Name: "init", Image: "busybox", Essential: false},
+			{
+				Name:  "app",
+				Image: "nginx",
+				DependsOn: []ContainerDependency{
+					{ContainerName: "init", Condition: "COMPLETE"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	if len(td.ContainerDefinitions[1].DependsOn) != 1 {
+		t.Fatalf("DependsOn len = %d, want 1", len(td.ContainerDefinitions[1].DependsOn))
+	}
+	if td.ContainerDefinitions[1].DependsOn[0].Condition != "COMPLETE" {
+		t.Errorf("DependsOn condition = %q, want COMPLETE", td.ContainerDefinitions[1].DependsOn[0].Condition)
+	}
+}

--- a/services/ecs/backend_stateful1.go
+++ b/services/ecs/backend_stateful1.go
@@ -7,8 +7,42 @@ type DeploymentCircuitBreaker struct {
 }
 
 // DeploymentConfiguration holds deployment settings for a service.
+// MinimumHealthyPercent and MaximumPercent default to the AWS values of 100 and 200.
 type DeploymentConfiguration struct {
 	DeploymentCircuitBreaker *DeploymentCircuitBreaker `json:"deploymentCircuitBreaker,omitempty"`
+	MinimumHealthyPercent    *int                      `json:"minimumHealthyPercent,omitempty"`
+	MaximumPercent           *int                      `json:"maximumPercent,omitempty"`
+}
+
+const (
+	defaultMinimumHealthyPercent = 100
+	defaultMaximumPercent        = 200
+)
+
+// withAWSDefaults fills in AWS-mandated defaults for unset deployment configuration fields.
+func (dc *DeploymentConfiguration) withAWSDefaults() *DeploymentConfiguration {
+	if dc == nil {
+		minPct := defaultMinimumHealthyPercent
+		maxPct := defaultMaximumPercent
+		return &DeploymentConfiguration{
+			MinimumHealthyPercent: &minPct,
+			MaximumPercent:        &maxPct,
+		}
+	}
+
+	out := *dc
+
+	if out.MinimumHealthyPercent == nil {
+		minPct := defaultMinimumHealthyPercent
+		out.MinimumHealthyPercent = &minPct
+	}
+
+	if out.MaximumPercent == nil {
+		maxPct := defaultMaximumPercent
+		out.MaximumPercent = &maxPct
+	}
+
+	return &out
 }
 
 // PlacementConstraint specifies a placement constraint for a task or service.

--- a/services/ecs/backend_stateful1.go
+++ b/services/ecs/backend_stateful1.go
@@ -24,6 +24,7 @@ func (dc *DeploymentConfiguration) withAWSDefaults() *DeploymentConfiguration {
 	if dc == nil {
 		minPct := defaultMinimumHealthyPercent
 		maxPct := defaultMaximumPercent
+
 		return &DeploymentConfiguration{
 			MinimumHealthyPercent: &minPct,
 			MaximumPercent:        &maxPct,

--- a/services/ecs/handler.go
+++ b/services/ecs/handler.go
@@ -509,17 +509,37 @@ type deploymentCircuitBreakerInput struct {
 
 type deploymentConfigurationInput struct {
 	DeploymentCircuitBreaker *deploymentCircuitBreakerInput `json:"deploymentCircuitBreaker,omitempty"`
+	MinimumHealthyPercent    *int                           `json:"minimumHealthyPercent,omitempty"`
+	MaximumPercent           *int                           `json:"maximumPercent,omitempty"`
+}
+
+type deploymentControllerInput struct {
+	Type string `json:"type"`
+}
+
+type awsvpcConfigurationInput struct {
+	Subnets        []string `json:"subnets"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+	AssignPublicIp string   `json:"assignPublicIp,omitempty"`
+}
+
+type networkConfigurationInput struct {
+	AwsvpcConfiguration *awsvpcConfigurationInput `json:"awsvpcConfiguration,omitempty"`
 }
 
 type registerTaskDefinitionInput struct {
-	Family               string                     `json:"family"`
-	NetworkMode          string                     `json:"networkMode,omitempty"`
-	CPU                  string                     `json:"cpu,omitempty"`
-	Memory               string                     `json:"memory,omitempty"`
-	PlatformFamily       string                     `json:"platformFamily,omitempty"`
-	Tags                 []Tag                      `json:"tags,omitempty"`
-	ContainerDefinitions []ContainerDefinition      `json:"containerDefinitions"`
-	PlacementConstraints []placementConstraintInput `json:"placementConstraints,omitempty"`
+	Family                  string                     `json:"family"`
+	TaskRoleArn             string                     `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn        string                     `json:"executionRoleArn,omitempty"`
+	NetworkMode             string                     `json:"networkMode,omitempty"`
+	CPU                     string                     `json:"cpu,omitempty"`
+	Memory                  string                     `json:"memory,omitempty"`
+	PlatformFamily          string                     `json:"platformFamily,omitempty"`
+	Tags                    []Tag                      `json:"tags,omitempty"`
+	ContainerDefinitions    []ContainerDefinition      `json:"containerDefinitions"`
+	Volumes                 []Volume                   `json:"volumes,omitempty"`
+	PlacementConstraints    []placementConstraintInput `json:"placementConstraints,omitempty"`
+	RequiresCompatibilities []string                   `json:"requiresCompatibilities,omitempty"`
 }
 
 type registerTaskDefinitionOutput struct {
@@ -531,14 +551,18 @@ func (h *Handler) handleRegisterTaskDefinition(
 	in *registerTaskDefinitionInput,
 ) (*registerTaskDefinitionOutput, error) {
 	td, err := h.Backend.RegisterTaskDefinition(RegisterTaskDefinitionInput{
-		Family:               in.Family,
-		NetworkMode:          in.NetworkMode,
-		CPU:                  in.CPU,
-		Memory:               in.Memory,
-		PlatformFamily:       in.PlatformFamily,
-		ContainerDefinitions: in.ContainerDefinitions,
-		PlacementConstraints: toPlacementConstraints(in.PlacementConstraints),
-		Tags:                 in.Tags,
+		Family:                  in.Family,
+		TaskRoleArn:             in.TaskRoleArn,
+		ExecutionRoleArn:        in.ExecutionRoleArn,
+		NetworkMode:             in.NetworkMode,
+		CPU:                     in.CPU,
+		Memory:                  in.Memory,
+		PlatformFamily:          in.PlatformFamily,
+		ContainerDefinitions:    in.ContainerDefinitions,
+		Volumes:                 in.Volumes,
+		PlacementConstraints:    toPlacementConstraints(in.PlacementConstraints),
+		RequiresCompatibilities: in.RequiresCompatibilities,
+		Tags:                    in.Tags,
 	})
 	if err != nil {
 		return nil, err
@@ -612,6 +636,7 @@ func (h *Handler) handleDeregisterTaskDefinition(
 
 type listTaskDefinitionsInput struct {
 	FamilyPrefix string `json:"familyPrefix,omitempty"`
+	Status       string `json:"status,omitempty"`
 	NextToken    string `json:"nextToken,omitempty"`
 	MaxResults   int    `json:"maxResults,omitempty"`
 }
@@ -625,7 +650,10 @@ func (h *Handler) handleListTaskDefinitions(
 	_ context.Context,
 	in *listTaskDefinitionsInput,
 ) (*listTaskDefinitionsOutput, error) {
-	arns, err := h.Backend.ListTaskDefinitions(in.FamilyPrefix)
+	arns, err := h.Backend.ListTaskDefinitionsFiltered(ListTaskDefinitionsInput{
+		FamilyPrefix: in.FamilyPrefix,
+		Status:       in.Status,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -660,15 +688,34 @@ type serviceConnectConfigurationInput struct {
 	Enabled   bool                         `json:"enabled"`
 }
 
+type loadBalancerInput struct {
+	TargetGroupArn   string `json:"targetGroupArn,omitempty"`
+	LoadBalancerName string `json:"loadBalancerName,omitempty"`
+	ContainerName    string `json:"containerName,omitempty"`
+	ContainerPort    int    `json:"containerPort,omitempty"`
+}
+
+type serviceRegistryInput struct {
+	RegistryArn   string `json:"registryArn,omitempty"`
+	Port          int    `json:"port,omitempty"`
+	ContainerPort int    `json:"containerPort,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+}
+
 type createServiceInput struct {
 	DeploymentConfiguration     *deploymentConfigurationInput     `json:"deploymentConfiguration,omitempty"`
+	DeploymentController        *deploymentControllerInput        `json:"deploymentController,omitempty"`
+	NetworkConfiguration        *networkConfigurationInput        `json:"networkConfiguration,omitempty"`
 	ServiceConnectConfiguration *serviceConnectConfigurationInput `json:"serviceConnectConfiguration,omitempty"`
 	ServiceName                 string                            `json:"serviceName"`
 	Cluster                     string                            `json:"cluster,omitempty"`
 	TaskDefinition              string                            `json:"taskDefinition"`
 	LaunchType                  string                            `json:"launchType,omitempty"`
 	SchedulingStrategy          string                            `json:"schedulingStrategy,omitempty"`
+	PropagateTags               string                            `json:"propagateTags,omitempty"`
 	Tags                        []Tag                             `json:"tags,omitempty"`
+	LoadBalancers               []loadBalancerInput               `json:"loadBalancers,omitempty"`
+	ServiceRegistries           []serviceRegistryInput            `json:"serviceRegistries,omitempty"`
 	CapacityProviderStrategy    []cpStrategyItemInput             `json:"capacityProviderStrategy,omitempty"`
 	PlacementConstraints        []placementConstraintInput        `json:"placementConstraints,omitempty"`
 	PlacementStrategy           []placementStrategyInput          `json:"placementStrategy,omitempty"`
@@ -686,8 +733,13 @@ func (h *Handler) handleCreateService(_ context.Context, in *createServiceInput)
 		TaskDefinition:              in.TaskDefinition,
 		LaunchType:                  in.LaunchType,
 		SchedulingStrategy:          in.SchedulingStrategy,
+		PropagateTags:               in.PropagateTags,
 		Tags:                        in.Tags,
+		LoadBalancers:               toLoadBalancers(in.LoadBalancers),
+		ServiceRegistries:           toServiceRegistries(in.ServiceRegistries),
 		DeploymentConfiguration:     toDeploymentConfiguration(in.DeploymentConfiguration),
+		DeploymentController:        toDeploymentController(in.DeploymentController),
+		NetworkConfiguration:        toNetworkConfiguration(in.NetworkConfiguration),
 		CapacityProviderStrategy:    toCPStrategyItems(in.CapacityProviderStrategy),
 		PlacementConstraints:        toPlacementConstraints(in.PlacementConstraints),
 		PlacementStrategy:           toPlacementStrategies(in.PlacementStrategy),
@@ -730,10 +782,13 @@ func (h *Handler) handleDescribeServices(
 type updateServiceInput struct {
 	DesiredCount                *int                              `json:"desiredCount,omitempty"`
 	DeploymentConfiguration     *deploymentConfigurationInput     `json:"deploymentConfiguration,omitempty"`
+	NetworkConfiguration        *networkConfigurationInput        `json:"networkConfiguration,omitempty"`
 	ServiceConnectConfiguration *serviceConnectConfigurationInput `json:"serviceConnectConfiguration,omitempty"`
 	Cluster                     string                            `json:"cluster,omitempty"`
 	Service                     string                            `json:"service"`
 	TaskDefinition              string                            `json:"taskDefinition,omitempty"`
+	PropagateTags               string                            `json:"propagateTags,omitempty"`
+	LoadBalancers               []loadBalancerInput               `json:"loadBalancers,omitempty"`
 	CapacityProviderStrategy    []cpStrategyItemInput             `json:"capacityProviderStrategy,omitempty"`
 	PlacementConstraints        []placementConstraintInput        `json:"placementConstraints,omitempty"`
 	PlacementStrategy           []placementStrategyInput          `json:"placementStrategy,omitempty"`
@@ -747,6 +802,9 @@ func (h *Handler) handleUpdateService(_ context.Context, in *updateServiceInput)
 	svc, err := h.Backend.UpdateService(UpdateServiceInput{
 		Cluster:                     in.Cluster,
 		Service:                     in.Service,
+		PropagateTags:               in.PropagateTags,
+		LoadBalancers:               toLoadBalancers(in.LoadBalancers),
+		NetworkConfiguration:        toNetworkConfiguration(in.NetworkConfiguration),
 		TaskDefinition:              in.TaskDefinition,
 		DesiredCount:                in.DesiredCount,
 		DeploymentConfiguration:     toDeploymentConfiguration(in.DeploymentConfiguration),
@@ -822,16 +880,18 @@ type taskOverrideInput struct {
 }
 
 type runTaskInput struct {
-	Overrides            *taskOverrideInput `json:"overrides,omitempty"`
-	Cluster              string             `json:"cluster,omitempty"`
-	TaskDefinition       string             `json:"taskDefinition"`
-	LaunchType           string             `json:"launchType,omitempty"`
-	Group                string             `json:"group,omitempty"`
-	StartedBy            string             `json:"startedBy,omitempty"`
-	PlatformVersion      string             `json:"platformVersion,omitempty"`
-	Tags                 []Tag              `json:"tags,omitempty"`
-	Count                int                `json:"count,omitempty"`
-	EnableECSManagedTags bool               `json:"enableECSManagedTags,omitempty"`
+	Overrides            *taskOverrideInput         `json:"overrides,omitempty"`
+	NetworkConfiguration *networkConfigurationInput `json:"networkConfiguration,omitempty"`
+	Cluster              string                     `json:"cluster,omitempty"`
+	TaskDefinition       string                     `json:"taskDefinition"`
+	LaunchType           string                     `json:"launchType,omitempty"`
+	Group                string                     `json:"group,omitempty"`
+	StartedBy            string                     `json:"startedBy,omitempty"`
+	PlatformVersion      string                     `json:"platformVersion,omitempty"`
+	PropagateTags        string                     `json:"propagateTags,omitempty"`
+	Tags                 []Tag                      `json:"tags,omitempty"`
+	Count                int                        `json:"count,omitempty"`
+	EnableECSManagedTags bool                       `json:"enableECSManagedTags,omitempty"`
 }
 
 type runTaskOutput struct {
@@ -847,9 +907,11 @@ func (h *Handler) handleRunTask(_ context.Context, in *runTaskInput) (*runTaskOu
 		Group:                in.Group,
 		StartedBy:            in.StartedBy,
 		PlatformVersion:      in.PlatformVersion,
+		PropagateTags:        in.PropagateTags,
 		EnableECSManagedTags: in.EnableECSManagedTags,
 		Tags:                 in.Tags,
 		Overrides:            toTaskOverride(in.Overrides),
+		NetworkConfiguration: toNetworkConfiguration(in.NetworkConfiguration),
 	})
 	if err != nil {
 		return nil, err
@@ -1005,34 +1067,72 @@ type deploymentCircuitBreakerView struct {
 
 type deploymentConfigurationView struct {
 	DeploymentCircuitBreaker *deploymentCircuitBreakerView `json:"deploymentCircuitBreaker,omitempty"`
+	MinimumHealthyPercent    *int                          `json:"minimumHealthyPercent,omitempty"`
+	MaximumPercent           *int                          `json:"maximumPercent,omitempty"`
+}
+
+type deploymentControllerView struct {
+	Type string `json:"type"`
+}
+
+type awsvpcConfigurationView struct {
+	Subnets        []string `json:"subnets"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+	AssignPublicIp string   `json:"assignPublicIp,omitempty"`
+}
+
+type networkConfigurationView struct {
+	AwsvpcConfiguration *awsvpcConfigurationView `json:"awsvpcConfiguration,omitempty"`
+}
+
+type loadBalancerView struct {
+	TargetGroupArn   string `json:"targetGroupArn,omitempty"`
+	LoadBalancerName string `json:"loadBalancerName,omitempty"`
+	ContainerName    string `json:"containerName,omitempty"`
+	ContainerPort    int    `json:"containerPort,omitempty"`
+}
+
+type serviceRegistryView struct {
+	RegistryArn   string `json:"registryArn,omitempty"`
+	Port          int    `json:"port,omitempty"`
+	ContainerPort int    `json:"containerPort,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
 }
 
 type taskDefinitionView struct {
-	TaskDefinitionArn    string                    `json:"taskDefinitionArn"`
-	Family               string                    `json:"family"`
-	NetworkMode          string                    `json:"networkMode,omitempty"`
-	Status               string                    `json:"status"`
-	CPU                  string                    `json:"cpu,omitempty"`
-	Memory               string                    `json:"memory,omitempty"`
-	PlatformFamily       string                    `json:"platformFamily,omitempty"`
-	ContainerDefinitions []ContainerDefinition     `json:"containerDefinitions"`
-	PlacementConstraints []placementConstraintView `json:"placementConstraints,omitempty"`
-	RegisteredAt         float64                   `json:"registeredAt"`
-	Revision             int                       `json:"revision"`
+	TaskDefinitionArn       string                    `json:"taskDefinitionArn"`
+	Family                  string                    `json:"family"`
+	TaskRoleArn             string                    `json:"taskRoleArn,omitempty"`
+	ExecutionRoleArn        string                    `json:"executionRoleArn,omitempty"`
+	NetworkMode             string                    `json:"networkMode,omitempty"`
+	Status                  string                    `json:"status"`
+	CPU                     string                    `json:"cpu,omitempty"`
+	Memory                  string                    `json:"memory,omitempty"`
+	PlatformFamily          string                    `json:"platformFamily,omitempty"`
+	ContainerDefinitions    []ContainerDefinition     `json:"containerDefinitions"`
+	Volumes                 []Volume                  `json:"volumes,omitempty"`
+	PlacementConstraints    []placementConstraintView `json:"placementConstraints,omitempty"`
+	RequiresCompatibilities []string                  `json:"requiresCompatibilities,omitempty"`
+	RegisteredAt            float64                   `json:"registeredAt"`
+	Revision                int                       `json:"revision"`
 }
 
 func toTaskDefinitionView(td TaskDefinition) taskDefinitionView {
 	v := taskDefinitionView{
-		TaskDefinitionArn:    td.TaskDefinitionArn,
-		Family:               td.Family,
-		NetworkMode:          td.NetworkMode,
-		Status:               td.Status,
-		CPU:                  td.CPU,
-		Memory:               td.Memory,
-		PlatformFamily:       td.PlatformFamily,
-		ContainerDefinitions: td.ContainerDefinitions,
-		RegisteredAt:         float64(td.RegisteredAt.Unix()),
-		Revision:             td.Revision,
+		TaskDefinitionArn:       td.TaskDefinitionArn,
+		Family:                  td.Family,
+		TaskRoleArn:             td.TaskRoleArn,
+		ExecutionRoleArn:        td.ExecutionRoleArn,
+		NetworkMode:             td.NetworkMode,
+		Status:                  td.Status,
+		CPU:                     td.CPU,
+		Memory:                  td.Memory,
+		PlatformFamily:          td.PlatformFamily,
+		ContainerDefinitions:    td.ContainerDefinitions,
+		Volumes:                 td.Volumes,
+		RequiresCompatibilities: td.RequiresCompatibilities,
+		RegisteredAt:            float64(td.RegisteredAt.Unix()),
+		Revision:                td.Revision,
 	}
 
 	for _, c := range td.PlacementConstraints {
@@ -1047,7 +1147,10 @@ func toDeploymentConfigurationView(dc *DeploymentConfiguration) *deploymentConfi
 		return nil
 	}
 
-	v := &deploymentConfigurationView{}
+	v := &deploymentConfigurationView{
+		MinimumHealthyPercent: dc.MinimumHealthyPercent,
+		MaximumPercent:        dc.MaximumPercent,
+	}
 
 	if dc.DeploymentCircuitBreaker != nil {
 		v.DeploymentCircuitBreaker = &deploymentCircuitBreakerView{
@@ -1079,13 +1182,18 @@ type serviceConnectConfigurationView struct {
 type serviceView struct {
 	ServiceConnectConfiguration *serviceConnectConfigurationView `json:"serviceConnectConfiguration,omitempty"`
 	DeploymentConfiguration     *deploymentConfigurationView     `json:"deploymentConfiguration,omitempty"`
+	DeploymentController        *deploymentControllerView        `json:"deploymentController,omitempty"`
+	NetworkConfiguration        *networkConfigurationView        `json:"networkConfiguration,omitempty"`
 	ClusterArn                  string                           `json:"clusterArn"`
 	TaskDefinition              string                           `json:"taskDefinition"`
 	Status                      string                           `json:"status"`
 	LaunchType                  string                           `json:"launchType,omitempty"`
 	SchedulingStrategy          string                           `json:"schedulingStrategy,omitempty"`
+	PropagateTags               string                           `json:"propagateTags,omitempty"`
 	ServiceArn                  string                           `json:"serviceArn"`
 	ServiceName                 string                           `json:"serviceName"`
+	LoadBalancers               []loadBalancerView               `json:"loadBalancers,omitempty"`
+	ServiceRegistries           []serviceRegistryView            `json:"serviceRegistries,omitempty"`
 	CapacityProviderStrategy    []cpStrategyItemInput            `json:"capacityProviderStrategy,omitempty"`
 	PlacementConstraints        []placementConstraintView        `json:"placementConstraints,omitempty"`
 	PlacementStrategy           []placementStrategyView          `json:"placementStrategy,omitempty"`
@@ -1105,13 +1213,27 @@ func toServiceView(s Service) serviceView {
 		Status:                      s.Status,
 		LaunchType:                  s.LaunchType,
 		SchedulingStrategy:          s.SchedulingStrategy,
+		PropagateTags:               s.PropagateTags,
 		CreatedAt:                   float64(s.CreatedAt.Unix()),
 		Tags:                        s.Tags,
 		DeploymentConfiguration:     toDeploymentConfigurationView(s.DeploymentConfiguration),
 		ServiceConnectConfiguration: toServiceConnectConfigurationView(s.ServiceConnectConfiguration),
+		NetworkConfiguration:        toNetworkConfigurationView(s.NetworkConfiguration),
 		DesiredCount:                s.DesiredCount,
 		PendingCount:                s.PendingCount,
 		RunningCount:                s.RunningCount,
+	}
+
+	if s.DeploymentController != nil {
+		v.DeploymentController = &deploymentControllerView{Type: s.DeploymentController.Type}
+	}
+
+	for _, lb := range s.LoadBalancers {
+		v.LoadBalancers = append(v.LoadBalancers, loadBalancerView(lb))
+	}
+
+	for _, sr := range s.ServiceRegistries {
+		v.ServiceRegistries = append(v.ServiceRegistries, serviceRegistryView(sr))
 	}
 
 	for _, item := range s.CapacityProviderStrategy {
@@ -1158,25 +1280,27 @@ type taskOverrideView struct {
 }
 
 type taskView struct {
-	Overrides            *taskOverrideView    `json:"overrides,omitempty"`
-	TaskArn              string               `json:"taskArn"`
-	ClusterArn           string               `json:"clusterArn"`
-	TaskDefinitionArn    string               `json:"taskDefinitionArn"`
-	LastStatus           string               `json:"lastStatus"`
-	DesiredStatus        string               `json:"desiredStatus"`
-	Connectivity         string               `json:"connectivity,omitempty"`
-	StoppedReason        string               `json:"stoppedReason,omitempty"`
-	Group                string               `json:"group,omitempty"`
-	LaunchType           string               `json:"launchType,omitempty"`
-	ContainerInstanceArn string               `json:"containerInstanceArn,omitempty"`
-	StartedBy            string               `json:"startedBy,omitempty"`
-	PlatformVersion      string               `json:"platformVersion,omitempty"`
-	PlatformFamily       string               `json:"platformFamily,omitempty"`
-	RuntimeID            string               `json:"runtimeId,omitempty"`
-	Attachments          []taskAttachmentView `json:"attachments,omitempty"`
-	StartedAt            float64              `json:"startedAt,omitempty"`
-	StoppedAt            float64              `json:"stoppedAt,omitempty"`
-	ConnectivityAt       float64              `json:"connectivityAt,omitempty"`
+	Overrides            *taskOverrideView         `json:"overrides,omitempty"`
+	NetworkConfiguration *networkConfigurationView `json:"networkConfiguration,omitempty"`
+	TaskArn              string                    `json:"taskArn"`
+	ClusterArn           string                    `json:"clusterArn"`
+	TaskDefinitionArn    string                    `json:"taskDefinitionArn"`
+	LastStatus           string                    `json:"lastStatus"`
+	DesiredStatus        string                    `json:"desiredStatus"`
+	Connectivity         string                    `json:"connectivity,omitempty"`
+	StoppedReason        string                    `json:"stoppedReason,omitempty"`
+	Group                string                    `json:"group,omitempty"`
+	LaunchType           string                    `json:"launchType,omitempty"`
+	ContainerInstanceArn string                    `json:"containerInstanceArn,omitempty"`
+	StartedBy            string                    `json:"startedBy,omitempty"`
+	PlatformVersion      string                    `json:"platformVersion,omitempty"`
+	PlatformFamily       string                    `json:"platformFamily,omitempty"`
+	RuntimeID            string                    `json:"runtimeId,omitempty"`
+	PropagateTags        string                    `json:"propagateTags,omitempty"`
+	Attachments          []taskAttachmentView       `json:"attachments,omitempty"`
+	StartedAt            float64                   `json:"startedAt,omitempty"`
+	StoppedAt            float64                   `json:"stoppedAt,omitempty"`
+	ConnectivityAt       float64                   `json:"connectivityAt,omitempty"`
 }
 
 func toTaskView(t Task) taskView {
@@ -1195,7 +1319,9 @@ func toTaskView(t Task) taskView {
 		PlatformVersion:      t.PlatformVersion,
 		PlatformFamily:       t.PlatformFamily,
 		RuntimeID:            t.RuntimeID,
+		PropagateTags:        t.PropagateTags,
 		Overrides:            toTaskOverrideView(t.Overrides),
+		NetworkConfiguration: toNetworkConfigurationView(t.NetworkConfiguration),
 	}
 
 	for _, a := range t.Attachments {
@@ -1233,7 +1359,10 @@ func toDeploymentConfiguration(in *deploymentConfigurationInput) *DeploymentConf
 		return nil
 	}
 
-	dc := &DeploymentConfiguration{}
+	dc := &DeploymentConfiguration{
+		MinimumHealthyPercent: in.MinimumHealthyPercent,
+		MaximumPercent:        in.MaximumPercent,
+	}
 
 	if in.DeploymentCircuitBreaker != nil {
 		dc.DeploymentCircuitBreaker = &DeploymentCircuitBreaker{
@@ -1243,6 +1372,81 @@ func toDeploymentConfiguration(in *deploymentConfigurationInput) *DeploymentConf
 	}
 
 	return dc
+}
+
+// toDeploymentController converts handler input to backend type.
+func toDeploymentController(in *deploymentControllerInput) *DeploymentController {
+	if in == nil {
+		return nil
+	}
+
+	return &DeploymentController{Type: in.Type}
+}
+
+// toNetworkConfiguration converts handler input to backend type.
+func toNetworkConfiguration(in *networkConfigurationInput) *NetworkConfiguration {
+	if in == nil {
+		return nil
+	}
+
+	nc := &NetworkConfiguration{}
+
+	if in.AwsvpcConfiguration != nil {
+		nc.AwsvpcConfiguration = &AwsvpcConfiguration{
+			Subnets:        in.AwsvpcConfiguration.Subnets,
+			SecurityGroups: in.AwsvpcConfiguration.SecurityGroups,
+			AssignPublicIp: in.AwsvpcConfiguration.AssignPublicIp,
+		}
+	}
+
+	return nc
+}
+
+// toNetworkConfigurationView converts backend type to handler view.
+func toNetworkConfigurationView(nc *NetworkConfiguration) *networkConfigurationView {
+	if nc == nil {
+		return nil
+	}
+
+	v := &networkConfigurationView{}
+
+	if nc.AwsvpcConfiguration != nil {
+		v.AwsvpcConfiguration = &awsvpcConfigurationView{
+			Subnets:        nc.AwsvpcConfiguration.Subnets,
+			SecurityGroups: nc.AwsvpcConfiguration.SecurityGroups,
+			AssignPublicIp: nc.AwsvpcConfiguration.AssignPublicIp,
+		}
+	}
+
+	return v
+}
+
+// toLoadBalancers converts handler input to backend type.
+func toLoadBalancers(in []loadBalancerInput) []LoadBalancer {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]LoadBalancer, len(in))
+	for i, lb := range in {
+		out[i] = LoadBalancer(lb)
+	}
+
+	return out
+}
+
+// toServiceRegistries converts handler input to backend type.
+func toServiceRegistries(in []serviceRegistryInput) []ServiceRegistry {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]ServiceRegistry, len(in))
+	for i, sr := range in {
+		out[i] = ServiceRegistry(sr)
+	}
+
+	return out
 }
 
 // toCPStrategyItems converts handler cpStrategyItemInput to backend CapacityProviderStrategyItem.

--- a/services/ecs/handler.go
+++ b/services/ecs/handler.go
@@ -518,9 +518,9 @@ type deploymentControllerInput struct {
 }
 
 type awsvpcConfigurationInput struct {
+	AssignPublicIp string   `json:"assignPublicIp,omitempty"` //nolint:revive,stylecheck // AWS API field name
 	Subnets        []string `json:"subnets"`
 	SecurityGroups []string `json:"securityGroups,omitempty"`
-	AssignPublicIp string   `json:"assignPublicIp,omitempty"`
 }
 
 type networkConfigurationInput struct {
@@ -697,9 +697,9 @@ type loadBalancerInput struct {
 
 type serviceRegistryInput struct {
 	RegistryArn   string `json:"registryArn,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
 	Port          int    `json:"port,omitempty"`
 	ContainerPort int    `json:"containerPort,omitempty"`
-	ContainerName string `json:"containerName,omitempty"`
 }
 
 type createServiceInput struct {
@@ -864,11 +864,12 @@ func (h *Handler) handleListServices(_ context.Context, in *listServicesInput) (
 // ----- Task handlers -----
 
 type containerOverrideInput struct {
-	CPU         *int           `json:"cpu,omitempty"`
-	Memory      *int           `json:"memory,omitempty"`
-	Name        string         `json:"name"`
-	Command     []string       `json:"command,omitempty"`
-	Environment []KeyValuePair `json:"environment,omitempty"`
+	CPU         *int              `json:"cpu,omitempty"`
+	Memory      *int              `json:"memory,omitempty"`
+	Name        string            `json:"name"`
+	Command     []string          `json:"command,omitempty"`
+	Environment []KeyValuePair    `json:"environment,omitempty"`
+	Secrets     []SecretReference `json:"secrets,omitempty"`
 }
 
 type taskOverrideInput struct {
@@ -1076,9 +1077,9 @@ type deploymentControllerView struct {
 }
 
 type awsvpcConfigurationView struct {
+	AssignPublicIp string   `json:"assignPublicIp,omitempty"` //nolint:revive,stylecheck // AWS API field name
 	Subnets        []string `json:"subnets"`
 	SecurityGroups []string `json:"securityGroups,omitempty"`
-	AssignPublicIp string   `json:"assignPublicIp,omitempty"`
 }
 
 type networkConfigurationView struct {
@@ -1094,9 +1095,9 @@ type loadBalancerView struct {
 
 type serviceRegistryView struct {
 	RegistryArn   string `json:"registryArn,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
 	Port          int    `json:"port,omitempty"`
 	ContainerPort int    `json:"containerPort,omitempty"`
-	ContainerName string `json:"containerName,omitempty"`
 }
 
 type taskDefinitionView struct {
@@ -1264,11 +1265,12 @@ type taskAttachmentView struct {
 }
 
 type containerOverrideView struct {
-	CPU         *int           `json:"cpu,omitempty"`
-	Memory      *int           `json:"memory,omitempty"`
-	Name        string         `json:"name"`
-	Command     []string       `json:"command,omitempty"`
-	Environment []KeyValuePair `json:"environment,omitempty"`
+	CPU         *int              `json:"cpu,omitempty"`
+	Memory      *int              `json:"memory,omitempty"`
+	Name        string            `json:"name"`
+	Command     []string          `json:"command,omitempty"`
+	Environment []KeyValuePair    `json:"environment,omitempty"`
+	Secrets     []SecretReference `json:"secrets,omitempty"`
 }
 
 type taskOverrideView struct {
@@ -1297,7 +1299,7 @@ type taskView struct {
 	PlatformFamily       string                    `json:"platformFamily,omitempty"`
 	RuntimeID            string                    `json:"runtimeId,omitempty"`
 	PropagateTags        string                    `json:"propagateTags,omitempty"`
-	Attachments          []taskAttachmentView       `json:"attachments,omitempty"`
+	Attachments          []taskAttachmentView      `json:"attachments,omitempty"`
 	StartedAt            float64                   `json:"startedAt,omitempty"`
 	StoppedAt            float64                   `json:"stoppedAt,omitempty"`
 	ConnectivityAt       float64                   `json:"connectivityAt,omitempty"`

--- a/services/ecs/handler.go
+++ b/services/ecs/handler.go
@@ -518,7 +518,7 @@ type deploymentControllerInput struct {
 }
 
 type awsvpcConfigurationInput struct {
-	AssignPublicIp string   `json:"assignPublicIp,omitempty"` //nolint:revive,stylecheck // AWS API field name
+	AssignPublicIP string   `json:"assignPublicIp,omitempty"`
 	Subnets        []string `json:"subnets"`
 	SecurityGroups []string `json:"securityGroups,omitempty"`
 }
@@ -1077,7 +1077,7 @@ type deploymentControllerView struct {
 }
 
 type awsvpcConfigurationView struct {
-	AssignPublicIp string   `json:"assignPublicIp,omitempty"` //nolint:revive,stylecheck // AWS API field name
+	AssignPublicIP string   `json:"assignPublicIp,omitempty"`
 	Subnets        []string `json:"subnets"`
 	SecurityGroups []string `json:"securityGroups,omitempty"`
 }
@@ -1397,7 +1397,7 @@ func toNetworkConfiguration(in *networkConfigurationInput) *NetworkConfiguration
 		nc.AwsvpcConfiguration = &AwsvpcConfiguration{
 			Subnets:        in.AwsvpcConfiguration.Subnets,
 			SecurityGroups: in.AwsvpcConfiguration.SecurityGroups,
-			AssignPublicIp: in.AwsvpcConfiguration.AssignPublicIp,
+			AssignPublicIP: in.AwsvpcConfiguration.AssignPublicIP,
 		}
 	}
 
@@ -1416,7 +1416,7 @@ func toNetworkConfigurationView(nc *NetworkConfiguration) *networkConfigurationV
 		v.AwsvpcConfiguration = &awsvpcConfigurationView{
 			Subnets:        nc.AwsvpcConfiguration.Subnets,
 			SecurityGroups: nc.AwsvpcConfiguration.SecurityGroups,
-			AssignPublicIp: nc.AwsvpcConfiguration.AssignPublicIp,
+			AssignPublicIP: nc.AwsvpcConfiguration.AssignPublicIP,
 		}
 	}
 

--- a/services/ecs/handler_parity_test.go
+++ b/services/ecs/handler_parity_test.go
@@ -1,0 +1,854 @@
+package ecs_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RegisterTaskDefinition parity tests ---------------------------------------
+
+func TestHandler_RegisterTaskDefinition_RequiresCompatibilities(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":                  "myapp",
+		"requiresCompatibilities": []string{"FARGATE"},
+		"cpu":                     "256",
+		"memory":                  "512",
+		"containerDefinitions": []map[string]any{
+			{"name": "app", "image": "nginx"},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	rcs := td["requiresCompatibilities"].([]any)
+	require.Len(t, rcs, 1)
+	assert.Equal(t, "FARGATE", rcs[0].(string))
+}
+
+func TestHandler_RegisterTaskDefinition_FargateValidation_BadCPU(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":                  "myapp",
+		"requiresCompatibilities": []string{"FARGATE"},
+		"cpu":                     "128",
+		"memory":                  "512",
+		"containerDefinitions": []map[string]any{
+			{"name": "app", "image": "nginx"},
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid Fargate CPU")
+}
+
+func TestHandler_RegisterTaskDefinition_FargateValidation_BadMemory(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":                  "myapp",
+		"requiresCompatibilities": []string{"FARGATE"},
+		"cpu":                     "256",
+		"memory":                  "9999",
+		"containerDefinitions": []map[string]any{
+			{"name": "app", "image": "nginx"},
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid Fargate memory")
+}
+
+func TestHandler_RegisterTaskDefinition_TaskRoleArn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":           "myapp",
+		"taskRoleArn":      "arn:aws:iam::000000000000:role/task-role",
+		"executionRoleArn": "arn:aws:iam::000000000000:role/exec-role",
+		"containerDefinitions": []map[string]any{
+			{"name": "app", "image": "nginx"},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	assert.Equal(t, "arn:aws:iam::000000000000:role/task-role", td["taskRoleArn"])
+	assert.Equal(t, "arn:aws:iam::000000000000:role/exec-role", td["executionRoleArn"])
+}
+
+func TestHandler_RegisterTaskDefinition_Volumes(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family": "myapp",
+		"volumes": []map[string]any{
+			{
+				"name": "data",
+				"host": map[string]any{"sourcePath": "/tmp/data"},
+			},
+			{
+				"name": "efs-vol",
+				"efsVolumeConfiguration": map[string]any{
+					"fileSystemId":      "fs-12345678",
+					"rootDirectory":     "/data",
+					"transitEncryption": "ENABLED",
+				},
+			},
+		},
+		"containerDefinitions": []map[string]any{
+			{
+				"name":  "app",
+				"image": "nginx",
+				"mountPoints": []map[string]any{
+					{"sourceVolume": "data", "containerPath": "/mnt/data"},
+				},
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	vols := td["volumes"].([]any)
+	require.Len(t, vols, 2)
+
+	vol0 := vols[0].(map[string]any)
+	assert.Equal(t, "data", vol0["name"])
+
+	vol1 := vols[1].(map[string]any)
+	efsCfg := vol1["efsVolumeConfiguration"].(map[string]any)
+	assert.Equal(t, "fs-12345678", efsCfg["fileSystemId"])
+}
+
+func TestHandler_RegisterTaskDefinition_LogConfiguration(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family": "myapp",
+		"containerDefinitions": []map[string]any{
+			{
+				"name":  "app",
+				"image": "nginx",
+				"logConfiguration": map[string]any{
+					"logDriver": "awslogs",
+					"options": map[string]string{
+						"awslogs-group": "/ecs/myapp",
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	cd := td["containerDefinitions"].([]any)[0].(map[string]any)
+	lc := cd["logConfiguration"].(map[string]any)
+	assert.Equal(t, "awslogs", lc["logDriver"])
+}
+
+func TestHandler_RegisterTaskDefinition_Secrets(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family": "myapp",
+		"containerDefinitions": []map[string]any{
+			{
+				"name":  "app",
+				"image": "nginx",
+				"secrets": []map[string]any{
+					{
+						"name":      "DB_PASSWORD",
+						"valueFrom": "arn:aws:secretsmanager:us-east-1:000000000000:secret:db-pass",
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	cd := td["containerDefinitions"].([]any)[0].(map[string]any)
+	secrets := cd["secrets"].([]any)
+	require.Len(t, secrets, 1)
+	s := secrets[0].(map[string]any)
+	assert.Equal(t, "DB_PASSWORD", s["name"])
+}
+
+func TestHandler_RegisterTaskDefinition_PortMapping_Extended(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family": "myapp",
+		"containerDefinitions": []map[string]any{
+			{
+				"name":  "app",
+				"image": "nginx",
+				"portMappings": []map[string]any{
+					{
+						"containerPort":      8080,
+						"protocol":           "tcp",
+						"appProtocol":        "http",
+						"containerPortRange": "8080-8090",
+						"name":               "web",
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	cd := td["containerDefinitions"].([]any)[0].(map[string]any)
+	pm := cd["portMappings"].([]any)[0].(map[string]any)
+	assert.Equal(t, "http", pm["appProtocol"])
+	assert.Equal(t, "8080-8090", pm["containerPortRange"])
+	assert.Equal(t, "web", pm["name"])
+}
+
+func TestHandler_RegisterTaskDefinition_HealthCheck(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family": "myapp",
+		"containerDefinitions": []map[string]any{
+			{
+				"name":  "app",
+				"image": "nginx",
+				"healthCheck": map[string]any{
+					"command":     []string{"CMD", "curl", "-f", "http://localhost/health"},
+					"interval":    30,
+					"timeout":     5,
+					"retries":     3,
+					"startPeriod": 10,
+				},
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	cd := td["containerDefinitions"].([]any)[0].(map[string]any)
+	hc := cd["healthCheck"].(map[string]any)
+	assert.Equal(t, float64(30), hc["interval"])
+	assert.Equal(t, float64(5), hc["timeout"])
+}
+
+// ListTaskDefinitions parity tests ------------------------------------------
+
+func TestHandler_ListTaskDefinitions_StatusFilter_Active(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Register two revisions.
+	rec1 := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx:1"}},
+	})
+	require.Equal(t, http.StatusOK, rec1.Code)
+	var out1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &out1))
+	arn1 := out1["taskDefinition"].(map[string]any)["taskDefinitionArn"].(string)
+
+	rec2 := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx:2"}},
+	})
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	// Deregister revision 1.
+	derecRec := doECSRequest(t, h, "DeregisterTaskDefinition", map[string]any{
+		"taskDefinition": arn1,
+	})
+	require.Equal(t, http.StatusOK, derecRec.Code)
+
+	// Default list (ACTIVE only).
+	listRec := doECSRequest(t, h, "ListTaskDefinitions", map[string]any{
+		"familyPrefix": "myapp",
+	})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listOut map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listOut))
+	arns := listOut["taskDefinitionArns"].([]any)
+	require.Len(t, arns, 1)
+	assert.True(t, strings.Contains(arns[0].(string), "myapp:2"))
+}
+
+func TestHandler_ListTaskDefinitions_StatusFilter_Inactive(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec1 := doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx:1"}},
+	})
+	require.Equal(t, http.StatusOK, rec1.Code)
+	var out1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &out1))
+	arn1 := out1["taskDefinition"].(map[string]any)["taskDefinitionArn"].(string)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx:2"}},
+	})
+
+	// Deregister revision 1.
+	_ = doECSRequest(t, h, "DeregisterTaskDefinition", map[string]any{
+		"taskDefinition": arn1,
+	})
+
+	// List INACTIVE.
+	listRec := doECSRequest(t, h, "ListTaskDefinitions", map[string]any{
+		"familyPrefix": "myapp",
+		"status":       "INACTIVE",
+	})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listOut map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listOut))
+	arns := listOut["taskDefinitionArns"].([]any)
+	require.Len(t, arns, 1)
+	assert.True(t, strings.Contains(arns[0].(string), "myapp:1"))
+}
+
+// CreateService parity tests ------------------------------------------------
+
+func TestHandler_CreateService_DeploymentConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	dc := svc["deploymentConfiguration"].(map[string]any)
+	assert.Equal(t, float64(100), dc["minimumHealthyPercent"])
+	assert.Equal(t, float64(200), dc["maximumPercent"])
+}
+
+func TestHandler_CreateService_DeploymentConfigCustom(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+		"deploymentConfiguration": map[string]any{
+			"minimumHealthyPercent": 50,
+			"maximumPercent":        150,
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	dc := svc["deploymentConfiguration"].(map[string]any)
+	assert.Equal(t, float64(50), dc["minimumHealthyPercent"])
+	assert.Equal(t, float64(150), dc["maximumPercent"])
+}
+
+func TestHandler_CreateService_DeploymentController_CodeDeploy_Rejected(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":          "my-svc",
+		"taskDefinition":       "myapp",
+		"desiredCount":         0,
+		"deploymentController": map[string]any{"type": "CODE_DEPLOY"},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CODE_DEPLOY")
+}
+
+func TestHandler_CreateService_DeploymentController_Rolling_Accepted(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":          "my-svc",
+		"taskDefinition":       "myapp",
+		"desiredCount":         0,
+		"deploymentController": map[string]any{"type": "ROLLING"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	dc := svc["deploymentController"].(map[string]any)
+	assert.Equal(t, "ROLLING", dc["type"])
+}
+
+func TestHandler_CreateService_LoadBalancers(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+		"loadBalancers": []map[string]any{
+			{
+				"targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/my-tg/abcd1234",
+				"containerName":  "app",
+				"containerPort":  8080,
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	lbs := svc["loadBalancers"].([]any)
+	require.Len(t, lbs, 1)
+	lb := lbs[0].(map[string]any)
+	assert.Equal(t, float64(8080), lb["containerPort"])
+	assert.Equal(t, "app", lb["containerName"])
+}
+
+func TestHandler_CreateService_ServiceRegistries(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+		"serviceRegistries": []map[string]any{
+			{
+				"registryArn":   "arn:aws:servicediscovery:us-east-1:000000000000:service/srv-abc123",
+				"containerName": "app",
+				"containerPort": 80,
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	regs := svc["serviceRegistries"].([]any)
+	require.Len(t, regs, 1)
+	reg := regs[0].(map[string]any)
+	assert.Equal(t, "app", reg["containerName"])
+}
+
+func TestHandler_CreateService_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+		"networkConfiguration": map[string]any{
+			"awsvpcConfiguration": map[string]any{
+				"subnets":        []string{"subnet-abc123", "subnet-def456"},
+				"securityGroups": []string{"sg-12345678"},
+				"assignPublicIp": "ENABLED",
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	nc := svc["networkConfiguration"].(map[string]any)
+	avpc := nc["awsvpcConfiguration"].(map[string]any)
+	subnets := avpc["subnets"].([]any)
+	assert.Len(t, subnets, 2)
+	assert.Equal(t, "ENABLED", avpc["assignPublicIp"])
+}
+
+func TestHandler_CreateService_PropagateTags(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+		"propagateTags":  "SERVICE",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	assert.Equal(t, "SERVICE", svc["propagateTags"])
+}
+
+func TestHandler_CreateService_PropagateTags_DefaultNone(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	assert.Equal(t, "NONE", svc["propagateTags"])
+}
+
+// RunTask parity tests -------------------------------------------------------
+
+func TestHandler_RunTask_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "RunTask", map[string]any{
+		"taskDefinition": "myapp",
+		"count":          1,
+		"networkConfiguration": map[string]any{
+			"awsvpcConfiguration": map[string]any{
+				"subnets":        []string{"subnet-abc123"},
+				"assignPublicIp": "DISABLED",
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	tasks := out["tasks"].([]any)
+	require.Len(t, tasks, 1)
+	task := tasks[0].(map[string]any)
+	nc := task["networkConfiguration"].(map[string]any)
+	avpc := nc["awsvpcConfiguration"].(map[string]any)
+	subnets := avpc["subnets"].([]any)
+	require.Len(t, subnets, 1)
+	assert.Equal(t, "subnet-abc123", subnets[0].(string))
+}
+
+func TestHandler_RunTask_PlatformVersion_BadVersion(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "RunTask", map[string]any{
+		"taskDefinition":  "myapp",
+		"count":           1,
+		"platformVersion": "9.9.9",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "platform version")
+}
+
+func TestHandler_RunTask_PlatformVersion_Latest(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "RunTask", map[string]any{
+		"taskDefinition":  "myapp",
+		"count":           1,
+		"platformVersion": "LATEST",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_RunTask_PropagateTags(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "RunTask", map[string]any{
+		"taskDefinition": "myapp",
+		"count":          1,
+		"propagateTags":  "TASK_DEFINITION",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	tasks := out["tasks"].([]any)
+	require.Len(t, tasks, 1)
+	task := tasks[0].(map[string]any)
+	assert.Equal(t, "TASK_DEFINITION", task["propagateTags"])
+}
+
+// UpdateService parity tests ------------------------------------------------
+
+func TestHandler_UpdateService_NetworkConfiguration(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+	_ = doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+	})
+
+	rec := doECSRequest(t, h, "UpdateService", map[string]any{
+		"service": "my-svc",
+		"networkConfiguration": map[string]any{
+			"awsvpcConfiguration": map[string]any{
+				"subnets": []string{"subnet-new123"},
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	nc := svc["networkConfiguration"].(map[string]any)
+	avpc := nc["awsvpcConfiguration"].(map[string]any)
+	subnets := avpc["subnets"].([]any)
+	require.Len(t, subnets, 1)
+	assert.Equal(t, "subnet-new123", subnets[0])
+}
+
+func TestHandler_UpdateService_LoadBalancers(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+	_ = doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+	})
+
+	rec := doECSRequest(t, h, "UpdateService", map[string]any{
+		"service": "my-svc",
+		"loadBalancers": []map[string]any{
+			{
+				"targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/new-tg/xyz",
+				"containerPort":  9090,
+			},
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	lbs := svc["loadBalancers"].([]any)
+	require.Len(t, lbs, 1)
+	lb := lbs[0].(map[string]any)
+	assert.Equal(t, float64(9090), lb["containerPort"])
+}
+
+func TestHandler_UpdateService_DeploymentConfig_MinMaxPercent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":               "myapp",
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+	_ = doECSRequest(t, h, "CreateService", map[string]any{
+		"serviceName":    "my-svc",
+		"taskDefinition": "myapp",
+		"desiredCount":   0,
+	})
+
+	rec := doECSRequest(t, h, "UpdateService", map[string]any{
+		"service": "my-svc",
+		"deploymentConfiguration": map[string]any{
+			"minimumHealthyPercent": 25,
+			"maximumPercent":        300,
+		},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	svc := out["service"].(map[string]any)
+	dc := svc["deploymentConfiguration"].(map[string]any)
+	assert.Equal(t, float64(25), dc["minimumHealthyPercent"])
+	assert.Equal(t, float64(300), dc["maximumPercent"])
+}
+
+// DescribeTaskDefinition parity tests ----------------------------------------
+
+func TestHandler_DescribeTaskDefinition_Volumes_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family": "myapp",
+		"volumes": []map[string]any{
+			{"name": "my-vol", "host": map[string]any{"sourcePath": "/tmp"}},
+		},
+		"containerDefinitions": []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "DescribeTaskDefinition", map[string]any{
+		"taskDefinition": "myapp",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	vols := td["volumes"].([]any)
+	require.Len(t, vols, 1)
+	vol := vols[0].(map[string]any)
+	assert.Equal(t, "my-vol", vol["name"])
+}
+
+func TestHandler_DescribeTaskDefinition_RequiresCompatibilities_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_ = doECSRequest(t, h, "RegisterTaskDefinition", map[string]any{
+		"family":                  "myapp",
+		"requiresCompatibilities": []string{"FARGATE", "EC2"},
+		"containerDefinitions":    []map[string]any{{"name": "app", "image": "nginx"}},
+	})
+
+	rec := doECSRequest(t, h, "DescribeTaskDefinition", map[string]any{
+		"taskDefinition": "myapp",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	td := out["taskDefinition"].(map[string]any)
+	rcs := td["requiresCompatibilities"].([]any)
+	assert.Len(t, rcs, 2)
+}

--- a/services/ecs/handler_parity_test.go
+++ b/services/ecs/handler_parity_test.go
@@ -3,7 +3,6 @@ package ecs_test
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -266,8 +265,8 @@ func TestHandler_RegisterTaskDefinition_HealthCheck(t *testing.T) {
 	td := out["taskDefinition"].(map[string]any)
 	cd := td["containerDefinitions"].([]any)[0].(map[string]any)
 	hc := cd["healthCheck"].(map[string]any)
-	assert.Equal(t, float64(30), hc["interval"])
-	assert.Equal(t, float64(5), hc["timeout"])
+	assert.InDelta(t, float64(30), hc["interval"], 0.001)
+	assert.InDelta(t, float64(5), hc["timeout"], 0.001)
 }
 
 // ListTaskDefinitions parity tests ------------------------------------------
@@ -309,7 +308,7 @@ func TestHandler_ListTaskDefinitions_StatusFilter_Active(t *testing.T) {
 	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listOut))
 	arns := listOut["taskDefinitionArns"].([]any)
 	require.Len(t, arns, 1)
-	assert.True(t, strings.Contains(arns[0].(string), "myapp:2"))
+	assert.Contains(t, arns[0].(string), "myapp:2")
 }
 
 func TestHandler_ListTaskDefinitions_StatusFilter_Inactive(t *testing.T) {
@@ -347,7 +346,7 @@ func TestHandler_ListTaskDefinitions_StatusFilter_Inactive(t *testing.T) {
 	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listOut))
 	arns := listOut["taskDefinitionArns"].([]any)
 	require.Len(t, arns, 1)
-	assert.True(t, strings.Contains(arns[0].(string), "myapp:1"))
+	assert.Contains(t, arns[0].(string), "myapp:1")
 }
 
 // CreateService parity tests ------------------------------------------------
@@ -373,8 +372,8 @@ func TestHandler_CreateService_DeploymentConfigDefaults(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	svc := out["service"].(map[string]any)
 	dc := svc["deploymentConfiguration"].(map[string]any)
-	assert.Equal(t, float64(100), dc["minimumHealthyPercent"])
-	assert.Equal(t, float64(200), dc["maximumPercent"])
+	assert.InDelta(t, float64(100), dc["minimumHealthyPercent"], 0.001)
+	assert.InDelta(t, float64(200), dc["maximumPercent"], 0.001)
 }
 
 func TestHandler_CreateService_DeploymentConfigCustom(t *testing.T) {
@@ -402,8 +401,8 @@ func TestHandler_CreateService_DeploymentConfigCustom(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	svc := out["service"].(map[string]any)
 	dc := svc["deploymentConfiguration"].(map[string]any)
-	assert.Equal(t, float64(50), dc["minimumHealthyPercent"])
-	assert.Equal(t, float64(150), dc["maximumPercent"])
+	assert.InDelta(t, float64(50), dc["minimumHealthyPercent"], 0.001)
+	assert.InDelta(t, float64(150), dc["maximumPercent"], 0.001)
 }
 
 func TestHandler_CreateService_DeploymentController_CodeDeploy_Rejected(t *testing.T) {
@@ -481,7 +480,7 @@ func TestHandler_CreateService_LoadBalancers(t *testing.T) {
 	lbs := svc["loadBalancers"].([]any)
 	require.Len(t, lbs, 1)
 	lb := lbs[0].(map[string]any)
-	assert.Equal(t, float64(8080), lb["containerPort"])
+	assert.InDelta(t, float64(8080), lb["containerPort"], 0.001)
 	assert.Equal(t, "app", lb["containerName"])
 }
 
@@ -766,7 +765,7 @@ func TestHandler_UpdateService_LoadBalancers(t *testing.T) {
 	lbs := svc["loadBalancers"].([]any)
 	require.Len(t, lbs, 1)
 	lb := lbs[0].(map[string]any)
-	assert.Equal(t, float64(9090), lb["containerPort"])
+	assert.InDelta(t, float64(9090), lb["containerPort"], 0.001)
 }
 
 func TestHandler_UpdateService_DeploymentConfig_MinMaxPercent(t *testing.T) {
@@ -797,8 +796,8 @@ func TestHandler_UpdateService_DeploymentConfig_MinMaxPercent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	svc := out["service"].(map[string]any)
 	dc := svc["deploymentConfiguration"].(map[string]any)
-	assert.Equal(t, float64(25), dc["minimumHealthyPercent"])
-	assert.Equal(t, float64(300), dc["maximumPercent"])
+	assert.InDelta(t, float64(25), dc["minimumHealthyPercent"], 0.001)
+	assert.InDelta(t, float64(300), dc["maximumPercent"], 0.001)
 }
 
 // DescribeTaskDefinition parity tests ----------------------------------------

--- a/services/ecs/reconciler.go
+++ b/services/ecs/reconciler.go
@@ -3,18 +3,26 @@ package ecs
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
 )
 
-const reconcileInterval = 5 * time.Second
+const (
+	reconcileInterval = 5 * time.Second
+	// maxConcurrentLaunches caps the number of concurrent task launches per cluster
+	// to prevent unbounded goroutine fanout when Docker is slow.
+	maxConcurrentLaunches = 5
+)
 
 // Reconciler manages ECS service desired-count reconciliation.
 // It runs in the background, comparing DesiredCount vs running task count
 // and starting or stopping tasks as needed.
 type Reconciler struct {
 	backend  *InMemoryBackend
+	sems     map[string]chan struct{} // per-cluster launch semaphore
+	semMu    sync.Mutex
 	interval time.Duration
 }
 
@@ -22,8 +30,24 @@ type Reconciler struct {
 func NewReconciler(backend *InMemoryBackend) *Reconciler {
 	return &Reconciler{
 		backend:  backend,
+		sems:     make(map[string]chan struct{}),
 		interval: reconcileInterval,
 	}
+}
+
+// clusterSem returns the per-cluster launch semaphore, creating it if needed.
+func (r *Reconciler) clusterSem(clusterName string) chan struct{} {
+	r.semMu.Lock()
+	defer r.semMu.Unlock()
+
+	if ch, ok := r.sems[clusterName]; ok {
+		return ch
+	}
+
+	ch := make(chan struct{}, maxConcurrentLaunches)
+	r.sems[clusterName] = ch
+
+	return ch
 }
 
 // Start launches the reconciliation loop. It runs until ctx is cancelled.
@@ -93,8 +117,24 @@ func (r *Reconciler) reconcileService(ctx context.Context, log *slog.Logger, sna
 			"toStart", toStart,
 		)
 
+		sem := r.clusterSem(snap.clusterName)
+
 		for range toStart {
-			if err := r.backend.StartTaskForService(snap.clusterName, svc.ServiceName, svc.TaskDefinition); err != nil {
+			select {
+			case sem <- struct{}{}:
+			default:
+				// Semaphore full — defer remaining launches to next tick.
+				log.DebugContext(ctx, "ECS reconciler: launch semaphore full, deferring",
+					"cluster", snap.clusterName,
+					"service", svc.ServiceName,
+				)
+				return nil
+			}
+
+			err := r.backend.StartTaskForService(snap.clusterName, svc.ServiceName, svc.TaskDefinition)
+			<-sem
+
+			if err != nil {
 				return err
 			}
 		}

--- a/services/ecs/reconciler.go
+++ b/services/ecs/reconciler.go
@@ -128,6 +128,7 @@ func (r *Reconciler) reconcileService(ctx context.Context, log *slog.Logger, sna
 					"cluster", snap.clusterName,
 					"service", svc.ServiceName,
 				)
+
 				return nil
 			}
 


### PR DESCRIPTION
Closes #1681

ECS AWS accuracy audit implementation by polecat topaz.
+2798 / -175 lines. Build clean, tests passing locally.