### PR TITLE
feat(wafv2): AWS-accuracy audit — address 24 gaps per #1857

### DIFF
--- a/services/cloudformation/resources_phase4.go
+++ b/services/cloudformation/resources_phase4.go
@@ -1,6 +1,7 @@
 package cloudformation
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -347,7 +348,12 @@ func (rc *ResourceCreator) createWAFv2WebACL(
 		scope = wafScopeRegional
 	}
 
-	acl, err := rc.backends.WAFv2.Backend.CreateWebACL(name, scope, "", "ALLOW", "", nil)
+	acl, err := rc.backends.WAFv2.Backend.CreateWebACL(
+		name, scope, "",
+		json.RawMessage(`{"Allow":{}}`), nil,
+		nil, nil, nil, nil, nil, nil,
+		nil,
+	)
 	if err != nil {
 		return "", fmt.Errorf("create WAFv2 WebACL %s: %w", name, err)
 	}
@@ -360,7 +366,7 @@ func (rc *ResourceCreator) deleteWAFv2WebACL(id string) error {
 		return nil
 	}
 
-	return rc.backends.WAFv2.Backend.DeleteWebACL(id)
+	return rc.backends.WAFv2.Backend.DeleteWebACL(id, "")
 }
 
 // ---- WAFv2 IPSet ----
@@ -402,7 +408,7 @@ func (rc *ResourceCreator) deleteWAFv2IPSet(id string) error {
 		return nil
 	}
 
-	return rc.backends.WAFv2.Backend.DeleteIPSet(id)
+	return rc.backends.WAFv2.Backend.DeleteIPSet(id, "")
 }
 
 // ---- WAFv2 RuleGroup ----

--- a/services/wafv2/backend.go
+++ b/services/wafv2/backend.go
@@ -1,9 +1,13 @@
 package wafv2
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
+	"net/netip"
+	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -37,6 +41,20 @@ var (
 	ErrLoggingConfigNotFound = awserr.New("WAFNonexistentItemException", awserr.ErrNotFound)
 	// ErrPermissionPolicyNotFound is returned when a permission policy does not exist.
 	ErrPermissionPolicyNotFound = awserr.New("WAFNonexistentItemException", awserr.ErrNotFound)
+	// ErrOptimisticLock is returned when the LockToken does not match.
+	ErrOptimisticLock = awserr.New("WAFOptimisticLockException", awserr.ErrConflict)
+	// ErrAssociatedItem is returned when a resource is referenced by another resource.
+	ErrAssociatedItem = awserr.New("WAFAssociatedItemException", awserr.ErrConflict)
+	// ErrLimitsExceeded is returned when a resource limit is exceeded.
+	ErrLimitsExceeded = awserr.New("WAFLimitsExceededException", awserr.ErrConflict)
+	// ErrInvalidOperation is returned when an operation is invalid.
+	ErrInvalidOperation = awserr.New("WAFInvalidOperationException", awserr.ErrInvalidParameter)
+	// ErrUnavailableEntity is returned when a resource is temporarily unavailable.
+	ErrUnavailableEntity = awserr.New("WAFUnavailableEntityException", awserr.ErrConflict)
+	// ErrTagOperation is returned when a tag operation fails validation.
+	ErrTagOperation = awserr.New("WAFTagOperationException", awserr.ErrInvalidParameter)
+	// ErrConfigurationWarning is returned when there is a configuration warning.
+	ErrConfigurationWarning = awserr.New("WAFConfigurationWarningException", awserr.ErrInvalidParameter)
 )
 
 const (
@@ -49,18 +67,61 @@ const (
 	// IPVersionIPv6 is the IPV6 address version.
 	IPVersionIPv6 = "IPV6"
 	wcuPerRule    = int64(1)
+
+	// maxIPSetEntries is the AWS-imposed cap on IP set entries.
+	maxIPSetEntries = 10_000
+	// maxRegexPatternSetEntries is the AWS-imposed cap on regex pattern set entries.
+	maxRegexPatternSetEntries = 10
+	// maxTagsPerResource is the AWS-imposed max number of tags per resource.
+	maxTagsPerResource = 50
+	// minRuleGroupCapacity is the minimum capacity for a rule group.
+	minRuleGroupCapacity = int64(1)
+	// maxRuleGroupCapacity is the maximum capacity for a rule group.
+	maxRuleGroupCapacity = int64(1500)
+	// minRateLimit is the minimum RateBasedStatement Limit.
+	minRateLimit = int64(100)
+	// maxRateLimit is the maximum RateBasedStatement Limit.
+	maxRateLimit = int64(2_000_000_000)
+	// maxTagKeyLen is the maximum length for a tag key.
+	maxTagKeyLen = 128
+	// maxTagValueLen is the maximum length for a tag value.
+	maxTagValueLen = 256
 )
+
+// validEvaluationWindowSecs contains the allowed EvaluationWindowSec values.
+var validEvaluationWindowSecs = map[int64]bool{ //nolint:gochecknoglobals // package-level lookup table
+	60: true, 120: true, 300: true, 600: true,
+	1800: true, 3600: true, 7200: true, 21600: true,
+}
+
+// RegexEntry represents a single regex pattern in AWS API shape.
+type RegexEntry struct {
+	RegexString string `json:"RegexString"`
+}
+
+// VisibilityConfig holds the parsed VisibilityConfig structure.
+type VisibilityConfig struct {
+	MetricName               string `json:"MetricName"`
+	SampledRequestsEnabled   bool   `json:"SampledRequestsEnabled"`
+	CloudWatchMetricsEnabled bool   `json:"CloudWatchMetricsEnabled"`
+}
 
 // WebACL represents an AWS WAFv2 Web ACL.
 type WebACL struct {
-	Tags             map[string]string `json:"tags,omitempty"`
-	ID               string            `json:"id"`
-	Name             string            `json:"name"`
-	Scope            string            `json:"scope"`
-	Description      string            `json:"description"`
-	DefaultAction    string            `json:"defaultAction"`
-	VisibilityConfig string            `json:"visibilityConfig"`
-	LockToken        string            `json:"lockToken"`
+	Tags                 map[string]string `json:"tags,omitempty"`
+	DefaultAction        json.RawMessage   `json:"defaultAction,omitempty"`
+	VisibilityConfig     json.RawMessage   `json:"visibilityConfig,omitempty"`
+	CustomResponseBodies json.RawMessage   `json:"customResponseBodies,omitempty"`
+	AssociationConfig    json.RawMessage   `json:"associationConfig,omitempty"`
+	CaptchaConfig        json.RawMessage   `json:"captchaConfig,omitempty"`
+	ChallengeConfig      json.RawMessage   `json:"challengeConfig,omitempty"`
+	ID                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	Scope                string            `json:"scope"`
+	Description          string            `json:"description"`
+	LockToken            string            `json:"lockToken"`
+	TokenDomains         []string          `json:"tokenDomains,omitempty"`
+	Rules                []map[string]any  `json:"rules,omitempty"`
 }
 
 // IPSet represents an AWS WAFv2 IP Set.
@@ -83,7 +144,7 @@ type RegexPatternSet struct {
 	Scope                 string            `json:"scope"`
 	Description           string            `json:"description"`
 	LockToken             string            `json:"lockToken"`
-	RegularExpressionList []string          `json:"regularExpressionList,omitempty"`
+	RegularExpressionList []RegexEntry      `json:"regularExpressionList,omitempty"`
 }
 
 // RuleGroup represents an AWS WAFv2 Rule Group.
@@ -112,18 +173,18 @@ type InMemoryBackend struct {
 	ipSets                 map[string]*IPSet
 	regexPatternSets       map[string]*RegexPatternSet
 	ruleGroups             map[string]*RuleGroup
-	apiKeys                map[string]*APIKey // key: scope+":"+apiKeyValue
-	loggingConfigs         map[string]bool    // resourceARN → configured
-	permissionPolicies     map[string]string  // resourceARN → policy JSON
-	webACLByARN            map[string]string  // ARN → webACL ID
-	ipSetByARN             map[string]string  // ARN → ipSet ID
-	regexPatternSetByARN   map[string]string  // ARN → regexPatternSet ID
-	ruleGroupByARN         map[string]string  // ARN → ruleGroup ID
-	webACLByNameScope      map[string]string  // "name:scope" → webACL ID (O(1) duplicate check)
-	ipSetByNameScope       map[string]string  // "name:scope" → ipSet ID (O(1) duplicate check)
-	regexPatternSetByScope map[string]string  // "name:scope" → regexPatternSet ID
-	ruleGroupByNameScope   map[string]string  // "name:scope" → ruleGroup ID
-	associations           map[string]string  // resourceARN → webACL ID (AssociateWebACL)
+	apiKeys                map[string]*APIKey         // key: scope+":"+apiKeyValue
+	loggingConfigs         map[string]json.RawMessage // resourceARN → full config JSON
+	permissionPolicies     map[string]string          // resourceARN → policy JSON
+	webACLByARN            map[string]string          // ARN → webACL ID
+	ipSetByARN             map[string]string          // ARN → ipSet ID
+	regexPatternSetByARN   map[string]string          // ARN → regexPatternSet ID
+	ruleGroupByARN         map[string]string          // ARN → ruleGroup ID
+	webACLByNameScope      map[string]string          // "name:scope" → webACL ID (O(1) duplicate check)
+	ipSetByNameScope       map[string]string          // "name:scope" → ipSet ID (O(1) duplicate check)
+	regexPatternSetByScope map[string]string          // "name:scope" → regexPatternSet ID
+	ruleGroupByNameScope   map[string]string          // "name:scope" → ruleGroup ID
+	associations           map[string]string          // resourceARN → webACL ID (AssociateWebACL)
 	mu                     *lockmetrics.RWMutex
 	accountID              string
 	region                 string
@@ -137,7 +198,7 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		regexPatternSets:       make(map[string]*RegexPatternSet),
 		ruleGroups:             make(map[string]*RuleGroup),
 		apiKeys:                make(map[string]*APIKey),
-		loggingConfigs:         make(map[string]bool),
+		loggingConfigs:         make(map[string]json.RawMessage),
 		permissionPolicies:     make(map[string]string),
 		webACLByARN:            make(map[string]string),
 		ipSetByARN:             make(map[string]string),
@@ -209,9 +270,272 @@ func nameScope(name, scope string) string {
 	return name + ":" + scope
 }
 
+// validateTags checks that tags conform to AWS constraints:
+// - Keys: 1–128 chars, cannot start with "aws:"
+// - Values: 0–256 chars
+// - Max 50 tags per resource.
+func validateTags(tags map[string]string) error {
+	if len(tags) > maxTagsPerResource {
+		return fmt.Errorf(
+			"%w: too many tags: %d (max %d)",
+			ErrTagOperation,
+			len(tags),
+			maxTagsPerResource,
+		)
+	}
+
+	for k, v := range tags {
+		if len(k) == 0 || len(k) > maxTagKeyLen {
+			return fmt.Errorf("%w: tag key %q must be 1–%d characters", ErrTagOperation, k, maxTagKeyLen)
+		}
+
+		if strings.HasPrefix(k, "aws:") {
+			return fmt.Errorf("%w: tag key %q uses reserved prefix aws", ErrTagOperation, k)
+		}
+
+		if len(v) > maxTagValueLen {
+			return fmt.Errorf("%w: tag value for key %q must be 0–%d characters", ErrTagOperation, k, maxTagValueLen)
+		}
+	}
+
+	return nil
+}
+
+// validateVisibilityConfig parses and validates a VisibilityConfig JSON blob.
+func validateVisibilityConfig(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var vc VisibilityConfig
+	if err := json.Unmarshal(raw, &vc); err != nil {
+		return fmt.Errorf("%w: invalid VisibilityConfig: %w", errInvalidRequest, err)
+	}
+
+	if vc.MetricName == "" {
+		return fmt.Errorf("%w: VisibilityConfig.MetricName is required", errInvalidRequest)
+	}
+
+	return nil
+}
+
+// maxStatementNestingDepth is the maximum allowed nesting depth for rule statements.
+const maxStatementNestingDepth = 3
+
+// nestedStatementKeys are statement wrapper keys that may contain nested statements.
+var nestedStatementKeys = []string{ //nolint:gochecknoglobals // package-level lookup table
+	"AndStatement", "OrStatement", "NotStatement",
+	"ManagedRuleGroupStatement", "RuleGroupReferenceStatement",
+}
+
+// validateStatement performs basic structural validation on a rule statement map.
+// It handles RateBasedStatement and RegexPatternReferenceStatement recursively (depth-limited).
+func validateStatement(stmt map[string]any, depth int) error { //nolint:gocognit
+	if depth > maxStatementNestingDepth {
+		return fmt.Errorf(
+			"%w: statement nesting exceeds maximum depth of %d",
+			errInvalidRequest,
+			maxStatementNestingDepth,
+		)
+	}
+
+	if rbs, isRBS := stmt["RateBasedStatement"].(map[string]any); isRBS {
+		return validateRateBasedStatement(rbs)
+	}
+
+	// Recurse into nested statement wrappers.
+	for _, key := range nestedStatementKeys {
+		nested, isNested := stmt[key].(map[string]any)
+		if !isNested {
+			continue
+		}
+
+		if inner, hasInner := nested["Statement"].(map[string]any); hasInner {
+			if err := validateStatement(inner, depth+1); err != nil {
+				return err
+			}
+		}
+
+		// AndStatement and OrStatement have Statements (plural).
+		stmts, hasStmts := nested["Statements"].([]any)
+		if hasStmts {
+			for _, s := range stmts {
+				sm, isSM := s.(map[string]any)
+				if isSM {
+					if err := validateStatement(sm, depth+1); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	// Validate regex patterns if present.
+	rps, hasRPS := stmt["RegexPatternSetReferenceStatement"].(map[string]any)
+	if hasRPS {
+		pattern, hasPattern := rps["RegexString"].(string)
+		if hasPattern {
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf("%w: invalid regex pattern %q: %w", errInvalidRequest, pattern, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateRateBasedStatement(rbs map[string]any) error {
+	limit, _ := toInt64(rbs["Limit"])
+	if limit < minRateLimit || limit > maxRateLimit {
+		return fmt.Errorf(
+			"%w: RateBasedStatement.Limit must be between %d and %d",
+			errInvalidRequest,
+			minRateLimit,
+			maxRateLimit,
+		)
+	}
+
+	if ewsRaw, ok := rbs["EvaluationWindowSec"]; ok {
+		ews, _ := toInt64(ewsRaw)
+		if !validEvaluationWindowSecs[ews] {
+			return fmt.Errorf(
+				"%w: RateBasedStatement.EvaluationWindowSec must be one of {60,120,300,600,1800,3600,7200,21600}",
+				errInvalidRequest,
+			)
+		}
+	}
+
+	return nil
+}
+
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+
+		return i, err == nil
+	}
+
+	return 0, false
+}
+
+// validateRules validates a slice of rules for a WebACL or RuleGroup.
+func validateRules(rules []map[string]any) error {
+	priorities := make(map[int64]bool)
+
+	for _, rule := range rules {
+		name, _ := rule["Name"].(string)
+		if name == "" {
+			return fmt.Errorf("%w: rule Name is required", errInvalidRequest)
+		}
+
+		priorityRaw, hasPriority := rule["Priority"]
+		if !hasPriority {
+			return fmt.Errorf("%w: rule %q is missing Priority", errInvalidRequest, name)
+		}
+
+		priority, ok := toInt64(priorityRaw)
+		if !ok {
+			return fmt.Errorf("%w: rule %q Priority must be an integer", errInvalidRequest, name)
+		}
+
+		if priorities[priority] {
+			return fmt.Errorf("%w: duplicate Priority %d in rules", errInvalidRequest, priority)
+		}
+
+		priorities[priority] = true
+
+		if _, hasStatement := rule["Statement"]; !hasStatement {
+			return fmt.Errorf("%w: rule %q is missing Statement", errInvalidRequest, name)
+		}
+
+		if stmt, isMap := rule["Statement"].(map[string]any); isMap {
+			if err := validateStatement(stmt, 0); err != nil {
+				return err
+			}
+		}
+
+		if _, hasVC := rule["VisibilityConfig"]; !hasVC {
+			return fmt.Errorf("%w: rule %q is missing VisibilityConfig", errInvalidRequest, name)
+		}
+	}
+
+	return nil
+}
+
+// validateCIDRs validates a list of CIDRs against the given IP version.
+func validateCIDRs(addresses []string, ipVersion string) error {
+	if len(addresses) > maxIPSetEntries {
+		return fmt.Errorf(
+			"%w: IP set exceeds maximum of %d addresses",
+			ErrLimitsExceeded,
+			maxIPSetEntries,
+		)
+	}
+
+	for _, addr := range addresses {
+		prefix, err := netip.ParsePrefix(addr)
+		if err != nil {
+			return fmt.Errorf("%w: invalid CIDR %q: %s", errInvalidRequest, addr, err.Error())
+		}
+
+		if ipVersion == IPVersionIPv4 && !prefix.Addr().Is4() {
+			return fmt.Errorf(
+				"%w: CIDR %q is not a valid IPv4 address for IPV4 set",
+				errInvalidRequest,
+				addr,
+			)
+		}
+
+		if ipVersion == IPVersionIPv6 && !prefix.Addr().Is6() {
+			return fmt.Errorf(
+				"%w: CIDR %q is not a valid IPv6 address for IPV6 set",
+				errInvalidRequest,
+				addr,
+			)
+		}
+	}
+
+	return nil
+}
+
+// validateRegexEntries validates a list of RegexEntry objects.
+func validateRegexEntries(entries []RegexEntry) error {
+	if len(entries) > maxRegexPatternSetEntries {
+		return fmt.Errorf(
+			"%w: regex pattern set exceeds maximum of %d entries",
+			ErrLimitsExceeded,
+			maxRegexPatternSetEntries,
+		)
+	}
+
+	for _, entry := range entries {
+		if _, err := regexp.Compile(entry.RegexString); err != nil {
+			return fmt.Errorf(
+				"%w: invalid regex %q: %s",
+				errInvalidRequest,
+				entry.RegexString,
+				err.Error(),
+			)
+		}
+	}
+
+	return nil
+}
+
 // CreateWebACL creates a new WebACL.
 func (b *InMemoryBackend) CreateWebACL(
-	name, scope, description, defaultAction, visibilityConfig string,
+	name, scope, description string,
+	defaultAction, visibilityConfig json.RawMessage,
+	rules []map[string]any,
+	tokenDomains []string,
+	customResponseBodies, associationConfig, captchaConfig, challengeConfig json.RawMessage,
 	tags map[string]string,
 ) (*WebACL, error) {
 	b.mu.Lock("CreateWebACL")
@@ -223,14 +547,20 @@ func (b *InMemoryBackend) CreateWebACL(
 
 	id := uuid.NewString()
 	w := &WebACL{
-		ID:               id,
-		Name:             name,
-		Scope:            scope,
-		Description:      description,
-		DefaultAction:    defaultAction,
-		VisibilityConfig: visibilityConfig,
-		LockToken:        uuid.NewString(),
-		Tags:             cloneTags(tags),
+		ID:                   id,
+		Name:                 name,
+		Scope:                scope,
+		Description:          description,
+		DefaultAction:        defaultAction,
+		VisibilityConfig:     visibilityConfig,
+		Rules:                cloneRules(rules),
+		TokenDomains:         cloneAddresses(tokenDomains),
+		CustomResponseBodies: customResponseBodies,
+		AssociationConfig:    associationConfig,
+		CaptchaConfig:        captchaConfig,
+		ChallengeConfig:      challengeConfig,
+		LockToken:            uuid.NewString(),
+		Tags:                 cloneTags(tags),
 	}
 	b.webACLs[id] = w
 	b.webACLByARN[b.WebACLARN(name, id, scope)] = id
@@ -238,6 +568,7 @@ func (b *InMemoryBackend) CreateWebACL(
 
 	return cloneWebACL(w), nil
 }
+
 func (b *InMemoryBackend) GetWebACL(id string) (*WebACL, error) {
 	b.mu.RLock("GetWebACL")
 	defer b.mu.RUnlock()
@@ -251,7 +582,13 @@ func (b *InMemoryBackend) GetWebACL(id string) (*WebACL, error) {
 }
 
 // UpdateWebACL updates a WebACL by ID.
-func (b *InMemoryBackend) UpdateWebACL(id, description, defaultAction, visibilityConfig string) (*WebACL, error) {
+func (b *InMemoryBackend) UpdateWebACL(
+	id, description, lockToken string,
+	defaultAction, visibilityConfig json.RawMessage,
+	rules []map[string]any,
+	tokenDomains []string,
+	customResponseBodies, associationConfig, captchaConfig, challengeConfig json.RawMessage,
+) (*WebACL, error) {
 	b.mu.Lock("UpdateWebACL")
 	defer b.mu.Unlock()
 
@@ -260,16 +597,44 @@ func (b *InMemoryBackend) UpdateWebACL(id, description, defaultAction, visibilit
 		return nil, fmt.Errorf("%w: web ACL %q not found", ErrWebACLNotFound, id)
 	}
 
+	if lockToken != "" && lockToken != w.LockToken {
+		return nil, fmt.Errorf("%w: lock token mismatch for web ACL %q", ErrOptimisticLock, id)
+	}
+
 	if description != "" {
 		w.Description = description
 	}
 
-	if defaultAction != "" {
+	if len(defaultAction) > 0 {
 		w.DefaultAction = defaultAction
 	}
 
-	if visibilityConfig != "" {
+	if len(visibilityConfig) > 0 {
 		w.VisibilityConfig = visibilityConfig
+	}
+
+	if rules != nil {
+		w.Rules = cloneRules(rules)
+	}
+
+	if tokenDomains != nil {
+		w.TokenDomains = cloneAddresses(tokenDomains)
+	}
+
+	if len(customResponseBodies) > 0 {
+		w.CustomResponseBodies = customResponseBodies
+	}
+
+	if len(associationConfig) > 0 {
+		w.AssociationConfig = associationConfig
+	}
+
+	if len(captchaConfig) > 0 {
+		w.CaptchaConfig = captchaConfig
+	}
+
+	if len(challengeConfig) > 0 {
+		w.ChallengeConfig = challengeConfig
 	}
 
 	w.LockToken = uuid.NewString()
@@ -278,13 +643,17 @@ func (b *InMemoryBackend) UpdateWebACL(id, description, defaultAction, visibilit
 }
 
 // DeleteWebACL deletes a WebACL by ID.
-func (b *InMemoryBackend) DeleteWebACL(id string) error {
+func (b *InMemoryBackend) DeleteWebACL(id, lockToken string) error {
 	b.mu.Lock("DeleteWebACL")
 	defer b.mu.Unlock()
 
 	w, ok := b.webACLs[id]
 	if !ok {
 		return fmt.Errorf("%w: web ACL %q not found", ErrWebACLNotFound, id)
+	}
+
+	if lockToken != "" && lockToken != w.LockToken {
+		return fmt.Errorf("%w: lock token mismatch for web ACL %q", ErrOptimisticLock, id)
 	}
 
 	delete(b.webACLByARN, b.WebACLARN(w.Name, w.ID, w.Scope))
@@ -369,13 +738,17 @@ func (b *InMemoryBackend) GetIPSet(id string) (*IPSet, error) {
 }
 
 // UpdateIPSet updates an IPSet by ID.
-func (b *InMemoryBackend) UpdateIPSet(id, description string, addresses []string) (*IPSet, error) {
+func (b *InMemoryBackend) UpdateIPSet(id, description, lockToken string, addresses []string) (*IPSet, error) {
 	b.mu.Lock("UpdateIPSet")
 	defer b.mu.Unlock()
 
 	s, ok := b.ipSets[id]
 	if !ok {
 		return nil, fmt.Errorf("%w: IP set %q not found", ErrIPSetNotFound, id)
+	}
+
+	if lockToken != "" && lockToken != s.LockToken {
+		return nil, fmt.Errorf("%w: lock token mismatch for IP set %q", ErrOptimisticLock, id)
 	}
 
 	if description != "" {
@@ -392,17 +765,21 @@ func (b *InMemoryBackend) UpdateIPSet(id, description string, addresses []string
 }
 
 // DeleteIPSet deletes an IPSet by ID.
-func (b *InMemoryBackend) DeleteIPSet(id string) error {
+func (b *InMemoryBackend) DeleteIPSet(id, lockToken string) error {
 	b.mu.Lock("DeleteIPSet")
 	defer b.mu.Unlock()
 
-	if s, ok := b.ipSets[id]; ok {
-		delete(b.ipSetByARN, b.IPSetARN(s.Name, s.ID, s.Scope))
-		delete(b.ipSetByNameScope, nameScope(s.Name, s.Scope))
-	} else {
+	s, ok := b.ipSets[id]
+	if !ok {
 		return fmt.Errorf("%w: IP set %q not found", ErrIPSetNotFound, id)
 	}
 
+	if lockToken != "" && lockToken != s.LockToken {
+		return fmt.Errorf("%w: lock token mismatch for IP set %q", ErrOptimisticLock, id)
+	}
+
+	delete(b.ipSetByARN, b.IPSetARN(s.Name, s.ID, s.Scope))
+	delete(b.ipSetByNameScope, nameScope(s.Name, s.Scope))
 	delete(b.ipSets, id)
 
 	return nil
@@ -549,6 +926,45 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) er
 func cloneWebACL(w *WebACL) *WebACL {
 	cp := *w
 	cp.Tags = maps.Clone(w.Tags)
+	cp.Rules = cloneRules(w.Rules)
+	cp.TokenDomains = cloneAddresses(w.TokenDomains)
+
+	// Clone RawMessage fields (byte slices).
+	if w.DefaultAction != nil {
+		da := make(json.RawMessage, len(w.DefaultAction))
+		copy(da, w.DefaultAction)
+		cp.DefaultAction = da
+	}
+
+	if w.VisibilityConfig != nil {
+		vc := make(json.RawMessage, len(w.VisibilityConfig))
+		copy(vc, w.VisibilityConfig)
+		cp.VisibilityConfig = vc
+	}
+
+	if w.CustomResponseBodies != nil {
+		crb := make(json.RawMessage, len(w.CustomResponseBodies))
+		copy(crb, w.CustomResponseBodies)
+		cp.CustomResponseBodies = crb
+	}
+
+	if w.AssociationConfig != nil {
+		ac := make(json.RawMessage, len(w.AssociationConfig))
+		copy(ac, w.AssociationConfig)
+		cp.AssociationConfig = ac
+	}
+
+	if w.CaptchaConfig != nil {
+		cc := make(json.RawMessage, len(w.CaptchaConfig))
+		copy(cc, w.CaptchaConfig)
+		cp.CaptchaConfig = cc
+	}
+
+	if w.ChallengeConfig != nil {
+		chc := make(json.RawMessage, len(w.ChallengeConfig))
+		copy(chc, w.ChallengeConfig)
+		cp.ChallengeConfig = chc
+	}
 
 	return &cp
 }
@@ -590,7 +1006,7 @@ func (b *InMemoryBackend) Reset() {
 	b.regexPatternSets = make(map[string]*RegexPatternSet)
 	b.ruleGroups = make(map[string]*RuleGroup)
 	b.apiKeys = make(map[string]*APIKey)
-	b.loggingConfigs = make(map[string]bool)
+	b.loggingConfigs = make(map[string]json.RawMessage)
 	b.permissionPolicies = make(map[string]string)
 	b.webACLByARN = make(map[string]string)
 	b.ipSetByARN = make(map[string]string)
@@ -694,7 +1110,7 @@ func (b *InMemoryBackend) DeleteAPIKey(scope, apiKey string) error {
 // CreateRegexPatternSet creates a new RegexPatternSet.
 func (b *InMemoryBackend) CreateRegexPatternSet(
 	name, scope, description string,
-	regularExpressionList []string,
+	regularExpressionList []RegexEntry,
 	tags map[string]string,
 ) (*RegexPatternSet, error) {
 	b.mu.Lock("CreateRegexPatternSet")
@@ -715,7 +1131,7 @@ func (b *InMemoryBackend) CreateRegexPatternSet(
 		Name:                  name,
 		Scope:                 scope,
 		Description:           description,
-		RegularExpressionList: cloneAddresses(regularExpressionList),
+		RegularExpressionList: cloneRegexEntries(regularExpressionList),
 		LockToken:             uuid.NewString(),
 		Tags:                  cloneTags(tags),
 	}
@@ -728,13 +1144,17 @@ func (b *InMemoryBackend) CreateRegexPatternSet(
 }
 
 // DeleteRegexPatternSet deletes a RegexPatternSet by ID.
-func (b *InMemoryBackend) DeleteRegexPatternSet(id string) error {
+func (b *InMemoryBackend) DeleteRegexPatternSet(id, lockToken string) error {
 	b.mu.Lock("DeleteRegexPatternSet")
 	defer b.mu.Unlock()
 
 	rps, ok := b.regexPatternSets[id]
 	if !ok {
 		return fmt.Errorf("%w: regex pattern set %q not found", ErrRegexPatternSetNotFound, id)
+	}
+
+	if lockToken != "" && lockToken != rps.LockToken {
+		return fmt.Errorf("%w: lock token mismatch for regex pattern set %q", ErrOptimisticLock, id)
 	}
 
 	delete(b.regexPatternSetByARN, b.RegexPatternSetARN(rps.Name, rps.ID, rps.Scope))
@@ -778,6 +1198,60 @@ func (b *InMemoryBackend) CreateRuleGroup(
 	return cloneRuleGroup(rg), nil
 }
 
+// DeleteRuleGroup deletes a RuleGroup by ID, checking for WebACL references.
+func (b *InMemoryBackend) DeleteRuleGroup(id, lockToken string) error {
+	b.mu.Lock("DeleteRuleGroup")
+	defer b.mu.Unlock()
+
+	rg, ok := b.ruleGroups[id]
+	if !ok {
+		return fmt.Errorf("%w: rule group %q not found", ErrRuleGroupNotFound, id)
+	}
+
+	if lockToken != "" && lockToken != rg.LockToken {
+		return fmt.Errorf("%w: lock token mismatch for rule group %q", ErrOptimisticLock, id)
+	}
+
+	// Check if this rule group is referenced by any WebACL.
+	rgARN := b.RuleGroupARN(rg.Name, rg.ID, rg.Scope)
+
+	for _, w := range b.webACLs {
+		for _, rule := range w.Rules {
+			if b.ruleReferencesARN(rule, rgARN) {
+				return fmt.Errorf(
+					"%w: rule group %q is referenced by web ACL %q",
+					ErrAssociatedItem,
+					id,
+					w.ID,
+				)
+			}
+		}
+	}
+
+	delete(b.ruleGroupByARN, rgARN)
+	delete(b.ruleGroupByNameScope, nameScope(rg.Name, rg.Scope))
+	delete(b.ruleGroups, id)
+
+	return nil
+}
+
+// ruleReferencesARN checks if a rule map references the given ARN.
+func (b *InMemoryBackend) ruleReferencesARN(rule map[string]any, arnStr string) bool {
+	stmt, isStmt := rule["Statement"].(map[string]any)
+	if !isStmt {
+		return false
+	}
+
+	rgrStmt, isRGR := stmt["RuleGroupReferenceStatement"].(map[string]any)
+	if !isRGR {
+		return false
+	}
+
+	ref, isStr := rgrStmt["ARN"].(string)
+
+	return isStr && ref == arnStr
+}
+
 // DeleteFirewallManagerRuleGroups removes all Firewall Manager rule group
 // associations from the WebACL identified by webACLARN, then returns a fresh
 // copy of the updated WebACL.
@@ -800,12 +1274,14 @@ func (b *InMemoryBackend) DeleteFirewallManagerRuleGroups(webACLARN string) (*We
 	return cloneWebACL(w), nil
 }
 
-// PutLoggingConfiguration stores a logging configuration for the given resource ARN.
-func (b *InMemoryBackend) PutLoggingConfiguration(resourceARN string) error {
+// PutLoggingConfiguration stores a full logging configuration JSON for the given resource ARN.
+func (b *InMemoryBackend) PutLoggingConfiguration(resourceARN string, configJSON json.RawMessage) error {
 	b.mu.Lock("PutLoggingConfiguration")
 	defer b.mu.Unlock()
 
-	b.loggingConfigs[resourceARN] = true
+	stored := make(json.RawMessage, len(configJSON))
+	copy(stored, configJSON)
+	b.loggingConfigs[resourceARN] = stored
 
 	return nil
 }
@@ -815,13 +1291,49 @@ func (b *InMemoryBackend) DeleteLoggingConfiguration(resourceARN string) error {
 	b.mu.Lock("DeleteLoggingConfiguration")
 	defer b.mu.Unlock()
 
-	if !b.loggingConfigs[resourceARN] {
+	if _, exists := b.loggingConfigs[resourceARN]; !exists {
 		return fmt.Errorf("%w: no logging configuration found for resource %q", ErrLoggingConfigNotFound, resourceARN)
 	}
 
 	delete(b.loggingConfigs, resourceARN)
 
 	return nil
+}
+
+// GetLoggingConfiguration returns the stored logging configuration JSON for the given resource ARN.
+func (b *InMemoryBackend) GetLoggingConfiguration(resourceARN string) (json.RawMessage, error) {
+	b.mu.RLock("GetLoggingConfiguration")
+	defer b.mu.RUnlock()
+
+	cfg, exists := b.loggingConfigs[resourceARN]
+	if !exists {
+		return nil, fmt.Errorf(
+			"%w: no logging configuration found for resource %q",
+			ErrLoggingConfigNotFound,
+			resourceARN,
+		)
+	}
+
+	out := make(json.RawMessage, len(cfg))
+	copy(out, cfg)
+
+	return out, nil
+}
+
+// ListLoggingConfigurations returns all stored logging configuration JSONs.
+func (b *InMemoryBackend) ListLoggingConfigurations() []json.RawMessage {
+	b.mu.RLock("ListLoggingConfigurations")
+	defer b.mu.RUnlock()
+
+	result := make([]json.RawMessage, 0, len(b.loggingConfigs))
+
+	for _, cfg := range b.loggingConfigs {
+		out := make(json.RawMessage, len(cfg))
+		copy(out, cfg)
+		result = append(result, out)
+	}
+
+	return result
 }
 
 // PutPermissionPolicy stores a permission policy for the given resource ARN.
@@ -879,8 +1391,8 @@ func (b *InMemoryBackend) ListRegexPatternSets() []*RegexPatternSet {
 
 // UpdateRegexPatternSet updates a RegexPatternSet by ID.
 func (b *InMemoryBackend) UpdateRegexPatternSet(
-	id, description string,
-	regularExpressionList []string,
+	id, description, lockToken string,
+	regularExpressionList []RegexEntry,
 ) (*RegexPatternSet, error) {
 	b.mu.Lock("UpdateRegexPatternSet")
 	defer b.mu.Unlock()
@@ -890,12 +1402,16 @@ func (b *InMemoryBackend) UpdateRegexPatternSet(
 		return nil, fmt.Errorf("%w: regex pattern set %q not found", ErrRegexPatternSetNotFound, id)
 	}
 
+	if lockToken != "" && lockToken != r.LockToken {
+		return nil, fmt.Errorf("%w: lock token mismatch for regex pattern set %q", ErrOptimisticLock, id)
+	}
+
 	if description != "" {
 		r.Description = description
 	}
 
 	if regularExpressionList != nil {
-		r.RegularExpressionList = cloneAddresses(regularExpressionList)
+		r.RegularExpressionList = cloneRegexEntries(regularExpressionList)
 	}
 
 	r.LockToken = uuid.NewString()
@@ -934,7 +1450,7 @@ func (b *InMemoryBackend) ListRuleGroups() []*RuleGroup {
 
 // UpdateRuleGroup updates a RuleGroup by ID.
 func (b *InMemoryBackend) UpdateRuleGroup(
-	id, description, visibilityConfig string,
+	id, description, visibilityConfig, lockToken string,
 	rules []map[string]any,
 ) (*RuleGroup, error) {
 	b.mu.Lock("UpdateRuleGroup")
@@ -943,6 +1459,10 @@ func (b *InMemoryBackend) UpdateRuleGroup(
 	rg, ok := b.ruleGroups[id]
 	if !ok {
 		return nil, fmt.Errorf("%w: rule group %q not found", ErrRuleGroupNotFound, id)
+	}
+
+	if lockToken != "" && lockToken != rg.LockToken {
+		return nil, fmt.Errorf("%w: lock token mismatch for rule group %q", ErrOptimisticLock, id)
 	}
 
 	if description != "" {
@@ -1001,22 +1521,6 @@ func (b *InMemoryBackend) GetDecryptedAPIKey(scope, apiKey string) (*APIKey, err
 	}, nil
 }
 
-// GetLoggingConfiguration returns whether a logging configuration exists for the given resource ARN.
-func (b *InMemoryBackend) GetLoggingConfiguration(resourceARN string) (bool, error) {
-	b.mu.RLock("GetLoggingConfiguration")
-	defer b.mu.RUnlock()
-
-	if !b.loggingConfigs[resourceARN] {
-		return false, fmt.Errorf(
-			"%w: no logging configuration found for resource %q",
-			ErrLoggingConfigNotFound,
-			resourceARN,
-		)
-	}
-
-	return true, nil
-}
-
 // GetPermissionPolicy returns the permission policy for the given resource ARN.
 func (b *InMemoryBackend) GetPermissionPolicy(resourceARN string) (string, error) {
 	b.mu.RLock("GetPermissionPolicy")
@@ -1060,9 +1564,20 @@ func (b *InMemoryBackend) ListResourcesForWebACL(webACLARN string) ([]string, er
 func cloneRegexPatternSet(r *RegexPatternSet) *RegexPatternSet {
 	cp := *r
 	cp.Tags = maps.Clone(r.Tags)
-	cp.RegularExpressionList = cloneAddresses(r.RegularExpressionList)
+	cp.RegularExpressionList = cloneRegexEntries(r.RegularExpressionList)
 
 	return &cp
+}
+
+func cloneRegexEntries(entries []RegexEntry) []RegexEntry {
+	if entries == nil {
+		return []RegexEntry{}
+	}
+
+	out := make([]RegexEntry, len(entries))
+	copy(out, entries)
+
+	return out
 }
 
 func cloneRuleGroup(rg *RuleGroup) *RuleGroup {

--- a/services/wafv2/backend.go
+++ b/services/wafv2/backend.go
@@ -86,12 +86,49 @@ const (
 	maxTagKeyLen = 128
 	// maxTagValueLen is the maximum length for a tag value.
 	maxTagValueLen = 256
+	// maxDescriptionLen is the AWS-imposed max length for resource descriptions.
+	maxDescriptionLen = 256
+	// maxRulePriority is the maximum priority value for a rule (0–1000).
+	maxRulePriority = int64(1000)
 )
 
 // validEvaluationWindowSecs contains the allowed EvaluationWindowSec values.
 var validEvaluationWindowSecs = map[int64]bool{ //nolint:gochecknoglobals // package-level lookup table
 	60: true, 120: true, 300: true, 600: true,
 	1800: true, 3600: true, 7200: true, 21600: true,
+}
+
+// validResourceNameRe is the pattern AWS requires for WAFv2 resource names.
+var validResourceNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-_]{0,127}$`)
+
+// validateResourceName checks that a WAFv2 resource name conforms to the AWS
+// allowed pattern: starts with alphanumeric, followed by alphanumeric, hyphen,
+// or underscore, up to 128 characters total.
+func validateResourceName(name string) error {
+	if !validResourceNameRe.MatchString(name) {
+		return fmt.Errorf(
+			"%w: Name %q must match ^[a-zA-Z0-9][a-zA-Z0-9-_]{0,127}$",
+			errInvalidRequest,
+			name,
+		)
+	}
+
+	return nil
+}
+
+// validateDescription checks that a resource description does not exceed the
+// AWS-imposed maximum of 256 characters.
+func validateDescription(description string) error {
+	if len(description) > maxDescriptionLen {
+		return fmt.Errorf(
+			"%w: Description must be at most %d characters, got %d",
+			errInvalidRequest,
+			maxDescriptionLen,
+			len(description),
+		)
+	}
+
+	return nil
 }
 
 // RegexEntry represents a single regex pattern in AWS API shape.
@@ -226,32 +263,43 @@ func validScope(scope string) bool {
 	return scope == ScopeRegional || scope == ScopeCloudFront
 }
 
+// arnRegion returns the correct region segment for a WAFv2 ARN. CLOUDFRONT
+// (global) resources use an empty region, matching the real AWS ARN format:
+// arn:aws:wafv2::123456789012:global/webacl/...
+func (b *InMemoryBackend) arnRegion(scope string) string {
+	if scope == ScopeCloudFront {
+		return ""
+	}
+
+	return b.region
+}
+
 // WebACLARN builds an ARN for a WebACL.
 func (b *InMemoryBackend) WebACLARN(name, id, scope string) string {
 	prefix := scopePrefix(scope)
 
-	return arn.Build("wafv2", b.region, b.accountID, prefix+"/webacl/"+name+"/"+id)
+	return arn.Build("wafv2", b.arnRegion(scope), b.accountID, prefix+"/webacl/"+name+"/"+id)
 }
 
 // IPSetARN builds a public ARN for an IPSet.
 func (b *InMemoryBackend) IPSetARN(name, id, scope string) string {
 	prefix := scopePrefix(scope)
 
-	return arn.Build("wafv2", b.region, b.accountID, prefix+"/ipset/"+name+"/"+id)
+	return arn.Build("wafv2", b.arnRegion(scope), b.accountID, prefix+"/ipset/"+name+"/"+id)
 }
 
 // RegexPatternSetARN builds an ARN for a RegexPatternSet.
 func (b *InMemoryBackend) RegexPatternSetARN(name, id, scope string) string {
 	prefix := scopePrefix(scope)
 
-	return arn.Build("wafv2", b.region, b.accountID, prefix+"/regexpatternset/"+name+"/"+id)
+	return arn.Build("wafv2", b.arnRegion(scope), b.accountID, prefix+"/regexpatternset/"+name+"/"+id)
 }
 
 // RuleGroupARN builds an ARN for a RuleGroup.
 func (b *InMemoryBackend) RuleGroupARN(name, id, scope string) string {
 	prefix := scopePrefix(scope)
 
-	return arn.Build("wafv2", b.region, b.accountID, prefix+"/rulegroup/"+name+"/"+id)
+	return arn.Build("wafv2", b.arnRegion(scope), b.accountID, prefix+"/rulegroup/"+name+"/"+id)
 }
 
 func apiKeyMapKey(scope, apiKey string) string {
@@ -428,42 +476,70 @@ func toInt64(v any) (int64, bool) {
 // validateRules validates a slice of rules for a WebACL or RuleGroup.
 func validateRules(rules []map[string]any) error {
 	priorities := make(map[int64]bool)
+	names := make(map[string]bool)
 
 	for _, rule := range rules {
-		name, _ := rule["Name"].(string)
-		if name == "" {
-			return fmt.Errorf("%w: rule Name is required", errInvalidRequest)
+		if err := validateSingleRule(rule, priorities, names); err != nil {
+			return err
 		}
+	}
 
-		priorityRaw, hasPriority := rule["Priority"]
-		if !hasPriority {
-			return fmt.Errorf("%w: rule %q is missing Priority", errInvalidRequest, name)
+	return nil
+}
+
+// validateSingleRule validates a single rule map and updates the seen priority
+// and name sets. Extracted to keep validateRules below the cognitive complexity
+// threshold.
+func validateSingleRule(rule map[string]any, priorities map[int64]bool, names map[string]bool) error {
+	name, _ := rule["Name"].(string)
+	if name == "" {
+		return fmt.Errorf("%w: rule Name is required", errInvalidRequest)
+	}
+
+	if names[name] {
+		return fmt.Errorf("%w: duplicate rule Name %q in rules", errInvalidRequest, name)
+	}
+
+	names[name] = true
+
+	priorityRaw, hasPriority := rule["Priority"]
+	if !hasPriority {
+		return fmt.Errorf("%w: rule %q is missing Priority", errInvalidRequest, name)
+	}
+
+	priority, ok := toInt64(priorityRaw)
+	if !ok {
+		return fmt.Errorf("%w: rule %q Priority must be an integer", errInvalidRequest, name)
+	}
+
+	if priority < 0 || priority > maxRulePriority {
+		return fmt.Errorf(
+			"%w: rule %q Priority must be between 0 and %d, got %d",
+			errInvalidRequest,
+			name,
+			maxRulePriority,
+			priority,
+		)
+	}
+
+	if priorities[priority] {
+		return fmt.Errorf("%w: duplicate Priority %d in rules", errInvalidRequest, priority)
+	}
+
+	priorities[priority] = true
+
+	if _, hasStatement := rule["Statement"]; !hasStatement {
+		return fmt.Errorf("%w: rule %q is missing Statement", errInvalidRequest, name)
+	}
+
+	if stmt, isMap := rule["Statement"].(map[string]any); isMap {
+		if err := validateStatement(stmt, 0); err != nil {
+			return err
 		}
+	}
 
-		priority, ok := toInt64(priorityRaw)
-		if !ok {
-			return fmt.Errorf("%w: rule %q Priority must be an integer", errInvalidRequest, name)
-		}
-
-		if priorities[priority] {
-			return fmt.Errorf("%w: duplicate Priority %d in rules", errInvalidRequest, priority)
-		}
-
-		priorities[priority] = true
-
-		if _, hasStatement := rule["Statement"]; !hasStatement {
-			return fmt.Errorf("%w: rule %q is missing Statement", errInvalidRequest, name)
-		}
-
-		if stmt, isMap := rule["Statement"].(map[string]any); isMap {
-			if err := validateStatement(stmt, 0); err != nil {
-				return err
-			}
-		}
-
-		if _, hasVC := rule["VisibilityConfig"]; !hasVC {
-			return fmt.Errorf("%w: rule %q is missing VisibilityConfig", errInvalidRequest, name)
-		}
+	if _, hasVC := rule["VisibilityConfig"]; !hasVC {
+		return fmt.Errorf("%w: rule %q is missing VisibilityConfig", errInvalidRequest, name)
 	}
 
 	return nil
@@ -656,19 +732,25 @@ func (b *InMemoryBackend) DeleteWebACL(id, lockToken string) error {
 		return fmt.Errorf("%w: lock token mismatch for web ACL %q", ErrOptimisticLock, id)
 	}
 
-	delete(b.webACLByARN, b.WebACLARN(w.Name, w.ID, w.Scope))
-	delete(b.webACLByNameScope, nameScope(w.Name, w.Scope))
-	delete(b.webACLs, id)
-
-	// Cascade: remove all resource associations for this WebACL.
-	for resourceARN, assocID := range b.associations {
+	// AWS returns WAFAssociatedItemException when the WebACL is still associated
+	// with a resource (e.g. an ALB or API Gateway stage).
+	for _, assocID := range b.associations {
 		if assocID == id {
-			delete(b.associations, resourceARN)
+			return fmt.Errorf(
+				"%w: web ACL %q is still associated with a resource; disassociate first",
+				ErrAssociatedItem,
+				id,
+			)
 		}
 	}
 
-	// Cascade: remove the WebACL's own logging config and permission policy.
 	webACLArnStr := b.WebACLARN(w.Name, w.ID, w.Scope)
+
+	delete(b.webACLByARN, webACLArnStr)
+	delete(b.webACLByNameScope, nameScope(w.Name, w.Scope))
+	delete(b.webACLs, id)
+
+	// Cascade: remove the WebACL's own logging config and permission policy.
 	delete(b.loggingConfigs, webACLArnStr)
 	delete(b.permissionPolicies, webACLArnStr)
 
@@ -1035,14 +1117,13 @@ func (b *InMemoryBackend) AssociateWebACL(webACLARN, resourceARN string) error {
 }
 
 // DisassociateWebACL removes the WebACL association from a resource ARN.
+// Per AWS behaviour, this is a no-op if no association exists (idempotent).
 func (b *InMemoryBackend) DisassociateWebACL(resourceARN string) error {
 	b.mu.Lock("DisassociateWebACL")
 	defer b.mu.Unlock()
 
-	if _, ok := b.associations[resourceARN]; !ok {
-		return fmt.Errorf("%w: no web ACL association found for resource %q", ErrAssociationNotFound, resourceARN)
-	}
-
+	// AWS treats DisassociateWebACL as idempotent — calling it when no
+	// association exists succeeds silently.
 	delete(b.associations, resourceARN)
 
 	return nil
@@ -1588,17 +1669,36 @@ func cloneRuleGroup(rg *RuleGroup) *RuleGroup {
 	return &cp
 }
 
+// shallowCopyRules returns a shallow copy of each rule map in rules.
+// Used as a fallback when JSON round-trip fails in cloneRules.
+func shallowCopyRules(rules []map[string]any) []map[string]any {
+	out := make([]map[string]any, len(rules))
+
+	for i, r := range rules {
+		rm := make(map[string]any, len(r))
+		maps.Copy(rm, r)
+		out[i] = rm
+	}
+
+	return out
+}
+
+// cloneRules performs a deep clone of a rules slice. A JSON round-trip is used
+// to ensure that nested maps and any json.RawMessage-backed values do not share
+// backing arrays with the original, preventing data races and mutation aliasing.
 func cloneRules(rules []map[string]any) []map[string]any {
 	if rules == nil {
 		return []map[string]any{}
 	}
 
-	out := make([]map[string]any, len(rules))
-	for i, r := range rules {
-		rm := make(map[string]any, len(r))
-		maps.Copy(rm, r)
+	data, marshalErr := json.Marshal(rules)
+	if marshalErr != nil {
+		return shallowCopyRules(rules)
+	}
 
-		out[i] = rm
+	var out []map[string]any
+	if unmarshalErr := json.Unmarshal(data, &out); unmarshalErr != nil {
+		return shallowCopyRules(rules)
 	}
 
 	return out

--- a/services/wafv2/export_test.go
+++ b/services/wafv2/export_test.go
@@ -1,5 +1,25 @@
 package wafv2
 
+import "encoding/json"
+
+// CreateWebACLSimple is a test helper that creates a WebACL with minimal parameters,
+// using the new extended backend signature. It accepts the old-style positional args
+// to ease migration of existing tests.
+func CreateWebACLSimple(
+	b StorageBackend,
+	name, scope, description, defaultAction string,
+	tags map[string]string,
+) (*WebACL, error) {
+	var da json.RawMessage
+	if defaultAction == "BLOCK" {
+		da = json.RawMessage(`{"Block":{}}`)
+	} else {
+		da = json.RawMessage(`{"Allow":{}}`)
+	}
+
+	return b.CreateWebACL(name, scope, description, da, nil, nil, nil, nil, nil, nil, nil, tags)
+}
+
 // WebACLCount returns the number of WebACLs in the backend.
 func WebACLCount(b *InMemoryBackend) int {
 	b.mu.RLock("WebACLCount")
@@ -62,6 +82,10 @@ func AddWebACLInternal(b *InMemoryBackend, w *WebACL) {
 		w.Tags = make(map[string]string)
 	}
 
+	if w.Rules == nil {
+		w.Rules = []map[string]any{}
+	}
+
 	b.webACLs[w.ID] = w
 	b.webACLByARN[b.WebACLARN(w.Name, w.ID, w.Scope)] = w.ID
 	b.webACLByNameScope[nameScope(w.Name, w.Scope)] = w.ID
@@ -95,7 +119,7 @@ func AddRegexPatternSetInternal(b *InMemoryBackend, r *RegexPatternSet) {
 	}
 
 	if r.RegularExpressionList == nil {
-		r.RegularExpressionList = []string{}
+		r.RegularExpressionList = []RegexEntry{}
 	}
 
 	b.regexPatternSets[r.ID] = r

--- a/services/wafv2/handler.go
+++ b/services/wafv2/handler.go
@@ -2,10 +2,12 @@ package wafv2
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 
@@ -31,6 +33,8 @@ const (
 	keyIPAddressVersion = "IPAddressVersion"
 	keyAddresses        = "Addresses"
 	keyRules            = "Rules"
+	keyCapacity         = "Capacity"
+	keyVendorName       = "VendorName"
 )
 
 const (
@@ -38,7 +42,29 @@ const (
 	wafv2TargetPrefix  = "AWSWAF_20190729."
 	wafv2MatchPriority = service.PriorityHeaderExact
 	defaultActionAllow = "ALLOW"
+
+	// maxAPIKeyTokenDomains is the AWS-imposed limit for token domains per API key.
+	maxAPIKeyTokenDomains = 5
+
+	// maxSampledRequestsItems is the maximum value for GetSampledRequests.MaxItems.
+	maxSampledRequestsItems = 500
 )
+
+// validLoggingDestinationPrefixes lists accepted ARN prefixes for logging destinations.
+var validLoggingDestinationPrefixes = []string{ //nolint:gochecknoglobals // package-level lookup table
+	"arn:aws:firehose:",
+	"arn:aws:s3:::",
+	"arn:aws:logs:",
+}
+
+// regionalResourceServices are the AWS service identifiers accepted for REGIONAL WebACL associations.
+var regionalResourceServices = []string{ //nolint:gochecknoglobals // package-level lookup table
+	"elasticloadbalancing",
+	"execute-api",
+	"appsync",
+	"cognito-idp",
+	"apprunner",
+}
 
 var (
 	errUnknownAction  = errors.New("unknown action")
@@ -287,43 +313,47 @@ func (h *Handler) handleError(c *echo.Context, err error) error {
 	var syntaxErr *json.SyntaxError
 	var typeErr *json.UnmarshalTypeError
 
+	var errType string
+	var statusCode int
+
 	switch {
 	case errors.Is(err, awserr.ErrNotFound):
-		payload, _ := json.Marshal(map[string]string{
-			keyTypeField:    "WAFNonexistentItemException",
-			keyMessageField: err.Error(),
-		})
-
-		return c.JSONBlob(http.StatusBadRequest, payload)
+		errType = "WAFNonexistentItemException"
+		statusCode = http.StatusBadRequest
+	case errors.Is(err, ErrOptimisticLock):
+		errType = "WAFOptimisticLockException"
+		statusCode = http.StatusBadRequest
+	case errors.Is(err, ErrAssociatedItem):
+		errType = "WAFAssociatedItemException"
+		statusCode = http.StatusBadRequest
+	case errors.Is(err, ErrLimitsExceeded):
+		errType = "WAFLimitsExceededException"
+		statusCode = http.StatusBadRequest
+	case errors.Is(err, ErrTagOperation):
+		errType = "WAFTagOperationException"
+		statusCode = http.StatusBadRequest
 	case errors.Is(err, awserr.ErrConflict):
-		payload, _ := json.Marshal(map[string]string{
-			keyTypeField:    "WAFDuplicateItemException",
-			keyMessageField: err.Error(),
-		})
-
-		return c.JSONBlob(http.StatusBadRequest, payload)
+		errType = "WAFDuplicateItemException"
+		statusCode = http.StatusBadRequest
 	case errors.Is(err, errInvalidRequest), errors.As(err, &syntaxErr), errors.As(err, &typeErr):
-		payload, _ := json.Marshal(map[string]string{
-			keyTypeField:    "WAFInvalidParameterException",
-			keyMessageField: err.Error(),
-		})
-
-		return c.JSONBlob(http.StatusBadRequest, payload)
+		errType = "WAFInvalidParameterException"
+		statusCode = http.StatusBadRequest
 	case errors.Is(err, errUnknownAction):
-		payload, _ := json.Marshal(map[string]string{
-			keyTypeField:    "WAFInvalidOperationException",
-			keyMessageField: err.Error(),
-		})
-
-		return c.JSONBlob(http.StatusBadRequest, payload)
+		errType = "WAFInvalidOperationException"
+		statusCode = http.StatusBadRequest
 	default:
-		payload, _ := json.Marshal(map[string]string{
-			keyTypeField:    "WAFInternalErrorException",
-			keyMessageField: err.Error(),
-		})
-
-		return c.JSONBlob(http.StatusInternalServerError, payload)
+		errType = "WAFInternalErrorException"
+		statusCode = http.StatusInternalServerError
 	}
+
+	payload, _ := json.Marshal(map[string]string{
+		keyTypeField:    errType,
+		keyMessageField: err.Error(),
+	})
+
+	c.Response().Header().Set("X-Amzn-Errortype", errType)
+
+	return c.JSONBlob(statusCode, payload)
 }
 
 // tagItem represents a key/value pair for Tags fields.
@@ -358,12 +388,18 @@ func tagsToItems(tags map[string]string) []tagItem {
 
 // createWebACLRequest is the request body for CreateWebACL.
 type createWebACLRequest struct {
-	Name             string          `json:"Name"`
-	Scope            string          `json:"Scope"`
-	Description      string          `json:"Description"`
-	DefaultAction    json.RawMessage `json:"DefaultAction"`
-	VisibilityConfig json.RawMessage `json:"VisibilityConfig"`
-	Tags             []tagItem       `json:"Tags"`
+	DefaultAction        json.RawMessage  `json:"DefaultAction"`
+	VisibilityConfig     json.RawMessage  `json:"VisibilityConfig"`
+	CustomResponseBodies json.RawMessage  `json:"CustomResponseBodies"`
+	AssociationConfig    json.RawMessage  `json:"AssociationConfig"`
+	CaptchaConfig        json.RawMessage  `json:"CaptchaConfig"`
+	ChallengeConfig      json.RawMessage  `json:"ChallengeConfig"`
+	Name                 string           `json:"Name"`
+	Scope                string           `json:"Scope"`
+	Description          string           `json:"Description"`
+	Tags                 []tagItem        `json:"Tags"`
+	TokenDomains         []string         `json:"TokenDomains"`
+	Rules                []map[string]any `json:"Rules"`
 }
 
 func (h *Handler) handleCreateWebACL(ctx context.Context, body []byte) ([]byte, error) {
@@ -384,16 +420,36 @@ func (h *Handler) handleCreateWebACL(ctx context.Context, body []byte) ([]byte, 
 		return nil, fmt.Errorf("%w: Scope must be %s or %s", errInvalidRequest, ScopeRegional, ScopeCloudFront)
 	}
 
-	defaultAction := extractDefaultAction(req.DefaultAction)
-	visibilityConfig := string(req.VisibilityConfig)
+	if err := validateVisibilityConfig(req.VisibilityConfig); err != nil {
+		return nil, err
+	}
+
+	if err := validateDefaultAction(req.DefaultAction); err != nil {
+		return nil, err
+	}
+
+	if err := validateRules(req.Rules); err != nil {
+		return nil, err
+	}
+
+	tags := tagsFromItems(req.Tags)
+	if err := validateTags(tags); err != nil {
+		return nil, err
+	}
 
 	w, err := h.Backend.CreateWebACL(
 		req.Name,
 		req.Scope,
 		req.Description,
-		defaultAction,
-		visibilityConfig,
-		tagsFromItems(req.Tags),
+		req.DefaultAction,
+		req.VisibilityConfig,
+		req.Rules,
+		req.TokenDomains,
+		req.CustomResponseBodies,
+		req.AssociationConfig,
+		req.CaptchaConfig,
+		req.ChallengeConfig,
+		tags,
 	)
 	if err != nil {
 		return nil, err
@@ -412,6 +468,27 @@ func (h *Handler) handleCreateWebACL(ctx context.Context, body []byte) ([]byte, 
 			keyLockToken: w.LockToken,
 		},
 	})
+}
+
+// validateDefaultAction validates that exactly one of Allow/Block is set in DefaultAction.
+func validateDefaultAction(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("%w: invalid DefaultAction JSON: %w", errInvalidRequest, err)
+	}
+
+	_, hasAllow := m["Allow"]
+	_, hasBlock := m["Block"]
+
+	if hasAllow && hasBlock {
+		return fmt.Errorf("%w: DefaultAction must specify exactly one of Allow or Block", errInvalidRequest)
+	}
+
+	return nil
 }
 
 // getWebACLRequest is the request body for GetWebACL.
@@ -436,33 +513,97 @@ func (h *Handler) handleGetWebACL(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if req.Scope != "" && w.Scope != req.Scope {
+		return nil, fmt.Errorf("%w: web ACL %q has scope %s, not %s", ErrWebACLNotFound, req.ID, w.Scope, req.Scope)
+	}
+
+	return h.marshalWebACL(w)
+}
+
+// marshalWebACL builds the canonical WebACL JSON response.
+func (h *Handler) marshalWebACL(w *WebACL) ([]byte, error) {
 	arnStr := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
-	defaultActionMap := buildDefaultActionMap(w.DefaultAction)
 	visConfig := parseVisibilityConfig(w.VisibilityConfig, w.Name)
 
+	defaultActionJSON := w.DefaultAction
+	if len(defaultActionJSON) == 0 {
+		defaultActionJSON = json.RawMessage(`{"Allow":{}}`)
+	}
+
+	var defaultActionMap any
+	if err := json.Unmarshal(defaultActionJSON, &defaultActionMap); err != nil {
+		defaultActionMap = map[string]any{"Allow": map[string]any{}}
+	}
+
+	rules := w.Rules
+	if rules == nil {
+		rules = []map[string]any{}
+	}
+
+	webACLMap := map[string]any{
+		"Id":                w.ID,
+		keyName:             w.Name,
+		keyARN:              arnStr,
+		keyLockToken:        w.LockToken,
+		keyDescription:      w.Description,
+		"DefaultAction":     defaultActionMap,
+		keyVisibilityConfig: visConfig,
+		keyRules:            rules,
+	}
+
+	if len(w.TokenDomains) > 0 {
+		webACLMap["TokenDomains"] = w.TokenDomains
+	}
+
+	if len(w.CustomResponseBodies) > 0 {
+		var crb any
+		if json.Unmarshal(w.CustomResponseBodies, &crb) == nil {
+			webACLMap["CustomResponseBodies"] = crb
+		}
+	}
+
+	if len(w.AssociationConfig) > 0 {
+		var ac any
+		if json.Unmarshal(w.AssociationConfig, &ac) == nil {
+			webACLMap["AssociationConfig"] = ac
+		}
+	}
+
+	if len(w.CaptchaConfig) > 0 {
+		var cc any
+		if json.Unmarshal(w.CaptchaConfig, &cc) == nil {
+			webACLMap["CaptchaConfig"] = cc
+		}
+	}
+
+	if len(w.ChallengeConfig) > 0 {
+		var chc any
+		if json.Unmarshal(w.ChallengeConfig, &chc) == nil {
+			webACLMap["ChallengeConfig"] = chc
+		}
+	}
+
 	return json.Marshal(map[string]any{
-		"WebACL": map[string]any{
-			"Id":                w.ID,
-			keyName:             w.Name,
-			keyARN:              arnStr,
-			keyLockToken:        w.LockToken,
-			keyDescription:      w.Description,
-			"DefaultAction":     defaultActionMap,
-			keyVisibilityConfig: visConfig,
-		},
+		"WebACL":     webACLMap,
 		keyLockToken: w.LockToken,
 	})
 }
 
 // updateWebACLRequest is the request body for UpdateWebACL.
 type updateWebACLRequest struct {
-	ID               string          `json:"Id"`
-	Name             string          `json:"Name"`
-	Scope            string          `json:"Scope"`
-	LockToken        string          `json:"LockToken"`
-	Description      string          `json:"Description"`
-	DefaultAction    json.RawMessage `json:"DefaultAction"`
-	VisibilityConfig json.RawMessage `json:"VisibilityConfig"`
+	DefaultAction        json.RawMessage  `json:"DefaultAction"`
+	VisibilityConfig     json.RawMessage  `json:"VisibilityConfig"`
+	CustomResponseBodies json.RawMessage  `json:"CustomResponseBodies"`
+	AssociationConfig    json.RawMessage  `json:"AssociationConfig"`
+	CaptchaConfig        json.RawMessage  `json:"CaptchaConfig"`
+	ChallengeConfig      json.RawMessage  `json:"ChallengeConfig"`
+	ID                   string           `json:"Id"`
+	Name                 string           `json:"Name"`
+	Scope                string           `json:"Scope"`
+	LockToken            string           `json:"LockToken"`
+	Description          string           `json:"Description"`
+	TokenDomains         []string         `json:"TokenDomains"`
+	Rules                []map[string]any `json:"Rules"`
 }
 
 func (h *Handler) handleUpdateWebACL(ctx context.Context, body []byte) ([]byte, error) {
@@ -475,10 +616,31 @@ func (h *Handler) handleUpdateWebACL(ctx context.Context, body []byte) ([]byte, 
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	defaultAction := extractDefaultAction(req.DefaultAction)
-	visibilityConfig := string(req.VisibilityConfig)
+	if err := validateVisibilityConfig(req.VisibilityConfig); err != nil {
+		return nil, err
+	}
 
-	w, err := h.Backend.UpdateWebACL(req.ID, req.Description, defaultAction, visibilityConfig)
+	if err := validateDefaultAction(req.DefaultAction); err != nil {
+		return nil, err
+	}
+
+	if err := validateRules(req.Rules); err != nil {
+		return nil, err
+	}
+
+	w, err := h.Backend.UpdateWebACL(
+		req.ID,
+		req.Description,
+		req.LockToken,
+		req.DefaultAction,
+		req.VisibilityConfig,
+		req.Rules,
+		req.TokenDomains,
+		req.CustomResponseBodies,
+		req.AssociationConfig,
+		req.CaptchaConfig,
+		req.ChallengeConfig,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +671,7 @@ func (h *Handler) handleDeleteWebACL(ctx context.Context, body []byte) ([]byte, 
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteWebACL(req.ID); err != nil {
+	if err := h.Backend.DeleteWebACL(req.ID, req.LockToken); err != nil {
 		return nil, err
 	}
 
@@ -526,6 +688,9 @@ type listWebACLsRequest struct {
 	Limit      int    `json:"Limit"`
 }
 
+// handleListWebACLs handles the ListWebACLs request.
+//
+//nolint:dupl // list handlers share structural similarity but operate on different types
 func (h *Handler) handleListWebACLs(body []byte) ([]byte, error) {
 	var req listWebACLsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -533,24 +698,45 @@ func (h *Handler) handleListWebACLs(body []byte) ([]byte, error) {
 	}
 
 	webACLs := h.Backend.ListWebACLs()
-	items := buildSummaryItems(webACLs, req.Scope,
-		func(w *WebACL) string { return w.Scope },
-		func(w *WebACL) map[string]string {
-			arnStr := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 
-			return map[string]string{
-				"Id":           w.ID,
-				keyName:        w.Name,
-				keyARN:         arnStr,
-				keyLockToken:   w.LockToken,
-				keyDescription: w.Description,
-			}
-		},
+	// Filter by scope.
+	filtered := make([]*WebACL, 0, len(webACLs))
+
+	for _, w := range webACLs {
+		if req.Scope != "" && w.Scope != req.Scope {
+			continue
+		}
+
+		filtered = append(filtered, w)
+	}
+
+	// Apply pagination.
+	items, nextMarker := paginateByName(
+		filtered,
+		func(w *WebACL) string { return w.Name },
+		req.NextMarker,
+		req.Limit,
 	)
 
-	return json.Marshal(map[string]any{
-		"WebACLs": items,
-	})
+	summaries := make([]map[string]string, 0, len(items))
+
+	for _, w := range items {
+		arnStr := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
+		summaries = append(summaries, map[string]string{
+			"Id":           w.ID,
+			keyName:        w.Name,
+			keyARN:         arnStr,
+			keyLockToken:   w.LockToken,
+			keyDescription: w.Description,
+		})
+	}
+
+	resp := map[string]any{"WebACLs": summaries}
+	if nextMarker != "" {
+		resp["NextMarker"] = nextMarker
+	}
+
+	return json.Marshal(resp)
 }
 
 // createIPSetRequest is the request body for CreateIPSet.
@@ -589,13 +775,22 @@ func (h *Handler) handleCreateIPSet(ctx context.Context, body []byte) ([]byte, e
 		return nil, fmt.Errorf("%w: IPAddressVersion must be %s or %s", errInvalidRequest, IPVersionIPv4, IPVersionIPv6)
 	}
 
+	if err := validateCIDRs(req.Addresses, req.IPAddressVersion); err != nil {
+		return nil, err
+	}
+
+	tags := tagsFromItems(req.Tags)
+	if err := validateTags(tags); err != nil {
+		return nil, err
+	}
+
 	s, err := h.Backend.CreateIPSet(
 		req.Name,
 		req.Scope,
 		req.Description,
 		req.IPAddressVersion,
 		req.Addresses,
-		tagsFromItems(req.Tags),
+		tags,
 	)
 	if err != nil {
 		return nil, err
@@ -638,6 +833,10 @@ func (h *Handler) handleGetIPSet(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if req.Scope != "" && s.Scope != req.Scope {
+		return nil, fmt.Errorf("%w: IP set %q has scope %s, not %s", ErrIPSetNotFound, req.ID, s.Scope, req.Scope)
+	}
+
 	arnStr := h.Backend.IPSetARN(s.Name, s.ID, s.Scope)
 
 	return json.Marshal(map[string]any{
@@ -674,7 +873,19 @@ func (h *Handler) handleUpdateIPSet(ctx context.Context, body []byte) ([]byte, e
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	s, err := h.Backend.UpdateIPSet(req.ID, req.Description, req.Addresses)
+	// Validate CIDRs against stored IP version — fetch first.
+	existing, err := h.Backend.GetIPSet(req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Addresses != nil {
+		if cidrErr := validateCIDRs(req.Addresses, existing.IPAddressVersion); cidrErr != nil {
+			return nil, cidrErr
+		}
+	}
+
+	s, err := h.Backend.UpdateIPSet(req.ID, req.Description, req.LockToken, req.Addresses)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +916,7 @@ func (h *Handler) handleDeleteIPSet(ctx context.Context, body []byte) ([]byte, e
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteIPSet(req.ID); err != nil {
+	if err := h.Backend.DeleteIPSet(req.ID, req.LockToken); err != nil {
 		return nil, err
 	}
 
@@ -722,6 +933,7 @@ type listIPSetsRequest struct {
 	Limit      int    `json:"Limit"`
 }
 
+//nolint:dupl // list handlers share structural similarity but operate on different types
 func (h *Handler) handleListIPSets(body []byte) ([]byte, error) {
 	var req listIPSetsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -729,24 +941,43 @@ func (h *Handler) handleListIPSets(body []byte) ([]byte, error) {
 	}
 
 	ipSets := h.Backend.ListIPSets()
-	items := buildSummaryItems(ipSets, req.Scope,
-		func(s *IPSet) string { return s.Scope },
-		func(s *IPSet) map[string]string {
-			arnStr := h.Backend.IPSetARN(s.Name, s.ID, s.Scope)
 
-			return map[string]string{
-				"Id":           s.ID,
-				keyName:        s.Name,
-				keyARN:         arnStr,
-				keyLockToken:   s.LockToken,
-				keyDescription: s.Description,
-			}
-		},
+	filtered := make([]*IPSet, 0, len(ipSets))
+
+	for _, s := range ipSets {
+		if req.Scope != "" && s.Scope != req.Scope {
+			continue
+		}
+
+		filtered = append(filtered, s)
+	}
+
+	items, nextMarker := paginateByName(
+		filtered,
+		func(s *IPSet) string { return s.Name },
+		req.NextMarker,
+		req.Limit,
 	)
 
-	return json.Marshal(map[string]any{
-		"IPSets": items,
-	})
+	summaries := make([]map[string]string, 0, len(items))
+
+	for _, s := range items {
+		arnStr := h.Backend.IPSetARN(s.Name, s.ID, s.Scope)
+		summaries = append(summaries, map[string]string{
+			"Id":           s.ID,
+			keyName:        s.Name,
+			keyARN:         arnStr,
+			keyLockToken:   s.LockToken,
+			keyDescription: s.Description,
+		})
+	}
+
+	resp := map[string]any{"IPSets": summaries}
+	if nextMarker != "" {
+		resp["NextMarker"] = nextMarker
+	}
+
+	return json.Marshal(resp)
 }
 
 // tagResourceRequest is the request body for TagResource.
@@ -765,7 +996,12 @@ func (h *Handler) handleTagResource(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: ResourceARN is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.TagResource(req.ResourceARN, tagsFromItems(req.Tags)); err != nil {
+	tags := tagsFromItems(req.Tags)
+	if err := validateTags(tags); err != nil {
+		return nil, err
+	}
+
+	if err := h.Backend.TagResource(req.ResourceARN, tags); err != nil {
 		return nil, err
 	}
 
@@ -823,38 +1059,11 @@ func (h *Handler) handleUntagResource(body []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func buildDefaultActionMap(action string) map[string]any {
-	switch strings.ToUpper(action) {
-	case "BLOCK":
-		return map[string]any{"Block": map[string]any{}}
-	default:
-		return map[string]any{"Allow": map[string]any{}}
-	}
-}
-
-// extractDefaultAction parses a DefaultAction JSON object and returns "ALLOW" or "BLOCK".
-func extractDefaultAction(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return defaultActionAllow
-	}
-
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return defaultActionAllow
-	}
-
-	if _, ok := m["Block"]; ok {
-		return "BLOCK"
-	}
-
-	return defaultActionAllow
-}
-
 // parseVisibilityConfig parses a stored VisibilityConfig JSON string or returns a default.
-func parseVisibilityConfig(stored, metricName string) map[string]any {
-	if stored != "" {
+func parseVisibilityConfig(stored json.RawMessage, metricName string) map[string]any {
+	if len(stored) > 0 {
 		var m map[string]any
-		if err := json.Unmarshal([]byte(stored), &m); err == nil {
+		if err := json.Unmarshal(stored, &m); err == nil {
 			return m
 		}
 	}
@@ -866,24 +1075,41 @@ func parseVisibilityConfig(stored, metricName string) map[string]any {
 	}
 }
 
-// buildSummaryItems filters and maps a slice of resources to summary maps.
-func buildSummaryItems[T any](
-	items []T,
-	scope string,
-	getScope func(T) string,
-	toMap func(T) map[string]string,
-) []map[string]string {
-	result := make([]map[string]string, 0, len(items))
+// paginateByName implements cursor-based pagination over name-sorted items.
+// The cursor is base64(last-name-seen). Returns the page of items and the
+// next marker (empty string if no more pages).
+func paginateByName[T any](items []T, getName func(T) string, nextMarker string, limit int) ([]T, string) {
+	// Decode cursor.
+	startAfter := ""
 
-	for _, item := range items {
-		if scope != "" && getScope(item) != scope {
-			continue
+	if nextMarker != "" {
+		decoded, err := base64.StdEncoding.DecodeString(nextMarker)
+		if err == nil {
+			startAfter = string(decoded)
 		}
-
-		result = append(result, toMap(item))
 	}
 
-	return result
+	// Skip items up to and including the cursor name.
+	start := 0
+
+	if startAfter != "" {
+		for start < len(items) && getName(items[start]) <= startAfter {
+			start++
+		}
+	}
+
+	items = items[start:]
+
+	// Apply limit.
+	if limit <= 0 || limit > len(items) {
+		return items, ""
+	}
+
+	page := items[:limit]
+	lastName := getName(page[len(page)-1])
+	newMarker := base64.StdEncoding.EncodeToString([]byte(lastName))
+
+	return page, newMarker
 }
 
 // associateWebACLRequest is the request body for AssociateWebACL.
@@ -906,11 +1132,49 @@ func (h *Handler) handleAssociateWebACL(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: ResourceArn is required", errInvalidRequest)
 	}
 
+	if err := h.validateAssociationScope(req.WebACLArn, req.ResourceArn); err != nil {
+		return nil, err
+	}
+
 	if err := h.Backend.AssociateWebACL(req.WebACLArn, req.ResourceArn); err != nil {
 		return nil, err
 	}
 
 	return nil, nil
+}
+
+// validateAssociationScope checks that the resource ARN's service is compatible with the WebACL scope.
+func (h *Handler) validateAssociationScope(webACLArn, resourceArn string) error {
+	// Determine WebACL scope from ARN (global → CLOUDFRONT, regional → REGIONAL).
+	if strings.Contains(webACLArn, "/global/") {
+		return fmt.Errorf(
+			"%w: CLOUDFRONT WebACL associations must be managed through the CloudFront API",
+			ErrInvalidOperation,
+		)
+	}
+
+	// For REGIONAL WebACLs, validate service.
+	service := extractARNService(resourceArn)
+	if slices.Contains(regionalResourceServices, service) {
+		return nil
+	}
+
+	// If service is unrecognised, still allow (for compatibility with unknown resource types).
+	return nil
+}
+
+const arnServiceIndex = 2 // position of service segment in arn:partition:SERVICE:...
+
+// extractARNService extracts the service segment from an ARN (arn:partition:SERVICE:...).
+func extractARNService(arnStr string) string {
+	const minARNParts = 3
+
+	parts := strings.Split(arnStr, ":")
+	if len(parts) >= minARNParts {
+		return parts[arnServiceIndex]
+	}
+
+	return ""
 }
 
 // disassociateWebACLRequest is the request body for DisassociateWebACL.
@@ -955,23 +1219,7 @@ func (h *Handler) handleGetWebACLForResource(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	arnStr := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
-	defaultActionMap := buildDefaultActionMap(w.DefaultAction)
-	visConfig := parseVisibilityConfig(w.VisibilityConfig, w.Name)
-
-	return json.Marshal(map[string]any{
-		"WebACL": map[string]any{
-			"Id":                w.ID,
-			keyName:             w.Name,
-			keyARN:              arnStr,
-			keyLockToken:        w.LockToken,
-			keyScope:            w.Scope,
-			keyDescription:      w.Description,
-			"DefaultAction":     defaultActionMap,
-			keyVisibilityConfig: visConfig,
-			keyRules:            []any{},
-		},
-	})
+	return h.marshalWebACL(w)
 }
 
 // checkCapacityRequest is the request body for CheckCapacity.
@@ -1016,6 +1264,14 @@ func (h *Handler) handleCreateAPIKey(ctx context.Context, body []byte) ([]byte, 
 		return nil, fmt.Errorf("%w: Scope is required", errInvalidRequest)
 	}
 
+	if len(req.TokenDomains) < 1 || len(req.TokenDomains) > maxAPIKeyTokenDomains {
+		return nil, fmt.Errorf(
+			"%w: TokenDomains must have 1 to %d entries",
+			errInvalidRequest,
+			maxAPIKeyTokenDomains,
+		)
+	}
+
 	a, err := h.Backend.CreateAPIKey(req.Scope, req.TokenDomains)
 	if err != nil {
 		return nil, err
@@ -1024,8 +1280,11 @@ func (h *Handler) handleCreateAPIKey(ctx context.Context, body []byte) ([]byte, 
 	log := logger.Load(ctx)
 	log.InfoContext(ctx, "wafv2: created API key", "scope", a.Scope)
 
+	// Emit a base64-encoded key value as AWS does.
+	encodedKey := base64.StdEncoding.EncodeToString([]byte(a.APIKeyValue))
+
 	return json.Marshal(map[string]any{
-		"APIKey": a.APIKeyValue,
+		"APIKey": encodedKey,
 	})
 }
 
@@ -1049,7 +1308,13 @@ func (h *Handler) handleDeleteAPIKey(ctx context.Context, body []byte) ([]byte, 
 		return nil, fmt.Errorf("%w: APIKey is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteAPIKey(req.Scope, req.APIKey); err != nil {
+	// API keys may be passed as base64-encoded values; try decoding first.
+	lookupKey := req.APIKey
+	if decoded, err := base64.StdEncoding.DecodeString(req.APIKey); err == nil {
+		lookupKey = string(decoded)
+	}
+
+	if err := h.Backend.DeleteAPIKey(req.Scope, lookupKey); err != nil {
 		return nil, err
 	}
 
@@ -1060,12 +1325,13 @@ func (h *Handler) handleDeleteAPIKey(ctx context.Context, body []byte) ([]byte, 
 }
 
 // createRegexPatternSetRequest is the request body for CreateRegexPatternSet.
+// RegularExpressionList accepts both []string and []{RegexString:...} shapes.
 type createRegexPatternSetRequest struct {
-	Name                  string    `json:"Name"`
-	Scope                 string    `json:"Scope"`
-	Description           string    `json:"Description"`
-	RegularExpressionList []string  `json:"RegularExpressionList"`
-	Tags                  []tagItem `json:"Tags"`
+	Name                  string          `json:"Name"`
+	Scope                 string          `json:"Scope"`
+	Description           string          `json:"Description"`
+	RegularExpressionList json.RawMessage `json:"RegularExpressionList"`
+	Tags                  []tagItem       `json:"Tags"`
 }
 
 func (h *Handler) handleCreateRegexPatternSet(ctx context.Context, body []byte) ([]byte, error) {
@@ -1086,12 +1352,26 @@ func (h *Handler) handleCreateRegexPatternSet(ctx context.Context, body []byte) 
 		return nil, fmt.Errorf("%w: Scope must be %s or %s", errInvalidRequest, ScopeRegional, ScopeCloudFront)
 	}
 
+	entries, err := parseRegexEntries(req.RegularExpressionList)
+	if err != nil {
+		return nil, err
+	}
+
+	if validateErr := validateRegexEntries(entries); validateErr != nil {
+		return nil, validateErr
+	}
+
+	tags := tagsFromItems(req.Tags)
+	if tagsErr := validateTags(tags); tagsErr != nil {
+		return nil, tagsErr
+	}
+
 	rps, err := h.Backend.CreateRegexPatternSet(
 		req.Name,
 		req.Scope,
 		req.Description,
-		req.RegularExpressionList,
-		tagsFromItems(req.Tags),
+		entries,
+		tags,
 	)
 	if err != nil {
 		return nil, err
@@ -1112,6 +1392,32 @@ func (h *Handler) handleCreateRegexPatternSet(ctx context.Context, body []byte) 
 	})
 }
 
+// parseRegexEntries accepts either []RegexEntry or []string and normalises to []RegexEntry.
+func parseRegexEntries(raw json.RawMessage) ([]RegexEntry, error) {
+	if len(raw) == 0 {
+		return []RegexEntry{}, nil
+	}
+
+	// Try object form first: [{"RegexString": "..."}]
+	var entries []RegexEntry
+	if err := json.Unmarshal(raw, &entries); err == nil {
+		return entries, nil
+	}
+
+	// Fall back to plain string form: ["...", "..."]
+	var strs []string
+	if err := json.Unmarshal(raw, &strs); err != nil {
+		return nil, fmt.Errorf("%w: RegularExpressionList must be an array of objects or strings", errInvalidRequest)
+	}
+
+	result := make([]RegexEntry, len(strs))
+	for i, s := range strs {
+		result[i] = RegexEntry{RegexString: s}
+	}
+
+	return result, nil
+}
+
 // deleteRegexPatternSetRequest is the request body for DeleteRegexPatternSet.
 type deleteRegexPatternSetRequest struct {
 	ID        string `json:"Id"`
@@ -1130,7 +1436,7 @@ func (h *Handler) handleDeleteRegexPatternSet(ctx context.Context, body []byte) 
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteRegexPatternSet(req.ID); err != nil {
+	if err := h.Backend.DeleteRegexPatternSet(req.ID, req.LockToken); err != nil {
 		return nil, err
 	}
 
@@ -1169,6 +1475,24 @@ func (h *Handler) handleCreateRuleGroup(ctx context.Context, body []byte) ([]byt
 		return nil, fmt.Errorf("%w: Scope must be %s or %s", errInvalidRequest, ScopeRegional, ScopeCloudFront)
 	}
 
+	if req.Capacity < minRuleGroupCapacity || req.Capacity > maxRuleGroupCapacity {
+		return nil, fmt.Errorf(
+			"%w: Capacity must be between %d and %d",
+			errInvalidRequest,
+			minRuleGroupCapacity,
+			maxRuleGroupCapacity,
+		)
+	}
+
+	if err := validateVisibilityConfig(req.VisibilityConfig); err != nil {
+		return nil, err
+	}
+
+	tags := tagsFromItems(req.Tags)
+	if err := validateTags(tags); err != nil {
+		return nil, err
+	}
+
 	rg, err := h.Backend.CreateRuleGroup(
 		req.Name,
 		req.Scope,
@@ -1176,7 +1500,7 @@ func (h *Handler) handleCreateRuleGroup(ctx context.Context, body []byte) ([]byt
 		string(req.VisibilityConfig),
 		req.Capacity,
 		req.Rules,
-		tagsFromItems(req.Tags),
+		tags,
 	)
 	if err != nil {
 		return nil, err
@@ -1298,6 +1622,16 @@ func (h *Handler) handleGetRegexPatternSet(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if req.Scope != "" && r.Scope != req.Scope {
+		return nil, fmt.Errorf(
+			"%w: regex pattern set %q has scope %s, not %s",
+			ErrRegexPatternSetNotFound,
+			req.ID,
+			r.Scope,
+			req.Scope,
+		)
+	}
+
 	arnStr := h.Backend.RegexPatternSetARN(r.Name, r.ID, r.Scope)
 
 	return json.Marshal(map[string]any{
@@ -1319,6 +1653,7 @@ type listRegexPatternSetsRequest struct {
 	Limit      int    `json:"Limit"`
 }
 
+//nolint:dupl // list handlers share structural similarity but operate on different types
 func (h *Handler) handleListRegexPatternSets(body []byte) ([]byte, error) {
 	var req listRegexPatternSetsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1326,30 +1661,52 @@ func (h *Handler) handleListRegexPatternSets(body []byte) ([]byte, error) {
 	}
 
 	sets := h.Backend.ListRegexPatternSets()
-	items := buildSummaryItems(sets, req.Scope,
-		func(r *RegexPatternSet) string { return r.Scope },
-		func(r *RegexPatternSet) map[string]string {
-			return map[string]string{
-				"Id":           r.ID,
-				keyName:        r.Name,
-				keyARN:         h.Backend.RegexPatternSetARN(r.Name, r.ID, r.Scope),
-				keyLockToken:   r.LockToken,
-				keyDescription: r.Description,
-			}
-		},
+
+	filtered := make([]*RegexPatternSet, 0, len(sets))
+
+	for _, r := range sets {
+		if req.Scope != "" && r.Scope != req.Scope {
+			continue
+		}
+
+		filtered = append(filtered, r)
+	}
+
+	items, nextMarker := paginateByName(
+		filtered,
+		func(r *RegexPatternSet) string { return r.Name },
+		req.NextMarker,
+		req.Limit,
 	)
 
-	return json.Marshal(map[string]any{"RegexPatternSets": items})
+	summaries := make([]map[string]string, 0, len(items))
+
+	for _, r := range items {
+		summaries = append(summaries, map[string]string{
+			"Id":           r.ID,
+			keyName:        r.Name,
+			keyARN:         h.Backend.RegexPatternSetARN(r.Name, r.ID, r.Scope),
+			keyLockToken:   r.LockToken,
+			keyDescription: r.Description,
+		})
+	}
+
+	resp := map[string]any{"RegexPatternSets": summaries}
+	if nextMarker != "" {
+		resp["NextMarker"] = nextMarker
+	}
+
+	return json.Marshal(resp)
 }
 
 // updateRegexPatternSetRequest is the request body for UpdateRegexPatternSet.
 type updateRegexPatternSetRequest struct {
-	ID                    string   `json:"Id"`
-	Name                  string   `json:"Name"`
-	Scope                 string   `json:"Scope"`
-	LockToken             string   `json:"LockToken"`
-	Description           string   `json:"Description"`
-	RegularExpressionList []string `json:"RegularExpressionList"`
+	ID                    string          `json:"Id"`
+	Name                  string          `json:"Name"`
+	Scope                 string          `json:"Scope"`
+	LockToken             string          `json:"LockToken"`
+	Description           string          `json:"Description"`
+	RegularExpressionList json.RawMessage `json:"RegularExpressionList"`
 }
 
 func (h *Handler) handleUpdateRegexPatternSet(ctx context.Context, body []byte) ([]byte, error) {
@@ -1362,7 +1719,16 @@ func (h *Handler) handleUpdateRegexPatternSet(ctx context.Context, body []byte) 
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	r, err := h.Backend.UpdateRegexPatternSet(req.ID, req.Description, req.RegularExpressionList)
+	entries, err := parseRegexEntries(req.RegularExpressionList)
+	if err != nil {
+		return nil, err
+	}
+
+	if validateErr := validateRegexEntries(entries); validateErr != nil {
+		return nil, validateErr
+	}
+
+	r, err := h.Backend.UpdateRegexPatternSet(req.ID, req.Description, req.LockToken, entries)
 	if err != nil {
 		return nil, err
 	}
@@ -1396,8 +1762,18 @@ func (h *Handler) handleGetRuleGroup(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if req.Scope != "" && rg.Scope != req.Scope {
+		return nil, fmt.Errorf(
+			"%w: rule group %q has scope %s, not %s",
+			ErrRuleGroupNotFound,
+			req.ID,
+			rg.Scope,
+			req.Scope,
+		)
+	}
+
 	arnStr := h.Backend.RuleGroupARN(rg.Name, rg.ID, rg.Scope)
-	visConfig := parseVisibilityConfig(rg.VisibilityConfig, rg.Name)
+	visConfig := parseVisibilityConfig(json.RawMessage(rg.VisibilityConfig), rg.Name)
 
 	return json.Marshal(map[string]any{
 		"RuleGroup": map[string]any{
@@ -1405,7 +1781,7 @@ func (h *Handler) handleGetRuleGroup(body []byte) ([]byte, error) {
 			keyName:             rg.Name,
 			keyARN:              arnStr,
 			keyDescription:      rg.Description,
-			"Capacity":          rg.Capacity,
+			keyCapacity:         rg.Capacity,
 			keyRules:            rg.Rules,
 			keyVisibilityConfig: visConfig,
 		},
@@ -1420,6 +1796,7 @@ type listRuleGroupsRequest struct {
 	Limit      int    `json:"Limit"`
 }
 
+//nolint:dupl // list handlers share structural similarity but operate on different types
 func (h *Handler) handleListRuleGroups(body []byte) ([]byte, error) {
 	var req listRuleGroupsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1427,20 +1804,42 @@ func (h *Handler) handleListRuleGroups(body []byte) ([]byte, error) {
 	}
 
 	groups := h.Backend.ListRuleGroups()
-	items := buildSummaryItems(groups, req.Scope,
-		func(rg *RuleGroup) string { return rg.Scope },
-		func(rg *RuleGroup) map[string]string {
-			return map[string]string{
-				"Id":           rg.ID,
-				keyName:        rg.Name,
-				keyARN:         h.Backend.RuleGroupARN(rg.Name, rg.ID, rg.Scope),
-				keyLockToken:   rg.LockToken,
-				keyDescription: rg.Description,
-			}
-		},
+
+	filtered := make([]*RuleGroup, 0, len(groups))
+
+	for _, rg := range groups {
+		if req.Scope != "" && rg.Scope != req.Scope {
+			continue
+		}
+
+		filtered = append(filtered, rg)
+	}
+
+	items, nextMarker := paginateByName(
+		filtered,
+		func(rg *RuleGroup) string { return rg.Name },
+		req.NextMarker,
+		req.Limit,
 	)
 
-	return json.Marshal(map[string]any{"RuleGroups": items})
+	summaries := make([]map[string]string, 0, len(items))
+
+	for _, rg := range items {
+		summaries = append(summaries, map[string]string{
+			"Id":           rg.ID,
+			keyName:        rg.Name,
+			keyARN:         h.Backend.RuleGroupARN(rg.Name, rg.ID, rg.Scope),
+			keyLockToken:   rg.LockToken,
+			keyDescription: rg.Description,
+		})
+	}
+
+	resp := map[string]any{"RuleGroups": summaries}
+	if nextMarker != "" {
+		resp["NextMarker"] = nextMarker
+	}
+
+	return json.Marshal(resp)
 }
 
 // updateRuleGroupRequest is the request body for UpdateRuleGroup.
@@ -1464,7 +1863,17 @@ func (h *Handler) handleUpdateRuleGroup(ctx context.Context, body []byte) ([]byt
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
-	rg, err := h.Backend.UpdateRuleGroup(req.ID, req.Description, string(req.VisibilityConfig), req.Rules)
+	if err := validateVisibilityConfig(req.VisibilityConfig); err != nil {
+		return nil, err
+	}
+
+	rg, err := h.Backend.UpdateRuleGroup(
+		req.ID,
+		req.Description,
+		string(req.VisibilityConfig),
+		req.LockToken,
+		req.Rules,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1489,17 +1898,31 @@ func (h *Handler) handleListAPIKeys(body []byte) ([]byte, error) {
 	}
 
 	keys := h.Backend.ListAPIKeys(req.Scope)
-	items := make([]map[string]any, 0, len(keys))
 
-	for _, k := range keys {
+	// Apply pagination.
+	page, nextMarker := paginateByName(
+		keys,
+		func(k *APIKey) string { return k.APIKeyValue },
+		req.NextMarker,
+		req.Limit,
+	)
+
+	items := make([]map[string]any, 0, len(page))
+
+	for _, k := range page {
 		items = append(items, map[string]any{
-			"APIKey":       k.APIKeyValue,
+			"APIKey":       base64.StdEncoding.EncodeToString([]byte(k.APIKeyValue)),
 			keyScope:       k.Scope,
 			"TokenDomains": k.TokenDomains,
 		})
 	}
 
-	return json.Marshal(map[string]any{"APIKeys": items})
+	resp := map[string]any{"APIKeys": items}
+	if nextMarker != "" {
+		resp["NextMarker"] = nextMarker
+	}
+
+	return json.Marshal(resp)
 }
 
 // getDecryptedAPIKeyRequest is the request body for GetDecryptedAPIKey.
@@ -1522,7 +1945,13 @@ func (h *Handler) handleGetDecryptedAPIKey(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: APIKey is required", errInvalidRequest)
 	}
 
-	a, err := h.Backend.GetDecryptedAPIKey(req.Scope, req.APIKey)
+	// API keys may be passed as base64-encoded values; try decoding first.
+	lookupKey := req.APIKey
+	if decoded, err := base64.StdEncoding.DecodeString(req.APIKey); err == nil {
+		lookupKey = string(decoded)
+	}
+
+	a, err := h.Backend.GetDecryptedAPIKey(req.Scope, lookupKey)
 	if err != nil {
 		return nil, err
 	}
@@ -1535,7 +1964,7 @@ func (h *Handler) handleGetDecryptedAPIKey(body []byte) ([]byte, error) {
 
 // putLoggingConfigurationRequest is the request body for PutLoggingConfiguration.
 type putLoggingConfigurationRequest struct {
-	LoggingConfiguration map[string]any `json:"LoggingConfiguration"`
+	LoggingConfiguration json.RawMessage `json:"LoggingConfiguration"`
 }
 
 func (h *Handler) handlePutLoggingConfiguration(ctx context.Context, body []byte) ([]byte, error) {
@@ -1544,21 +1973,63 @@ func (h *Handler) handlePutLoggingConfiguration(ctx context.Context, body []byte
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	resourceARN, _ := req.LoggingConfiguration["ResourceArn"].(string)
-	if resourceARN == "" {
+	// Extract ResourceArn for validation.
+	var cfg map[string]json.RawMessage
+	if err := json.Unmarshal(req.LoggingConfiguration, &cfg); err != nil {
+		return nil, fmt.Errorf("%w: invalid LoggingConfiguration JSON: %w", errInvalidRequest, err)
+	}
+
+	var resourceARN string
+	if raw, ok := cfg["ResourceArn"]; ok {
+		if err := json.Unmarshal(raw, &resourceARN); err != nil || resourceARN == "" {
+			return nil, fmt.Errorf("%w: LoggingConfiguration.ResourceArn is required", errInvalidRequest)
+		}
+	} else {
 		return nil, fmt.Errorf("%w: LoggingConfiguration.ResourceArn is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.PutLoggingConfiguration(resourceARN); err != nil {
+	// Validate destination ARN prefixes.
+	if destRaw, ok := cfg["LogDestinationConfigs"]; ok {
+		var destinations []string
+		if unmarshalErr := json.Unmarshal(destRaw, &destinations); unmarshalErr == nil {
+			for _, dest := range destinations {
+				if destErr := validateLoggingDestination(dest); destErr != nil {
+					return nil, destErr
+				}
+			}
+		}
+	}
+
+	if err := h.Backend.PutLoggingConfiguration(resourceARN, req.LoggingConfiguration); err != nil {
 		return nil, err
 	}
 
 	log := logger.Load(ctx)
 	log.InfoContext(ctx, "wafv2: put logging configuration", "resourceArn", resourceARN)
 
+	var respCfg any
+	if err := json.Unmarshal(req.LoggingConfiguration, &respCfg); err != nil {
+		respCfg = map[string]any{"ResourceArn": resourceARN}
+	}
+
 	return json.Marshal(map[string]any{
-		"LoggingConfiguration": map[string]any{"ResourceArn": resourceARN},
+		"LoggingConfiguration": respCfg,
 	})
+}
+
+// validateLoggingDestination checks that a destination ARN has an accepted prefix.
+func validateLoggingDestination(dest string) error {
+	for _, prefix := range validLoggingDestinationPrefixes {
+		if strings.HasPrefix(dest, prefix) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"%w: LogDestinationConfig ARN %q must start with one of: firehose, s3, or CloudWatch Logs",
+		errInvalidRequest,
+		dest,
+	)
 }
 
 // getLoggingConfigurationRequest is the request body for GetLoggingConfiguration.
@@ -1576,12 +2047,18 @@ func (h *Handler) handleGetLoggingConfiguration(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: ResourceArn is required", errInvalidRequest)
 	}
 
-	if _, err := h.Backend.GetLoggingConfiguration(req.ResourceArn); err != nil {
+	cfgJSON, err := h.Backend.GetLoggingConfiguration(req.ResourceArn)
+	if err != nil {
 		return nil, err
 	}
 
+	var cfg any
+	if unmarshalErr := json.Unmarshal(cfgJSON, &cfg); unmarshalErr != nil {
+		cfg = map[string]any{"ResourceArn": req.ResourceArn}
+	}
+
 	return json.Marshal(map[string]any{
-		"LoggingConfiguration": map[string]any{"ResourceArn": req.ResourceArn},
+		"LoggingConfiguration": cfg,
 	})
 }
 
@@ -1676,15 +2153,29 @@ func (h *Handler) handleDeleteRuleGroup(ctx context.Context, body []byte) ([]byt
 		return nil, fmt.Errorf("%w: Id is required", errInvalidRequest)
 	}
 
+	if err := h.Backend.DeleteRuleGroup(req.ID, req.LockToken); err != nil {
+		return nil, err
+	}
+
 	log := logger.Load(ctx)
 	log.InfoContext(ctx, "wafv2: deleted rule group", "id", req.ID)
 
 	return nil, nil
 }
 
-// handleDescribeAllManagedProducts returns an empty list of managed products.
+// handleDescribeAllManagedProducts returns the catalog of managed products.
 func (h *Handler) handleDescribeAllManagedProducts(_ []byte) ([]byte, error) {
-	return json.Marshal(map[string]any{"ManagedProducts": []any{}})
+	products := make([]map[string]any, 0, len(getManagedRuleGroups()))
+
+	for _, mrg := range getManagedRuleGroups() {
+		products = append(products, map[string]any{
+			keyVendorName:        mrg.VendorName,
+			"ManagedRuleSetName": mrg.Name,
+			"ProductDescription": mrg.Description,
+		})
+	}
+
+	return json.Marshal(map[string]any{"ManagedProducts": products})
 }
 
 // describeManagedProductsByVendorRequest is the request body for DescribeManagedProductsByVendor.
@@ -1693,14 +2184,28 @@ type describeManagedProductsByVendorRequest struct {
 	VendorName string `json:"VendorName"`
 }
 
-// handleDescribeManagedProductsByVendor returns an empty list of managed products for a vendor.
+// handleDescribeManagedProductsByVendor returns catalog entries filtered by vendor.
 func (h *Handler) handleDescribeManagedProductsByVendor(body []byte) ([]byte, error) {
 	var req describeManagedProductsByVendorRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	return json.Marshal(map[string]any{"ManagedProducts": []any{}})
+	products := make([]map[string]any, 0)
+
+	for _, mrg := range getManagedRuleGroups() {
+		if req.VendorName != "" && mrg.VendorName != req.VendorName {
+			continue
+		}
+
+		products = append(products, map[string]any{
+			keyVendorName:        mrg.VendorName,
+			"ManagedRuleSetName": mrg.Name,
+			"ProductDescription": mrg.Description,
+		})
+	}
+
+	return json.Marshal(map[string]any{"ManagedProducts": products})
 }
 
 // describeManagedRuleGroupRequest is the request body for DescribeManagedRuleGroup.
@@ -1711,17 +2216,32 @@ type describeManagedRuleGroupRequest struct {
 	VersionName string `json:"VersionName"`
 }
 
-// handleDescribeManagedRuleGroup returns a stub managed rule group description.
+// handleDescribeManagedRuleGroup returns catalog data for the requested managed rule group.
 func (h *Handler) handleDescribeManagedRuleGroup(body []byte) ([]byte, error) {
 	var req describeManagedRuleGroupRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
+	// Look up catalog entry.
+	for _, mrg := range getManagedRuleGroups() {
+		if mrg.VendorName == req.VendorName && mrg.Name == req.Name {
+			return json.Marshal(map[string]any{
+				keyCapacity:       mrg.Capacity,
+				keyRules:          []any{},
+				"SnsTopicArn":     "",
+				"AvailableLabels": []any{},
+				"ConsumedLabels":  []any{},
+				"Description":     mrg.Description,
+			})
+		}
+	}
+
+	// Not found — return minimal stub so callers don't break.
 	const defaultManagedRuleGroupCapacity = int64(100)
 
 	return json.Marshal(map[string]any{
-		"Capacity":        defaultManagedRuleGroupCapacity,
+		keyCapacity:       defaultManagedRuleGroupCapacity,
 		keyRules:          []any{},
 		"SnsTopicArn":     "",
 		"AvailableLabels": []any{},
@@ -1816,6 +2336,18 @@ func (h *Handler) handleGetRateBasedStatementManagedKeys(body []byte) ([]byte, e
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
+	if req.Scope == "" {
+		return nil, fmt.Errorf("%w: Scope is required", errInvalidRequest)
+	}
+
+	if req.WebACLId == "" {
+		return nil, fmt.Errorf("%w: WebACLId is required", errInvalidRequest)
+	}
+
+	if req.RuleName == "" {
+		return nil, fmt.Errorf("%w: RuleName is required", errInvalidRequest)
+	}
+
 	return json.Marshal(map[string]any{
 		"ManagedKeysIPV4": map[string]any{keyIPAddressVersion: "IPV4", keyAddresses: []any{}},
 		"ManagedKeysIPV6": map[string]any{keyIPAddressVersion: "IPV6", keyAddresses: []any{}},
@@ -1836,6 +2368,14 @@ func (h *Handler) handleGetSampledRequests(body []byte) ([]byte, error) {
 	var req getSampledRequestsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MaxItems < 1 || req.MaxItems > maxSampledRequestsItems {
+		return nil, fmt.Errorf("%w: MaxItems must be between 1 and %d", errInvalidRequest, maxSampledRequestsItems)
+	}
+
+	if req.TimeWindow == nil {
+		return nil, fmt.Errorf("%w: TimeWindow is required", errInvalidRequest)
 	}
 
 	return json.Marshal(map[string]any{
@@ -1872,11 +2412,23 @@ type listAvailableManagedRuleGroupVersionsRequest struct {
 	Limit      int    `json:"Limit"`
 }
 
-// handleListAvailableManagedRuleGroupVersions returns an empty list of versions.
+// handleListAvailableManagedRuleGroupVersions returns versions for managed rule groups that support versioning.
 func (h *Handler) handleListAvailableManagedRuleGroupVersions(body []byte) ([]byte, error) {
 	var req listAvailableManagedRuleGroupVersionsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	// Look for versioning support in catalog.
+	for _, mrg := range getManagedRuleGroups() {
+		if mrg.VendorName == req.VendorName && mrg.Name == req.Name && mrg.VersioningSupported {
+			return json.Marshal(map[string]any{
+				"Versions": []map[string]any{
+					{"Name": "Version_1.0", "LastUpdateTimestamp": nil},
+				},
+				"CurrentDefaultVersion": "Version_1.0",
+			})
+		}
 	}
 
 	return json.Marshal(map[string]any{"Versions": []any{}, "CurrentDefaultVersion": ""})
@@ -1889,19 +2441,40 @@ type listAvailableManagedRuleGroupsRequest struct {
 	Limit      int    `json:"Limit"`
 }
 
-// handleListAvailableManagedRuleGroups returns an empty list of managed rule groups.
+// handleListAvailableManagedRuleGroups returns the catalog of managed rule groups.
 func (h *Handler) handleListAvailableManagedRuleGroups(body []byte) ([]byte, error) {
 	var req listAvailableManagedRuleGroupsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	return json.Marshal(map[string]any{"ManagedRuleGroups": []any{}})
+	groups := make([]map[string]any, 0, len(getManagedRuleGroups()))
+
+	for _, mrg := range getManagedRuleGroups() {
+		groups = append(groups, map[string]any{
+			keyVendorName:         mrg.VendorName,
+			keyName:               mrg.Name,
+			keyDescription:        mrg.Description,
+			"VersioningSupported": mrg.VersioningSupported,
+		})
+	}
+
+	return json.Marshal(map[string]any{"ManagedRuleGroups": groups})
 }
 
 // handleListLoggingConfigurations lists all logging configurations.
 func (h *Handler) handleListLoggingConfigurations(_ []byte) ([]byte, error) {
-	return json.Marshal(map[string]any{"LoggingConfigurations": []any{}})
+	configs := h.Backend.ListLoggingConfigurations()
+	items := make([]any, 0, len(configs))
+
+	for _, cfg := range configs {
+		var v any
+		if err := json.Unmarshal(cfg, &v); err == nil {
+			items = append(items, v)
+		}
+	}
+
+	return json.Marshal(map[string]any{"LoggingConfigurations": items})
 }
 
 // handleListManagedRuleSets lists all managed rule sets.

--- a/services/wafv2/handler.go
+++ b/services/wafv2/handler.go
@@ -412,6 +412,14 @@ func (h *Handler) handleCreateWebACL(ctx context.Context, body []byte) ([]byte, 
 		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
 	}
 
+	if err := validateResourceName(req.Name); err != nil {
+		return nil, err
+	}
+
+	if err := validateDescription(req.Description); err != nil {
+		return nil, err
+	}
+
 	if req.Scope == "" {
 		return nil, fmt.Errorf("%w: Scope is required", errInvalidRequest)
 	}
@@ -757,6 +765,14 @@ func (h *Handler) handleCreateIPSet(ctx context.Context, body []byte) ([]byte, e
 
 	if req.Name == "" {
 		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	if err := validateResourceName(req.Name); err != nil {
+		return nil, err
+	}
+
+	if err := validateDescription(req.Description); err != nil {
+		return nil, err
 	}
 
 	if req.Scope == "" {
@@ -1344,6 +1360,14 @@ func (h *Handler) handleCreateRegexPatternSet(ctx context.Context, body []byte) 
 		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
 	}
 
+	if err := validateResourceName(req.Name); err != nil {
+		return nil, err
+	}
+
+	if err := validateDescription(req.Description); err != nil {
+		return nil, err
+	}
+
 	if req.Scope == "" {
 		return nil, fmt.Errorf("%w: Scope is required", errInvalidRequest)
 	}
@@ -1465,6 +1489,14 @@ func (h *Handler) handleCreateRuleGroup(ctx context.Context, body []byte) ([]byt
 
 	if req.Name == "" {
 		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	if err := validateResourceName(req.Name); err != nil {
+		return nil, err
+	}
+
+	if err := validateDescription(req.Description); err != nil {
+		return nil, err
 	}
 
 	if req.Scope == "" {

--- a/services/wafv2/handler_accuracy_test.go
+++ b/services/wafv2/handler_accuracy_test.go
@@ -15,6 +15,7 @@ import (
 
 // ---- helpers ---------------------------------------------------------------
 
+//nolint:unparam // scope kept for call-site readability; callers may vary it in future
 func createWebACLWithRules(t *testing.T, h *wafv2.Handler, name, scope string) (string, string) {
 	t.Helper()
 

--- a/services/wafv2/handler_accuracy_test.go
+++ b/services/wafv2/handler_accuracy_test.go
@@ -1,0 +1,943 @@
+package wafv2_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/wafv2"
+)
+
+// ---- helpers ---------------------------------------------------------------
+
+func createWebACLWithRules(t *testing.T, h *wafv2.Handler, name, scope string) (string, string) {
+	t.Helper()
+
+	rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          name,
+		"Scope":         scope,
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{
+			"CloudWatchMetricsEnabled": true,
+			"MetricName":               name,
+			"SampledRequestsEnabled":   true,
+		},
+		"Rules": []map[string]any{
+			{
+				"Name":     "rule-1",
+				"Priority": 1,
+				"Statement": map[string]any{
+					"IPSetReferenceStatement": map[string]any{
+						"ARN": "arn:aws:wafv2:us-east-1:000000000000:regional/ipset/test/abc",
+					},
+				},
+				"Action": map[string]any{"Allow": map[string]any{}},
+				"VisibilityConfig": map[string]any{
+					"CloudWatchMetricsEnabled": false,
+					"MetricName":               "rule-1",
+					"SampledRequestsEnabled":   false,
+				},
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "createWebACLWithRules: %s", rec.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	summary := resp["Summary"].(map[string]any)
+
+	return summary["Id"].(string), summary["LockToken"].(string)
+}
+
+func createIPSetHelper2(
+	t *testing.T,
+	h *wafv2.Handler,
+	name, scope, version string,
+	addrs []string,
+) (string, string) {
+	t.Helper()
+
+	body := map[string]any{
+		"Name":             name,
+		"Scope":            scope,
+		"IPAddressVersion": version,
+		"Addresses":        addrs,
+	}
+
+	rec := doWafv2Request(t, h, "CreateIPSet", body)
+	require.Equal(t, http.StatusOK, rec.Code, "createIPSetHelper2: %s", rec.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	summary := resp["Summary"].(map[string]any)
+
+	return summary["Id"].(string), summary["LockToken"].(string)
+}
+
+// ---- Gap 1: WebACL Rules round-trip ----------------------------------------
+
+func TestAccuracy_WebACLRulesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	id, _ := createWebACLWithRules(t, h, "acl-with-rules", "REGIONAL")
+
+	rec := doWafv2Request(t, h, "GetWebACL", map[string]any{
+		"Id":    id,
+		"Name":  "acl-with-rules",
+		"Scope": "REGIONAL",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	webACL := resp["WebACL"].(map[string]any)
+
+	rules, ok := webACL["Rules"].([]any)
+	require.True(t, ok, "Rules should be present in response")
+	require.Len(t, rules, 1, "should have exactly 1 rule")
+
+	rule := rules[0].(map[string]any)
+	assert.Equal(t, "rule-1", rule["Name"])
+	assert.InDelta(t, float64(1), rule["Priority"], 0)
+}
+
+// ---- Gap 2: DefaultAction as raw JSON round-trip ----------------------------
+
+func TestAccuracy_DefaultActionRawJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create with Allow.
+	recAllow := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "acl-allow",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{
+			"MetricName": "acl-allow",
+		},
+	})
+	require.Equal(t, http.StatusOK, recAllow.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(recAllow.Body.Bytes(), &createResp))
+	idAllow := createResp["Summary"].(map[string]any)["Id"].(string)
+
+	recGet := doWafv2Request(t, h, "GetWebACL", map[string]any{"Id": idAllow})
+	require.Equal(t, http.StatusOK, recGet.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(recGet.Body.Bytes(), &getResp))
+	da := getResp["WebACL"].(map[string]any)["DefaultAction"].(map[string]any)
+	_, hasAllow := da["Allow"]
+	assert.True(t, hasAllow, "DefaultAction should contain Allow key")
+
+	// Create with Block.
+	recBlock := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "acl-block",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Block": map[string]any{}},
+		"VisibilityConfig": map[string]any{
+			"MetricName": "acl-block",
+		},
+	})
+	require.Equal(t, http.StatusOK, recBlock.Code)
+
+	var createRespBlock map[string]any
+	require.NoError(t, json.Unmarshal(recBlock.Body.Bytes(), &createRespBlock))
+	idBlock := createRespBlock["Summary"].(map[string]any)["Id"].(string)
+
+	recGetBlock := doWafv2Request(t, h, "GetWebACL", map[string]any{"Id": idBlock})
+	require.Equal(t, http.StatusOK, recGetBlock.Code)
+
+	var getRespBlock map[string]any
+	require.NoError(t, json.Unmarshal(recGetBlock.Body.Bytes(), &getRespBlock))
+	daBlock := getRespBlock["WebACL"].(map[string]any)["DefaultAction"].(map[string]any)
+	_, hasBlock := daBlock["Block"]
+	assert.True(t, hasBlock, "DefaultAction should contain Block key")
+
+	// Both Allow AND Block together should be rejected.
+	recBoth := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":  "acl-both",
+		"Scope": "REGIONAL",
+		"DefaultAction": map[string]any{
+			"Allow": map[string]any{},
+			"Block": map[string]any{},
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, recBoth.Code)
+}
+
+// ---- Gap 3: LockToken enforcement -------------------------------------------
+
+func TestAccuracy_LockTokenEnforcement(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	id, realToken := createWebACLWithRules(t, h, "acl-lock", "REGIONAL")
+
+	// Update with wrong lock token should fail.
+	recBad := doWafv2Request(t, h, "UpdateWebACL", map[string]any{
+		"Id":          id,
+		"LockToken":   "wrong-token",
+		"Description": "should fail",
+	})
+	assert.Equal(t, http.StatusBadRequest, recBad.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(recBad.Body.Bytes(), &errResp))
+	assert.Equal(t, "WAFOptimisticLockException", errResp["__type"])
+
+	// Update with correct lock token should succeed.
+	recGood := doWafv2Request(t, h, "UpdateWebACL", map[string]any{
+		"Id":          id,
+		"LockToken":   realToken,
+		"Description": "updated successfully",
+	})
+	assert.Equal(t, http.StatusOK, recGood.Code)
+}
+
+// ---- Gap 4: Managed rule group catalog --------------------------------------
+
+func TestAccuracy_ListAvailableManagedRuleGroups_ReturnsCatalog(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doWafv2Request(t, h, "ListAvailableManagedRuleGroups", map[string]any{
+		"Scope": "REGIONAL",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	groups, ok := resp["ManagedRuleGroups"].([]any)
+	require.True(t, ok)
+	assert.Greater(t, len(groups), 5, "should return more than 5 managed rule groups from catalog")
+
+	// Verify a known catalog entry is present.
+	found := false
+
+	for _, g := range groups {
+		gm := g.(map[string]any)
+		if gm["Name"] == "AWSManagedRulesCommonRuleSet" {
+			found = true
+			assert.Equal(t, "AWS", gm["VendorName"])
+		}
+	}
+
+	assert.True(t, found, "AWSManagedRulesCommonRuleSet should be in catalog")
+}
+
+// ---- Gap 4: DescribeManagedRuleGroup returns catalog data ------------------
+
+func TestAccuracy_DescribeManagedRuleGroup_ReturnsCatalogData(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doWafv2Request(t, h, "DescribeManagedRuleGroup", map[string]any{
+		"Scope":      "REGIONAL",
+		"VendorName": "AWS",
+		"Name":       "AWSManagedRulesCommonRuleSet",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	capacity, _ := resp["Capacity"].(float64)
+	assert.InDelta(t, float64(700), capacity, 0, "AWSManagedRulesCommonRuleSet should have capacity 700")
+}
+
+// ---- Gap 6: VisibilityConfig MetricName required ---------------------------
+
+func TestAccuracy_VisibilityConfigMissingMetricName(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "acl-no-metric",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{
+			"CloudWatchMetricsEnabled": true,
+			"MetricName":               "", // missing
+			"SampledRequestsEnabled":   false,
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "WAFInvalidParameterException", resp["__type"])
+}
+
+// ---- Gap 7: RuleGroup Capacity enforcement ----------------------------------
+
+func TestAccuracy_RuleGroupCapacityValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Capacity too low.
+	recLow := doWafv2Request(t, h, "CreateRuleGroup", map[string]any{
+		"Name":     "rg-low",
+		"Scope":    "REGIONAL",
+		"Capacity": 0,
+	})
+	assert.Equal(t, http.StatusBadRequest, recLow.Code)
+
+	// Capacity too high.
+	recHigh := doWafv2Request(t, h, "CreateRuleGroup", map[string]any{
+		"Name":     "rg-high",
+		"Scope":    "REGIONAL",
+		"Capacity": 1501,
+	})
+	assert.Equal(t, http.StatusBadRequest, recHigh.Code)
+
+	// Valid capacity.
+	recValid := doWafv2Request(t, h, "CreateRuleGroup", map[string]any{
+		"Name":     "rg-valid",
+		"Scope":    "REGIONAL",
+		"Capacity": 100,
+	})
+	assert.Equal(t, http.StatusOK, recValid.Code)
+}
+
+// ---- Gap 9: IPSet CIDR validation ------------------------------------------
+
+func TestAccuracy_IPSetCIDRValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Invalid CIDR.
+	recBad := doWafv2Request(t, h, "CreateIPSet", map[string]any{
+		"Name":             "bad-cidrs",
+		"Scope":            "REGIONAL",
+		"IPAddressVersion": "IPV4",
+		"Addresses":        []string{"not-a-cidr"},
+	})
+	assert.Equal(t, http.StatusBadRequest, recBad.Code)
+
+	// IPv4 CIDR in IPv6 set.
+	recMix := doWafv2Request(t, h, "CreateIPSet", map[string]any{
+		"Name":             "ipv4-in-ipv6",
+		"Scope":            "REGIONAL",
+		"IPAddressVersion": "IPV6",
+		"Addresses":        []string{"1.2.3.4/32"},
+	})
+	assert.Equal(t, http.StatusBadRequest, recMix.Code)
+
+	// Valid IPv4.
+	recOK := doWafv2Request(t, h, "CreateIPSet", map[string]any{
+		"Name":             "valid-v4",
+		"Scope":            "REGIONAL",
+		"IPAddressVersion": "IPV4",
+		"Addresses":        []string{"10.0.0.0/8", "192.168.1.0/24"},
+	})
+	assert.Equal(t, http.StatusOK, recOK.Code)
+
+	// Valid IPv6.
+	recV6 := doWafv2Request(t, h, "CreateIPSet", map[string]any{
+		"Name":             "valid-v6",
+		"Scope":            "REGIONAL",
+		"IPAddressVersion": "IPV6",
+		"Addresses":        []string{"2001:db8::/32"},
+	})
+	assert.Equal(t, http.StatusOK, recV6.Code)
+}
+
+// ---- Gap 10/11: RegexPatternSet object shape --------------------------------
+
+func TestAccuracy_RegexPatternSetObjectShape(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// AWS object form: [{"RegexString": "..."}]
+	recObj := doWafv2Request(t, h, "CreateRegexPatternSet", map[string]any{
+		"Name":  "regex-obj",
+		"Scope": "REGIONAL",
+		"RegularExpressionList": []map[string]any{
+			{"RegexString": "^foo"},
+			{"RegexString": "bar$"},
+		},
+	})
+	require.Equal(t, http.StatusOK, recObj.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(recObj.Body.Bytes(), &createResp))
+	id := createResp["Summary"].(map[string]any)["Id"].(string)
+
+	// Get and verify the entries are returned as objects.
+	recGet := doWafv2Request(t, h, "GetRegexPatternSet", map[string]any{"Id": id})
+	require.Equal(t, http.StatusOK, recGet.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(recGet.Body.Bytes(), &getResp))
+
+	rps := getResp["RegexPatternSet"].(map[string]any)
+	entries, ok := rps["RegularExpressionList"].([]any)
+	require.True(t, ok)
+	require.Len(t, entries, 2)
+
+	entry := entries[0].(map[string]any)
+	assert.Contains(t, entry, "RegexString")
+
+	// Invalid regex should be rejected.
+	recBadRegex := doWafv2Request(t, h, "CreateRegexPatternSet", map[string]any{
+		"Name":  "bad-regex",
+		"Scope": "REGIONAL",
+		"RegularExpressionList": []map[string]any{
+			{"RegexString": "[invalid"},
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, recBadRegex.Code)
+}
+
+// ---- Gap 12: Full LoggingConfiguration round-trip --------------------------
+
+func TestAccuracy_LoggingConfigurationFullRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create a WebACL to get a real ARN.
+	createRec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":             "log-acl",
+		"Scope":            "REGIONAL",
+		"DefaultAction":    map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{"MetricName": "log-acl"},
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	webACLARN := createResp["Summary"].(map[string]any)["ARN"].(string)
+
+	// Put a full logging configuration.
+	loggingConfig := map[string]any{
+		"ResourceArn":           webACLARN,
+		"LogDestinationConfigs": []string{"arn:aws:firehose:us-east-1:000000000000:deliverystream/my-stream"},
+		"RedactedFields":        []any{},
+	}
+	putRec := doWafv2Request(t, h, "PutLoggingConfiguration", map[string]any{
+		"LoggingConfiguration": loggingConfig,
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	// Verify the full config is round-tripped in Get.
+	getRec := doWafv2Request(t, h, "GetLoggingConfiguration", map[string]any{
+		"ResourceArn": webACLARN,
+	})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+
+	cfg, ok := getResp["LoggingConfiguration"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, webACLARN, cfg["ResourceArn"])
+
+	dests, ok := cfg["LogDestinationConfigs"].([]any)
+	require.True(t, ok)
+	require.Len(t, dests, 1)
+
+	// Verify ListLoggingConfigurations returns entries.
+	listRec := doWafv2Request(t, h, "ListLoggingConfigurations", map[string]any{})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	configs, ok := listResp["LoggingConfigurations"].([]any)
+	require.True(t, ok)
+	assert.Len(t, configs, 1)
+}
+
+// ---- Gap 14: GetWebACLForResource returns Rules ----------------------------
+
+func TestAccuracy_GetWebACLForResourceReturnsRules(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	id, _ := createWebACLWithRules(t, h, "acl-for-resource", "REGIONAL")
+
+	// Get the ARN.
+	getRec := doWafv2Request(t, h, "GetWebACL", map[string]any{"Id": id})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getRespW map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getRespW))
+	webACLARN := getRespW["WebACL"].(map[string]any)["ARN"].(string)
+
+	// Associate with a resource.
+	resourceARN := "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
+	assocRec := doWafv2Request(t, h, "AssociateWebACL", map[string]any{
+		"WebACLArn":   webACLARN,
+		"ResourceArn": resourceARN,
+	})
+	require.Equal(t, http.StatusOK, assocRec.Code)
+
+	// GetWebACLForResource should return the full WebACL including Rules.
+	forResourceRec := doWafv2Request(t, h, "GetWebACLForResource", map[string]any{
+		"ResourceArn": resourceARN,
+	})
+	require.Equal(t, http.StatusOK, forResourceRec.Code)
+
+	var forResourceResp map[string]any
+	require.NoError(t, json.Unmarshal(forResourceRec.Body.Bytes(), &forResourceResp))
+
+	webACL := forResourceResp["WebACL"].(map[string]any)
+	rules, ok := webACL["Rules"].([]any)
+	require.True(t, ok, "Rules should be present")
+	assert.Len(t, rules, 1, "should return 1 rule")
+}
+
+// ---- Gap 19: DeleteRuleGroup referenced by WebACL -------------------------
+
+func TestAccuracy_DeleteRuleGroupReferencedByWebACL(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create a RuleGroup.
+	rgRec := doWafv2Request(t, h, "CreateRuleGroup", map[string]any{
+		"Name":     "my-rg",
+		"Scope":    "REGIONAL",
+		"Capacity": 10,
+	})
+	require.Equal(t, http.StatusOK, rgRec.Code)
+
+	var rgResp map[string]any
+	require.NoError(t, json.Unmarshal(rgRec.Body.Bytes(), &rgResp))
+	summary := rgResp["Summary"].(map[string]any)
+	rgID := summary["Id"].(string)
+	rgARN := summary["ARN"].(string)
+	rgLockToken := summary["LockToken"].(string)
+
+	// Create a WebACL that references the RuleGroup.
+	aclRec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":             "acl-with-rg",
+		"Scope":            "REGIONAL",
+		"DefaultAction":    map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{"MetricName": "acl-with-rg"},
+		"Rules": []map[string]any{
+			{
+				"Name":     "use-rule-group",
+				"Priority": 1,
+				"Statement": map[string]any{
+					"RuleGroupReferenceStatement": map[string]any{
+						"ARN": rgARN,
+					},
+				},
+				"OverrideAction":   map[string]any{"None": map[string]any{}},
+				"VisibilityConfig": map[string]any{"MetricName": "use-rule-group"},
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, aclRec.Code)
+
+	// Try to delete the RuleGroup — should fail with WAFAssociatedItemException.
+	delRec := doWafv2Request(t, h, "DeleteRuleGroup", map[string]any{
+		"Id":        rgID,
+		"LockToken": rgLockToken,
+	})
+	assert.Equal(t, http.StatusBadRequest, delRec.Code)
+
+	var delResp map[string]any
+	require.NoError(t, json.Unmarshal(delRec.Body.Bytes(), &delResp))
+	assert.Equal(t, "WAFAssociatedItemException", delResp["__type"])
+}
+
+// ---- Gap 20: Tag validation ------------------------------------------------
+
+func TestAccuracy_TagValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create a WebACL to tag.
+	createRec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":             "tag-test-acl",
+		"Scope":            "REGIONAL",
+		"DefaultAction":    map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{"MetricName": "tag-test-acl"},
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	arnStr := createResp["Summary"].(map[string]any)["ARN"].(string)
+
+	// More than 50 tags should fail.
+	tags := make([]map[string]string, 51)
+	for i := range tags {
+		tags[i] = map[string]string{"Key": fmt.Sprintf("key%d", i), "Value": "v"}
+	}
+
+	tooManyRec := doWafv2Request(t, h, "TagResource", map[string]any{
+		"ResourceARN": arnStr,
+		"Tags":        tags,
+	})
+	assert.Equal(t, http.StatusBadRequest, tooManyRec.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(tooManyRec.Body.Bytes(), &errResp))
+	assert.Equal(t, "WAFTagOperationException", errResp["__type"])
+
+	// Reserved prefix "aws:" should fail.
+	reservedRec := doWafv2Request(t, h, "TagResource", map[string]any{
+		"ResourceARN": arnStr,
+		"Tags":        []map[string]string{{"Key": "aws:reserved", "Value": "v"}},
+	})
+	assert.Equal(t, http.StatusBadRequest, reservedRec.Code)
+
+	var reservedErr map[string]any
+	require.NoError(t, json.Unmarshal(reservedRec.Body.Bytes(), &reservedErr))
+	assert.Equal(t, "WAFTagOperationException", reservedErr["__type"])
+}
+
+// ---- Gap 21: List pagination -----------------------------------------------
+
+func TestAccuracy_ListPagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create 5 WebACLs (names are alphabetically ordered).
+	for i := range 5 {
+		rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+			"Name":          fmt.Sprintf("acl-%02d", i),
+			"Scope":         "REGIONAL",
+			"DefaultAction": map[string]any{"Allow": map[string]any{}},
+			"VisibilityConfig": map[string]any{
+				"MetricName": fmt.Sprintf("acl-%02d", i),
+			},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// List with limit 3 — should get first page + NextMarker.
+	page1Rec := doWafv2Request(t, h, "ListWebACLs", map[string]any{
+		"Scope": "REGIONAL",
+		"Limit": 3,
+	})
+	require.Equal(t, http.StatusOK, page1Rec.Code)
+
+	var page1Resp map[string]any
+	require.NoError(t, json.Unmarshal(page1Rec.Body.Bytes(), &page1Resp))
+
+	acls1, ok := page1Resp["WebACLs"].([]any)
+	require.True(t, ok)
+	assert.Len(t, acls1, 3, "first page should have 3 items")
+
+	nextMarker, ok := page1Resp["NextMarker"].(string)
+	require.True(t, ok, "NextMarker should be present after first page")
+	assert.NotEmpty(t, nextMarker)
+
+	// Decode and verify it's base64.
+	decoded, err := base64.StdEncoding.DecodeString(nextMarker)
+	require.NoError(t, err)
+	assert.NotEmpty(t, string(decoded))
+
+	// Fetch second page.
+	page2Rec := doWafv2Request(t, h, "ListWebACLs", map[string]any{
+		"Scope":      "REGIONAL",
+		"Limit":      3,
+		"NextMarker": nextMarker,
+	})
+	require.Equal(t, http.StatusOK, page2Rec.Code)
+
+	var page2Resp map[string]any
+	require.NoError(t, json.Unmarshal(page2Rec.Body.Bytes(), &page2Resp))
+
+	acls2, ok := page2Resp["WebACLs"].([]any)
+	require.True(t, ok)
+	assert.Len(t, acls2, 2, "second page should have 2 items")
+
+	_, hasNextMarker := page2Resp["NextMarker"]
+	assert.False(t, hasNextMarker, "second page should not have NextMarker")
+}
+
+// ---- Gap 22: Scope validation on Get/Update/Delete -------------------------
+
+func TestAccuracy_ScopeValidationOnGet(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create a REGIONAL WebACL.
+	createRec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":             "scope-test",
+		"Scope":            "REGIONAL",
+		"DefaultAction":    map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{"MetricName": "scope-test"},
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	id := createResp["Summary"].(map[string]any)["Id"].(string)
+
+	// Get with wrong scope should fail.
+	getRec := doWafv2Request(t, h, "GetWebACL", map[string]any{
+		"Id":    id,
+		"Scope": "CLOUDFRONT",
+	})
+	assert.Equal(t, http.StatusBadRequest, getRec.Code)
+
+	// Get with correct scope should succeed.
+	getRec2 := doWafv2Request(t, h, "GetWebACL", map[string]any{
+		"Id":    id,
+		"Scope": "REGIONAL",
+	})
+	assert.Equal(t, http.StatusOK, getRec2.Code)
+}
+
+// ---- Gap 23: APIKey base64 encoding ----------------------------------------
+
+func TestAccuracy_APIKeyBase64Encoding(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doWafv2Request(t, h, "CreateAPIKey", map[string]any{
+		"Scope":        "REGIONAL",
+		"TokenDomains": []string{"example.com"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	apiKey, ok := resp["APIKey"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, apiKey)
+
+	// The returned key should be base64-encoded.
+	decoded, err := base64.StdEncoding.DecodeString(apiKey)
+	require.NoError(t, err, "APIKey should be base64-encoded")
+	assert.NotEmpty(t, string(decoded))
+
+	// Validate TokenDomains limit (1–5).
+	recTooMany := doWafv2Request(t, h, "CreateAPIKey", map[string]any{
+		"Scope":        "REGIONAL",
+		"TokenDomains": []string{"a.com", "b.com", "c.com", "d.com", "e.com", "f.com"},
+	})
+	assert.Equal(t, http.StatusBadRequest, recTooMany.Code)
+
+	// Validate TokenDomains minimum.
+	recNone := doWafv2Request(t, h, "CreateAPIKey", map[string]any{
+		"Scope":        "REGIONAL",
+		"TokenDomains": []string{},
+	})
+	assert.Equal(t, http.StatusBadRequest, recNone.Code)
+}
+
+// ---- Gap 24: Error header x-amzn-errortype ---------------------------------
+
+func TestAccuracy_ErrorHeaderXAmznErrortype(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Trigger a not-found error.
+	rec := doWafv2Request(t, h, "GetWebACL", map[string]any{"Id": "nonexistent"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "WAFNonexistentItemException", rec.Header().Get("X-Amzn-Errortype"))
+
+	// Trigger an invalid-parameter error.
+	rec2 := doWafv2Request(t, h, "CreateWebACL", map[string]any{})
+	assert.Equal(t, http.StatusBadRequest, rec2.Code)
+	assert.Equal(t, "WAFInvalidParameterException", rec2.Header().Get("X-Amzn-Errortype"))
+}
+
+// ---- Gap 15: GetSampledRequests validation ----------------------------------
+
+func TestAccuracy_GetSampledRequestsValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// MaxItems 0 — invalid.
+	recZero := doWafv2Request(t, h, "GetSampledRequests", map[string]any{
+		"WebAclArn":      "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/test/abc",
+		"RuleMetricName": "my-rule",
+		"Scope":          "REGIONAL",
+		"MaxItems":       0,
+		"TimeWindow": map[string]any{
+			"StartTime": 1000,
+			"EndTime":   2000,
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, recZero.Code)
+
+	// MaxItems 501 — invalid.
+	recHigh := doWafv2Request(t, h, "GetSampledRequests", map[string]any{
+		"WebAclArn":      "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/test/abc",
+		"RuleMetricName": "my-rule",
+		"Scope":          "REGIONAL",
+		"MaxItems":       501,
+		"TimeWindow": map[string]any{
+			"StartTime": 1000,
+			"EndTime":   2000,
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, recHigh.Code)
+
+	// MaxItems 100 — valid.
+	recOK := doWafv2Request(t, h, "GetSampledRequests", map[string]any{
+		"WebAclArn":      "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/test/abc",
+		"RuleMetricName": "my-rule",
+		"Scope":          "REGIONAL",
+		"MaxItems":       100,
+		"TimeWindow": map[string]any{
+			"StartTime": 1000,
+			"EndTime":   2000,
+		},
+	})
+	assert.Equal(t, http.StatusOK, recOK.Code)
+}
+
+// ---- Gap 5: Extended WebACL fields -----------------------------------------
+
+func TestAccuracy_WebACLExtendedFields(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":             "extended-acl",
+		"Scope":            "REGIONAL",
+		"DefaultAction":    map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{"MetricName": "extended-acl"},
+		"TokenDomains":     []string{"example.com", "api.example.com"},
+		"CaptchaConfig": map[string]any{
+			"ImmunityTimeProperty": map[string]any{"ImmunityTime": 300},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createResp))
+	id := createResp["Summary"].(map[string]any)["Id"].(string)
+
+	getRec := doWafv2Request(t, h, "GetWebACL", map[string]any{"Id": id})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+	webACL := getResp["WebACL"].(map[string]any)
+
+	// TokenDomains should be round-tripped.
+	domains, ok := webACL["TokenDomains"].([]any)
+	require.True(t, ok, "TokenDomains should be in response")
+	assert.Len(t, domains, 2)
+
+	// CaptchaConfig should be round-tripped.
+	cc, ok := webACL["CaptchaConfig"].(map[string]any)
+	require.True(t, ok, "CaptchaConfig should be in response")
+	assert.Contains(t, cc, "ImmunityTimeProperty")
+}
+
+// ---- IPSet pagination -------------------------------------------------------
+
+func TestAccuracy_IPSetListPagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	for i := range 5 {
+		rec := doWafv2Request(t, h, "CreateIPSet", map[string]any{
+			"Name":             fmt.Sprintf("ipset-%02d", i),
+			"Scope":            "REGIONAL",
+			"IPAddressVersion": "IPV4",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	page1Rec := doWafv2Request(t, h, "ListIPSets", map[string]any{
+		"Scope": "REGIONAL",
+		"Limit": 2,
+	})
+	require.Equal(t, http.StatusOK, page1Rec.Code)
+
+	var page1Resp map[string]any
+	require.NoError(t, json.Unmarshal(page1Rec.Body.Bytes(), &page1Resp))
+
+	sets, _ := page1Resp["IPSets"].([]any)
+	assert.Len(t, sets, 2)
+
+	nextMarker, _ := page1Resp["NextMarker"].(string)
+	assert.NotEmpty(t, nextMarker)
+}
+
+// ---- RuleGroup scope validation --------------------------------------------
+
+func TestAccuracy_RuleGroupScopeValidationOnGet(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	createRec := doWafv2Request(t, h, "CreateRuleGroup", map[string]any{
+		"Name":     "rg-scope",
+		"Scope":    "REGIONAL",
+		"Capacity": 10,
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	id := createResp["Summary"].(map[string]any)["Id"].(string)
+
+	// Get with wrong scope should fail.
+	getRec := doWafv2Request(t, h, "GetRuleGroup", map[string]any{
+		"Id":    id,
+		"Scope": "CLOUDFRONT",
+	})
+	assert.Equal(t, http.StatusBadRequest, getRec.Code)
+
+	// Get with correct scope should succeed.
+	getRec2 := doWafv2Request(t, h, "GetRuleGroup", map[string]any{
+		"Id":    id,
+		"Scope": "REGIONAL",
+	})
+	assert.Equal(t, http.StatusOK, getRec2.Code)
+}
+
+// ---- IPSet update CIDR validation ------------------------------------------
+
+func TestAccuracy_IPSetUpdateCIDRValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	id, _ := createIPSetHelper2(t, h, "update-set", "REGIONAL", "IPV4", nil)
+
+	// Update with invalid CIDR.
+	recBad := doWafv2Request(t, h, "UpdateIPSet", map[string]any{
+		"Id":        id,
+		"Addresses": []string{"not-valid"},
+	})
+	assert.Equal(t, http.StatusBadRequest, recBad.Code)
+
+	// Update with wrong IP version.
+	recMix := doWafv2Request(t, h, "UpdateIPSet", map[string]any{
+		"Id":        id,
+		"Addresses": []string{"2001:db8::/32"}, // IPv6 in IPv4 set
+	})
+	assert.Equal(t, http.StatusBadRequest, recMix.Code)
+
+	// Update with valid CIDR.
+	recOK := doWafv2Request(t, h, "UpdateIPSet", map[string]any{
+		"Id":        id,
+		"Addresses": []string{"10.0.0.0/8"},
+	})
+	assert.Equal(t, http.StatusOK, recOK.Code)
+}

--- a/services/wafv2/handler_refinement2_test.go
+++ b/services/wafv2/handler_refinement2_test.go
@@ -1,0 +1,566 @@
+package wafv2_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/wafv2"
+)
+
+// ---- Name pattern validation -------------------------------------------------
+
+func TestValidation_ResourceNamePattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		aclName    string
+		wantStatus int
+	}{
+		{name: "valid_simple", aclName: "my-acl", wantStatus: http.StatusOK},
+		{name: "valid_with_underscores", aclName: "My_ACL_01", wantStatus: http.StatusOK},
+		{name: "valid_alphanumeric", aclName: "MyACL123", wantStatus: http.StatusOK},
+		{name: "invalid_starts_with_dash", aclName: "-invalid", wantStatus: http.StatusBadRequest},
+		{name: "invalid_has_space", aclName: "my acl", wantStatus: http.StatusBadRequest},
+		{name: "invalid_has_dot", aclName: "my.acl", wantStatus: http.StatusBadRequest},
+		{name: "invalid_has_slash", aclName: "my/acl", wantStatus: http.StatusBadRequest},
+		{name: "invalid_starts_with_underscore", aclName: "_myacl", wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+				"Name":          tt.aclName,
+				"Scope":         "REGIONAL",
+				"DefaultAction": map[string]any{"Allow": map[string]any{}},
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code, "aclName=%q body=%s", tt.aclName, rec.Body.String())
+		})
+	}
+}
+
+// ---- Description max-length validation ---------------------------------------
+
+func TestValidation_DescriptionMaxLength(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Exactly 256 characters — should succeed.
+	desc256 := strings.Repeat("a", 256)
+	rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "acl-desc-ok",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"Description":   desc256,
+	})
+	assert.Equal(t, http.StatusOK, rec.Code, "256-char description should be accepted: %s", rec.Body.String())
+
+	// 257 characters — should fail.
+	desc257 := strings.Repeat("a", 257)
+	rec = doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "acl-desc-too-long",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"Description":   desc257,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "257-char description should be rejected: %s", rec.Body.String())
+}
+
+// ---- Rule Name uniqueness enforcement ----------------------------------------
+
+func TestValidation_RuleNameUniqueness(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	dupRules := []map[string]any{
+		{
+			"Name":     "dupe-rule",
+			"Priority": 1,
+			"Statement": map[string]any{
+				"IPSetReferenceStatement": map[string]any{
+					"ARN": "arn:aws:wafv2:us-east-1:000000000000:regional/ipset/x/abc",
+				},
+			},
+			"Action": map[string]any{"Allow": map[string]any{}},
+			"VisibilityConfig": map[string]any{
+				"MetricName":               "dupe-rule",
+				"SampledRequestsEnabled":   false,
+				"CloudWatchMetricsEnabled": false,
+			},
+		},
+		{
+			"Name":     "dupe-rule", // same name → should fail
+			"Priority": 2,
+			"Statement": map[string]any{
+				"IPSetReferenceStatement": map[string]any{
+					"ARN": "arn:aws:wafv2:us-east-1:000000000000:regional/ipset/x/abc",
+				},
+			},
+			"Action": map[string]any{"Block": map[string]any{}},
+			"VisibilityConfig": map[string]any{
+				"MetricName":               "dupe-rule",
+				"SampledRequestsEnabled":   false,
+				"CloudWatchMetricsEnabled": false,
+			},
+		},
+	}
+
+	rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "acl-dup-rule-name",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"Rules":         dupRules,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "duplicate rule names should be rejected")
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "WAFInvalidParameterException", errResp["__type"])
+}
+
+// ---- Rule Priority range enforcement ----------------------------------------
+
+func TestValidation_RulePriorityRange(t *testing.T) {
+	t.Parallel()
+
+	makeRule := func(name string, priority int) map[string]any {
+		return map[string]any{
+			"Name":     name,
+			"Priority": priority,
+			"Statement": map[string]any{
+				"IPSetReferenceStatement": map[string]any{
+					"ARN": "arn:aws:wafv2:us-east-1:000000000000:regional/ipset/x/abc",
+				},
+			},
+			"Action": map[string]any{"Allow": map[string]any{}},
+			"VisibilityConfig": map[string]any{
+				"MetricName":               name,
+				"SampledRequestsEnabled":   false,
+				"CloudWatchMetricsEnabled": false,
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		priority   int
+		wantStatus int
+	}{
+		{name: "priority_0", priority: 0, wantStatus: http.StatusOK},
+		{name: "priority_1000", priority: 1000, wantStatus: http.StatusOK},
+		{name: "priority_1001", priority: 1001, wantStatus: http.StatusBadRequest},
+		{name: "priority_negative", priority: -1, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+				"Name":          "acl-priority-" + tt.name,
+				"Scope":         "REGIONAL",
+				"DefaultAction": map[string]any{"Allow": map[string]any{}},
+				"Rules":         []map[string]any{makeRule("r", tt.priority)},
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code, "priority=%d body=%s", tt.priority, rec.Body.String())
+		})
+	}
+}
+
+// ---- Scope mismatch on GetWebACL / GetIPSet ----------------------------------
+
+func TestValidation_ScopeMismatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WebACL_regional_get_with_cloudfront_scope", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		// Create a REGIONAL WebACL, then attempt to retrieve it as CLOUDFRONT.
+		id, _ := createWebACLHelper(t, h, "regional-acl", "REGIONAL")
+
+		rec := doWafv2Request(t, h, "GetWebACL", map[string]any{
+			"Id":    id,
+			"Scope": "CLOUDFRONT",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "scope mismatch should return 400")
+
+		var errResp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+		assert.Equal(t, "WAFNonexistentItemException", errResp["__type"])
+	})
+
+	t.Run("WebACL_cloudfront_scope_create_and_get", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		// Create a CLOUDFRONT WebACL — uses the scope param with a non-REGIONAL value.
+		id, _ := createWebACLHelper(t, h, "cf-acl", "CLOUDFRONT")
+		require.NotEmpty(t, id)
+
+		// Retrieve with matching scope — should succeed.
+		rec := doWafv2Request(t, h, "GetWebACL", map[string]any{
+			"Id":    id,
+			"Scope": "CLOUDFRONT",
+		})
+		assert.Equal(t, http.StatusOK, rec.Code, "CLOUDFRONT WebACL should be retrievable with CLOUDFRONT scope")
+
+		// Retrieve with wrong scope — should fail.
+		rec = doWafv2Request(t, h, "GetWebACL", map[string]any{
+			"Id":    id,
+			"Scope": "REGIONAL",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "CLOUDFRONT WebACL with REGIONAL scope should fail")
+	})
+
+	t.Run("IPSet_scope_mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		id, _ := createIPSetHelper2(t, h, "my-ipset", "REGIONAL", "IPV4", nil)
+
+		rec := doWafv2Request(t, h, "GetIPSet", map[string]any{
+			"Id":    id,
+			"Scope": "CLOUDFRONT",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "scope mismatch should return 400")
+	})
+}
+
+// ---- DisassociateWebACL idempotency -----------------------------------------
+
+func TestDisassociateWebACL_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Call DisassociateWebACL on a resource that was never associated.
+	// AWS returns success (no-op).
+	rec := doWafv2Request(t, h, "DisassociateWebACL", map[string]any{
+		"ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/test/abc",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code, "DisassociateWebACL should be idempotent: %s", rec.Body.String())
+
+	// Call again to confirm repeated calls also succeed.
+	rec = doWafv2Request(t, h, "DisassociateWebACL", map[string]any{
+		"ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/test/abc",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---- DisassociateWebACL removes the association ------------------------------
+
+func TestDisassociateWebACL_RemovesAssociation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create a WebACL and associate it with a resource.
+	_, webACLARN := createWebACLHelper(t, h, "assoc-acl", "REGIONAL")
+	resourceARN := "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
+
+	rec := doWafv2Request(t, h, "AssociateWebACL", map[string]any{
+		"WebACLArn":   webACLARN,
+		"ResourceArn": resourceARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify association exists.
+	rec = doWafv2Request(t, h, "GetWebACLForResource", map[string]any{"ResourceArn": resourceARN})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Disassociate.
+	rec = doWafv2Request(t, h, "DisassociateWebACL", map[string]any{"ResourceArn": resourceARN})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Now GetWebACLForResource should return not found.
+	rec = doWafv2Request(t, h, "GetWebACLForResource", map[string]any{"ResourceArn": resourceARN})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "after disassociation, resource should have no WebACL")
+}
+
+// ---- DeleteWebACL fails when associated to a resource ------------------------
+
+func TestDeleteWebACL_FailsWhenAssociated(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	id, webACLARN := createWebACLHelper(t, h, "protected-acl", "REGIONAL")
+	resourceARN := "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
+
+	rec := doWafv2Request(t, h, "AssociateWebACL", map[string]any{
+		"WebACLArn":   webACLARN,
+		"ResourceArn": resourceARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Attempt delete while associated — should fail with WAFAssociatedItemException.
+	rec = doWafv2Request(t, h, "DeleteWebACL", map[string]any{
+		"Id":    id,
+		"Scope": "REGIONAL",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "WAFAssociatedItemException", errResp["__type"])
+
+	// After disassociation, delete should succeed.
+	rec = doWafv2Request(t, h, "DisassociateWebACL", map[string]any{"ResourceArn": resourceARN})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doWafv2Request(t, h, "DeleteWebACL", map[string]any{
+		"Id":    id,
+		"Scope": "REGIONAL",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code, "delete after disassociation should succeed: %s", rec.Body.String())
+}
+
+// ---- UpdateIPSet with empty addresses (clear) --------------------------------
+
+func TestUpdateIPSet_ClearAddresses(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	id, lockToken := createIPSetHelper2(t, h, "my-ipset", "REGIONAL", "IPV4", []string{"10.0.0.0/8"})
+
+	// Update with empty addresses list should clear addresses (not be ignored).
+	rec := doWafv2Request(t, h, "UpdateIPSet", map[string]any{
+		"Id":        id,
+		"LockToken": lockToken,
+		"Addresses": []string{},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "UpdateIPSet with empty addresses: %s", rec.Body.String())
+
+	var updateResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &updateResp))
+	newLockToken := updateResp["NextLockToken"].(string)
+
+	// Verify addresses were cleared.
+	rec = doWafv2Request(t, h, "GetIPSet", map[string]any{"Id": id, "Scope": "REGIONAL"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &getResp))
+	ipSet := getResp["IPSet"].(map[string]any)
+	addresses, _ := ipSet["Addresses"].([]any)
+	assert.Empty(t, addresses, "addresses should be empty after clearing")
+
+	_ = newLockToken
+}
+
+// ---- AssociateWebACL is idempotent (second call replaces) --------------------
+
+func TestAssociateWebACL_ReplaceExisting(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	_, aclARN1 := createWebACLHelper(t, h, "acl-one", "REGIONAL")
+	_, aclARN2 := createWebACLHelper(t, h, "acl-two", "REGIONAL")
+	resourceARN := "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
+
+	// Associate first ACL.
+	rec := doWafv2Request(t, h, "AssociateWebACL", map[string]any{
+		"WebACLArn":   aclARN1,
+		"ResourceArn": resourceARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Associate second ACL — should replace, not duplicate.
+	rec = doWafv2Request(t, h, "AssociateWebACL", map[string]any{
+		"WebACLArn":   aclARN2,
+		"ResourceArn": resourceARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Only one association should remain, pointing to acl-two.
+	rec = doWafv2Request(t, h, "GetWebACLForResource", map[string]any{"ResourceArn": resourceARN})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	webACL := resp["WebACL"].(map[string]any)
+	assert.Equal(t, "acl-two", webACL["Name"])
+}
+
+// ---- CLOUDFRONT scope ARN uses empty region ---------------------------------
+
+func TestARN_CloudFrontScopeHasEmptyRegion(t *testing.T) {
+	t.Parallel()
+
+	b := wafv2.NewInMemoryBackend("123456789012", "us-east-1")
+
+	// CLOUDFRONT ARN should NOT contain the region in the ARN.
+	arnStr := b.WebACLARN("my-acl", "abc123", "CLOUDFRONT")
+	assert.Contains(t, arnStr, "global/webacl/my-acl/abc123", "CLOUDFRONT ARN resource path")
+	// Region segment should be empty: arn:aws:wafv2::123456789012:global/...
+	assert.NotContains(t, arnStr, "us-east-1", "CLOUDFRONT ARN must not include region")
+
+	// REGIONAL ARN should include the region.
+	arnRegional := b.WebACLARN("my-acl", "abc123", "REGIONAL")
+	assert.Contains(t, arnRegional, "us-east-1", "REGIONAL ARN must include region")
+	assert.Contains(t, arnRegional, "regional/webacl/my-acl/abc123")
+}
+
+// ---- ListLoggingConfigurations returns stored configs -----------------------
+
+func TestListLoggingConfigurations_ReturnsStoredConfigs(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	arn1 := "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/acl-a/id1"
+	arn2 := "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/acl-b/id2"
+
+	for _, a := range []string{arn1, arn2} {
+		rec := doWafv2Request(t, h, "PutLoggingConfiguration", map[string]any{
+			"LoggingConfiguration": map[string]any{
+				"ResourceArn":           a,
+				"LogDestinationConfigs": []string{"arn:aws:s3:::my-log-bucket"},
+			},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	rec := doWafv2Request(t, h, "ListLoggingConfigurations", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	configs, _ := resp["LoggingConfigurations"].([]any)
+	assert.Len(t, configs, 2, "ListLoggingConfigurations should return 2 stored configs")
+}
+
+// ---- GetWebACLForResource returns not-found when no association exists -------
+
+func TestGetWebACLForResource_NotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doWafv2Request(t, h, "GetWebACLForResource", map[string]any{
+		"ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/no-acl/xyz",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "WAFNonexistentItemException", errResp["__type"])
+}
+
+// ---- CheckCapacity handles nil / empty rules gracefully ---------------------
+
+func TestCheckCapacity_NilRules(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// nil rules → capacity 0.
+	rec := doWafv2Request(t, h, "CheckCapacity", map[string]any{
+		"Scope": "REGIONAL",
+		"Rules": nil,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	capacity, _ := resp["ConsumedCapacity"].(float64)
+	assert.InDelta(t, float64(0), capacity, 0, "nil rules capacity should be 0")
+
+	// Empty rules → capacity 0.
+	rec = doWafv2Request(t, h, "CheckCapacity", map[string]any{
+		"Scope": "REGIONAL",
+		"Rules": []any{},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	capacity, _ = resp["ConsumedCapacity"].(float64)
+	assert.InDelta(t, float64(0), capacity, 0, "empty rules capacity should be 0")
+}
+
+// ---- CreateWebACL duplicate Name+Scope returns WAFDuplicateItemException ----
+
+func TestCreateWebACL_DuplicateNameScope(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	createWebACLHelper(t, h, "dup-acl", "REGIONAL")
+
+	rec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "dup-acl",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "WAFDuplicateItemException", errResp["__type"])
+}
+
+// ---- LockToken changes on each UpdateWebACL ---------------------------------
+
+func TestLockToken_RotatesOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	// Use createWebACLWithRules (REGIONAL scope) which returns (id, lockToken).
+	id, token1 := createWebACLWithRules(t, h, "lock-rotation", "REGIONAL")
+
+	rec := doWafv2Request(t, h, "UpdateWebACL", map[string]any{
+		"Id":          id,
+		"LockToken":   token1,
+		"Description": "updated",
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "update with correct token: %s", rec.Body.String())
+
+	var updateResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &updateResp))
+	token2 := updateResp["NextLockToken"].(string)
+
+	assert.NotEmpty(t, token2)
+	assert.NotEqual(t, token1, token2, "LockToken must rotate on every successful update")
+}
+
+// ---- IPSet name pattern validation ------------------------------------------
+
+func TestValidation_IPSetNamePattern(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doWafv2Request(t, h, "CreateIPSet", map[string]any{
+		"Name":             "my.invalid.ipset",
+		"Scope":            "REGIONAL",
+		"IPAddressVersion": "IPV4",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "IPSet name with dots should be rejected")
+}
+
+// ---- RuleGroup name pattern validation --------------------------------------
+
+func TestValidation_RuleGroupNamePattern(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doWafv2Request(t, h, "CreateRuleGroup", map[string]any{
+		"Name":     "invalid name!",
+		"Scope":    "REGIONAL",
+		"Capacity": 10,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "RuleGroup name with spaces/special chars should be rejected")
+}

--- a/services/wafv2/handler_test.go
+++ b/services/wafv2/handler_test.go
@@ -135,7 +135,7 @@ func TestHandler_CreateWebACL(t *testing.T) {
 			body: map[string]any{
 				"Name":          "my-web-acl",
 				"Scope":         "REGIONAL",
-				"DefaultAction": "ALLOW",
+				"DefaultAction": map[string]any{"Allow": map[string]any{}},
 			},
 			wantStatus: http.StatusOK,
 			wantID:     true,
@@ -188,7 +188,7 @@ func TestHandler_GetWebACL(t *testing.T) {
 		{
 			name: "existing",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 
 				return w.ID
 			},
@@ -233,7 +233,7 @@ func TestHandler_UpdateWebACL(t *testing.T) {
 		{
 			name: "existing",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 
 				return w.ID
 			},
@@ -242,7 +242,7 @@ func TestHandler_UpdateWebACL(t *testing.T) {
 					"Id":          id,
 					"Name":        "my-acl",
 					"Scope":       "REGIONAL",
-					"LockToken":   "tok",
+					"LockToken":   "",
 					"Description": "updated",
 				}
 			},
@@ -254,7 +254,7 @@ func TestHandler_UpdateWebACL(t *testing.T) {
 				return "nonexistent"
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusBadRequest,
 		},
@@ -290,12 +290,12 @@ func TestHandler_DeleteWebACL(t *testing.T) {
 		{
 			name: "existing",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 
 				return w.ID
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "my-acl", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "my-acl", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusOK,
 		},
@@ -305,7 +305,7 @@ func TestHandler_DeleteWebACL(t *testing.T) {
 				return "nonexistent"
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusBadRequest,
 		},
@@ -339,8 +339,8 @@ func TestHandler_ListWebACLs(t *testing.T) {
 		{
 			name: "with_items",
 			setup: func(h *wafv2.Handler) {
-				_, _ = h.Backend.CreateWebACL("acl1", "REGIONAL", "", "ALLOW", "", nil)
-				_, _ = h.Backend.CreateWebACL("acl2", "REGIONAL", "", "BLOCK", "", nil)
+				_, _ = wafv2.CreateWebACLSimple(h.Backend, "acl1", "REGIONAL", "", "ALLOW", nil)
+				_, _ = wafv2.CreateWebACLSimple(h.Backend, "acl2", "REGIONAL", "", "BLOCK", nil)
 			},
 			wantCount: 2,
 		},
@@ -482,7 +482,7 @@ func TestHandler_UpdateIPSet(t *testing.T) {
 					"Id":        id,
 					"Name":      "my-ipset",
 					"Scope":     "REGIONAL",
-					"LockToken": "tok",
+					"LockToken": "",
 					"Addresses": []string{"10.0.0.0/8"},
 				}
 			},
@@ -498,7 +498,7 @@ func TestHandler_UpdateIPSet(t *testing.T) {
 					"Id":        id,
 					"Name":      "x",
 					"Scope":     "REGIONAL",
-					"LockToken": "tok",
+					"LockToken": "",
 					"Addresses": []string{},
 				}
 			},
@@ -541,7 +541,7 @@ func TestHandler_DeleteIPSet(t *testing.T) {
 				return s.ID
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "my-ipset", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "my-ipset", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusOK,
 		},
@@ -551,7 +551,7 @@ func TestHandler_DeleteIPSet(t *testing.T) {
 				return "nonexistent"
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusBadRequest,
 		},
@@ -625,7 +625,7 @@ func TestHandler_TagResource_and_ListTags(t *testing.T) {
 		{
 			name: "tags_flow",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("tagged-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "tagged-acl", "REGIONAL", "", "ALLOW", nil)
 
 				return h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 			},
@@ -770,7 +770,7 @@ func TestBackend_Reset(t *testing.T) {
 
 	b := wafv2.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.CreateWebACL("acl1", "REGIONAL", "", "ALLOW", "", nil)
+	_, err := wafv2.CreateWebACLSimple(b, "acl1", "REGIONAL", "", "ALLOW", nil)
 	require.NoError(t, err)
 	_, err = b.CreateIPSet("set1", "REGIONAL", "", "IPV4", nil, nil)
 	require.NoError(t, err)
@@ -792,7 +792,7 @@ func TestHandler_AssociateWebACL(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *wafv2.Handler) (string, string) {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 				webACLARN := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 
 				return webACLARN, "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
@@ -809,7 +809,7 @@ func TestHandler_AssociateWebACL(t *testing.T) {
 		{
 			name: "missing_resource_arn",
 			setup: func(h *wafv2.Handler) (string, string) {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 				webACLARN := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 
 				return webACLARN, ""
@@ -860,7 +860,7 @@ func TestHandler_DisassociateWebACL(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 				webACLARN := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 				resourceARN := "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
 				require.NoError(t, h.Backend.AssociateWebACL(webACLARN, resourceARN))
@@ -914,7 +914,7 @@ func TestHandler_GetWebACLForResource(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 				webACLARN := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 				resourceARN := "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/abc"
 				require.NoError(t, h.Backend.AssociateWebACL(webACLARN, resourceARN))
@@ -978,12 +978,12 @@ func TestHandler_UntagResource(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL(
+				w, _ := wafv2.CreateWebACLSimple(
+					h.Backend,
 					"tagged-acl",
 					"REGIONAL",
 					"",
 					"ALLOW",
-					"",
 					map[string]string{"env": "prod", "team": "ops"},
 				)
 				arnStr := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
@@ -1260,8 +1260,8 @@ func TestHandler_ListWebACLs_Scope_Filter(t *testing.T) {
 		{
 			name: "filter_cloudfront",
 			setup: func(h *wafv2.Handler) {
-				_, _ = h.Backend.CreateWebACL("regional-acl", "REGIONAL", "", "ALLOW", "", nil)
-				_, _ = h.Backend.CreateWebACL("cf-acl", "CLOUDFRONT", "", "ALLOW", "", nil)
+				_, _ = wafv2.CreateWebACLSimple(h.Backend, "regional-acl", "REGIONAL", "", "ALLOW", nil)
+				_, _ = wafv2.CreateWebACLSimple(h.Backend, "cf-acl", "CLOUDFRONT", "", "ALLOW", nil)
 			},
 			scope:     "CLOUDFRONT",
 			wantCount: 1,
@@ -1269,8 +1269,8 @@ func TestHandler_ListWebACLs_Scope_Filter(t *testing.T) {
 		{
 			name: "no_filter_returns_all",
 			setup: func(h *wafv2.Handler) {
-				_, _ = h.Backend.CreateWebACL("regional-acl", "REGIONAL", "", "ALLOW", "", nil)
-				_, _ = h.Backend.CreateWebACL("cf-acl", "CLOUDFRONT", "", "ALLOW", "", nil)
+				_, _ = wafv2.CreateWebACLSimple(h.Backend, "regional-acl", "REGIONAL", "", "ALLOW", nil)
+				_, _ = wafv2.CreateWebACLSimple(h.Backend, "cf-acl", "CLOUDFRONT", "", "ALLOW", nil)
 			},
 			scope:     "",
 			wantCount: 2,
@@ -1404,7 +1404,7 @@ func TestHandler_GetWebACL_BlockDefaultAction(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
-	w, err := h.Backend.CreateWebACL("blocked-acl", "REGIONAL", "", "BLOCK", "", nil)
+	w, err := wafv2.CreateWebACLSimple(h.Backend, "blocked-acl", "REGIONAL", "", "BLOCK", nil)
 	require.NoError(t, err)
 
 	rec := doWafv2Request(t, h, "GetWebACL", map[string]any{
@@ -1459,7 +1459,7 @@ func TestBackend_Snapshot_And_Restore(t *testing.T) {
 		{
 			name: "with_webacls_and_ipsets",
 			setup: func(b *wafv2.InMemoryBackend) {
-				_, _ = b.CreateWebACL("acl1", "REGIONAL", "desc", "ALLOW", "", nil)
+				_, _ = wafv2.CreateWebACLSimple(b, "acl1", "REGIONAL", "desc", "ALLOW", nil)
 				_, _ = b.CreateIPSet("set1", "REGIONAL", "desc", "IPV4", []string{"1.2.3.4/32"}, nil)
 			},
 			wantIDs: 1,
@@ -1492,7 +1492,7 @@ func TestHandler_Snapshot_And_Restore(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
-	_, err := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+	_, err := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 	require.NoError(t, err)
 
 	snap := h.Snapshot()
@@ -1526,14 +1526,29 @@ func TestHandler_GetWebACL_WithVisibilityConfig(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
-	visConfig := `{"CloudWatchMetricsEnabled":true,"MetricName":"my-acl","SampledRequestsEnabled":true}`
-	w, err := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", visConfig, nil)
-	require.NoError(t, err)
+
+	// Create WebACL via HTTP API to include VisibilityConfig.
+	createRec := doWafv2Request(t, h, "CreateWebACL", map[string]any{
+		"Name":          "my-acl",
+		"Scope":         "REGIONAL",
+		"DefaultAction": map[string]any{"Allow": map[string]any{}},
+		"VisibilityConfig": map[string]any{
+			"CloudWatchMetricsEnabled": true,
+			"MetricName":               "my-acl",
+			"SampledRequestsEnabled":   true,
+		},
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResult map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResult))
+	summary := createResult["Summary"].(map[string]any)
+	id := summary["Id"].(string)
 
 	rec := doWafv2Request(t, h, "GetWebACL", map[string]any{
-		"Id":    w.ID,
-		"Name":  w.Name,
-		"Scope": w.Scope,
+		"Id":    id,
+		"Name":  "my-acl",
+		"Scope": "REGIONAL",
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -1550,8 +1565,7 @@ func TestHandler_GetWebACLForResource_WithVisibilityConfig(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
-	visConfig := `{"CloudWatchMetricsEnabled":true,"MetricName":"my-acl","SampledRequestsEnabled":true}`
-	w, err := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "BLOCK", visConfig, nil)
+	w, err := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "BLOCK", nil)
 	require.NoError(t, err)
 
 	webACLARN := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
@@ -1668,7 +1682,7 @@ func TestHandler_CreateAndDeleteAPIKey(t *testing.T) {
 		},
 		{
 			name:       "delete_missing_scope",
-			createBody: map[string]any{"Scope": "REGIONAL"},
+			createBody: map[string]any{"Scope": "REGIONAL", "TokenDomains": []string{"example.com"}},
 			deleteBody: func(_ string) map[string]any {
 				return map[string]any{"APIKey": "somekey"}
 			},
@@ -1677,7 +1691,7 @@ func TestHandler_CreateAndDeleteAPIKey(t *testing.T) {
 		},
 		{
 			name:       "delete_missing_key",
-			createBody: map[string]any{"Scope": "REGIONAL"},
+			createBody: map[string]any{"Scope": "REGIONAL", "TokenDomains": []string{"example.com"}},
 			deleteBody: func(_ string) map[string]any {
 				return map[string]any{"Scope": "REGIONAL"}
 			},
@@ -1686,7 +1700,7 @@ func TestHandler_CreateAndDeleteAPIKey(t *testing.T) {
 		},
 		{
 			name:       "delete_not_found",
-			createBody: map[string]any{"Scope": "REGIONAL"},
+			createBody: map[string]any{"Scope": "REGIONAL", "TokenDomains": []string{"example.com"}},
 			deleteBody: func(_ string) map[string]any {
 				return map[string]any{"Scope": "REGIONAL", "APIKey": "nonexistent-key"}
 			},
@@ -1807,7 +1821,7 @@ func TestHandler_DeleteRegexPatternSet(t *testing.T) {
 				return rps.ID
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "my-regex", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "my-regex", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusOK,
 		},
@@ -1817,7 +1831,7 @@ func TestHandler_DeleteRegexPatternSet(t *testing.T) {
 				return "nonexistent"
 			},
 			body: func(id string) map[string]any {
-				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Id": id, "Name": "x", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusBadRequest,
 		},
@@ -1827,7 +1841,7 @@ func TestHandler_DeleteRegexPatternSet(t *testing.T) {
 				return ""
 			},
 			body: func(_ string) map[string]any {
-				return map[string]any{"Name": "x", "Scope": "REGIONAL", "LockToken": "tok"}
+				return map[string]any{"Name": "x", "Scope": "REGIONAL", "LockToken": ""}
 			},
 			wantStatus: http.StatusBadRequest,
 		},
@@ -1932,7 +1946,7 @@ func TestHandler_DeleteFirewallManagerRuleGroups(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 
 				return h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
 			},
@@ -1993,9 +2007,12 @@ func TestHandler_DeleteLoggingConfiguration(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *wafv2.Handler) string {
-				w, _ := h.Backend.CreateWebACL("my-acl", "REGIONAL", "", "ALLOW", "", nil)
+				w, _ := wafv2.CreateWebACLSimple(h.Backend, "my-acl", "REGIONAL", "", "ALLOW", nil)
 				arnStr := h.Backend.WebACLARN(w.Name, w.ID, w.Scope)
-				require.NoError(t, h.Backend.PutLoggingConfiguration(arnStr))
+				require.NoError(
+					t,
+					h.Backend.PutLoggingConfiguration(arnStr, json.RawMessage(`{"ResourceArn":"`+arnStr+`"}`)),
+				)
 
 				return arnStr
 			},
@@ -2146,7 +2163,7 @@ func TestBackend_Snapshot_WithNewResources(t *testing.T) {
 
 	b := wafv2.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreateRegexPatternSet("my-regex", "REGIONAL", "", []string{"^foo"}, nil)
+	_, err := b.CreateRegexPatternSet("my-regex", "REGIONAL", "", []wafv2.RegexEntry{{RegexString: "^foo"}}, nil)
 	require.NoError(t, err)
 
 	_, err = b.CreateRuleGroup("my-rg", "REGIONAL", "", "", 10, nil, nil)
@@ -2164,5 +2181,5 @@ func TestBackend_Snapshot_WithNewResources(t *testing.T) {
 	// Verify regex pattern sets are restored (via delete which requires lookup).
 	rps2, err := b.CreateRegexPatternSet("another-regex", "REGIONAL", "", nil, nil)
 	require.NoError(t, err)
-	require.NoError(t, b.DeleteRegexPatternSet(rps2.ID))
+	require.NoError(t, b.DeleteRegexPatternSet(rps2.ID, ""))
 }

--- a/services/wafv2/handler_test.go
+++ b/services/wafv2/handler_test.go
@@ -877,11 +877,13 @@ func TestHandler_DisassociateWebACL(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name: "not_found",
+			// AWS DisassociateWebACL is idempotent — calling it when no
+			// association exists succeeds (no-op), matching real AWS behaviour.
+			name: "not_found_idempotent",
 			setup: func(_ *wafv2.Handler) string {
 				return "arn:aws:ec2:us-east-1:000000000000:instance/i-nonexistent"
 			},
-			wantStatus: http.StatusBadRequest,
+			wantStatus: http.StatusOK,
 		},
 	}
 

--- a/services/wafv2/interfaces.go
+++ b/services/wafv2/interfaces.go
@@ -1,5 +1,7 @@
 package wafv2
 
+import "encoding/json"
+
 // StorageBackend is the interface for WAFv2 storage operations.
 type StorageBackend interface {
 	AccountID() string
@@ -9,12 +11,22 @@ type StorageBackend interface {
 	RegexPatternSetARN(name, id, scope string) string
 	RuleGroupARN(name, id, scope string) string
 	CreateWebACL(
-		name, scope, description, defaultAction, visibilityConfig string,
+		name, scope, description string,
+		defaultAction, visibilityConfig json.RawMessage,
+		rules []map[string]any,
+		tokenDomains []string,
+		customResponseBodies, associationConfig, captchaConfig, challengeConfig json.RawMessage,
 		tags map[string]string,
 	) (*WebACL, error)
 	GetWebACL(id string) (*WebACL, error)
-	UpdateWebACL(id, description, defaultAction, visibilityConfig string) (*WebACL, error)
-	DeleteWebACL(id string) error
+	UpdateWebACL(
+		id, description, lockToken string,
+		defaultAction, visibilityConfig json.RawMessage,
+		rules []map[string]any,
+		tokenDomains []string,
+		customResponseBodies, associationConfig, captchaConfig, challengeConfig json.RawMessage,
+	) (*WebACL, error)
+	DeleteWebACL(id, lockToken string) error
 	ListWebACLs() []*WebACL
 	CreateIPSet(
 		name, scope, description, ipAddressVersion string,
@@ -22,8 +34,8 @@ type StorageBackend interface {
 		tags map[string]string,
 	) (*IPSet, error)
 	GetIPSet(id string) (*IPSet, error)
-	UpdateIPSet(id, description string, addresses []string) (*IPSet, error)
-	DeleteIPSet(id string) error
+	UpdateIPSet(id, description, lockToken string, addresses []string) (*IPSet, error)
+	DeleteIPSet(id, lockToken string) error
 	ListIPSets() []*IPSet
 	TagResource(resourceARN string, tags map[string]string) error
 	ListTagsForResource(resourceARN string) (map[string]string, error)
@@ -36,12 +48,15 @@ type StorageBackend interface {
 	CreateAPIKey(scope string, tokenDomains []string) (*APIKey, error)
 	CreateRegexPatternSet(
 		name, scope, description string,
-		regularExpressionList []string,
+		regularExpressionList []RegexEntry,
 		tags map[string]string,
 	) (*RegexPatternSet, error)
 	GetRegexPatternSet(id string) (*RegexPatternSet, error)
 	ListRegexPatternSets() []*RegexPatternSet
-	UpdateRegexPatternSet(id, description string, regularExpressionList []string) (*RegexPatternSet, error)
+	UpdateRegexPatternSet(
+		id, description, lockToken string,
+		regularExpressionList []RegexEntry,
+	) (*RegexPatternSet, error)
 	CreateRuleGroup(
 		name, scope, description, visibilityConfig string,
 		capacity int64,
@@ -50,18 +65,20 @@ type StorageBackend interface {
 	) (*RuleGroup, error)
 	GetRuleGroup(id string) (*RuleGroup, error)
 	ListRuleGroups() []*RuleGroup
-	UpdateRuleGroup(id, description, visibilityConfig string, rules []map[string]any) (*RuleGroup, error)
+	UpdateRuleGroup(id, description, visibilityConfig, lockToken string, rules []map[string]any) (*RuleGroup, error)
+	DeleteRuleGroup(id, lockToken string) error
 	DeleteAPIKey(scope, apiKey string) error
 	DeleteFirewallManagerRuleGroups(webACLARN string) (*WebACL, error)
+	PutLoggingConfiguration(resourceARN string, configJSON json.RawMessage) error
 	DeleteLoggingConfiguration(resourceARN string) error
+	GetLoggingConfiguration(resourceARN string) (json.RawMessage, error)
+	ListLoggingConfigurations() []json.RawMessage
 	DeletePermissionPolicy(resourceARN string) error
-	DeleteRegexPatternSet(id string) error
+	DeleteRegexPatternSet(id, lockToken string) error
 	ListAPIKeys(scope string) []*APIKey
 	GetDecryptedAPIKey(scope, apiKey string) (*APIKey, error)
-	GetLoggingConfiguration(resourceARN string) (bool, error)
 	GetPermissionPolicy(resourceARN string) (string, error)
 	ListResourcesForWebACL(webACLARN string) ([]string, error)
-	PutLoggingConfiguration(resourceARN string) error
 	PutPermissionPolicy(resourceARN, policy string) error
 	Snapshot() []byte
 	Restore(data []byte) error

--- a/services/wafv2/managed_rules.go
+++ b/services/wafv2/managed_rules.go
@@ -1,0 +1,104 @@
+package wafv2
+
+const awsVendorName = "AWS"
+
+// managedRuleGroupInfo holds catalog metadata for an AWS Managed Rule Group.
+type managedRuleGroupInfo struct {
+	VendorName          string
+	Name                string
+	Description         string
+	Capacity            int64
+	VersioningSupported bool
+}
+
+// getManagedRuleGroups returns the static catalog of common AWS Managed Rule Groups.
+func getManagedRuleGroups() []managedRuleGroupInfo {
+	return []managedRuleGroupInfo{
+		{
+			VendorName:          awsVendorName,
+			Name:                "AWSManagedRulesCommonRuleSet",
+			Capacity:            700, //nolint:mnd // AWS-defined capacity value
+			Description:         "Contains rules that are generally applicable to web applications.",
+			VersioningSupported: true,
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesKnownBadInputsRuleSet",
+			Capacity:    200, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules to block request patterns known to be invalid.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesAmazonIpReputationList",
+			Capacity:    25, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules based on Amazon threat intelligence.",
+		},
+		{
+			VendorName:          awsVendorName,
+			Name:                "AWSManagedRulesBotControlRuleSet",
+			Capacity:            50, //nolint:mnd // AWS-defined capacity value
+			Description:         "Provides protection against automated bots.",
+			VersioningSupported: true,
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesATPRuleSet",
+			Capacity:    50, //nolint:mnd // AWS-defined capacity value
+			Description: "Account Takeover Prevention.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesACFPRuleSet",
+			Capacity:    50, //nolint:mnd // AWS-defined capacity value
+			Description: "Account Creation Fraud Prevention.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesAnonymousIpList",
+			Capacity:    50, //nolint:mnd // AWS-defined capacity value
+			Description: "Blocks requests from IPs known for hosting anonymous proxies.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesSQLiRuleSet",
+			Capacity:    200, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules to block SQL injection attacks.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesLinuxRuleSet",
+			Capacity:    200, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules for Linux-specific vulnerabilities.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesUnixRuleSet",
+			Capacity:    100, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules for POSIX and POSIX-like OS vulnerabilities.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesWindowsRuleSet",
+			Capacity:    200, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules for Windows-specific vulnerabilities.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesPHPRuleSet",
+			Capacity:    100, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules for PHP-specific vulnerabilities.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesWordPressRuleSet",
+			Capacity:    100, //nolint:mnd // AWS-defined capacity value
+			Description: "Contains rules for WordPress vulnerabilities.",
+		},
+		{
+			VendorName:  awsVendorName,
+			Name:        "AWSManagedRulesAdminProtectionRuleSet",
+			Capacity:    100, //nolint:mnd // AWS-defined capacity value
+			Description: "Provides protection for admin pages.",
+		},
+	}
+}

--- a/services/wafv2/persistence.go
+++ b/services/wafv2/persistence.go
@@ -11,7 +11,7 @@ type backendSnapshot struct {
 	RegexPatternSets   map[string]*RegexPatternSet `json:"regexPatternSets,omitempty"`
 	RuleGroups         map[string]*RuleGroup       `json:"ruleGroups,omitempty"`
 	APIKeys            map[string]*APIKey          `json:"apiKeys,omitempty"`
-	LoggingConfigs     map[string]bool             `json:"loggingConfigs,omitempty"`
+	LoggingConfigs     map[string]json.RawMessage  `json:"loggingConfigs,omitempty"`
 	PermissionPolicies map[string]string           `json:"permissionPolicies,omitempty"`
 	Associations       map[string]string           `json:"associations,omitempty"`
 	AccountID          string                      `json:"accountID"`
@@ -70,7 +70,7 @@ func (snap *backendSnapshot) ensureNonNilMaps() {
 	}
 
 	if snap.LoggingConfigs == nil {
-		snap.LoggingConfigs = make(map[string]bool)
+		snap.LoggingConfigs = make(map[string]json.RawMessage)
 	}
 
 	if snap.PermissionPolicies == nil {

--- a/test/e2e/wafv2_test.go
+++ b/test/e2e/wafv2_test.go
@@ -20,8 +20,11 @@ func TestWafv2Dashboard(t *testing.T) {
 		"e2e-test-acl",
 		"REGIONAL",
 		"test web ACL",
-		"ALLOW",
-		"",
+		[]byte(`{"Allow":{}}`),
+		[]byte(`{"SampledRequestsEnabled":true,"CloudWatchMetricsEnabled":true,"MetricName":"e2e-test-acl"}`),
+		nil,
+		nil,
+		nil, nil, nil, nil,
 		map[string]string{"Environment": "test"},
 	)
 	require.NoError(t, err)

--- a/ui/src/routes/waf/+page.svelte
+++ b/ui/src/routes/waf/+page.svelte
@@ -355,6 +355,7 @@
 						<thead class="bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-400 uppercase text-xs">
 							<tr>
 								<th class="px-4 py-3 text-left">Web ACL Name</th>
+								<th class="px-4 py-3 text-left">Default Action</th>
 								<th class="px-4 py-3 text-left">Description</th>
 								<th class="px-4 py-3 text-left">Actions</th>
 							</tr>
@@ -364,6 +365,15 @@
 								<tr class="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
 									<td class="px-4 py-3">
 										<button onclick={() => selectWebACL(acl)} class="text-red-600 dark:text-red-400 hover:underline font-medium">{acl.Name}</button>
+									</td>
+									<td class="px-4 py-3 text-xs">
+										{#if acl.DefaultAction}
+											<span class={`px-2 py-0.5 rounded font-medium ${Object.keys(acl.DefaultAction)[0] === 'Allow' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
+												{Object.keys(acl.DefaultAction)[0]?.toUpperCase() ?? '-'}
+											</span>
+										{:else}
+											<span class="text-gray-400">-</span>
+										{/if}
 									</td>
 									<td class="px-4 py-3 text-xs text-gray-500">{acl.Description ?? '-'}</td>
 									<td class="px-4 py-3">
@@ -397,7 +407,7 @@
 					</thead>
 					<tbody class="divide-y divide-gray-100 dark:divide-gray-800">
 						{#each ipSets as ipset}
-							<tr><td class="px-4 py-3 font-medium">{ipset.Name}</td><td class="px-4 py-3 text-xs text-gray-500">-</td><td class="px-4 py-3 text-xs text-gray-500">{ipset.Description ?? '-'}</td></tr>
+							<tr><td class="px-4 py-3 font-medium">{ipset.Name}</td><td class="px-4 py-3 text-xs text-gray-500">{ipset.IPAddressVersion ?? '-'}</td><td class="px-4 py-3 text-xs text-gray-500">{ipset.Description ?? '-'}</td></tr>
 						{/each}
 					</tbody>
 				</table>
@@ -422,7 +432,7 @@
 					</thead>
 					<tbody class="divide-y divide-gray-100 dark:divide-gray-800">
 						{#each ruleGroups as rg}
-							<tr><td class="px-4 py-3 font-medium">{rg.Name}</td><td class="px-4 py-3 text-gray-600">-</td><td class="px-4 py-3 text-xs text-gray-500">{rg.Description ?? '-'}</td></tr>
+							<tr><td class="px-4 py-3 font-medium">{rg.Name}</td><td class="px-4 py-3 text-gray-600">{rg.Capacity ?? '-'}</td><td class="px-4 py-3 text-xs text-gray-500">{rg.Description ?? '-'}</td></tr>
 						{/each}
 					</tbody>
 				</table>

--- a/ui/src/routes/waf/+page.svelte
+++ b/ui/src/routes/waf/+page.svelte
@@ -355,7 +355,6 @@
 						<thead class="bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-400 uppercase text-xs">
 							<tr>
 								<th class="px-4 py-3 text-left">Web ACL Name</th>
-								<th class="px-4 py-3 text-left">Default Action</th>
 								<th class="px-4 py-3 text-left">Description</th>
 								<th class="px-4 py-3 text-left">Actions</th>
 							</tr>
@@ -365,15 +364,6 @@
 								<tr class="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
 									<td class="px-4 py-3">
 										<button onclick={() => selectWebACL(acl)} class="text-red-600 dark:text-red-400 hover:underline font-medium">{acl.Name}</button>
-									</td>
-									<td class="px-4 py-3 text-xs">
-										{#if acl.DefaultAction}
-											<span class={`px-2 py-0.5 rounded font-medium ${Object.keys(acl.DefaultAction)[0] === 'Allow' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-												{Object.keys(acl.DefaultAction)[0]?.toUpperCase() ?? '-'}
-											</span>
-										{:else}
-											<span class="text-gray-400">-</span>
-										{/if}
 									</td>
 									<td class="px-4 py-3 text-xs text-gray-500">{acl.Description ?? '-'}</td>
 									<td class="px-4 py-3">
@@ -401,13 +391,12 @@
 					<thead class="bg-gray-50 dark:bg-gray-800 text-xs text-gray-500 uppercase">
 						<tr>
 							<th class="px-4 py-3 text-left">Name</th>
-							<th class="px-4 py-3 text-left">IP Version</th>
 							<th class="px-4 py-3 text-left">Description</th>
 						</tr>
 					</thead>
 					<tbody class="divide-y divide-gray-100 dark:divide-gray-800">
 						{#each ipSets as ipset}
-							<tr><td class="px-4 py-3 font-medium">{ipset.Name}</td><td class="px-4 py-3 text-xs text-gray-500">{ipset.IPAddressVersion ?? '-'}</td><td class="px-4 py-3 text-xs text-gray-500">{ipset.Description ?? '-'}</td></tr>
+							<tr><td class="px-4 py-3 font-medium">{ipset.Name}</td><td class="px-4 py-3 text-xs text-gray-500">{ipset.Description ?? '-'}</td></tr>
 						{/each}
 					</tbody>
 				</table>
@@ -426,13 +415,12 @@
 					<thead class="bg-gray-50 dark:bg-gray-800 text-xs text-gray-500 uppercase">
 						<tr>
 							<th class="px-4 py-3 text-left">Name</th>
-							<th class="px-4 py-3 text-left">Capacity</th>
 							<th class="px-4 py-3 text-left">Description</th>
 						</tr>
 					</thead>
 					<tbody class="divide-y divide-gray-100 dark:divide-gray-800">
 						{#each ruleGroups as rg}
-							<tr><td class="px-4 py-3 font-medium">{rg.Name}</td><td class="px-4 py-3 text-gray-600">{rg.Capacity ?? '-'}</td><td class="px-4 py-3 text-xs text-gray-500">{rg.Description ?? '-'}</td></tr>
+							<tr><td class="px-4 py-3 font-medium">{rg.Name}</td><td class="px-4 py-3 text-xs text-gray-500">{rg.Description ?? '-'}</td></tr>
 						{/each}
 					</tbody>
 				</table>


### PR DESCRIPTION
## Summary

- Implements AWS parity for WAFv2 service across 24 accuracy gaps identified in issue #1857
- Adds `Rules`, `DefaultAction` (raw JSON), extended config fields to WebACL with full round-trip
- Implements LockToken enforcement on all mutating operations (optimistic concurrency control)
- Adds static managed rule group catalog (14 entries) replacing stubs
- Enforces CIDR validation, regex compilation, capacity limits, tag limits, pagination with NextMarker cursors
- Full LoggingConfiguration JSON round-trip; `x-amzn-errortype` header on all errors
- New `managed_rules.go` with catalog; new `handler_accuracy_test.go` with 22 accuracy tests
- Updated `cloudformation/resources_phase4.go` for new backend signatures

## Test plan

- [ ] All existing wafv2 tests pass: `go test ./services/wafv2/...`
- [ ] All 22 new accuracy tests pass: `go test ./services/wafv2/... -run TestAccuracy`
- [ ] Lint clean: `make lint-fix && make lint`
- [ ] CloudFormation integration unbroken: `go test ./services/cloudformation/...`

Closes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)