### PR TITLE
fix(test): set PortRangeStart/End in TestMultipleServersStartupAndShutdown (go-98uo)

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -76,10 +76,12 @@ func startServerOnPort(t *testing.T, port int, demo bool, stopChan chan struct{}
 	defer cancel()
 
 	cli := CLI{
-		LogLevel: "info",
-		Port:     strconv.Itoa(port),
-		Region:   "us-east-1",
-		Demo:     demo,
+		LogLevel:       "info",
+		Port:           strconv.Itoa(port),
+		Region:         "us-east-1",
+		Demo:           demo,
+		PortRangeStart: 10000,
+		PortRangeEnd:   10100,
 	}
 
 	errChan := make(chan error, 1)


### PR DESCRIPTION
## Problem

`TestMultipleServersStartupAndShutdown` constructs `CLI{}` directly, bypassing kong's tag-based defaults. This leaves `PortRangeStart=0` and `PortRangeEnd=0`, causing `setupPortAllocator` to log a warning and return `nil`. Downstream code that relies on a non-nil port allocator then fails intermittently.

## Fix

Set `PortRangeStart: 10000, PortRangeEnd: 10100` explicitly in `startServerOnPort` — matching the kong `default` values that CLI parsing would normally apply.

## Verification

```
go test -count=20 -run TestMultipleServersStartupAndShutdown  →  20/20 PASS
```

Fixes: go-98uo

🤖 Generated with [Claude Code](https://claude.com/claude-code)