### PR TITLE
fix: skip coverage badge if coverage file missing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         continue-on-error: true
 
       - name: Generate coverage badge
+        if: hashFiles('coverage.out') != ''
         uses: vladopajic/go-test-coverage@v2
         with:
           profile: coverage.out


### PR DESCRIPTION
When terraform tests timeout with || true, coverage.out may not exist. Skip badge generation if missing instead of failing. Allows badges job to complete successfully and unblock merge queue.