### PR TITLE
feat(apigateway): AWS accuracy follow-up per #1696

### DIFF
--- a/services/apigateway/accesslog.go
+++ b/services/apigateway/accesslog.go
@@ -118,8 +118,6 @@ func accessLogStreamName(apiID, stageName string) string {
 	return apiID + "/" + stageName
 }
 
-const requestIDNodeMask = 0xffffffffffff // 48-bit node component of request ID
-
 // generateRequestID creates a random hex request ID similar to the AWS API Gateway format.
 func generateRequestID() string {
 	var b [16]byte
@@ -128,7 +126,9 @@ func generateRequestID() string {
 	c := binary.BigEndian.Uint16(b[4:6])
 	d := binary.BigEndian.Uint16(b[6:8])
 	e := binary.BigEndian.Uint16(b[8:10])
-	f := binary.BigEndian.Uint64(b[8:16]) & requestIDNodeMask
+	// b[10:16] gives 48 independent bits for f, non-overlapping with e (b[8:10]).
+	f := uint64(b[10])<<40 | uint64(b[11])<<32 | uint64(b[12])<<24 |
+		uint64(b[13])<<16 | uint64(b[14])<<8 | uint64(b[15])
 
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", a, c, d, e, f)
 }

--- a/services/apigateway/accesslog.go
+++ b/services/apigateway/accesslog.go
@@ -1,0 +1,141 @@
+package apigateway
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// accessLogWriter wraps http.ResponseWriter to capture status code and response size for access logging.
+type accessLogWriter struct {
+	http.ResponseWriter
+	statusCode int
+	size       int
+}
+
+func newAccessLogWriter(w http.ResponseWriter) *accessLogWriter {
+	return &accessLogWriter{ResponseWriter: w, statusCode: http.StatusOK}
+}
+
+func (a *accessLogWriter) WriteHeader(code int) {
+	a.statusCode = code
+	a.ResponseWriter.WriteHeader(code)
+}
+
+func (a *accessLogWriter) Write(b []byte) (int, error) {
+	n, err := a.ResponseWriter.Write(b)
+	a.size += n
+
+	return n, err
+}
+
+// emitAccessLog emits a single access log entry to CloudWatch Logs when the stage has
+// AccessLogSettings configured and a LogEmitter is wired up on the handler.
+// The format string supports $context.* substitution variables per the AWS specification.
+func (h *Handler) emitAccessLog(
+	apiID, stageName string,
+	r *http.Request,
+	alw *accessLogWriter,
+	requestID string,
+	latency time.Duration,
+) {
+	if h.logsEmitter == nil {
+		return
+	}
+
+	stage, err := h.Backend.GetStage(apiID, stageName)
+	if err != nil || stage == nil || stage.AccessLogSettings == nil {
+		return
+	}
+
+	destARN := stage.AccessLogSettings.DestinationARN
+	if destARN == "" {
+		return
+	}
+
+	format := stage.AccessLogSettings.Format
+	if format == "" {
+		format = defaultAccessLogFormat
+	}
+
+	line := formatAccessLogEntry(format, r, alw, requestID, latency, apiID, stageName)
+	groupName := logGroupFromARN(destARN)
+
+	events := []LogEvent{
+		{
+			Timestamp: time.Now().UnixMilli(),
+			Message:   line,
+		},
+	}
+
+	_ = h.logsEmitter.PutLogEvents(groupName, accessLogStreamName(apiID, stageName), events)
+}
+
+// defaultAccessLogFormat is the default access log format when none is specified.
+const defaultAccessLogFormat = "$context.requestId $context.httpMethod $context.path " +
+	"$context.status $context.responseLength $context.responseLatencyMs"
+
+// formatAccessLogEntry substitutes $context.* placeholders in the format string.
+func formatAccessLogEntry(
+	format string,
+	r *http.Request,
+	alw *accessLogWriter,
+	requestID string,
+	latency time.Duration,
+	apiID, stageName string,
+) string {
+	replacer := strings.NewReplacer(
+		"$context.requestId", requestID,
+		"$context.httpMethod", r.Method,
+		"$context.path", r.URL.Path,
+		"$context.resourcePath", r.URL.Path,
+		"$context.status", strconv.Itoa(alw.statusCode),
+		"$context.responseLength", strconv.Itoa(alw.size),
+		"$context.responseLatencyMs", strconv.FormatInt(latency.Milliseconds(), 10),
+		"$context.protocol", "HTTP/1.1",
+		"$context.stage", stageName,
+		"$context.apiId", apiID,
+		"$context.sourceIp", extractClientIP(r),
+		"$context.identity.sourceIp", extractClientIP(r),
+		"$context.requestTime", time.Now().Format("02/Jan/2006:15:04:05 -0700"),
+	)
+
+	return replacer.Replace(format)
+}
+
+// logGroupFromARN extracts the CloudWatch log group name from a log group ARN.
+// Handles:
+//   - "arn:aws:logs:region:account:log-group:/my/group" → "/my/group"
+//   - "/my/group" (already a name)
+func logGroupFromARN(arn string) string {
+	const logGroupPrefix = ":log-group:"
+	if idx := strings.LastIndex(arn, logGroupPrefix); idx >= 0 {
+		return arn[idx+len(logGroupPrefix):]
+	}
+
+	return arn
+}
+
+// accessLogStreamName returns a consistent stream name for the given API/stage.
+func accessLogStreamName(apiID, stageName string) string {
+	return apiID + "/" + stageName
+}
+
+const requestIDNodeMask = 0xffffffffffff // 48-bit node component of request ID
+
+// generateRequestID creates a random hex request ID similar to the AWS API Gateway format.
+func generateRequestID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	a := binary.BigEndian.Uint32(b[0:4])
+	c := binary.BigEndian.Uint16(b[4:6])
+	d := binary.BigEndian.Uint16(b[6:8])
+	e := binary.BigEndian.Uint16(b[8:10])
+	f := binary.BigEndian.Uint64(b[8:16]) & requestIDNodeMask
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", a, c, d, e, f)
+}

--- a/services/apigateway/accesslog.go
+++ b/services/apigateway/accesslog.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-// accessLogWriter wraps http.ResponseWriter to capture status code and response size for access logging.
+// accessLogWriter wraps http.ResponseWriter to capture the status code for access logging.
+// It delegates all writes to the underlying ResponseWriter without modification.
 type accessLogWriter struct {
 	http.ResponseWriter
 	statusCode int
-	size       int
 }
 
 func newAccessLogWriter(w http.ResponseWriter) *accessLogWriter {
@@ -24,13 +24,6 @@ func newAccessLogWriter(w http.ResponseWriter) *accessLogWriter {
 func (a *accessLogWriter) WriteHeader(code int) {
 	a.statusCode = code
 	a.ResponseWriter.WriteHeader(code)
-}
-
-func (a *accessLogWriter) Write(b []byte) (int, error) {
-	n, err := a.ResponseWriter.Write(b)
-	a.size += n
-
-	return n, err
 }
 
 // emitAccessLog emits a single access log entry to CloudWatch Logs when the stage has
@@ -94,7 +87,7 @@ func formatAccessLogEntry(
 		"$context.path", r.URL.Path,
 		"$context.resourcePath", r.URL.Path,
 		"$context.status", strconv.Itoa(alw.statusCode),
-		"$context.responseLength", strconv.Itoa(alw.size),
+		"$context.responseLength", "-",
 		"$context.responseLatencyMs", strconv.FormatInt(latency.Milliseconds(), 10),
 		"$context.protocol", "HTTP/1.1",
 		"$context.stage", stageName,

--- a/services/apigateway/accuracy_test.go
+++ b/services/apigateway/accuracy_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -826,6 +827,1165 @@ func TestGetExport_Swagger20(t *testing.T) {
 	assert.Contains(t, security[0], "api_key")
 }
 
+// --- API Key Enforcement ---
+
+func TestProxy_APIKeyRequired_BlocksMissingKey(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "key-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+		APIKeyRequired:    true,
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Request without API key → 403.
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestProxy_APIKeyRequired_AllowsValidKey(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "key-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	// Create an enabled API key.
+	apiKey, _ := backend.CreateAPIKey(apigateway.CreateAPIKeyInput{
+		Name:    "test-key",
+		Value:   "abc123secret",
+		Enabled: true,
+	})
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+		APIKeyRequired:    true,
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+	_ = apiKey
+
+	// Request with valid API key → 200.
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Api-Key", "abc123secret")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_APIKeyRequired_BlocksInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "key-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.CreateAPIKey(apigateway.CreateAPIKeyInput{
+		Name:    "test-key",
+		Value:   "correct-key",
+		Enabled: true,
+	})
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+		APIKeyRequired:    true,
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Wrong API key → 403.
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Api-Key", "wrong-key")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestProxy_APIKeyRequired_BlocksDisabledKey(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "key-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	// Disabled key.
+	_, _ = backend.CreateAPIKey(apigateway.CreateAPIKeyInput{
+		Name:    "disabled-key",
+		Value:   "disabled-secret",
+		Enabled: false,
+	})
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+		APIKeyRequired:    true,
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Disabled key → 403.
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Api-Key", "disabled-secret")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestProxy_APIKeySource_AUTHORIZER_UsesAuthorizerContext(t *testing.T) {
+	t.Parallel()
+
+	// Lambda authorizer returns usageIdentifierKey in context.
+	authResp := `{"principalId":"user1","policyDocument":{"Version":"2012-10-17",` +
+		`"Statement":[{"Effect":"Allow","Action":"execute-api:Invoke","Resource":"*"}]},` +
+		`"context":{"usageIdentifierKey":"context-key-value"}}`
+	invoker := &proxyMockInvoker{response: []byte(authResp)}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLambdaInvoker(invoker)
+	e := echo.New()
+
+	// API with apiKeySource = AUTHORIZER.
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{
+		Name:         "auth-key-api",
+		APIKeySource: "AUTHORIZER",
+	})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	// Create API key matching the authorizer context value.
+	_, _ = backend.CreateAPIKey(apigateway.CreateAPIKeyInput{
+		Name:    "ctx-key",
+		Value:   "context-key-value",
+		Enabled: true,
+	})
+
+	const authURI = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions" +
+		"/arn:aws:lambda:us-east-1:000000000000:function:auth-fn/invocations"
+	authBody := `{"restApiId":"` + api.ID + `","name":"ctx-auth","type":"TOKEN",` +
+		`"authorizerUri":"` + authURI + `",` +
+		`"identitySource":"method.request.header.Authorization",` +
+		`"authorizerResultTtlInSeconds":0}`
+	authRec := postWithHandler(t, h, e, "CreateAuthorizer", authBody)
+	require.Equal(t, http.StatusCreated, authRec.Code)
+	var auth map[string]any
+	require.NoError(t, json.Unmarshal(authRec.Body.Bytes(), &auth))
+	authID := auth["id"].(string)
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "TOKEN",
+		AuthorizerID:      authID,
+		APIKeyRequired:    true,
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Request: no x-api-key header — key should come from authorizer context.
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer token123")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	// Should succeed because authorizer context contains matching API key.
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_APIKeySource_AUTHORIZER_BlocksMissingContextKey(t *testing.T) {
+	t.Parallel()
+
+	// Authorizer returns Allow but no usageIdentifierKey.
+	authResp := `{"principalId":"user1","policyDocument":{"Version":"2012-10-17",` +
+		`"Statement":[{"Effect":"Allow","Action":"execute-api:Invoke","Resource":"*"}]}}`
+	invoker := &proxyMockInvoker{response: []byte(authResp)}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLambdaInvoker(invoker)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{
+		Name:         "auth-key-api-2",
+		APIKeySource: "AUTHORIZER",
+	})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	const authURI = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions" +
+		"/arn:aws:lambda:us-east-1:000000000000:function:auth-fn2/invocations"
+	authBody := `{"restApiId":"` + api.ID + `","name":"no-ctx-auth","type":"TOKEN",` +
+		`"authorizerUri":"` + authURI + `",` +
+		`"identitySource":"method.request.header.Authorization",` +
+		`"authorizerResultTtlInSeconds":0}`
+	authRec := postWithHandler(t, h, e, "CreateAuthorizer", authBody)
+	require.Equal(t, http.StatusCreated, authRec.Code)
+	var auth map[string]any
+	require.NoError(t, json.Unmarshal(authRec.Body.Bytes(), &auth))
+	authID := auth["id"].(string)
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "TOKEN",
+		AuthorizerID:      authID,
+		APIKeyRequired:    true,
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// No key in authorizer context → 403.
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer token123")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// --- Canary routing ---
+
+func TestProxy_CanarySettings_FullPercentRouteToCanary(t *testing.T) {
+	t.Parallel()
+
+	// Track which function name was invoked.
+	var invokedFunctions []string
+	mu := &sync.Mutex{}
+	invoker := &funcTrackingInvoker{
+		tracked:  &invokedFunctions,
+		mu:       mu,
+		response: []byte(`{"statusCode":200,"body":"ok"}`),
+	}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLambdaInvoker(invoker)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "canary-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	// Integration uses ${stageVariables.fnName} to allow canary override.
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{
+		Type:       "AWS_PROXY",
+		HTTPMethod: "POST",
+		URI: "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions" +
+			"/${stageVariables.fnName}/invocations",
+	})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	canarySVOverrides := map[string]string{"fnName": "canary-function"}
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		Variables:    map[string]string{"fnName": "stable-function"},
+		CanarySettings: &apigateway.CanarySettings{
+			PercentTraffic:         100.0, // All traffic to canary.
+			DeploymentID:           depl.ID,
+			StageVariableOverrides: canarySVOverrides,
+		},
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	mu.Lock()
+	fns := invokedFunctions
+	mu.Unlock()
+
+	// With 100% canary traffic, should always use canary-function.
+	require.Len(t, fns, 1)
+	assert.Equal(t, "canary-function", fns[0])
+}
+
+func TestProxy_CanarySettings_ZeroPercentNoCanary(t *testing.T) {
+	t.Parallel()
+
+	var invokedFunctions []string
+	mu := &sync.Mutex{}
+	invoker := &funcTrackingInvoker{
+		tracked:  &invokedFunctions,
+		mu:       mu,
+		response: []byte(`{"statusCode":200,"body":"ok"}`),
+	}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLambdaInvoker(invoker)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "no-canary-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{
+		Type:       "AWS_PROXY",
+		HTTPMethod: "POST",
+		URI: "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions" +
+			"/${stageVariables.fnName}/invocations",
+	})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		Variables:    map[string]string{"fnName": "stable-function"},
+		CanarySettings: &apigateway.CanarySettings{
+			PercentTraffic:         0, // No canary traffic.
+			StageVariableOverrides: map[string]string{"fnName": "canary-function"},
+		},
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	mu.Lock()
+	fns := invokedFunctions
+	mu.Unlock()
+
+	// 0% canary → always stable function.
+	require.Len(t, fns, 1)
+	assert.Equal(t, "stable-function", fns[0])
+}
+
+func TestProxy_CanarySettings_PartialPercentStatistical(t *testing.T) {
+	t.Parallel()
+
+	var invokedFunctions []string
+	mu := &sync.Mutex{}
+	invoker := &funcTrackingInvoker{
+		tracked:  &invokedFunctions,
+		mu:       mu,
+		response: []byte(`{"statusCode":200,"body":"ok"}`),
+	}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLambdaInvoker(invoker)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "partial-canary-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{
+		Type:       "AWS_PROXY",
+		HTTPMethod: "POST",
+		URI: "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions" +
+			"/${stageVariables.fnName}/invocations",
+	})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		Variables:    map[string]string{"fnName": "stable-function"},
+		CanarySettings: &apigateway.CanarySettings{
+			PercentTraffic:         50.0,
+			StageVariableOverrides: map[string]string{"fnName": "canary-function"},
+		},
+	})
+
+	// Send 200 requests and verify both stable and canary functions are invoked.
+	for range 200 {
+		url := "/restapis/" + api.ID + "/prod/_user_request_/"
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		_ = h.Handler()(c)
+	}
+
+	mu.Lock()
+	fns := append([]string(nil), invokedFunctions...)
+	mu.Unlock()
+
+	canaryCount := 0
+	stableCount := 0
+	for _, fn := range fns {
+		switch fn {
+		case "canary-function":
+			canaryCount++
+		case "stable-function":
+			stableCount++
+		}
+	}
+
+	// Statistical: with 50% canary and 200 requests, both should be hit.
+	// Allow wide margin (10% to 90% canary rate) due to randomness.
+	assert.Positive(t, canaryCount, "should route some traffic to canary")
+	assert.Positive(t, stableCount, "should route some traffic to stable")
+}
+
+// --- Resource policy enforcement ---
+
+func TestProxy_ResourcePolicy_AllowAll(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	policy := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Principal":"*","Action":"execute-api:Invoke","Resource":"*"}]}`
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{
+		Name:   "policy-allow-api",
+		Policy: policy,
+	})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	// Allow policy → request goes through.
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_ResourcePolicy_DenyAll(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	// Policy: deny everything.
+	policy := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Deny","Principal":"*","Action":"execute-api:Invoke","Resource":"*"}]}`
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{
+		Name:   "policy-deny-api",
+		Policy: policy,
+	})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestProxy_ResourcePolicy_AllowWithDenyOverride(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	// Policy: allow all, but deny takes precedence when present.
+	policy := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Principal":"*","Action":"execute-api:Invoke","Resource":"*"},` +
+		`{"Effect":"Deny","Principal":"*","Action":"execute-api:Invoke","Resource":"*"}]}`
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{
+		Name:   "policy-allow-deny-api",
+		Policy: policy,
+	})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	// Deny overrides Allow → 403.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestProxy_ResourcePolicy_EmptyPolicyAllowsAll(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	// No policy attached.
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "no-policy-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	// No policy → all requests allowed.
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_ResourcePolicy_MultipleActions(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	// Policy with action as an array.
+	policy := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Principal":"*","Action":["execute-api:Invoke","execute-api:*"],"Resource":"*"}]}`
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{
+		Name:   "policy-multi-action-api",
+		Policy: policy,
+	})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- CloudWatch Access Logging ---
+
+func TestProxy_AccessLog_EmitsOnRequest(t *testing.T) {
+	t.Parallel()
+
+	emitter := &captureLogEmitter{}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLogsEmitter(emitter)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "log-emit-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		AccessLogSettings: &apigateway.AccessLogSettings{
+			DestinationARN: "arn:aws:logs:us-east-1:123456789012:log-group:/api/access",
+			Format:         "$context.httpMethod $context.path $context.status",
+		},
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	emitter.mu.Lock()
+	events := emitter.events
+	emitter.mu.Unlock()
+
+	require.NotEmpty(t, events, "should have emitted at least one access log event")
+	assert.Contains(t, events[0].Message, "GET")
+	assert.Contains(t, events[0].Message, "200")
+}
+
+func TestProxy_AccessLog_NoEmitWithoutSettings(t *testing.T) {
+	t.Parallel()
+
+	emitter := &captureLogEmitter{}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLogsEmitter(emitter)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "no-log-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+
+	// Stage without access log settings.
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	emitter.mu.Lock()
+	events := emitter.events
+	emitter.mu.Unlock()
+
+	// No access log settings → no events emitted.
+	assert.Empty(t, events)
+}
+
+func TestProxy_AccessLog_NoEmitWithoutEmitter(t *testing.T) {
+	t.Parallel()
+
+	// No logsEmitter configured — should not panic.
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend) // no SetLogsEmitter
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "no-emitter-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "prod", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		AccessLogSettings: &apigateway.AccessLogSettings{
+			DestinationARN: "arn:aws:logs:us-east-1:123456789012:log-group:/api/access",
+		},
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	// Should complete without panicking.
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_AccessLog_CustomFormat(t *testing.T) {
+	t.Parallel()
+
+	emitter := &captureLogEmitter{}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLogsEmitter(emitter)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "custom-log-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "POST",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "POST", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "POST", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		AccessLogSettings: &apigateway.AccessLogSettings{
+			DestinationARN: "arn:aws:logs:us-east-1:123:log-group:/my/log",
+			Format: `{"requestId":"$context.requestId","method":"$context.httpMethod",` +
+				`"latency":$context.responseLatencyMs}`,
+		},
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	emitter.mu.Lock()
+	events := emitter.events
+	emitter.mu.Unlock()
+
+	require.NotEmpty(t, events)
+	// Verify JSON-format log line contains the method.
+	assert.Contains(t, events[0].Message, `"method":"POST"`)
+}
+
+func TestProxy_AccessLog_LogGroupNameExtractedFromARN(t *testing.T) {
+	t.Parallel()
+
+	emitter := &captureLogEmitter{}
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	h.SetLogsEmitter(emitter)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "arn-log-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:         api.ID,
+		ResourceID:        rootID,
+		HTTPMethod:        "GET",
+		AuthorizationType: "NONE",
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "GET", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "GET", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+		AccessLogSettings: &apigateway.AccessLogSettings{
+			DestinationARN: "arn:aws:logs:us-east-1:123456789012:log-group:/prod/access-logs",
+		},
+	})
+
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	emitter.mu.Lock()
+	groups := emitter.groups
+	emitter.mu.Unlock()
+
+	require.NotEmpty(t, groups)
+	// Log group name should be extracted from ARN (not the full ARN).
+	assert.Equal(t, "/prod/access-logs", groups[0])
+}
+
+// --- proxy: request body model validation ---
+
+func TestProxy_ModelValidation_BlocksMissingRequiredField(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "model-val-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	schema := `{"type":"object","required":["name","email"],` +
+		`"properties":{"name":{"type":"string"},"email":{"type":"string"}}}`
+	model, _ := backend.CreateModel(apigateway.CreateModelInput{
+		RestAPIID:   api.ID,
+		Name:        "CreateUser",
+		ContentType: "application/json",
+		Schema:      schema,
+	})
+
+	rv, _ := backend.CreateRequestValidator(api.ID, apigateway.CreateRequestValidatorInput{
+		Name:                "body-validator",
+		ValidateRequestBody: true,
+	})
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:          api.ID,
+		ResourceID:         rootID,
+		HTTPMethod:         "POST",
+		AuthorizationType:  "NONE",
+		RequestValidatorID: rv.ID,
+		RequestModels:      map[string]string{"application/json": model.Name},
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "POST", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "POST", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Body with missing required "email" field.
+	body := strings.NewReader(`{"name":"Alice"}`)
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "email")
+}
+
+func TestProxy_ModelValidation_AllowsAllRequiredFieldsPresent(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "model-allow-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	schema := `{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}`
+	model, _ := backend.CreateModel(apigateway.CreateModelInput{
+		RestAPIID:   api.ID,
+		Name:        "Item",
+		ContentType: "application/json",
+		Schema:      schema,
+	})
+
+	rv, _ := backend.CreateRequestValidator(api.ID, apigateway.CreateRequestValidatorInput{
+		Name:                "body-validator",
+		ValidateRequestBody: true,
+	})
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:          api.ID,
+		ResourceID:         rootID,
+		HTTPMethod:         "POST",
+		AuthorizationType:  "NONE",
+		RequestValidatorID: rv.ID,
+		RequestModels:      map[string]string{"application/json": model.Name},
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "POST", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "POST", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Body with all required fields present.
+	body := strings.NewReader(`{"name":"Widget"}`)
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_ModelValidation_SkipsWhenNoValidateBodyFlag(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "model-skip-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	schema := `{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}`
+	model, _ := backend.CreateModel(apigateway.CreateModelInput{
+		RestAPIID:   api.ID,
+		Name:        "Item",
+		ContentType: "application/json",
+		Schema:      schema,
+	})
+
+	// Validator with ValidateRequestBody = false.
+	rv, _ := backend.CreateRequestValidator(api.ID, apigateway.CreateRequestValidatorInput{
+		Name:                "params-only-validator",
+		ValidateRequestBody: false,
+	})
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:          api.ID,
+		ResourceID:         rootID,
+		HTTPMethod:         "POST",
+		AuthorizationType:  "NONE",
+		RequestValidatorID: rv.ID,
+		RequestModels:      map[string]string{"application/json": model.Name},
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "POST", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "POST", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Body missing required field — should still pass because ValidateRequestBody = false.
+	body := strings.NewReader(`{}`)
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProxy_ModelValidation_FallsBackToJSONModelForUnknownContentType(t *testing.T) {
+	t.Parallel()
+
+	backend := apigateway.NewInMemoryBackend()
+	h := apigateway.NewHandler(backend)
+	e := echo.New()
+
+	api, _ := backend.CreateRestAPI(apigateway.CreateRestAPIInput{Name: "model-ct-api"})
+	resources, _, _ := backend.GetResources(api.ID, "", 0)
+	rootID := resources[0].ID
+
+	schema := `{"type":"object","required":["id"],"properties":{"id":{"type":"string"}}}`
+	model, _ := backend.CreateModel(apigateway.CreateModelInput{
+		RestAPIID:   api.ID,
+		Name:        "Thing",
+		ContentType: "application/json",
+		Schema:      schema,
+	})
+
+	rv, _ := backend.CreateRequestValidator(api.ID, apigateway.CreateRequestValidatorInput{
+		Name:                "body-validator",
+		ValidateRequestBody: true,
+	})
+	_, _ = backend.PutMethod(apigateway.PutMethodInput{
+		RestAPIID:          api.ID,
+		ResourceID:         rootID,
+		HTTPMethod:         "POST",
+		AuthorizationType:  "NONE",
+		RequestValidatorID: rv.ID,
+		// Only JSON model registered — request uses different Content-Type.
+		RequestModels: map[string]string{"application/json": model.Name},
+	})
+	_, _ = backend.PutIntegration(api.ID, rootID, "POST", apigateway.PutIntegrationInput{Type: "MOCK"})
+	_, _ = backend.PutIntegrationResponse(api.ID, rootID, "POST", "200", apigateway.PutIntegrationResponseInput{})
+	depl, _ := backend.CreateDeployment(api.ID, "", "v1")
+	_, _ = backend.CreateStage(apigateway.CreateStageInput{
+		RestAPIID:    api.ID,
+		StageName:    "prod",
+		DeploymentID: depl.ID,
+	})
+
+	// Content-Type is "text/plain" but fallback to application/json model applies.
+	// Missing required "id" field → blocked.
+	body := strings.NewReader(`{"name":"no-id"}`)
+	url := "/restapis/" + api.ID + "/prod/_user_request_/"
+	req := httptest.NewRequest(http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 // --- helpers ---
 
 type countingInvoker struct {
@@ -837,4 +1997,35 @@ func (c *countingInvoker) InvokeFunction(_ context.Context, _, _ string, _ []byt
 	*c.count++
 
 	return c.response, http.StatusOK, nil
+}
+
+// funcTrackingInvoker records the function names passed to InvokeFunction.
+type funcTrackingInvoker struct {
+	tracked  *[]string
+	mu       *sync.Mutex
+	response []byte
+}
+
+func (f *funcTrackingInvoker) InvokeFunction(_ context.Context, fn, _ string, _ []byte) ([]byte, int, error) {
+	f.mu.Lock()
+	*f.tracked = append(*f.tracked, fn)
+	f.mu.Unlock()
+
+	return f.response, http.StatusOK, nil
+}
+
+// captureLogEmitter collects log events for test assertions.
+type captureLogEmitter struct {
+	events []apigateway.LogEvent
+	groups []string
+	mu     sync.Mutex
+}
+
+func (c *captureLogEmitter) PutLogEvents(groupName, _ string, events []apigateway.LogEvent) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, events...)
+	c.groups = append(c.groups, groupName)
+
+	return nil
 }

--- a/services/apigateway/handler.go
+++ b/services/apigateway/handler.go
@@ -606,11 +606,24 @@ type getExportInput struct {
 	ExportType string `json:"exportType"`
 }
 
+// LogEvent is a single log event for CloudWatch Logs emission.
+type LogEvent struct {
+	Message   string
+	Timestamp int64 // Unix milliseconds
+}
+
+// LogEmitter emits log events to a CloudWatch Logs log group and stream.
+// The log group must exist before PutLogEvents is called.
+type LogEmitter interface {
+	PutLogEvents(groupName, streamName string, events []LogEvent) error
+}
+
 // Handler is the Echo HTTP service handler for API Gateway operations.
 type Handler struct {
 	Backend        StorageBackend
 	authCache      *authorizerCache
 	lambda         LambdaInvoker
+	logsEmitter    LogEmitter
 	httpClient     *http.Client
 	selRegexpCache sync.Map // map[string]*regexp.Regexp — compiled selection-pattern regexps
 }
@@ -627,6 +640,12 @@ func NewHandler(backend StorageBackend) *Handler {
 // SetLambdaInvoker configures the Lambda invoker for AWS_PROXY integrations.
 func (h *Handler) SetLambdaInvoker(lambda LambdaInvoker) {
 	h.lambda = lambda
+}
+
+// SetLogsEmitter configures the CloudWatch Logs emitter for access logging.
+// When set, access logs are emitted to the log group in Stage.AccessLogSettings.DestinationARN.
+func (h *Handler) SetLogsEmitter(le LogEmitter) {
+	h.logsEmitter = le
 }
 
 // SetHTTPClient configures the HTTP client used for HTTP/HTTP_PROXY integrations.

--- a/services/apigateway/proxy.go
+++ b/services/apigateway/proxy.go
@@ -141,6 +141,7 @@ func BuildProxyEvent(
 // authorizerCacheEntry holds a cached authorizer result.
 type authorizerCacheEntry struct {
 	expiresAt time.Time
+	context   map[string]any
 	key       string
 	allowed   bool
 }
@@ -169,36 +170,36 @@ func newAuthorizerCacheWithMaxEntries(maxEntries int) *authorizerCache {
 	}
 }
 
-// get returns (allowed, found) for the given cache key.
-func (c *authorizerCache) get(key string) (bool, bool) {
+// get returns (allowed, context, found) for the given cache key.
+func (c *authorizerCache) get(key string) (bool, map[string]any, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	elem, ok := c.entries[key]
 	if !ok {
-		return false, false
+		return false, nil, false
 	}
 
 	e, ok := elem.Value.(authorizerCacheEntry)
 	if !ok {
 		c.removeElement(elem)
 
-		return false, false
+		return false, nil, false
 	}
 
 	if time.Now().After(e.expiresAt) {
 		c.removeElement(elem)
 
-		return false, false
+		return false, nil, false
 	}
 
 	c.order.MoveToFront(elem)
 
-	return e.allowed, true
+	return e.allowed, e.context, true
 }
 
 // set stores the result for the given cache key with a TTL.
-func (c *authorizerCache) set(key string, allowed bool, ttl time.Duration) {
+func (c *authorizerCache) set(key string, allowed bool, context map[string]any, ttl time.Duration) {
 	if ttl <= 0 {
 		return
 	}
@@ -212,6 +213,7 @@ func (c *authorizerCache) set(key string, allowed bool, ttl time.Duration) {
 			c.removeElement(elem)
 		} else {
 			entry.allowed = allowed
+			entry.context = context
 			entry.expiresAt = time.Now().Add(ttl)
 			elem.Value = entry
 			c.order.MoveToFront(elem)
@@ -223,6 +225,7 @@ func (c *authorizerCache) set(key string, allowed bool, ttl time.Duration) {
 	elem := c.order.PushFront(authorizerCacheEntry{
 		key:       key,
 		allowed:   allowed,
+		context:   context,
 		expiresAt: time.Now().Add(ttl),
 	})
 	c.entries[key] = elem
@@ -463,6 +466,8 @@ func (h *Handler) stageVars(apiID, stageName string) map[string]string {
 		return stage.Variables
 	}
 
+	// Limitation: only stage variable overrides are applied; CanarySettings.DeploymentID is not
+	// used to select a different deployment. Full multi-deployment canary routing is not implemented.
 	overrides := stage.CanarySettings.StageVariableOverrides
 	if len(overrides) == 0 {
 		return stage.Variables
@@ -557,14 +562,14 @@ func (h *Handler) runAuthorizer(
 	// Build cache key: for TOKEN type use the token, for REQUEST type use the full path.
 	cacheKey := h.authorizerCacheKey(r, auth, authorizerID)
 	if ttl > 0 {
-		if allowed, found := h.authCache.get(cacheKey); found {
+		if allowed, cachedContext, found := h.authCache.get(cacheKey); found {
 			if !allowed {
 				http.Error(w, "Forbidden", http.StatusForbidden)
 
 				return true, nil
 			}
 
-			return false, nil // context not cached — callers must re-invoke if they need it
+			return false, cachedContext
 		}
 	}
 
@@ -594,7 +599,7 @@ func (h *Handler) runAuthorizer(
 
 	// Evaluate the policy document to determine allow/deny.
 	allowed := isAuthorizerAllowed(&authResp)
-	h.authCache.set(cacheKey, allowed, ttl)
+	h.authCache.set(cacheKey, allowed, authResp.Context, ttl)
 
 	if !allowed {
 		http.Error(w, "Forbidden", http.StatusForbidden)
@@ -683,7 +688,7 @@ func (h *Handler) validateRequestBody(
 		return true
 	}
 
-	r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	if len(bodyBytes) > 0 && !json.Valid(bodyBytes) {
 		http.Error(w, "Bad Request: request body must be valid JSON", http.StatusBadRequest)
@@ -877,7 +882,7 @@ type resourcePolicyStatement struct {
 
 // evaluateResourcePolicy parses the IAM policy attached to a REST API and evaluates
 // whether the request is permitted. Returns true (allow) or false (deny).
-// An empty, missing, or unparseable policy allows all requests (fail-open).
+// An empty or missing policy allows all requests; an unparseable policy denies (AWS semantics).
 func evaluateResourcePolicy(policy string, r *http.Request) bool {
 	if policy == "" {
 		return true
@@ -885,7 +890,7 @@ func evaluateResourcePolicy(policy string, r *http.Request) bool {
 
 	var doc resourcePolicyDoc
 	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
-		return true // fail open on parse error
+		return false // malformed policy: deny per AWS semantics
 	}
 
 	sourceIP := extractClientIP(r)
@@ -1005,8 +1010,8 @@ func extractClientIP(r *http.Request) string {
 	}
 
 	if r.RemoteAddr != "" {
-		if idx := strings.LastIndexByte(r.RemoteAddr, ':'); idx >= 0 {
-			return r.RemoteAddr[:idx]
+		if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+			return host
 		}
 
 		return r.RemoteAddr

--- a/services/apigateway/proxy.go
+++ b/services/apigateway/proxy.go
@@ -5,12 +5,15 @@ import (
 	"compress/gzip"
 	"container/list"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -257,60 +260,115 @@ func (c *authorizerCache) removeElement(elem *list.Element) {
 func (h *Handler) handleProxyRequest(apiID, stageName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		start := time.Now()
+		requestID := generateRequestID()
 
-		// Find the resource and integration.
-		resources, _, err := h.Backend.GetResources(apiID, "", 0)
-		if err != nil {
-			logger.Load(ctx).ErrorContext(ctx, "APIGateway proxy: failed to get resources", "error", err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		// Wrap the writer to capture status/size for access logging.
+		alw := newAccessLogWriter(w)
 
+		defer func() {
+			h.emitAccessLog(apiID, stageName, r, alw, requestID, time.Since(start))
+		}()
+
+		// Evaluate REST API resource policy before dispatching.
+		if denied := h.checkResourcePolicy(apiID, r, alw); denied {
 			return
 		}
 
-		// Match request path to resource path, extracting any path parameters.
-		resource, pathParams := findMatchingResource(resources, r.URL.Path, stageName)
-		if resource == nil {
-			http.NotFound(w, r)
-
+		resource, pathParams, ok := h.resolveResource(ctx, apiID, stageName, r, alw)
+		if !ok {
 			return
 		}
 
-		// Handle CORS preflight OPTIONS request.
-		if r.Method == http.MethodOptions {
-			if resource.CorsConfiguration != nil {
-				h.writeCORSPreflight(w, r, resource.CorsConfiguration)
-
-				return
-			}
-		}
-
-		// Attach CORS headers to the response when configured.
-		if resource.CorsConfiguration != nil {
-			h.addCORSHeaders(w, r, resource.CorsConfiguration)
-		}
-
-		// Apply method-level access controls (authorizer + request validator).
-		if denied := h.applyMethodControls(ctx, w, r, apiID, stageName, resource.ID); denied {
+		// Apply method-level access controls (authorizer + API key + request validator).
+		if denied := h.applyMethodControls(ctx, alw, r, apiID, stageName, resource.ID); denied {
 			return
 		}
 
-		// Get the integration.
-		integration, err := h.Backend.GetIntegration(apiID, resource.ID, r.Method)
-		if err != nil {
-			// Fall back to any method.
-			integration, err = h.Backend.GetIntegration(apiID, resource.ID, "ANY")
-			if err != nil {
-				http.NotFound(w, r)
-
-				return
-			}
+		integration, ok := h.resolveIntegration(apiID, resource, r, alw)
+		if !ok {
+			return
 		}
 
-		h.dispatchIntegration(ctx, w, r, apiID, stageName, resource, integration, pathParams)
+		h.dispatchIntegration(ctx, alw, r, apiID, stageName, resource, integration, pathParams)
 	}
 }
 
-// applyMethodControls runs the authorizer and request validator for the matched method.
+// checkResourcePolicy evaluates the REST API resource policy. Returns true (denied) when
+// the policy rejects the request and the response has already been written.
+func (h *Handler) checkResourcePolicy(apiID string, r *http.Request, w http.ResponseWriter) bool {
+	api, err := h.Backend.GetRestAPI(apiID)
+	if err != nil || api == nil || api.Policy == "" {
+		return false
+	}
+
+	if !evaluateResourcePolicy(api.Policy, r) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+
+		return true
+	}
+
+	return false
+}
+
+// resolveResource finds the matching resource for the request path and handles CORS.
+// Returns (resource, pathParams, true) on success; (nil, nil, false) when the response was written.
+func (h *Handler) resolveResource(
+	ctx context.Context,
+	apiID, stageName string,
+	r *http.Request,
+	w http.ResponseWriter,
+) (*Resource, map[string]string, bool) {
+	resources, _, err := h.Backend.GetResources(apiID, "", 0)
+	if err != nil {
+		logger.Load(ctx).ErrorContext(ctx, "APIGateway proxy: failed to get resources", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+
+		return nil, nil, false
+	}
+
+	resource, pathParams := findMatchingResource(resources, r.URL.Path, stageName)
+	if resource == nil {
+		http.NotFound(w, r)
+
+		return nil, nil, false
+	}
+
+	if r.Method == http.MethodOptions && resource.CorsConfiguration != nil {
+		h.writeCORSPreflight(w, r, resource.CorsConfiguration)
+
+		return nil, nil, false
+	}
+
+	if resource.CorsConfiguration != nil {
+		h.addCORSHeaders(w, r, resource.CorsConfiguration)
+	}
+
+	return resource, pathParams, true
+}
+
+// resolveIntegration looks up the integration for a resource+method, falling back to ANY.
+// Returns (integration, true) on success; (nil, false) when the response was written.
+func (h *Handler) resolveIntegration(
+	apiID string,
+	resource *Resource,
+	r *http.Request,
+	w http.ResponseWriter,
+) (*Integration, bool) {
+	integration, err := h.Backend.GetIntegration(apiID, resource.ID, r.Method)
+	if err != nil {
+		integration, err = h.Backend.GetIntegration(apiID, resource.ID, "ANY")
+		if err != nil {
+			http.NotFound(w, r)
+
+			return nil, false
+		}
+	}
+
+	return integration, true
+}
+
+// applyMethodControls runs the authorizer, request validator, and API key check for the matched method.
 // Returns true if the request was denied and the response has already been written.
 func (h *Handler) applyMethodControls(
 	ctx context.Context,
@@ -327,14 +385,23 @@ func (h *Handler) applyMethodControls(
 		return false
 	}
 
+	var authContext map[string]any
 	if method.AuthorizerID != "" {
-		if h.runAuthorizer(ctx, w, r, apiID, stageName, method.AuthorizerID) {
+		denied, ac := h.runAuthorizer(ctx, w, r, apiID, stageName, method.AuthorizerID)
+		if denied {
+			return true
+		}
+		authContext = ac
+	}
+
+	if method.APIKeyRequired {
+		if h.runAPIKeyCheck(ctx, w, r, apiID, authContext) {
 			return true
 		}
 	}
 
 	if method.RequestValidatorID != "" {
-		if h.runRequestValidator(ctx, w, r, apiID, method.RequestValidatorID) {
+		if h.runRequestValidator(ctx, w, r, apiID, method.RequestValidatorID, method) {
 			return true
 		}
 	}
@@ -381,14 +448,53 @@ func (h *Handler) dispatchIntegration(
 }
 
 // stageVars fetches stage variables for the given API/stage (returns nil on error).
+// Canary StageVariableOverrides are applied when this request is routed to the canary.
 func (h *Handler) stageVars(apiID, stageName string) map[string]string {
 	stage, err := h.Backend.GetStage(apiID, stageName)
 	if err != nil || stage == nil {
 		return nil
 	}
 
-	return stage.Variables
+	if stage.CanarySettings == nil || stage.CanarySettings.PercentTraffic <= 0 {
+		return stage.Variables
+	}
+
+	if !shouldRouteToCanary(stage.CanarySettings.PercentTraffic) {
+		return stage.Variables
+	}
+
+	overrides := stage.CanarySettings.StageVariableOverrides
+	if len(overrides) == 0 {
+		return stage.Variables
+	}
+
+	merged := make(map[string]string, len(stage.Variables)+len(overrides))
+	maps.Copy(merged, stage.Variables)
+	maps.Copy(merged, overrides)
+
+	return merged
 }
+
+// shouldRouteToCanary returns true with probability percentTraffic/100.
+// Used to implement weighted canary traffic splitting.
+func shouldRouteToCanary(percentTraffic float64) bool {
+	if percentTraffic >= canaryMaxPercent {
+		return true
+	}
+
+	if percentTraffic <= 0 {
+		return false
+	}
+
+	const uint64Max = 1 << 64 // maximum value of uint64 + 1 (as float64)
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	sample := float64(binary.BigEndian.Uint64(b[:])) / uint64Max
+
+	return sample*canaryMaxPercent < percentTraffic
+}
+
+const canaryMaxPercent = 100.0
 
 // interpolateStageVars substitutes ${stageVariables.X} placeholders in s with values from vars.
 func interpolateStageVars(s string, vars map[string]string) string {
@@ -417,18 +523,19 @@ type AuthorizerEvent struct {
 	HTTPMethod            string             `json:"httpMethod,omitempty"`
 }
 
-// runAuthorizer invokes the Lambda authorizer and returns true if the request
-// should be denied (i.e., the response was written with a 4xx status).
+// runAuthorizer invokes the Lambda authorizer and returns (denied bool, authContext map[string]any).
+// When denied=true the response has already been written with a 4xx status.
+// authContext carries the Lambda authorizer context (e.g. usageIdentifierKey for AUTHORIZER apiKeySource).
 func (h *Handler) runAuthorizer(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
 	apiID, stageName, authorizerID string,
-) bool {
+) (bool, map[string]any) {
 	if h.lambda == nil {
 		http.Error(w, "Lambda integration not configured", http.StatusServiceUnavailable)
 
-		return true
+		return true, nil
 	}
 
 	auth, err := h.Backend.GetAuthorizer(apiID, authorizerID)
@@ -436,7 +543,7 @@ func (h *Handler) runAuthorizer(
 		logger.Load(ctx).WarnContext(ctx, "APIGateway proxy: authorizer not found", "authorizerId", authorizerID)
 		http.Error(w, "Authorizer configuration error", http.StatusInternalServerError)
 
-		return true
+		return true, nil
 	}
 
 	// Determine TTL for cache (authorizer-level setting, default 300 s).
@@ -454,10 +561,10 @@ func (h *Handler) runAuthorizer(
 			if !allowed {
 				http.Error(w, "Forbidden", http.StatusForbidden)
 
-				return true
+				return true, nil
 			}
 
-			return false
+			return false, nil // context not cached — callers must re-invoke if they need it
 		}
 	}
 
@@ -473,7 +580,7 @@ func (h *Handler) runAuthorizer(
 			"authorizerId", authorizerID, "error", invokeErr)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 
-		return true
+		return true, nil
 	}
 
 	// Parse the authorizer response (IAM policy document).
@@ -482,7 +589,7 @@ func (h *Handler) runAuthorizer(
 		logger.Load(ctx).WarnContext(ctx, "APIGateway proxy: failed to parse authorizer response", "error", parseErr)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 
-		return true
+		return true, nil
 	}
 
 	// Evaluate the policy document to determine allow/deny.
@@ -492,10 +599,10 @@ func (h *Handler) runAuthorizer(
 	if !allowed {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, authResp.Context
 }
 
 // authorizerCacheKey builds the cache key for an authorizer invocation.
@@ -544,6 +651,7 @@ func (h *Handler) runRequestValidator(
 	w http.ResponseWriter,
 	r *http.Request,
 	apiID, validatorID string,
+	method *Method,
 ) bool {
 	rv, err := h.Backend.GetRequestValidator(apiID, validatorID)
 	if err != nil {
@@ -554,24 +662,357 @@ func (h *Handler) runRequestValidator(
 	}
 
 	if rv.ValidateRequestBody && r.Body != nil {
-		bodyBytes, readErr := io.ReadAll(http.MaxBytesReader(w, r.Body, maxProxyRequestBodyBytes))
-		if readErr != nil {
-			http.Error(w, "Bad Request: failed to read body", http.StatusBadRequest)
+		return h.validateRequestBody(ctx, w, r, apiID, method)
+	}
 
-			return true
-		}
+	return false
+}
 
-		// Replace body so downstream handlers can still read it.
-		r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
+// validateRequestBody reads the request body, enforces JSON validity, and delegates model validation.
+func (h *Handler) validateRequestBody(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	apiID string,
+	method *Method,
+) bool {
+	bodyBytes, readErr := io.ReadAll(http.MaxBytesReader(w, r.Body, maxProxyRequestBodyBytes))
+	if readErr != nil {
+		http.Error(w, "Bad Request: failed to read body", http.StatusBadRequest)
 
-		if len(bodyBytes) > 0 && !json.Valid(bodyBytes) {
-			http.Error(w, "Bad Request: request body must be valid JSON", http.StatusBadRequest)
+		return true
+	}
+
+	r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
+
+	if len(bodyBytes) > 0 && !json.Valid(bodyBytes) {
+		http.Error(w, "Bad Request: request body must be valid JSON", http.StatusBadRequest)
+
+		return true
+	}
+
+	if len(bodyBytes) > 0 {
+		return h.runModelValidation(ctx, w, r, apiID, method, bodyBytes)
+	}
+
+	return false
+}
+
+// runModelValidation resolves the request model by Content-Type and validates the body.
+// Returns true if validation failed and the response has already been written.
+func (h *Handler) runModelValidation(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	apiID string,
+	method *Method,
+	bodyBytes []byte,
+) bool {
+	if method == nil || len(method.RequestModels) == 0 {
+		return false
+	}
+
+	ct := normaliseContentType(r.Header.Get("Content-Type"))
+	modelName, ok := method.RequestModels[ct]
+	if !ok {
+		modelName, ok = method.RequestModels[contentTypeJSON]
+	}
+
+	if !ok || modelName == "" {
+		return false
+	}
+
+	return h.validateBodyAgainstModel(ctx, w, apiID, modelName, bodyBytes)
+}
+
+// normaliseContentType strips parameters (e.g. "; charset=utf-8") from a Content-Type value.
+func normaliseContentType(ct string) string {
+	if ct == "" {
+		return contentTypeJSON
+	}
+
+	if before, _, found := strings.Cut(ct, ";"); found {
+		return strings.TrimSpace(before)
+	}
+
+	return ct
+}
+
+// validateBodyAgainstModel validates the request body JSON against the "required" fields
+// declared in the named model's JSON Schema. Returns true if validation failed.
+// Implements a subset of JSON Schema draft 4 "required" array enforcement.
+func (h *Handler) validateBodyAgainstModel(
+	ctx context.Context,
+	w http.ResponseWriter,
+	apiID, modelName string,
+	bodyBytes []byte,
+) bool {
+	model, err := h.Backend.GetModel(apiID, modelName)
+	if err != nil || model == nil || model.Schema == "" {
+		return false // no schema → skip validation
+	}
+
+	required, parseErr := extractRequiredFields(model.Schema)
+	if parseErr != nil || len(required) == 0 {
+		return false
+	}
+
+	// Parse body as object.
+	var bodyObj map[string]json.RawMessage
+	if unmarshalErr := json.Unmarshal(bodyBytes, &bodyObj); unmarshalErr != nil {
+		return false // not an object — already checked JSON validity above
+	}
+
+	for _, field := range required {
+		if _, present := bodyObj[field]; !present {
+			msg := fmt.Sprintf("Bad Request: body missing required field %q (model %q)", field, modelName)
+			http.Error(w, msg, http.StatusBadRequest)
+			logger.Load(ctx).WarnContext(ctx, "APIGateway proxy: model validation failed",
+				"field", field, "model", modelName)
 
 			return true
 		}
 	}
 
 	return false
+}
+
+// extractRequiredFields parses the "required" array from a JSON Schema string.
+// Returns the list of required field names, or nil if absent.
+func extractRequiredFields(schema string) ([]string, error) {
+	var s struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(schema), &s); err != nil {
+		return nil, err
+	}
+
+	return s.Required, nil
+}
+
+// runAPIKeyCheck verifies the API key when method.APIKeyRequired is true.
+// Returns true if the request should be denied (response already written).
+// authContext is the Lambda authorizer response context; used when apiKeySource == "AUTHORIZER".
+func (h *Handler) runAPIKeyCheck(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	apiID string,
+	authContext map[string]any,
+) bool {
+	api, err := h.Backend.GetRestAPI(apiID)
+	if err != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+
+		return true
+	}
+
+	keyValue := resolveAPIKeyValue(r, api, authContext)
+
+	if keyValue == "" {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+
+		return true
+	}
+
+	apiKeys, listErr := h.Backend.GetAPIKeys()
+	if listErr != nil {
+		logger.Load(ctx).WarnContext(ctx, "APIGateway proxy: failed to list API keys", "error", listErr)
+		http.Error(w, "Forbidden", http.StatusForbidden)
+
+		return true
+	}
+
+	for _, k := range apiKeys {
+		if k.Enabled && k.Value == keyValue {
+			return false
+		}
+	}
+
+	http.Error(w, "Forbidden", http.StatusForbidden)
+
+	return true
+}
+
+const (
+	apiKeySourceHeader     = "HEADER"
+	apiKeySourceAuthorizer = "AUTHORIZER"
+)
+
+// resolveAPIKeyValue extracts the API key value from the request based on the configured source.
+// HEADER source: uses the x-api-key request header.
+// AUTHORIZER source: uses usageIdentifierKey from the Lambda authorizer context.
+func resolveAPIKeyValue(r *http.Request, api *RestAPI, authContext map[string]any) string {
+	source := apiKeySourceHeader
+	if api != nil && api.APIKeySource == apiKeySourceAuthorizer {
+		source = apiKeySourceAuthorizer
+	}
+
+	if source == apiKeySourceAuthorizer {
+		if authContext != nil {
+			if v, ok := authContext["usageIdentifierKey"].(string); ok {
+				return v
+			}
+		}
+
+		return ""
+	}
+
+	return r.Header.Get("X-Api-Key")
+}
+
+// resourcePolicyDoc is a simplified IAM policy document attached to a REST API.
+type resourcePolicyDoc struct {
+	Statement []resourcePolicyStatement `json:"Statement"`
+}
+
+// resourcePolicyStatement is a single statement in a resource policy.
+type resourcePolicyStatement struct {
+	Condition map[string]map[string]any `json:"Condition,omitempty"`
+	Effect    string                    `json:"Effect"`
+	Action    json.RawMessage           `json:"Action"`
+	Resource  json.RawMessage           `json:"Resource"`
+	Principal json.RawMessage           `json:"Principal"`
+}
+
+// evaluateResourcePolicy parses the IAM policy attached to a REST API and evaluates
+// whether the request is permitted. Returns true (allow) or false (deny).
+// An empty, missing, or unparseable policy allows all requests (fail-open).
+func evaluateResourcePolicy(policy string, r *http.Request) bool {
+	if policy == "" {
+		return true
+	}
+
+	var doc resourcePolicyDoc
+	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
+		return true // fail open on parse error
+	}
+
+	sourceIP := extractClientIP(r)
+	allow := false
+
+	for _, stmt := range doc.Statement {
+		if !policyStatementMatchesRequest(stmt, sourceIP) {
+			continue
+		}
+
+		switch strings.ToUpper(stmt.Effect) {
+		case "DENY":
+			return false
+		case "ALLOW":
+			allow = true
+		}
+	}
+
+	return allow
+}
+
+// policyStatementMatchesRequest checks whether a policy statement applies to the request.
+// Evaluates action "execute-api:Invoke" and optional IpAddress condition.
+func policyStatementMatchesRequest(stmt resourcePolicyStatement, sourceIP string) bool {
+	if !policyActionMatchesInvoke(stmt.Action) {
+		return false
+	}
+
+	if len(stmt.Condition) == 0 {
+		return true
+	}
+
+	if ipCond, ok := stmt.Condition["IpAddress"]; ok {
+		raw, hasKey := ipCond["aws:SourceIp"]
+		if hasKey && !clientIPMatchesCondition(sourceIP, raw) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// policyActionMatchesInvoke checks whether the statement's Action covers "execute-api:Invoke".
+func policyActionMatchesInvoke(action json.RawMessage) bool {
+	if len(action) == 0 {
+		return false
+	}
+
+	var single string
+	if err := json.Unmarshal(action, &single); err == nil {
+		return single == "*" || strings.EqualFold(single, "execute-api:Invoke")
+	}
+
+	var multi []string
+	if err := json.Unmarshal(action, &multi); err != nil {
+		return false
+	}
+
+	for _, a := range multi {
+		if a == "*" || strings.EqualFold(a, "execute-api:Invoke") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// clientIPMatchesCondition checks whether sourceIP matches the IpAddress condition value.
+// The condition value may be a single CIDR string or a list of CIDR strings.
+func clientIPMatchesCondition(sourceIP string, raw any) bool {
+	switch v := raw.(type) {
+	case string:
+		return ipMatchesCIDROrExact(sourceIP, v)
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && ipMatchesCIDROrExact(sourceIP, s) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// ipMatchesCIDROrExact checks whether sourceIP equals or is contained within the CIDR.
+// Supports both exact IP addresses and CIDR notation (e.g., "10.0.0.0/8").
+func ipMatchesCIDROrExact(sourceIP, cidr string) bool {
+	if sourceIP == cidr {
+		return true
+	}
+
+	ip := net.ParseIP(sourceIP)
+	if ip == nil {
+		return false
+	}
+
+	if strings.ContainsRune(cidr, '/') {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return false
+		}
+
+		return network.Contains(ip)
+	}
+
+	return ip.Equal(net.ParseIP(cidr))
+}
+
+// extractClientIP returns the best-effort client IP from the request.
+func extractClientIP(r *http.Request) string {
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if first, _, found := strings.Cut(fwd, ","); found {
+			return strings.TrimSpace(first)
+		}
+
+		return strings.TrimSpace(fwd)
+	}
+
+	if r.RemoteAddr != "" {
+		if idx := strings.LastIndexByte(r.RemoteAddr, ':'); idx >= 0 {
+			return r.RemoteAddr[:idx]
+		}
+
+		return r.RemoteAddr
+	}
+
+	return ""
 }
 
 // buildAuthorizerEvent constructs the event payload for the Lambda authorizer.
@@ -721,7 +1162,7 @@ func (h *Handler) handleAWSProxy(
 	var lambdaResp LambdaProxyResponse
 	if parseErr := json.Unmarshal(respBytes, &lambdaResp); parseErr != nil {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(respBytes) //nolint:gosec // local emulation: response passthrough is intentional
+		_, _ = w.Write(respBytes)
 
 		return
 	}
@@ -1040,7 +1481,6 @@ func (h *Handler) handleHTTPProxy(
 	r *http.Request,
 	integration *Integration,
 ) {
-	//nolint:gosec // local emulation: integration URI is test-configured
 	targetReq, err := http.NewRequestWithContext(
 		ctx,
 		r.Method,
@@ -1103,7 +1543,7 @@ func (h *Handler) handleMockIntegration(w http.ResponseWriter, integration *Inte
 	w.Header().Set("Content-Type", contentTypeJSON)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(statusCode)
-	_, _ = w.Write([]byte(body)) //nolint:gosec // local emulation: mock integration body is test-configured
+	_, _ = w.Write([]byte(body))
 }
 
 // mockResponse resolves the status code and body for a MOCK integration.

--- a/services/apigateway/proxy_internal_test.go
+++ b/services/apigateway/proxy_internal_test.go
@@ -32,9 +32,9 @@ func TestAuthorizerCacheSet(t *testing.T) {
 		{
 			name: "evicts_lru_when_max_entries_reached",
 			setup: func(cache *authorizerCache) {
-				cache.set("a", true, time.Minute)
-				cache.set("b", false, time.Minute)
-				_, _ = cache.get("a")
+				cache.set("a", true, nil, time.Minute)
+				cache.set("b", false, nil, time.Minute)
+				_, _, _ = cache.get("a")
 			},
 			key:           "c",
 			ttl:           time.Minute,
@@ -60,14 +60,14 @@ func TestAuthorizerCacheSet(t *testing.T) {
 				tt.setup(cache)
 			}
 
-			cache.set(tt.key, tt.wantVal, tt.ttl)
-			gotVal, gotHit := cache.get(tt.key)
+			cache.set(tt.key, tt.wantVal, nil, tt.ttl)
+			gotVal, _, gotHit := cache.get(tt.key)
 			assert.Equal(t, tt.wantHit, gotHit)
 			assert.Equal(t, tt.wantVal, gotVal)
 
 			if tt.checkEviction {
-				_, retainedHit := cache.get(tt.retainedKey)
-				_, evictedHit := cache.get(tt.evictedKey)
+				_, _, retainedHit := cache.get(tt.retainedKey)
+				_, _, evictedHit := cache.get(tt.evictedKey)
 				require.True(t, retainedHit)
 				assert.False(t, evictedHit)
 			}


### PR DESCRIPTION
## Summary

Follow-up to #1749. Implements remaining gaps from issue #1696 not covered in the first PR:

- **Access logging** (item #12): `accesslog.go` adds `AccessLogWriter` + `emitAccessLog` that pushes `$context.*` formatted entries to CloudWatch Logs when `AccessLogSettings.DestinationARN` is configured on the stage. Uses `crypto/rand` request IDs.
- **Resource policy enforcement** (item #14): `evaluateResourcePolicy` now runs at the start of every proxy request, rejecting calls that don't match the REST API's IAM resource policy.
- **API key source routing** (item #9): `resolveAPIKeyValue` + `runAPIKeyCheck` support both `HEADER` (`X-Api-Key`) and `AUTHORIZER` (`usageIdentifierKey` from Lambda authorizer context) sources.
- **Request body validation against models** (item #5): `validateBodyAgainstModel` enforces JSON Schema `"required"` fields declared in the named model; `normaliseContentType` strips charset parameters for Content-Type matching.

Refactors `handleProxyRequest` and `runRequestValidator` into focused helpers to bring gocognit scores below the 20-point limit.

## Test plan

- [x] `go test ./services/apigateway/... -short -count=1` passes
- [x] `go vet ./services/apigateway/...` clean
- [x] `golangci-lint run ./services/apigateway/...` — 0 issues
- [x] 1191 new test lines covering access log emission, resource policy, API key check (valid/invalid/disabled/AUTHORIZER source), model validation (required fields present/missing)

Closes #1696

🤖 Generated with [Claude Code](https://claude.com/claude-code)