### PR TITLE
feat(xray): AWS-accuracy audit — 18 gaps per #1856

### DIFF
--- a/services/xray/backend.go
+++ b/services/xray/backend.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"math"
+	"regexp"
+	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,7 +20,8 @@ import (
 )
 
 const (
-	statusActive = "ACTIVE"
+	statusActive   = "ACTIVE"
+	statusUpdating = "UPDATING"
 )
 
 var (
@@ -36,6 +41,16 @@ var (
 	ErrIndexingRuleNotFound = awserr.New("InvalidRequestException", awserr.ErrNotFound)
 	// ErrValidation is returned when a request fails field-level validation.
 	ErrValidation = awserr.New("InvalidRequestException", awserr.ErrInvalidParameter)
+	// ErrInvalidSamplingRule is returned when sampling rule fields fail validation.
+	ErrInvalidSamplingRule = awserr.New("InvalidSamplingRuleException", awserr.ErrInvalidParameter)
+	// ErrInvalidPolicyRevisionID is returned when a policy revision ID does not match.
+	ErrInvalidPolicyRevisionID = awserr.New("InvalidPolicyRevisionIdException", awserr.ErrConflict)
+	// ErrMalformedPolicyDocument is returned when a policy document is not valid JSON.
+	ErrMalformedPolicyDocument = awserr.New("MalformedPolicyDocumentException", awserr.ErrInvalidParameter)
+	// ErrTooManyPolicies is returned when the max policy count is exceeded.
+	ErrTooManyPolicies = awserr.New("InvalidRequestException", awserr.ErrInvalidParameter)
+	// ErrBatchGetTracesLimit is returned when more than 5 trace IDs are requested.
+	ErrBatchGetTracesLimit = awserr.New("InvalidRequestException", awserr.ErrInvalidParameter)
 )
 
 // InsightsConfiguration holds insight notification/notification settings for a group.
@@ -69,6 +84,61 @@ type SamplingRule struct {
 	FixedRate     float64           `json:"fixedRate"`
 	Priority      int32             `json:"priority"`
 	ReservoirSize int32             `json:"reservoirSize"`
+}
+
+// SamplingRuleUpdate holds pointer-semantic updates for UpdateSamplingRule.
+// A nil pointer means "no change"; a non-nil pointer (even to zero/empty) means "apply".
+type SamplingRuleUpdate struct {
+	ResourceARN   *string
+	ServiceName   *string
+	ServiceType   *string
+	Host          *string
+	HTTPMethod    *string
+	URLPath       *string
+	FixedRate     *float64
+	Priority      *int32
+	ReservoirSize *int32
+}
+
+// Segment is a parsed X-Ray segment document.
+type Segment struct {
+	AWS         map[string]any `json:"aws,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	HTTP        *SegmentHTTP   `json:"http,omitempty"`
+	Namespace   string         `json:"namespace,omitempty"`
+	Document    string         `json:"-"`
+	TraceID     string         `json:"trace_id"`
+	ID          string         `json:"id"`
+	ParentID    string         `json:"parent_id,omitempty"`
+	Name        string         `json:"name"`
+	Origin      string         `json:"origin,omitempty"`
+	Subsegments []Segment      `json:"subsegments,omitempty"`
+	StartTime   float64        `json:"start_time"`
+	EndTime     float64        `json:"end_time,omitempty"`
+	Error       bool           `json:"error"`
+	Fault       bool           `json:"fault"`
+	Throttle    bool           `json:"throttle"`
+}
+
+// SegmentHTTP holds HTTP request/response data from a segment.
+type SegmentHTTP struct {
+	Request  *SegmentHTTPRequest  `json:"request,omitempty"`
+	Response *SegmentHTTPResponse `json:"response,omitempty"`
+}
+
+// SegmentHTTPRequest holds HTTP request fields from a segment.
+type SegmentHTTPRequest struct {
+	URL       string `json:"url,omitempty"`
+	Method    string `json:"method,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+	ClientIP  string `json:"client_ip,omitempty"`
+}
+
+// SegmentHTTPResponse holds HTTP response fields from a segment.
+type SegmentHTTPResponse struct {
+	Status        int `json:"status,omitempty"`
+	ContentLength int `json:"content_length,omitempty"`
 }
 
 // Trace represents a collected X-Ray trace with its constituent segments.
@@ -131,6 +201,15 @@ type SamplingStatisticSummary struct {
 	BorrowCount  int32     `json:"borrowCount"`
 }
 
+// TelemetryRecord holds a single telemetry data point.
+type TelemetryRecord struct {
+	Timestamp              time.Time `json:"timestamp"`
+	SegmentsReceivedCount  int32     `json:"segmentsReceivedCount"`
+	SegmentsSentCount      int32     `json:"segmentsSentCount"`
+	SegmentsSpilloverCount int32     `json:"segmentsSpilloverCount"`
+	SegmentsRejectedCount  int32     `json:"segmentsRejectedCount"`
+}
+
 const (
 	// encTypeNone is the X-Ray encryption type for no encryption.
 	encTypeNone = "NONE"
@@ -148,23 +227,57 @@ const (
 	// compaction. Compacting only when the slice has grown to twice the cap
 	// keeps the per-call cost amortized O(1).
 	segmentCompactionHighWater = maxSegmentsPerTrace + maxSegmentsPerTrace
+	// maxResourcePolicies is the maximum number of resource policies per account.
+	maxResourcePolicies = 5
+	// maxBatchGetTraces is the maximum number of trace IDs in a BatchGetTraces call.
+	maxBatchGetTraces = 5
+	// telemetryRingSize is the capacity of the telemetry ring buffer.
+	telemetryRingSize = 100
+	// maxServiceNameLen is the maximum length of a sampling rule ServiceName.
+	maxServiceNameLen = 64
+	// nanosPerSecond is the number of nanoseconds in a second.
+	nanosPerSecond = 1e9
+	// filterParts3 is the expected length of a 3-part filter expression.
+	filterParts3 = 3
+	// filterParts2 is the expected length of a 2-part filter expression.
+	filterParts2 = 2
+	// serviceGraphTotalCount is the key for the TotalCount stat in service graph nodes.
+	serviceGraphTotalCount = "TotalCount"
+)
+
+// validKMSKeyID checks whether a KMS KeyId is in an acceptable format:
+// alias/... | arn:aws:kms:... | UUID (hex with dashes, 36 chars).
+//
+//nolint:lll // regex is intentionally long; splitting would harm readability
+var validKMSKeyID = regexp.MustCompile(
+	`^(alias/[a-zA-Z0-9/_-]+|arn:aws:kms:[a-z0-9-]+:\d+:key/[a-zA-Z0-9/_-]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$`,
 )
 
 // InMemoryBackend is the in-memory store for X-Ray resources.
 type InMemoryBackend struct {
-	groups                  map[string]*Group
-	samplingRules           map[string]*SamplingRule
-	traces                  map[string]*Trace
-	insights                map[string]*Insight
-	insightEvents           map[string][]*InsightEvent
-	resourcePolicies        map[string]*ResourcePolicy
-	traceRetrievals         map[string]*TraceRetrieval
-	retrievedTraces         map[string][]*Trace
-	resourceTags            map[string]map[string]string
-	encryptionConfig        *EncryptionConfig
-	mu                      *lockmetrics.RWMutex
-	traceSegmentDestination string
-	indexingRules           []*IndexingRule
+	groups        map[string]*Group
+	samplingRules map[string]*SamplingRule
+	traces        map[string]*Trace
+	// parsedSegments indexes segments by traceID+":"+segID
+	parsedSegments map[string]*Segment
+	// traceSegments maps traceID → list of segments (pointers into parsedSegments)
+	traceSegments        map[string][]*Segment
+	insights             map[string]*Insight
+	insightEvents        map[string][]*InsightEvent
+	resourcePolicies     map[string]*ResourcePolicy
+	traceRetrievals      map[string]*TraceRetrieval
+	retrievedTraces      map[string][]*Trace
+	resourceTags         map[string]map[string]string
+	encryptionConfig     *EncryptionConfig
+	mu                   *lockmetrics.RWMutex
+	traceSegmentDest     string
+	indexingRules        []*IndexingRule
+	lastRuleModification time.Time
+	// samplingStats accumulates per-rule statistics from PutSamplingTargets docs.
+	samplingStats map[string]*SamplingStatisticSummary
+	// telemetry is a ring buffer of the last telemetryRingSize records.
+	telemetry    []*TelemetryRecord
+	telemetryIdx int
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
@@ -173,6 +286,8 @@ func NewInMemoryBackend() *InMemoryBackend {
 		groups:           make(map[string]*Group),
 		samplingRules:    make(map[string]*SamplingRule),
 		traces:           make(map[string]*Trace),
+		parsedSegments:   make(map[string]*Segment),
+		traceSegments:    make(map[string][]*Segment),
 		insights:         make(map[string]*Insight),
 		insightEvents:    make(map[string][]*InsightEvent),
 		resourcePolicies: make(map[string]*ResourcePolicy),
@@ -180,6 +295,8 @@ func NewInMemoryBackend() *InMemoryBackend {
 		retrievedTraces:  make(map[string][]*Trace),
 		resourceTags:     make(map[string]map[string]string),
 		indexingRules:    defaultIndexingRules(),
+		samplingStats:    make(map[string]*SamplingStatisticSummary),
+		telemetry:        make([]*TelemetryRecord, telemetryRingSize),
 		mu:               lockmetrics.New("xray"),
 		encryptionConfig: &EncryptionConfig{
 			Type:   "NONE",
@@ -242,7 +359,28 @@ func (b *InMemoryBackend) CreateGroup(name, filterExpr string) (*Group, error) {
 	return cloneGroup(g), nil
 }
 
-// GetGroup returns the group with the given name.
+// CreateGroupWithInsights creates a new group with full InsightsConfiguration.
+func (b *InMemoryBackend) CreateGroupWithInsights(name, filterExpr string, ic InsightsConfiguration) (*Group, error) {
+	b.mu.Lock("CreateGroupWithInsights")
+	defer b.mu.Unlock()
+
+	if _, ok := b.groups[name]; ok {
+		return nil, fmt.Errorf("%w: group %s already exists", ErrGroupAlreadyExists, name)
+	}
+
+	g := &Group{
+		GroupARN:              groupARN(name),
+		GroupName:             name,
+		FilterExpression:      filterExpr,
+		InsightsConfiguration: ic,
+		CreatedAt:             time.Now(),
+	}
+	b.groups[name] = g
+
+	return cloneGroup(g), nil
+}
+
+// GetGroup returns the group with the given name, or by ARN if name is empty.
 func (b *InMemoryBackend) GetGroup(name string) (*Group, error) {
 	b.mu.RLock("GetGroup")
 	defer b.mu.RUnlock()
@@ -253,6 +391,20 @@ func (b *InMemoryBackend) GetGroup(name string) (*Group, error) {
 	}
 
 	return cloneGroup(g), nil
+}
+
+// GetGroupByARN returns the group with the given ARN.
+func (b *InMemoryBackend) GetGroupByARN(arn string) (*Group, error) {
+	b.mu.RLock("GetGroupByARN")
+	defer b.mu.RUnlock()
+
+	for _, g := range b.groups {
+		if g.GroupARN == arn {
+			return cloneGroup(g), nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: group with ARN %s not found", ErrGroupNotFound, arn)
 }
 
 // GetGroups returns all groups sorted by name.
@@ -287,6 +439,39 @@ func (b *InMemoryBackend) UpdateGroup(name, filterExpr string) (*Group, error) {
 	return cloneGroup(g), nil
 }
 
+// UpdateGroupByARN updates a group by ARN or name.
+func (b *InMemoryBackend) UpdateGroupByARN(name, arn, filterExpr string) (*Group, error) {
+	b.mu.Lock("UpdateGroupByARN")
+	defer b.mu.Unlock()
+
+	var g *Group
+
+	if arn != "" {
+		for _, grp := range b.groups {
+			if grp.GroupARN == arn {
+				g = grp
+
+				break
+			}
+		}
+	} else {
+		g = b.groups[name]
+	}
+
+	if g == nil {
+		key := name
+		if arn != "" {
+			key = arn
+		}
+
+		return nil, fmt.Errorf("%w: group %s not found", ErrGroupNotFound, key)
+	}
+
+	g.FilterExpression = filterExpr
+
+	return cloneGroup(g), nil
+}
+
 // DeleteGroup removes the group with the given name.
 func (b *InMemoryBackend) DeleteGroup(name string) error {
 	b.mu.Lock("DeleteGroup")
@@ -297,6 +482,57 @@ func (b *InMemoryBackend) DeleteGroup(name string) error {
 	}
 
 	delete(b.groups, name)
+
+	return nil
+}
+
+// DeleteGroupByARN removes the group with the given ARN or name.
+func (b *InMemoryBackend) DeleteGroupByARN(name, arn string) error {
+	b.mu.Lock("DeleteGroupByARN")
+	defer b.mu.Unlock()
+
+	if arn != "" {
+		for n, g := range b.groups {
+			if g.GroupARN == arn {
+				delete(b.groups, n)
+
+				return nil
+			}
+		}
+
+		return fmt.Errorf("%w: group with ARN %s not found", ErrGroupNotFound, arn)
+	}
+
+	if _, ok := b.groups[name]; !ok {
+		return fmt.Errorf("%w: group %s not found", ErrGroupNotFound, name)
+	}
+
+	delete(b.groups, name)
+
+	return nil
+}
+
+// ValidateSamplingRule validates sampling rule fields per AWS constraints.
+func ValidateSamplingRule(rule SamplingRule) error {
+	if rule.RuleName == "" || len(rule.RuleName) > 32 {
+		return fmt.Errorf("%w: RuleName must be 1-32 characters", ErrInvalidSamplingRule)
+	}
+
+	if len(rule.ServiceName) > maxServiceNameLen {
+		return fmt.Errorf("%w: ServiceName must be at most %d characters", ErrInvalidSamplingRule, maxServiceNameLen)
+	}
+
+	if rule.Priority < 1 || rule.Priority > 9999 {
+		return fmt.Errorf("%w: Priority must be between 1 and 9999", ErrInvalidSamplingRule)
+	}
+
+	if rule.FixedRate < 0 || rule.FixedRate > 1.0 {
+		return fmt.Errorf("%w: FixedRate must be between 0.0 and 1.0", ErrInvalidSamplingRule)
+	}
+
+	if rule.ReservoirSize < 0 {
+		return fmt.Errorf("%w: ReservoirSize must be >= 0", ErrInvalidSamplingRule)
+	}
 
 	return nil
 }
@@ -315,6 +551,7 @@ func (b *InMemoryBackend) CreateSamplingRule(rule SamplingRule) (*SamplingRule, 
 	rule.CreatedAt = now
 	rule.ModifiedAt = now
 	b.samplingRules[rule.RuleName] = &rule
+	b.lastRuleModification = now
 
 	return cloneRule(&rule), nil
 }
@@ -337,6 +574,7 @@ func (b *InMemoryBackend) GetSamplingRules() []SamplingRule {
 }
 
 // UpdateSamplingRule updates the mutable fields of an existing sampling rule.
+// It accepts a SamplingRule struct where non-zero values are applied (legacy API).
 func (b *InMemoryBackend) UpdateSamplingRule(ruleName string, updates SamplingRule) (*SamplingRule, error) {
 	b.mu.Lock("UpdateSamplingRule")
 	defer b.mu.Unlock()
@@ -344,14 +582,6 @@ func (b *InMemoryBackend) UpdateSamplingRule(ruleName string, updates SamplingRu
 	r, ok := b.samplingRules[ruleName]
 	if !ok {
 		return nil, fmt.Errorf("%w: sampling rule %s not found", ErrSamplingRuleNotFound, ruleName)
-	}
-
-	if updates.FixedRate >= 0 {
-		r.FixedRate = updates.FixedRate
-	}
-
-	if updates.ReservoirSize >= 0 {
-		r.ReservoirSize = updates.ReservoirSize
 	}
 
 	if updates.ResourceARN != "" {
@@ -383,6 +613,62 @@ func (b *InMemoryBackend) UpdateSamplingRule(ruleName string, updates SamplingRu
 	}
 
 	r.ModifiedAt = time.Now()
+	b.lastRuleModification = r.ModifiedAt
+
+	return cloneRule(r), nil
+}
+
+// UpdateSamplingRuleWithPointers applies pointer-semantic updates so zero values apply.
+func (b *InMemoryBackend) UpdateSamplingRuleWithPointers(
+	ruleName string,
+	updates SamplingRuleUpdate,
+) (*SamplingRule, error) {
+	b.mu.Lock("UpdateSamplingRuleWithPointers")
+	defer b.mu.Unlock()
+
+	r, ok := b.samplingRules[ruleName]
+	if !ok {
+		return nil, fmt.Errorf("%w: sampling rule %s not found", ErrSamplingRuleNotFound, ruleName)
+	}
+
+	if updates.FixedRate != nil {
+		r.FixedRate = *updates.FixedRate
+	}
+
+	if updates.ReservoirSize != nil {
+		r.ReservoirSize = *updates.ReservoirSize
+	}
+
+	if updates.ResourceARN != nil {
+		r.ResourceARN = *updates.ResourceARN
+	}
+
+	if updates.ServiceName != nil {
+		r.ServiceName = *updates.ServiceName
+	}
+
+	if updates.ServiceType != nil {
+		r.ServiceType = *updates.ServiceType
+	}
+
+	if updates.Host != nil {
+		r.Host = *updates.Host
+	}
+
+	if updates.HTTPMethod != nil {
+		r.HTTPMethod = *updates.HTTPMethod
+	}
+
+	if updates.URLPath != nil {
+		r.URLPath = *updates.URLPath
+	}
+
+	if updates.Priority != nil {
+		r.Priority = *updates.Priority
+	}
+
+	r.ModifiedAt = time.Now()
+	b.lastRuleModification = r.ModifiedAt
 
 	return cloneRule(r), nil
 }
@@ -399,6 +685,7 @@ func (b *InMemoryBackend) DeleteSamplingRule(ruleName string) (*SamplingRule, er
 
 	deleted := cloneRule(r)
 	delete(b.samplingRules, ruleName)
+	b.lastRuleModification = time.Now()
 
 	return deleted, nil
 }
@@ -406,10 +693,11 @@ func (b *InMemoryBackend) DeleteSamplingRule(ruleName string) (*SamplingRule, er
 // segmentHeader is used to extract the trace_id from a raw segment JSON.
 type segmentHeader struct {
 	TraceID string `json:"trace_id"`
+	ID      string `json:"id"`
 }
 
-// PutTraceSegments stores raw segment JSON strings and returns the list of
-// unprocessed segment IDs (empty slice means all segments were accepted).
+// PutTraceSegments stores raw segment JSON strings, parses them into typed Segment structs,
+// and returns the list of unprocessed segment IDs (empty slice means all segments were accepted).
 func (b *InMemoryBackend) PutTraceSegments(segments []string) []string {
 	b.mu.Lock("PutTraceSegments")
 	defer b.mu.Unlock()
@@ -434,13 +722,7 @@ func (b *InMemoryBackend) PutTraceSegments(segments []string) []string {
 			b.traces[hdr.TraceID] = t
 		}
 
-		// Cap per-trace segment count so a single misbehaving trace cannot
-		// consume unbounded memory before the janitor's TTL sweep evicts it.
-		// Compact only when the slice has grown to twice the cap so the per-call
-		// cost is amortized O(1) rather than O(cap) on every insert past the cap.
-		// Reslice into a fresh backing array so the dropped prefix and any
-		// over-allocated tail are released for GC immediately rather than
-		// pinned for the lifetime of the trace.
+		// Cap per-trace segment count.
 		if len(t.Segments) >= segmentCompactionHighWater {
 			trimmed := make([]string, maxSegmentsPerTrace, segmentCompactionHighWater)
 			copy(trimmed, t.Segments[len(t.Segments)-maxSegmentsPerTrace:])
@@ -448,6 +730,27 @@ func (b *InMemoryBackend) PutTraceSegments(segments []string) []string {
 		}
 
 		t.Segments = append(t.Segments, seg)
+
+		// Parse into typed Segment struct and index it.
+		var parsed Segment
+		if err := json.Unmarshal([]byte(seg), &parsed); err == nil {
+			parsed.Document = seg
+
+			segKey := hdr.TraceID + ":" + parsed.ID
+			b.parsedSegments[segKey] = &parsed
+			b.traceSegments[hdr.TraceID] = append(b.traceSegments[hdr.TraceID], &parsed)
+
+			// Update trace StartTime from the earliest segment start_time.
+			if parsed.StartTime > 0 {
+				segStart := time.Unix(
+					int64(parsed.StartTime),
+					int64((parsed.StartTime-math.Floor(parsed.StartTime))*nanosPerSecond),
+				)
+				if segStart.Before(t.StartTime) {
+					t.StartTime = segStart
+				}
+			}
+		}
 	}
 
 	return unprocessed
@@ -490,6 +793,33 @@ func (b *InMemoryBackend) GetTrace(traceID string) *Trace {
 	return &cp
 }
 
+// GetParsedSegments returns a copy of the parsed segments for a given trace ID.
+func (b *InMemoryBackend) GetParsedSegments(traceID string) []*Segment {
+	b.mu.RLock("GetParsedSegments")
+	defer b.mu.RUnlock()
+
+	segs := b.traceSegments[traceID]
+	out := make([]*Segment, len(segs))
+	copy(out, segs)
+
+	return out
+}
+
+// GetAllParsedSegments returns all parsed segments.
+func (b *InMemoryBackend) GetAllParsedSegments() map[string][]*Segment {
+	b.mu.RLock("GetAllParsedSegments")
+	defer b.mu.RUnlock()
+
+	out := make(map[string][]*Segment, len(b.traceSegments))
+	for k, v := range b.traceSegments {
+		cp := make([]*Segment, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+
+	return out
+}
+
 // Reset clears all backend state, resetting to an empty store.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
@@ -498,18 +828,29 @@ func (b *InMemoryBackend) Reset() {
 	b.groups = make(map[string]*Group)
 	b.samplingRules = make(map[string]*SamplingRule)
 	b.traces = make(map[string]*Trace)
+	b.parsedSegments = make(map[string]*Segment)
+	b.traceSegments = make(map[string][]*Segment)
 	b.insights = make(map[string]*Insight)
 	b.insightEvents = make(map[string][]*InsightEvent)
 	b.resourcePolicies = make(map[string]*ResourcePolicy)
 	b.traceRetrievals = make(map[string]*TraceRetrieval)
+	b.samplingStats = make(map[string]*SamplingStatisticSummary)
+	b.telemetry = make([]*TelemetryRecord, telemetryRingSize)
+	b.telemetryIdx = 0
 	b.indexingRules = defaultIndexingRules()
 	b.encryptionConfig = &EncryptionConfig{Type: "NONE", Status: statusActive}
+	b.lastRuleModification = time.Time{}
 }
 
 // GetEncryptionConfig returns the current X-Ray encryption configuration.
+// If the current status is UPDATING, this call advances it to ACTIVE.
 func (b *InMemoryBackend) GetEncryptionConfig() *EncryptionConfig {
-	b.mu.RLock("GetEncryptionConfig")
-	defer b.mu.RUnlock()
+	b.mu.Lock("GetEncryptionConfig")
+	defer b.mu.Unlock()
+
+	if b.encryptionConfig.Status == statusUpdating {
+		b.encryptionConfig.Status = statusActive
+	}
 
 	cp := *b.encryptionConfig
 
@@ -518,22 +859,36 @@ func (b *InMemoryBackend) GetEncryptionConfig() *EncryptionConfig {
 
 // PutEncryptionConfig updates the X-Ray encryption configuration.
 // encType must be one of "NONE" or "KMS". keyID is only used when encType is "KMS".
+// When encType is KMS the keyID must match alias/..., ARN, or UUID format.
+// The status is initially set to UPDATING; the next GET will advance it to ACTIVE.
 func (b *InMemoryBackend) PutEncryptionConfig(encType, keyID string) (*EncryptionConfig, error) {
 	if encType != encTypeNone && encType != encTypeKMS {
 		return nil, fmt.Errorf("%w: Type must be NONE or KMS", ErrValidation)
 	}
 
-	if encType == encTypeKMS && keyID == "" {
-		return nil, fmt.Errorf("%w: KeyId is required when Type is KMS", ErrValidation)
+	if encType == encTypeKMS {
+		if keyID == "" {
+			return nil, fmt.Errorf("%w: KeyId is required when Type is KMS", ErrValidation)
+		}
+
+		if !validKMSKeyID.MatchString(keyID) {
+			return nil, fmt.Errorf("%w: KeyId must be alias/..., key ARN, or UUID", ErrValidation)
+		}
 	}
 
 	b.mu.Lock("PutEncryptionConfig")
 	defer b.mu.Unlock()
 
+	status := statusActive
+
+	if encType == encTypeKMS {
+		status = statusUpdating
+	}
+
 	b.encryptionConfig = &EncryptionConfig{
 		Type:   encType,
 		KeyID:  keyID,
-		Status: statusActive,
+		Status: status,
 	}
 
 	cp := *b.encryptionConfig
@@ -598,20 +953,40 @@ func (b *InMemoryBackend) GetInsightEvents(insightID string) ([]*InsightEvent, e
 	return out, nil
 }
 
+// isValidInsightState returns true if s is a recognised insight state name.
+func isValidInsightState(s string) bool {
+	return s == statusActive || s == "CLOSED"
+}
+
 // GetInsightSummaries returns all insights as summaries, optionally filtered by state.
-// If states is empty, all insights are returned.
-func (b *InMemoryBackend) GetInsightSummaries(states []string) []Insight {
+// If states is empty, all insights are returned. "ALL" matches both ACTIVE and CLOSED.
+// Unknown states return ErrValidation.
+func (b *InMemoryBackend) GetInsightSummaries(states []string) ([]Insight, error) {
 	b.mu.RLock("GetInsightSummaries")
 	defer b.mu.RUnlock()
 
+	// Validate states and resolve ALL.
+	wantAll := len(states) == 0
 	stateSet := make(map[string]bool, len(states))
+
 	for _, s := range states {
+		if s == "ALL" {
+			wantAll = true
+
+			continue
+		}
+
+		if !isValidInsightState(s) {
+			return nil, fmt.Errorf("%w: unknown insight state %q", ErrValidation, s)
+		}
+
 		stateSet[s] = true
 	}
 
 	out := make([]Insight, 0, len(b.insights))
+
 	for _, i := range b.insights {
-		if len(stateSet) > 0 && !stateSet[i.State] {
+		if !wantAll && !stateSet[i.State] {
 			continue
 		}
 
@@ -622,7 +997,7 @@ func (b *InMemoryBackend) GetInsightSummaries(states []string) []Insight {
 		return out[i].InsightID < out[j].InsightID
 	})
 
-	return out
+	return out, nil
 }
 
 // --- Resource policy operations ---
@@ -634,9 +1009,33 @@ func cloneResourcePolicy(p *ResourcePolicy) *ResourcePolicy {
 }
 
 // PutResourcePolicy creates or updates a resource policy with the given name and document.
-func (b *InMemoryBackend) PutResourcePolicy(policyName, policyDocument string) *ResourcePolicy {
+// Returns ErrTooManyPolicies if the account already has maxResourcePolicies.
+// Returns ErrInvalidPolicyRevisionID if revisionID doesn't match the stored one.
+// Returns ErrMalformedPolicyDocument if policyDocument is not valid JSON.
+func (b *InMemoryBackend) PutResourcePolicy(policyName, policyDocument, revisionID string) (*ResourcePolicy, error) {
+	// Validate JSON.
+	var js json.RawMessage
+	if err := json.Unmarshal([]byte(policyDocument), &js); err != nil {
+		return nil, fmt.Errorf("%w: policy document is not valid JSON: %w", ErrMalformedPolicyDocument, err)
+	}
+
 	b.mu.Lock("PutResourcePolicy")
 	defer b.mu.Unlock()
+
+	existing, exists := b.resourcePolicies[policyName]
+
+	if !exists && len(b.resourcePolicies) >= maxResourcePolicies {
+		return nil, fmt.Errorf(
+			"%w: maximum of %d resource policies per account",
+			ErrTooManyPolicies,
+			maxResourcePolicies,
+		)
+	}
+
+	// Revision ID check: if a revision is provided it must match the stored one.
+	if revisionID != "" && exists && existing.PolicyRevisionID != revisionID {
+		return nil, fmt.Errorf("%w: policy revision ID does not match", ErrInvalidPolicyRevisionID)
+	}
 
 	p := &ResourcePolicy{
 		PolicyName:       policyName,
@@ -645,7 +1044,7 @@ func (b *InMemoryBackend) PutResourcePolicy(policyName, policyDocument string) *
 	}
 	b.resourcePolicies[policyName] = p
 
-	return cloneResourcePolicy(p)
+	return cloneResourcePolicy(p), nil
 }
 
 // ListResourcePolicies returns all resource policies sorted by name.
@@ -737,20 +1136,105 @@ func (b *InMemoryBackend) GetRetrievedTracesGraph(retrievalToken string) (string
 
 // --- Sampling statistic operations ---
 
-// GetSamplingStatisticSummaries returns an empty list of sampling statistic summaries.
-// In a production implementation statistics would be accumulated per sampling rule.
+// GetSamplingStatisticSummaries returns accumulated sampling statistic summaries.
 func (b *InMemoryBackend) GetSamplingStatisticSummaries() []SamplingStatisticSummary {
 	b.mu.RLock("GetSamplingStatisticSummaries")
 	defer b.mu.RUnlock()
 
-	return []SamplingStatisticSummary{}
+	out := make([]SamplingStatisticSummary, 0, len(b.samplingStats))
+	for _, s := range b.samplingStats {
+		cp := *s
+		out = append(out, cp)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].RuleName < out[j].RuleName
+	})
+
+	return out
+}
+
+// SamplingStatisticsDocument is a single document submitted in GetSamplingTargets.
+type SamplingStatisticsDocument struct {
+	RuleName     string
+	ClientID     string
+	RequestCount int32
+	SampledCount int32
+	BorrowCount  int32
 }
 
 // SamplingTargetResult holds the per-document results of GetSamplingTargets.
 type SamplingTargetResult struct {
-	RuleName      string
-	FixedRate     float64
-	ReservoirSize int32
+	ReservoirQuotaTTL time.Time
+	RuleName          string
+	FixedRate         float64
+	ReservoirSize     int32
+}
+
+// UnprocessedStatisticsResult holds results for unknown rule names.
+type UnprocessedStatisticsResult struct {
+	RuleName  string
+	ErrorCode string
+	Message   string
+}
+
+// GetSamplingTargets returns target documents for the provided stat documents.
+// Rules that do not exist are returned in the unprocessed list.
+// Statistics from known rules are accumulated for GetSamplingStatisticSummaries.
+func (b *InMemoryBackend) GetSamplingTargets(
+	docs []SamplingStatisticsDocument,
+) ([]SamplingTargetResult, []UnprocessedStatisticsResult) {
+	b.mu.Lock("GetSamplingTargets")
+	defer b.mu.Unlock()
+
+	targets := make([]SamplingTargetResult, 0, len(docs))
+	unprocessed := make([]UnprocessedStatisticsResult, 0)
+
+	for _, d := range docs {
+		r, ok := b.samplingRules[d.RuleName]
+		if !ok {
+			unprocessed = append(unprocessed, UnprocessedStatisticsResult{
+				RuleName:  d.RuleName,
+				ErrorCode: "404",
+				Message:   "Rule not found",
+			})
+
+			continue
+		}
+
+		// Accumulate statistics.
+		if existing := b.samplingStats[d.RuleName]; existing != nil {
+			existing.RequestCount += d.RequestCount
+			existing.SampledCount += d.SampledCount
+			existing.BorrowCount += d.BorrowCount
+			existing.Timestamp = time.Now()
+		} else {
+			b.samplingStats[d.RuleName] = &SamplingStatisticSummary{
+				RuleName:     d.RuleName,
+				RequestCount: d.RequestCount,
+				SampledCount: d.SampledCount,
+				BorrowCount:  d.BorrowCount,
+				Timestamp:    time.Now(),
+			}
+		}
+
+		targets = append(targets, SamplingTargetResult{
+			RuleName:          r.RuleName,
+			FixedRate:         r.FixedRate,
+			ReservoirSize:     r.ReservoirSize,
+			ReservoirQuotaTTL: time.Now().Add(samplingTargetInterval * time.Second),
+		})
+	}
+
+	return targets, unprocessed
+}
+
+// LastRuleModification returns the timestamp of the last sampling rule modification.
+func (b *InMemoryBackend) LastRuleModification() time.Time {
+	b.mu.RLock("LastRuleModification")
+	defer b.mu.RUnlock()
+
+	return b.lastRuleModification
 }
 
 // --- Tag operations ---
@@ -808,23 +1292,340 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) []map[string]s
 	return out
 }
 
-// --- Service graph operations ---
+// --- serviceNode is used to build the service graph ---
 
-// GetServiceGraph returns a simplified service graph derived from stored traces.
-// Each unique service name found in segments is returned as a node.
-func (b *InMemoryBackend) GetServiceGraph(_, _ time.Time) []map[string]any {
+type serviceNode struct {
+	Name          string
+	Type          string
+	ReferenceID   int
+	OkCount       int64
+	ErrorCount    int64
+	ThrottleCount int64
+	FaultCount    int64
+	TotalCount    int64
+	TotalRespTime float64
+	StartTime     float64
+	EndTime       float64
+	IsRoot        bool
+}
+
+// serviceKey identifies a unique service node in the service graph.
+type serviceKey struct{ Name, Type string }
+
+// edgeKey identifies a directed edge between two service nodes.
+type edgeKey struct{ From, To serviceKey }
+
+// accumulateServiceNodes builds nodeMap and segToService from the trace segments.
+func accumulateServiceNodes(
+	traceSegs map[string][]*Segment,
+) (map[serviceKey]*serviceNode, map[string]serviceKey) {
+	nodeMap := map[serviceKey]*serviceNode{}
+	segToService := map[string]serviceKey{}
+	refID := 0
+
+	for _, segs := range traceSegs {
+		for _, seg := range segs {
+			svcType := seg.Origin
+			if svcType == "" {
+				svcType = seg.Namespace
+			}
+
+			key := serviceKey{Name: seg.Name, Type: svcType}
+
+			node, ok := nodeMap[key]
+			if !ok {
+				node = &serviceNode{Name: seg.Name, Type: svcType, ReferenceID: refID}
+				refID++
+				nodeMap[key] = node
+			}
+
+			accumulateNodeStats(node, seg)
+			segToService[seg.ID] = key
+		}
+	}
+
+	return nodeMap, segToService
+}
+
+// accumulateNodeStats updates a service node with stats from a single segment.
+func accumulateNodeStats(node *serviceNode, seg *Segment) {
+	if seg.StartTime > 0 && (node.StartTime == 0 || seg.StartTime < node.StartTime) {
+		node.StartTime = seg.StartTime
+	}
+
+	if seg.EndTime > node.EndTime {
+		node.EndTime = seg.EndTime
+	}
+
+	node.TotalCount++
+
+	switch {
+	case seg.Fault:
+		node.FaultCount++
+	case seg.Error && seg.Throttle:
+		node.ThrottleCount++
+	case seg.Error:
+		node.ErrorCount++
+	default:
+		node.OkCount++
+	}
+
+	if seg.EndTime > 0 && seg.StartTime > 0 {
+		node.TotalRespTime += seg.EndTime - seg.StartTime
+	}
+
+	if seg.ParentID == "" {
+		node.IsRoot = true
+	}
+}
+
+// buildEdgeSet returns the set of directed edges between service nodes.
+func buildEdgeSet(
+	traceSegs map[string][]*Segment,
+	segToService map[string]serviceKey,
+) map[edgeKey]bool {
+	edgeSet := map[edgeKey]bool{}
+
+	for _, segs := range traceSegs {
+		for _, seg := range segs {
+			if seg.ParentID == "" {
+				continue
+			}
+
+			parentKey, ok := segToService[seg.ParentID]
+			if !ok {
+				continue
+			}
+
+			childKey := segToService[seg.ID]
+			if childKey != parentKey {
+				edgeSet[edgeKey{From: childKey, To: parentKey}] = true
+			}
+		}
+	}
+
+	return edgeSet
+}
+
+// nodeToView converts a service node to its JSON output representation.
+func nodeToView(
+	key serviceKey,
+	node *serviceNode,
+	edgeSet map[edgeKey]bool,
+	nodeMap map[serviceKey]*serviceNode,
+) map[string]any {
+	nodeEdges := make([]map[string]any, 0)
+
+	for e := range edgeSet {
+		if e.From == key {
+			to := nodeMap[e.To]
+			nodeEdges = append(nodeEdges, map[string]any{
+				"ReferenceId": to.ReferenceID,
+			})
+		}
+	}
+
+	return map[string]any{
+		"ReferenceId": node.ReferenceID,
+		"Name":        node.Name,
+		"Type":        node.Type,
+		"State":       "active",
+		"Root":        node.IsRoot,
+		"StartTime":   node.StartTime,
+		"EndTime":     node.EndTime,
+		"Edges":       nodeEdges,
+		"SummaryStatistics": map[string]any{
+			"OkCount": node.OkCount,
+			"ErrorStatistics": map[string]any{
+				"ThrottleCount":        node.ThrottleCount,
+				"OtherCount":           node.ErrorCount,
+				serviceGraphTotalCount: node.ThrottleCount + node.ErrorCount,
+			},
+			"FaultStatistics": map[string]any{
+				serviceGraphTotalCount: node.FaultCount,
+			},
+			serviceGraphTotalCount: node.TotalCount,
+			"TotalResponseTime":    node.TotalRespTime,
+			"DurationHistogram":    []any{},
+		},
+	}
+}
+
+// buildServiceGraph builds service nodes from a map of traceID → segments.
+func buildServiceGraph(traceSegs map[string][]*Segment) []map[string]any {
+	nodeMap, segToService := accumulateServiceNodes(traceSegs)
+	edgeSet := buildEdgeSet(traceSegs, segToService)
+
+	nodes := make([]map[string]any, 0, len(nodeMap))
+
+	for key, node := range nodeMap {
+		nodes = append(nodes, nodeToView(key, node, edgeSet, nodeMap))
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		ri, _ := nodes[i]["ReferenceId"].(int)
+		rj, _ := nodes[j]["ReferenceId"].(int)
+
+		return ri < rj
+	})
+
+	return nodes
+}
+
+// GetServiceGraph returns a service graph derived from stored traces in the time window.
+func (b *InMemoryBackend) GetServiceGraph(startTime, endTime time.Time) []map[string]any {
 	b.mu.RLock("GetServiceGraph")
 	defer b.mu.RUnlock()
 
-	return []map[string]any{}
+	// Filter segments to those within the time window.
+	filtered := map[string][]*Segment{}
+
+	for traceID, segs := range b.traceSegments {
+		var inWindow []*Segment
+
+		for _, seg := range segs {
+			if seg.StartTime == 0 {
+				inWindow = append(inWindow, seg)
+
+				continue
+			}
+
+			t := time.Unix(int64(seg.StartTime), 0)
+			if !t.Before(startTime) && !t.After(endTime) {
+				inWindow = append(inWindow, seg)
+			}
+		}
+
+		if len(inWindow) > 0 {
+			filtered[traceID] = inWindow
+		}
+	}
+
+	if len(filtered) == 0 {
+		return []map[string]any{}
+	}
+
+	return buildServiceGraph(filtered)
 }
 
-// GetTraceGraph returns an empty service graph for the specified trace IDs.
-func (b *InMemoryBackend) GetTraceGraph(_ []string) []map[string]any {
+// GetTraceGraph returns a service graph scoped to the given trace IDs.
+func (b *InMemoryBackend) GetTraceGraph(traceIDs []string) []map[string]any {
 	b.mu.RLock("GetTraceGraph")
 	defer b.mu.RUnlock()
 
-	return []map[string]any{}
+	filtered := map[string][]*Segment{}
+
+	for _, id := range traceIDs {
+		if segs, ok := b.traceSegments[id]; ok {
+			filtered[id] = segs
+		}
+	}
+
+	if len(filtered) == 0 {
+		return []map[string]any{}
+	}
+
+	return buildServiceGraph(filtered)
+}
+
+// GetTimeSeriesServiceStatistics returns per-period bucketed statistics.
+// tsBucket accumulates time-series statistics for one time period.
+type tsBucket struct {
+	OkCount       int64
+	ErrorCount    int64
+	ThrottleCount int64
+	FaultCount    int64
+	TotalCount    int64
+	TotalRespTime float64
+}
+
+// accumulateToBucket adds one segment's stats into the appropriate time bucket.
+func accumulateToBucket(buckets map[int64]*tsBucket, seg *Segment, period int) {
+	bk := (int64(seg.StartTime) / int64(period)) * int64(period)
+
+	bkt := buckets[bk]
+	if bkt == nil {
+		bkt = &tsBucket{}
+		buckets[bk] = bkt
+	}
+
+	bkt.TotalCount++
+
+	switch {
+	case seg.Fault:
+		bkt.FaultCount++
+	case seg.Error && seg.Throttle:
+		bkt.ThrottleCount++
+	case seg.Error:
+		bkt.ErrorCount++
+	default:
+		bkt.OkCount++
+	}
+
+	if seg.EndTime > seg.StartTime {
+		bkt.TotalRespTime += seg.EndTime - seg.StartTime
+	}
+}
+
+// tsBucketToView converts a tsBucket to its JSON output map.
+func tsBucketToView(k int64, bkt *tsBucket) map[string]any {
+	return map[string]any{
+		"Timestamp": float64(k),
+		"ServiceSummaryStatistics": map[string]any{
+			"OkCount": bkt.OkCount,
+			"ErrorStatistics": map[string]any{
+				"ThrottleCount":        bkt.ThrottleCount,
+				"OtherCount":           bkt.ErrorCount,
+				serviceGraphTotalCount: bkt.ThrottleCount + bkt.ErrorCount,
+			},
+			"FaultStatistics": map[string]any{
+				serviceGraphTotalCount: bkt.FaultCount,
+			},
+			serviceGraphTotalCount: bkt.TotalCount,
+			"TotalResponseTime":    bkt.TotalRespTime,
+		},
+	}
+}
+
+// GetTimeSeriesServiceStatistics returns per-period bucketed statistics for segments in the time window.
+func (b *InMemoryBackend) GetTimeSeriesServiceStatistics(startTime, endTime time.Time, period int) []map[string]any {
+	b.mu.RLock("GetTimeSeriesServiceStatistics")
+	defer b.mu.RUnlock()
+
+	if period <= 0 {
+		period = 60
+	}
+
+	buckets := map[int64]*tsBucket{}
+
+	for _, segs := range b.traceSegments {
+		for _, seg := range segs {
+			if seg.StartTime == 0 {
+				continue
+			}
+
+			t := time.Unix(int64(seg.StartTime), 0)
+			if t.Before(startTime) || t.After(endTime) {
+				continue
+			}
+
+			accumulateToBucket(buckets, seg, period)
+		}
+	}
+
+	keys := make([]int64, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	out := make([]map[string]any, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, tsBucketToView(k, buckets[k]))
+	}
+
+	return out
 }
 
 // --- Trace segment destination operations ---
@@ -834,11 +1635,11 @@ func (b *InMemoryBackend) GetTraceSegmentDestination() string {
 	b.mu.RLock("GetTraceSegmentDestination")
 	defer b.mu.RUnlock()
 
-	if b.traceSegmentDestination == "" {
+	if b.traceSegmentDest == "" {
 		return "XRay"
 	}
 
-	return b.traceSegmentDestination
+	return b.traceSegmentDest
 }
 
 // UpdateTraceSegmentDestination sets the trace segment destination and returns it.
@@ -846,7 +1647,7 @@ func (b *InMemoryBackend) UpdateTraceSegmentDestination(destination string) stri
 	b.mu.Lock("UpdateTraceSegmentDestination")
 	defer b.mu.Unlock()
 
-	b.traceSegmentDestination = destination
+	b.traceSegmentDest = destination
 
 	return destination
 }
@@ -932,29 +1733,264 @@ func (b *InMemoryBackend) UpdateIndexingRule(name string) (*IndexingRule, error)
 	return nil, fmt.Errorf("%w: indexing rule %s not found", ErrIndexingRuleNotFound, name)
 }
 
-// GetSamplingTargets returns target documents for the provided rule names.
-// Rules that do not exist are returned in the unprocessed list.
-func (b *InMemoryBackend) GetSamplingTargets(ruleNames []string) ([]SamplingTargetResult, []string) {
-	b.mu.RLock("GetSamplingTargets")
-	defer b.mu.RUnlock()
+// PutTelemetryRecords stores telemetry records in a ring buffer.
+func (b *InMemoryBackend) PutTelemetryRecords(records []TelemetryRecord) {
+	b.mu.Lock("PutTelemetryRecords")
+	defer b.mu.Unlock()
 
-	targets := make([]SamplingTargetResult, 0, len(ruleNames))
-	unprocessed := make([]string, 0, len(ruleNames))
+	for i := range records {
+		b.telemetry[b.telemetryIdx%telemetryRingSize] = &records[i]
+		b.telemetryIdx++
+	}
+}
 
-	for _, name := range ruleNames {
-		r, ok := b.samplingRules[name]
-		if !ok {
-			unprocessed = append(unprocessed, name)
+// TraceSummaryData holds derived data for GetTraceSummaries response.
+type TraceSummaryData struct {
+	Annotations  map[string]any
+	HTTP         *TraceSummaryHTTP
+	TraceID      string
+	EntryPoint   string
+	ServiceIDs   []TraceSummaryServiceID
+	Duration     float64
+	ResponseTime float64
+	ApproxTime   float64
+	HasFault     bool
+	HasError     bool
+	HasThrottle  bool
+	IsPartial    bool
+}
 
-			continue
-		}
+// TraceSummaryHTTP holds HTTP fields for a trace summary.
+type TraceSummaryHTTP struct {
+	HTTPURL    string
+	HTTPMethod string
+	ClientIP   string
+	UserAgent  string
+	HTTPStatus int
+}
 
-		targets = append(targets, SamplingTargetResult{
-			RuleName:      r.RuleName,
-			FixedRate:     r.FixedRate,
-			ReservoirSize: r.ReservoirSize,
-		})
+// TraceSummaryServiceID is a service identifier in a trace summary.
+type TraceSummaryServiceID struct {
+	Name string
+	Type string
+}
+
+// extractRootHTTP populates HTTP fields from the root segment's HTTP data.
+// Returns the updated (or newly created) TraceSummaryHTTP pointer.
+func extractRootHTTP(segHTTP *SegmentHTTP, existing *TraceSummaryHTTP) *TraceSummaryHTTP {
+	if segHTTP == nil {
+		return existing
 	}
 
-	return targets, unprocessed
+	if segHTTP.Request != nil {
+		if existing == nil {
+			existing = &TraceSummaryHTTP{}
+		}
+
+		existing.HTTPURL = segHTTP.Request.URL
+		existing.HTTPMethod = segHTTP.Request.Method
+		existing.ClientIP = segHTTP.Request.ClientIP
+		existing.UserAgent = segHTTP.Request.UserAgent
+	}
+
+	if segHTTP.Response != nil {
+		if existing == nil {
+			existing = &TraceSummaryHTTP{}
+		}
+
+		existing.HTTPStatus = segHTTP.Response.Status
+	}
+
+	return existing
+}
+
+// BuildTraceSummary derives TraceSummaryData from parsed segments.
+func BuildTraceSummary(traceID string, segs []*Segment) TraceSummaryData {
+	summary := TraceSummaryData{
+		TraceID:     traceID,
+		ApproxTime:  float64(time.Now().Unix()),
+		Annotations: map[string]any{},
+	}
+
+	if len(segs) == 0 {
+		summary.IsPartial = true
+
+		return summary
+	}
+
+	var minStart, maxEnd float64
+
+	seen := map[serviceKey]bool{}
+	hasRoot := false
+
+	for _, seg := range segs {
+		accumulateTraceSummaryFlags(&summary, seg)
+
+		if seg.StartTime > 0 && (minStart == 0 || seg.StartTime < minStart) {
+			minStart = seg.StartTime
+		}
+
+		if seg.EndTime > maxEnd {
+			maxEnd = seg.EndTime
+		}
+
+		maps.Copy(summary.Annotations, seg.Annotations)
+
+		svcType := seg.Origin
+		if svcType == "" {
+			svcType = seg.Namespace
+		}
+
+		key := serviceKey{Name: seg.Name, Type: svcType}
+		if !seen[key] {
+			seen[key] = true
+			summary.ServiceIDs = append(summary.ServiceIDs, TraceSummaryServiceID{Name: seg.Name, Type: svcType})
+		}
+
+		// Root segment has no parent.
+		if seg.ParentID == "" {
+			hasRoot = true
+			summary.EntryPoint = seg.Name
+			summary.HTTP = extractRootHTTP(seg.HTTP, summary.HTTP)
+		}
+	}
+
+	if !hasRoot {
+		summary.IsPartial = true
+	}
+
+	if maxEnd > 0 && minStart > 0 {
+		summary.Duration = maxEnd - minStart
+	}
+
+	// ResponseTime: root segment duration or overall duration.
+	summary.ResponseTime = summary.Duration
+
+	return summary
+}
+
+// accumulateTraceSummaryFlags copies boolean fault/error/throttle flags from a segment.
+func accumulateTraceSummaryFlags(summary *TraceSummaryData, seg *Segment) {
+	if seg.Fault {
+		summary.HasFault = true
+	}
+
+	if seg.Error {
+		summary.HasError = true
+	}
+
+	if seg.Throttle {
+		summary.HasThrottle = true
+	}
+}
+
+// evaluateHTTPStatusFilter matches `http.status = N` expressions.
+func evaluateHTTPStatusFilter(expr string, http *TraceSummaryHTTP) bool {
+	parts := strings.Fields(expr)
+	if len(parts) != filterParts3 || parts[1] != "=" {
+		return false
+	}
+
+	n, err := strconv.Atoi(parts[2])
+	if err != nil || http == nil {
+		return false
+	}
+
+	return http.HTTPStatus == n
+}
+
+// compareResponseTime applies a comparison operator to response time.
+func compareResponseTime(op string, rt, n float64) bool {
+	switch op {
+	case ">":
+		return rt > n
+	case ">=":
+		return rt >= n
+	case "<":
+		return rt < n
+	case "<=":
+		return rt <= n
+	case "=":
+		return rt == n
+	}
+
+	return false
+}
+
+// evaluateResponseTimeFilter matches `responsetime OP N.N` expressions.
+func evaluateResponseTimeFilter(expr string, rt float64) bool {
+	parts := strings.Fields(expr)
+	if len(parts) != filterParts3 {
+		return false
+	}
+
+	n, err := strconv.ParseFloat(parts[2], 64)
+	if err != nil {
+		return false
+	}
+
+	return compareResponseTime(parts[1], rt, n)
+}
+
+// evaluateAnnotationFilter matches `annotation.KEY = "VALUE"` expressions.
+func evaluateAnnotationFilter(expr string, annotations map[string]any) bool {
+	parts := strings.SplitN(expr, "=", filterParts2)
+	if len(parts) != filterParts2 {
+		return false
+	}
+
+	key := strings.TrimSpace(parts[0])
+	key = key[len("annotation."):]
+	val := strings.TrimSpace(parts[1])
+	val = strings.Trim(val, `"`)
+
+	v, ok := annotations[key]
+
+	return ok && fmt.Sprintf("%v", v) == val
+}
+
+// evaluateFilter checks a trace summary against a simple filter expression.
+// Supported tokens:
+//   - `fault`                      — trace has fault
+//   - `error`                      — trace has error
+//   - `http.status = N`            — HTTP status equals N
+//   - `responsetime > N.N`         — response time comparison (also >=, <, <=, =)
+//   - `annotation.KEY = "VALUE"`   — annotation match
+//
+// Empty expression always returns true.
+func evaluateFilter(expr string, summary TraceSummaryData) bool {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return true
+	}
+
+	lower := strings.ToLower(expr)
+
+	switch lower {
+	case "fault":
+		return summary.HasFault
+	case "error":
+		return summary.HasError
+	case "throttle":
+		return summary.HasThrottle
+	}
+
+	if strings.HasPrefix(lower, "http.status") {
+		return evaluateHTTPStatusFilter(expr, summary.HTTP)
+	}
+
+	if strings.HasPrefix(lower, "responsetime") {
+		return evaluateResponseTimeFilter(expr, summary.ResponseTime)
+	}
+
+	if strings.HasPrefix(lower, "annotation.") {
+		return evaluateAnnotationFilter(expr, summary.Annotations)
+	}
+
+	return false
+}
+
+// EvaluateFilter is exported for tests.
+func EvaluateFilter(expr string, summary TraceSummaryData) bool {
+	return evaluateFilter(expr, summary)
 }

--- a/services/xray/handler.go
+++ b/services/xray/handler.go
@@ -420,10 +420,14 @@ func (h *Handler) handleError(c *echo.Context, _ string, err error) error {
 		})
 	case errors.Is(err, awserr.ErrConflict):
 		typeName := errInvalidRequestException
-		if errors.Is(err, ErrGroupAlreadyExists) {
+
+		switch {
+		case errors.Is(err, ErrGroupAlreadyExists):
 			typeName = "GroupAlreadyExistsException"
-		} else if errors.Is(err, ErrSamplingRuleAlreadyExists) {
+		case errors.Is(err, ErrSamplingRuleAlreadyExists):
 			typeName = "RuleAlreadyExistsException"
+		case errors.Is(err, ErrInvalidPolicyRevisionID):
+			typeName = "InvalidPolicyRevisionIdException"
 		}
 
 		return c.JSON(http.StatusBadRequest, map[string]string{
@@ -431,8 +435,16 @@ func (h *Handler) handleError(c *echo.Context, _ string, err error) error {
 			keyMessageField: err.Error(),
 		})
 	case errors.Is(err, awserr.ErrInvalidParameter):
+		typeName := errInvalidRequestException
+
+		if errors.Is(err, ErrInvalidSamplingRule) {
+			typeName = "InvalidSamplingRuleException"
+		} else if errors.Is(err, ErrMalformedPolicyDocument) {
+			typeName = "MalformedPolicyDocumentException"
+		}
+
 		return c.JSON(http.StatusBadRequest, map[string]string{
-			keyTypeField:    errInvalidRequestException,
+			keyTypeField:    typeName,
 			keyMessageField: err.Error(),
 		})
 	case errors.Is(err, errInvalidRequest), errors.Is(err, errUnknownPath),
@@ -495,14 +507,19 @@ func (h *Handler) handleCreateGroup(_ context.Context, body []byte) ([]byte, err
 		return nil, fmt.Errorf("%w: GroupName is required", errInvalidRequest)
 	}
 
-	g, err := h.Backend.CreateGroup(in.GroupName, in.FilterExpression)
-	if err != nil {
-		return nil, err
+	// Validate: NotificationsEnabled=true requires InsightsEnabled=true.
+	if in.InsightsConfiguration.NotificationsEnabled && !in.InsightsConfiguration.InsightsEnabled {
+		return nil, fmt.Errorf("%w: NotificationsEnabled requires InsightsEnabled to be true", errInvalidRequest)
 	}
 
-	g.InsightsConfiguration = InsightsConfiguration{
+	ic := InsightsConfiguration{
 		InsightsEnabled:      in.InsightsConfiguration.InsightsEnabled,
 		NotificationsEnabled: in.InsightsConfiguration.NotificationsEnabled,
+	}
+
+	g, err := h.Backend.CreateGroupWithInsights(in.GroupName, in.FilterExpression, ic)
+	if err != nil {
+		return nil, err
 	}
 
 	return json.Marshal(map[string]any{
@@ -512,6 +529,7 @@ func (h *Handler) handleCreateGroup(_ context.Context, body []byte) ([]byte, err
 
 type getGroupInput struct {
 	GroupName string `json:"GroupName"`
+	GroupARN  string `json:"GroupARN"`
 }
 
 func (h *Handler) handleGetGroup(_ context.Context, body []byte) ([]byte, error) {
@@ -522,11 +540,21 @@ func (h *Handler) handleGetGroup(_ context.Context, body []byte) ([]byte, error)
 		}
 	}
 
-	if in.GroupName == "" {
-		return nil, fmt.Errorf("%w: GroupName is required", errInvalidRequest)
+	if in.GroupName == "" && in.GroupARN == "" {
+		return nil, fmt.Errorf("%w: GroupName or GroupARN is required", errInvalidRequest)
 	}
 
-	g, err := h.Backend.GetGroup(in.GroupName)
+	var (
+		g   *Group
+		err error
+	)
+
+	if in.GroupARN != "" {
+		g, err = h.Backend.GetGroupByARN(in.GroupARN)
+	} else {
+		g, err = h.Backend.GetGroup(in.GroupName)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -551,8 +579,10 @@ func (h *Handler) handleGetGroups(_ context.Context, _ []byte) ([]byte, error) {
 }
 
 type updateGroupInput struct {
-	GroupName        string `json:"GroupName"`
-	FilterExpression string `json:"FilterExpression"`
+	GroupName             string             `json:"GroupName"`
+	GroupARN              string             `json:"GroupARN"`
+	FilterExpression      string             `json:"FilterExpression"`
+	InsightsConfiguration insightsConfigView `json:"InsightsConfiguration"`
 }
 
 func (h *Handler) handleUpdateGroup(_ context.Context, body []byte) ([]byte, error) {
@@ -563,11 +593,11 @@ func (h *Handler) handleUpdateGroup(_ context.Context, body []byte) ([]byte, err
 		}
 	}
 
-	if in.GroupName == "" {
+	if in.GroupName == "" && in.GroupARN == "" {
 		return nil, fmt.Errorf("%w: GroupName is required", errInvalidRequest)
 	}
 
-	g, err := h.Backend.UpdateGroup(in.GroupName, in.FilterExpression)
+	g, err := h.Backend.UpdateGroupByARN(in.GroupName, in.GroupARN, in.FilterExpression)
 	if err != nil {
 		return nil, err
 	}
@@ -579,6 +609,7 @@ func (h *Handler) handleUpdateGroup(_ context.Context, body []byte) ([]byte, err
 
 type deleteGroupInput struct {
 	GroupName string `json:"GroupName"`
+	GroupARN  string `json:"GroupARN"`
 }
 
 func (h *Handler) handleDeleteGroup(_ context.Context, body []byte) ([]byte, error) {
@@ -589,11 +620,11 @@ func (h *Handler) handleDeleteGroup(_ context.Context, body []byte) ([]byte, err
 		}
 	}
 
-	if in.GroupName == "" {
+	if in.GroupName == "" && in.GroupARN == "" {
 		return nil, fmt.Errorf("%w: GroupName is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteGroup(in.GroupName); err != nil {
+	if err := h.Backend.DeleteGroupByARN(in.GroupName, in.GroupARN); err != nil {
 		return nil, err
 	}
 
@@ -696,6 +727,10 @@ func (h *Handler) handleCreateSamplingRule(_ context.Context, body []byte) ([]by
 		Attributes:    in.SamplingRule.Attributes,
 	}
 
+	if err := ValidateSamplingRule(rule); err != nil {
+		return nil, err
+	}
+
 	r, err := h.Backend.CreateSamplingRule(rule)
 	if err != nil {
 		return nil, err
@@ -720,21 +755,23 @@ func (h *Handler) handleGetSamplingRules(_ context.Context, _ []byte) ([]byte, e
 	})
 }
 
-type samplingRuleUpdate struct {
-	RuleName      string  `json:"RuleName"`
-	ResourceARN   string  `json:"ResourceARN"`
-	ServiceName   string  `json:"ServiceName"`
-	ServiceType   string  `json:"ServiceType"`
-	Host          string  `json:"Host"`
-	HTTPMethod    string  `json:"HTTPMethod"`
-	URLPath       string  `json:"URLPath"`
-	FixedRate     float64 `json:"FixedRate"`
-	Priority      int32   `json:"Priority"`
-	ReservoirSize int32   `json:"ReservoirSize"`
+// samplingRuleUpdateInput uses json.RawMessage so we can detect which fields
+// were explicitly provided (even zero values like FixedRate=0).
+type samplingRuleUpdateInput struct {
+	ResourceARN   *string  `json:"ResourceARN"`
+	ServiceName   *string  `json:"ServiceName"`
+	ServiceType   *string  `json:"ServiceType"`
+	Host          *string  `json:"Host"`
+	HTTPMethod    *string  `json:"HTTPMethod"`
+	URLPath       *string  `json:"URLPath"`
+	FixedRate     *float64 `json:"FixedRate"`
+	Priority      *int32   `json:"Priority"`
+	ReservoirSize *int32   `json:"ReservoirSize"`
+	RuleName      string   `json:"RuleName"`
 }
 
 type updateSamplingRuleInput struct {
-	SamplingRuleUpdate samplingRuleUpdate `json:"SamplingRuleUpdate"`
+	SamplingRuleUpdate samplingRuleUpdateInput `json:"SamplingRuleUpdate"`
 }
 
 func (h *Handler) handleUpdateSamplingRule(_ context.Context, body []byte) ([]byte, error) {
@@ -749,7 +786,7 @@ func (h *Handler) handleUpdateSamplingRule(_ context.Context, body []byte) ([]by
 		return nil, fmt.Errorf("%w: RuleName is required", errInvalidRequest)
 	}
 
-	updates := SamplingRule{
+	updates := SamplingRuleUpdate{
 		ResourceARN:   in.SamplingRuleUpdate.ResourceARN,
 		ServiceName:   in.SamplingRuleUpdate.ServiceName,
 		ServiceType:   in.SamplingRuleUpdate.ServiceType,
@@ -761,7 +798,7 @@ func (h *Handler) handleUpdateSamplingRule(_ context.Context, body []byte) ([]by
 		ReservoirSize: in.SamplingRuleUpdate.ReservoirSize,
 	}
 
-	r, err := h.Backend.UpdateSamplingRule(in.SamplingRuleUpdate.RuleName, updates)
+	r, err := h.Backend.UpdateSamplingRuleWithPointers(in.SamplingRuleUpdate.RuleName, updates)
 	if err != nil {
 		return nil, err
 	}
@@ -829,18 +866,122 @@ func (h *Handler) handlePutTraceSegments(_ context.Context, body []byte) ([]byte
 	})
 }
 
-func (h *Handler) handlePutTelemetryRecords(_ context.Context, _ []byte) ([]byte, error) {
+type telemetryRecordInput struct {
+	Timestamp              float64 `json:"Timestamp"`
+	SegmentsReceivedCount  int32   `json:"SegmentsReceivedCount"`
+	SegmentsSentCount      int32   `json:"SegmentsSentCount"`
+	SegmentsSpilloverCount int32   `json:"SegmentsSpilloverCount"`
+	SegmentsRejectedCount  int32   `json:"SegmentsRejectedCount"`
+}
+
+type putTelemetryRecordsInput struct {
+	TelemetryRecords []telemetryRecordInput `json:"TelemetryRecords"`
+}
+
+func (h *Handler) handlePutTelemetryRecords(_ context.Context, body []byte) ([]byte, error) {
+	var in putTelemetryRecordsInput
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &in); err != nil {
+			return nil, err
+		}
+	}
+
+	records := make([]TelemetryRecord, 0, len(in.TelemetryRecords))
+
+	for _, r := range in.TelemetryRecords {
+		ts := time.Now()
+		if r.Timestamp > 0 {
+			ts = time.Unix(int64(r.Timestamp), 0)
+		}
+
+		records = append(records, TelemetryRecord{
+			Timestamp:              ts,
+			SegmentsReceivedCount:  r.SegmentsReceivedCount,
+			SegmentsSentCount:      r.SegmentsSentCount,
+			SegmentsSpilloverCount: r.SegmentsSpilloverCount,
+			SegmentsRejectedCount:  r.SegmentsRejectedCount,
+		})
+	}
+
+	if len(records) > 0 {
+		h.Backend.PutTelemetryRecords(records)
+	}
+
 	return json.Marshal(map[string]any{})
 }
 
 type getTraceSummariesInput struct {
-	StartTime float64 `json:"StartTime"`
-	EndTime   float64 `json:"EndTime"`
+	FilterExpression string  `json:"FilterExpression"`
+	TimeRangeType    string  `json:"TimeRangeType"`
+	NextToken        string  `json:"NextToken"`
+	StartTime        float64 `json:"StartTime"`
+	EndTime          float64 `json:"EndTime"`
+}
+
+type traceSummaryHTTPView struct {
+	HTTPURL    string `json:"HttpURL,omitempty"`
+	HTTPMethod string `json:"HttpMethod,omitempty"`
+	ClientIP   string `json:"ClientIp,omitempty"`
+	UserAgent  string `json:"UserAgent,omitempty"`
+	HTTPStatus int    `json:"HttpStatus,omitempty"`
+}
+
+type traceSummaryServiceIDView struct {
+	Name string `json:"Name"`
+	Type string `json:"Type"`
 }
 
 type traceSummary struct {
-	ID       string  `json:"Id"`
-	Duration float64 `json:"Duration"`
+	HTTP            *traceSummaryHTTPView       `json:"Http,omitempty"`
+	Annotations     map[string]any              `json:"Annotations,omitempty"`
+	ID              string                      `json:"Id"`
+	EntryPoint      string                      `json:"EntryPoint,omitempty"`
+	ServiceIds      []traceSummaryServiceIDView `json:"ServiceIds,omitempty"` //nolint:revive // AWS API field name
+	Duration        float64                     `json:"Duration"`
+	ResponseTime    float64                     `json:"ResponseTime"`
+	ApproximateTime float64                     `json:"ApproximateTime"`
+	HasFault        bool                        `json:"HasFault"`
+	HasError        bool                        `json:"HasError"`
+	HasThrottle     bool                        `json:"HasThrottle"`
+	IsPartial       bool                        `json:"IsPartial"`
+}
+
+// buildTraceSummaryView converts a TraceSummaryData to the JSON view struct.
+func buildTraceSummaryView(traceID string, sd TraceSummaryData) traceSummary {
+	s := traceSummary{
+		ID:              traceID,
+		Duration:        sd.Duration,
+		ResponseTime:    sd.ResponseTime,
+		ApproximateTime: sd.ApproxTime,
+		HasFault:        sd.HasFault,
+		HasError:        sd.HasError,
+		HasThrottle:     sd.HasThrottle,
+		IsPartial:       sd.IsPartial,
+		EntryPoint:      sd.EntryPoint,
+	}
+
+	if sd.HTTP != nil {
+		s.HTTP = &traceSummaryHTTPView{
+			HTTPStatus: sd.HTTP.HTTPStatus,
+			HTTPURL:    sd.HTTP.HTTPURL,
+			HTTPMethod: sd.HTTP.HTTPMethod,
+			ClientIP:   sd.HTTP.ClientIP,
+			UserAgent:  sd.HTTP.UserAgent,
+		}
+	}
+
+	if len(sd.Annotations) > 0 {
+		s.Annotations = sd.Annotations
+	}
+
+	if len(sd.ServiceIDs) > 0 {
+		s.ServiceIds = make([]traceSummaryServiceIDView, 0, len(sd.ServiceIDs))
+		for _, svc := range sd.ServiceIDs {
+			s.ServiceIds = append(s.ServiceIds, traceSummaryServiceIDView(svc))
+		}
+	}
+
+	return s
 }
 
 func (h *Handler) handleGetTraceSummaries(_ context.Context, body []byte) ([]byte, error) {
@@ -852,6 +993,8 @@ func (h *Handler) handleGetTraceSummaries(_ context.Context, body []byte) ([]byt
 	}
 
 	traces := h.Backend.GetTraceSummaries()
+	allSegs := h.Backend.GetAllParsedSegments()
+
 	summaries := make([]traceSummary, 0, len(traces))
 
 	for i := range traces {
@@ -863,10 +1006,14 @@ func (h *Handler) handleGetTraceSummaries(_ context.Context, body []byte) ([]byt
 			}
 		}
 
-		summaries = append(summaries, traceSummary{
-			ID:       traces[i].TraceID,
-			Duration: 0,
-		})
+		segs := allSegs[traces[i].TraceID]
+		sd := BuildTraceSummary(traces[i].TraceID, segs)
+
+		if !evaluateFilter(in.FilterExpression, sd) {
+			continue
+		}
+
+		summaries = append(summaries, buildTraceSummaryView(traces[i].TraceID, sd))
 	}
 
 	return json.Marshal(map[string]any{
@@ -880,10 +1027,15 @@ type batchGetTracesInput struct {
 	TraceIDs []string `json:"TraceIds"`
 }
 
+type batchSegmentOutput struct {
+	ID       string `json:"Id"`
+	Document string `json:"Document"`
+}
+
 type traceOutput struct {
-	ID       string   `json:"Id"`
-	Segments []string `json:"Segments"`
-	Duration float64  `json:"Duration"`
+	ID       string               `json:"Id"`
+	Segments []batchSegmentOutput `json:"Segments"`
+	Duration float64              `json:"Duration"`
 }
 
 func (h *Handler) handleBatchGetTraces(_ context.Context, body []byte) ([]byte, error) {
@@ -892,6 +1044,11 @@ func (h *Handler) handleBatchGetTraces(_ context.Context, body []byte) ([]byte, 
 		if err := json.Unmarshal(body, &in); err != nil {
 			return nil, err
 		}
+	}
+
+	if len(in.TraceIDs) > maxBatchGetTraces {
+		return nil, fmt.Errorf("%w: BatchGetTraces supports at most %d trace IDs, got %d",
+			ErrBatchGetTracesLimit, maxBatchGetTraces, len(in.TraceIDs))
 	}
 
 	traces := make([]traceOutput, 0, len(in.TraceIDs))
@@ -905,10 +1062,37 @@ func (h *Handler) handleBatchGetTraces(_ context.Context, body []byte) ([]byte, 
 			continue
 		}
 
+		segs := h.Backend.GetParsedSegments(id)
+		sd := BuildTraceSummary(id, segs)
+
+		segViews := make([]batchSegmentOutput, 0, len(segs))
+		for _, seg := range segs {
+			segViews = append(segViews, batchSegmentOutput{
+				ID:       seg.ID,
+				Document: seg.Document,
+			})
+		}
+
+		// Fall back to raw segments when parsed segments are unavailable.
+		if len(segViews) == 0 {
+			for _, rawDoc := range t.Segments {
+				var hdr struct {
+					ID string `json:"id"`
+				}
+
+				if err := json.Unmarshal([]byte(rawDoc), &hdr); err == nil {
+					segViews = append(segViews, batchSegmentOutput{
+						ID:       hdr.ID,
+						Document: rawDoc,
+					})
+				}
+			}
+		}
+
 		traces = append(traces, traceOutput{
 			ID:       t.TraceID,
-			Duration: 0,
-			Segments: t.Segments,
+			Duration: sd.Duration,
+			Segments: segViews,
 		})
 	}
 
@@ -1182,7 +1366,11 @@ func (h *Handler) handleGetInsightSummaries(_ context.Context, body []byte) ([]b
 		}
 	}
 
-	summaries := h.Backend.GetInsightSummaries(in.States)
+	summaries, err := h.Backend.GetInsightSummaries(in.States)
+	if err != nil {
+		return nil, err
+	}
+
 	views := make([]insightView, 0, len(summaries))
 
 	for i := range summaries {
@@ -1268,10 +1456,11 @@ type getSamplingTargetsInput struct {
 }
 
 type samplingTargetDocumentView struct {
-	RuleName       string  `json:"RuleName"`
-	FixedRate      float64 `json:"FixedRate"`
-	ReservoirQuota int32   `json:"ReservoirQuota"`
-	Interval       int32   `json:"Interval"`
+	RuleName          string  `json:"RuleName"`
+	ReservoirQuotaTTL float64 `json:"ReservoirQuotaTTL"`
+	FixedRate         float64 `json:"FixedRate"`
+	ReservoirQuota    int32   `json:"ReservoirQuota"`
+	Interval          int32   `json:"Interval"`
 }
 
 type unprocessedStatisticsView struct {
@@ -1288,36 +1477,42 @@ func (h *Handler) handleGetSamplingTargets(_ context.Context, body []byte) ([]by
 		}
 	}
 
-	ruleNames := make([]string, 0, len(in.SamplingStatisticsDocuments))
+	docs := make([]SamplingStatisticsDocument, 0, len(in.SamplingStatisticsDocuments))
 	for _, d := range in.SamplingStatisticsDocuments {
-		ruleNames = append(ruleNames, d.RuleName)
+		docs = append(docs, SamplingStatisticsDocument(d))
 	}
 
-	targets, unprocessedNames := h.Backend.GetSamplingTargets(ruleNames)
+	targets, unprocessed := h.Backend.GetSamplingTargets(docs)
 
 	targetViews := make([]samplingTargetDocumentView, 0, len(targets))
 	for _, t := range targets {
 		targetViews = append(targetViews, samplingTargetDocumentView{
-			RuleName:       t.RuleName,
-			FixedRate:      t.FixedRate,
-			ReservoirQuota: t.ReservoirSize,
-			Interval:       samplingTargetInterval,
+			RuleName:          t.RuleName,
+			FixedRate:         t.FixedRate,
+			ReservoirQuota:    t.ReservoirSize,
+			ReservoirQuotaTTL: float64(t.ReservoirQuotaTTL.Unix()),
+			Interval:          samplingTargetInterval,
 		})
 	}
 
-	unprocessedViews := make([]unprocessedStatisticsView, 0, len(unprocessedNames))
-	for _, name := range unprocessedNames {
-		unprocessedViews = append(unprocessedViews, unprocessedStatisticsView{
-			RuleName:  name,
-			ErrorCode: "RuleDoesNotExist",
-			Message:   "sampling rule " + name + " not found",
-		})
+	unprocessedViews := make([]unprocessedStatisticsView, 0, len(unprocessed))
+	for _, u := range unprocessed {
+		unprocessedViews = append(unprocessedViews, unprocessedStatisticsView(u))
+	}
+
+	lastMod := h.Backend.LastRuleModification()
+	var lastModTS float64
+
+	if !lastMod.IsZero() {
+		lastModTS = float64(lastMod.Unix())
+	} else {
+		lastModTS = float64(time.Now().Unix())
 	}
 
 	return json.Marshal(map[string]any{
 		"SamplingTargetDocuments": targetViews,
 		"UnprocessedStatistics":   unprocessedViews,
-		"LastRuleModification":    float64(time.Now().Unix()),
+		"LastRuleModification":    lastModTS,
 	})
 }
 
@@ -1354,9 +1549,10 @@ func (h *Handler) handleListResourcePolicies(_ context.Context, _ []byte) ([]byt
 // --- PutResourcePolicy ---
 
 type putResourcePolicyInput struct {
-	PolicyName       string `json:"PolicyName"`
-	PolicyDocument   string `json:"PolicyDocument"`
-	PolicyRevisionID string `json:"PolicyRevisionId"`
+	PolicyName               string `json:"PolicyName"`
+	PolicyDocument           string `json:"PolicyDocument"`
+	PolicyRevisionID         string `json:"PolicyRevisionId"`
+	BypassPolicyLockoutCheck bool   `json:"BypassPolicyLockoutCheck"`
 }
 
 func (h *Handler) handlePutResourcePolicy(_ context.Context, body []byte) ([]byte, error) {
@@ -1375,7 +1571,10 @@ func (h *Handler) handlePutResourcePolicy(_ context.Context, body []byte) ([]byt
 		return nil, fmt.Errorf("%w: PolicyDocument is required", errInvalidRequest)
 	}
 
-	p := h.Backend.PutResourcePolicy(in.PolicyName, in.PolicyDocument)
+	p, err := h.Backend.PutResourcePolicy(in.PolicyName, in.PolicyDocument, in.PolicyRevisionID)
+	if err != nil {
+		return nil, err
+	}
 
 	return json.Marshal(map[string]any{
 		"ResourcePolicy": toResourcePolicyView(p),

--- a/services/xray/handler_accuracy_test.go
+++ b/services/xray/handler_accuracy_test.go
@@ -1,0 +1,873 @@
+package xray_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/xray"
+)
+
+// segJSON builds a minimal segment JSON string.
+func segJSON(traceID, segID, parentID, name string, startTime, endTime float64, fault, hasError, throttle bool) string {
+	d := fmt.Sprintf(
+		`{"trace_id":%q,"id":%q,"name":%q,"start_time":%f,"end_time":%f,"fault":%v,"error":%v,"throttle":%v`,
+		traceID, segID, name, startTime, endTime, fault, hasError, throttle,
+	)
+
+	if parentID != "" {
+		d += fmt.Sprintf(`,"parent_id":%q`, parentID)
+	}
+
+	d += "}"
+
+	return d
+}
+
+// segJSONWithHTTP builds a segment with HTTP fields.
+func segJSONWithHTTP(traceID, segID, name string, startTime, endTime float64, status int, method, url string) string {
+	return fmt.Sprintf(
+		`{"trace_id":%q,"id":%q,"name":%q,"start_time":%f,"end_time":%f,`+
+			`"http":{"request":{"method":%q,"url":%q},"response":{"status":%d}}}`,
+		traceID, segID, name, startTime, endTime, method, url, status,
+	)
+}
+
+// --- Test 1: PutTraceSegments + GetTraceSummaries round-trip ---
+
+func TestAccuracy_PutAndGetTraceSummaries_Populated(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+	seg := segJSONWithHTTP("1-acc-001", "seg1", "my-service", now-1, now, 200, "GET", "https://example.com/api")
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{seg},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	getRec := doXrayRequest(t, h, "/TraceSummaries", map[string]any{
+		"StartTime": now - 60,
+		"EndTime":   now + 60,
+	})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &resp))
+
+	summaries, ok := resp["TraceSummaries"].([]any)
+	require.True(t, ok)
+	require.Len(t, summaries, 1)
+
+	s, ok := summaries[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "1-acc-001", s["Id"])
+
+	// Duration should be non-zero (endTime - startTime = ~1 second).
+	dur, ok := s["Duration"].(float64)
+	require.True(t, ok)
+	assert.Greater(t, dur, 0.0)
+
+	// HasFault / HasError should be false.
+	assert.Equal(t, false, s["HasFault"])
+	assert.Equal(t, false, s["HasError"])
+
+	// Http fields should be populated.
+	httpField, ok := s["Http"].(map[string]any)
+	require.True(t, ok, "Http field should be present")
+	assert.Equal(t, "GET", httpField["HttpMethod"])
+	assert.Equal(t, "https://example.com/api", httpField["HttpURL"])
+	assert.InDelta(t, 200.0, httpField["HttpStatus"], 0.001)
+}
+
+// --- Test 2: BatchGetTraces correct Segments shape + 5-trace cap ---
+
+func TestAccuracy_BatchGetTraces_SegmentShape(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			segJSON("1-bgt-001", "seg1", "", "svc", now-2, now-1, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/Traces", map[string]any{
+		"TraceIds": []string{"1-bgt-001"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	traces, ok := resp["Traces"].([]any)
+	require.True(t, ok)
+	require.Len(t, traces, 1)
+
+	traceObj, ok := traces[0].(map[string]any)
+	require.True(t, ok)
+
+	segs, ok := traceObj["Segments"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, segs)
+
+	seg0, ok := segs[0].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, seg0["Id"], "each segment must have an Id")
+	assert.NotEmpty(t, seg0["Document"], "each segment must have a Document")
+}
+
+func TestAccuracy_BatchGetTraces_5TraceCap(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	ids := []string{"1-cap-001", "1-cap-002", "1-cap-003", "1-cap-004", "1-cap-005", "1-cap-006"}
+
+	rec := doXrayRequest(t, h, "/Traces", map[string]any{"TraceIds": ids})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Test 3: GetServiceGraph returns non-empty nodes after PutTraceSegments ---
+
+func TestAccuracy_GetServiceGraph_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			segJSON("1-sg-001", "seg1", "", "frontend", now-5, now-4, false, false, false),
+			segJSON("1-sg-001", "seg2", "seg1", "backend", now-4, now-3, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/ServiceGraph", map[string]any{
+		"StartTime": now - 10,
+		"EndTime":   now + 10,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	services, ok := resp["Services"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, services, "service graph should have nodes after segments are stored")
+}
+
+// --- Test 4: GetTraceSummaries FilterExpression `fault` filter ---
+
+func TestAccuracy_GetTraceSummaries_FaultFilter(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			// Faulted trace
+			segJSON("1-filter-fault", "seg1", "", "svc", now-5, now-4, true, false, false),
+			// Non-faulted trace
+			segJSON("1-filter-ok", "seg2", "", "svc", now-3, now-2, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/TraceSummaries", map[string]any{
+		"FilterExpression": "fault",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	summaries, ok := resp["TraceSummaries"].([]any)
+	require.True(t, ok)
+	require.Len(t, summaries, 1, "only one trace should match the fault filter")
+
+	s, ok := summaries[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "1-filter-fault", s["Id"])
+	assert.Equal(t, true, s["HasFault"])
+}
+
+// --- Test 5: GetTraceSummaries TimeRangeType ---
+
+func TestAccuracy_GetTraceSummaries_TimeRangeType(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			segJSON("1-trt-001", "seg1", "", "svc", now-5, now-4, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/TraceSummaries", map[string]any{
+		"StartTime":     now - 60,
+		"EndTime":       now + 60,
+		"TimeRangeType": "TraceId",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// Should still return the trace — TimeRangeType is accepted without error.
+	summaries, ok := resp["TraceSummaries"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, summaries)
+}
+
+// --- Test 6: GetInsightSummaries ALL state returns both ACTIVE and CLOSED ---
+
+func TestAccuracy_GetInsightSummaries_ALLState(t *testing.T) {
+	t.Parallel()
+
+	h, b := newTestHandlerWithBackend(t)
+	b.AddInsightInternal(xray.Insight{InsightID: "all-active", State: "ACTIVE", StartTime: time.Now()})
+	b.AddInsightInternal(xray.Insight{InsightID: "all-closed", State: "CLOSED", StartTime: time.Now()})
+
+	rec := doXrayRequest(t, h, "/GetInsightSummaries", map[string]any{
+		"States": []any{"ALL"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	summaries, ok := resp["InsightSummaries"].([]any)
+	require.True(t, ok)
+	assert.Len(t, summaries, 2, "ALL should return both ACTIVE and CLOSED insights")
+}
+
+// --- Test 7: GetInsightSummaries unknown state returns error ---
+
+func TestAccuracy_GetInsightSummaries_UnknownState(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doXrayRequest(t, h, "/GetInsightSummaries", map[string]any{
+		"States": []any{"BOGUS"},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Test 8: SamplingRule Priority validation (0 rejected, 10000 rejected) ---
+
+func TestAccuracy_SamplingRule_PriorityValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		priority   int
+		wantStatus int
+	}{
+		{name: "priority 0 rejected", priority: 0, wantStatus: http.StatusBadRequest},
+		{name: "priority 1 accepted", priority: 1, wantStatus: http.StatusOK},
+		{name: "priority 9999 accepted", priority: 9999, wantStatus: http.StatusOK},
+		{name: "priority 10000 rejected", priority: 10000, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doXrayRequest(t, h, "/CreateSamplingRule", map[string]any{
+				"SamplingRule": map[string]any{
+					"RuleName":  fmt.Sprintf("prio-rule-%d", tt.priority),
+					"Priority":  tt.priority,
+					"FixedRate": 0.1,
+				},
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// --- Test 9: SamplingRule FixedRate validation (>1.0 rejected) ---
+
+func TestAccuracy_SamplingRule_FixedRateValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		fixedRate  float64
+		wantStatus int
+	}{
+		{name: "fixedRate 0.0 accepted", fixedRate: 0.0, wantStatus: http.StatusOK},
+		{name: "fixedRate 1.0 accepted", fixedRate: 1.0, wantStatus: http.StatusOK},
+		{name: "fixedRate 1.1 rejected", fixedRate: 1.1, wantStatus: http.StatusBadRequest},
+		{name: "fixedRate -0.1 rejected", fixedRate: -0.1, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doXrayRequest(t, h, "/CreateSamplingRule", map[string]any{
+				"SamplingRule": map[string]any{
+					"RuleName":  fmt.Sprintf("rate-rule-%.2f", tt.fixedRate+10),
+					"Priority":  1,
+					"FixedRate": tt.fixedRate,
+				},
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// --- Test 10: GetSamplingTargets returns LastRuleModification and ReservoirQuotaTTL ---
+
+func TestAccuracy_GetSamplingTargets_LastRuleModAndTTL(t *testing.T) {
+	t.Parallel()
+
+	h, b := newTestHandlerWithBackend(t)
+	b.AddSamplingRuleInternal(xray.SamplingRule{RuleName: "ttl-rule", FixedRate: 0.05, ReservoirSize: 5, Priority: 1})
+
+	rec := doXrayRequest(t, h, "/GetSamplingTargets", map[string]any{
+		"SamplingStatisticsDocuments": []map[string]any{
+			{"RuleName": "ttl-rule", "ClientId": "c-1", "RequestCount": 100, "SampledCount": 5, "BorrowCount": 0},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// LastRuleModification should be a timestamp.
+	lastMod, ok := resp["LastRuleModification"].(float64)
+	require.True(t, ok, "LastRuleModification should be a float64 timestamp")
+	assert.Greater(t, lastMod, 0.0)
+
+	// Target should have ReservoirQuotaTTL.
+	targets, ok := resp["SamplingTargetDocuments"].([]any)
+	require.True(t, ok)
+	require.Len(t, targets, 1)
+
+	target, ok := targets[0].(map[string]any)
+	require.True(t, ok)
+
+	ttl, ok := target["ReservoirQuotaTTL"].(float64)
+	require.True(t, ok, "ReservoirQuotaTTL should be present")
+	assert.Greater(t, ttl, float64(time.Now().Unix()), "TTL should be in the future")
+}
+
+// --- Test 11: GetSamplingStatisticSummaries after PutSamplingTargets ---
+
+func TestAccuracy_GetSamplingStatisticSummaries_AfterPut(t *testing.T) {
+	t.Parallel()
+
+	h, b := newTestHandlerWithBackend(t)
+	b.AddSamplingRuleInternal(xray.SamplingRule{RuleName: "stat-rule", FixedRate: 0.05, ReservoirSize: 5, Priority: 1})
+
+	// Submit statistics via GetSamplingTargets.
+	putRec := doXrayRequest(t, h, "/GetSamplingTargets", map[string]any{
+		"SamplingStatisticsDocuments": []map[string]any{
+			{"RuleName": "stat-rule", "ClientId": "c-1", "RequestCount": 200, "SampledCount": 10, "BorrowCount": 2},
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	// Now fetch summaries.
+	rec := doXrayRequest(t, h, "/GetSamplingStatisticSummaries", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	summaries, ok := resp["SamplingStatisticSummaries"].([]any)
+	require.True(t, ok)
+	require.Len(t, summaries, 1)
+
+	s, ok := summaries[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "stat-rule", s["RuleName"])
+	assert.InDelta(t, 200.0, s["RequestCount"], 0.001)
+	assert.InDelta(t, 10.0, s["SampledCount"], 0.001)
+	assert.InDelta(t, 2.0, s["BorrowCount"], 0.001)
+}
+
+// --- Test 12: Encryption KeyId format validation (bad format rejected) ---
+
+func TestAccuracy_Encryption_KeyIdFormatValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		keyID      string
+		wantStatus int
+	}{
+		{
+			name:       "alias format accepted",
+			keyID:      "alias/my-key",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "ARN format accepted",
+			keyID:      "arn:aws:kms:us-east-1:123456789012:key/abc-123",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "UUID format accepted",
+			keyID:      "12345678-1234-1234-1234-123456789abc",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "random string rejected",
+			keyID:      "not-a-valid-key-id",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty rejected for KMS",
+			keyID:      "",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			body := map[string]any{"Type": "KMS"}
+
+			if tt.keyID != "" {
+				body["KeyId"] = tt.keyID
+			}
+
+			rec := doXrayRequest(t, h, "/EncryptionConfig", body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// --- Test 13: Encryption UPDATING status after PUT ---
+
+func TestAccuracy_Encryption_UpdatingStatusAfterPut(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	putRec := doXrayRequest(t, h, "/EncryptionConfig", map[string]any{
+		"Type":  "KMS",
+		"KeyId": "alias/my-key",
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	var putResp map[string]any
+	require.NoError(t, json.Unmarshal(putRec.Body.Bytes(), &putResp))
+
+	enc, ok := putResp["EncryptionConfig"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "UPDATING", enc["Status"], "status should be UPDATING immediately after PUT")
+
+	// GET should advance to ACTIVE.
+	getRec := doXrayGETRequest(t, h, "/EncryptionConfig")
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+
+	enc2, ok := getResp["EncryptionConfig"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ACTIVE", enc2["Status"], "status should be ACTIVE after first GET")
+}
+
+// --- Test 14: Resource policy max 5 cap ---
+
+func TestAccuracy_ResourcePolicy_MaxFiveCap(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create 5 policies — should all succeed.
+	for i := 1; i <= 5; i++ {
+		rec := doXrayRequest(t, h, "/PutResourcePolicy", map[string]any{
+			"PolicyName":     fmt.Sprintf("policy-%d", i),
+			"PolicyDocument": `{"Version":"2012-10-17"}`,
+		})
+		require.Equal(t, http.StatusOK, rec.Code, "policy %d should succeed", i)
+	}
+
+	// 6th should fail.
+	rec := doXrayRequest(t, h, "/PutResourcePolicy", map[string]any{
+		"PolicyName":     "policy-6",
+		"PolicyDocument": `{"Version":"2012-10-17"}`,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "6th policy should be rejected")
+}
+
+// --- Test 15: Resource policy revision-ID mismatch ---
+
+func TestAccuracy_ResourcePolicy_RevisionIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create a policy.
+	createRec := doXrayRequest(t, h, "/PutResourcePolicy", map[string]any{
+		"PolicyName":     "rev-policy",
+		"PolicyDocument": `{"Version":"2012-10-17"}`,
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	// Update with wrong revision ID — should fail.
+	updateRec := doXrayRequest(t, h, "/PutResourcePolicy", map[string]any{
+		"PolicyName":       "rev-policy",
+		"PolicyDocument":   `{"Version":"2012-10-17","Statement":[]}`,
+		"PolicyRevisionId": "wrong-revision-id",
+	})
+	assert.Equal(t, http.StatusBadRequest, updateRec.Code)
+}
+
+// --- Test 16: Group ARN-based lookup ---
+
+func TestAccuracy_Group_ARNBasedLookup(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	createRec := doXrayRequest(t, h, "/CreateGroup", map[string]any{
+		"GroupName": "arn-lookup-group",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+
+	group, ok := createResp["Group"].(map[string]any)
+	require.True(t, ok)
+
+	groupARN, ok := group["GroupARN"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, groupARN)
+
+	// Get by ARN.
+	getRec := doXrayRequest(t, h, "/GetGroup", map[string]any{
+		"GroupARN": groupARN,
+	})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+
+	g2, ok := getResp["Group"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "arn-lookup-group", g2["GroupName"])
+}
+
+// --- Test 17: PutTelemetryRecords accepted (no error) ---
+
+func TestAccuracy_PutTelemetryRecords_Accepted(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doXrayRequest(t, h, "/TelemetryRecords", map[string]any{
+		"TelemetryRecords": []map[string]any{
+			{
+				"Timestamp":              float64(time.Now().Unix()),
+				"SegmentsReceivedCount":  100,
+				"SegmentsSentCount":      95,
+				"SegmentsSpilloverCount": 5,
+				"SegmentsRejectedCount":  0,
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// Response should be an empty JSON object.
+	assert.Empty(t, resp)
+}
+
+// --- Test 18: GetTimeSeriesServiceStatistics returns bucketed data after PutTraceSegments ---
+
+func TestAccuracy_GetTimeSeriesServiceStatistics_BucketedData(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			segJSON("1-ts-001", "seg1", "", "svc", now-30, now-29, false, false, false),
+			segJSON("1-ts-002", "seg2", "", "svc", now-10, now-9, false, true, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/TimeSeriesServiceStatistics", map[string]any{
+		"StartTime": now - 60,
+		"EndTime":   now + 60,
+		"Period":    60,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	stats, ok := resp["TimeSeriesServiceStatistics"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, stats, "should return at least one time-series bucket")
+
+	// Each entry should have Timestamp and ServiceSummaryStatistics.
+	entry, ok := stats[0].(map[string]any)
+	require.True(t, ok)
+	assert.NotNil(t, entry["Timestamp"])
+	assert.NotNil(t, entry["ServiceSummaryStatistics"])
+
+	assert.Equal(t, false, resp["ContainsOldGroupVersions"])
+}
+
+// --- Test 19: GetTraceGraph returns nodes for listed trace IDs ---
+
+func TestAccuracy_GetTraceGraph_ReturnsNodes(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			segJSON("1-tg-001", "seg1", "", "service-a", now-5, now-4, false, false, false),
+			segJSON("1-tg-001", "seg2", "seg1", "service-b", now-4, now-3, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/TraceGraph", map[string]any{
+		"TraceIds": []string{"1-tg-001"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	services, ok := resp["Services"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, services, "trace graph should have service nodes")
+}
+
+// --- Test 20: UpdateSamplingRule can set FixedRate=0 (zero value applies) ---
+
+func TestAccuracy_UpdateSamplingRule_ZeroFixedRate(t *testing.T) {
+	t.Parallel()
+
+	h, b := newTestHandlerWithBackend(t)
+	b.AddSamplingRuleInternal(xray.SamplingRule{RuleName: "zero-rate-rule", FixedRate: 0.5, Priority: 1})
+
+	rec := doXrayRequest(t, h, "/UpdateSamplingRule", map[string]any{
+		"SamplingRuleUpdate": map[string]any{
+			"RuleName":  "zero-rate-rule",
+			"FixedRate": 0.0,
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	record, ok := resp["SamplingRuleRecord"].(map[string]any)
+	require.True(t, ok)
+
+	rule, ok := record["SamplingRule"].(map[string]any)
+	require.True(t, ok)
+
+	fixedRate, ok := rule["FixedRate"].(float64)
+	require.True(t, ok)
+	assert.InDelta(t, 0.0, fixedRate, 1e-9, "FixedRate should have been updated to 0.0")
+}
+
+// --- Bonus test: HasFault and HasError propagation ---
+
+func TestAccuracy_TraceSummary_FaultAndErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			segJSON("1-prop-fault", "seg1", "", "svc", now-5, now-4, true, false, false),
+			segJSON("1-prop-err", "seg2", "", "svc", now-3, now-2, false, true, false),
+			segJSON("1-prop-ok", "seg3", "", "svc", now-1, now, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/TraceSummaries", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	summaries, ok := resp["TraceSummaries"].([]any)
+	require.True(t, ok)
+
+	byID := map[string]map[string]any{}
+
+	for _, s := range summaries {
+		sm, isSM := s.(map[string]any)
+		require.True(t, isSM)
+		byID[sm["Id"].(string)] = sm
+	}
+
+	require.Contains(t, byID, "1-prop-fault")
+	assert.Equal(t, true, byID["1-prop-fault"]["HasFault"])
+
+	require.Contains(t, byID, "1-prop-err")
+	assert.Equal(t, true, byID["1-prop-err"]["HasError"])
+
+	require.Contains(t, byID, "1-prop-ok")
+	assert.Equal(t, false, byID["1-prop-ok"]["HasFault"])
+	assert.Equal(t, false, byID["1-prop-ok"]["HasError"])
+}
+
+// --- Bonus test: Group NotificationsEnabled requires InsightsEnabled ---
+
+func TestAccuracy_Group_NotificationsEnabledRequiresInsightsEnabled(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doXrayRequest(t, h, "/CreateGroup", map[string]any{
+		"GroupName": "bad-group",
+		"InsightsConfiguration": map[string]any{
+			"InsightsEnabled":      false,
+			"NotificationsEnabled": true,
+		},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Bonus test: Resource policy JSON validation ---
+
+func TestAccuracy_ResourcePolicy_JSONValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doXrayRequest(t, h, "/PutResourcePolicy", map[string]any{
+		"PolicyName":     "bad-json-policy",
+		"PolicyDocument": "not-valid-json{",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Bonus test: GetTraceGraph returns empty for unknown trace IDs ---
+
+func TestAccuracy_GetTraceGraph_EmptyForUnknownTraces(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doXrayRequest(t, h, "/TraceGraph", map[string]any{
+		"TraceIds": []string{"1-unknown-trace"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	services, ok := resp["Services"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, services)
+}
+
+// --- Bonus test: GetSamplingTargets returns UnprocessedStatistics for unknown rule ---
+
+func TestAccuracy_GetSamplingTargets_UnprocessedWithErrorCode(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doXrayRequest(t, h, "/GetSamplingTargets", map[string]any{
+		"SamplingStatisticsDocuments": []map[string]any{
+			{"RuleName": "no-such-rule", "ClientId": "c-1", "RequestCount": 10, "SampledCount": 1, "BorrowCount": 0},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	unprocessed, ok := resp["UnprocessedStatistics"].([]any)
+	require.True(t, ok)
+	require.Len(t, unprocessed, 1)
+
+	u, ok := unprocessed[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "no-such-rule", u["RuleName"])
+	assert.NotEmpty(t, u["ErrorCode"])
+	assert.NotEmpty(t, u["Message"])
+}
+
+// --- Bonus test: GetTraceSummaries throttle filter ---
+
+func TestAccuracy_GetTraceSummaries_ThrottleFilter(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	now := float64(time.Now().Unix())
+
+	putRec := doXrayRequest(t, h, "/TraceSegments", map[string]any{
+		"TraceSegmentDocuments": []string{
+			// Throttled trace (error=true AND throttle=true per X-Ray convention)
+			segJSON("1-throttle-001", "seg1", "", "svc", now-5, now-4, false, true, true),
+			// Non-throttled trace
+			segJSON("1-throttle-002", "seg2", "", "svc", now-3, now-2, false, false, false),
+		},
+	})
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec := doXrayRequest(t, h, "/TraceSummaries", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	summaries, ok := resp["TraceSummaries"].([]any)
+	require.True(t, ok)
+
+	byID := map[string]bool{}
+	for _, s := range summaries {
+		sm, isSM := s.(map[string]any)
+		require.True(t, isSM)
+
+		if throttle, tOK := sm["HasThrottle"].(bool); tOK && throttle {
+			byID[sm["Id"].(string)] = true
+		}
+	}
+
+	assert.Contains(t, byID, "1-throttle-001", "throttled trace should have HasThrottle=true")
+}

--- a/services/xray/handler_missing_ops.go
+++ b/services/xray/handler_missing_ops.go
@@ -11,6 +11,8 @@ import (
 
 type getServiceGraphInput struct {
 	NextToken string  `json:"NextToken"`
+	GroupName string  `json:"GroupName"`
+	GroupARN  string  `json:"GroupARN"`
 	StartTime float64 `json:"StartTime"`
 	EndTime   float64 `json:"EndTime"`
 }
@@ -38,9 +40,14 @@ func (h *Handler) handleGetServiceGraph(_ context.Context, body []byte) ([]byte,
 // --- GetTimeSeriesServiceStatistics ---
 
 type getTimeSeriesServiceStatisticsInput struct {
-	NextToken string  `json:"NextToken"`
-	StartTime float64 `json:"StartTime"`
-	EndTime   float64 `json:"EndTime"`
+	NextToken                string  `json:"NextToken"`
+	EntitySelectorExpression string  `json:"EntitySelectorExpression"`
+	GroupName                string  `json:"GroupName"`
+	GroupARN                 string  `json:"GroupARN"`
+	StartTime                float64 `json:"StartTime"`
+	EndTime                  float64 `json:"EndTime"`
+	Period                   int     `json:"Period"`
+	ForecastStatistics       bool    `json:"ForecastStatistics"`
 }
 
 func (h *Handler) handleGetTimeSeriesServiceStatistics(_ context.Context, body []byte) ([]byte, error) {
@@ -55,8 +62,20 @@ func (h *Handler) handleGetTimeSeriesServiceStatistics(_ context.Context, body [
 		return nil, fmt.Errorf("%w: StartTime and EndTime are required", errInvalidRequest)
 	}
 
+	period := in.Period
+	if period <= 0 {
+		period = 60
+	}
+
+	stats := h.Backend.GetTimeSeriesServiceStatistics(
+		time.Unix(int64(in.StartTime), 0),
+		time.Unix(int64(in.EndTime), 0),
+		period,
+	)
+
 	return json.Marshal(map[string]any{
-		"TimeSeriesServiceStatistics": []any{},
+		"TimeSeriesServiceStatistics": stats,
+		"ContainsOldGroupVersions":    false,
 		keyNextToken:                  "",
 	})
 }
@@ -95,7 +114,7 @@ func (h *Handler) handleGetTraceSegmentDestination(_ context.Context, _ []byte) 
 
 	return json.Marshal(map[string]any{
 		"Destination": dest,
-		"Status":      "ACTIVE",
+		"Status":      statusActive,
 	})
 }
 
@@ -291,6 +310,6 @@ func (h *Handler) handleUpdateTraceSegmentDestination(_ context.Context, body []
 
 	return json.Marshal(map[string]any{
 		"Destination": dest,
-		"Status":      "ACTIVE",
+		"Status":      statusActive,
 	})
 }

--- a/services/xray/interfaces.go
+++ b/services/xray/interfaces.go
@@ -6,45 +6,64 @@ import "time"
 // All mutating methods must be safe for concurrent use.
 type StorageBackend interface {
 	CreateGroup(name, filterExpr string) (*Group, error)
+	CreateGroupWithInsights(name, filterExpr string, ic InsightsConfiguration) (*Group, error)
 	GetGroup(name string) (*Group, error)
+	GetGroupByARN(arn string) (*Group, error)
 	GetGroups() []Group
 	UpdateGroup(name, filterExpr string) (*Group, error)
+	UpdateGroupByARN(name, arn, filterExpr string) (*Group, error)
 	DeleteGroup(name string) error
+	DeleteGroupByARN(name, arn string) error
 	CreateSamplingRule(rule SamplingRule) (*SamplingRule, error)
 	GetSamplingRules() []SamplingRule
 	UpdateSamplingRule(ruleName string, updates SamplingRule) (*SamplingRule, error)
+	UpdateSamplingRuleWithPointers(ruleName string, updates SamplingRuleUpdate) (*SamplingRule, error)
 	DeleteSamplingRule(ruleName string) (*SamplingRule, error)
 	PutTraceSegments(segments []string) []string
 	GetTraceSummaries() []Trace
 	GetTrace(traceID string) *Trace
+	GetParsedSegments(traceID string) []*Segment
+	GetAllParsedSegments() map[string][]*Segment
 	Reset()
 	GetEncryptionConfig() *EncryptionConfig
 	PutEncryptionConfig(encType, keyID string) (*EncryptionConfig, error)
 	Snapshot() []byte
 	Restore(data []byte) error
-	// New operations
+	// Insight operations
+	GetInsight(insightID string) (*Insight, error)
+	GetInsightEvents(insightID string) ([]*InsightEvent, error)
+	GetInsightSummaries(states []string) ([]Insight, error)
+	// Resource policy operations
 	CancelTraceRetrieval(retrievalToken string)
 	DeleteResourcePolicy(policyName string) error
 	ListResourcePolicies() []ResourcePolicy
-	PutResourcePolicy(policyName, policyDocument string) *ResourcePolicy
+	PutResourcePolicy(policyName, policyDocument, revisionID string) (*ResourcePolicy, error)
+	// Indexing rules
 	GetIndexingRules() []*IndexingRule
-	GetInsight(insightID string) (*Insight, error)
-	GetInsightEvents(insightID string) ([]*InsightEvent, error)
-	GetInsightSummaries(states []string) []Insight
+	// Retrieval
 	GetRetrievedTracesGraph(retrievalToken string) (string, []*Trace)
+	// Sampling statistics
 	GetSamplingStatisticSummaries() []SamplingStatisticSummary
-	GetSamplingTargets(ruleNames []string) ([]SamplingTargetResult, []string)
-	// New ops (gh-1185)
+	GetSamplingTargets(docs []SamplingStatisticsDocument) ([]SamplingTargetResult, []UnprocessedStatisticsResult)
+	LastRuleModification() time.Time
+	// Service graph operations
 	GetServiceGraph(startTime, endTime time.Time) []map[string]any
 	GetTraceGraph(traceIDs []string) []map[string]any
+	GetTimeSeriesServiceStatistics(startTime, endTime time.Time, period int) []map[string]any
+	// Destination
 	GetTraceSegmentDestination() string
+	UpdateTraceSegmentDestination(destination string) string
+	// Retrieval list
 	ListRetrievedTraces(retrievalToken string) (string, []*Trace)
+	// Tags
 	ListTagsForResource(resourceARN string) []map[string]string
 	StartTraceRetrieval(traceIDs []string) string
 	TagResource(resourceARN string, tags map[string]string)
 	UntagResource(resourceARN string, tagKeys []string)
+	// Indexing rule update
 	UpdateIndexingRule(name string) (*IndexingRule, error)
-	UpdateTraceSegmentDestination(destination string) string
+	// Telemetry
+	PutTelemetryRecords(records []TelemetryRecord)
 }
 
 // Compile-time assertion: InMemoryBackend must implement StorageBackend.

--- a/services/xray/persistence.go
+++ b/services/xray/persistence.go
@@ -3,18 +3,21 @@ package xray
 import (
 	"encoding/json"
 	"log/slog"
+	"time"
 )
 
 type backendSnapshot struct {
-	EncryptionConfig *EncryptionConfig          `json:"encryptionConfig,omitempty"`
-	Groups           map[string]*Group          `json:"groups"`
-	SamplingRules    map[string]*SamplingRule   `json:"samplingRules"`
-	Traces           map[string]*Trace          `json:"traces"`
-	Insights         map[string]*Insight        `json:"insights"`
-	InsightEvents    map[string][]*InsightEvent `json:"insightEvents"`
-	ResourcePolicies map[string]*ResourcePolicy `json:"resourcePolicies"`
-	TraceRetrievals  map[string]*TraceRetrieval `json:"traceRetrievals"`
-	IndexingRules    []*IndexingRule            `json:"indexingRules,omitempty"`
+	LastRuleModification time.Time                            `json:"lastRuleModification"`
+	EncryptionConfig     *EncryptionConfig                    `json:"encryptionConfig,omitempty"`
+	Groups               map[string]*Group                    `json:"groups"`
+	SamplingRules        map[string]*SamplingRule             `json:"samplingRules"`
+	Traces               map[string]*Trace                    `json:"traces"`
+	Insights             map[string]*Insight                  `json:"insights"`
+	InsightEvents        map[string][]*InsightEvent           `json:"insightEvents"`
+	ResourcePolicies     map[string]*ResourcePolicy           `json:"resourcePolicies"`
+	TraceRetrievals      map[string]*TraceRetrieval           `json:"traceRetrievals"`
+	SamplingStats        map[string]*SamplingStatisticSummary `json:"samplingStats,omitempty"`
+	IndexingRules        []*IndexingRule                      `json:"indexingRules,omitempty"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -32,15 +35,17 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	}
 
 	snap := backendSnapshot{
-		EncryptionConfig: &cfgCopy,
-		Groups:           b.groups,
-		SamplingRules:    b.samplingRules,
-		Traces:           b.traces,
-		Insights:         b.insights,
-		InsightEvents:    b.insightEvents,
-		ResourcePolicies: b.resourcePolicies,
-		TraceRetrievals:  b.traceRetrievals,
-		IndexingRules:    rules,
+		EncryptionConfig:     &cfgCopy,
+		Groups:               b.groups,
+		SamplingRules:        b.samplingRules,
+		Traces:               b.traces,
+		Insights:             b.insights,
+		InsightEvents:        b.insightEvents,
+		ResourcePolicies:     b.resourcePolicies,
+		TraceRetrievals:      b.traceRetrievals,
+		IndexingRules:        rules,
+		SamplingStats:        b.samplingStats,
+		LastRuleModification: b.lastRuleModification,
 	}
 
 	data, err := json.Marshal(snap)
@@ -82,6 +87,10 @@ func ensureNonNilMaps(snap *backendSnapshot) {
 	if snap.TraceRetrievals == nil {
 		snap.TraceRetrievals = make(map[string]*TraceRetrieval)
 	}
+
+	if snap.SamplingStats == nil {
+		snap.SamplingStats = make(map[string]*SamplingStatisticSummary)
+	}
 }
 
 // Restore loads backend state from a JSON snapshot.
@@ -104,6 +113,8 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.insightEvents = snap.InsightEvents
 	b.resourcePolicies = snap.ResourcePolicies
 	b.traceRetrievals = snap.TraceRetrievals
+	b.samplingStats = snap.SamplingStats
+	b.lastRuleModification = snap.LastRuleModification
 
 	if snap.EncryptionConfig != nil {
 		b.encryptionConfig = snap.EncryptionConfig
@@ -111,6 +122,22 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 
 	if len(snap.IndexingRules) > 0 {
 		b.indexingRules = snap.IndexingRules
+	}
+
+	// Rebuild parsed segment indexes from stored traces.
+	b.parsedSegments = make(map[string]*Segment)
+	b.traceSegments = make(map[string][]*Segment)
+
+	for traceID, t := range b.traces {
+		for _, rawSeg := range t.Segments {
+			var seg Segment
+			if err := json.Unmarshal([]byte(rawSeg), &seg); err == nil {
+				seg.Document = rawSeg
+				segKey := traceID + ":" + seg.ID
+				b.parsedSegments[segKey] = &seg
+				b.traceSegments[traceID] = append(b.traceSegments[traceID], &seg)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Brings `services/xray/` to AWS parity per issue #1856. Implements 18 identified gaps with 2,173 net lines added.

### What changed

- **Segment parsing** (Gap 1): Full typed `Segment`/`SegmentHTTP` structs parsed in `PutTraceSegments` and indexed by trace ID + segment ID
- **GetTraceSummaries** (Gaps 2-3): Rich `TraceSummary` response (Duration, ResponseTime, HasFault/Error/Throttle, HTTP fields, EntryPoint, IsPartial); `FilterExpression` evaluator (fault/error/http.status/responsetime/annotation); `TimeRangeType` + `NextToken` accepted
- **BatchGetTraces** (Gap 4): Enforces 5-trace cap; returns `{Id, Document}` per segment
- **GetServiceGraph** (Gap 5): Real directed graph with per-service OkCount/ErrorStatistics/FaultStatistics/TotalResponseTime; `GroupName`/`GroupARN` accepted
- **GetTimeSeriesServiceStatistics** (Gap 6): Bucketed by configurable `Period` (default 60s)
- **GetTraceGraph** (Gap 7): Trace-scoped service graph
- **GetInsightSummaries** (Gap 9): Validates states (ACTIVE/CLOSED/ALL); returns `InvalidRequestException` for unknown states
- **SamplingRule validation** (Gap 11): Priority 1-9999, FixedRate 0-1.0, ReservoirSize ≥0, RuleName 1-32 chars, ServiceName ≤64 chars
- **UpdateSamplingRule** (Gap 12): Pointer-semantic detection so zero values (FixedRate=0.0) apply correctly
- **GetSamplingTargets** (Gap 13): Tracks `lastRuleModification`, accumulates stats from documents, sets `ReservoirQuotaTTL = now+10s`, returns `UnprocessedStatistics` for unknown rules
- **GetSamplingStatisticSummaries** (Gap 14): Returns accumulated per-rule stats
- **Encryption** (Gap 15): KeyId validation (alias/... | KMS ARN | UUID); status `UPDATING` on PUT → `ACTIVE` on first GET
- **Resource policies** (Gap 16): Max 5 cap; `PolicyRevisionId` per policy (UUID); revision mismatch → `InvalidPolicyRevisionIdException`; JSON document validation
- **Groups** (Gap 17): `GroupARN` lookup on Get/Update/Delete; `InsightsConfiguration` stored atomically; validates `NotificationsEnabled` requires `InsightsEnabled`
- **PutTelemetryRecords** (Gap 18): Parses and stores in 100-slot ring buffer
- **Persistence**: `Snapshot`/`Restore` updated for all new state (parsedSegments rebuilt from raw segments)
- **Tests**: `handler_accuracy_test.go` with 23 accuracy tests covering all gaps

## Test plan

- [x] `go build ./services/xray/...` — clean
- [x] `go test -count=1 ./services/xray/...` — all tests pass
- [x] `golangci-lint run ./services/xray/...` — 0 issues
- [x] 23 new accuracy tests in `handler_accuracy_test.go`
- [x] All existing tests pass (backend, handler, refinement, new ops, persistence, janitor, SDK completeness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)