### PR TITLE
feat(codebuild): batch 1 — implement 38 stateful ops (go-nv48)

### DIFF
--- a/services/codebuild/backend.go
+++ b/services/codebuild/backend.go
@@ -57,6 +57,7 @@ type Project struct {
 	Arn          string             `json:"arn"`
 	Description  string             `json:"description,omitempty"`
 	ServiceRole  string             `json:"serviceRole,omitempty"`
+	Visibility   string             `json:"projectVisibility,omitempty"`
 	Environment  ProjectEnvironment `json:"environment"`
 	Created      float64            `json:"created,omitempty"`
 	LastModified float64            `json:"lastModified,omitempty"`
@@ -152,6 +153,27 @@ type Webhook struct {
 	BuildType    string `json:"buildType,omitempty"`
 }
 
+// SourceCredentials represents imported source credentials.
+type SourceCredentials struct {
+	Arn        string `json:"arn"`
+	ServerType string `json:"serverType"`
+	AuthType   string `json:"authType"`
+}
+
+// CodeCoverage represents a code coverage entry returned by DescribeCodeCoverages.
+type CodeCoverage struct {
+	FilePath       string  `json:"filePath,omitempty"`
+	BranchCoverage float64 `json:"branchCoverage,omitempty"`
+	LineCoverage   float64 `json:"lineCoverage,omitempty"`
+}
+
+// TestCase represents a test case entry returned by DescribeTestCases.
+type TestCase struct {
+	Name     string  `json:"name,omitempty"`
+	Status   string  `json:"status,omitempty"`
+	Duration float64 `json:"duration,omitempty"`
+}
+
 // InMemoryBackend is a thread-safe in-memory store for CodeBuild resources.
 type InMemoryBackend struct {
 	projects            map[string]*Project
@@ -168,6 +190,12 @@ type InMemoryBackend struct {
 	commandExecutions   map[string]*CommandExecution   // ID → CommandExecution
 	sandboxes           map[string]*Sandbox            // ID → Sandbox
 	webhooks            map[string]*Webhook            // projectName → Webhook
+	resourcePolicies    map[string]string              // ARN → policy JSON
+	sourceCredentials   map[string]*SourceCredentials  // ARN → creds
+	sandboxesByProject  map[string]map[string]struct{} // project name → sandbox ID set
+	batchesByProject    map[string]map[string]struct{} // project name → batch ID set
+	commandsBySandbox   map[string]map[string]struct{} // sandboxID → commandExecution ID set
+	reportsByGroup      map[string]map[string]struct{} // reportGroupARN → report ARN set
 	mu                  *lockmetrics.RWMutex
 	accountID           string
 	region              string
@@ -190,6 +218,12 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		commandExecutions:   make(map[string]*CommandExecution),
 		sandboxes:           make(map[string]*Sandbox),
 		webhooks:            make(map[string]*Webhook),
+		resourcePolicies:    make(map[string]string),
+		sourceCredentials:   make(map[string]*SourceCredentials),
+		sandboxesByProject:  make(map[string]map[string]struct{}),
+		batchesByProject:    make(map[string]map[string]struct{}),
+		commandsBySandbox:   make(map[string]map[string]struct{}),
+		reportsByGroup:      make(map[string]map[string]struct{}),
 		accountID:           accountID,
 		region:              region,
 		mu:                  lockmetrics.New("codebuild"),
@@ -218,6 +252,12 @@ func (b *InMemoryBackend) Reset() {
 	b.commandExecutions = make(map[string]*CommandExecution)
 	b.sandboxes = make(map[string]*Sandbox)
 	b.webhooks = make(map[string]*Webhook)
+	b.resourcePolicies = make(map[string]string)
+	b.sourceCredentials = make(map[string]*SourceCredentials)
+	b.sandboxesByProject = make(map[string]map[string]struct{})
+	b.batchesByProject = make(map[string]map[string]struct{})
+	b.commandsBySandbox = make(map[string]map[string]struct{})
+	b.reportsByGroup = make(map[string]map[string]struct{})
 }
 
 func (b *InMemoryBackend) buildProjectARN(name string) string {
@@ -845,6 +885,12 @@ func (b *InMemoryBackend) AddReportInternal(r *Report) {
 	defer b.mu.Unlock()
 
 	b.reports[r.Arn] = r
+	if r.ReportGroupArn != "" {
+		if b.reportsByGroup[r.ReportGroupArn] == nil {
+			b.reportsByGroup[r.ReportGroupArn] = make(map[string]struct{})
+		}
+		b.reportsByGroup[r.ReportGroupArn][r.Arn] = struct{}{}
+	}
 }
 
 // BatchGetReports returns reports by ARN. Missing ARNs are returned separately.
@@ -1036,6 +1082,11 @@ func (b *InMemoryBackend) StartBuildBatch(projectName string) (*BuildBatch, erro
 	}
 	b.buildBatches[id] = bb
 
+	if b.batchesByProject[projectName] == nil {
+		b.batchesByProject[projectName] = make(map[string]struct{})
+	}
+	b.batchesByProject[projectName][id] = struct{}{}
+
 	out := *bb
 
 	return &out, nil
@@ -1061,6 +1112,11 @@ func (b *InMemoryBackend) StartCommandExecution(sandboxID, command, execType str
 	_ = execType
 	b.commandExecutions[id] = ce
 
+	if b.commandsBySandbox[sandboxID] == nil {
+		b.commandsBySandbox[sandboxID] = make(map[string]struct{})
+	}
+	b.commandsBySandbox[sandboxID][id] = struct{}{}
+
 	out := *ce
 
 	return &out, nil
@@ -1083,9 +1139,443 @@ func (b *InMemoryBackend) StartSandbox(projectName string) (*Sandbox, error) {
 	}
 	b.sandboxes[id] = sb
 
+	if b.sandboxesByProject[projectName] == nil {
+		b.sandboxesByProject[projectName] = make(map[string]struct{})
+	}
+	b.sandboxesByProject[projectName][id] = struct{}{}
+
 	out := *sb
 
 	return &out, nil
+}
+
+// --- Webhook operations ---
+
+// --- Source Credentials operations ---
+
+// ImportSourceCredentials imports source credentials and returns the ARN.
+func (b *InMemoryBackend) ImportSourceCredentials(authType, serverType, token string) (string, error) {
+	b.mu.Lock("ImportSourceCredentials")
+	defer b.mu.Unlock()
+
+	_ = token
+	arnStr := "arn:aws:codebuild:" + b.region + ":" + b.accountID + ":token/" + serverType
+	b.sourceCredentials[arnStr] = &SourceCredentials{
+		Arn:        arnStr,
+		ServerType: serverType,
+		AuthType:   authType,
+	}
+
+	return arnStr, nil
+}
+
+// DeleteSourceCredentials removes source credentials by ARN.
+func (b *InMemoryBackend) DeleteSourceCredentials(arnStr string) error {
+	b.mu.Lock("DeleteSourceCredentials")
+	defer b.mu.Unlock()
+
+	if _, ok := b.sourceCredentials[arnStr]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.sourceCredentials, arnStr)
+
+	return nil
+}
+
+// ListSourceCredentials returns all stored source credentials.
+func (b *InMemoryBackend) ListSourceCredentials() []*SourceCredentials {
+	b.mu.RLock("ListSourceCredentials")
+	defer b.mu.RUnlock()
+
+	result := make([]*SourceCredentials, 0, len(b.sourceCredentials))
+	for _, sc := range b.sourceCredentials {
+		out := *sc
+		result = append(result, &out)
+	}
+
+	return result
+}
+
+// --- Resource Policy operations ---
+
+// PutResourcePolicy stores a resource policy for the given ARN.
+func (b *InMemoryBackend) PutResourcePolicy(resourceArn, policy string) error {
+	b.mu.Lock("PutResourcePolicy")
+	defer b.mu.Unlock()
+
+	b.resourcePolicies[resourceArn] = policy
+
+	return nil
+}
+
+// GetResourcePolicy returns the resource policy for the given ARN, or "{}" if not found.
+func (b *InMemoryBackend) GetResourcePolicy(resourceArn string) (string, error) {
+	b.mu.RLock("GetResourcePolicy")
+	defer b.mu.RUnlock()
+
+	if p, ok := b.resourcePolicies[resourceArn]; ok {
+		return p, nil
+	}
+
+	return "{}", nil
+}
+
+// DeleteResourcePolicy removes the resource policy for the given ARN (idempotent).
+func (b *InMemoryBackend) DeleteResourcePolicy(resourceArn string) error {
+	b.mu.Lock("DeleteResourcePolicy")
+	defer b.mu.Unlock()
+
+	delete(b.resourcePolicies, resourceArn)
+
+	return nil
+}
+
+// --- Extended Report operations ---
+
+// DeleteReport removes a report by ARN.
+func (b *InMemoryBackend) DeleteReport(arnStr string) error {
+	b.mu.Lock("DeleteReport")
+	defer b.mu.Unlock()
+
+	r, ok := b.reports[arnStr]
+	if !ok {
+		return ErrNotFound
+	}
+
+	if r.ReportGroupArn != "" {
+		if set, ok2 := b.reportsByGroup[r.ReportGroupArn]; ok2 {
+			delete(set, arnStr)
+		}
+	}
+
+	delete(b.reports, arnStr)
+
+	return nil
+}
+
+// ListReports returns all report ARNs in sorted order.
+func (b *InMemoryBackend) ListReports() []string {
+	b.mu.RLock("ListReports")
+	defer b.mu.RUnlock()
+
+	arns := make([]string, 0, len(b.reports))
+	for a := range b.reports {
+		arns = append(arns, a)
+	}
+
+	sort.Strings(arns)
+
+	return arns
+}
+
+// ListReportsForReportGroup returns all report ARNs for the given report group ARN.
+func (b *InMemoryBackend) ListReportsForReportGroup(reportGroupArn string) []string {
+	b.mu.RLock("ListReportsForReportGroup")
+	defer b.mu.RUnlock()
+
+	set := b.reportsByGroup[reportGroupArn]
+	arns := make([]string, 0, len(set))
+	for a := range set {
+		arns = append(arns, a)
+	}
+
+	sort.Strings(arns)
+
+	return arns
+}
+
+// --- Extended ReportGroup operations ---
+
+// DeleteReportGroup removes a report group by ARN.
+func (b *InMemoryBackend) DeleteReportGroup(arnStr string) error {
+	b.mu.Lock("DeleteReportGroup")
+	defer b.mu.Unlock()
+
+	name, ok := b.reportGroupARNIndex[arnStr]
+	if !ok {
+		return ErrNotFound
+	}
+
+	delete(b.reportGroups, name)
+	delete(b.reportGroupARNIndex, arnStr)
+
+	return nil
+}
+
+// UpdateReportGroup updates the export config of a report group.
+func (b *InMemoryBackend) UpdateReportGroup(arnStr string, exportConfig *ReportExportConfig) (*ReportGroup, error) {
+	b.mu.Lock("UpdateReportGroup")
+	defer b.mu.Unlock()
+
+	name, ok := b.reportGroupARNIndex[arnStr]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	rg := b.reportGroups[name]
+	if exportConfig != nil {
+		rg.ExportConfig = *exportConfig
+	}
+
+	rg.LastModified = float64(time.Now().Unix())
+	out := *rg
+
+	return &out, nil
+}
+
+// --- Extended Webhook operations ---
+
+// DeleteWebhook removes the webhook for a project.
+func (b *InMemoryBackend) DeleteWebhook(projectName string) error {
+	b.mu.Lock("DeleteWebhook")
+	defer b.mu.Unlock()
+
+	if _, ok := b.webhooks[projectName]; !ok {
+		return ErrNotFound
+	}
+
+	delete(b.webhooks, projectName)
+
+	return nil
+}
+
+// UpdateWebhook updates the branchFilter and buildType of an existing webhook.
+func (b *InMemoryBackend) UpdateWebhook(projectName, branchFilter, buildType string) (*Webhook, error) {
+	b.mu.Lock("UpdateWebhook")
+	defer b.mu.Unlock()
+
+	w, ok := b.webhooks[projectName]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	w.BranchFilter = branchFilter
+	w.BuildType = buildType
+	out := *w
+
+	return &out, nil
+}
+
+// --- Extended Fleet operations ---
+
+// UpdateFleet updates the base capacity of a fleet.
+func (b *InMemoryBackend) UpdateFleet(arnStr string, baseCapacity int32) (*Fleet, error) {
+	b.mu.Lock("UpdateFleet")
+	defer b.mu.Unlock()
+
+	name, ok := b.fleetARNIndex[arnStr]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	f := b.fleets[name]
+	f.BaseCapacity = baseCapacity
+	f.LastModified = float64(time.Now().Unix())
+	out := *f
+
+	return &out, nil
+}
+
+// --- Extended BuildBatch operations ---
+
+// RetryBuildBatch creates a new build batch with the same project as an existing one.
+func (b *InMemoryBackend) RetryBuildBatch(id string) (*BuildBatch, error) {
+	b.mu.Lock("RetryBuildBatch")
+	defer b.mu.Unlock()
+
+	existing, ok := b.buildBatches[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	projectName := existing.ProjectName
+	newID := projectName + ":" + uuid.NewString()
+	bb := &BuildBatch{
+		ID:               newID,
+		ProjectName:      projectName,
+		BuildBatchStatus: "IN_PROGRESS",
+		StartTime:        float64(time.Now().Unix()),
+	}
+	b.buildBatches[newID] = bb
+
+	if b.batchesByProject[projectName] == nil {
+		b.batchesByProject[projectName] = make(map[string]struct{})
+	}
+	b.batchesByProject[projectName][newID] = struct{}{}
+
+	out := *bb
+
+	return &out, nil
+}
+
+// StopBuildBatch marks a build batch as STOPPED.
+func (b *InMemoryBackend) StopBuildBatch(id string) (*BuildBatch, error) {
+	b.mu.Lock("StopBuildBatch")
+	defer b.mu.Unlock()
+
+	bb, ok := b.buildBatches[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	bb.BuildBatchStatus = "STOPPED"
+	out := *bb
+
+	return &out, nil
+}
+
+// ListBuildBatchesForProject returns all batch IDs for a project in sorted order.
+func (b *InMemoryBackend) ListBuildBatchesForProject(projectName string) ([]string, error) {
+	b.mu.RLock("ListBuildBatchesForProject")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.projects[projectName]; !ok {
+		return nil, ErrNotFound
+	}
+
+	set := b.batchesByProject[projectName]
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+
+	return ids, nil
+}
+
+// --- Extended Sandbox operations ---
+
+// StopSandbox marks a sandbox as STOPPED.
+func (b *InMemoryBackend) StopSandbox(id string) (*Sandbox, error) {
+	b.mu.Lock("StopSandbox")
+	defer b.mu.Unlock()
+
+	sb, ok := b.sandboxes[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	sb.Status = "STOPPED"
+	out := *sb
+
+	return &out, nil
+}
+
+// ListSandboxesForProject returns all sandbox IDs for a project in sorted order.
+func (b *InMemoryBackend) ListSandboxesForProject(projectName string) ([]string, error) {
+	b.mu.RLock("ListSandboxesForProject")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.projects[projectName]; !ok {
+		return nil, ErrNotFound
+	}
+
+	set := b.sandboxesByProject[projectName]
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+
+	return ids, nil
+}
+
+// --- Extended CommandExecution operations ---
+
+// ListCommandExecutionsForSandbox returns all command execution IDs for a sandbox in sorted order.
+func (b *InMemoryBackend) ListCommandExecutionsForSandbox(sandboxID string) ([]string, error) {
+	b.mu.RLock("ListCommandExecutionsForSandbox")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.sandboxes[sandboxID]; !ok {
+		return nil, ErrNotFound
+	}
+
+	set := b.commandsBySandbox[sandboxID]
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+
+	return ids, nil
+}
+
+// --- Extended Project operations ---
+
+// UpdateProjectVisibility sets the visibility of a project by ARN.
+func (b *InMemoryBackend) UpdateProjectVisibility(projectArn, visibility string) error {
+	b.mu.Lock("UpdateProjectVisibility")
+	defer b.mu.Unlock()
+
+	name, ok := b.projectARNIndex[projectArn]
+	if !ok {
+		return ErrNotFound
+	}
+
+	b.projects[name].Visibility = visibility
+
+	return nil
+}
+
+// InvalidateProjectCache is a no-op cache invalidation (returns ErrNotFound if project missing).
+func (b *InMemoryBackend) InvalidateProjectCache(projectName string) error {
+	b.mu.RLock("InvalidateProjectCache")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.projects[projectName]; !ok {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// --- Misc read-only operations ---
+
+// DescribeCodeCoverages returns an empty list (no state needed).
+func (b *InMemoryBackend) DescribeCodeCoverages(_ string) ([]CodeCoverage, error) {
+	return []CodeCoverage{}, nil
+}
+
+// DescribeTestCases returns an empty list (no state needed).
+func (b *InMemoryBackend) DescribeTestCases(_ string) ([]TestCase, error) {
+	return []TestCase{}, nil
+}
+
+// GetReportGroupTrend returns an empty stats map (no state needed).
+func (b *InMemoryBackend) GetReportGroupTrend(_ string) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+// ListSharedProjects returns an empty list (no shared projects in emulator).
+func (b *InMemoryBackend) ListSharedProjects() []string {
+	return []string{}
+}
+
+// ListSharedReportGroups returns an empty list (no shared report groups in emulator).
+func (b *InMemoryBackend) ListSharedReportGroups() []string {
+	return []string{}
+}
+
+// ListCuratedEnvironmentImages returns a minimal hardcoded list of curated images.
+func (b *InMemoryBackend) ListCuratedEnvironmentImages() []map[string]any {
+	return []map[string]any{
+		{
+			"platform": "UBUNTU",
+			"languages": []map[string]any{
+				{
+					"language": "PYTHON",
+					"images": []map[string]any{
+						{"name": "aws/codebuild/standard:7.0"},
+					},
+				},
+			},
+		},
+	}
 }
 
 // --- Webhook operations ---

--- a/services/codebuild/backend.go
+++ b/services/codebuild/backend.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	// buildStatusSucceeded is the terminal succeeded status for builds/batches.
-	buildStatusSucceeded = "SUCCEEDED"
+	buildStatusSucceeded  = "SUCCEEDED"
+	buildStatusInProgress = "IN_PROGRESS"
+	buildStatusStopped    = "STOPPED"
 )
 
 var (
@@ -443,7 +444,7 @@ func (b *InMemoryBackend) StartBuild(projectName string) (*Build, error) {
 		ID:           fullID,
 		Arn:          b.buildBuildARN(projectName, buildID),
 		ProjectName:  projectName,
-		BuildStatus:  "IN_PROGRESS",
+		BuildStatus:  buildStatusInProgress,
 		StartTime:    float64(time.Now().Unix()),
 		CurrentPhase: "SUBMITTED",
 	}
@@ -561,7 +562,7 @@ func (b *InMemoryBackend) RetryBuild(id string) (*Build, error) {
 		ID:           fullID,
 		Arn:          b.buildBuildARN(projectName, buildID),
 		ProjectName:  projectName,
-		BuildStatus:  "IN_PROGRESS",
+		BuildStatus:  buildStatusInProgress,
 		StartTime:    float64(time.Now().Unix()),
 		CurrentPhase: "SUBMITTED",
 	}
@@ -1394,7 +1395,7 @@ func (b *InMemoryBackend) RetryBuildBatch(id string) (*BuildBatch, error) {
 	bb := &BuildBatch{
 		ID:               newID,
 		ProjectName:      projectName,
-		BuildBatchStatus: "IN_PROGRESS",
+		BuildBatchStatus: buildStatusInProgress,
 		StartTime:        float64(time.Now().Unix()),
 	}
 	b.buildBatches[newID] = bb
@@ -1419,7 +1420,7 @@ func (b *InMemoryBackend) StopBuildBatch(id string) (*BuildBatch, error) {
 		return nil, ErrNotFound
 	}
 
-	bb.BuildBatchStatus = "STOPPED"
+	bb.BuildBatchStatus = buildStatusStopped
 	out := *bb
 
 	return &out, nil
@@ -1457,7 +1458,7 @@ func (b *InMemoryBackend) StopSandbox(id string) (*Sandbox, error) {
 		return nil, ErrNotFound
 	}
 
-	sb.Status = "STOPPED"
+	sb.Status = buildStatusStopped
 	out := *sb
 
 	return &out, nil

--- a/services/codebuild/codebuild_ops_test.go
+++ b/services/codebuild/codebuild_ops_test.go
@@ -1,0 +1,968 @@
+package codebuild_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/codebuild"
+)
+
+// helpers
+
+func createTestProject(t *testing.T, h *codebuild.Handler, name string) {
+	t.Helper()
+
+	rec := doRequest(t, h, "CreateProject", map[string]any{
+		"name":      name,
+		"source":    map[string]any{"type": "NO_SOURCE"},
+		"artifacts": map[string]any{"type": "NO_ARTIFACTS"},
+		"environment": map[string]any{
+			"type":        "LINUX_CONTAINER",
+			"image":       "aws/codebuild/standard:5.0",
+			"computeType": "BUILD_GENERAL1_SMALL",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func projectARN(t *testing.T, h *codebuild.Handler, name string) string {
+	t.Helper()
+
+	rec := doRequest(t, h, "BatchGetProjects", map[string]any{"names": []string{name}})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Projects []struct {
+			Arn string `json:"arn"`
+		} `json:"projects"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	require.NotEmpty(t, out.Projects)
+
+	return out.Projects[0].Arn
+}
+
+// TestCodeBuild_SourceCredentials covers Import, List, Delete.
+func TestCodeBuild_SourceCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("import_returns_arn", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ImportSourceCredentials", map[string]any{
+			"authType":   "PERSONAL_ACCESS_TOKEN",
+			"serverType": "GITHUB",
+			"token":      "my-token",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Arn string `json:"arn"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Contains(t, out.Arn, "GITHUB")
+	})
+
+	t.Run("import_missing_token", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ImportSourceCredentials", map[string]any{
+			"authType":   "PERSONAL_ACCESS_TOKEN",
+			"serverType": "GITHUB",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("list_after_import", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		doRequest(t, h, "ImportSourceCredentials", map[string]any{
+			"authType":   "PERSONAL_ACCESS_TOKEN",
+			"serverType": "BITBUCKET",
+			"token":      "tok",
+		})
+
+		rec := doRequest(t, h, "ListSourceCredentials", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			SourceCredentialsInfos []map[string]any `json:"sourceCredentialsInfos"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		require.Len(t, out.SourceCredentialsInfos, 1)
+		assert.Equal(t, "BITBUCKET", out.SourceCredentialsInfos[0]["serverType"])
+		assert.Equal(t, "PERSONAL_ACCESS_TOKEN", out.SourceCredentialsInfos[0]["authType"])
+	})
+
+	t.Run("delete_existing", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		importRec := doRequest(t, h, "ImportSourceCredentials", map[string]any{
+			"authType":   "PERSONAL_ACCESS_TOKEN",
+			"serverType": "GITHUB",
+			"token":      "tok",
+		})
+		require.Equal(t, http.StatusOK, importRec.Code)
+
+		var importOut struct {
+			Arn string `json:"arn"`
+		}
+		require.NoError(t, json.NewDecoder(importRec.Body).Decode(&importOut))
+
+		delRec := doRequest(t, h, "DeleteSourceCredentials", map[string]any{"arn": importOut.Arn})
+		assert.Equal(t, http.StatusOK, delRec.Code)
+
+		// Verify gone.
+		listRec := doRequest(t, h, "ListSourceCredentials", nil)
+		var listOut struct {
+			SourceCredentialsInfos []map[string]any `json:"sourceCredentialsInfos"`
+		}
+		require.NoError(t, json.NewDecoder(listRec.Body).Decode(&listOut))
+		assert.Empty(t, listOut.SourceCredentialsInfos)
+	})
+
+	t.Run("delete_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DeleteSourceCredentials", map[string]any{
+			"arn": "arn:aws:codebuild:us-east-1:000000000000:token/GHOST",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("delete_missing_arn", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DeleteSourceCredentials", map[string]any{})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_ResourcePolicy covers Put, Get, Delete.
+func TestCodeBuild_ResourcePolicy(t *testing.T) {
+	t.Parallel()
+
+	const resArn = "arn:aws:codebuild:us-east-1:000000000000:report-group/my-rg"
+	const policy = `{"Version":"2012-10-17"}`
+
+	t.Run("put_and_get", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+
+		putRec := doRequest(t, h, "PutResourcePolicy", map[string]any{
+			"resourceArn": resArn,
+			"policy":      policy,
+		})
+		require.Equal(t, http.StatusOK, putRec.Code)
+
+		var putOut struct {
+			ResourceArn string `json:"resourceArn"`
+		}
+		require.NoError(t, json.NewDecoder(putRec.Body).Decode(&putOut))
+		assert.Equal(t, resArn, putOut.ResourceArn)
+
+		getRec := doRequest(t, h, "GetResourcePolicy", map[string]any{"resourceArn": resArn})
+		require.Equal(t, http.StatusOK, getRec.Code)
+
+		var getOut struct {
+			Policy string `json:"policy"`
+		}
+		require.NoError(t, json.NewDecoder(getRec.Body).Decode(&getOut))
+		assert.JSONEq(t, policy, getOut.Policy)
+	})
+
+	t.Run("get_missing_returns_empty_json", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "GetResourcePolicy", map[string]any{
+			"resourceArn": "arn:aws:codebuild:us-east-1:000000000000:report-group/ghost",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Policy string `json:"policy"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Equal(t, "{}", out.Policy)
+	})
+
+	t.Run("delete_idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		doRequest(t, h, "PutResourcePolicy", map[string]any{
+			"resourceArn": resArn,
+			"policy":      policy,
+		})
+
+		del1 := doRequest(t, h, "DeleteResourcePolicy", map[string]any{"resourceArn": resArn})
+		assert.Equal(t, http.StatusOK, del1.Code)
+
+		del2 := doRequest(t, h, "DeleteResourcePolicy", map[string]any{"resourceArn": resArn})
+		assert.Equal(t, http.StatusOK, del2.Code)
+
+		// Policy should now return default.
+		getRec := doRequest(t, h, "GetResourcePolicy", map[string]any{"resourceArn": resArn})
+		var out struct {
+			Policy string `json:"policy"`
+		}
+		require.NoError(t, json.NewDecoder(getRec.Body).Decode(&out))
+		assert.Equal(t, "{}", out.Policy)
+	})
+
+	t.Run("put_missing_fields", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "PutResourcePolicy", map[string]any{"resourceArn": resArn})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("get_missing_resource_arn", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "GetResourcePolicy", map[string]any{})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_Reports covers DeleteReport, ListReports, ListReportsForReportGroup.
+func TestCodeBuild_Reports(t *testing.T) {
+	t.Parallel()
+
+	t.Run("list_reports_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListReports", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Reports []string `json:"reports"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Empty(t, out.Reports)
+	})
+
+	t.Run("list_reports_after_seed", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		h.Backend.AddReportInternal(&codebuild.Report{
+			Arn:    "arn:aws:codebuild:us-east-1:000000000000:report/rg1:r1",
+			Status: "SUCCEEDED",
+		})
+		h.Backend.AddReportInternal(&codebuild.Report{
+			Arn:    "arn:aws:codebuild:us-east-1:000000000000:report/rg1:r2",
+			Status: "FAILED",
+		})
+
+		rec := doRequest(t, h, "ListReports", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Reports []string `json:"reports"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Len(t, out.Reports, 2)
+	})
+
+	t.Run("delete_report", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		reportArn := "arn:aws:codebuild:us-east-1:000000000000:report/rg1:del1"
+		h.Backend.AddReportInternal(&codebuild.Report{
+			Arn:    reportArn,
+			Status: "SUCCEEDED",
+		})
+
+		delRec := doRequest(t, h, "DeleteReport", map[string]any{"arn": reportArn})
+		assert.Equal(t, http.StatusOK, delRec.Code)
+
+		// Verify gone.
+		listRec := doRequest(t, h, "ListReports", nil)
+		var out struct {
+			Reports []string `json:"reports"`
+		}
+		require.NoError(t, json.NewDecoder(listRec.Body).Decode(&out))
+		assert.Empty(t, out.Reports)
+	})
+
+	t.Run("delete_report_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DeleteReport", map[string]any{
+			"arn": "arn:aws:codebuild:us-east-1:000000000000:report/rg1:ghost",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("list_reports_for_report_group", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rgArn := "arn:aws:codebuild:us-east-1:000000000000:report-group/my-rg"
+
+		h.Backend.AddReportInternal(&codebuild.Report{
+			Arn:            "arn:aws:codebuild:us-east-1:000000000000:report/my-rg:r1",
+			ReportGroupArn: rgArn,
+			Status:         "SUCCEEDED",
+		})
+		h.Backend.AddReportInternal(&codebuild.Report{
+			Arn:            "arn:aws:codebuild:us-east-1:000000000000:report/my-rg:r2",
+			ReportGroupArn: rgArn,
+			Status:         "FAILED",
+		})
+		// Different group.
+		h.Backend.AddReportInternal(&codebuild.Report{
+			Arn:            "arn:aws:codebuild:us-east-1:000000000000:report/other-rg:r1",
+			ReportGroupArn: "arn:aws:codebuild:us-east-1:000000000000:report-group/other-rg",
+			Status:         "SUCCEEDED",
+		})
+
+		rec := doRequest(t, h, "ListReportsForReportGroup", map[string]any{
+			"reportGroupArn": rgArn,
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Reports []string `json:"reports"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Len(t, out.Reports, 2)
+		for _, r := range out.Reports {
+			assert.Contains(t, r, "my-rg")
+		}
+	})
+}
+
+// TestCodeBuild_ReportGroups covers DeleteReportGroup, UpdateReportGroup.
+func TestCodeBuild_ReportGroups(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delete_report_group", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createRec := doRequest(t, h, "CreateReportGroup", map[string]any{
+			"name": "rg-to-delete",
+			"type": "TEST",
+		})
+		require.Equal(t, http.StatusOK, createRec.Code)
+
+		var createOut struct {
+			ReportGroup struct {
+				Arn string `json:"arn"`
+			} `json:"reportGroup"`
+		}
+		require.NoError(t, json.NewDecoder(createRec.Body).Decode(&createOut))
+		rgArn := createOut.ReportGroup.Arn
+
+		delRec := doRequest(t, h, "DeleteReportGroup", map[string]any{"arn": rgArn})
+		assert.Equal(t, http.StatusOK, delRec.Code)
+
+		// Verify gone.
+		batchRec := doRequest(t, h, "BatchGetReportGroups", map[string]any{
+			"reportGroupArns": []string{rgArn},
+		})
+		var batchOut struct {
+			ReportGroupsNotFound []string `json:"reportGroupsNotFound"`
+		}
+		require.NoError(t, json.NewDecoder(batchRec.Body).Decode(&batchOut))
+		assert.Len(t, batchOut.ReportGroupsNotFound, 1)
+	})
+
+	t.Run("delete_report_group_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DeleteReportGroup", map[string]any{
+			"arn": "arn:aws:codebuild:us-east-1:000000000000:report-group/ghost",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("update_report_group", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createRec := doRequest(t, h, "CreateReportGroup", map[string]any{
+			"name": "rg-to-update",
+			"type": "TEST",
+			"exportConfig": map[string]any{
+				"exportConfigType": "NO_EXPORT",
+			},
+		})
+		require.Equal(t, http.StatusOK, createRec.Code)
+
+		var createOut struct {
+			ReportGroup struct {
+				Arn string `json:"arn"`
+			} `json:"reportGroup"`
+		}
+		require.NoError(t, json.NewDecoder(createRec.Body).Decode(&createOut))
+		rgArn := createOut.ReportGroup.Arn
+
+		updateRec := doRequest(t, h, "UpdateReportGroup", map[string]any{
+			"arn": rgArn,
+			"exportConfig": map[string]any{
+				"exportConfigType": "S3",
+			},
+		})
+		require.Equal(t, http.StatusOK, updateRec.Code)
+
+		var updateOut struct {
+			ReportGroup struct {
+				ExportConfig struct {
+					ExportConfigType string `json:"exportConfigType"`
+				} `json:"exportConfig"`
+			} `json:"reportGroup"`
+		}
+		require.NoError(t, json.NewDecoder(updateRec.Body).Decode(&updateOut))
+		assert.Equal(t, "S3", updateOut.ReportGroup.ExportConfig.ExportConfigType)
+	})
+
+	t.Run("update_report_group_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "UpdateReportGroup", map[string]any{
+			"arn": "arn:aws:codebuild:us-east-1:000000000000:report-group/ghost",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_Webhooks covers DeleteWebhook, UpdateWebhook.
+func TestCodeBuild_Webhooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delete_webhook", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "wh-del-proj")
+		doRequest(t, h, "CreateWebhook", map[string]any{
+			"projectName":  "wh-del-proj",
+			"branchFilter": "main",
+		})
+
+		delRec := doRequest(t, h, "DeleteWebhook", map[string]any{"projectName": "wh-del-proj"})
+		assert.Equal(t, http.StatusOK, delRec.Code)
+	})
+
+	t.Run("delete_webhook_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DeleteWebhook", map[string]any{"projectName": "ghost-proj"})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("update_webhook", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "wh-upd-proj")
+		doRequest(t, h, "CreateWebhook", map[string]any{
+			"projectName":  "wh-upd-proj",
+			"branchFilter": "main",
+			"buildType":    "BUILD",
+		})
+
+		updRec := doRequest(t, h, "UpdateWebhook", map[string]any{
+			"projectName":  "wh-upd-proj",
+			"branchFilter": "develop",
+			"buildType":    "BUILD_BATCH",
+		})
+		require.Equal(t, http.StatusOK, updRec.Code)
+
+		var out struct {
+			Webhook struct {
+				BranchFilter string `json:"branchFilter"`
+				BuildType    string `json:"buildType"`
+			} `json:"webhook"`
+		}
+		require.NoError(t, json.NewDecoder(updRec.Body).Decode(&out))
+		assert.Equal(t, "develop", out.Webhook.BranchFilter)
+		assert.Equal(t, "BUILD_BATCH", out.Webhook.BuildType)
+	})
+
+	t.Run("update_webhook_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "UpdateWebhook", map[string]any{
+			"projectName":  "ghost-proj",
+			"branchFilter": "main",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_Fleet covers UpdateFleet.
+func TestCodeBuild_Fleet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("update_fleet", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createRec := doRequest(t, h, "CreateFleet", map[string]any{
+			"name":         "upd-fleet",
+			"baseCapacity": 2,
+		})
+		require.Equal(t, http.StatusOK, createRec.Code)
+
+		var createOut struct {
+			Fleet struct {
+				Arn          string `json:"arn"`
+				BaseCapacity int    `json:"baseCapacity"`
+			} `json:"fleet"`
+		}
+		require.NoError(t, json.NewDecoder(createRec.Body).Decode(&createOut))
+		fleetArn := createOut.Fleet.Arn
+
+		updRec := doRequest(t, h, "UpdateFleet", map[string]any{
+			"arn":          fleetArn,
+			"baseCapacity": 5,
+		})
+		require.Equal(t, http.StatusOK, updRec.Code)
+
+		var updOut struct {
+			Fleet struct {
+				BaseCapacity int `json:"baseCapacity"`
+			} `json:"fleet"`
+		}
+		require.NoError(t, json.NewDecoder(updRec.Body).Decode(&updOut))
+		assert.Equal(t, 5, updOut.Fleet.BaseCapacity)
+	})
+
+	t.Run("update_fleet_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "UpdateFleet", map[string]any{
+			"arn":          "arn:aws:codebuild:us-east-1:000000000000:fleet/ghost",
+			"baseCapacity": 1,
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_BuildBatch covers RetryBuildBatch, StopBuildBatch, ListBuildBatchesForProject.
+func TestCodeBuild_BuildBatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stop_build_batch", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "batch-proj")
+
+		startRec := doRequest(t, h, "StartBuildBatch", map[string]any{"projectName": "batch-proj"})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		var startOut struct {
+			BuildBatch struct {
+				ID string `json:"id"`
+			} `json:"buildBatch"`
+		}
+		require.NoError(t, json.NewDecoder(startRec.Body).Decode(&startOut))
+		batchID := startOut.BuildBatch.ID
+
+		stopRec := doRequest(t, h, "StopBuildBatch", map[string]any{"id": batchID})
+		require.Equal(t, http.StatusOK, stopRec.Code)
+
+		var stopOut struct {
+			BuildBatch struct {
+				BuildBatchStatus string `json:"buildBatchStatus"`
+			} `json:"buildBatch"`
+		}
+		require.NoError(t, json.NewDecoder(stopRec.Body).Decode(&stopOut))
+		assert.Equal(t, "STOPPED", stopOut.BuildBatch.BuildBatchStatus)
+	})
+
+	t.Run("stop_build_batch_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "StopBuildBatch", map[string]any{"id": "ghost-proj:ghost-batch"})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("retry_build_batch", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "batch-retry-proj")
+
+		startRec := doRequest(t, h, "StartBuildBatch", map[string]any{"projectName": "batch-retry-proj"})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		var startOut struct {
+			BuildBatch struct {
+				ID string `json:"id"`
+			} `json:"buildBatch"`
+		}
+		require.NoError(t, json.NewDecoder(startRec.Body).Decode(&startOut))
+		batchID := startOut.BuildBatch.ID
+
+		retryRec := doRequest(t, h, "RetryBuildBatch", map[string]any{"id": batchID})
+		require.Equal(t, http.StatusOK, retryRec.Code)
+
+		var retryOut struct {
+			BuildBatch struct {
+				ID               string `json:"id"`
+				BuildBatchStatus string `json:"buildBatchStatus"`
+				ProjectName      string `json:"projectName"`
+			} `json:"buildBatch"`
+		}
+		require.NoError(t, json.NewDecoder(retryRec.Body).Decode(&retryOut))
+		assert.NotEqual(t, batchID, retryOut.BuildBatch.ID)
+		assert.Equal(t, "IN_PROGRESS", retryOut.BuildBatch.BuildBatchStatus)
+		assert.Equal(t, "batch-retry-proj", retryOut.BuildBatch.ProjectName)
+	})
+
+	t.Run("retry_build_batch_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "RetryBuildBatch", map[string]any{"id": "ghost-proj:ghost"})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("list_build_batches_for_project", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "batch-list-proj")
+
+		// Start 2 batches.
+		doRequest(t, h, "StartBuildBatch", map[string]any{"projectName": "batch-list-proj"})
+		doRequest(t, h, "StartBuildBatch", map[string]any{"projectName": "batch-list-proj"})
+
+		listRec := doRequest(t, h, "ListBuildBatchesForProject", map[string]any{
+			"projectName": "batch-list-proj",
+		})
+		require.Equal(t, http.StatusOK, listRec.Code)
+
+		var out struct {
+			IDs []string `json:"ids"`
+		}
+		require.NoError(t, json.NewDecoder(listRec.Body).Decode(&out))
+		assert.Len(t, out.IDs, 2)
+	})
+
+	t.Run("list_build_batches_for_project_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListBuildBatchesForProject", map[string]any{
+			"projectName": "ghost-proj",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_Sandbox covers StopSandbox, ListSandboxesForProject, ListCommandExecutionsForSandbox.
+func TestCodeBuild_Sandbox(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stop_sandbox", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "sandbox-proj")
+
+		startRec := doRequest(t, h, "StartSandbox", map[string]any{"projectName": "sandbox-proj"})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		var startOut struct {
+			Sandbox struct {
+				ID string `json:"id"`
+			} `json:"sandbox"`
+		}
+		require.NoError(t, json.NewDecoder(startRec.Body).Decode(&startOut))
+		sandboxID := startOut.Sandbox.ID
+
+		stopRec := doRequest(t, h, "StopSandbox", map[string]any{"id": sandboxID})
+		require.Equal(t, http.StatusOK, stopRec.Code)
+
+		var stopOut struct {
+			Sandbox struct {
+				Status string `json:"status"`
+			} `json:"sandbox"`
+		}
+		require.NoError(t, json.NewDecoder(stopRec.Body).Decode(&stopOut))
+		assert.Equal(t, "STOPPED", stopOut.Sandbox.Status)
+	})
+
+	t.Run("stop_sandbox_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "StopSandbox", map[string]any{"id": "ghost-sandbox"})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("list_sandboxes_for_project", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "sandbox-list-proj")
+
+		doRequest(t, h, "StartSandbox", map[string]any{"projectName": "sandbox-list-proj"})
+		doRequest(t, h, "StartSandbox", map[string]any{"projectName": "sandbox-list-proj"})
+
+		listRec := doRequest(t, h, "ListSandboxesForProject", map[string]any{
+			"projectName": "sandbox-list-proj",
+		})
+		require.Equal(t, http.StatusOK, listRec.Code)
+
+		var out struct {
+			IDs []string `json:"ids"`
+		}
+		require.NoError(t, json.NewDecoder(listRec.Body).Decode(&out))
+		assert.Len(t, out.IDs, 2)
+	})
+
+	t.Run("list_sandboxes_for_project_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListSandboxesForProject", map[string]any{
+			"projectName": "ghost-proj",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("list_command_executions_for_sandbox", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "ce-proj")
+
+		startRec := doRequest(t, h, "StartSandbox", map[string]any{"projectName": "ce-proj"})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		var startOut struct {
+			Sandbox struct {
+				ID string `json:"id"`
+			} `json:"sandbox"`
+		}
+		require.NoError(t, json.NewDecoder(startRec.Body).Decode(&startOut))
+		sandboxID := startOut.Sandbox.ID
+
+		doRequest(t, h, "StartCommandExecution", map[string]any{
+			"sandboxId": sandboxID,
+			"command":   "echo hello",
+			"type":      "COMMAND",
+		})
+		doRequest(t, h, "StartCommandExecution", map[string]any{
+			"sandboxId": sandboxID,
+			"command":   "echo world",
+			"type":      "COMMAND",
+		})
+
+		listRec := doRequest(t, h, "ListCommandExecutionsForSandbox", map[string]any{
+			"sandboxId": sandboxID,
+		})
+		require.Equal(t, http.StatusOK, listRec.Code)
+
+		var out struct {
+			CommandExecutions []string `json:"commandExecutions"`
+		}
+		require.NoError(t, json.NewDecoder(listRec.Body).Decode(&out))
+		assert.Len(t, out.CommandExecutions, 2)
+	})
+
+	t.Run("list_command_executions_for_sandbox_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListCommandExecutionsForSandbox", map[string]any{
+			"sandboxId": "ghost-sandbox",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_Project covers UpdateProjectVisibility, InvalidateProjectCache.
+func TestCodeBuild_Project(t *testing.T) {
+	t.Parallel()
+
+	t.Run("update_project_visibility", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "vis-proj")
+		arn := projectARN(t, h, "vis-proj")
+
+		rec := doRequest(t, h, "UpdateProjectVisibility", map[string]any{
+			"projectArn":        arn,
+			"projectVisibility": "PUBLIC_READ",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			ProjectArn        string `json:"projectArn"`
+			ProjectVisibility string `json:"projectVisibility"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Equal(t, arn, out.ProjectArn)
+		assert.Equal(t, "PUBLIC_READ", out.ProjectVisibility)
+	})
+
+	t.Run("update_project_visibility_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "UpdateProjectVisibility", map[string]any{
+			"projectArn":        "arn:aws:codebuild:us-east-1:000000000000:project/ghost",
+			"projectVisibility": "PRIVATE",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("update_project_visibility_missing_arn", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "UpdateProjectVisibility", map[string]any{
+			"projectVisibility": "PRIVATE",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("invalidate_project_cache", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestProject(t, h, "cache-proj")
+
+		rec := doRequest(t, h, "InvalidateProjectCache", map[string]any{"projectName": "cache-proj"})
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("invalidate_project_cache_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "InvalidateProjectCache", map[string]any{"projectName": "ghost-proj"})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// TestCodeBuild_Misc covers DescribeCodeCoverages, DescribeTestCases, GetReportGroupTrend,
+// ListSharedProjects, ListSharedReportGroups, ListCuratedEnvironmentImages.
+func TestCodeBuild_Misc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("describe_code_coverages_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DescribeCodeCoverages", map[string]any{
+			"reportArn": "arn:aws:codebuild:us-east-1:000000000000:report/rg:r1",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			CodeCoverages []any `json:"codeCoverages"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Empty(t, out.CodeCoverages)
+	})
+
+	t.Run("describe_test_cases_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "DescribeTestCases", map[string]any{
+			"reportArn": "arn:aws:codebuild:us-east-1:000000000000:report/rg:r1",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			TestCases []any `json:"testCases"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Empty(t, out.TestCases)
+	})
+
+	t.Run("get_report_group_trend_returns_empty_stats", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "GetReportGroupTrend", map[string]any{
+			"reportGroupArn": "arn:aws:codebuild:us-east-1:000000000000:report-group/rg",
+			"trendField":     "PASS_RATE",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Stats map[string]any `json:"stats"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.NotNil(t, out.Stats)
+	})
+
+	t.Run("list_shared_projects_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListSharedProjects", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Projects []string `json:"projects"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Empty(t, out.Projects)
+	})
+
+	t.Run("list_shared_report_groups_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListSharedReportGroups", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			ReportGroups []string `json:"reportGroups"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		assert.Empty(t, out.ReportGroups)
+	})
+
+	t.Run("list_curated_environment_images_returns_platforms", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "ListCuratedEnvironmentImages", nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Platforms []map[string]any `json:"platforms"`
+		}
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+		require.NotEmpty(t, out.Platforms)
+		assert.Equal(t, "UBUNTU", out.Platforms[0]["platform"])
+	})
+}

--- a/services/codebuild/handler.go
+++ b/services/codebuild/handler.go
@@ -952,6 +952,8 @@ func (h *Handler) handleDeleteResourcePolicy(
 		return nil, fmt.Errorf("%w: resourceArn is required", errInvalidRequest)
 	}
 
+	_ = h.Backend.DeleteResourcePolicy(in.ResourceArn)
+
 	return &deleteResourcePolicyOutput{}, nil
 }
 
@@ -971,6 +973,10 @@ func (h *Handler) handleDeleteSourceCredentials(
 		return nil, fmt.Errorf("%w: arn is required", errInvalidRequest)
 	}
 
+	if err := h.Backend.DeleteSourceCredentials(in.Arn); err != nil {
+		return nil, err
+	}
+
 	return &deleteSourceCredentialsOutput{Arn: in.Arn}, nil
 }
 
@@ -983,6 +989,10 @@ type deleteWebhookOutput struct{}
 func (h *Handler) handleDeleteWebhook(_ context.Context, in *deleteWebhookInput) (*deleteWebhookOutput, error) {
 	if in.ProjectName == "" {
 		return nil, fmt.Errorf("%w: projectName is required", errInvalidRequest)
+	}
+
+	if err := h.Backend.DeleteWebhook(in.ProjectName); err != nil {
+		return nil, err
 	}
 
 	return &deleteWebhookOutput{}, nil
@@ -998,9 +1008,23 @@ type describeCodeCoveragesOutput struct {
 
 func (h *Handler) handleDescribeCodeCoverages(
 	_ context.Context,
-	_ *describeCodeCoveragesInput,
+	in *describeCodeCoveragesInput,
 ) (*describeCodeCoveragesOutput, error) {
-	return &describeCodeCoveragesOutput{CodeCoverages: []map[string]any{}}, nil
+	coverages, err := h.Backend.DescribeCodeCoverages(in.ReportArn)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]any, 0, len(coverages))
+	for _, c := range coverages {
+		result = append(result, map[string]any{
+			"filePath":       c.FilePath,
+			"branchCoverage": c.BranchCoverage,
+			"lineCoverage":   c.LineCoverage,
+		})
+	}
+
+	return &describeCodeCoveragesOutput{CodeCoverages: result}, nil
 }
 
 type describeTestCasesInput struct {
@@ -1013,9 +1037,23 @@ type describeTestCasesOutput struct {
 
 func (h *Handler) handleDescribeTestCases(
 	_ context.Context,
-	_ *describeTestCasesInput,
+	in *describeTestCasesInput,
 ) (*describeTestCasesOutput, error) {
-	return &describeTestCasesOutput{TestCases: []map[string]any{}}, nil
+	cases, err := h.Backend.DescribeTestCases(in.ReportArn)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]any, 0, len(cases))
+	for _, tc := range cases {
+		result = append(result, map[string]any{
+			"name":     tc.Name,
+			"status":   tc.Status,
+			"duration": tc.Duration,
+		})
+	}
+
+	return &describeTestCasesOutput{TestCases: result}, nil
 }
 
 type getReportGroupTrendInput struct {
@@ -1029,9 +1067,14 @@ type getReportGroupTrendOutput struct {
 
 func (h *Handler) handleGetReportGroupTrend(
 	_ context.Context,
-	_ *getReportGroupTrendInput,
+	in *getReportGroupTrendInput,
 ) (*getReportGroupTrendOutput, error) {
-	return &getReportGroupTrendOutput{Stats: map[string]any{}}, nil
+	stats, err := h.Backend.GetReportGroupTrend(in.ReportGroupArn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getReportGroupTrendOutput{Stats: stats}, nil
 }
 
 type getResourcePolicyInput struct {
@@ -1050,7 +1093,12 @@ func (h *Handler) handleGetResourcePolicy(
 		return nil, fmt.Errorf("%w: resourceArn is required", errInvalidRequest)
 	}
 
-	return &getResourcePolicyOutput{Policy: "{}"}, nil
+	policy, err := h.Backend.GetResourcePolicy(in.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getResourcePolicyOutput{Policy: policy}, nil
 }
 
 type importSourceCredentialsInput struct {
@@ -1072,7 +1120,12 @@ func (h *Handler) handleImportSourceCredentials(
 		return nil, fmt.Errorf("%w: token is required", errInvalidRequest)
 	}
 
-	return &importSourceCredentialsOutput{Arn: "arn:aws:codebuild:us-east-1:000000000000:token/" + in.ServerType}, nil
+	arnStr, err := h.Backend.ImportSourceCredentials(in.AuthType, in.ServerType, in.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &importSourceCredentialsOutput{Arn: arnStr}, nil
 }
 
 type invalidateProjectCacheInput struct {
@@ -1087,6 +1140,10 @@ func (h *Handler) handleInvalidateProjectCache(
 ) (*invalidateProjectCacheOutput, error) {
 	if in.ProjectName == "" {
 		return nil, fmt.Errorf("%w: projectName is required", errInvalidRequest)
+	}
+
+	if err := h.Backend.InvalidateProjectCache(in.ProjectName); err != nil {
+		return nil, err
 	}
 
 	return &invalidateProjectCacheOutput{}, nil
@@ -1118,7 +1175,12 @@ func (h *Handler) handleListBuildBatchesForProject(
 		return nil, fmt.Errorf("%w: projectName is required", errInvalidRequest)
 	}
 
-	return &listBuildBatchesForProjectOutput{IDs: []string{}}, nil
+	ids, err := h.Backend.ListBuildBatchesForProject(in.ProjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &listBuildBatchesForProjectOutput{IDs: ids}, nil
 }
 
 type listCommandExecutionsForSandboxInput struct {
@@ -1137,7 +1199,12 @@ func (h *Handler) handleListCommandExecutionsForSandbox(
 		return nil, fmt.Errorf("%w: sandboxId is required", errInvalidRequest)
 	}
 
-	return &listCommandExecutionsForSandboxOutput{CommandExecutions: []string{}}, nil
+	ids, err := h.Backend.ListCommandExecutionsForSandbox(in.SandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &listCommandExecutionsForSandboxOutput{CommandExecutions: ids}, nil
 }
 
 type listCuratedEnvironmentImagesInput struct{}
@@ -1150,7 +1217,7 @@ func (h *Handler) handleListCuratedEnvironmentImages(
 	_ context.Context,
 	_ *listCuratedEnvironmentImagesInput,
 ) (*listCuratedEnvironmentImagesOutput, error) {
-	return &listCuratedEnvironmentImagesOutput{Platforms: []map[string]any{}}, nil
+	return &listCuratedEnvironmentImagesOutput{Platforms: h.Backend.ListCuratedEnvironmentImages()}, nil
 }
 
 type listFleetsInput struct{}
@@ -1180,7 +1247,7 @@ type listReportsOutput struct {
 }
 
 func (h *Handler) handleListReports(_ context.Context, _ *listReportsInput) (*listReportsOutput, error) {
-	return &listReportsOutput{Reports: []string{}}, nil
+	return &listReportsOutput{Reports: h.Backend.ListReports()}, nil
 }
 
 type listReportsForReportGroupInput struct {
@@ -1193,9 +1260,9 @@ type listReportsForReportGroupOutput struct {
 
 func (h *Handler) handleListReportsForReportGroup(
 	_ context.Context,
-	_ *listReportsForReportGroupInput,
+	in *listReportsForReportGroupInput,
 ) (*listReportsForReportGroupOutput, error) {
-	return &listReportsForReportGroupOutput{Reports: []string{}}, nil
+	return &listReportsForReportGroupOutput{Reports: h.Backend.ListReportsForReportGroup(in.ReportGroupArn)}, nil
 }
 
 type listSandboxesInput struct{}
@@ -1224,7 +1291,12 @@ func (h *Handler) handleListSandboxesForProject(
 		return nil, fmt.Errorf("%w: projectName is required", errInvalidRequest)
 	}
 
-	return &listSandboxesForProjectOutput{IDs: []string{}}, nil
+	ids, err := h.Backend.ListSandboxesForProject(in.ProjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &listSandboxesForProjectOutput{IDs: ids}, nil
 }
 
 type listSharedProjectsInput struct{}
@@ -1237,7 +1309,7 @@ func (h *Handler) handleListSharedProjects(
 	_ context.Context,
 	_ *listSharedProjectsInput,
 ) (*listSharedProjectsOutput, error) {
-	return &listSharedProjectsOutput{Projects: []string{}}, nil
+	return &listSharedProjectsOutput{Projects: h.Backend.ListSharedProjects()}, nil
 }
 
 type listSharedReportGroupsInput struct{}
@@ -1250,7 +1322,7 @@ func (h *Handler) handleListSharedReportGroups(
 	_ context.Context,
 	_ *listSharedReportGroupsInput,
 ) (*listSharedReportGroupsOutput, error) {
-	return &listSharedReportGroupsOutput{ReportGroups: []string{}}, nil
+	return &listSharedReportGroupsOutput{ReportGroups: h.Backend.ListSharedReportGroups()}, nil
 }
 
 type listSourceCredentialsInput struct{}
@@ -1263,7 +1335,17 @@ func (h *Handler) handleListSourceCredentials(
 	_ context.Context,
 	_ *listSourceCredentialsInput,
 ) (*listSourceCredentialsOutput, error) {
-	return &listSourceCredentialsOutput{SourceCredentialsInfos: []map[string]any{}}, nil
+	creds := h.Backend.ListSourceCredentials()
+	infos := make([]map[string]any, 0, len(creds))
+	for _, c := range creds {
+		infos = append(infos, map[string]any{
+			"arn":        c.Arn,
+			"serverType": c.ServerType,
+			"authType":   c.AuthType,
+		})
+	}
+
+	return &listSourceCredentialsOutput{SourceCredentialsInfos: infos}, nil
 }
 
 type putResourcePolicyInput struct {
@@ -1283,6 +1365,10 @@ func (h *Handler) handlePutResourcePolicy(
 		return nil, fmt.Errorf("%w: resourceArn and policy are required", errInvalidRequest)
 	}
 
+	if err := h.Backend.PutResourcePolicy(in.ResourceArn, in.Policy); err != nil {
+		return nil, err
+	}
+
 	return &putResourcePolicyOutput{ResourceArn: in.ResourceArn}, nil
 }
 
@@ -1299,7 +1385,12 @@ func (h *Handler) handleRetryBuildBatch(_ context.Context, in *retryBuildBatchIn
 		return nil, fmt.Errorf("%w: id is required", errInvalidRequest)
 	}
 
-	return &retryBuildBatchOutput{}, nil
+	bb, err := h.Backend.RetryBuildBatch(in.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &retryBuildBatchOutput{BuildBatch: bb}, nil
 }
 
 type startBuildBatchInput struct {
@@ -1402,7 +1493,12 @@ func (h *Handler) handleStopBuildBatch(_ context.Context, in *stopBuildBatchInpu
 		return nil, fmt.Errorf("%w: id is required", errInvalidRequest)
 	}
 
-	return &stopBuildBatchOutput{}, nil
+	bb, err := h.Backend.StopBuildBatch(in.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stopBuildBatchOutput{BuildBatch: bb}, nil
 }
 
 type stopSandboxInput struct {
@@ -1418,7 +1514,12 @@ func (h *Handler) handleStopSandbox(_ context.Context, in *stopSandboxInput) (*s
 		return nil, fmt.Errorf("%w: id is required", errInvalidRequest)
 	}
 
-	return &stopSandboxOutput{}, nil
+	sb, err := h.Backend.StopSandbox(in.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stopSandboxOutput{Sandbox: sb}, nil
 }
 
 type updateFleetInput struct {
@@ -1435,7 +1536,12 @@ func (h *Handler) handleUpdateFleet(_ context.Context, in *updateFleetInput) (*u
 		return nil, fmt.Errorf("%w: arn is required", errInvalidRequest)
 	}
 
-	return &updateFleetOutput{}, nil
+	f, err := h.Backend.UpdateFleet(in.Arn, in.BaseCapacity)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateFleetOutput{Fleet: f}, nil
 }
 
 type updateProjectVisibilityInput struct {
@@ -1454,6 +1560,10 @@ func (h *Handler) handleUpdateProjectVisibility(
 ) (*updateProjectVisibilityOutput, error) {
 	if in.ProjectArn == "" {
 		return nil, fmt.Errorf("%w: projectArn is required", errInvalidRequest)
+	}
+
+	if err := h.Backend.UpdateProjectVisibility(in.ProjectArn, in.ProjectVisibility); err != nil {
+		return nil, err
 	}
 
 	return &updateProjectVisibilityOutput{
@@ -1479,7 +1589,12 @@ func (h *Handler) handleUpdateReportGroup(
 		return nil, fmt.Errorf("%w: arn is required", errInvalidRequest)
 	}
 
-	return &updateReportGroupOutput{}, nil
+	rg, err := h.Backend.UpdateReportGroup(in.Arn, in.ExportConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateReportGroupOutput{ReportGroup: rg}, nil
 }
 
 type updateWebhookInput struct {
@@ -1497,5 +1612,10 @@ func (h *Handler) handleUpdateWebhook(_ context.Context, in *updateWebhookInput)
 		return nil, fmt.Errorf("%w: projectName is required", errInvalidRequest)
 	}
 
-	return &updateWebhookOutput{}, nil
+	w, err := h.Backend.UpdateWebhook(in.ProjectName, in.BranchFilter, in.BuildType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateWebhookOutput{Webhook: w}, nil
 }

--- a/services/codebuild/handler.go
+++ b/services/codebuild/handler.go
@@ -909,6 +909,10 @@ func (h *Handler) handleDeleteReport(_ context.Context, in *deleteReportInput) (
 		return nil, fmt.Errorf("%w: arn is required", errInvalidRequest)
 	}
 
+	if err := h.Backend.DeleteReport(in.Arn); err != nil {
+		return nil, err
+	}
+
 	return &deleteReportOutput{}, nil
 }
 
@@ -925,6 +929,10 @@ func (h *Handler) handleDeleteReportGroup(
 ) (*deleteReportGroupOutput, error) {
 	if in.Arn == "" {
 		return nil, fmt.Errorf("%w: arn is required", errInvalidRequest)
+	}
+
+	if err := h.Backend.DeleteReportGroup(in.Arn); err != nil {
+		return nil, err
 	}
 
 	return &deleteReportGroupOutput{}, nil

--- a/services/codebuild/janitor.go
+++ b/services/codebuild/janitor.go
@@ -18,7 +18,7 @@ const (
 
 // isTerminalBuild reports whether the given build status is terminal.
 func isTerminalBuild(status string) bool {
-	return status == "SUCCEEDED" || status == "FAILED" || status == "STOPPED" ||
+	return status == buildStatusSucceeded || status == "FAILED" || status == buildStatusStopped ||
 		status == "TIMED_OUT" || status == "FAULT"
 }
 

--- a/services/codebuild/persistence.go
+++ b/services/codebuild/persistence.go
@@ -17,6 +17,12 @@ type backendSnapshot struct {
 	CommandExecutions   map[string]*CommandExecution   `json:"commandExecutions"`
 	Sandboxes           map[string]*Sandbox            `json:"sandboxes"`
 	Webhooks            map[string]*Webhook            `json:"webhooks"`
+	ResourcePolicies    map[string]string              `json:"resourcePolicies"`
+	SourceCredentials   map[string]*SourceCredentials  `json:"sourceCredentials"`
+	SandboxesByProject  map[string]map[string]struct{} `json:"sandboxesByProject"`
+	BatchesByProject    map[string]map[string]struct{} `json:"batchesByProject"`
+	CommandsBySandbox   map[string]map[string]struct{} `json:"commandsBySandbox"`
+	ReportsByGroup      map[string]map[string]struct{} `json:"reportsByGroup"`
 	AccountID           string                         `json:"accountID"`
 	Region              string                         `json:"region"`
 }
@@ -24,60 +30,73 @@ type backendSnapshot struct {
 // ensureNonNil replaces nil maps in the snapshot with empty initialized maps
 // so callers don't need to guard against nil after a Restore.
 func (s *backendSnapshot) ensureNonNil() {
+	s.ensureNonNilCore()
+	s.ensureNonNilExt()
+}
+
+func (s *backendSnapshot) ensureNonNilCore() {
 	if s.Projects == nil {
 		s.Projects = make(map[string]*Project)
 	}
-
 	if s.Builds == nil {
 		s.Builds = make(map[string]*Build)
 	}
-
 	if s.BuildsByProject == nil {
 		s.BuildsByProject = make(map[string]map[string]struct{})
 	}
-
 	if s.ProjectARNIndex == nil {
 		s.ProjectARNIndex = make(map[string]string)
 	}
-
 	if s.BuildARNIndex == nil {
 		s.BuildARNIndex = make(map[string]string)
 	}
-
 	if s.Fleets == nil {
 		s.Fleets = make(map[string]*Fleet)
 	}
-
 	if s.FleetARNIndex == nil {
 		s.FleetARNIndex = make(map[string]string)
 	}
-
 	if s.ReportGroups == nil {
 		s.ReportGroups = make(map[string]*ReportGroup)
 	}
-
 	if s.ReportGroupARNIndex == nil {
 		s.ReportGroupARNIndex = make(map[string]string)
 	}
-
 	if s.Reports == nil {
 		s.Reports = make(map[string]*Report)
 	}
+}
 
+func (s *backendSnapshot) ensureNonNilExt() {
 	if s.BuildBatches == nil {
 		s.BuildBatches = make(map[string]*BuildBatch)
 	}
-
 	if s.CommandExecutions == nil {
 		s.CommandExecutions = make(map[string]*CommandExecution)
 	}
-
 	if s.Sandboxes == nil {
 		s.Sandboxes = make(map[string]*Sandbox)
 	}
-
 	if s.Webhooks == nil {
 		s.Webhooks = make(map[string]*Webhook)
+	}
+	if s.ResourcePolicies == nil {
+		s.ResourcePolicies = make(map[string]string)
+	}
+	if s.SourceCredentials == nil {
+		s.SourceCredentials = make(map[string]*SourceCredentials)
+	}
+	if s.SandboxesByProject == nil {
+		s.SandboxesByProject = make(map[string]map[string]struct{})
+	}
+	if s.BatchesByProject == nil {
+		s.BatchesByProject = make(map[string]map[string]struct{})
+	}
+	if s.CommandsBySandbox == nil {
+		s.CommandsBySandbox = make(map[string]map[string]struct{})
+	}
+	if s.ReportsByGroup == nil {
+		s.ReportsByGroup = make(map[string]map[string]struct{})
 	}
 }
 
@@ -101,6 +120,12 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		CommandExecutions:   b.commandExecutions,
 		Sandboxes:           b.sandboxes,
 		Webhooks:            b.webhooks,
+		ResourcePolicies:    b.resourcePolicies,
+		SourceCredentials:   b.sourceCredentials,
+		SandboxesByProject:  b.sandboxesByProject,
+		BatchesByProject:    b.batchesByProject,
+		CommandsBySandbox:   b.commandsBySandbox,
+		ReportsByGroup:      b.reportsByGroup,
 		AccountID:           b.accountID,
 		Region:              b.region,
 	}
@@ -137,6 +162,12 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.commandExecutions = snap.CommandExecutions
 	b.sandboxes = snap.Sandboxes
 	b.webhooks = snap.Webhooks
+	b.resourcePolicies = snap.ResourcePolicies
+	b.sourceCredentials = snap.SourceCredentials
+	b.sandboxesByProject = snap.SandboxesByProject
+	b.batchesByProject = snap.BatchesByProject
+	b.commandsBySandbox = snap.CommandsBySandbox
+	b.reportsByGroup = snap.ReportsByGroup
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 


### PR DESCRIPTION
## Summary
CodeBuild batch-1 (38 ops): BuildBatch lifecycle, Fleet, ReportGroup, Webhook, SourceCredentials, etc.

## Test plan
- [ ] CI green
- [ ] Copilot review
- [ ] Devin review