### PR TITLE
fix: add timeout to badges workflow step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run all tests with combined coverage
         run: make total-coverage || true
         continue-on-error: true
+        timeout-minutes: 45
 
       - name: Generate coverage badge
         if: hashFiles('coverage.out') != ''


### PR DESCRIPTION
Add timeout-minutes: 45 to the test coverage step in main branch CI. This prevents the step from hanging indefinitely when tests run over, ensuring the job completes within a bounded timeframe.