### PR TITLE
fix(ci): Fix badges check timing flakes (go-3zef)

### DIFF
--- a/services/apigatewaymanagementapi/admin_test.go
+++ b/services/apigatewaymanagementapi/admin_test.go
@@ -268,8 +268,8 @@ func TestAdmin_Prune(t *testing.T) {
 	_, err := h.Backend.CreateConnection("old", "1.1.1.1", "ua")
 	require.NoError(t, err)
 
-	// Gap must be large enough to remain reliable on slow/contended CI runners.
-	time.Sleep(100 * time.Millisecond)
+	// Gap must exceed the prune threshold with enough margin for slow CI runners.
+	time.Sleep(500 * time.Millisecond)
 
 	_, err = h.Backend.CreateConnection("new", "2.2.2.2", "ua")
 	require.NoError(t, err)
@@ -278,7 +278,7 @@ func TestAdmin_Prune(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Len(t, h.Backend.ListConnections(), 2)
 
-	pruned := h.Backend.PruneIdle(50 * time.Millisecond)
+	pruned := h.Backend.PruneIdle(200 * time.Millisecond)
 	assert.Equal(t, []string{"old"}, pruned)
 	assert.Len(t, h.Backend.ListConnections(), 1)
 }

--- a/services/databrew/backend_test.go
+++ b/services/databrew/backend_test.go
@@ -498,12 +498,11 @@ func TestStartJobRun_TransitionsToSucceeded(t *testing.T) {
 	require.NoError(t, err)
 	_, err = b.StartJobRun("run-j2")
 	require.NoError(t, err)
-	// Wait for async transition.
-	time.Sleep(300 * time.Millisecond)
-	runs, err := b.ListJobRuns("run-j2")
-	require.NoError(t, err)
-	require.Len(t, runs, 1)
-	assert.Equal(t, "SUCCEEDED", runs[0].State)
+	// Poll for async state transition instead of fixed sleep.
+	require.Eventually(t, func() bool {
+		runs, err := b.ListJobRuns("run-j2")
+		return err == nil && len(runs) == 1 && runs[0].State == "SUCCEEDED"
+	}, 3*time.Second, 25*time.Millisecond)
 }
 
 func TestStartJobRun_JobNotFound(t *testing.T) {

--- a/services/databrew/backend_test.go
+++ b/services/databrew/backend_test.go
@@ -500,8 +500,9 @@ func TestStartJobRun_TransitionsToSucceeded(t *testing.T) {
 	require.NoError(t, err)
 	// Poll for async state transition instead of fixed sleep.
 	require.Eventually(t, func() bool {
-		runs, err := b.ListJobRuns("run-j2")
-		return err == nil && len(runs) == 1 && runs[0].State == "SUCCEEDED"
+		runs, e := b.ListJobRuns("run-j2")
+
+		return e == nil && len(runs) == 1 && runs[0].State == "SUCCEEDED"
 	}, 3*time.Second, 25*time.Millisecond)
 }
 


### PR DESCRIPTION
## Summary

Infrastructure fix for P0 blocker: badges check failing on main branch.

- **Issue**: go-3zef (badges check timing flakes)
- **Branch**: polecat/jasper/go-3zef
- **Fix**: Replace fixed sleeps with polling, increase margins for CI runners
- **Status**: Pre-verified, ready for merge once CI passes

---
*Created by Gas Town Refinery*