### PR TITLE
feat(textract): AWS-accuracy audit — 25 gaps per #1850

### DIFF
--- a/services/textract/backend.go
+++ b/services/textract/backend.go
@@ -1,9 +1,11 @@
 package textract
 
 import (
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,76 +58,316 @@ const (
 // adapterVersionActive is the status for a ready adapter version.
 const adapterVersionActive = "ACTIVE"
 
+// adapterVersionCreating is the status during creation.
+const adapterVersionCreating = "CREATION_IN_PROGRESS"
+
+// adapterAllowedFeatureTypes restricts adapter creation to FORMS and QUERIES only
+// per AWS API constraints. Package-level var avoids reallocation per call.
+var adapterAllowedFeatureTypes = map[string]bool{ //nolint:gochecknoglobals // package-level avoids per-call alloc
+	featureTypeForms:   true,
+	featureTypeQueries: true,
+}
+
+// BoundingBox represents the bounding box of a detected element.
+type BoundingBox struct {
+	Width  float64 `json:"Width"`
+	Height float64 `json:"Height"`
+	Left   float64 `json:"Left"`
+	Top    float64 `json:"Top"`
+}
+
+// Point represents a polygon vertex.
+type Point struct {
+	X float64 `json:"X"`
+	Y float64 `json:"Y"`
+}
+
+// Geometry contains bounding box and polygon for a block.
+type Geometry struct {
+	BoundingBox *BoundingBox `json:"BoundingBox"`
+	Polygon     []Point      `json:"Polygon"`
+}
+
+// Relationship describes child/value relationships between blocks.
+type Relationship struct {
+	Type string   `json:"Type"`
+	Ids  []string `json:"Ids"` //nolint:revive // AWS SDK field name convention
+}
+
+// QueryBlock holds query metadata for QUERY blocks.
+type QueryBlock struct {
+	Text  string   `json:"Text"`
+	Alias string   `json:"Alias"`
+	Pages []string `json:"Pages"`
+}
+
 // Block represents a detected text element returned by Textract.
 type Block struct {
-	BlockType  string  `json:"BlockType"`
-	Text       string  `json:"Text"`
-	ID         string  `json:"Id"`
-	Confidence float64 `json:"Confidence"`
+	RowIndex        *int           `json:"RowIndex,omitempty"`
+	ColumnIndex     *int           `json:"ColumnIndex,omitempty"`
+	Query           *QueryBlock    `json:"Query,omitempty"`
+	Page            *int           `json:"Page,omitempty"`
+	Geometry        *Geometry      `json:"Geometry,omitempty"`
+	ColumnSpan      *int           `json:"ColumnSpan,omitempty"`
+	RowSpan         *int           `json:"RowSpan,omitempty"`
+	BlockType       string         `json:"BlockType"`
+	SelectionStatus string         `json:"SelectionStatus,omitempty"`
+	Text            string         `json:"Text"`
+	ID              string         `json:"Id"`
+	TextType        string         `json:"TextType,omitempty"`
+	EntityTypes     []string       `json:"EntityTypes,omitempty"`
+	Relationships   []Relationship `json:"Relationships,omitempty"`
+	Confidence      float64        `json:"Confidence"`
+	ColumnHeader    bool           `json:"ColumnHeader,omitempty"`
+}
+
+// WarningBlock represents a warning returned in async job responses.
+type WarningBlock struct {
+	ErrorCode string `json:"ErrorCode"`
+	Pages     []int  `json:"Pages"`
+}
+
+// OutputConfig holds S3 output configuration for async jobs.
+type OutputConfig struct {
+	S3Bucket string `json:"S3Bucket"`
+	S3Prefix string `json:"S3Prefix"`
+}
+
+// NotificationChannel holds SNS topic configuration.
+type NotificationChannel struct {
+	RoleArn     string `json:"RoleArn"`
+	SNSTopicArn string `json:"SNSTopicArn"`
+}
+
+// QueriesConfig holds query configuration for AnalyzeDocument.
+type QueriesConfig struct {
+	Queries []QueryEntry `json:"Queries"`
+}
+
+// QueryEntry is a single query with text, alias and page filters.
+type QueryEntry struct {
+	Text  string   `json:"Text"`
+	Alias string   `json:"Alias"`
+	Pages []string `json:"Pages"`
 }
 
 // DocumentJob represents an asynchronous Textract document job.
 type DocumentJob struct {
-	CreationTime time.Time `json:"creationTime"`
-	JobID        string    `json:"jobId"`
-	JobStatus    string    `json:"jobStatus"`
-	JobType      string    `json:"jobType"` // "DocumentAnalysis" or "TextDetection"
-	Blocks       []Block   `json:"blocks"`
+	CreationTime        time.Time            `json:"creationTime"`
+	JobID               string               `json:"jobId"`
+	JobStatus           string               `json:"jobStatus"`
+	JobType             string               `json:"jobType"` // "DocumentAnalysis" or "TextDetection"
+	Blocks              []Block              `json:"blocks"`
+	OutputConfig        *OutputConfig        `json:"outputConfig,omitempty"`
+	NotificationChannel *NotificationChannel `json:"notificationChannel,omitempty"`
+	JobTag              string               `json:"jobTag,omitempty"`
+	ClientRequestToken  string               `json:"clientRequestToken,omitempty"`
+	StatusMessage       string               `json:"statusMessage,omitempty"`
+	Warnings            []WarningBlock       `json:"warnings,omitempty"`
+}
+
+// ExpenseDetection holds a detected expense field value.
+type ExpenseDetection struct {
+	Geometry   *Geometry `json:"Geometry,omitempty"`
+	Text       string    `json:"Text"`
+	Confidence float64   `json:"Confidence"`
+}
+
+// ExpenseGroupProperty describes an expense group membership.
+type ExpenseGroupProperty struct {
+	Id    string   `json:"Id"` //nolint:revive,staticcheck // AWS SDK field name convention
+	Types []string `json:"Types"`
+}
+
+// ExpenseField represents a single field in an expense document.
+type ExpenseField struct {
+	Type            *ExpenseDetection      `json:"Type,omitempty"`
+	LabelDetection  *ExpenseDetection      `json:"LabelDetection,omitempty"`
+	ValueDetection  *ExpenseDetection      `json:"ValueDetection,omitempty"`
+	Currency        *ExpenseDetection      `json:"Currency,omitempty"`
+	GroupProperties []ExpenseGroupProperty `json:"GroupProperties,omitempty"`
+	PageNumber      int                    `json:"PageNumber"`
+}
+
+// LineItem represents a single line item in an expense document.
+type LineItem struct {
+	LineItemExpenseFields []ExpenseField `json:"LineItemExpenseFields"`
+}
+
+// LineItemGroup represents a group of line items.
+type LineItemGroup struct {
+	LineItems          []LineItem `json:"LineItems"`
+	LineItemGroupIndex int        `json:"LineItemGroupIndex"`
 }
 
 // ExpenseDocument represents a single expense document result.
 type ExpenseDocument struct {
-	Blocks       []Block `json:"Blocks"`
-	ExpenseIndex int     `json:"ExpenseIndex"`
+	Blocks         []Block         `json:"Blocks"`
+	SummaryFields  []ExpenseField  `json:"SummaryFields,omitempty"`
+	LineItemGroups []LineItemGroup `json:"LineItemGroups,omitempty"`
+	ExpenseIndex   int             `json:"ExpenseIndex"`
 }
 
-// ExpenseJob represents an asynchronous Textract expense analysis job.
-type ExpenseJob struct {
-	CreationTime     time.Time         `json:"creationTime"`
-	JobID            string            `json:"jobId"`
-	JobStatus        string            `json:"jobStatus"`
-	ExpenseDocuments []ExpenseDocument `json:"expenseDocuments"`
+// NormalizedValue holds a normalized field value.
+type NormalizedValue struct {
+	Value     string `json:"Value"`
+	ValueType string `json:"ValueType"`
+}
+
+// AnalyzeIDDetections holds a detected ID field.
+type AnalyzeIDDetections struct {
+	Geometry        *Geometry        `json:"Geometry,omitempty"`
+	NormalizedValue *NormalizedValue `json:"NormalizedValue,omitempty"`
+	Text            string           `json:"Text"`
+	Confidence      float64          `json:"Confidence"`
+}
+
+// IdentityDocumentField holds a single field from an ID document.
+type IdentityDocumentField struct {
+	Type           *AnalyzeIDDetections `json:"Type,omitempty"`
+	ValueDetection *AnalyzeIDDetections `json:"ValueDetection,omitempty"`
 }
 
 // IdentityDocument represents a single identity document result.
 type IdentityDocument struct {
-	Blocks        []Block `json:"Blocks"`
-	DocumentIndex int     `json:"DocumentIndex"`
+	Blocks                 []Block                 `json:"Blocks"`
+	IdentityDocumentFields []IdentityDocumentField `json:"IdentityDocumentFields,omitempty"`
+	DocumentIndex          int                     `json:"DocumentIndex"`
+}
+
+// LendingDetection holds a detected lending field value.
+type LendingDetection struct {
+	Geometry        *Geometry `json:"Geometry,omitempty"`
+	Text            string    `json:"Text,omitempty"`
+	SelectionStatus string    `json:"SelectionStatus,omitempty"`
+	Confidence      float64   `json:"Confidence"`
+}
+
+// LendingField is a single field detected in a lending document.
+type LendingField struct {
+	Type           *LendingDetection `json:"Type,omitempty"`
+	ValueDetection *LendingDetection `json:"ValueDetection,omitempty"`
+	KeyDetection   *LendingDetection `json:"KeyDetection,omitempty"`
+	PageNumber     int               `json:"PageNumber"`
+}
+
+// SignatureDetection represents a detected signature.
+type SignatureDetection struct {
+	Geometry   *Geometry `json:"Geometry,omitempty"`
+	Confidence float64   `json:"Confidence"`
+}
+
+// LendingDocument holds the extracted fields for a lending page.
+type LendingDocument struct {
+	LendingFields       []LendingField       `json:"LendingFields,omitempty"`
+	SignatureDetections []SignatureDetection `json:"SignatureDetections,omitempty"`
+}
+
+// Extraction holds the extraction results for a single lending page.
+type Extraction struct {
+	LendingDocument *LendingDocument `json:"LendingDocument,omitempty"`
+	ExpenseDocument *ExpenseDocument `json:"ExpenseDocument,omitempty"`
+}
+
+// PageClassification holds the page classification for a lending page.
+type PageClassification struct {
+	PageType   []LendingDetection `json:"PageType"`
+	PageNumber []LendingDetection `json:"PageNumber"`
 }
 
 // LendingResult represents a single lending analysis result page.
 type LendingResult struct {
+	PageClassification *PageClassification `json:"PageClassification,omitempty"`
+	Extractions        []Extraction        `json:"Extractions,omitempty"`
+	Page               int                 `json:"Page"`
+}
+
+// SplitDocument describes a sub-document within a group.
+type SplitDocument struct {
+	Pages []int `json:"Pages"`
+	Index int   `json:"Index"`
+}
+
+// DetectedSignature describes a detected signature page.
+type DetectedSignature struct {
 	Page int `json:"Page"`
+}
+
+// DocumentGroup groups documents of the same type in a lending summary.
+type DocumentGroup struct {
+	Type                 string              `json:"Type"`
+	SplitDocuments       []SplitDocument     `json:"SplitDocuments,omitempty"`
+	DetectedSignatures   []DetectedSignature `json:"DetectedSignatures,omitempty"`
+	UndetectedSignatures []DetectedSignature `json:"UndetectedSignatures,omitempty"`
+}
+
+// LendingSummary summarizes lending analysis results.
+type LendingSummary struct {
+	DocumentGroups          []DocumentGroup `json:"DocumentGroups,omitempty"`
+	UndetectedDocumentTypes []string        `json:"UndetectedDocumentTypes,omitempty"`
 }
 
 // LendingJob represents an asynchronous Textract lending analysis job.
 type LendingJob struct {
-	CreationTime time.Time       `json:"creationTime"`
-	JobID        string          `json:"jobId"`
-	JobStatus    string          `json:"jobStatus"`
-	Results      []LendingResult `json:"results"`
+	CreationTime        time.Time            `json:"creationTime"`
+	JobID               string               `json:"jobId"`
+	JobStatus           string               `json:"jobStatus"`
+	Results             []LendingResult      `json:"results"`
+	Summary             *LendingSummary      `json:"summary,omitempty"`
+	OutputConfig        *OutputConfig        `json:"outputConfig,omitempty"`
+	NotificationChannel *NotificationChannel `json:"notificationChannel,omitempty"`
+	JobTag              string               `json:"jobTag,omitempty"`
+	ClientRequestToken  string               `json:"clientRequestToken,omitempty"`
+	StatusMessage       string               `json:"statusMessage,omitempty"`
+	Warnings            []WarningBlock       `json:"warnings,omitempty"`
+}
+
+// EvaluationMetrics holds model evaluation metrics for an adapter version.
+type EvaluationMetrics struct {
+	F1Score   float64 `json:"F1Score"`
+	Precision float64 `json:"Precision"`
+	Recall    float64 `json:"Recall"`
+}
+
+// DatasetConfig holds dataset configuration for an adapter version.
+type DatasetConfig struct {
+	ManifestS3Object *S3ObjectRef `json:"ManifestS3Object,omitempty"`
+}
+
+// S3ObjectRef is an S3 object reference.
+type S3ObjectRef struct {
+	Bucket  string `json:"Bucket"`
+	Name    string `json:"Name"`
+	Version string `json:"Version,omitempty"`
 }
 
 // Adapter represents a Textract Adapter.
 type Adapter struct {
-	CreationTime time.Time         `json:"creationTime"`
-	Tags         map[string]string `json:"tags"`
-	AdapterID    string            `json:"adapterId"`
-	AdapterName  string            `json:"adapterName"`
-	AutoUpdate   string            `json:"autoUpdate"`
-	Description  string            `json:"description"`
-	FeatureTypes []string          `json:"featureTypes"`
+	CreationTime       time.Time         `json:"creationTime"`
+	Tags               map[string]string `json:"tags"`
+	AdapterID          string            `json:"adapterId"`
+	AdapterName        string            `json:"adapterName"`
+	AutoUpdate         string            `json:"autoUpdate"`
+	Description        string            `json:"description"`
+	ClientRequestToken string            `json:"clientRequestToken,omitempty"`
+	FeatureTypes       []string          `json:"featureTypes"`
 }
 
 // AdapterVersion represents a version of a Textract Adapter.
 type AdapterVersion struct {
-	CreationTime   time.Time         `json:"creationTime"`
-	Tags           map[string]string `json:"tags"`
-	AdapterID      string            `json:"adapterId"`
-	AdapterVersion string            `json:"adapterVersion"`
-	Status         string            `json:"status"`
-	StatusMessage  string            `json:"statusMessage"`
-	FeatureTypes   []string          `json:"featureTypes"`
+	CreationTime      time.Time          `json:"creationTime"`
+	Tags              map[string]string  `json:"tags"`
+	DatasetConfig     *DatasetConfig     `json:"datasetConfig,omitempty"`
+	OutputConfig      *OutputConfig      `json:"outputConfig,omitempty"`
+	EvaluationMetrics *EvaluationMetrics `json:"evaluationMetrics,omitempty"`
+	AdapterID         string             `json:"adapterId"`
+	AdapterVersion    string             `json:"adapterVersion"`
+	Status            string             `json:"status"`
+	StatusMessage     string             `json:"statusMessage"`
+	//nolint:revive,staticcheck // KMSKeyId: AWS SDK field name convention
+	KMSKeyId           string   `json:"kmsKeyId,omitempty"`
+	ClientRequestToken string   `json:"clientRequestToken,omitempty"`
+	FeatureTypes       []string `json:"featureTypes"`
 }
 
 // maxJobHistory is the maximum number of completed jobs retained in memory.
@@ -134,42 +376,51 @@ const maxJobHistory = 10000
 // MaxJobHistory is the exported value for testing.
 const MaxJobHistory = maxJobHistory
 
-// allowedFeatureTypes returns the set of allowed feature type values for an adapter.
-func allowedFeatureTypes() map[string]bool {
-	return map[string]bool{
-		featureTypeTables:     true,
-		featureTypeForms:      true,
-		featureTypeQueries:    true,
-		featureTypeSignatures: true,
-		featureTypeLayout:     true,
-	}
+// ExpenseJob represents an asynchronous Textract expense analysis job.
+type ExpenseJob struct {
+	CreationTime        time.Time            `json:"creationTime"`
+	JobID               string               `json:"jobId"`
+	JobStatus           string               `json:"jobStatus"`
+	ExpenseDocuments    []ExpenseDocument    `json:"expenseDocuments"`
+	OutputConfig        *OutputConfig        `json:"outputConfig,omitempty"`
+	NotificationChannel *NotificationChannel `json:"notificationChannel,omitempty"`
+	JobTag              string               `json:"jobTag,omitempty"`
+	ClientRequestToken  string               `json:"clientRequestToken,omitempty"`
+	StatusMessage       string               `json:"statusMessage,omitempty"`
+	Warnings            []WarningBlock       `json:"warnings,omitempty"`
 }
 
 // InMemoryBackend is the in-memory store for Textract jobs.
 type InMemoryBackend struct {
-	jobs            map[string]*DocumentJob
-	expenseJobs     map[string]*ExpenseJob
-	lendingJobs     map[string]*LendingJob
-	adapters        map[string]*Adapter
-	adapterVersions map[string]*AdapterVersion // key: adapterId+"#"+version
-	mu              *lockmetrics.RWMutex
-	accountID       string
-	region          string
-	maxJobs         int
+	jobs                   map[string]*DocumentJob
+	expenseJobs            map[string]*ExpenseJob
+	lendingJobs            map[string]*LendingJob
+	adapters               map[string]*Adapter
+	adapterVersions        map[string]*AdapterVersion // key: adapterId+"#"+version
+	clientTokenToJobID     map[string]string          // dedup: ClientRequestToken → JobID
+	adapterClientTokenToID map[string]string          // dedup: ClientRequestToken → AdapterID
+	mu                     *lockmetrics.RWMutex
+	accountID              string
+	region                 string
+	maxJobs                int
+	asyncJobDelay          time.Duration // how long before async jobs transition to SUCCEEDED
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		jobs:            make(map[string]*DocumentJob),
-		expenseJobs:     make(map[string]*ExpenseJob),
-		lendingJobs:     make(map[string]*LendingJob),
-		adapters:        make(map[string]*Adapter),
-		adapterVersions: make(map[string]*AdapterVersion),
-		mu:              lockmetrics.New("textract"),
-		accountID:       accountID,
-		region:          region,
-		maxJobs:         maxJobHistory,
+		jobs:                   make(map[string]*DocumentJob),
+		expenseJobs:            make(map[string]*ExpenseJob),
+		lendingJobs:            make(map[string]*LendingJob),
+		adapters:               make(map[string]*Adapter),
+		adapterVersions:        make(map[string]*AdapterVersion),
+		clientTokenToJobID:     make(map[string]string),
+		adapterClientTokenToID: make(map[string]string),
+		mu:                     lockmetrics.New("textract"),
+		accountID:              accountID,
+		region:                 region,
+		maxJobs:                maxJobHistory,
+		asyncJobDelay:          defaultAsyncJobDelay,
 	}
 }
 
@@ -189,6 +440,8 @@ func (b *InMemoryBackend) Reset() {
 	b.lendingJobs = make(map[string]*LendingJob)
 	b.adapters = make(map[string]*Adapter)
 	b.adapterVersions = make(map[string]*AdapterVersion)
+	b.clientTokenToJobID = make(map[string]string)
+	b.adapterClientTokenToID = make(map[string]string)
 }
 
 const (
@@ -198,21 +451,524 @@ const (
 	confidenceWord2 = 99.7
 	confidenceWord3 = 99.9
 	blockTypeWord   = "WORD"
+
+	// Block type string constants to avoid repeated literals.
+	blockTypeKeyValueSet = "KEY_VALUE_SET"
+	blockTypeCell        = "CELL"
+
+	// Relationship type constants.
+	relTypeChild  = "CHILD"
+	relTypeValue  = "VALUE"
+	relTypeAnswer = "ANSWER"
+
+	// Confidence constants for generated blocks.
+	confidenceKV          = 95.0
+	confidenceKV2         = 93.0
+	confidenceWordForm    = 99.0
+	confidenceSelElem     = 97.0
+	confidenceTable       = 99.0
+	confidenceTableCell   = 98.0
+	confidenceQuery       = 100.0
+	confidenceQueryResult = 50.0
+	confidenceSignature   = 80.0
+	confidenceLayout      = 95.0
+
+	// Geometry coordinate constants for generated blocks.
+	geoLeft   = 0.05
+	geoTop1   = 0.05
+	geoTop2   = 0.12
+	geoWidth  = 0.9
+	geoHeight = 0.04
+	geoWide   = 0.6
+
+	geoWordLeft1  = 0.05
+	geoWordLeft2  = 0.16
+	geoWordLeft3  = 0.27
+	geoWordWidth  = 0.10
+	geoWordWidth3 = 0.06
+
+	geoFormValLeft = 0.36
+	geoFormWidth   = 0.30
+	geoFormTop1    = 0.22
+	geoFormTop2    = 0.28
+	geoSelTop      = 0.34
+	geoSelWidth    = 0.02
+	geoSelHeight   = 0.02
+
+	geoTableLeft   = 0.05
+	geoTableTop    = 0.40
+	geoTableWidth  = 0.80
+	geoTableHeight = 0.20
+	geoCell1Left   = 0.05
+	geoCell1Width  = 0.40
+	geoCell2Left   = 0.45
+	geoCellTop1    = 0.40
+	geoCellTop2    = 0.48
+	geoCellHeight  = 0.08
+
+	geoSigLeft   = 0.05
+	geoSigTop    = 0.65
+	geoSigWidth  = 0.20
+	geoSigHeight = 0.06
+
+	geoHdrLeft   = 0.05
+	geoHdrTop    = 0.02
+	geoHdrWidth  = 0.90
+	geoHdrHeight = 0.04
+
+	geoBodyLeft   = 0.05
+	geoBodyTop    = 0.08
+	geoBodyWidth  = 0.90
+	geoBodyHeight = 0.50
+
+	geoFtrLeft   = 0.05
+	geoFtrTop    = 0.92
+	geoFtrWidth  = 0.90
+	geoFtrHeight = 0.04
+
+	// Confidence for expense/ID/lending generated fields.
+	confidenceExpenseHigh = 99.0
+	confidenceExpenseMed  = 98.0
+	confidenceExpenseLI   = 97.0
+	confidenceExpenseLI2  = 96.0
+
+	confidenceLending  = 95.0
+	confidenceLending2 = 94.0
+	confidenceLendSig  = 85.0
+
+	// Geometry for lending signature.
+	geoLendSigLeft   = 0.1
+	geoLendSigTop    = 0.8
+	geoLendSigWidth  = 0.3
+	geoLendSigHeight = 0.06
 )
 
-// syntheticBlocks returns a fixed set of synthetic text blocks for a document.
-func syntheticBlocks(documentURI string) []Block {
-	return []Block{
-		{BlockType: "PAGE", Text: "", Confidence: confidencePage, ID: uuid.NewString()},
-		{
-			BlockType:  "LINE",
-			Text:       "Synthetic extracted text from " + documentURI,
-			Confidence: confidenceLine,
-			ID:         uuid.NewString(),
+// makeGeometry creates a simple bounding-box geometry with a polygon.
+func makeGeometry(left, top, width, height float64) *Geometry {
+	return &Geometry{
+		BoundingBox: &BoundingBox{
+			Left:   left,
+			Top:    top,
+			Width:  width,
+			Height: height,
 		},
-		{BlockType: blockTypeWord, Text: "Synthetic", Confidence: confidenceWord1, ID: uuid.NewString()},
-		{BlockType: blockTypeWord, Text: "extracted", Confidence: confidenceWord2, ID: uuid.NewString()},
-		{BlockType: blockTypeWord, Text: "text", Confidence: confidenceWord3, ID: uuid.NewString()},
+		Polygon: []Point{
+			{X: left, Y: top},
+			{X: left + width, Y: top},
+			{X: left + width, Y: top + height},
+			{X: left, Y: top + height},
+		},
+	}
+}
+
+// syntheticBlocks returns a properly structured set of PAGE/LINE/WORD blocks
+// with Geometry and Relationships wired per AWS spec.
+func syntheticBlocks(documentURI string) []Block {
+	pageID := uuid.NewString()
+	line1ID := uuid.NewString()
+	line2ID := uuid.NewString()
+	word1ID := uuid.NewString()
+	word2ID := uuid.NewString()
+	word3ID := uuid.NewString()
+	word4ID := uuid.NewString()
+	word5ID := uuid.NewString()
+
+	page1 := 1
+
+	pageBlock := Block{
+		BlockType:  "PAGE",
+		Text:       "",
+		Confidence: confidencePage,
+		ID:         pageID,
+		Page:       &page1,
+		Geometry:   makeGeometry(0, 0, 1, 1),
+		Relationships: []Relationship{
+			{Type: relTypeChild, Ids: []string{line1ID, line2ID}},
+		},
+	}
+
+	line1Text := "Synthetic extracted text from " + documentURI
+	line1Block := Block{
+		BlockType:  "LINE",
+		Text:       line1Text,
+		Confidence: confidenceLine,
+		ID:         line1ID,
+		Page:       &page1,
+		Geometry:   makeGeometry(geoLeft, geoTop1, geoWidth, geoHeight),
+		Relationships: []Relationship{
+			{Type: relTypeChild, Ids: []string{word1ID, word2ID, word3ID}},
+		},
+	}
+
+	line2Block := Block{
+		BlockType:  "LINE",
+		Text:       "Document processed successfully",
+		Confidence: confidenceLine,
+		ID:         line2ID,
+		Page:       &page1,
+		Geometry:   makeGeometry(geoLeft, geoTop2, geoWide, geoHeight),
+		Relationships: []Relationship{
+			{Type: relTypeChild, Ids: []string{word4ID, word5ID}},
+		},
+	}
+
+	return []Block{
+		pageBlock,
+		line1Block,
+		line2Block,
+		{
+			BlockType:  blockTypeWord,
+			Text:       "Synthetic",
+			Confidence: confidenceWord1,
+			ID:         word1ID,
+			Page:       &page1,
+			Geometry:   makeGeometry(geoWordLeft1, geoTop1, geoWordWidth, geoHeight),
+		},
+		{
+			BlockType:  blockTypeWord,
+			Text:       "extracted",
+			Confidence: confidenceWord2,
+			ID:         word2ID,
+			Page:       &page1,
+			Geometry:   makeGeometry(geoWordLeft2, geoTop1, geoWordWidth, geoHeight),
+		},
+		{
+			BlockType:  blockTypeWord,
+			Text:       "text",
+			Confidence: confidenceWord3,
+			ID:         word3ID,
+			Page:       &page1,
+			Geometry:   makeGeometry(geoWordLeft3, geoTop1, geoWordWidth3, geoHeight),
+		},
+		{
+			BlockType:  blockTypeWord,
+			Text:       "Document",
+			Confidence: confidenceWord1,
+			ID:         word4ID,
+			Page:       &page1,
+			Geometry:   makeGeometry(geoWordLeft1, geoTop2, geoWordWidth, geoHeight),
+		},
+		{
+			BlockType:  blockTypeWord,
+			Text:       "processed",
+			Confidence: confidenceWord2,
+			ID:         word5ID,
+			Page:       &page1,
+			Geometry:   makeGeometry(geoWordLeft2, geoTop2, geoWordWidth, geoHeight),
+		},
+	}
+}
+
+// analyzeDocumentBlocks generates blocks for AnalyzeDocument based on feature types
+// and queries config.
+func analyzeDocumentBlocks(documentURI string, featureTypes []string, queries *QueriesConfig) []Block {
+	blocks := syntheticBlocks(documentURI)
+
+	featureSet := make(map[string]bool, len(featureTypes))
+	for _, ft := range featureTypes {
+		featureSet[ft] = true
+	}
+
+	page1 := 1
+
+	if featureSet[featureTypeForms] {
+		blocks = append(blocks, buildFormsBlocks(page1)...)
+	}
+
+	if featureSet[featureTypeTables] {
+		blocks = append(blocks, buildTablesBlocks(page1)...)
+	}
+
+	if featureSet[featureTypeQueries] && queries != nil {
+		blocks = append(blocks, buildQueryBlocks(queries, page1)...)
+	}
+
+	if featureSet[featureTypeSignatures] {
+		blocks = append(blocks, buildSignatureBlocks(page1)...)
+	}
+
+	if featureSet[featureTypeLayout] {
+		blocks = append(blocks, buildLayoutBlocks(page1)...)
+	}
+
+	return blocks
+}
+
+// buildFormsBlocks builds KEY_VALUE_SET and SELECTION_ELEMENT blocks.
+func buildFormsBlocks(page int) []Block {
+	keyWord1ID := uuid.NewString()
+	keyWord2ID := uuid.NewString()
+	valueWord1ID := uuid.NewString()
+	valueWord2ID := uuid.NewString()
+	key1ID := uuid.NewString()
+	val1ID := uuid.NewString()
+	key2ID := uuid.NewString()
+	val2ID := uuid.NewString()
+	selID := uuid.NewString()
+
+	blocks := []Block{
+		// Key 1
+		{
+			BlockType:   blockTypeKeyValueSet,
+			ID:          key1ID,
+			Confidence:  confidenceKV,
+			EntityTypes: []string{"KEY"},
+			Page:        &page,
+			Geometry:    makeGeometry(geoLeft, geoFormTop1, geoFormWidth, geoHeight),
+			Relationships: []Relationship{
+				{Type: relTypeValue, Ids: []string{val1ID}},
+				{Type: relTypeChild, Ids: []string{keyWord1ID}},
+			},
+		},
+		// Value 1
+		{
+			BlockType:   blockTypeKeyValueSet,
+			ID:          val1ID,
+			Confidence:  confidenceKV,
+			EntityTypes: []string{"VALUE"},
+			Page:        &page,
+			Geometry:    makeGeometry(geoFormValLeft, geoFormTop1, geoFormWidth, geoHeight),
+			Relationships: []Relationship{
+				{Type: relTypeChild, Ids: []string{valueWord1ID}},
+			},
+		},
+		// Word for key1
+		{
+			BlockType:  blockTypeWord,
+			ID:         keyWord1ID,
+			Text:       "Name:",
+			Confidence: confidenceWordForm,
+			Page:       &page,
+			Geometry:   makeGeometry(geoLeft, geoFormTop1, geoWordWidth, geoHeight),
+		},
+		// Word for value1
+		{
+			BlockType:  blockTypeWord,
+			ID:         valueWord1ID,
+			Text:       "John",
+			Confidence: confidenceWordForm,
+			Page:       &page,
+			Geometry:   makeGeometry(geoFormValLeft, geoFormTop1, geoWordWidth, geoHeight),
+		},
+		// Key 2
+		{
+			BlockType:   blockTypeKeyValueSet,
+			ID:          key2ID,
+			Confidence:  confidenceKV2,
+			EntityTypes: []string{"KEY"},
+			Page:        &page,
+			Geometry:    makeGeometry(geoLeft, geoFormTop2, geoFormWidth, geoHeight),
+			Relationships: []Relationship{
+				{Type: relTypeValue, Ids: []string{val2ID}},
+				{Type: relTypeChild, Ids: []string{keyWord2ID}},
+			},
+		},
+		// Value 2
+		{
+			BlockType:   blockTypeKeyValueSet,
+			ID:          val2ID,
+			Confidence:  confidenceKV2,
+			EntityTypes: []string{"VALUE"},
+			Page:        &page,
+			Geometry:    makeGeometry(geoFormValLeft, geoFormTop2, geoFormWidth, geoHeight),
+			Relationships: []Relationship{
+				{Type: relTypeChild, Ids: []string{valueWord2ID}},
+			},
+		},
+		// Word for key2
+		{
+			BlockType:  blockTypeWord,
+			ID:         keyWord2ID,
+			Text:       "Status:",
+			Confidence: confidenceWordForm,
+			Page:       &page,
+			Geometry:   makeGeometry(geoLeft, geoFormTop2, geoWordWidth, geoHeight),
+		},
+		// Word for value2
+		{
+			BlockType:  blockTypeWord,
+			ID:         valueWord2ID,
+			Text:       "Active",
+			Confidence: confidenceWordForm,
+			Page:       &page,
+			Geometry:   makeGeometry(geoFormValLeft, geoFormTop2, geoWordWidth, geoHeight),
+		},
+		// Selection element
+		{
+			BlockType:       "SELECTION_ELEMENT",
+			ID:              selID,
+			Confidence:      confidenceSelElem,
+			SelectionStatus: "SELECTED",
+			Page:            &page,
+			Geometry:        makeGeometry(geoLeft, geoSelTop, geoSelWidth, geoSelHeight),
+		},
+	}
+
+	return blocks
+}
+
+// buildTablesBlocks builds TABLE and CELL blocks.
+func buildTablesBlocks(page int) []Block {
+	tableID := uuid.NewString()
+	cell11 := uuid.NewString()
+	cell12 := uuid.NewString()
+	cell21 := uuid.NewString()
+	cell22 := uuid.NewString()
+
+	row1 := 1
+	row2 := 2
+	col1 := 1
+	col2 := 2
+	span1 := 1
+
+	return []Block{
+		{
+			BlockType:  "TABLE",
+			ID:         tableID,
+			Confidence: confidenceTable,
+			Page:       &page,
+			Geometry:   makeGeometry(geoTableLeft, geoTableTop, geoTableWidth, geoTableHeight),
+			Relationships: []Relationship{
+				{Type: relTypeChild, Ids: []string{cell11, cell12, cell21, cell22}},
+			},
+		},
+		{
+			BlockType:    blockTypeCell,
+			ID:           cell11,
+			Text:         "Header 1",
+			Confidence:   confidenceTable,
+			Page:         &page,
+			Geometry:     makeGeometry(geoCell1Left, geoCellTop1, geoCell1Width, geoCellHeight),
+			RowIndex:     &row1,
+			ColumnIndex:  &col1,
+			RowSpan:      &span1,
+			ColumnSpan:   &span1,
+			EntityTypes:  []string{"COLUMN_HEADER"},
+			ColumnHeader: true,
+		},
+		{
+			BlockType:    blockTypeCell,
+			ID:           cell12,
+			Text:         "Header 2",
+			Confidence:   confidenceTable,
+			Page:         &page,
+			Geometry:     makeGeometry(geoCell2Left, geoCellTop1, geoCell1Width, geoCellHeight),
+			RowIndex:     &row1,
+			ColumnIndex:  &col2,
+			RowSpan:      &span1,
+			ColumnSpan:   &span1,
+			EntityTypes:  []string{"COLUMN_HEADER"},
+			ColumnHeader: true,
+		},
+		{
+			BlockType:   blockTypeCell,
+			ID:          cell21,
+			Text:        "Value 1",
+			Confidence:  confidenceTableCell,
+			Page:        &page,
+			Geometry:    makeGeometry(geoCell1Left, geoCellTop2, geoCell1Width, geoCellHeight),
+			RowIndex:    &row2,
+			ColumnIndex: &col1,
+			RowSpan:     &span1,
+			ColumnSpan:  &span1,
+		},
+		{
+			BlockType:   blockTypeCell,
+			ID:          cell22,
+			Text:        "Value 2",
+			Confidence:  confidenceTableCell,
+			Page:        &page,
+			Geometry:    makeGeometry(geoCell2Left, geoCellTop2, geoCell1Width, geoCellHeight),
+			RowIndex:    &row2,
+			ColumnIndex: &col2,
+			RowSpan:     &span1,
+			ColumnSpan:  &span1,
+		},
+	}
+}
+
+// buildQueryBlocks builds QUERY and QUERY_RESULT blocks for each query.
+func buildQueryBlocks(queries *QueriesConfig, page int) []Block {
+	const blocksPerQuery = 2 // one QUERY + one QUERY_RESULT per query entry
+	blocks := make([]Block, 0, len(queries.Queries)*blocksPerQuery)
+
+	for _, q := range queries.Queries {
+		queryID := uuid.NewString()
+		resultID := uuid.NewString()
+
+		pages := q.Pages
+		if len(pages) == 0 {
+			pages = []string{"1"}
+		}
+
+		blocks = append(blocks,
+			Block{
+				BlockType:  "QUERY",
+				ID:         queryID,
+				Confidence: confidenceQuery,
+				Page:       &page,
+				Query: &QueryBlock{
+					Text:  q.Text,
+					Alias: q.Alias,
+					Pages: pages,
+				},
+				Relationships: []Relationship{
+					{Type: relTypeAnswer, Ids: []string{resultID}},
+				},
+			},
+			Block{
+				BlockType:  "QUERY_RESULT",
+				ID:         resultID,
+				Text:       "(no answer)",
+				Confidence: confidenceQueryResult,
+				Page:       &page,
+			},
+		)
+	}
+
+	return blocks
+}
+
+// buildSignatureBlocks builds SIGNATURE blocks.
+func buildSignatureBlocks(page int) []Block {
+	return []Block{
+		{
+			BlockType:  "SIGNATURE",
+			ID:         uuid.NewString(),
+			Confidence: confidenceSignature,
+			Page:       &page,
+			Geometry:   makeGeometry(geoSigLeft, geoSigTop, geoSigWidth, geoSigHeight),
+		},
+	}
+}
+
+// buildLayoutBlocks builds LAYOUT_* blocks.
+func buildLayoutBlocks(page int) []Block {
+	return []Block{
+		{
+			BlockType:  "LAYOUT_HEADER",
+			ID:         uuid.NewString(),
+			Text:       "Document Header",
+			Confidence: confidenceLayout,
+			Page:       &page,
+			Geometry:   makeGeometry(geoHdrLeft, geoHdrTop, geoHdrWidth, geoHdrHeight),
+		},
+		{
+			BlockType:  "LAYOUT_TEXT",
+			ID:         uuid.NewString(),
+			Text:       "Body text content",
+			Confidence: confidenceLayout,
+			Page:       &page,
+			Geometry:   makeGeometry(geoBodyLeft, geoBodyTop, geoBodyWidth, geoBodyHeight),
+		},
+		{
+			BlockType:  "LAYOUT_FOOTER",
+			ID:         uuid.NewString(),
+			Text:       "Page 1",
+			Confidence: confidenceLayout,
+			Page:       &page,
+			Geometry:   makeGeometry(geoFtrLeft, geoFtrTop, geoFtrWidth, geoFtrHeight),
+		},
 	}
 }
 
@@ -221,6 +977,11 @@ func cloneJob(j *DocumentJob) *DocumentJob {
 	cp := *j
 	cp.Blocks = make([]Block, len(j.Blocks))
 	copy(cp.Blocks, j.Blocks)
+
+	if j.Warnings != nil {
+		cp.Warnings = make([]WarningBlock, len(j.Warnings))
+		copy(cp.Warnings, j.Warnings)
+	}
 
 	return &cp
 }
@@ -234,6 +995,10 @@ func cloneExpenseJob(j *ExpenseJob) *ExpenseJob {
 		docCopy := doc
 		docCopy.Blocks = make([]Block, len(doc.Blocks))
 		copy(docCopy.Blocks, doc.Blocks)
+		docCopy.SummaryFields = make([]ExpenseField, len(doc.SummaryFields))
+		copy(docCopy.SummaryFields, doc.SummaryFields)
+		docCopy.LineItemGroups = make([]LineItemGroup, len(doc.LineItemGroups))
+		copy(docCopy.LineItemGroups, doc.LineItemGroups)
 		cp.ExpenseDocuments[i] = docCopy
 	}
 
@@ -245,6 +1010,11 @@ func cloneLendingJob(j *LendingJob) *LendingJob {
 	cp := *j
 	cp.Results = make([]LendingResult, len(j.Results))
 	copy(cp.Results, j.Results)
+
+	if j.Warnings != nil {
+		cp.Warnings = make([]WarningBlock, len(j.Warnings))
+		copy(cp.Warnings, j.Warnings)
+	}
 
 	return &cp
 }
@@ -328,38 +1098,107 @@ func (b *InMemoryBackend) trimLendingJobsIfNeeded() {
 	}
 }
 
-// AnalyzeDocument performs a synchronous document analysis and returns synthetic blocks.
+// AnalyzeDocument performs a synchronous document analysis and returns blocks
+// based on the requested feature types.
 func (b *InMemoryBackend) AnalyzeDocument(documentURI string) []Block {
 	return syntheticBlocks(documentURI)
 }
 
-// DetectDocumentText performs synchronous text detection and returns synthetic blocks.
+// AnalyzeDocumentWithFeatures performs synchronous document analysis using feature types.
+func (b *InMemoryBackend) AnalyzeDocumentWithFeatures(
+	documentURI string,
+	featureTypes []string,
+	queries *QueriesConfig,
+) []Block {
+	return analyzeDocumentBlocks(documentURI, featureTypes, queries)
+}
+
+// DetectDocumentText performs synchronous text detection and returns proper blocks.
 func (b *InMemoryBackend) DetectDocumentText(documentURI string) []Block {
 	return syntheticBlocks(documentURI)
 }
 
+// defaultAsyncJobDelay is the default time before a new async job transitions from IN_PROGRESS to SUCCEEDED.
+const defaultAsyncJobDelay = 200 * time.Millisecond
+
 // StartDocumentAnalysis creates an async document analysis job.
 func (b *InMemoryBackend) StartDocumentAnalysis(documentURI string) (*DocumentJob, error) {
+	return b.StartDocumentAnalysisWithOptions(documentURI, nil, nil, nil, "", "")
+}
+
+// StartDocumentAnalysisWithOptions creates an async document analysis job with full options.
+func (b *InMemoryBackend) StartDocumentAnalysisWithOptions(
+	documentURI string,
+	featureTypes []string,
+	queries *QueriesConfig,
+	outputConfig *OutputConfig,
+	jobTag, clientRequestToken string,
+) (*DocumentJob, error) {
 	b.mu.Lock("StartDocumentAnalysis")
-	defer b.mu.Unlock()
+
+	// Idempotency: if token already seen, return existing job.
+	if clientRequestToken != "" {
+		if existingID, ok := b.clientTokenToJobID[clientRequestToken]; ok {
+			if existing, ok2 := b.jobs[existingID]; ok2 {
+				result := cloneJob(existing)
+				b.mu.Unlock()
+
+				return result, nil
+			}
+		}
+	}
 
 	jobID := uuid.NewString()
+	blocks := analyzeDocumentBlocks(documentURI, featureTypes, queries)
 	job := &DocumentJob{
-		JobID:        jobID,
-		JobStatus:    jobStatusSucceeded,
-		JobType:      jobTypeDocumentAnalysis,
-		CreationTime: time.Now(),
-		Blocks:       syntheticBlocks(documentURI),
+		JobID:              jobID,
+		JobStatus:          jobStatusInProgress,
+		JobType:            jobTypeDocumentAnalysis,
+		CreationTime:       time.Now(),
+		Blocks:             blocks,
+		OutputConfig:       outputConfig,
+		JobTag:             jobTag,
+		ClientRequestToken: clientRequestToken,
 	}
 	b.jobs[jobID] = job
 	b.trimJobsIfNeeded()
 
-	return cloneJob(job), nil
+	if clientRequestToken != "" {
+		b.clientTokenToJobID[clientRequestToken] = jobID
+	}
+
+	if b.asyncJobDelay == 0 {
+		// Synchronous mode (tests): complete immediately under the same lock.
+		job.JobStatus = jobStatusSucceeded
+		result := cloneJob(job)
+		b.mu.Unlock()
+
+		return result, nil
+	}
+
+	b.mu.Unlock()
+
+	// Transition to SUCCEEDED after a short delay.
+	go func() {
+		time.Sleep(b.asyncJobDelay)
+
+		b.mu.Lock("StartDocumentAnalysis-complete")
+		defer b.mu.Unlock()
+
+		if j, ok := b.jobs[jobID]; ok {
+			j.JobStatus = jobStatusSucceeded
+		}
+	}()
+
+	b.mu.RLock("StartDocumentAnalysis-read")
+	result := cloneJob(b.jobs[jobID])
+	b.mu.RUnlock()
+
+	return result, nil
 }
 
 // GetDocumentAnalysis retrieves the results of a document analysis job.
-// It returns a direct pointer to the stored job (lazy/CoW — no allocation on read path).
-// Callers MUST NOT mutate the returned value.
+// Returns a clone of the stored job.
 func (b *InMemoryBackend) GetDocumentAnalysis(jobID string) (*DocumentJob, error) {
 	b.mu.RLock("GetDocumentAnalysis")
 	defer b.mu.RUnlock()
@@ -369,31 +1208,84 @@ func (b *InMemoryBackend) GetDocumentAnalysis(jobID string) (*DocumentJob, error
 		return nil, fmt.Errorf("%w: job %s not found", ErrJobNotFound, jobID)
 	}
 
-	return job, nil
+	return cloneJob(job), nil
 }
 
 // StartDocumentTextDetection creates an async text detection job.
 func (b *InMemoryBackend) StartDocumentTextDetection(documentURI string) (*DocumentJob, error) {
+	return b.StartDocumentTextDetectionWithOptions(documentURI, nil, nil, "", "")
+}
+
+// StartDocumentTextDetectionWithOptions creates an async text detection job with options.
+func (b *InMemoryBackend) StartDocumentTextDetectionWithOptions(
+	documentURI string,
+	outputConfig *OutputConfig,
+	notificationChannel *NotificationChannel,
+	jobTag, clientRequestToken string,
+) (*DocumentJob, error) {
 	b.mu.Lock("StartDocumentTextDetection")
-	defer b.mu.Unlock()
+
+	// Idempotency: if token already seen, return existing job.
+	if clientRequestToken != "" {
+		if existingID, ok := b.clientTokenToJobID[clientRequestToken]; ok {
+			if existing, ok2 := b.jobs[existingID]; ok2 {
+				result := cloneJob(existing)
+				b.mu.Unlock()
+
+				return result, nil
+			}
+		}
+	}
 
 	jobID := uuid.NewString()
 	job := &DocumentJob{
-		JobID:        jobID,
-		JobStatus:    jobStatusSucceeded,
-		JobType:      jobTypeTextDetection,
-		CreationTime: time.Now(),
-		Blocks:       syntheticBlocks(documentURI),
+		JobID:               jobID,
+		JobStatus:           jobStatusInProgress,
+		JobType:             jobTypeTextDetection,
+		CreationTime:        time.Now(),
+		Blocks:              syntheticBlocks(documentURI),
+		OutputConfig:        outputConfig,
+		NotificationChannel: notificationChannel,
+		JobTag:              jobTag,
+		ClientRequestToken:  clientRequestToken,
 	}
 	b.jobs[jobID] = job
 	b.trimJobsIfNeeded()
 
-	return cloneJob(job), nil
+	if clientRequestToken != "" {
+		b.clientTokenToJobID[clientRequestToken] = jobID
+	}
+
+	if b.asyncJobDelay == 0 {
+		job.JobStatus = jobStatusSucceeded
+		result := cloneJob(job)
+		b.mu.Unlock()
+
+		return result, nil
+	}
+
+	b.mu.Unlock()
+
+	go func() {
+		time.Sleep(b.asyncJobDelay)
+
+		b.mu.Lock("StartDocumentTextDetection-complete")
+		defer b.mu.Unlock()
+
+		if j, ok := b.jobs[jobID]; ok {
+			j.JobStatus = jobStatusSucceeded
+		}
+	}()
+
+	b.mu.RLock("StartDocumentTextDetection-read")
+	result := cloneJob(b.jobs[jobID])
+	b.mu.RUnlock()
+
+	return result, nil
 }
 
 // GetDocumentTextDetection retrieves the results of a text detection job.
-// It returns a direct pointer to the stored job (lazy/CoW — no allocation on read path).
-// Callers MUST NOT mutate the returned value.
+// Returns a clone of the stored job.
 func (b *InMemoryBackend) GetDocumentTextDetection(jobID string) (*DocumentJob, error) {
 	b.mu.RLock("GetDocumentTextDetection")
 	defer b.mu.RUnlock()
@@ -403,7 +1295,7 @@ func (b *InMemoryBackend) GetDocumentTextDetection(jobID string) (*DocumentJob, 
 		return nil, fmt.Errorf("%w: job %s not found", ErrJobNotFound, jobID)
 	}
 
-	return job, nil
+	return cloneJob(job), nil
 }
 
 // ListJobs returns all stored jobs sorted by creation time (newest first).
@@ -422,6 +1314,40 @@ func (b *InMemoryBackend) ListJobs() []DocumentJob {
 	})
 
 	return out
+}
+
+// paginateBlocks applies MaxResults and NextToken pagination to a blocks slice.
+// Returns the page of blocks and a new NextToken (empty string means no more pages).
+func paginateBlocks(blocks []Block, maxResults int, nextToken string) ([]Block, string) {
+	offset := 0
+
+	if nextToken != "" {
+		decoded, err := base64.StdEncoding.DecodeString(nextToken)
+		if err == nil {
+			if n, err2 := strconv.Atoi(string(decoded)); err2 == nil && n >= 0 && n < len(blocks) {
+				offset = n
+			}
+		}
+	}
+
+	if offset >= len(blocks) {
+		return []Block{}, ""
+	}
+
+	end := len(blocks)
+	if maxResults > 0 && offset+maxResults < end {
+		end = offset + maxResults
+	}
+
+	page := make([]Block, end-offset)
+	copy(page, blocks[offset:end])
+
+	newToken := ""
+	if end < len(blocks) {
+		newToken = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(end)))
+	}
+
+	return page, newToken
 }
 
 // adapterVersionKey returns the storage key for an adapter version.
@@ -457,54 +1383,234 @@ func cloneTags(tags map[string]string) map[string]string {
 	return cp
 }
 
-// AnalyzeExpense performs a synchronous expense analysis and returns synthetic expense documents.
-func (b *InMemoryBackend) AnalyzeExpense(documentURI string) []ExpenseDocument {
-	return []ExpenseDocument{
+// syntheticExpenseDocument builds a realistic expense document.
+func syntheticExpenseDocument(documentURI string) ExpenseDocument {
+	blocks := syntheticBlocks(documentURI)
+
+	summaryFields := []ExpenseField{
 		{
-			ExpenseIndex: 1,
-			Blocks:       syntheticBlocks(documentURI),
+			Type:           &ExpenseDetection{Text: "VENDOR_NAME", Confidence: confidenceExpenseHigh},
+			ValueDetection: &ExpenseDetection{Text: "Acme Corp", Confidence: confidenceExpenseHigh},
+			PageNumber:     1,
 		},
+		{
+			Type:           &ExpenseDetection{Text: "TOTAL", Confidence: confidenceExpenseHigh},
+			ValueDetection: &ExpenseDetection{Text: "$123.45", Confidence: confidenceExpenseHigh},
+			PageNumber:     1,
+			Currency:       &ExpenseDetection{Text: "USD", Confidence: confidenceExpenseHigh},
+		},
+		{
+			Type:           &ExpenseDetection{Text: "INVOICE_RECEIPT_DATE", Confidence: confidenceExpenseMed},
+			ValueDetection: &ExpenseDetection{Text: "2024-01-01", Confidence: confidenceExpenseMed},
+			PageNumber:     1,
+		},
+	}
+
+	lineItemGroups := []LineItemGroup{
+		{
+			LineItemGroupIndex: 1,
+			LineItems: []LineItem{
+				{
+					LineItemExpenseFields: []ExpenseField{
+						{
+							Type:           &ExpenseDetection{Text: "ITEM", Confidence: confidenceExpenseLI},
+							ValueDetection: &ExpenseDetection{Text: "Widget A", Confidence: confidenceExpenseLI},
+							PageNumber:     1,
+						},
+						{
+							Type:           &ExpenseDetection{Text: "PRICE", Confidence: confidenceExpenseLI},
+							ValueDetection: &ExpenseDetection{Text: "$45.00", Confidence: confidenceExpenseLI},
+							PageNumber:     1,
+						},
+					},
+				},
+				{
+					LineItemExpenseFields: []ExpenseField{
+						{
+							Type:           &ExpenseDetection{Text: "ITEM", Confidence: confidenceExpenseLI2},
+							ValueDetection: &ExpenseDetection{Text: "Widget B", Confidence: confidenceExpenseLI2},
+							PageNumber:     1,
+						},
+						{
+							Type:           &ExpenseDetection{Text: "PRICE", Confidence: confidenceExpenseLI2},
+							ValueDetection: &ExpenseDetection{Text: "$78.45", Confidence: confidenceExpenseLI2},
+							PageNumber:     1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ExpenseDocument{
+		ExpenseIndex:   1,
+		Blocks:         blocks,
+		SummaryFields:  summaryFields,
+		LineItemGroups: lineItemGroups,
 	}
 }
 
-// AnalyzeID performs a synchronous ID analysis and returns synthetic identity documents.
+// AnalyzeExpense performs a synchronous expense analysis and returns expense documents.
+func (b *InMemoryBackend) AnalyzeExpense(documentURI string) []ExpenseDocument {
+	doc := syntheticExpenseDocument(documentURI)
+
+	return []ExpenseDocument{doc}
+}
+
+// syntheticIDDocument builds a realistic identity document.
+func syntheticIDDocument(documentURI string, index int) IdentityDocument {
+	blocks := syntheticBlocks(documentURI)
+
+	fields := []IdentityDocumentField{
+		{
+			Type:           &AnalyzeIDDetections{Text: "FIRST_NAME", Confidence: confidenceExpenseHigh},
+			ValueDetection: &AnalyzeIDDetections{Text: "JANE", Confidence: confidenceExpenseHigh},
+		},
+		{
+			Type:           &AnalyzeIDDetections{Text: "LAST_NAME", Confidence: confidenceExpenseHigh},
+			ValueDetection: &AnalyzeIDDetections{Text: "DOE", Confidence: confidenceExpenseHigh},
+		},
+		{
+			Type: &AnalyzeIDDetections{Text: "DATE_OF_BIRTH", Confidence: confidenceExpenseMed},
+			ValueDetection: &AnalyzeIDDetections{
+				Text:            "1990-01-15",
+				Confidence:      confidenceExpenseMed,
+				NormalizedValue: &NormalizedValue{Value: "1990-01-15", ValueType: "DATE"},
+			},
+		},
+		{
+			Type: &AnalyzeIDDetections{Text: "EXPIRATION_DATE", Confidence: confidenceExpenseMed},
+			ValueDetection: &AnalyzeIDDetections{
+				Text:            "2030-12-31",
+				Confidence:      confidenceExpenseMed,
+				NormalizedValue: &NormalizedValue{Value: "2030-12-31", ValueType: "DATE"},
+			},
+		},
+		{
+			Type:           &AnalyzeIDDetections{Text: "DOCUMENT_NUMBER", Confidence: confidenceExpenseHigh},
+			ValueDetection: &AnalyzeIDDetections{Text: "D12345678", Confidence: confidenceExpenseHigh},
+		},
+	}
+
+	return IdentityDocument{
+		DocumentIndex:          index,
+		Blocks:                 blocks,
+		IdentityDocumentFields: fields,
+	}
+}
+
+// AnalyzeID performs a synchronous ID analysis and returns identity documents.
 func (b *InMemoryBackend) AnalyzeID(documentURIs []string) []IdentityDocument {
 	docs := make([]IdentityDocument, 0, len(documentURIs))
 	for i, uri := range documentURIs {
-		docs = append(docs, IdentityDocument{
-			DocumentIndex: i + 1,
-			Blocks:        syntheticBlocks(uri),
-		})
+		docs = append(docs, syntheticIDDocument(uri, i+1))
 	}
 
 	return docs
 }
 
+// syntheticLendingResults builds realistic lending results.
+func syntheticLendingResults() []LendingResult {
+	return []LendingResult{
+		{
+			Page: 1,
+			PageClassification: &PageClassification{
+				PageType:   []LendingDetection{{Text: "PAYSTUB", Confidence: confidenceLending}},
+				PageNumber: []LendingDetection{{Text: "1", Confidence: confidencePage}},
+			},
+			Extractions: []Extraction{
+				{
+					LendingDocument: &LendingDocument{
+						LendingFields: []LendingField{
+							{
+								Type:           &LendingDetection{Text: "BORROWER_NAME", Confidence: confidenceLending},
+								ValueDetection: &LendingDetection{Text: "Jane Doe", Confidence: confidenceLending},
+								PageNumber:     1,
+							},
+							{
+								Type:           &LendingDetection{Text: "GROSS_INCOME", Confidence: confidenceLending2},
+								ValueDetection: &LendingDetection{Text: "$5000.00", Confidence: confidenceLending2},
+								PageNumber:     1,
+							},
+						},
+						SignatureDetections: []SignatureDetection{
+							{
+								Confidence: confidenceLendSig,
+								Geometry: makeGeometry(
+									geoLendSigLeft, geoLendSigTop,
+									geoLendSigWidth, geoLendSigHeight,
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// syntheticLendingSummary builds a realistic lending summary.
+func syntheticLendingSummary() *LendingSummary {
+	return &LendingSummary{
+		DocumentGroups: []DocumentGroup{
+			{
+				Type: "PAYSTUB",
+				SplitDocuments: []SplitDocument{
+					{Index: 1, Pages: []int{1}},
+				},
+				DetectedSignatures: []DetectedSignature{
+					{Page: 1},
+				},
+			},
+		},
+		UndetectedDocumentTypes: []string{},
+	}
+}
+
 // StartExpenseAnalysis creates an async expense analysis job.
 func (b *InMemoryBackend) StartExpenseAnalysis(documentURI string) (*ExpenseJob, error) {
 	b.mu.Lock("StartExpenseAnalysis")
-	defer b.mu.Unlock()
 
 	jobID := uuid.NewString()
 	job := &ExpenseJob{
-		JobID:        jobID,
-		JobStatus:    jobStatusSucceeded,
-		CreationTime: time.Now(),
-		ExpenseDocuments: []ExpenseDocument{
-			{
-				ExpenseIndex: 1,
-				Blocks:       syntheticBlocks(documentURI),
-			},
-		},
+		JobID:            jobID,
+		JobStatus:        jobStatusInProgress,
+		CreationTime:     time.Now(),
+		ExpenseDocuments: []ExpenseDocument{syntheticExpenseDocument(documentURI)},
 	}
 	b.expenseJobs[jobID] = job
 	b.trimExpenseJobsIfNeeded()
 
-	return cloneExpenseJob(job), nil
+	if b.asyncJobDelay == 0 {
+		job.JobStatus = jobStatusSucceeded
+		result := cloneExpenseJob(job)
+		b.mu.Unlock()
+
+		return result, nil
+	}
+
+	b.mu.Unlock()
+
+	go func() {
+		time.Sleep(b.asyncJobDelay)
+
+		b.mu.Lock("StartExpenseAnalysis-complete")
+		defer b.mu.Unlock()
+
+		if j, ok := b.expenseJobs[jobID]; ok {
+			j.JobStatus = jobStatusSucceeded
+		}
+	}()
+
+	b.mu.RLock("StartExpenseAnalysis-read")
+	result := cloneExpenseJob(b.expenseJobs[jobID])
+	b.mu.RUnlock()
+
+	return result, nil
 }
 
 // GetExpenseAnalysis retrieves the results of an expense analysis job.
-// It returns a deep clone so callers may safely mutate the returned value.
+// Returns a deep clone so callers may safely mutate the returned value.
 func (b *InMemoryBackend) GetExpenseAnalysis(jobID string) (*ExpenseJob, error) {
 	b.mu.RLock("GetExpenseAnalysis")
 	defer b.mu.RUnlock()
@@ -520,24 +1626,48 @@ func (b *InMemoryBackend) GetExpenseAnalysis(jobID string) (*ExpenseJob, error) 
 // StartLendingAnalysis creates an async lending analysis job.
 func (b *InMemoryBackend) StartLendingAnalysis(_ string) (*LendingJob, error) {
 	b.mu.Lock("StartLendingAnalysis")
-	defer b.mu.Unlock()
 
 	jobID := uuid.NewString()
 	job := &LendingJob{
 		JobID:        jobID,
-		JobStatus:    jobStatusSucceeded,
+		JobStatus:    jobStatusInProgress,
 		CreationTime: time.Now(),
-		Results:      []LendingResult{{Page: 1}},
+		Results:      syntheticLendingResults(),
+		Summary:      syntheticLendingSummary(),
 	}
 	b.lendingJobs[jobID] = job
 	b.trimLendingJobsIfNeeded()
 
-	return cloneLendingJob(job), nil
+	if b.asyncJobDelay == 0 {
+		job.JobStatus = jobStatusSucceeded
+		result := cloneLendingJob(job)
+		b.mu.Unlock()
+
+		return result, nil
+	}
+
+	b.mu.Unlock()
+
+	go func() {
+		time.Sleep(b.asyncJobDelay)
+
+		b.mu.Lock("StartLendingAnalysis-complete")
+		defer b.mu.Unlock()
+
+		if j, ok := b.lendingJobs[jobID]; ok {
+			j.JobStatus = jobStatusSucceeded
+		}
+	}()
+
+	b.mu.RLock("StartLendingAnalysis-read")
+	result := cloneLendingJob(b.lendingJobs[jobID])
+	b.mu.RUnlock()
+
+	return result, nil
 }
 
 // GetLendingAnalysis retrieves the results of a lending analysis job.
-// It returns a direct pointer to the stored job (lazy/CoW — no allocation on read path).
-// Callers MUST NOT mutate the returned value.
+// Returns a clone of the stored job.
 func (b *InMemoryBackend) GetLendingAnalysis(jobID string) (*LendingJob, error) {
 	b.mu.RLock("GetLendingAnalysis")
 	defer b.mu.RUnlock()
@@ -547,19 +1677,19 @@ func (b *InMemoryBackend) GetLendingAnalysis(jobID string) (*LendingJob, error) 
 		return nil, fmt.Errorf("%w: lending job %s not found", ErrJobNotFound, jobID)
 	}
 
-	return job, nil
+	return cloneLendingJob(job), nil
 }
 
-// validateFeatureTypes checks that the given slice contains at least one valid feature type.
-func validateFeatureTypes(featureTypes []string) error {
+// validateAdapterFeatureTypes checks that adapter feature types are restricted to FORMS and QUERIES.
+func validateAdapterFeatureTypes(featureTypes []string) error {
 	if len(featureTypes) == 0 {
 		return fmt.Errorf("%w: FeatureTypes must contain at least one value", ErrValidation)
 	}
 
 	for _, ft := range featureTypes {
-		if !allowedFeatureTypes()[ft] {
+		if !adapterAllowedFeatureTypes[ft] {
 			return fmt.Errorf(
-				"%w: invalid FeatureType %q (valid: TABLES, FORMS, QUERIES, SIGNATURES, LAYOUT)",
+				"%w: invalid FeatureType %q for adapter (valid: FORMS, QUERIES)",
 				ErrValidation,
 				ft,
 			)
@@ -569,13 +1699,123 @@ func validateFeatureTypes(featureTypes []string) error {
 	return nil
 }
 
+// buildAdapterARN constructs an ARN for a Textract adapter.
+func buildAdapterARN(region, accountID, adapterID string) string {
+	return fmt.Sprintf("arn:aws:textract:%s:%s:adapter/%s", region, accountID, adapterID)
+}
+
+// buildAdapterVersionARN constructs an ARN for a Textract adapter version.
+func buildAdapterVersionARN(region, accountID, adapterID, version string) string {
+	return fmt.Sprintf("arn:aws:textract:%s:%s:adapter/%s/version/%s", region, accountID, adapterID, version)
+}
+
+// arnAdapterID extracts the adapter ID from a Textract adapter ARN.
+// Returns empty string if the ARN is not an adapter ARN (e.g. it's a version ARN).
+func arnAdapterID(resourceARN string) string {
+	if len(resourceARN) <= 8 || resourceARN[:4] != "arn:" {
+		return ""
+	}
+
+	const prefix = "adapter/"
+
+	idx := lastIndex(resourceARN, prefix)
+	if idx < 0 {
+		return ""
+	}
+
+	rest := resourceARN[idx+len(prefix):]
+	if contains(rest, "/version/") {
+		return ""
+	}
+
+	return rest
+}
+
+// resolveARNToAdapter finds an adapter by ARN or adapter ID.
+func (b *InMemoryBackend) resolveARNToAdapter(resourceARN string) (*Adapter, bool) {
+	// Try direct adapter ID match first.
+	for _, a := range b.adapters {
+		if a.AdapterID == resourceARN {
+			return a, true
+		}
+	}
+
+	// Try ARN match: arn:aws:textract:region:account:adapter/adapterID
+	adapterID := arnAdapterID(resourceARN)
+	if adapterID == "" {
+		return nil, false
+	}
+
+	for _, a := range b.adapters {
+		if a.AdapterID == adapterID {
+			return a, true
+		}
+	}
+
+	return nil, false
+}
+
+// resolveARNToAdapterVersion finds an adapter version by ARN.
+func (b *InMemoryBackend) resolveARNToAdapterVersion(resourceARN string) (*AdapterVersion, bool) {
+	const versionPrefix = "/version/"
+
+	idx := lastIndex(resourceARN, versionPrefix)
+	if idx < 0 {
+		return nil, false
+	}
+
+	adapterPart := resourceARN[:idx]
+	version := resourceARN[idx+len(versionPrefix):]
+
+	// Extract adapter ID from adapter part.
+	const adapterPrefix = "adapter/"
+
+	adIdx := lastIndex(adapterPart, adapterPrefix)
+	if adIdx < 0 {
+		return nil, false
+	}
+
+	adapterID := adapterPart[adIdx+len(adapterPrefix):]
+	key := adapterVersionKey(adapterID, version)
+	av, ok := b.adapterVersions[key]
+
+	return av, ok
+}
+
+// lastIndex finds the last occurrence of substr in s.
+func lastIndex(s, substr string) int {
+	last := -1
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			last = i
+		}
+	}
+
+	return last
+}
+
+// contains checks if s contains substr.
+func contains(s, substr string) bool {
+	return lastIndex(s, substr) >= 0
+}
+
 // CreateAdapter creates a new Textract adapter and returns it.
 func (b *InMemoryBackend) CreateAdapter(
 	name, description, autoUpdate string,
 	featureTypes []string,
 	tags map[string]string,
 ) (*Adapter, error) {
-	if err := validateFeatureTypes(featureTypes); err != nil {
+	return b.CreateAdapterWithToken(name, description, autoUpdate, featureTypes, tags, "")
+}
+
+// CreateAdapterWithToken creates an adapter with ClientRequestToken dedup.
+func (b *InMemoryBackend) CreateAdapterWithToken(
+	name, description, autoUpdate string,
+	featureTypes []string,
+	tags map[string]string,
+	clientRequestToken string,
+) (*Adapter, error) {
+	if err := validateAdapterFeatureTypes(featureTypes); err != nil {
 		return nil, err
 	}
 
@@ -591,17 +1831,31 @@ func (b *InMemoryBackend) CreateAdapter(
 	b.mu.Lock("CreateAdapter")
 	defer b.mu.Unlock()
 
+	// Idempotency check.
+	if clientRequestToken != "" {
+		if existingID, ok := b.adapterClientTokenToID[clientRequestToken]; ok {
+			if existing, ok2 := b.adapters[existingID]; ok2 {
+				return cloneAdapter(existing), nil
+			}
+		}
+	}
+
 	adapterID := uuid.NewString()
 	adapter := &Adapter{
-		AdapterID:    adapterID,
-		AdapterName:  name,
-		AutoUpdate:   autoUpdate,
-		CreationTime: time.Now(),
-		Description:  description,
-		FeatureTypes: append([]string{}, featureTypes...),
-		Tags:         cloneTags(tags),
+		AdapterID:          adapterID,
+		AdapterName:        name,
+		AutoUpdate:         autoUpdate,
+		CreationTime:       time.Now(),
+		Description:        description,
+		FeatureTypes:       append([]string{}, featureTypes...),
+		Tags:               cloneTags(tags),
+		ClientRequestToken: clientRequestToken,
 	}
 	b.adapters[adapterID] = adapter
+
+	if clientRequestToken != "" {
+		b.adapterClientTokenToID[clientRequestToken] = adapterID
+	}
 
 	return cloneAdapter(adapter), nil
 }
@@ -682,13 +1936,32 @@ func (b *InMemoryBackend) DeleteAdapter(adapterID string) error {
 	return nil
 }
 
+// deterministic evaluation metrics for adapter versions.
+const (
+	evalF1Score   = 0.85
+	evalPrecision = 0.88
+	evalRecall    = 0.82
+)
+
 // CreateAdapterVersion creates a new version for an existing adapter.
 func (b *InMemoryBackend) CreateAdapterVersion(adapterID string, tags map[string]string) (*AdapterVersion, error) {
+	return b.CreateAdapterVersionWithOptions(adapterID, tags, nil, nil, "", "")
+}
+
+// CreateAdapterVersionWithOptions creates an adapter version with full options.
+func (b *InMemoryBackend) CreateAdapterVersionWithOptions(
+	adapterID string,
+	tags map[string]string,
+	datasetConfig *DatasetConfig,
+	outputConfig *OutputConfig,
+	kmsKeyID, clientRequestToken string,
+) (*AdapterVersion, error) {
 	b.mu.Lock("CreateAdapterVersion")
-	defer b.mu.Unlock()
 
 	adapter, ok := b.adapters[adapterID]
 	if !ok {
+		b.mu.Unlock()
+
 		return nil, fmt.Errorf("%w: adapter %s not found", ErrAdapterNotFound, adapterID)
 	}
 
@@ -698,12 +1971,49 @@ func (b *InMemoryBackend) CreateAdapterVersion(adapterID string, tags map[string
 		AdapterVersion: version,
 		CreationTime:   time.Now(),
 		FeatureTypes:   append([]string{}, adapter.FeatureTypes...),
-		Status:         adapterVersionActive,
-		Tags:           cloneTags(tags),
+		// Start in CREATION_IN_PROGRESS; goroutine transitions to ACTIVE.
+		Status:             adapterVersionCreating,
+		Tags:               cloneTags(tags),
+		DatasetConfig:      datasetConfig,
+		OutputConfig:       outputConfig,
+		KMSKeyId:           kmsKeyID,
+		ClientRequestToken: clientRequestToken,
+		EvaluationMetrics: &EvaluationMetrics{
+			F1Score:   evalF1Score,
+			Precision: evalPrecision,
+			Recall:    evalRecall,
+		},
 	}
 	b.adapterVersions[adapterVersionKey(adapterID, version)] = av
 
-	return cloneAdapterVersion(av), nil
+	if b.asyncJobDelay == 0 {
+		av.Status = adapterVersionActive
+		result := cloneAdapterVersion(av)
+		b.mu.Unlock()
+
+		return result, nil
+	}
+
+	b.mu.Unlock()
+
+	// Transition to ACTIVE after a short delay.
+	go func() {
+		time.Sleep(b.asyncJobDelay)
+
+		b.mu.Lock("CreateAdapterVersion-complete")
+		defer b.mu.Unlock()
+
+		key := adapterVersionKey(adapterID, version)
+		if stored, ok2 := b.adapterVersions[key]; ok2 {
+			stored.Status = adapterVersionActive
+		}
+	}()
+
+	b.mu.RLock("CreateAdapterVersion-read")
+	result := cloneAdapterVersion(b.adapterVersions[adapterVersionKey(adapterID, version)])
+	b.mu.RUnlock()
+
+	return result, nil
 }
 
 // GetAdapterVersion retrieves a specific adapter version.
@@ -757,57 +2067,73 @@ func (b *InMemoryBackend) DeleteAdapterVersion(adapterID, version string) error 
 	return nil
 }
 
-// TagResource adds or replaces tags on an adapter.
+// TagResource adds or replaces tags on an adapter or adapter version identified by ARN.
 func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string) error {
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	// We identify adapters by ARN (resourceARN). For simplicity we also accept
-	// adapter IDs directly as the resource identifier.
-	for _, a := range b.adapters {
-		if a.AdapterID == resourceARN {
-			maps.Copy(a.Tags, tags)
+	// Try adapter version first (ARN contains /version/).
+	if av, ok := b.resolveARNToAdapterVersion(resourceARN); ok {
+		maps.Copy(av.Tags, tags)
 
-			return nil
-		}
+		return nil
+	}
+
+	// Try adapter.
+	if a, ok := b.resolveARNToAdapter(resourceARN); ok {
+		maps.Copy(a.Tags, tags)
+
+		return nil
 	}
 
 	return fmt.Errorf("%w: resource %s not found", ErrAdapterNotFound, resourceARN)
 }
 
-// UntagResource removes the specified tag keys from an adapter.
+// UntagResource removes the specified tag keys from an adapter or adapter version.
 func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	for _, a := range b.adapters {
-		if a.AdapterID == resourceARN {
-			for _, k := range tagKeys {
-				delete(a.Tags, k)
-			}
-
-			return nil
+	// Try adapter version first.
+	if av, ok := b.resolveARNToAdapterVersion(resourceARN); ok {
+		for _, k := range tagKeys {
+			delete(av.Tags, k)
 		}
+
+		return nil
+	}
+
+	// Try adapter.
+	if a, ok := b.resolveARNToAdapter(resourceARN); ok {
+		for _, k := range tagKeys {
+			delete(a.Tags, k)
+		}
+
+		return nil
 	}
 
 	return fmt.Errorf("%w: resource %s not found", ErrAdapterNotFound, resourceARN)
 }
 
-// ListTagsForResource returns a copy of the tags for an adapter.
+// ListTagsForResource returns a copy of the tags for an adapter or adapter version.
 func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]string, error) {
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	for _, a := range b.adapters {
-		if a.AdapterID == resourceARN {
-			return cloneTags(a.Tags), nil
-		}
+	// Try adapter version first.
+	if av, ok := b.resolveARNToAdapterVersion(resourceARN); ok {
+		return cloneTags(av.Tags), nil
+	}
+
+	// Try adapter.
+	if a, ok := b.resolveARNToAdapter(resourceARN); ok {
+		return cloneTags(a.Tags), nil
 	}
 
 	return nil, fmt.Errorf("%w: resource %s not found", ErrAdapterNotFound, resourceARN)
 }
 
-// GetLendingAnalysisSummary returns a lightweight summary of a lending analysis job.
+// GetLendingAnalysisSummary returns a summary of a lending analysis job.
 func (b *InMemoryBackend) GetLendingAnalysisSummary(jobID string) (*LendingJob, error) {
 	b.mu.RLock("GetLendingAnalysisSummary")
 	defer b.mu.RUnlock()
@@ -817,9 +2143,24 @@ func (b *InMemoryBackend) GetLendingAnalysisSummary(jobID string) (*LendingJob, 
 		return nil, fmt.Errorf("%w: lending job %s not found", ErrJobNotFound, jobID)
 	}
 
-	// Return a summary: same job but without per-page lending results.
+	// Return a summary: same job status and summary, without per-page lending results.
 	cp := *job
 	cp.Results = nil
 
 	return &cp, nil
+}
+
+// BuildAdapterARN returns the ARN for an adapter (exported for handler use).
+func (b *InMemoryBackend) BuildAdapterARN(adapterID string) string {
+	return buildAdapterARN(b.region, b.accountID, adapterID)
+}
+
+// BuildAdapterVersionARN returns the ARN for an adapter version (exported for handler use).
+func (b *InMemoryBackend) BuildAdapterVersionARN(adapterID, version string) string {
+	return buildAdapterVersionARN(b.region, b.accountID, adapterID, version)
+}
+
+// PaginateBlocks applies pagination to blocks (exported for handler use).
+func PaginateBlocks(blocks []Block, maxResults int, nextToken string) ([]Block, string) {
+	return paginateBlocks(blocks, maxResults, nextToken)
 }

--- a/services/textract/backend_test.go
+++ b/services/textract/backend_test.go
@@ -13,7 +13,7 @@ import (
 func TestInMemoryBackend_AnalyzeDocument(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 	blocks := b.AnalyzeDocument("s3://my-bucket/doc.pdf")
 
 	assert.NotEmpty(t, blocks)
@@ -23,7 +23,7 @@ func TestInMemoryBackend_AnalyzeDocument(t *testing.T) {
 func TestInMemoryBackend_DetectDocumentText(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 	blocks := b.DetectDocumentText("s3://my-bucket/doc.pdf")
 
 	assert.NotEmpty(t, blocks)
@@ -47,7 +47,7 @@ func TestInMemoryBackend_StartAndGetDocumentAnalysis(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+			b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 
 			job, err := b.StartDocumentAnalysis(tt.documentURI)
 
@@ -75,7 +75,7 @@ func TestInMemoryBackend_StartAndGetDocumentAnalysis(t *testing.T) {
 func TestInMemoryBackend_GetDocumentAnalysis_NotFound(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 	_, err := b.GetDocumentAnalysis("nonexistent-job-id")
 
 	require.Error(t, err)
@@ -100,7 +100,7 @@ func TestInMemoryBackend_StartAndGetDocumentTextDetection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+			b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 
 			job, err := b.StartDocumentTextDetection(tt.documentURI)
 
@@ -128,7 +128,7 @@ func TestInMemoryBackend_StartAndGetDocumentTextDetection(t *testing.T) {
 func TestInMemoryBackend_GetDocumentTextDetection_NotFound(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 	_, err := b.GetDocumentTextDetection("nonexistent-job-id")
 
 	require.Error(t, err)
@@ -138,7 +138,7 @@ func TestInMemoryBackend_GetDocumentTextDetection_NotFound(t *testing.T) {
 func TestInMemoryBackend_ListJobs(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 
 	_, err := b.StartDocumentAnalysis("s3://bucket/doc1.pdf")
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestInMemoryBackend_ListJobs(t *testing.T) {
 func TestInMemoryBackend_GetDocumentAnalysis_WrongType(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 
 	job, err := b.StartDocumentTextDetection("s3://bucket/doc.png")
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestInMemoryBackend_GetDocumentAnalysis_WrongType(t *testing.T) {
 func TestInMemoryBackend_GetDocumentTextDetection_WrongType(t *testing.T) {
 	t.Parallel()
 
-	b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 
 	job, err := b.StartDocumentAnalysis("s3://bucket/doc.pdf")
 	require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestInMemoryBackend_JobHistoryCap(t *testing.T) {
 			if tt.name == "above_cap_trims_oldest" {
 				b = textract.NewInMemoryBackendWithCap(5)
 			} else {
-				b = textract.NewInMemoryBackend("123456789012", "us-east-1")
+				b = textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 			}
 
 			for range tt.insertAna {
@@ -278,7 +278,7 @@ func TestInMemoryBackend_PersistenceSnapshotRestore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b := textract.NewInMemoryBackend("123456789012", "us-east-1")
+			b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 
 			var lastJobID string
 
@@ -299,7 +299,7 @@ func TestInMemoryBackend_PersistenceSnapshotRestore(t *testing.T) {
 			snap := b.Snapshot()
 			require.NotNil(t, snap)
 
-			b2 := textract.NewInMemoryBackend("123456789012", "us-east-1")
+			b2 := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 			require.NoError(t, b2.Restore(snap))
 
 			jobs := b2.ListJobs()

--- a/services/textract/export_test.go
+++ b/services/textract/export_test.go
@@ -1,11 +1,27 @@
 package textract
 
+import "time"
+
 // NewInMemoryBackendWithCap creates a backend with a custom job history cap for testing.
 func NewInMemoryBackendWithCap(maxJobs int) *InMemoryBackend {
 	b := NewInMemoryBackend("123456789012", "us-east-1")
 	b.maxJobs = maxJobs
 
 	return b
+}
+
+// NewInMemoryBackendSync creates a backend where async jobs complete synchronously (zero delay).
+// Use this for tests that need immediate SUCCEEDED status without time.Sleep.
+func NewInMemoryBackendSync(accountID, region string) *InMemoryBackend {
+	b := NewInMemoryBackend(accountID, region)
+	b.asyncJobDelay = 0
+
+	return b
+}
+
+// SetBackendAsyncDelay sets the async job completion delay on a specific backend.
+func SetBackendAsyncDelay(b *InMemoryBackend, d time.Duration) {
+	b.asyncJobDelay = d
 }
 
 // JobCount returns the number of document jobs stored in the backend (for testing).

--- a/services/textract/handler.go
+++ b/services/textract/handler.go
@@ -230,7 +230,8 @@ func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err 
 
 // documentInput is the input for synchronous document operations.
 type documentInput struct {
-	Document struct {
+	QueriesConfig *QueriesConfig `json:"QueriesConfig"`
+	Document      struct {
 		S3Object struct {
 			Bucket string `json:"Bucket"`
 			Name   string `json:"Name"`
@@ -240,10 +241,20 @@ type documentInput struct {
 	FeatureTypes []string `json:"FeatureTypes"`
 }
 
-// documentResponse is the response for synchronous document operations.
-type documentResponse struct {
-	Blocks           []Block `json:"Blocks"`
-	DocumentMetadata struct {
+// analyzeDocumentResponse is the response for AnalyzeDocument.
+type analyzeDocumentResponse struct {
+	AnalyzeDocumentModelVersion string  `json:"AnalyzeDocumentModelVersion"`
+	Blocks                      []Block `json:"Blocks"`
+	DocumentMetadata            struct {
+		Pages int `json:"Pages"`
+	} `json:"DocumentMetadata"`
+}
+
+// detectDocumentTextResponse is the response for DetectDocumentText.
+type detectDocumentTextResponse struct {
+	DetectDocumentTextModelVersion string  `json:"DetectDocumentTextModelVersion"`
+	Blocks                         []Block `json:"Blocks"`
+	DocumentMetadata               struct {
 		Pages int `json:"Pages"`
 	} `json:"DocumentMetadata"`
 }
@@ -259,11 +270,22 @@ func documentURI(bucket, key string) string {
 func (h *Handler) handleAnalyzeDocument(
 	_ context.Context,
 	in *documentInput,
-) (*documentResponse, error) {
+) (*analyzeDocumentResponse, error) {
 	uri := documentURI(in.Document.S3Object.Bucket, in.Document.S3Object.Name)
-	blocks := h.Backend.AnalyzeDocument(uri)
 
-	resp := &documentResponse{Blocks: blocks}
+	var blocks []Block
+
+	if b, ok := h.Backend.(*InMemoryBackend); ok {
+		blocks = b.AnalyzeDocumentWithFeatures(uri, in.FeatureTypes, in.QueriesConfig)
+	} else {
+		blocks = h.Backend.AnalyzeDocument(uri)
+	}
+
+	resp := &analyzeDocumentResponse{
+		Blocks:                      blocks,
+		AnalyzeDocumentModelVersion: modelVersion10,
+	}
+	// Pages=1 for now; should reflect actual page count for multi-page PDFs.
 	resp.DocumentMetadata.Pages = 1
 
 	return resp, nil
@@ -272,11 +294,15 @@ func (h *Handler) handleAnalyzeDocument(
 func (h *Handler) handleDetectDocumentText(
 	_ context.Context,
 	in *documentInput,
-) (*documentResponse, error) {
+) (*detectDocumentTextResponse, error) {
 	uri := documentURI(in.Document.S3Object.Bucket, in.Document.S3Object.Name)
 	blocks := h.Backend.DetectDocumentText(uri)
 
-	resp := &documentResponse{Blocks: blocks}
+	resp := &detectDocumentTextResponse{
+		Blocks:                         blocks,
+		DetectDocumentTextModelVersion: modelVersion10,
+	}
+	// Pages=1 for now; should reflect actual page count for multi-page PDFs.
 	resp.DocumentMetadata.Pages = 1
 
 	return resp, nil
@@ -284,17 +310,18 @@ func (h *Handler) handleDetectDocumentText(
 
 // asyncInput is the input for async document operations.
 type asyncInput struct {
-	DocumentLocation struct {
+	NotificationChannel *NotificationChannel `json:"NotificationChannel"`
+	OutputConfig        *OutputConfig        `json:"OutputConfig"`
+	QueriesConfig       *QueriesConfig       `json:"QueriesConfig"`
+	DocumentLocation    struct {
 		S3Object struct {
 			Bucket string `json:"Bucket"`
 			Name   string `json:"Name"`
 		} `json:"S3Object"`
 	} `json:"DocumentLocation"`
-	NotificationChannel struct {
-		RoleArn     string `json:"RoleArn"`
-		SNSTopicArn string `json:"SNSTopicArn"`
-	} `json:"NotificationChannel"`
-	FeatureTypes []string `json:"FeatureTypes"`
+	JobTag             string   `json:"JobTag"`
+	ClientRequestToken string   `json:"ClientRequestToken"`
+	FeatureTypes       []string `json:"FeatureTypes"`
 }
 
 type startJobResponse struct {
@@ -314,7 +341,22 @@ func (h *Handler) handleStartDocumentAnalysis(
 
 	uri := "s3://" + bucket + "/" + key
 
-	job, err := h.Backend.StartDocumentAnalysis(uri)
+	var job *DocumentJob
+	var err error
+
+	if b, ok := h.Backend.(*InMemoryBackend); ok {
+		job, err = b.StartDocumentAnalysisWithOptions(
+			uri,
+			in.FeatureTypes,
+			in.QueriesConfig,
+			in.OutputConfig,
+			in.JobTag,
+			in.ClientRequestToken,
+		)
+	} else {
+		job, err = h.Backend.StartDocumentAnalysis(uri)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -322,14 +364,22 @@ func (h *Handler) handleStartDocumentAnalysis(
 	return &startJobResponse{JobID: job.JobID}, nil
 }
 
+// getJobInput is the input for Get* async job operations.
 type getJobInput struct {
-	JobID string `json:"JobId"`
+	JobID      string `json:"JobId"`
+	NextToken  string `json:"NextToken"`
+	MaxResults int    `json:"MaxResults"`
 }
 
-type getJobResponse struct {
-	JobStatus        string  `json:"JobStatus"`
-	Blocks           []Block `json:"Blocks"`
-	DocumentMetadata struct {
+// getDocumentAnalysisResponse is the response for GetDocumentAnalysis.
+type getDocumentAnalysisResponse struct {
+	JobStatus                   string         `json:"JobStatus"`
+	NextToken                   string         `json:"NextToken,omitempty"`
+	StatusMessage               string         `json:"StatusMessage,omitempty"`
+	AnalyzeDocumentModelVersion string         `json:"AnalyzeDocumentModelVersion"`
+	Blocks                      []Block        `json:"Blocks"`
+	Warnings                    []WarningBlock `json:"Warnings,omitempty"`
+	DocumentMetadata            struct {
 		Pages int `json:"Pages"`
 	} `json:"DocumentMetadata"`
 }
@@ -337,7 +387,7 @@ type getJobResponse struct {
 func (h *Handler) handleGetDocumentAnalysis(
 	_ context.Context,
 	in *getJobInput,
-) (*getJobResponse, error) {
+) (*getDocumentAnalysisResponse, error) {
 	if in.JobID == "" {
 		return nil, fmt.Errorf("%w: JobID is required", errInvalidRequest)
 	}
@@ -347,9 +397,15 @@ func (h *Handler) handleGetDocumentAnalysis(
 		return nil, err
 	}
 
-	resp := &getJobResponse{
-		JobStatus: job.JobStatus,
-		Blocks:    job.Blocks,
+	blocks, nextToken := PaginateBlocks(job.Blocks, in.MaxResults, in.NextToken)
+
+	resp := &getDocumentAnalysisResponse{
+		JobStatus:                   job.JobStatus,
+		Blocks:                      blocks,
+		NextToken:                   nextToken,
+		StatusMessage:               job.StatusMessage,
+		Warnings:                    job.Warnings,
+		AnalyzeDocumentModelVersion: modelVersion10,
 	}
 	resp.DocumentMetadata.Pages = 1
 
@@ -369,7 +425,21 @@ func (h *Handler) handleStartDocumentTextDetection(
 
 	uri := "s3://" + bucket + "/" + key
 
-	job, err := h.Backend.StartDocumentTextDetection(uri)
+	var job *DocumentJob
+	var err error
+
+	if b, ok := h.Backend.(*InMemoryBackend); ok {
+		job, err = b.StartDocumentTextDetectionWithOptions(
+			uri,
+			in.OutputConfig,
+			in.NotificationChannel,
+			in.JobTag,
+			in.ClientRequestToken,
+		)
+	} else {
+		job, err = h.Backend.StartDocumentTextDetection(uri)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -377,10 +447,23 @@ func (h *Handler) handleStartDocumentTextDetection(
 	return &startJobResponse{JobID: job.JobID}, nil
 }
 
+// getDocumentTextDetectionResponse is the response for GetDocumentTextDetection.
+type getDocumentTextDetectionResponse struct {
+	JobStatus                      string         `json:"JobStatus"`
+	NextToken                      string         `json:"NextToken,omitempty"`
+	StatusMessage                  string         `json:"StatusMessage,omitempty"`
+	DetectDocumentTextModelVersion string         `json:"DetectDocumentTextModelVersion"`
+	Blocks                         []Block        `json:"Blocks"`
+	Warnings                       []WarningBlock `json:"Warnings,omitempty"`
+	DocumentMetadata               struct {
+		Pages int `json:"Pages"`
+	} `json:"DocumentMetadata"`
+}
+
 func (h *Handler) handleGetDocumentTextDetection(
 	_ context.Context,
 	in *getJobInput,
-) (*getJobResponse, error) {
+) (*getDocumentTextDetectionResponse, error) {
 	if in.JobID == "" {
 		return nil, fmt.Errorf("%w: JobID is required", errInvalidRequest)
 	}
@@ -390,9 +473,15 @@ func (h *Handler) handleGetDocumentTextDetection(
 		return nil, err
 	}
 
-	resp := &getJobResponse{
-		JobStatus: job.JobStatus,
-		Blocks:    job.Blocks,
+	blocks, nextToken := PaginateBlocks(job.Blocks, in.MaxResults, in.NextToken)
+
+	resp := &getDocumentTextDetectionResponse{
+		JobStatus:                      job.JobStatus,
+		Blocks:                         blocks,
+		NextToken:                      nextToken,
+		StatusMessage:                  job.StatusMessage,
+		Warnings:                       job.Warnings,
+		DetectDocumentTextModelVersion: modelVersion10,
 	}
 	resp.DocumentMetadata.Pages = 1
 
@@ -477,11 +566,12 @@ func (h *Handler) handleAnalyzeID(
 
 // createAdapterInput is the input for CreateAdapter.
 type createAdapterInput struct {
-	Tags         map[string]string `json:"Tags"`
-	AdapterName  string            `json:"AdapterName"`
-	AutoUpdate   string            `json:"AutoUpdate"`
-	Description  string            `json:"Description"`
-	FeatureTypes []string          `json:"FeatureTypes"`
+	Tags               map[string]string `json:"Tags"`
+	AdapterName        string            `json:"AdapterName"`
+	AutoUpdate         string            `json:"AutoUpdate"`
+	Description        string            `json:"Description"`
+	ClientRequestToken string            `json:"ClientRequestToken"`
+	FeatureTypes       []string          `json:"FeatureTypes"`
 }
 
 // createAdapterResponse is the response for CreateAdapter.
@@ -497,7 +587,18 @@ func (h *Handler) handleCreateAdapter(
 		return nil, fmt.Errorf("%w: AdapterName is required", errInvalidRequest)
 	}
 
-	adapter, err := h.Backend.CreateAdapter(in.AdapterName, in.Description, in.AutoUpdate, in.FeatureTypes, in.Tags)
+	var adapter *Adapter
+	var err error
+
+	if b, ok := h.Backend.(*InMemoryBackend); ok {
+		adapter, err = b.CreateAdapterWithToken(
+			in.AdapterName, in.Description, in.AutoUpdate,
+			in.FeatureTypes, in.Tags, in.ClientRequestToken,
+		)
+	} else {
+		adapter, err = h.Backend.CreateAdapter(in.AdapterName, in.Description, in.AutoUpdate, in.FeatureTypes, in.Tags)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -646,8 +747,13 @@ func (h *Handler) handleDeleteAdapter(
 
 // createAdapterVersionInput is the input for CreateAdapterVersion.
 type createAdapterVersionInput struct {
-	Tags      map[string]string `json:"Tags"`
-	AdapterID string            `json:"AdapterId"`
+	Tags               map[string]string `json:"Tags"`
+	DatasetConfig      *DatasetConfig    `json:"DatasetConfig"`
+	OutputConfig       *OutputConfig     `json:"OutputConfig"`
+	AdapterID          string            `json:"AdapterId"`
+	ClientRequestToken string            `json:"ClientRequestToken"`
+	//nolint:revive,staticcheck // KMSKeyId: AWS SDK field name convention
+	KMSKeyId string `json:"KMSKeyId"`
 }
 
 // createAdapterVersionResponse is the response for CreateAdapterVersion.
@@ -664,7 +770,19 @@ func (h *Handler) handleCreateAdapterVersion(
 		return nil, fmt.Errorf("%w: AdapterId is required", errInvalidRequest)
 	}
 
-	av, err := h.Backend.CreateAdapterVersion(in.AdapterID, in.Tags)
+	var av *AdapterVersion
+	var err error
+
+	if b, ok := h.Backend.(*InMemoryBackend); ok {
+		av, err = b.CreateAdapterVersionWithOptions(
+			in.AdapterID, in.Tags,
+			in.DatasetConfig, in.OutputConfig,
+			in.KMSKeyId, in.ClientRequestToken,
+		)
+	} else {
+		av, err = h.Backend.CreateAdapterVersion(in.AdapterID, in.Tags)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -683,13 +801,18 @@ type getAdapterVersionInput struct {
 
 // getAdapterVersionResponse is the response for GetAdapterVersion.
 type getAdapterVersionResponse struct {
-	Tags           map[string]string `json:"Tags"`
-	AdapterID      string            `json:"AdapterId"`
-	AdapterVersion string            `json:"AdapterVersion"`
-	CreationTime   string            `json:"CreationTime"`
-	Status         string            `json:"Status"`
-	StatusMessage  string            `json:"StatusMessage"`
-	FeatureTypes   []string          `json:"FeatureTypes"`
+	Tags              map[string]string  `json:"Tags"`
+	DatasetConfig     *DatasetConfig     `json:"DatasetConfig,omitempty"`
+	OutputConfig      *OutputConfig      `json:"OutputConfig,omitempty"`
+	EvaluationMetrics *EvaluationMetrics `json:"EvaluationMetrics,omitempty"`
+	AdapterID         string             `json:"AdapterId"`
+	AdapterVersion    string             `json:"AdapterVersion"`
+	CreationTime      string             `json:"CreationTime"`
+	Status            string             `json:"Status"`
+	StatusMessage     string             `json:"StatusMessage"`
+	//nolint:revive,staticcheck // KMSKeyId: AWS SDK field name convention
+	KMSKeyId     string   `json:"KMSKeyId,omitempty"`
+	FeatureTypes []string `json:"FeatureTypes"`
 }
 
 func (h *Handler) handleGetAdapterVersion(
@@ -710,13 +833,17 @@ func (h *Handler) handleGetAdapterVersion(
 	}
 
 	return &getAdapterVersionResponse{
-		AdapterID:      av.AdapterID,
-		AdapterVersion: av.AdapterVersion,
-		CreationTime:   av.CreationTime.Format("2006-01-02T15:04:05Z"),
-		FeatureTypes:   av.FeatureTypes,
-		Status:         av.Status,
-		StatusMessage:  av.StatusMessage,
-		Tags:           av.Tags,
+		AdapterID:         av.AdapterID,
+		AdapterVersion:    av.AdapterVersion,
+		CreationTime:      av.CreationTime.Format("2006-01-02T15:04:05Z"),
+		FeatureTypes:      av.FeatureTypes,
+		Status:            av.Status,
+		StatusMessage:     av.StatusMessage,
+		Tags:              av.Tags,
+		DatasetConfig:     av.DatasetConfig,
+		OutputConfig:      av.OutputConfig,
+		KMSKeyId:          av.KMSKeyId,
+		EvaluationMetrics: av.EvaluationMetrics,
 	}, nil
 }
 
@@ -862,13 +989,17 @@ func (h *Handler) handleListTagsForResource(
 
 // getExpenseAnalysisInput is the input for GetExpenseAnalysis.
 type getExpenseAnalysisInput struct {
-	JobID string `json:"JobId"`
+	JobID      string `json:"JobId"`
+	NextToken  string `json:"NextToken"`
+	MaxResults int    `json:"MaxResults"`
 }
 
 // getExpenseAnalysisResponse is the response for GetExpenseAnalysis.
 type getExpenseAnalysisResponse struct {
 	AnalyzeExpenseModelVersion string            `json:"AnalyzeExpenseModelVersion"`
 	JobStatus                  string            `json:"JobStatus"`
+	StatusMessage              string            `json:"StatusMessage,omitempty"`
+	Warnings                   []WarningBlock    `json:"Warnings,omitempty"`
 	ExpenseDocuments           []ExpenseDocument `json:"ExpenseDocuments"`
 	DocumentMetadata           struct {
 		Pages int `json:"Pages"`
@@ -892,6 +1023,8 @@ func (h *Handler) handleGetExpenseAnalysis(
 		AnalyzeExpenseModelVersion: modelVersion10,
 		ExpenseDocuments:           job.ExpenseDocuments,
 		JobStatus:                  job.JobStatus,
+		StatusMessage:              job.StatusMessage,
+		Warnings:                   job.Warnings,
 	}
 	resp.DocumentMetadata.Pages = 1
 
@@ -906,6 +1039,10 @@ type startExpenseAnalysisInput struct {
 			Name   string `json:"Name"`
 		} `json:"S3Object"`
 	} `json:"DocumentLocation"`
+	NotificationChannel *NotificationChannel `json:"NotificationChannel"`
+	OutputConfig        *OutputConfig        `json:"OutputConfig"`
+	JobTag              string               `json:"JobTag"`
+	ClientRequestToken  string               `json:"ClientRequestToken"`
 }
 
 func (h *Handler) handleStartExpenseAnalysis(
@@ -931,13 +1068,17 @@ func (h *Handler) handleStartExpenseAnalysis(
 
 // getLendingAnalysisInput is the input for GetLendingAnalysis.
 type getLendingAnalysisInput struct {
-	JobID string `json:"JobId"`
+	JobID      string `json:"JobId"`
+	NextToken  string `json:"NextToken"`
+	MaxResults int    `json:"MaxResults"`
 }
 
 // getLendingAnalysisResponse is the response for GetLendingAnalysis.
 type getLendingAnalysisResponse struct {
 	AnalyzeLendingModelVersion string          `json:"AnalyzeLendingModelVersion"`
 	JobStatus                  string          `json:"JobStatus"`
+	StatusMessage              string          `json:"StatusMessage,omitempty"`
+	Warnings                   []WarningBlock  `json:"Warnings,omitempty"`
 	Results                    []LendingResult `json:"Results"`
 	DocumentMetadata           struct {
 		Pages int `json:"Pages"`
@@ -960,6 +1101,8 @@ func (h *Handler) handleGetLendingAnalysis(
 	resp := &getLendingAnalysisResponse{
 		AnalyzeLendingModelVersion: modelVersion10,
 		JobStatus:                  job.JobStatus,
+		StatusMessage:              job.StatusMessage,
+		Warnings:                   job.Warnings,
 		Results:                    job.Results,
 	}
 	resp.DocumentMetadata.Pages = 1
@@ -974,8 +1117,10 @@ type getLendingAnalysisSummaryInput struct {
 
 // getLendingAnalysisSummaryResponse is the response for GetLendingAnalysisSummary.
 type getLendingAnalysisSummaryResponse struct {
-	AnalyzeLendingModelVersion string `json:"AnalyzeLendingModelVersion"`
-	JobStatus                  string `json:"JobStatus"`
+	Summary                    *LendingSummary `json:"Summary,omitempty"`
+	AnalyzeLendingModelVersion string          `json:"AnalyzeLendingModelVersion"`
+	JobStatus                  string          `json:"JobStatus"`
+	StatusMessage              string          `json:"StatusMessage,omitempty"`
 	DocumentMetadata           struct {
 		Pages int `json:"Pages"`
 	} `json:"DocumentMetadata"`
@@ -997,6 +1142,8 @@ func (h *Handler) handleGetLendingAnalysisSummary(
 	resp := &getLendingAnalysisSummaryResponse{
 		AnalyzeLendingModelVersion: modelVersion10,
 		JobStatus:                  job.JobStatus,
+		StatusMessage:              job.StatusMessage,
+		Summary:                    job.Summary,
 	}
 	resp.DocumentMetadata.Pages = 1
 
@@ -1011,6 +1158,10 @@ type startLendingAnalysisInput struct {
 			Name   string `json:"Name"`
 		} `json:"S3Object"`
 	} `json:"DocumentLocation"`
+	NotificationChannel *NotificationChannel `json:"NotificationChannel"`
+	OutputConfig        *OutputConfig        `json:"OutputConfig"`
+	JobTag              string               `json:"JobTag"`
+	ClientRequestToken  string               `json:"ClientRequestToken"`
 }
 
 func (h *Handler) handleStartLendingAnalysis(

--- a/services/textract/handler_accuracy_test.go
+++ b/services/textract/handler_accuracy_test.go
@@ -1,0 +1,1023 @@
+package textract_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/textract"
+)
+
+// ---- helpers ----
+
+func newAccuracyHandler(t *testing.T) *textract.Handler {
+	t.Helper()
+
+	return textract.NewHandler(textract.NewInMemoryBackendSync("123456789012", "us-east-1"))
+}
+
+// blocksOfType returns all blocks in the JSON response body that match blockType.
+func blocksOfType(t *testing.T, body []byte, blockType string) []map[string]any {
+	t.Helper()
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(body, &resp))
+
+	raw, ok := resp["Blocks"].([]any)
+	require.True(t, ok, "response should have Blocks array")
+
+	var out []map[string]any
+
+	for _, b := range raw {
+		bm, ok2 := b.(map[string]any)
+		if !ok2 {
+			continue
+		}
+
+		if bm["BlockType"] == blockType {
+			out = append(out, bm)
+		}
+	}
+
+	return out
+}
+
+// Test 1: DetectDocumentText returns PAGE/LINE/WORD blocks with Relationships.
+func TestAccuracy_DetectDocumentText_BlockStructure(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "DetectDocumentText", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	pages := blocksOfType(t, rec.Body.Bytes(), "PAGE")
+	lines := blocksOfType(t, rec.Body.Bytes(), "LINE")
+	words := blocksOfType(t, rec.Body.Bytes(), "WORD")
+
+	assert.NotEmpty(t, pages, "expected at least one PAGE block")
+	assert.NotEmpty(t, lines, "expected at least one LINE block")
+	assert.NotEmpty(t, words, "expected at least one WORD block")
+
+	// PAGE block should have CHILD relationships.
+	page := pages[0]
+	rels, ok := page["Relationships"].([]any)
+	assert.True(t, ok, "PAGE block should have Relationships")
+	assert.NotEmpty(t, rels, "PAGE Relationships should not be empty")
+}
+
+// Test 2: DetectDocumentText returns DetectDocumentTextModelVersion.
+func TestAccuracy_DetectDocumentText_ModelVersion(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "DetectDocumentText", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "1.0", resp["DetectDocumentTextModelVersion"])
+}
+
+// Test 3: AnalyzeDocument FORMS → KEY_VALUE_SET blocks present.
+func TestAccuracy_AnalyzeDocument_Forms_KeyValueSetBlocks(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "form.pdf"},
+		},
+		"FeatureTypes": []string{"FORMS"},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	kvBlocks := blocksOfType(t, rec.Body.Bytes(), "KEY_VALUE_SET")
+	assert.NotEmpty(t, kvBlocks, "FORMS feature should produce KEY_VALUE_SET blocks")
+
+	// Check for KEY and VALUE entity types.
+	var hasKey, hasValue bool
+
+	for _, blk := range kvBlocks {
+		if ets, ok := blk["EntityTypes"].([]any); ok {
+			for _, et := range ets {
+				switch et.(string) {
+				case "KEY":
+					hasKey = true
+				case "VALUE":
+					hasValue = true
+				}
+			}
+		}
+	}
+
+	assert.True(t, hasKey, "should have KEY blocks")
+	assert.True(t, hasValue, "should have VALUE blocks")
+}
+
+// Test 4: AnalyzeDocument TABLES → TABLE+CELL blocks present.
+func TestAccuracy_AnalyzeDocument_Tables_TableCellBlocks(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "table.pdf"},
+		},
+		"FeatureTypes": []string{"TABLES"},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	tables := blocksOfType(t, rec.Body.Bytes(), "TABLE")
+	cells := blocksOfType(t, rec.Body.Bytes(), "CELL")
+
+	assert.NotEmpty(t, tables, "TABLES feature should produce TABLE blocks")
+	assert.NotEmpty(t, cells, "TABLES feature should produce CELL blocks")
+
+	// CELL blocks should have RowIndex and ColumnIndex.
+	for _, cell := range cells {
+		_, hasRow := cell["RowIndex"]
+		_, hasCol := cell["ColumnIndex"]
+		assert.True(t, hasRow, "CELL should have RowIndex")
+		assert.True(t, hasCol, "CELL should have ColumnIndex")
+	}
+}
+
+// Test 5: AnalyzeDocument QUERIES with QueriesConfig → QUERY+QUERY_RESULT blocks.
+func TestAccuracy_AnalyzeDocument_Queries_QueryBlocks(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+		"FeatureTypes": []string{"QUERIES"},
+		"QueriesConfig": map[string]any{
+			"Queries": []any{
+				map[string]any{"Text": "What is the total?", "Alias": "TOTAL"},
+				map[string]any{"Text": "Who is the vendor?", "Alias": "VENDOR"},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	queryBlocks := blocksOfType(t, rec.Body.Bytes(), "QUERY")
+	resultBlocks := blocksOfType(t, rec.Body.Bytes(), "QUERY_RESULT")
+
+	assert.Len(t, queryBlocks, 2, "should have 2 QUERY blocks (one per query)")
+	assert.Len(t, resultBlocks, 2, "should have 2 QUERY_RESULT blocks")
+
+	// Each QUERY block should have an ANSWER relationship.
+	for _, qb := range queryBlocks {
+		rels, ok := qb["Relationships"].([]any)
+		assert.True(t, ok, "QUERY block should have Relationships")
+
+		var hasAnswer bool
+
+		for _, rel := range rels {
+			rm, ok2 := rel.(map[string]any)
+			if ok2 && rm["Type"] == "ANSWER" {
+				hasAnswer = true
+			}
+		}
+
+		assert.True(t, hasAnswer, "QUERY block should have ANSWER relationship")
+	}
+}
+
+// Test 6: AnalyzeDocument SIGNATURES → SIGNATURE block.
+func TestAccuracy_AnalyzeDocument_Signatures_SignatureBlock(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "signed.pdf"},
+		},
+		"FeatureTypes": []string{"SIGNATURES"},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	sigBlocks := blocksOfType(t, rec.Body.Bytes(), "SIGNATURE")
+	assert.NotEmpty(t, sigBlocks, "SIGNATURES feature should produce SIGNATURE blocks")
+
+	// SIGNATURE block should have Geometry.
+	sig := sigBlocks[0]
+	_, hasGeom := sig["Geometry"]
+	assert.True(t, hasGeom, "SIGNATURE block should have Geometry")
+}
+
+// Test 7: AnalyzeDocument LAYOUT → LAYOUT_TEXT block.
+func TestAccuracy_AnalyzeDocument_Layout_LayoutBlocks(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "layout.pdf"},
+		},
+		"FeatureTypes": []string{"LAYOUT"},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	layoutText := blocksOfType(t, rec.Body.Bytes(), "LAYOUT_TEXT")
+	layoutHeader := blocksOfType(t, rec.Body.Bytes(), "LAYOUT_HEADER")
+	layoutFooter := blocksOfType(t, rec.Body.Bytes(), "LAYOUT_FOOTER")
+
+	assert.NotEmpty(t, layoutText, "LAYOUT feature should produce LAYOUT_TEXT blocks")
+	assert.NotEmpty(t, layoutHeader, "LAYOUT feature should produce LAYOUT_HEADER blocks")
+	assert.NotEmpty(t, layoutFooter, "LAYOUT feature should produce LAYOUT_FOOTER blocks")
+}
+
+// Test 8: AnalyzeDocument includes AnalyzeDocumentModelVersion in response.
+func TestAccuracy_AnalyzeDocument_ModelVersion(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+		"FeatureTypes": []string{"FORMS"},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "1.0", resp["AnalyzeDocumentModelVersion"])
+}
+
+// Test 9: AnalyzeExpense returns SummaryFields with VENDOR_NAME and TOTAL.
+func TestAccuracy_AnalyzeExpense_SummaryFields(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeExpense", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "invoice.pdf"},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	docs, ok := resp["ExpenseDocuments"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, docs)
+
+	doc, ok := docs[0].(map[string]any)
+	require.True(t, ok)
+
+	summaryFields, ok := doc["SummaryFields"].([]any)
+	require.True(t, ok, "ExpenseDocument should have SummaryFields")
+	require.NotEmpty(t, summaryFields)
+
+	var fieldTypes []string
+
+	for _, sf := range summaryFields {
+		sfm, ok2 := sf.(map[string]any)
+		if !ok2 {
+			continue
+		}
+
+		if typeField, ok3 := sfm["Type"].(map[string]any); ok3 {
+			if text, ok4 := typeField["Text"].(string); ok4 {
+				fieldTypes = append(fieldTypes, text)
+			}
+		}
+	}
+
+	assert.Contains(t, fieldTypes, "VENDOR_NAME")
+	assert.Contains(t, fieldTypes, "TOTAL")
+}
+
+// Test 10: AnalyzeExpense returns LineItemGroups with items.
+func TestAccuracy_AnalyzeExpense_LineItemGroups(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeExpense", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "invoice.pdf"},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	docs, _ := resp["ExpenseDocuments"].([]any)
+	require.NotEmpty(t, docs)
+
+	doc, _ := docs[0].(map[string]any)
+	groups, ok := doc["LineItemGroups"].([]any)
+	require.True(t, ok, "ExpenseDocument should have LineItemGroups")
+	require.NotEmpty(t, groups)
+
+	group, ok := groups[0].(map[string]any)
+	require.True(t, ok)
+
+	items, ok := group["LineItems"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, items, "LineItemGroup should have LineItems")
+}
+
+// Test 11: AnalyzeID returns IdentityDocumentFields with FIRST_NAME and DATE_OF_BIRTH.
+func TestAccuracy_AnalyzeID_IdentityDocumentFields(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeID", map[string]any{
+		"DocumentPages": []any{
+			map[string]any{
+				"S3Object": map[string]any{"Bucket": "b", "Name": "id-front.jpg"},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	docs, ok := resp["IdentityDocuments"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, docs)
+
+	doc, ok := docs[0].(map[string]any)
+	require.True(t, ok)
+
+	fields, ok := doc["IdentityDocumentFields"].([]any)
+	require.True(t, ok, "IdentityDocument should have IdentityDocumentFields")
+	require.NotEmpty(t, fields)
+
+	var fieldTypes []string
+
+	for _, f := range fields {
+		fm, ok2 := f.(map[string]any)
+		if !ok2 {
+			continue
+		}
+
+		if typeField, ok3 := fm["Type"].(map[string]any); ok3 {
+			if text, ok4 := typeField["Text"].(string); ok4 {
+				fieldTypes = append(fieldTypes, text)
+			}
+		}
+	}
+
+	assert.Contains(t, fieldTypes, "FIRST_NAME")
+	assert.Contains(t, fieldTypes, "DATE_OF_BIRTH")
+	assert.Contains(t, fieldTypes, "DOCUMENT_NUMBER")
+}
+
+// Test 12: AnalyzeID DATE_OF_BIRTH has NormalizedValue with ValueType=DATE.
+func TestAccuracy_AnalyzeID_NormalizedValue_Date(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeID", map[string]any{
+		"DocumentPages": []any{
+			map[string]any{
+				"S3Object": map[string]any{"Bucket": "b", "Name": "id.jpg"},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	docs, _ := resp["IdentityDocuments"].([]any)
+	doc, _ := docs[0].(map[string]any)
+	fields, _ := doc["IdentityDocumentFields"].([]any)
+
+	var foundDateNormalized bool
+
+	for _, f := range fields {
+		fm, ok := f.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		typeField, ok2 := fm["Type"].(map[string]any)
+		if !ok2 || typeField["Text"] != "DATE_OF_BIRTH" {
+			continue
+		}
+
+		valDet, ok3 := fm["ValueDetection"].(map[string]any)
+		if !ok3 {
+			continue
+		}
+
+		normVal, ok4 := valDet["NormalizedValue"].(map[string]any)
+		if ok4 && normVal["ValueType"] == "DATE" {
+			foundDateNormalized = true
+		}
+	}
+
+	assert.True(t, foundDateNormalized, "DATE_OF_BIRTH should have NormalizedValue with ValueType=DATE")
+}
+
+// Test 13: StartDocumentTextDetection → GetDocumentTextDetection pagination (MaxResults).
+func TestAccuracy_GetDocumentTextDetection_Pagination(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	startRec := doTextractRequest(t, h, "StartDocumentTextDetection", map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp map[string]string
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	jobID := startResp["JobId"]
+
+	// Get first page with MaxResults=3.
+	getRec1 := doTextractRequest(t, h, "GetDocumentTextDetection", map[string]any{
+		"JobId":      jobID,
+		"MaxResults": 3,
+	})
+	require.Equal(t, http.StatusOK, getRec1.Code)
+
+	var getResp1 map[string]any
+	require.NoError(t, json.Unmarshal(getRec1.Body.Bytes(), &getResp1))
+
+	blocks1, _ := getResp1["Blocks"].([]any)
+	assert.Len(t, blocks1, 3, "first page should have 3 blocks")
+
+	nextToken, _ := getResp1["NextToken"].(string)
+	assert.NotEmpty(t, nextToken, "NextToken should be present when more blocks exist")
+
+	// Get second page using the NextToken.
+	getRec2 := doTextractRequest(t, h, "GetDocumentTextDetection", map[string]any{
+		"JobId":      jobID,
+		"MaxResults": 10,
+		"NextToken":  nextToken,
+	})
+	require.Equal(t, http.StatusOK, getRec2.Code)
+
+	var getResp2 map[string]any
+	require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getResp2))
+
+	blocks2, _ := getResp2["Blocks"].([]any)
+	assert.NotEmpty(t, blocks2, "second page should have remaining blocks")
+}
+
+// Test 14: StartDocumentAnalysis with ClientRequestToken idempotency.
+func TestAccuracy_StartDocumentAnalysis_ClientRequestToken_Idempotency(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	startBody := map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+		"ClientRequestToken": "unique-token-abc123",
+	}
+
+	// First call.
+	rec1 := doTextractRequest(t, h, "StartDocumentAnalysis", startBody)
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	var resp1 map[string]string
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
+	jobID1 := resp1["JobId"]
+
+	// Second call with same token should return same JobId.
+	rec2 := doTextractRequest(t, h, "StartDocumentAnalysis", startBody)
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	var resp2 map[string]string
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	jobID2 := resp2["JobId"]
+
+	assert.Equal(t, jobID1, jobID2, "same ClientRequestToken should return the same JobId")
+}
+
+// Test 15: Get* returns IN_PROGRESS then SUCCEEDED with proper async delay.
+func TestAccuracy_AsyncJob_InProgressThenSucceeded(t *testing.T) {
+	t.Parallel()
+
+	// Use a backend with a short async delay (not zero, so we can observe IN_PROGRESS).
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
+	textract.SetBackendAsyncDelay(b, 50*time.Millisecond)
+	h := textract.NewHandler(b)
+
+	startRec := doTextractRequest(t, h, "StartDocumentAnalysis", map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+		"FeatureTypes": []string{"FORMS"},
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp map[string]string
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	jobID := startResp["JobId"]
+
+	// Immediately after start, job should be IN_PROGRESS.
+	getRec1 := doTextractRequest(t, h, "GetDocumentAnalysis", map[string]any{"JobId": jobID})
+	require.Equal(t, http.StatusOK, getRec1.Code)
+
+	var getResp1 map[string]any
+	require.NoError(t, json.Unmarshal(getRec1.Body.Bytes(), &getResp1))
+	assert.Equal(t, "IN_PROGRESS", getResp1["JobStatus"])
+
+	// After delay, job should be SUCCEEDED.
+	time.Sleep(200 * time.Millisecond)
+
+	getRec2 := doTextractRequest(t, h, "GetDocumentAnalysis", map[string]any{"JobId": jobID})
+	require.Equal(t, http.StatusOK, getRec2.Code)
+
+	var getResp2 map[string]any
+	require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getResp2))
+	assert.Equal(t, "SUCCEEDED", getResp2["JobStatus"])
+}
+
+// Test 16: Get* Blocks have Geometry present.
+func TestAccuracy_GetDocumentAnalysis_Blocks_HaveGeometry(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	startRec := doTextractRequest(t, h, "StartDocumentAnalysis", map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+		"FeatureTypes": []string{"FORMS"},
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp map[string]string
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	jobID := startResp["JobId"]
+
+	getRec := doTextractRequest(t, h, "GetDocumentAnalysis", map[string]any{"JobId": jobID})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+
+	blocks, _ := getResp["Blocks"].([]any)
+	require.NotEmpty(t, blocks)
+
+	// At least the PAGE block should have Geometry.
+	var hasGeometry bool
+
+	for _, b := range blocks {
+		bm, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if _, ok2 := bm["Geometry"]; ok2 {
+			hasGeometry = true
+
+			break
+		}
+	}
+
+	assert.True(t, hasGeometry, "blocks should have Geometry")
+}
+
+// Test 17: CreateAdapter with invalid FeatureType (TABLES) → error.
+func TestAccuracy_CreateAdapter_InvalidFeatureType_TABLES(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
+		"AdapterName":  "bad-adapter",
+		"FeatureTypes": []string{"TABLES"},
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "TABLES is not valid for adapters")
+}
+
+// Test 18: CreateAdapter ClientRequestToken dedup returns same AdapterId.
+func TestAccuracy_CreateAdapter_ClientRequestToken_Dedup(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	body := map[string]any{
+		"AdapterName":        "dedup-adapter",
+		"FeatureTypes":       []string{"FORMS"},
+		"ClientRequestToken": "adapter-token-xyz",
+	}
+
+	rec1 := doTextractRequest(t, h, "CreateAdapter", body)
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	var resp1 map[string]string
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
+
+	rec2 := doTextractRequest(t, h, "CreateAdapter", body)
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	var resp2 map[string]string
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+
+	assert.Equal(t, resp1["AdapterId"], resp2["AdapterId"], "same token should return same AdapterId")
+}
+
+// Test 19: CreateAdapterVersion includes DatasetConfig in GetAdapterVersion.
+func TestAccuracy_CreateAdapterVersion_DatasetConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	// Create adapter first.
+	createAdapterRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
+		"AdapterName":  "dataset-adapter",
+		"FeatureTypes": []string{"FORMS"},
+	})
+	require.Equal(t, http.StatusOK, createAdapterRec.Code)
+
+	var createAdapterResp map[string]string
+	require.NoError(t, json.Unmarshal(createAdapterRec.Body.Bytes(), &createAdapterResp))
+	adapterID := createAdapterResp["AdapterId"]
+
+	// Create adapter version with DatasetConfig.
+	createVersionRec := doTextractRequest(t, h, "CreateAdapterVersion", map[string]any{
+		"AdapterId": adapterID,
+		"DatasetConfig": map[string]any{
+			"ManifestS3Object": map[string]any{
+				"Bucket": "my-dataset-bucket",
+				"Name":   "manifest.json",
+			},
+		},
+		"KMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/abcd1234",
+	})
+	require.Equal(t, http.StatusOK, createVersionRec.Code)
+
+	var createVersionResp map[string]string
+	require.NoError(t, json.Unmarshal(createVersionRec.Body.Bytes(), &createVersionResp))
+	adapterVersion := createVersionResp["AdapterVersion"]
+
+	// Get adapter version and check DatasetConfig is present.
+	getVersionRec := doTextractRequest(t, h, "GetAdapterVersion", map[string]any{
+		"AdapterId":      adapterID,
+		"AdapterVersion": adapterVersion,
+	})
+	require.Equal(t, http.StatusOK, getVersionRec.Code)
+
+	var getVersionResp map[string]any
+	require.NoError(t, json.Unmarshal(getVersionRec.Body.Bytes(), &getVersionResp))
+
+	datasetConfig, ok := getVersionResp["DatasetConfig"].(map[string]any)
+	require.True(t, ok, "GetAdapterVersion should include DatasetConfig")
+	manifest, ok2 := datasetConfig["ManifestS3Object"].(map[string]any)
+	require.True(t, ok2)
+	assert.Equal(t, "my-dataset-bucket", manifest["Bucket"])
+
+	assert.Equal(t, "arn:aws:kms:us-east-1:123456789012:key/abcd1234", getVersionResp["KMSKeyId"])
+}
+
+// Test 20: AdapterVersion starts CREATION_IN_PROGRESS then becomes ACTIVE.
+func TestAccuracy_AdapterVersion_InProgressThenActive(t *testing.T) {
+	t.Parallel()
+
+	// Use a backend with a short async delay.
+	b := textract.NewInMemoryBackendSync("123456789012", "us-east-1")
+	textract.SetBackendAsyncDelay(b, 50*time.Millisecond)
+	h := textract.NewHandler(b)
+
+	// Create adapter.
+	createAdapterRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
+		"AdapterName":  "lifecycle-adapter",
+		"FeatureTypes": []string{"FORMS"},
+	})
+	require.Equal(t, http.StatusOK, createAdapterRec.Code)
+
+	var createAdapterResp map[string]string
+	require.NoError(t, json.Unmarshal(createAdapterRec.Body.Bytes(), &createAdapterResp))
+	adapterID := createAdapterResp["AdapterId"]
+
+	// Create version.
+	createVersionRec := doTextractRequest(t, h, "CreateAdapterVersion", map[string]any{
+		"AdapterId": adapterID,
+	})
+	require.Equal(t, http.StatusOK, createVersionRec.Code)
+
+	var createVersionResp map[string]string
+	require.NoError(t, json.Unmarshal(createVersionRec.Body.Bytes(), &createVersionResp))
+	adapterVersion := createVersionResp["AdapterVersion"]
+
+	// Immediately check: should be CREATION_IN_PROGRESS.
+	getRec1 := doTextractRequest(t, h, "GetAdapterVersion", map[string]any{
+		"AdapterId":      adapterID,
+		"AdapterVersion": adapterVersion,
+	})
+	require.Equal(t, http.StatusOK, getRec1.Code)
+
+	var getResp1 map[string]any
+	require.NoError(t, json.Unmarshal(getRec1.Body.Bytes(), &getResp1))
+	assert.Equal(t, "CREATION_IN_PROGRESS", getResp1["Status"])
+
+	// After delay, should be ACTIVE.
+	time.Sleep(200 * time.Millisecond)
+
+	getRec2 := doTextractRequest(t, h, "GetAdapterVersion", map[string]any{
+		"AdapterId":      adapterID,
+		"AdapterVersion": adapterVersion,
+	})
+	require.Equal(t, http.StatusOK, getRec2.Code)
+
+	var getResp2 map[string]any
+	require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getResp2))
+	assert.Equal(t, "ACTIVE", getResp2["Status"])
+}
+
+// Test 21: AdapterVersion EvaluationMetrics are returned in GetAdapterVersion.
+func TestAccuracy_AdapterVersion_EvaluationMetrics(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	createAdapterRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
+		"AdapterName":  "metrics-adapter",
+		"FeatureTypes": []string{"QUERIES"},
+	})
+	require.Equal(t, http.StatusOK, createAdapterRec.Code)
+
+	var createAdapterResp map[string]string
+	require.NoError(t, json.Unmarshal(createAdapterRec.Body.Bytes(), &createAdapterResp))
+	adapterID := createAdapterResp["AdapterId"]
+
+	createVersionRec := doTextractRequest(t, h, "CreateAdapterVersion", map[string]any{
+		"AdapterId": adapterID,
+	})
+	require.Equal(t, http.StatusOK, createVersionRec.Code)
+
+	var createVersionResp map[string]string
+	require.NoError(t, json.Unmarshal(createVersionRec.Body.Bytes(), &createVersionResp))
+	adapterVersion := createVersionResp["AdapterVersion"]
+
+	getVersionRec := doTextractRequest(t, h, "GetAdapterVersion", map[string]any{
+		"AdapterId":      adapterID,
+		"AdapterVersion": adapterVersion,
+	})
+	require.Equal(t, http.StatusOK, getVersionRec.Code)
+
+	var getVersionResp map[string]any
+	require.NoError(t, json.Unmarshal(getVersionRec.Body.Bytes(), &getVersionResp))
+
+	evalMetrics, ok := getVersionResp["EvaluationMetrics"].(map[string]any)
+	require.True(t, ok, "GetAdapterVersion should include EvaluationMetrics")
+	assert.InDelta(t, 0.85, evalMetrics["F1Score"], 0.001)
+	assert.InDelta(t, 0.88, evalMetrics["Precision"], 0.001)
+	assert.InDelta(t, 0.82, evalMetrics["Recall"], 0.001)
+}
+
+// Test 22: TagResource by ARN + ListTagsForResource round-trip.
+func TestAccuracy_TagResource_ByARN_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	b := h.Backend.(*textract.InMemoryBackend)
+
+	createRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
+		"AdapterName":  "arn-tag-adapter",
+		"FeatureTypes": []string{"FORMS"},
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]string
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	adapterID := createResp["AdapterId"]
+
+	// Build an ARN using the backend helper.
+	arn := b.BuildAdapterARN(adapterID)
+	assert.Contains(t, arn, adapterID)
+	assert.Contains(t, arn, "arn:aws:textract:")
+
+	// Tag via ARN.
+	tagRec := doTextractRequest(t, h, "TagResource", map[string]any{
+		"ResourceARN": arn,
+		"Tags":        map[string]string{"env": "prod", "purpose": "accuracy-test"},
+	})
+	require.Equal(t, http.StatusOK, tagRec.Code)
+
+	// List via ARN.
+	listRec := doTextractRequest(t, h, "ListTagsForResource", map[string]any{
+		"ResourceARN": arn,
+	})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	tags, ok := listResp["Tags"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "prod", tags["env"])
+	assert.Equal(t, "accuracy-test", tags["purpose"])
+}
+
+// Test 23: AdapterVersion ARN tagging works.
+func TestAccuracy_TagResource_AdapterVersionARN(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	b := h.Backend.(*textract.InMemoryBackend)
+
+	// Create adapter.
+	createAdapterRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
+		"AdapterName":  "version-tag-adapter",
+		"FeatureTypes": []string{"QUERIES"},
+	})
+	require.Equal(t, http.StatusOK, createAdapterRec.Code)
+
+	var createAdapterResp map[string]string
+	require.NoError(t, json.Unmarshal(createAdapterRec.Body.Bytes(), &createAdapterResp))
+	adapterID := createAdapterResp["AdapterId"]
+
+	// Create adapter version.
+	createVersionRec := doTextractRequest(t, h, "CreateAdapterVersion", map[string]any{
+		"AdapterId": adapterID,
+	})
+	require.Equal(t, http.StatusOK, createVersionRec.Code)
+
+	var createVersionResp map[string]string
+	require.NoError(t, json.Unmarshal(createVersionRec.Body.Bytes(), &createVersionResp))
+	adapterVersion := createVersionResp["AdapterVersion"]
+
+	// Build ARN.
+	versionARN := b.BuildAdapterVersionARN(adapterID, adapterVersion)
+	assert.Contains(t, versionARN, "version/")
+
+	// Tag via version ARN.
+	tagRec := doTextractRequest(t, h, "TagResource", map[string]any{
+		"ResourceARN": versionARN,
+		"Tags":        map[string]string{"version-tag": "v1"},
+	})
+	require.Equal(t, http.StatusOK, tagRec.Code)
+
+	// List via version ARN.
+	listRec := doTextractRequest(t, h, "ListTagsForResource", map[string]any{
+		"ResourceARN": versionARN,
+	})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	tags, ok := listResp["Tags"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "v1", tags["version-tag"])
+}
+
+// Test 24: GetLendingAnalysis returns expanded LendingResult with extractions.
+func TestAccuracy_GetLendingAnalysis_ExpandedLendingResult(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	startRec := doTextractRequest(t, h, "StartLendingAnalysis", map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "loan.pdf"},
+		},
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp map[string]string
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	jobID := startResp["JobId"]
+
+	getRec := doTextractRequest(t, h, "GetLendingAnalysis", map[string]any{"JobId": jobID})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+	assert.Equal(t, "SUCCEEDED", getResp["JobStatus"])
+
+	results, ok := getResp["Results"].([]any)
+	require.True(t, ok, "GetLendingAnalysis should return Results")
+	require.NotEmpty(t, results)
+
+	result, ok := results[0].(map[string]any)
+	require.True(t, ok)
+
+	// Check PageClassification is present.
+	_, hasPC := result["PageClassification"]
+	assert.True(t, hasPC, "LendingResult should have PageClassification")
+
+	// Check Extractions are present.
+	extractions, ok := result["Extractions"].([]any)
+	assert.True(t, ok, "LendingResult should have Extractions")
+	assert.NotEmpty(t, extractions)
+}
+
+// Test 25: GetLendingAnalysisSummary returns populated Summary.
+func TestAccuracy_GetLendingAnalysisSummary_PopulatedSummary(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	startRec := doTextractRequest(t, h, "StartLendingAnalysis", map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "loan.pdf"},
+		},
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp map[string]string
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	jobID := startResp["JobId"]
+
+	getRec := doTextractRequest(t, h, "GetLendingAnalysisSummary", map[string]any{"JobId": jobID})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+	assert.Equal(t, "SUCCEEDED", getResp["JobStatus"])
+
+	summary, ok := getResp["Summary"].(map[string]any)
+	require.True(t, ok, "GetLendingAnalysisSummary should return a Summary")
+
+	docGroups, ok := summary["DocumentGroups"].([]any)
+	require.True(t, ok, "Summary should have DocumentGroups")
+	assert.NotEmpty(t, docGroups)
+}
+
+// Test 26: GetDocumentAnalysis pagination with MaxResults produces NextToken.
+func TestAccuracy_GetDocumentAnalysis_Pagination_NextToken(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+
+	startRec := doTextractRequest(t, h, "StartDocumentAnalysis", map[string]any{
+		"DocumentLocation": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "doc.pdf"},
+		},
+		"FeatureTypes": []string{"TABLES", "FORMS"},
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp map[string]string
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	jobID := startResp["JobId"]
+
+	// Get with small MaxResults to trigger NextToken.
+	getRec := doTextractRequest(t, h, "GetDocumentAnalysis", map[string]any{
+		"JobId":      jobID,
+		"MaxResults": 2,
+	})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getResp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+
+	blocks, _ := getResp["Blocks"].([]any)
+	assert.Len(t, blocks, 2)
+
+	nextToken, hasToken := getResp["NextToken"].(string)
+	assert.True(t, hasToken && nextToken != "", "NextToken should be set when more pages exist")
+}
+
+// Test 27: AnalyzeDocument FORMS has SELECTION_ELEMENT block.
+func TestAccuracy_AnalyzeDocument_Forms_SelectionElement(t *testing.T) {
+	t.Parallel()
+
+	h := newAccuracyHandler(t)
+	rec := doTextractRequest(t, h, "AnalyzeDocument", map[string]any{
+		"Document": map[string]any{
+			"S3Object": map[string]any{"Bucket": "b", "Name": "form.pdf"},
+		},
+		"FeatureTypes": []string{"FORMS"},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	selBlocks := blocksOfType(t, rec.Body.Bytes(), "SELECTION_ELEMENT")
+	require.NotEmpty(t, selBlocks, "FORMS feature should include SELECTION_ELEMENT blocks")
+
+	sel := selBlocks[0]
+	status, _ := sel["SelectionStatus"].(string)
+	assert.NotEmpty(t, status, "SELECTION_ELEMENT should have SelectionStatus")
+}

--- a/services/textract/handler_refinement1_test.go
+++ b/services/textract/handler_refinement1_test.go
@@ -18,7 +18,7 @@ import (
 func newTestBackend(t *testing.T) *textract.InMemoryBackend {
 	t.Helper()
 
-	return textract.NewInMemoryBackend("123456789012", "us-east-1")
+	return textract.NewInMemoryBackendSync("123456789012", "us-east-1")
 }
 
 func newTestHandlerR1(t *testing.T) *textract.Handler {
@@ -69,7 +69,7 @@ func TestRefinement1_BackendReset(t *testing.T) {
 	_, err := b.StartDocumentAnalysis("s3://bucket/doc.pdf")
 	require.NoError(t, err)
 
-	_, err = b.CreateAdapter("myAdapter", "desc", "DISABLED", []string{"TABLES"}, nil)
+	_, err = b.CreateAdapter("myAdapter", "desc", "DISABLED", []string{"FORMS"}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, textract.JobCount(b))
@@ -237,9 +237,10 @@ func TestRefinement1_CreateAdapter_FeatureTypeValidation(t *testing.T) {
 		wantStatus   int
 	}{
 		{
-			name:         "valid TABLES",
+			// TABLES is not allowed for adapters (only FORMS and QUERIES per AWS spec).
+			name:         "TABLES returns 400 for adapter",
 			featureTypes: []string{"TABLES"},
-			wantStatus:   http.StatusOK,
+			wantStatus:   http.StatusBadRequest,
 		},
 		{
 			name:         "valid FORMS",
@@ -252,8 +253,8 @@ func TestRefinement1_CreateAdapter_FeatureTypeValidation(t *testing.T) {
 			wantStatus:   http.StatusOK,
 		},
 		{
-			name:         "multiple valid types",
-			featureTypes: []string{"TABLES", "FORMS"},
+			name:         "multiple valid types FORMS+QUERIES",
+			featureTypes: []string{"FORMS", "QUERIES"},
 			wantStatus:   http.StatusOK,
 		},
 		{
@@ -305,7 +306,7 @@ func TestRefinement1_CreateAdapter_AutoUpdateValidation(t *testing.T) {
 			h := newTestHandlerR1(t)
 			rec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
 				"AdapterName":  "adapter",
-				"FeatureTypes": []string{"TABLES"},
+				"FeatureTypes": []string{"FORMS"},
 				"AutoUpdate":   tt.autoUpdate,
 			})
 
@@ -322,7 +323,7 @@ func TestRefinement1_UpdateAdapter_HappyPath(t *testing.T) {
 
 	createRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
 		"AdapterName":  "my-adapter",
-		"FeatureTypes": []string{"TABLES"},
+		"FeatureTypes": []string{"FORMS"},
 		"Description":  "original",
 	})
 	require.Equal(t, http.StatusOK, createRec.Code)
@@ -369,7 +370,7 @@ func TestRefinement1_ListAdapters_HappyPath(t *testing.T) {
 	for _, name := range []string{"alpha", "beta", "gamma"} {
 		rec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
 			"AdapterName":  name,
-			"FeatureTypes": []string{"TABLES"},
+			"FeatureTypes": []string{"FORMS"},
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 	}
@@ -437,7 +438,7 @@ func TestRefinement1_TagResource_HappyPath(t *testing.T) {
 
 	createRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
 		"AdapterName":  "taggable-adapter",
-		"FeatureTypes": []string{"TABLES"},
+		"FeatureTypes": []string{"FORMS"},
 	})
 	var createResp map[string]string
 	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
@@ -470,7 +471,7 @@ func TestRefinement1_UntagResource_HappyPath(t *testing.T) {
 
 	createRec := doTextractRequest(t, h, "CreateAdapter", map[string]any{
 		"AdapterName":  "tagged-adapter",
-		"FeatureTypes": []string{"TABLES"},
+		"FeatureTypes": []string{"FORMS"},
 		"Tags":         map[string]string{"env": "dev", "team": "ml"},
 	})
 	var createResp map[string]string
@@ -548,7 +549,7 @@ func TestRefinement1_DeleteAdapter_CascadesVersions(t *testing.T) {
 
 	b := newTestBackend(t)
 
-	adapter, err := b.CreateAdapter("cascade-test", "", "DISABLED", []string{"TABLES"}, nil)
+	adapter, err := b.CreateAdapter("cascade-test", "", "DISABLED", []string{"FORMS"}, nil)
 	require.NoError(t, err)
 
 	_, err = b.CreateAdapterVersion(adapter.AdapterID, nil)
@@ -706,7 +707,7 @@ func TestRefinement1_CloneTags_NilInput(t *testing.T) {
 
 	b := newTestBackend(t)
 	// Create adapter without tags.
-	adapter, err := b.CreateAdapter("no-tags", "", "DISABLED", []string{"TABLES"}, nil)
+	adapter, err := b.CreateAdapter("no-tags", "", "DISABLED", []string{"FORMS"}, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, adapter.Tags)
 }

--- a/services/textract/handler_test.go
+++ b/services/textract/handler_test.go
@@ -18,7 +18,7 @@ import (
 func newTestHandler(t *testing.T) *textract.Handler {
 	t.Helper()
 
-	return textract.NewHandler(textract.NewInMemoryBackend("123456789012", "us-east-1"))
+	return textract.NewHandler(textract.NewInMemoryBackendSync("123456789012", "us-east-1"))
 }
 
 func doTextractRequest(

--- a/services/textract/persistence.go
+++ b/services/textract/persistence.go
@@ -3,14 +3,17 @@ package textract
 import (
 	"encoding/json"
 	"log/slog"
+	"maps"
 )
 
 type backendSnapshot struct {
-	Jobs            map[string]*DocumentJob    `json:"jobs"`
-	ExpenseJobs     map[string]*ExpenseJob     `json:"expenseJobs"`
-	LendingJobs     map[string]*LendingJob     `json:"lendingJobs"`
-	Adapters        map[string]*Adapter        `json:"adapters"`
-	AdapterVersions map[string]*AdapterVersion `json:"adapterVersions"`
+	Jobs                   map[string]*DocumentJob    `json:"jobs"`
+	ExpenseJobs            map[string]*ExpenseJob     `json:"expenseJobs"`
+	LendingJobs            map[string]*LendingJob     `json:"lendingJobs"`
+	Adapters               map[string]*Adapter        `json:"adapters"`
+	AdapterVersions        map[string]*AdapterVersion `json:"adapterVersions"`
+	ClientTokenToJobID     map[string]string          `json:"clientTokenToJobId,omitempty"`
+	AdapterClientTokenToID map[string]string          `json:"adapterClientTokenToId,omitempty"`
 }
 
 // ensureNonNilMaps guarantees that all map fields in the snapshot are non-nil.
@@ -33,6 +36,14 @@ func (s *backendSnapshot) ensureNonNilMaps() {
 
 	if s.AdapterVersions == nil {
 		s.AdapterVersions = make(map[string]*AdapterVersion)
+	}
+
+	if s.ClientTokenToJobID == nil {
+		s.ClientTokenToJobID = make(map[string]string)
+	}
+
+	if s.AdapterClientTokenToID == nil {
+		s.AdapterClientTokenToID = make(map[string]string)
 	}
 }
 
@@ -67,12 +78,20 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		adapterVersionsCopy[k] = cloneAdapterVersion(v)
 	}
 
+	tokenMapCopy := make(map[string]string, len(b.clientTokenToJobID))
+	maps.Copy(tokenMapCopy, b.clientTokenToJobID)
+
+	adapterTokenMapCopy := make(map[string]string, len(b.adapterClientTokenToID))
+	maps.Copy(adapterTokenMapCopy, b.adapterClientTokenToID)
+
 	snap := backendSnapshot{
-		Jobs:            jobsCopy,
-		ExpenseJobs:     expenseJobsCopy,
-		LendingJobs:     lendingJobsCopy,
-		Adapters:        adaptersCopy,
-		AdapterVersions: adapterVersionsCopy,
+		Jobs:                   jobsCopy,
+		ExpenseJobs:            expenseJobsCopy,
+		LendingJobs:            lendingJobsCopy,
+		Adapters:               adaptersCopy,
+		AdapterVersions:        adapterVersionsCopy,
+		ClientTokenToJobID:     tokenMapCopy,
+		AdapterClientTokenToID: adapterTokenMapCopy,
 	}
 
 	data, err := json.Marshal(snap)
@@ -104,6 +123,8 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.lendingJobs = snap.LendingJobs
 	b.adapters = snap.Adapters
 	b.adapterVersions = snap.AdapterVersions
+	b.clientTokenToJobID = snap.ClientTokenToJobID
+	b.adapterClientTokenToID = snap.AdapterClientTokenToID
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #1850

Brings `services/textract/` to AWS API parity by implementing all 25 gaps identified in the accuracy audit. Total diff: 2809 insertions / 256 deletions.

### Structs expanded
- `Block`: added `Geometry`, `Relationships`, `EntityTypes`, `SelectionStatus`, `RowIndex`/`ColumnIndex`/`RowSpan`/`ColumnSpan`, `Page`, `Query`, `TextType`, `ColumnHeader`
- New geometry types: `BoundingBox`, `Point`, `Geometry`, `Relationship`, `QueryBlock`
- `ExpenseDocument`: `SummaryFields` (VENDOR_NAME, TOTAL, INVOICE_RECEIPT_DATE) + `LineItemGroups` with 2 line items
- `IdentityDocument`: `IdentityDocumentFields` with FIRST_NAME, LAST_NAME, DATE_OF_BIRTH (NormalizedValue), EXPIRATION_DATE, DOCUMENT_NUMBER
- `LendingResult`: `PageClassification`, `Extractions` (LendingDocument with LendingFields + SignatureDetections)
- `LendingJob`: `Summary` (LendingSummary with DocumentGroups)
- `AdapterVersion`: `DatasetConfig`, `OutputConfig`, `KMSKeyId`, `EvaluationMetrics` (F1=0.85, Precision=0.88, Recall=0.82)
- Job structs: `OutputConfig`, `NotificationChannel`, `JobTag`, `ClientRequestToken`, `StatusMessage`, `Warnings`

### API improvements
- `DetectDocumentText` / `AnalyzeDocument`: proper PAGE→LINE→WORD block hierarchy with wired Relationships and Geometry; ModelVersion="1.0" in responses
- `AnalyzeDocument`: branch by FeatureTypes — KEY_VALUE_SET+SELECTION_ELEMENT (FORMS), TABLE+CELL (TABLES), QUERY+QUERY_RESULT (QUERIES), SIGNATURE (SIGNATURES), LAYOUT_* (LAYOUT)
- `Get*` pagination: `MaxResults` + base64-encoded `NextToken`
- `Get*` responses: `StatusMessage`, `Warnings` fields
- `Start*` idempotency: `ClientRequestToken` dedup for DocumentAnalysis, TextDetection
- `CreateAdapter`: `ClientRequestToken` dedup; feature types restricted to FORMS+QUERIES per AWS spec
- `CreateAdapterVersion`: `DatasetConfig`, `OutputConfig`, `KMSKeyId`; starts `CREATION_IN_PROGRESS`, goroutine transitions to `ACTIVE`
- `TagResource`/`UntagResource`/`ListTagsForResource`: proper ARN resolution for adapters and adapter versions
- `GetLendingAnalysisSummary`: returns populated `Summary` with DocumentGroups

### Async behaviour
- All `Start*` jobs now begin as `IN_PROGRESS`; a goroutine transitions to `SUCCEEDED` after a configurable delay (200ms production, 0 for tests via `NewInMemoryBackendSync`)
- Per-backend delay field (no global state mutation → race-free parallel tests)

### Persistence
- `Snapshot`/`Restore` persists `clientTokenToJobID` and `adapterClientTokenToID` dedup maps

### Tests
- `handler_accuracy_test.go`: 27 new accuracy tests covering all 25 gaps
- Existing tests updated: `NewInMemoryBackendSync` for zero-delay; TABLES→FORMS for adapter creation (TABLES invalid for adapters per AWS spec)

## Test plan
- [x] `go test ./services/textract/... -race` passes (all 27+ accuracy tests + existing suite)
- [x] `golangci-lint run ./services/textract/...` → 0 issues
- [x] `make lint-fix && make lint` → 0 Go issues (UI OOM unrelated)
- [x] `go build ./services/textract/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)