### PR TITLE
feat(timestreamwrite): AWS-accuracy audit — 15 gaps per #1851

### DIFF
--- a/services/timestreamwrite/backend.go
+++ b/services/timestreamwrite/backend.go
@@ -35,6 +35,36 @@ var (
 	ErrResourceNotFound = awserr.New("ResourceNotFoundException", awserr.ErrNotFound)
 )
 
+// RejectedRecord describes a single record that could not be written due to a version conflict.
+type RejectedRecord struct {
+	Reason          string `json:"Reason"`
+	ExistingVersion int64  `json:"ExistingVersion,omitempty"`
+	RecordIndex     int    `json:"RecordIndex"`
+}
+
+// RejectedRecordsError is returned by WriteRecords when one or more records are
+// rejected due to version conflicts.
+type RejectedRecordsError struct {
+	RejectedRecords []RejectedRecord
+}
+
+func (e *RejectedRecordsError) Error() string {
+	return fmt.Sprintf(
+		"RejectedRecordsException: %d record(s) rejected due to version conflict",
+		len(e.RejectedRecords),
+	)
+}
+
+// Is satisfies errors.Is so that errors.Is(err, ErrRejectedRecords) returns true.
+func (e *RejectedRecordsError) Is(target error) bool {
+	_, ok := target.(*RejectedRecordsError)
+
+	return ok
+}
+
+// ErrRejectedRecords is the sentinel used with errors.Is for RejectedRecordsError.
+var ErrRejectedRecords = &RejectedRecordsError{}
+
 const (
 	// BatchLoadStatusCreated indicates a task has been created and is pending execution.
 	BatchLoadStatusCreated = "CREATED"
@@ -64,9 +94,68 @@ type RetentionProperties struct {
 	MagneticStoreRetentionPeriodInDays int64 `json:"MagneticStoreRetentionPeriodInDays,omitempty"`
 }
 
-// MagneticStoreWriteProperties configures rejected-record delivery for the magnetic store.
+// S3Configuration holds S3 location config for rejected-record delivery.
+type S3Configuration struct {
+	BucketName       string `json:"bucket_name,omitempty"`
+	ObjectKeyPrefix  string `json:"object_key_prefix,omitempty"`
+	EncryptionOption string `json:"encryption_option,omitempty"`
+	KmsKeyID         string `json:"kms_key_id,omitempty"`
+}
+
+// MagneticStoreRejectedDataLocation configures where rejected magnetic-store records are written.
+type MagneticStoreRejectedDataLocation struct {
+	S3Configuration *S3Configuration `json:"s3_configuration,omitempty"`
+}
+
+// MagneticStoreWriteProperties configures magnetic store writes and rejected-record delivery.
 type MagneticStoreWriteProperties struct {
-	EnableMagneticStoreWrites bool `json:"EnableMagneticStoreWrites"`
+	MagneticStoreRejectedDataLocation *MagneticStoreRejectedDataLocation `json:"magnetic_store_rejected_data_location,omitempty"` //nolint:lll // AWS field name is inherently long
+	EnableMagneticStoreWrites         bool                               `json:"enable_magnetic_store_writes"`
+}
+
+// PartitionKeyType specifies whether a partition key is a dimension or measure key.
+type PartitionKeyType = string
+
+const (
+	PartitionKeyTypeDimension PartitionKeyType = "DIMENSION"
+	PartitionKeyTypeMeasure   PartitionKeyType = "MEASURE"
+)
+
+// PartitionKeyEnforcementLevel controls whether a dimension partition key is required on write.
+type PartitionKeyEnforcementLevel = string
+
+const (
+	PartitionKeyEnforcementRequired PartitionKeyEnforcementLevel = "REQUIRED"
+	PartitionKeyEnforcementOptional PartitionKeyEnforcementLevel = "OPTIONAL"
+)
+
+// PartitionKey defines a single key in a table's composite partition key schema.
+type PartitionKey struct {
+	Type                PartitionKeyType             `json:"type"`
+	Name                string                       `json:"name,omitempty"`
+	EnforcementInRecord PartitionKeyEnforcementLevel `json:"enforcement_in_record,omitempty"`
+}
+
+// Schema defines the composite partition key configuration for a table.
+type Schema struct {
+	CompositePartitionKey []PartitionKey `json:"composite_partition_key,omitempty"`
+}
+
+// MeasureValue holds a name-value-type triple for multi-measure (MULTI type) records.
+type MeasureValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+// BatchLoadProgressReport captures incremental progress metrics for a batch load task.
+type BatchLoadProgressReport struct {
+	BytesMetered            int64 `json:"bytes_metered,omitempty"`
+	FileFailures            int64 `json:"file_failures,omitempty"`
+	ParseFailures           int64 `json:"parse_failures,omitempty"`
+	RecordIngestionFailures int64 `json:"record_ingestion_failures,omitempty"`
+	RecordsIngested         int64 `json:"records_ingested,omitempty"`
+	RecordsProcessed        int64 `json:"records_processed,omitempty"`
 }
 
 // Database represents a Timestream database.
@@ -85,6 +174,7 @@ type Table struct {
 	LastUpdatedTime              time.Time                     `json:"last_updated_time"`
 	RetentionProperties          *RetentionProperties          `json:"retention_properties,omitempty"`
 	MagneticStoreWriteProperties *MagneticStoreWriteProperties `json:"magnetic_store_write_properties,omitempty"`
+	Schema                       *Schema                       `json:"schema,omitempty"`
 	DatabaseName                 string                        `json:"database_name"`
 	TableName                    string                        `json:"table_name"`
 	ARN                          string                        `json:"arn"`
@@ -93,21 +183,23 @@ type Table struct {
 
 // Dimension holds a name/value pair for a time-series record.
 type Dimension struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name               string `json:"name"`
+	Value              string `json:"value"`
+	DimensionValueType string `json:"dimension_value_type,omitempty"`
 }
 
 // Record represents a time-series data point written to a table.
 type Record struct {
 	// InternalTimestamp is the parsed value of Time, used for retention sweeping.
-	InternalTimestamp time.Time   `json:"-"`
-	MeasureName       string      `json:"measure_name"`
-	MeasureValue      string      `json:"measure_value"`
-	MeasureValueType  string      `json:"measure_value_type"`
-	Time              string      `json:"time"`
-	TimeUnit          string      `json:"time_unit"`
-	Dimensions        []Dimension `json:"dimensions,omitempty"`
-	Version           int64       `json:"version,omitempty"`
+	InternalTimestamp time.Time      `json:"-"`
+	MeasureName       string         `json:"measure_name"`
+	MeasureValue      string         `json:"measure_value"`
+	MeasureValueType  string         `json:"measure_value_type"`
+	Time              string         `json:"time"`
+	TimeUnit          string         `json:"time_unit"`
+	Dimensions        []Dimension    `json:"dimensions,omitempty"`
+	MeasureValues     []MeasureValue `json:"measure_values,omitempty"`
+	Version           int64          `json:"version,omitempty"`
 }
 
 // DataSourceS3Configuration holds S3 source configuration for batch loads.
@@ -135,6 +227,7 @@ type BatchLoadTask struct {
 	ResumableUntil          *time.Time               `json:"resumable_until,omitempty"`
 	DataSourceConfiguration *DataSourceConfiguration `json:"data_source_configuration,omitempty"`
 	ReportConfiguration     *ReportConfiguration     `json:"report_configuration,omitempty"`
+	ProgressReport          *BatchLoadProgressReport `json:"progress_report,omitempty"`
 	TargetDatabaseName      string                   `json:"target_database_name"`
 	TargetTableName         string                   `json:"target_table_name"`
 	TaskID                  string                   `json:"task_id"`
@@ -143,14 +236,18 @@ type BatchLoadTask struct {
 	RecordVersion           int64                    `json:"record_version,omitempty"`
 }
 
-// tableRecords owns the records slice and per-table mutex for a single table.
+// tableRecords owns the records slice, dedup index, and per-table mutex for a single table.
 // Storing the slice and lock together inside a pointer lets WriteRecords mutate
 // the slice through the pointer without writing to the enclosing maps in
 // b.records — which would race against concurrent WriteRecords calls to other
 // tables in the same database under the global read-lock.
+//
+// recordIndex maps a record's dedup key (measure+time+dimensions) to its position in
+// the records slice, enabling O(1) version-based upsert lookups.
 type tableRecords struct {
-	mu      *lockmetrics.RWMutex
-	records []Record
+	mu          *lockmetrics.RWMutex
+	recordIndex map[string]int
+	records     []Record
 }
 
 // InMemoryBackend is the in-memory store for Timestream Write resources.
@@ -380,6 +477,7 @@ func (b *InMemoryBackend) UpdateDatabase(name, kmsKeyID string) (*Database, erro
 type CreateTableInput struct {
 	RetentionProperties          *RetentionProperties
 	MagneticStoreWriteProperties *MagneticStoreWriteProperties
+	Schema                       *Schema
 }
 
 // CreateTable creates a new table in the specified database with optional initial tags.
@@ -412,10 +510,14 @@ func (b *InMemoryBackend) CreateTable(
 	if inp != nil {
 		tbl.RetentionProperties = inp.RetentionProperties
 		tbl.MagneticStoreWriteProperties = inp.MagneticStoreWriteProperties
+		tbl.Schema = inp.Schema
 	}
 
 	b.tables[dbName][tblName] = tbl
-	b.records[dbName][tblName] = &tableRecords{mu: lockmetrics.New("timestreamwrite.table")}
+	b.records[dbName][tblName] = &tableRecords{
+		mu:          lockmetrics.New("timestreamwrite.table"),
+		recordIndex: make(map[string]int),
+	}
 	b.databases[dbName].TableCount++
 
 	if len(tags) > 0 {
@@ -500,6 +602,7 @@ func (b *InMemoryBackend) DeleteTable(dbName, tblName string) error {
 type UpdateTableInput struct {
 	RetentionProperties          *RetentionProperties
 	MagneticStoreWriteProperties *MagneticStoreWriteProperties
+	Schema                       *Schema
 }
 
 // UpdateTable updates a table's properties.
@@ -524,6 +627,10 @@ func (b *InMemoryBackend) UpdateTable(dbName, tblName string, inp *UpdateTableIn
 		if inp.MagneticStoreWriteProperties != nil {
 			tbl.MagneticStoreWriteProperties = inp.MagneticStoreWriteProperties
 		}
+
+		if inp.Schema != nil {
+			tbl.Schema = inp.Schema
+		}
 	}
 
 	tbl.LastUpdatedTime = time.Now()
@@ -534,8 +641,22 @@ func (b *InMemoryBackend) UpdateTable(dbName, tblName string, inp *UpdateTableIn
 
 // WriteRecordsOutput summarises the results of a WriteRecords call.
 type WriteRecordsOutput struct {
-	Total       int32
-	MemoryStore int32
+	RejectedRecords []RejectedRecord
+	Total           int32
+	MemoryStore     int32
+}
+
+// recordKey computes a deterministic dedup key for a record using measure name,
+// time, time unit, and sorted dimension name=value pairs.
+func recordKey(r Record) string {
+	dims := make([]string, 0, len(r.Dimensions))
+	for _, d := range r.Dimensions {
+		dims = append(dims, d.Name+"="+d.Value)
+	}
+
+	sort.Strings(dims)
+
+	return strings.Join([]string{r.MeasureName, r.Time, r.TimeUnit, strings.Join(dims, ",")}, "\x00")
 }
 
 // WriteRecords appends records to the specified table.
@@ -565,20 +686,61 @@ func (b *InMemoryBackend) WriteRecords(dbName, tblName string, records []Record)
 	slot.mu.Lock("WriteRecords")
 	defer slot.mu.Unlock()
 
-	// Append first, then stamp InternalTimestamp on the copies inside slot.records
-	// so that we never mutate the caller's input slice (which they may share
-	// across goroutines).
-	start := len(slot.records)
-	slot.records = append(slot.records, records...)
+	if slot.recordIndex == nil {
+		slot.recordIndex = make(map[string]int)
+	}
 
-	for i := start; i < len(slot.records); i++ {
-		slot.records[i].InternalTimestamp = parseTimestreamTime(slot.records[i].Time, slot.records[i].TimeUnit)
+	var rejected []RejectedRecord
+	var inserted int32
+
+	for i, r := range records {
+		key := recordKey(r)
+
+		// Normalise version: Version 0 is treated as 1 per AWS docs.
+		newVersion := r.Version
+		if newVersion == 0 {
+			newVersion = 1
+		}
+
+		if idx, exists := slot.recordIndex[key]; exists {
+			// Record with same dedup key exists — apply version upsert.
+			existingVersion := slot.records[idx].Version
+			if existingVersion == 0 {
+				existingVersion = 1
+			}
+
+			if newVersion > existingVersion {
+				// Higher version: update the existing record in-place.
+				cp := r
+				cp.Version = newVersion
+				cp.InternalTimestamp = parseTimestreamTime(r.Time, r.TimeUnit)
+				slot.records[idx] = cp
+				inserted++
+			} else {
+				// Same or lower version: reject.
+				rejected = append(rejected, RejectedRecord{
+					RecordIndex:     i,
+					Reason:          "Record with same dimensions, time and measure name already exists with same or higher version",
+					ExistingVersion: existingVersion,
+				})
+			}
+		} else {
+			// New record: append and index.
+			cp := r
+			cp.Version = newVersion
+			cp.InternalTimestamp = parseTimestreamTime(r.Time, r.TimeUnit)
+			slot.recordIndex[key] = len(slot.records)
+			slot.records = append(slot.records, cp)
+			inserted++
+		}
+	}
+
+	if len(rejected) > 0 {
+		return nil, &RejectedRecordsError{RejectedRecords: rejected}
 	}
 
 	// Record counts are bounded by request size limits (< MaxInt32).
-	count := int32(len(records)) //#nosec G115
-
-	return &WriteRecordsOutput{Total: count, MemoryStore: count}, nil
+	return &WriteRecordsOutput{Total: inserted, MemoryStore: inserted}, nil //#nosec G115
 }
 
 func parseTimestreamTime(ts, unit string) time.Time {
@@ -649,6 +811,11 @@ func (b *InMemoryBackend) pruneTableRecords(dbName, tblName string, tbl *Table, 
 	pruned := len(slot.records) - len(newRecords)
 	if pruned > 0 {
 		slot.records = newRecords
+		// Rebuild the dedup index after pruning to keep offsets consistent.
+		slot.recordIndex = make(map[string]int, len(newRecords))
+		for i, r := range slot.records {
+			slot.recordIndex[recordKey(r)] = i
+		}
 	}
 
 	return pruned
@@ -862,7 +1029,8 @@ func (b *InMemoryBackend) AddTableInternal(tbl *Table) {
 	}
 
 	b.records[tbl.DatabaseName][tbl.TableName] = &tableRecords{
-		mu: lockmetrics.New("timestreamwrite.table"),
+		mu:          lockmetrics.New("timestreamwrite.table"),
+		recordIndex: make(map[string]int),
 	}
 
 	if db, ok := b.databases[tbl.DatabaseName]; ok {

--- a/services/timestreamwrite/export_test.go
+++ b/services/timestreamwrite/export_test.go
@@ -61,3 +61,20 @@ func TableMutexCount(b *InMemoryBackend) int {
 
 	return total
 }
+
+// RecordCount returns the number of records stored for a specific table.
+// Exposed for testing only.
+func RecordCount(b *InMemoryBackend, dbName, tblName string) int {
+	b.mu.RLock("RecordCount")
+	defer b.mu.RUnlock()
+
+	slot := b.records[dbName][tblName]
+	if slot == nil {
+		return 0
+	}
+
+	slot.mu.RLock("RecordCount")
+	defer slot.mu.RUnlock()
+
+	return len(slot.records)
+}

--- a/services/timestreamwrite/handler.go
+++ b/services/timestreamwrite/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 	"github.com/blackbirdworks/gopherstack/pkgs/config"
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/page"
 	"github.com/blackbirdworks/gopherstack/pkgs/service"
 )
 
@@ -23,7 +24,11 @@ const (
 	keyMessageField = "message"
 )
 
-const endpointCachePeriodMinutes = 60
+const (
+	endpointCachePeriodMinutes = 60
+	// defaultTimestreamMaxResults is the default page size when MaxResults is not specified.
+	defaultTimestreamMaxResults = 100
+)
 
 var (
 	errUnknownAction  = errors.New("unknown action")
@@ -190,8 +195,15 @@ func (h *Handler) dispatch(ctx context.Context, action string, body []byte) ([]b
 func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err error) error {
 	var syntaxErr *json.SyntaxError
 	var typeErr *json.UnmarshalTypeError
+	var rejectedErr *RejectedRecordsError
 
 	switch {
+	case errors.As(err, &rejectedErr):
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			keyTypeField:      "RejectedRecordsException",
+			keyMessageField:   err.Error(),
+			"RejectedRecords": rejectedErr.RejectedRecords,
+		})
 	case errors.Is(err, awserr.ErrNotFound):
 		return c.JSON(http.StatusBadRequest, map[string]string{
 			keyTypeField:    "ResourceNotFoundException",
@@ -245,6 +257,7 @@ type listDatabasesInput struct {
 }
 
 type listDatabasesOutput struct {
+	NextToken string         `json:"NextToken,omitempty"`
 	Databases []databaseView `json:"Databases"`
 }
 
@@ -258,6 +271,7 @@ type updateDatabaseInput struct {
 }
 
 type createTableInput struct {
+	Schema                       *schemaInput                  `json:"Schema,omitempty"`
 	RetentionProperties          *retentionPropertiesInput     `json:"RetentionProperties,omitempty"`
 	MagneticStoreWriteProperties *magneticStoreWritePropsInput `json:"MagneticStoreWriteProperties,omitempty"`
 	DatabaseName                 string                        `json:"DatabaseName"`
@@ -270,8 +284,30 @@ type retentionPropertiesInput struct {
 	MagneticStoreRetentionPeriodInDays int64 `json:"MagneticStoreRetentionPeriodInDays"`
 }
 
+type s3ConfigInput struct {
+	BucketName       string `json:"BucketName,omitempty"`
+	ObjectKeyPrefix  string `json:"ObjectKeyPrefix,omitempty"`
+	EncryptionOption string `json:"EncryptionOption,omitempty"`
+	KmsKeyID         string `json:"KmsKeyId,omitempty"`
+}
+
+type magneticStoreRejectedDataLocationInput struct {
+	S3Configuration *s3ConfigInput `json:"S3Configuration,omitempty"`
+}
+
 type magneticStoreWritePropsInput struct {
-	EnableMagneticStoreWrites bool `json:"EnableMagneticStoreWrites"`
+	MagneticStoreRejectedDataLocation *magneticStoreRejectedDataLocationInput `json:"MagneticStoreRejectedDataLocation,omitempty"` //nolint:lll // AWS field name is inherently long
+	EnableMagneticStoreWrites         bool                                    `json:"EnableMagneticStoreWrites"`
+}
+
+type partitionKeyInput struct {
+	Type                string `json:"Type"`
+	Name                string `json:"Name,omitempty"`
+	EnforcementInRecord string `json:"EnforcementInRecord,omitempty"`
+}
+
+type schemaInput struct {
+	CompositePartitionKey []partitionKeyInput `json:"CompositePartitionKey,omitempty"`
 }
 
 type tableInput struct {
@@ -280,6 +316,7 @@ type tableInput struct {
 }
 
 type updateTableInput struct {
+	Schema                       *schemaInput                  `json:"Schema,omitempty"`
 	RetentionProperties          *retentionPropertiesInput     `json:"RetentionProperties,omitempty"`
 	MagneticStoreWriteProperties *magneticStoreWritePropsInput `json:"MagneticStoreWriteProperties,omitempty"`
 	DatabaseName                 string                        `json:"DatabaseName"`
@@ -290,7 +327,18 @@ type tableOutput struct {
 	Table tableView `json:"Table"`
 }
 
+type partitionKeyView struct {
+	Type                string `json:"Type"`
+	Name                string `json:"Name,omitempty"`
+	EnforcementInRecord string `json:"EnforcementInRecord,omitempty"`
+}
+
+type schemaView struct {
+	CompositePartitionKey []partitionKeyView `json:"CompositePartitionKey,omitempty"`
+}
+
 type tableView struct {
+	Schema                       *schemaView                   `json:"Schema,omitempty"`
 	RetentionProperties          *retentionPropertiesInput     `json:"RetentionProperties,omitempty"`
 	MagneticStoreWriteProperties *magneticStoreWritePropsInput `json:"MagneticStoreWriteProperties,omitempty"`
 	Arn                          string                        `json:"Arn"`
@@ -308,28 +356,38 @@ type listTablesInput struct {
 }
 
 type listTablesOutput struct {
-	Tables []tableView `json:"Tables"`
+	NextToken string      `json:"NextToken,omitempty"`
+	Tables    []tableView `json:"Tables"`
 }
 
 type writeRecordsInput struct {
-	DatabaseName string        `json:"DatabaseName"`
-	TableName    string        `json:"TableName"`
-	Records      []recordInput `json:"Records"`
+	CommonAttributes *recordInput  `json:"CommonAttributes,omitempty"`
+	DatabaseName     string        `json:"DatabaseName"`
+	TableName        string        `json:"TableName"`
+	Records          []recordInput `json:"Records"`
+}
+
+type measureValueInput struct {
+	Name  string `json:"Name"`
+	Value string `json:"Value"`
+	Type  string `json:"Type"`
 }
 
 type recordInput struct {
-	MeasureName      string           `json:"MeasureName"`
-	MeasureValue     string           `json:"MeasureValue"`
-	MeasureValueType string           `json:"MeasureValueType"`
-	Time             string           `json:"Time"`
-	TimeUnit         string           `json:"TimeUnit"`
-	Dimensions       []dimensionInput `json:"Dimensions"`
-	Version          int64            `json:"Version"`
+	MeasureName      string              `json:"MeasureName"`
+	MeasureValue     string              `json:"MeasureValue"`
+	MeasureValueType string              `json:"MeasureValueType"`
+	Time             string              `json:"Time"`
+	TimeUnit         string              `json:"TimeUnit"`
+	Dimensions       []dimensionInput    `json:"Dimensions"`
+	MeasureValues    []measureValueInput `json:"MeasureValues"`
+	Version          int64               `json:"Version"`
 }
 
 type dimensionInput struct {
-	Name  string `json:"Name"`
-	Value string `json:"Value"`
+	Name               string `json:"Name"`
+	Value              string `json:"Value"`
+	DimensionValueType string `json:"DimensionValueType,omitempty"`
 }
 
 type writeRecordsOutput struct {
@@ -378,6 +436,62 @@ type emptyOutput struct{}
 
 // --- handlers ---
 
+// buildCreateTableInput converts handler-level optional table-property inputs into a
+// *CreateTableInput for the backend.  Returns nil when all inputs are nil.
+func buildCreateTableInput(
+	rp *retentionPropertiesInput,
+	mswp *magneticStoreWritePropsInput,
+	sc *schemaInput,
+) *CreateTableInput {
+	if rp == nil && mswp == nil && sc == nil {
+		return nil
+	}
+
+	inp := &CreateTableInput{}
+
+	if rp != nil {
+		inp.RetentionProperties = &RetentionProperties{
+			MemoryStoreRetentionPeriodInHours:  rp.MemoryStoreRetentionPeriodInHours,
+			MagneticStoreRetentionPeriodInDays: rp.MagneticStoreRetentionPeriodInDays,
+		}
+	}
+
+	if mswp != nil {
+		backendMSWP := &MagneticStoreWriteProperties{
+			EnableMagneticStoreWrites: mswp.EnableMagneticStoreWrites,
+		}
+
+		if mswp.MagneticStoreRejectedDataLocation != nil {
+			loc := mswp.MagneticStoreRejectedDataLocation
+			backendLoc := &MagneticStoreRejectedDataLocation{}
+
+			if loc.S3Configuration != nil {
+				backendLoc.S3Configuration = &S3Configuration{
+					BucketName:       loc.S3Configuration.BucketName,
+					ObjectKeyPrefix:  loc.S3Configuration.ObjectKeyPrefix,
+					EncryptionOption: loc.S3Configuration.EncryptionOption,
+					KmsKeyID:         loc.S3Configuration.KmsKeyID,
+				}
+			}
+
+			backendMSWP.MagneticStoreRejectedDataLocation = backendLoc
+		}
+
+		inp.MagneticStoreWriteProperties = backendMSWP
+	}
+
+	if sc != nil && len(sc.CompositePartitionKey) > 0 {
+		keys := make([]PartitionKey, 0, len(sc.CompositePartitionKey))
+		for _, pk := range sc.CompositePartitionKey {
+			keys = append(keys, PartitionKey(pk))
+		}
+
+		inp.Schema = &Schema{CompositePartitionKey: keys}
+	}
+
+	return inp
+}
+
 func toDatabaseView(db *Database) databaseView {
 	return databaseView{
 		Arn:             db.ARN,
@@ -407,9 +521,36 @@ func toTableView(tbl *Table) tableView {
 	}
 
 	if tbl.MagneticStoreWriteProperties != nil {
-		v.MagneticStoreWriteProperties = &magneticStoreWritePropsInput{
+		mswp := &magneticStoreWritePropsInput{
 			EnableMagneticStoreWrites: tbl.MagneticStoreWriteProperties.EnableMagneticStoreWrites,
 		}
+
+		if tbl.MagneticStoreWriteProperties.MagneticStoreRejectedDataLocation != nil {
+			loc := tbl.MagneticStoreWriteProperties.MagneticStoreRejectedDataLocation
+			inputLoc := &magneticStoreRejectedDataLocationInput{}
+
+			if loc.S3Configuration != nil {
+				inputLoc.S3Configuration = &s3ConfigInput{
+					BucketName:       loc.S3Configuration.BucketName,
+					ObjectKeyPrefix:  loc.S3Configuration.ObjectKeyPrefix,
+					EncryptionOption: loc.S3Configuration.EncryptionOption,
+					KmsKeyID:         loc.S3Configuration.KmsKeyID,
+				}
+			}
+
+			mswp.MagneticStoreRejectedDataLocation = inputLoc
+		}
+
+		v.MagneticStoreWriteProperties = mswp
+	}
+
+	if tbl.Schema != nil && len(tbl.Schema.CompositePartitionKey) > 0 {
+		keys := make([]partitionKeyView, 0, len(tbl.Schema.CompositePartitionKey))
+		for _, pk := range tbl.Schema.CompositePartitionKey {
+			keys = append(keys, partitionKeyView(pk))
+		}
+
+		v.Schema = &schemaView{CompositePartitionKey: keys}
 	}
 
 	return v
@@ -451,16 +592,17 @@ func (h *Handler) handleDescribeDatabase(
 
 func (h *Handler) handleListDatabases(
 	_ context.Context,
-	_ *listDatabasesInput,
+	in *listDatabasesInput,
 ) (*listDatabasesOutput, error) {
 	dbs := h.Backend.ListDatabases()
-	views := make([]databaseView, 0, len(dbs))
+	pg := page.New(dbs, in.NextToken, in.MaxResults, defaultTimestreamMaxResults)
+	views := make([]databaseView, 0, len(pg.Data))
 
-	for i := range dbs {
-		views = append(views, toDatabaseView(&dbs[i]))
+	for i := range pg.Data {
+		views = append(views, toDatabaseView(&pg.Data[i]))
 	}
 
-	return &listDatabasesOutput{Databases: views}, nil
+	return &listDatabasesOutput{Databases: views, NextToken: pg.Next}, nil
 }
 
 func (h *Handler) handleDeleteDatabase(
@@ -504,24 +646,7 @@ func (h *Handler) handleCreateTable(
 
 	tags := tagsFromInput(in.Tags)
 
-	var inp *CreateTableInput
-
-	if in.RetentionProperties != nil || in.MagneticStoreWriteProperties != nil {
-		inp = &CreateTableInput{}
-
-		if in.RetentionProperties != nil {
-			inp.RetentionProperties = &RetentionProperties{
-				MemoryStoreRetentionPeriodInHours:  in.RetentionProperties.MemoryStoreRetentionPeriodInHours,
-				MagneticStoreRetentionPeriodInDays: in.RetentionProperties.MagneticStoreRetentionPeriodInDays,
-			}
-		}
-
-		if in.MagneticStoreWriteProperties != nil {
-			inp.MagneticStoreWriteProperties = &MagneticStoreWriteProperties{
-				EnableMagneticStoreWrites: in.MagneticStoreWriteProperties.EnableMagneticStoreWrites,
-			}
-		}
-	}
+	inp := buildCreateTableInput(in.RetentionProperties, in.MagneticStoreWriteProperties, in.Schema)
 
 	tbl, err := h.Backend.CreateTable(in.DatabaseName, in.TableName, tags, inp)
 	if err != nil {
@@ -560,12 +685,14 @@ func (h *Handler) handleListTables(
 		return nil, err
 	}
 
-	views := make([]tableView, 0, len(tbls))
-	for i := range tbls {
-		views = append(views, toTableView(&tbls[i]))
+	pg := page.New(tbls, in.NextToken, in.MaxResults, defaultTimestreamMaxResults)
+	views := make([]tableView, 0, len(pg.Data))
+
+	for i := range pg.Data {
+		views = append(views, toTableView(&pg.Data[i]))
 	}
 
-	return &listTablesOutput{Tables: views}, nil
+	return &listTablesOutput{Tables: views, NextToken: pg.Next}, nil
 }
 
 func (h *Handler) handleDeleteTable(
@@ -592,21 +719,13 @@ func (h *Handler) handleUpdateTable(
 	}
 
 	var inp *UpdateTableInput
+	cti := buildCreateTableInput(in.RetentionProperties, in.MagneticStoreWriteProperties, in.Schema)
 
-	if in.RetentionProperties != nil || in.MagneticStoreWriteProperties != nil {
-		inp = &UpdateTableInput{}
-
-		if in.RetentionProperties != nil {
-			inp.RetentionProperties = &RetentionProperties{
-				MemoryStoreRetentionPeriodInHours:  in.RetentionProperties.MemoryStoreRetentionPeriodInHours,
-				MagneticStoreRetentionPeriodInDays: in.RetentionProperties.MagneticStoreRetentionPeriodInDays,
-			}
-		}
-
-		if in.MagneticStoreWriteProperties != nil {
-			inp.MagneticStoreWriteProperties = &MagneticStoreWriteProperties{
-				EnableMagneticStoreWrites: in.MagneticStoreWriteProperties.EnableMagneticStoreWrites,
-			}
+	if cti != nil {
+		inp = &UpdateTableInput{
+			RetentionProperties:          cti.RetentionProperties,
+			MagneticStoreWriteProperties: cti.MagneticStoreWriteProperties,
+			Schema:                       cti.Schema,
 		}
 	}
 
@@ -629,20 +748,8 @@ func (h *Handler) handleWriteRecords(
 	records := make([]Record, 0, len(in.Records))
 
 	for _, r := range in.Records {
-		dims := make([]Dimension, 0, len(r.Dimensions))
-		for _, d := range r.Dimensions {
-			dims = append(dims, Dimension(d))
-		}
-
-		records = append(records, Record{
-			Dimensions:       dims,
-			MeasureName:      r.MeasureName,
-			MeasureValue:     r.MeasureValue,
-			MeasureValueType: r.MeasureValueType,
-			Time:             r.Time,
-			TimeUnit:         r.TimeUnit,
-			Version:          r.Version,
-		})
+		merged := mergeRecordWithCommon(r, in.CommonAttributes)
+		records = append(records, recordInputToBackend(merged))
 	}
 
 	result, err := h.Backend.WriteRecords(in.DatabaseName, in.TableName, records)
@@ -655,6 +762,91 @@ func (h *Handler) handleWriteRecords(
 	out.RecordsIngested.MemoryStore = result.MemoryStore
 
 	return out, nil
+}
+
+// mergeRecordWithCommon merges CommonAttributes into a record per AWS semantics:
+// record-specific values take priority; common fills in missing fields and dimensions.
+func mergeRecordWithCommon(r recordInput, common *recordInput) recordInput {
+	if common == nil {
+		return r
+	}
+
+	merged := r
+
+	// Merge dimensions: start with common, override with record-specific on name conflict.
+	dimSet := make(map[string]dimensionInput, len(common.Dimensions)+len(r.Dimensions))
+	for _, d := range common.Dimensions {
+		dimSet[d.Name] = d
+	}
+
+	for _, d := range r.Dimensions {
+		dimSet[d.Name] = d
+	}
+
+	if len(dimSet) > 0 {
+		dims := make([]dimensionInput, 0, len(dimSet))
+		for _, d := range dimSet {
+			dims = append(dims, d)
+		}
+
+		sort.Slice(dims, func(i, j int) bool { return dims[i].Name < dims[j].Name })
+		merged.Dimensions = dims
+	}
+
+	// Fill scalar fields from common when record does not set them.
+	if merged.MeasureName == "" {
+		merged.MeasureName = common.MeasureName
+	}
+
+	if merged.MeasureValue == "" {
+		merged.MeasureValue = common.MeasureValue
+	}
+
+	if merged.MeasureValueType == "" {
+		merged.MeasureValueType = common.MeasureValueType
+	}
+
+	if merged.Time == "" {
+		merged.Time = common.Time
+	}
+
+	if merged.TimeUnit == "" {
+		merged.TimeUnit = common.TimeUnit
+	}
+
+	if merged.Version == 0 {
+		merged.Version = common.Version
+	}
+
+	if len(merged.MeasureValues) == 0 {
+		merged.MeasureValues = common.MeasureValues
+	}
+
+	return merged
+}
+
+// recordInputToBackend converts a handler-level recordInput to the backend Record type.
+func recordInputToBackend(r recordInput) Record {
+	dims := make([]Dimension, 0, len(r.Dimensions))
+	for _, d := range r.Dimensions {
+		dims = append(dims, Dimension(d))
+	}
+
+	mvs := make([]MeasureValue, 0, len(r.MeasureValues))
+	for _, mv := range r.MeasureValues {
+		mvs = append(mvs, MeasureValue(mv))
+	}
+
+	return Record{
+		Dimensions:       dims,
+		MeasureName:      r.MeasureName,
+		MeasureValue:     r.MeasureValue,
+		MeasureValueType: r.MeasureValueType,
+		Time:             r.Time,
+		TimeUnit:         r.TimeUnit,
+		MeasureValues:    mvs,
+		Version:          r.Version,
+	}
 }
 
 func (h *Handler) handleTagResource(
@@ -760,6 +952,7 @@ type batchLoadTaskDescriptionView struct {
 	ResumableUntil          *float64               `json:"ResumableUntil,omitempty"`
 	DataSourceConfiguration *dataSourceConfigInput `json:"DataSourceConfiguration,omitempty"`
 	ReportConfiguration     *reportConfigInput     `json:"ReportConfiguration,omitempty"`
+	ProgressReport          *progressReportView    `json:"ProgressReport,omitempty"`
 	TaskID                  string                 `json:"TaskId"`
 	TargetDatabaseName      string                 `json:"TargetDatabaseName"`
 	TargetTableName         string                 `json:"TargetTableName"`
@@ -791,7 +984,17 @@ type batchLoadTaskSummaryView struct {
 }
 
 type listBatchLoadTasksOutput struct {
+	NextToken      string                     `json:"NextToken,omitempty"`
 	BatchLoadTasks []batchLoadTaskSummaryView `json:"BatchLoadTasks"`
+}
+
+type progressReportView struct {
+	BytesMetered            int64 `json:"BytesMetered,omitempty"`
+	FileFailures            int64 `json:"FileFailures,omitempty"`
+	ParseFailures           int64 `json:"ParseFailures,omitempty"`
+	RecordIngestionFailures int64 `json:"RecordIngestionFailures,omitempty"`
+	RecordsIngested         int64 `json:"RecordsIngested,omitempty"`
+	RecordsProcessed        int64 `json:"RecordsProcessed,omitempty"`
 }
 
 func toBatchLoadTaskDescriptionView(task *BatchLoadTask) batchLoadTaskDescriptionView {
@@ -804,6 +1007,17 @@ func toBatchLoadTaskDescriptionView(task *BatchLoadTask) batchLoadTaskDescriptio
 		LastUpdatedTime:    float64(task.LastUpdatedTime.Unix()),
 		ErrorMessage:       task.ErrorMessage,
 		RecordVersion:      task.RecordVersion,
+	}
+
+	if task.ProgressReport != nil {
+		v.ProgressReport = &progressReportView{
+			BytesMetered:            task.ProgressReport.BytesMetered,
+			FileFailures:            task.ProgressReport.FileFailures,
+			ParseFailures:           task.ProgressReport.ParseFailures,
+			RecordIngestionFailures: task.ProgressReport.RecordIngestionFailures,
+			RecordsIngested:         task.ProgressReport.RecordsIngested,
+			RecordsProcessed:        task.ProgressReport.RecordsProcessed,
+		}
 	}
 
 	if task.ResumableUntil != nil {
@@ -948,13 +1162,14 @@ func (h *Handler) handleListBatchLoadTasks(
 	in *listBatchLoadTasksInput,
 ) (*listBatchLoadTasksOutput, error) {
 	tasks := h.Backend.ListBatchLoadTasks(in.TaskStatus)
-	views := make([]batchLoadTaskSummaryView, 0, len(tasks))
+	pg := page.New(tasks, in.NextToken, in.MaxResults, defaultTimestreamMaxResults)
+	views := make([]batchLoadTaskSummaryView, 0, len(pg.Data))
 
-	for i := range tasks {
-		views = append(views, toBatchLoadTaskSummaryView(&tasks[i]))
+	for i := range pg.Data {
+		views = append(views, toBatchLoadTaskSummaryView(&pg.Data[i]))
 	}
 
-	return &listBatchLoadTasksOutput{BatchLoadTasks: views}, nil
+	return &listBatchLoadTasksOutput{BatchLoadTasks: views, NextToken: pg.Next}, nil
 }
 
 func (h *Handler) handleResumeBatchLoadTask(

--- a/services/timestreamwrite/handler_accuracy_test.go
+++ b/services/timestreamwrite/handler_accuracy_test.go
@@ -1,0 +1,1100 @@
+package timestreamwrite_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/timestreamwrite"
+)
+
+// --- Gap 1: Schema / PartitionKey on Table ---
+
+// TestAccuracy_CreateTableWithSchema verifies that a composite partition key schema
+// is stored and returned by CreateTable per the AWS API.
+func TestAccuracy_CreateTableWithSchema(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "schema-db"})
+
+	rec := doRequest(t, h, "CreateTable", map[string]any{
+		"DatabaseName": "schema-db",
+		"TableName":    "schema-tbl",
+		"Schema": map[string]any{
+			"CompositePartitionKey": []map[string]any{
+				{"Type": "DIMENSION", "Name": "region", "EnforcementInRecord": "REQUIRED"},
+				{"Type": "MEASURE", "EnforcementInRecord": "OPTIONAL"},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	tbl := out["Table"].(map[string]any)
+	schema, ok := tbl["Schema"].(map[string]any)
+	require.True(t, ok, "Schema should be present in response")
+
+	keys := schema["CompositePartitionKey"].([]any)
+	require.Len(t, keys, 2)
+
+	first := keys[0].(map[string]any)
+	assert.Equal(t, "DIMENSION", first["Type"])
+	assert.Equal(t, "region", first["Name"])
+	assert.Equal(t, "REQUIRED", first["EnforcementInRecord"])
+}
+
+// TestAccuracy_DescribeTableReturnsSchema verifies Schema survives DescribeTable.
+func TestAccuracy_DescribeTableReturnsSchema(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "desc-schema-db"})
+	doRequest(t, h, "CreateTable", map[string]any{
+		"DatabaseName": "desc-schema-db",
+		"TableName":    "desc-schema-tbl",
+		"Schema": map[string]any{
+			"CompositePartitionKey": []map[string]any{
+				{"Type": "MEASURE"},
+			},
+		},
+	})
+
+	rec := doRequest(t, h, "DescribeTable", map[string]any{
+		"DatabaseName": "desc-schema-db",
+		"TableName":    "desc-schema-tbl",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	tbl := out["Table"].(map[string]any)
+	schema, ok := tbl["Schema"].(map[string]any)
+	require.True(t, ok, "Schema should be present in DescribeTable response")
+	keys := schema["CompositePartitionKey"].([]any)
+	assert.Len(t, keys, 1)
+	assert.Equal(t, "MEASURE", keys[0].(map[string]any)["Type"])
+}
+
+// TestAccuracy_UpdateTableWithSchema verifies Schema can be set via UpdateTable.
+func TestAccuracy_UpdateTableWithSchema(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "upd-schema-db"})
+	doRequest(t, h, "CreateTable", map[string]any{
+		"DatabaseName": "upd-schema-db",
+		"TableName":    "upd-schema-tbl",
+	})
+
+	rec := doRequest(t, h, "UpdateTable", map[string]any{
+		"DatabaseName": "upd-schema-db",
+		"TableName":    "upd-schema-tbl",
+		"Schema": map[string]any{
+			"CompositePartitionKey": []map[string]any{
+				{"Type": "DIMENSION", "Name": "account_id", "EnforcementInRecord": "REQUIRED"},
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	tbl := out["Table"].(map[string]any)
+	schema := tbl["Schema"].(map[string]any)
+	keys := schema["CompositePartitionKey"].([]any)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "account_id", keys[0].(map[string]any)["Name"])
+}
+
+// TestAccuracy_ListTablesIncludesSchema verifies Schema appears in ListTables output.
+func TestAccuracy_ListTablesIncludesSchema(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "ls-schema-db"})
+	doRequest(t, h, "CreateTable", map[string]any{
+		"DatabaseName": "ls-schema-db",
+		"TableName":    "ls-schema-tbl",
+		"Schema": map[string]any{
+			"CompositePartitionKey": []map[string]any{
+				{"Type": "DIMENSION", "Name": "host"},
+			},
+		},
+	})
+
+	rec := doRequest(t, h, "ListTables", map[string]string{"DatabaseName": "ls-schema-db"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	tables := out["Tables"].([]any)
+	require.Len(t, tables, 1)
+
+	schema := tables[0].(map[string]any)["Schema"].(map[string]any)
+	keys := schema["CompositePartitionKey"].([]any)
+	assert.Equal(t, "host", keys[0].(map[string]any)["Name"])
+}
+
+// --- Gap 2: MagneticStoreRejectedDataLocation ---
+
+// TestAccuracy_MagneticStoreRejectedDataLocation verifies S3 config for rejected records
+// is stored and returned in the table view.
+func TestAccuracy_MagneticStoreRejectedDataLocation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "msrdl-db"})
+
+	rec := doRequest(t, h, "CreateTable", map[string]any{
+		"DatabaseName": "msrdl-db",
+		"TableName":    "msrdl-tbl",
+		"MagneticStoreWriteProperties": map[string]any{
+			"EnableMagneticStoreWrites": true,
+			"MagneticStoreRejectedDataLocation": map[string]any{
+				"S3Configuration": map[string]any{
+					"BucketName":       "rejected-records-bucket",
+					"ObjectKeyPrefix":  "errors/",
+					"EncryptionOption": "SSE_S3",
+				},
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	tbl := out["Table"].(map[string]any)
+	mswp := tbl["MagneticStoreWriteProperties"].(map[string]any)
+	assert.True(t, mswp["EnableMagneticStoreWrites"].(bool))
+
+	loc := mswp["MagneticStoreRejectedDataLocation"].(map[string]any)
+	s3cfg := loc["S3Configuration"].(map[string]any)
+	assert.Equal(t, "rejected-records-bucket", s3cfg["BucketName"])
+	assert.Equal(t, "errors/", s3cfg["ObjectKeyPrefix"])
+	assert.Equal(t, "SSE_S3", s3cfg["EncryptionOption"])
+}
+
+// TestAccuracy_MagneticStoreRejectedDataLocationRoundTrip verifies MSRDL survives DescribeTable.
+func TestAccuracy_MagneticStoreRejectedDataLocationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	h := timestreamwrite.NewHandler(b)
+
+	_, err := b.CreateDatabase("msrdl2-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("msrdl2-db", "msrdl2-tbl", nil, &timestreamwrite.CreateTableInput{
+		MagneticStoreWriteProperties: &timestreamwrite.MagneticStoreWriteProperties{
+			EnableMagneticStoreWrites: true,
+			MagneticStoreRejectedDataLocation: &timestreamwrite.MagneticStoreRejectedDataLocation{
+				S3Configuration: &timestreamwrite.S3Configuration{
+					BucketName: "err-bucket",
+					KmsKeyID:   "arn:aws:kms:us-east-1:000000000000:key/abc",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rec := doRequest(t, h, "DescribeTable", map[string]any{
+		"DatabaseName": "msrdl2-db",
+		"TableName":    "msrdl2-tbl",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	tbl := out["Table"].(map[string]any)
+	mswp := tbl["MagneticStoreWriteProperties"].(map[string]any)
+	loc := mswp["MagneticStoreRejectedDataLocation"].(map[string]any)
+	s3cfg := loc["S3Configuration"].(map[string]any)
+	assert.Equal(t, "err-bucket", s3cfg["BucketName"])
+	assert.Equal(t, "arn:aws:kms:us-east-1:000000000000:key/abc", s3cfg["KmsKeyId"])
+}
+
+// --- Gap 3: Record.MeasureValues (MULTI type) ---
+
+// TestAccuracy_WriteRecordsMultiMeasure verifies that MULTI-type records with
+// MeasureValues are accepted and stored correctly.
+func TestAccuracy_WriteRecordsMultiMeasure(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "multi-db"})
+	doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "multi-db", "TableName": "multi-tbl"})
+
+	rec := doRequest(t, h, "WriteRecords", map[string]any{
+		"DatabaseName": "multi-db",
+		"TableName":    "multi-tbl",
+		"Records": []map[string]any{
+			{
+				"MeasureName":      "metrics",
+				"MeasureValueType": "MULTI",
+				"Time":             "1609459200000",
+				"TimeUnit":         "MILLISECONDS",
+				"MeasureValues": []map[string]any{
+					{"Name": "cpu", "Value": "45.3", "Type": "DOUBLE"},
+					{"Name": "mem", "Value": "8192", "Type": "BIGINT"},
+					{"Name": "disk_ok", "Value": "true", "Type": "BOOLEAN"},
+				},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	ingested := out["RecordsIngested"].(map[string]any)
+	assert.Equal(t, 1, int(ingested["Total"].(float64)))
+}
+
+// TestAccuracy_BackendStoresMeasureValues verifies MeasureValues survive in the backend.
+func TestAccuracy_BackendStoresMeasureValues(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("mv-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("mv-db", "mv-tbl", nil, nil)
+	require.NoError(t, err)
+
+	records := []timestreamwrite.Record{
+		{
+			MeasureName:      "system",
+			MeasureValueType: "MULTI",
+			Time:             "1609459200000",
+			TimeUnit:         "MILLISECONDS",
+			MeasureValues: []timestreamwrite.MeasureValue{
+				{Name: "cpu", Value: "12.5", Type: "DOUBLE"},
+				{Name: "status", Value: "healthy", Type: "VARCHAR"},
+			},
+		},
+	}
+
+	out, err := b.WriteRecords("mv-db", "mv-tbl", records)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), out.Total)
+}
+
+// --- Gap 4: WriteRecords CommonAttributes ---
+
+// TestAccuracy_WriteRecordsCommonAttributes verifies that CommonAttributes dimensions
+// are merged into each record per the AWS specification.
+func TestAccuracy_WriteRecordsCommonAttributes(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "ca-db"})
+	doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "ca-db", "TableName": "ca-tbl"})
+
+	rec := doRequest(t, h, "WriteRecords", map[string]any{
+		"DatabaseName": "ca-db",
+		"TableName":    "ca-tbl",
+		"CommonAttributes": map[string]any{
+			"Dimensions": []map[string]any{
+				{"Name": "region", "Value": "us-east-1"},
+				{"Name": "env", "Value": "prod"},
+			},
+			"Time":     "1609459200000",
+			"TimeUnit": "MILLISECONDS",
+		},
+		"Records": []map[string]any{
+			{
+				"MeasureName":      "cpu",
+				"MeasureValue":     "65.4",
+				"MeasureValueType": "DOUBLE",
+				// No Dimensions or Time — should come from CommonAttributes
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	ingested := out["RecordsIngested"].(map[string]any)
+	assert.Equal(t, 1, int(ingested["Total"].(float64)))
+}
+
+// TestAccuracy_WriteRecordsCommonAttributesMerge verifies record-specific dimensions
+// override CommonAttributes on name conflict.
+func TestAccuracy_WriteRecordsCommonAttributesMerge(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "cam-db"})
+	doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "cam-db", "TableName": "cam-tbl"})
+
+	// Two unique records: first with no override, second with dimension override.
+	rec := doRequest(t, h, "WriteRecords", map[string]any{
+		"DatabaseName": "cam-db",
+		"TableName":    "cam-tbl",
+		"CommonAttributes": map[string]any{
+			"Time":     "1609459200000",
+			"TimeUnit": "MILLISECONDS",
+			"Dimensions": []map[string]any{
+				{"Name": "env", "Value": "prod"},
+			},
+		},
+		"Records": []map[string]any{
+			{
+				"MeasureName":      "r1",
+				"MeasureValue":     "1",
+				"MeasureValueType": "DOUBLE",
+			},
+			{
+				"MeasureName":      "r2",
+				"MeasureValue":     "2",
+				"MeasureValueType": "DOUBLE",
+				"Dimensions": []map[string]any{
+					{"Name": "env", "Value": "staging"}, // overrides common
+				},
+			},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	ingested := out["RecordsIngested"].(map[string]any)
+	assert.Equal(t, 2, int(ingested["Total"].(float64)))
+}
+
+// --- Gap 5: Pagination ---
+
+// TestAccuracy_ListDatabasesPagination verifies NextToken pagination for ListDatabases.
+func TestAccuracy_ListDatabasesPagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	for _, name := range []string{"aaa", "bbb", "ccc", "ddd", "eee"} {
+		doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": name})
+	}
+
+	// First page: MaxResults=2.
+	rec1 := doRequest(t, h, "ListDatabases", map[string]any{"MaxResults": 2})
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	var out1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &out1))
+
+	dbs1 := out1["Databases"].([]any)
+	assert.Len(t, dbs1, 2)
+
+	nextToken, ok := out1["NextToken"].(string)
+	require.True(t, ok && nextToken != "", "NextToken should be non-empty when more pages exist")
+
+	// Second page.
+	rec2 := doRequest(t, h, "ListDatabases", map[string]any{"MaxResults": 2, "NextToken": nextToken})
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	var out2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &out2))
+
+	dbs2 := out2["Databases"].([]any)
+	assert.Len(t, dbs2, 2)
+
+	// Third page (final).
+	nextToken2 := out2["NextToken"].(string)
+	rec3 := doRequest(t, h, "ListDatabases", map[string]any{"MaxResults": 2, "NextToken": nextToken2})
+	require.Equal(t, http.StatusOK, rec3.Code)
+
+	var out3 map[string]any
+	require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &out3))
+
+	dbs3 := out3["Databases"].([]any)
+	assert.Len(t, dbs3, 1)
+	// No NextToken on final page.
+	assert.Empty(t, out3["NextToken"])
+}
+
+// TestAccuracy_ListDatabasesNoNextTokenWhenFits verifies no NextToken when all results fit.
+func TestAccuracy_ListDatabasesNoNextTokenWhenFits(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "only-db"})
+
+	rec := doRequest(t, h, "ListDatabases", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	assert.Empty(t, out["NextToken"])
+}
+
+// TestAccuracy_ListTablesPagination verifies NextToken pagination for ListTables.
+func TestAccuracy_ListTablesPagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "pg-db"})
+
+	for _, name := range []string{"t1", "t2", "t3"} {
+		doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "pg-db", "TableName": name})
+	}
+
+	rec1 := doRequest(t, h, "ListTables", map[string]any{"DatabaseName": "pg-db", "MaxResults": 2})
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	var out1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &out1))
+
+	tbls1 := out1["Tables"].([]any)
+	assert.Len(t, tbls1, 2)
+
+	nextToken := out1["NextToken"].(string)
+	assert.NotEmpty(t, nextToken)
+
+	rec2 := doRequest(t, h, "ListTables", map[string]any{
+		"DatabaseName": "pg-db",
+		"MaxResults":   2,
+		"NextToken":    nextToken,
+	})
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	var out2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &out2))
+
+	tbls2 := out2["Tables"].([]any)
+	assert.Len(t, tbls2, 1)
+	assert.Empty(t, out2["NextToken"])
+}
+
+// TestAccuracy_ListBatchLoadTasksPagination verifies NextToken pagination for ListBatchLoadTasks.
+func TestAccuracy_ListBatchLoadTasksPagination(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	h := timestreamwrite.NewHandler(b)
+
+	now := time.Now()
+	b.AddDatabaseInternal(&timestreamwrite.Database{
+		DatabaseName: "blt-pg-db",
+		ARN:          "arn:aws:timestream:us-east-1:000000000000:database/blt-pg-db",
+		CreationTime: now, LastUpdatedTime: now,
+	})
+	b.AddTableInternal(&timestreamwrite.Table{
+		DatabaseName: "blt-pg-db", TableName: "blt-pg-tbl",
+		TableStatus: "ACTIVE", ARN: "arn:aws:timestream:us-east-1:000000000000:database/blt-pg-db/table/blt-pg-tbl",
+		CreationTime: now, LastUpdatedTime: now,
+	})
+
+	for i := range 4 {
+		b.AddBatchLoadTaskInternal(&timestreamwrite.BatchLoadTask{
+			TaskID:             "task-" + string(rune('a'+i)),
+			TargetDatabaseName: "blt-pg-db",
+			TargetTableName:    "blt-pg-tbl",
+			TaskStatus:         "CREATED",
+			CreationTime:       now.Add(time.Duration(i) * time.Second),
+			LastUpdatedTime:    now,
+		})
+	}
+
+	rec1 := doRequest(t, h, "ListBatchLoadTasks", map[string]any{"MaxResults": 2})
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	var out1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &out1))
+
+	tasks1 := out1["BatchLoadTasks"].([]any)
+	assert.Len(t, tasks1, 2)
+
+	nextToken := out1["NextToken"].(string)
+	assert.NotEmpty(t, nextToken)
+
+	rec2 := doRequest(t, h, "ListBatchLoadTasks", map[string]any{"MaxResults": 2, "NextToken": nextToken})
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	var out2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &out2))
+
+	tasks2 := out2["BatchLoadTasks"].([]any)
+	assert.Len(t, tasks2, 2)
+	assert.Empty(t, out2["NextToken"])
+}
+
+// --- Gap 6: BatchLoadProgressReport ---
+
+// TestAccuracy_DescribeBatchLoadTaskProgressReport verifies ProgressReport is returned
+// when set on a task.
+func TestAccuracy_DescribeBatchLoadTaskProgressReport(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	h := timestreamwrite.NewHandler(b)
+
+	now := time.Now()
+	pr := &timestreamwrite.BatchLoadProgressReport{
+		RecordsProcessed:        1000,
+		RecordsIngested:         950,
+		RecordIngestionFailures: 50,
+		ParseFailures:           5,
+		BytesMetered:            1024 * 1024,
+	}
+	b.AddBatchLoadTaskInternal(&timestreamwrite.BatchLoadTask{
+		TaskID:             "pr-task",
+		TargetDatabaseName: "pr-db",
+		TargetTableName:    "pr-tbl",
+		TaskStatus:         timestreamwrite.BatchLoadStatusInProgress,
+		CreationTime:       now,
+		LastUpdatedTime:    now,
+		ProgressReport:     pr,
+	})
+
+	rec := doRequest(t, h, "DescribeBatchLoadTask", map[string]string{"TaskId": "pr-task"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+
+	desc := out["BatchLoadTaskDescription"].(map[string]any)
+	report := desc["ProgressReport"].(map[string]any)
+	assert.Equal(t, 1000, int(report["RecordsProcessed"].(float64)))
+	assert.Equal(t, 950, int(report["RecordsIngested"].(float64)))
+	assert.Equal(t, 50, int(report["RecordIngestionFailures"].(float64)))
+	assert.Equal(t, 5, int(report["ParseFailures"].(float64)))
+	assert.Equal(t, 1024*1024, int(report["BytesMetered"].(float64)))
+}
+
+// TestAccuracy_DescribeBatchLoadTaskNoProgressReport verifies ProgressReport is omitted
+// when not set.
+func TestAccuracy_DescribeBatchLoadTaskNoProgressReport(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "npr-db"})
+	doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "npr-db", "TableName": "npr-tbl"})
+
+	cr := doRequest(t, h, "CreateBatchLoadTask", map[string]any{
+		"TargetDatabaseName": "npr-db",
+		"TargetTableName":    "npr-tbl",
+	})
+	require.Equal(t, http.StatusOK, cr.Code)
+
+	var createOut map[string]any
+	require.NoError(t, json.Unmarshal(cr.Body.Bytes(), &createOut))
+	taskID := createOut["TaskId"].(string)
+
+	dr := doRequest(t, h, "DescribeBatchLoadTask", map[string]string{"TaskId": taskID})
+	require.Equal(t, http.StatusOK, dr.Code)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(dr.Body.Bytes(), &out))
+
+	desc := out["BatchLoadTaskDescription"].(map[string]any)
+	_, hasPR := desc["ProgressReport"]
+	assert.False(t, hasPR, "ProgressReport should be absent when not set")
+}
+
+// --- Gap 7: Dimension.DimensionValueType ---
+
+// TestAccuracy_DimensionValueTypePassthrough verifies that DimensionValueType is
+// preserved in the backend when specified on WriteRecords.
+func TestAccuracy_DimensionValueTypePassthrough(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("dvt-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("dvt-db", "dvt-tbl", nil, nil)
+	require.NoError(t, err)
+
+	records := []timestreamwrite.Record{
+		{
+			MeasureName:      "cpu",
+			MeasureValue:     "42.5",
+			MeasureValueType: "DOUBLE",
+			Time:             "1609459200000",
+			TimeUnit:         "MILLISECONDS",
+			Dimensions: []timestreamwrite.Dimension{
+				{Name: "host", Value: "server-1", DimensionValueType: "VARCHAR"},
+			},
+		},
+	}
+
+	out, err := b.WriteRecords("dvt-db", "dvt-tbl", records)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), out.Total)
+}
+
+// TestAccuracy_WriteRecordsDimensionValueType verifies DimensionValueType is accepted
+// via the HTTP handler.
+func TestAccuracy_WriteRecordsDimensionValueType(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "dvth-db"})
+	doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "dvth-db", "TableName": "dvth-tbl"})
+
+	rec := doRequest(t, h, "WriteRecords", map[string]any{
+		"DatabaseName": "dvth-db",
+		"TableName":    "dvth-tbl",
+		"Records": []map[string]any{
+			{
+				"MeasureName":      "latency",
+				"MeasureValue":     "23",
+				"MeasureValueType": "BIGINT",
+				"Time":             "1609459200000",
+				"TimeUnit":         "MILLISECONDS",
+				"Dimensions": []map[string]any{
+					{"Name": "endpoint", "Value": "/api/health", "DimensionValueType": "VARCHAR"},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- Gap 8 & 9: Record version upsert and RejectedRecordsException ---
+
+// TestAccuracy_WriteRecordsVersionUpsert verifies that a record with a higher version
+// replaces the existing record without error.
+func TestAccuracy_WriteRecordsVersionUpsert(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("vu-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("vu-db", "vu-tbl", nil, nil)
+	require.NoError(t, err)
+
+	record := timestreamwrite.Record{
+		MeasureName:      "cpu",
+		MeasureValue:     "10.0",
+		MeasureValueType: "DOUBLE",
+		Time:             "1609459200000",
+		TimeUnit:         "MILLISECONDS",
+		Version:          1,
+	}
+
+	out, err := b.WriteRecords("vu-db", "vu-tbl", []timestreamwrite.Record{record})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), out.Total)
+
+	// Same key, higher version: upsert succeeds.
+	record.Version = 2
+	record.MeasureValue = "20.0"
+	out2, err := b.WriteRecords("vu-db", "vu-tbl", []timestreamwrite.Record{record})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), out2.Total)
+}
+
+// TestAccuracy_WriteRecordsVersionConflictReturnsError verifies that a lower/equal
+// version write returns a RejectedRecordsError.
+func TestAccuracy_WriteRecordsVersionConflictReturnsError(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("vc-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("vc-db", "vc-tbl", nil, nil)
+	require.NoError(t, err)
+
+	record := timestreamwrite.Record{
+		MeasureName:      "mem",
+		MeasureValue:     "8192",
+		MeasureValueType: "BIGINT",
+		Time:             "1609459200001",
+		TimeUnit:         "MILLISECONDS",
+		Version:          2,
+	}
+
+	_, err = b.WriteRecords("vc-db", "vc-tbl", []timestreamwrite.Record{record})
+	require.NoError(t, err)
+
+	// Same record, lower version: should be rejected.
+	record.Version = 1
+	_, err = b.WriteRecords("vc-db", "vc-tbl", []timestreamwrite.Record{record})
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	require.ErrorAs(t, err, &rejErr)
+	require.Len(t, rejErr.RejectedRecords, 1)
+	assert.Equal(t, 0, rejErr.RejectedRecords[0].RecordIndex)
+	assert.Equal(t, int64(2), rejErr.RejectedRecords[0].ExistingVersion)
+}
+
+// TestAccuracy_WriteRecordsSameVersionConflict verifies that a same-version write
+// (when version already stored) is also rejected per AWS upsert rules.
+func TestAccuracy_WriteRecordsSameVersionConflict(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("sv-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("sv-db", "sv-tbl", nil, nil)
+	require.NoError(t, err)
+
+	record := timestreamwrite.Record{
+		MeasureName:      "rps",
+		MeasureValue:     "500",
+		MeasureValueType: "BIGINT",
+		Time:             "1609459200002",
+		TimeUnit:         "MILLISECONDS",
+		Version:          3,
+	}
+
+	_, err = b.WriteRecords("sv-db", "sv-tbl", []timestreamwrite.Record{record})
+	require.NoError(t, err)
+
+	// Same version: rejected.
+	_, err = b.WriteRecords("sv-db", "sv-tbl", []timestreamwrite.Record{record})
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	require.ErrorAs(t, err, &rejErr)
+	assert.Len(t, rejErr.RejectedRecords, 1)
+}
+
+// TestAccuracy_WriteRecordsRejectedRecordsHTTP verifies that the handler returns
+// 400 with __type=RejectedRecordsException on version conflict.
+func TestAccuracy_WriteRecordsRejectedRecordsHTTP(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateDatabase", map[string]string{"DatabaseName": "rr-db"})
+	doRequest(t, h, "CreateTable", map[string]any{"DatabaseName": "rr-db", "TableName": "rr-tbl"})
+
+	writeBody := map[string]any{
+		"DatabaseName": "rr-db",
+		"TableName":    "rr-tbl",
+		"Records": []map[string]any{
+			{
+				"MeasureName":      "errors",
+				"MeasureValue":     "5",
+				"MeasureValueType": "BIGINT",
+				"Time":             "1609459200000",
+				"TimeUnit":         "MILLISECONDS",
+				"Version":          int64(5),
+			},
+		},
+	}
+
+	// First write succeeds.
+	rec1 := doRequest(t, h, "WriteRecords", writeBody)
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	// Same record, lower version — should fail with RejectedRecordsException.
+	writeBody["Records"] = []map[string]any{
+		{
+			"MeasureName":      "errors",
+			"MeasureValue":     "5",
+			"MeasureValueType": "BIGINT",
+			"Time":             "1609459200000",
+			"TimeUnit":         "MILLISECONDS",
+			"Version":          int64(3),
+		},
+	}
+
+	rec2 := doRequest(t, h, "WriteRecords", writeBody)
+	assert.Equal(t, http.StatusBadRequest, rec2.Code)
+
+	var errBody map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &errBody))
+	assert.Equal(t, "RejectedRecordsException", errBody["__type"])
+
+	rejected, ok := errBody["RejectedRecords"].([]any)
+	require.True(t, ok, "RejectedRecords should be present in error response")
+	assert.Len(t, rejected, 1)
+}
+
+// TestAccuracy_WriteRecordsPartialReject verifies that when some records pass and
+// some fail version checks, only the failed ones are rejected.
+func TestAccuracy_WriteRecordsPartialReject(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("pr2-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("pr2-db", "pr2-tbl", nil, nil)
+	require.NoError(t, err)
+
+	existing := timestreamwrite.Record{
+		MeasureName: "load", MeasureValue: "1.0", MeasureValueType: "DOUBLE",
+		Time: "1609459200000", TimeUnit: "MILLISECONDS", Version: 3,
+	}
+	_, err = b.WriteRecords("pr2-db", "pr2-tbl", []timestreamwrite.Record{existing})
+	require.NoError(t, err)
+
+	// Two records: one new (should pass), one conflicting (should fail).
+	records := []timestreamwrite.Record{
+		{
+			MeasureName: "load2", MeasureValue: "2.0", MeasureValueType: "DOUBLE",
+			Time: "1609459200001", TimeUnit: "MILLISECONDS", Version: 1,
+		},
+		existing, // same key, same version → rejected
+	}
+
+	_, err = b.WriteRecords("pr2-db", "pr2-tbl", records)
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	require.ErrorAs(t, err, &rejErr)
+	// Only the second record (index 1) should be rejected.
+	require.Len(t, rejErr.RejectedRecords, 1)
+	assert.Equal(t, 1, rejErr.RejectedRecords[0].RecordIndex)
+}
+
+// --- Gap 10: New records after upsert preserve dedup index ---
+
+// TestAccuracy_WriteRecordsUpsertAndNewRecord verifies that after a successful upsert,
+// subsequent writes to the same key require a further-incremented version.
+func TestAccuracy_WriteRecordsUpsertAndNewRecord(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("uan-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("uan-db", "uan-tbl", nil, nil)
+	require.NoError(t, err)
+
+	base := timestreamwrite.Record{
+		MeasureName: "ops", MeasureValue: "100", MeasureValueType: "BIGINT",
+		Time: "1609459200000", TimeUnit: "MILLISECONDS", Version: 1,
+	}
+
+	// First write.
+	_, err = b.WriteRecords("uan-db", "uan-tbl", []timestreamwrite.Record{base})
+	require.NoError(t, err)
+
+	// Upsert with higher version.
+	upserted := base
+	upserted.Version = 2
+	upserted.MeasureValue = "200"
+	_, err = b.WriteRecords("uan-db", "uan-tbl", []timestreamwrite.Record{upserted})
+	require.NoError(t, err)
+
+	// Now try with version 1 (lower than upserted version 2): should fail.
+	lower := base
+	lower.Version = 1
+	_, err = b.WriteRecords("uan-db", "uan-tbl", []timestreamwrite.Record{lower})
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	require.ErrorAs(t, err, &rejErr)
+	assert.Equal(t, int64(2), rejErr.RejectedRecords[0].ExistingVersion)
+}
+
+// --- Gap 11: BatchLoadTask Schema types ---
+
+// TestAccuracy_PartitionKeyTypes verifies the exported PartitionKeyType constants match AWS values.
+func TestAccuracy_PartitionKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "DIMENSION", timestreamwrite.PartitionKeyTypeDimension)
+	assert.Equal(t, "MEASURE", timestreamwrite.PartitionKeyTypeMeasure)
+	assert.Equal(t, "REQUIRED", timestreamwrite.PartitionKeyEnforcementRequired)
+	assert.Equal(t, "OPTIONAL", timestreamwrite.PartitionKeyEnforcementOptional)
+}
+
+// --- Gap 12: ErrRejectedRecords sentinel ---
+
+// TestAccuracy_ErrRejectedRecordsSentinel verifies errors.As matches RejectedRecordsError.
+func TestAccuracy_ErrRejectedRecordsSentinel(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("sentinel-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("sentinel-db", "sentinel-tbl", nil, nil)
+	require.NoError(t, err)
+
+	rec := timestreamwrite.Record{
+		MeasureName: "x", MeasureValue: "1", MeasureValueType: "DOUBLE",
+		Time: "1609459200000", TimeUnit: "MILLISECONDS", Version: 5,
+	}
+	_, err = b.WriteRecords("sentinel-db", "sentinel-tbl", []timestreamwrite.Record{rec})
+	require.NoError(t, err)
+
+	rec.Version = 1
+	_, err = b.WriteRecords("sentinel-db", "sentinel-tbl", []timestreamwrite.Record{rec})
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	assert.ErrorAs(t, err, &rejErr, "error should be detectable as *RejectedRecordsError")
+}
+
+// --- Gap 13: Snapshot/Restore round-trip with new fields ---
+
+// TestAccuracy_SnapshotRestorePreservesSchema verifies Schema survives snapshot/restore.
+func TestAccuracy_SnapshotRestorePreservesSchema(t *testing.T) {
+	t.Parallel()
+
+	b1 := timestreamwrite.NewInMemoryBackend()
+	_, err := b1.CreateDatabase("snap-schema-db", nil)
+	require.NoError(t, err)
+	_, err = b1.CreateTable("snap-schema-db", "snap-schema-tbl", nil, &timestreamwrite.CreateTableInput{
+		Schema: &timestreamwrite.Schema{
+			CompositePartitionKey: []timestreamwrite.PartitionKey{
+				{Type: "DIMENSION", Name: "az", EnforcementInRecord: "REQUIRED"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := b1.Snapshot()
+	require.NoError(t, err)
+
+	b2 := timestreamwrite.NewInMemoryBackend()
+	require.NoError(t, b2.Restore(data))
+
+	tbl, err := b2.DescribeTable("snap-schema-db", "snap-schema-tbl")
+	require.NoError(t, err)
+	require.NotNil(t, tbl.Schema)
+	require.Len(t, tbl.Schema.CompositePartitionKey, 1)
+	assert.Equal(t, "az", tbl.Schema.CompositePartitionKey[0].Name)
+}
+
+// TestAccuracy_SnapshotRestorePreservesMSRDL verifies MagneticStoreRejectedDataLocation
+// survives snapshot/restore.
+func TestAccuracy_SnapshotRestorePreservesMSRDL(t *testing.T) {
+	t.Parallel()
+
+	b1 := timestreamwrite.NewInMemoryBackend()
+	_, err := b1.CreateDatabase("snap-msrdl-db", nil)
+	require.NoError(t, err)
+	_, err = b1.CreateTable("snap-msrdl-db", "snap-msrdl-tbl", nil, &timestreamwrite.CreateTableInput{
+		MagneticStoreWriteProperties: &timestreamwrite.MagneticStoreWriteProperties{
+			EnableMagneticStoreWrites: true,
+			MagneticStoreRejectedDataLocation: &timestreamwrite.MagneticStoreRejectedDataLocation{
+				S3Configuration: &timestreamwrite.S3Configuration{
+					BucketName: "snap-bucket",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := b1.Snapshot()
+	require.NoError(t, err)
+
+	b2 := timestreamwrite.NewInMemoryBackend()
+	require.NoError(t, b2.Restore(data))
+
+	tbl, err := b2.DescribeTable("snap-msrdl-db", "snap-msrdl-tbl")
+	require.NoError(t, err)
+	require.NotNil(t, tbl.MagneticStoreWriteProperties)
+	require.NotNil(t, tbl.MagneticStoreWriteProperties.MagneticStoreRejectedDataLocation)
+	require.NotNil(t, tbl.MagneticStoreWriteProperties.MagneticStoreRejectedDataLocation.S3Configuration)
+	assert.Equal(t, "snap-bucket",
+		tbl.MagneticStoreWriteProperties.MagneticStoreRejectedDataLocation.S3Configuration.BucketName)
+}
+
+// TestAccuracy_SnapshotRestorePreservesRecordIndex verifies that after restore, the
+// version-based upsert index works correctly (version conflicts are detected).
+func TestAccuracy_SnapshotRestorePreservesRecordIndex(t *testing.T) {
+	t.Parallel()
+
+	b1 := timestreamwrite.NewInMemoryBackend()
+	_, err := b1.CreateDatabase("snap-idx-db", nil)
+	require.NoError(t, err)
+	_, err = b1.CreateTable("snap-idx-db", "snap-idx-tbl", nil, nil)
+	require.NoError(t, err)
+
+	rec := timestreamwrite.Record{
+		MeasureName: "metric", MeasureValue: "7", MeasureValueType: "BIGINT",
+		Time: "1609459200000", TimeUnit: "MILLISECONDS", Version: 4,
+	}
+	_, err = b1.WriteRecords("snap-idx-db", "snap-idx-tbl", []timestreamwrite.Record{rec})
+	require.NoError(t, err)
+
+	data, err := b1.Snapshot()
+	require.NoError(t, err)
+
+	b2 := timestreamwrite.NewInMemoryBackend()
+	require.NoError(t, b2.Restore(data))
+
+	// After restore, writing with lower version should be rejected.
+	rec.Version = 2
+	_, err = b2.WriteRecords("snap-idx-db", "snap-idx-tbl", []timestreamwrite.Record{rec})
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	require.ErrorAs(t, err, &rejErr)
+	assert.Equal(t, int64(4), rejErr.RejectedRecords[0].ExistingVersion)
+}
+
+// --- Gap 14: BatchLoadProgressReport in backend struct ---
+
+// TestAccuracy_BackendBatchLoadProgressReport verifies BatchLoadProgressReport
+// is stored and returned via DescribeBatchLoadTask.
+func TestAccuracy_BackendBatchLoadProgressReport(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	pr := &timestreamwrite.BatchLoadProgressReport{
+		RecordsProcessed: 500,
+		RecordsIngested:  480,
+	}
+	b.AddBatchLoadTaskInternal(&timestreamwrite.BatchLoadTask{
+		TaskID:             "prb-task",
+		TargetDatabaseName: "pr-db",
+		TargetTableName:    "pr-tbl",
+		TaskStatus:         timestreamwrite.BatchLoadStatusInProgress,
+		CreationTime:       time.Now(),
+		LastUpdatedTime:    time.Now(),
+		ProgressReport:     pr,
+	})
+
+	task, err := b.DescribeBatchLoadTask("prb-task")
+	require.NoError(t, err)
+	require.NotNil(t, task.ProgressReport)
+	assert.Equal(t, int64(500), task.ProgressReport.RecordsProcessed)
+	assert.Equal(t, int64(480), task.ProgressReport.RecordsIngested)
+}
+
+// --- Gap 15: WriteRecords DefaultVersion ---
+
+// TestAccuracy_WriteRecordsDefaultVersionIsOne verifies that records without an explicit
+// Version are treated as Version=1, and re-writing without Version is rejected.
+func TestAccuracy_WriteRecordsDefaultVersionIsOne(t *testing.T) {
+	t.Parallel()
+
+	b := timestreamwrite.NewInMemoryBackend()
+	_, err := b.CreateDatabase("dv-db", nil)
+	require.NoError(t, err)
+	_, err = b.CreateTable("dv-db", "dv-tbl", nil, nil)
+	require.NoError(t, err)
+
+	rec := timestreamwrite.Record{
+		MeasureName:      "metric",
+		MeasureValue:     "1",
+		MeasureValueType: "BIGINT",
+		Time:             "1609459200000",
+		TimeUnit:         "MILLISECONDS",
+		// No Version — defaults to 1
+	}
+
+	_, err = b.WriteRecords("dv-db", "dv-tbl", []timestreamwrite.Record{rec})
+	require.NoError(t, err)
+
+	// Writing same record again without version (still 0→1) should fail.
+	_, err = b.WriteRecords("dv-db", "dv-tbl", []timestreamwrite.Record{rec})
+	require.Error(t, err)
+
+	var rejErr *timestreamwrite.RejectedRecordsError
+	require.ErrorAs(t, err, &rejErr)
+	assert.Equal(t, int64(1), rejErr.RejectedRecords[0].ExistingVersion)
+}

--- a/services/timestreamwrite/persistence.go
+++ b/services/timestreamwrite/persistence.go
@@ -106,13 +106,21 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 
 	// Convert snapshot's flat record map back into per-table slots so that
 	// each table owns its own mutex and slice independent of the enclosing maps.
+	// Rebuild the dedup index from the restored records so that version-based
+	// upsert works correctly after restore.
 	b.records = make(map[string]map[string]*tableRecords, len(snap.Records))
 	for dbName, tblRecs := range snap.Records {
 		b.records[dbName] = make(map[string]*tableRecords, len(tblRecs))
 		for tblName, recs := range tblRecs {
+			idx := make(map[string]int, len(recs))
+			for i, r := range recs {
+				idx[recordKey(r)] = i
+			}
+
 			b.records[dbName][tblName] = &tableRecords{
-				mu:      lockmetrics.New("timestreamwrite.table"),
-				records: recs,
+				mu:          lockmetrics.New("timestreamwrite.table"),
+				records:     recs,
+				recordIndex: idx,
 			}
 		}
 	}
@@ -156,8 +164,11 @@ func (b *InMemoryBackend) ensureNonNilMapsFromSnapshot() {
 		for tblName := range tbls {
 			if b.records[dbName][tblName] == nil {
 				b.records[dbName][tblName] = &tableRecords{
-					mu: lockmetrics.New("timestreamwrite.table"),
+					mu:          lockmetrics.New("timestreamwrite.table"),
+					recordIndex: make(map[string]int),
 				}
+			} else if b.records[dbName][tblName].recordIndex == nil {
+				b.records[dbName][tblName].recordIndex = make(map[string]int)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Timestream Write AWS-accuracy audit addressing 15 gaps in the mock implementation.

**New types:**
- `Schema`, `PartitionKey` (DIMENSION/MEASURE), `PartitionKeyEnforcementLevel` — composite partition key support on tables
- `S3Configuration`, `MagneticStoreRejectedDataLocation` — rejected-record delivery config in `MagneticStoreWriteProperties`
- `MeasureValue` — MULTI-type record support in `WriteRecords`
- `BatchLoadProgressReport` — progress tracking on batch load tasks
- `RejectedRecord`, `RejectedRecordsError` — version-conflict error type returned by `WriteRecords`

**Behavioral fixes:**
- `WriteRecords` now implements version-based upsert per AWS spec: higher version replaces existing record; same or lower version returns `RejectedRecordsException` (400) with per-record `RejectedRecords` array in body
- `WriteRecords.CommonAttributes` merging: common dimensions merged into each record, record-specific values override common on conflict; scalar fields (MeasureName, Time, TimeUnit, Version) filled from common when omitted
- `ListDatabases`, `ListTables`, `ListBatchLoadTasks` now support `NextToken` + `MaxResults` pagination via `pkgs/page.New` (default 100 items/page)
- `Dimension.DimensionValueType` field stored and passed through

**Persistence:**
- `Restore` rebuilds `recordIndex` from stored records so version-based upsert works correctly after snapshot restore

## Test plan

- [x] `go test ./services/timestreamwrite/... -count=1` passes (43 new accuracy tests)
- [x] `golangci-lint run ./services/timestreamwrite/...` — 0 issues
- [x] `go vet ./services/timestreamwrite/...` — clean
- [x] Rebased on latest main

Closes #1851

🤖 Generated with [Claude Code](https://claude.com/claude-code)