### PR TITLE
fix(ci): add git clean -fd before badges branch checkout (go-yz99)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
           git fetch origin badges || true
 
           if git show-ref --verify --quiet refs/remotes/origin/badges; then
+            git clean -fd
             git checkout badges
             NEW_BRANCH=false
           else


### PR DESCRIPTION
## Problem

`badges` job on `main.yml` fails with:

```
error: The following untracked working tree files would be overwritten by checkout
```

Previous steps generate untracked files (`coverage.out`, `.badges/*.svg`) that conflict with files tracked in the `badges` branch.

## Fix

Add `git clean -fd` before `git checkout badges`. Safe because badge SVGs are already copied to `/tmp/badges/` at line 58 before the checkout.

Note: different from #1890 (jasper's fix) — same symptom, different root cause location.

Fixes: go-yz99

🤖 Generated with [Claude Code](https://claude.com/claude-code)