### PR TITLE
feat(sagemaker): implement 50 real stateful ops batch 1 (go-htj8)

### DIFF
--- a/services/sagemaker/backend.go
+++ b/services/sagemaker/backend.go
@@ -525,6 +525,8 @@ func (b *InMemoryBackend) Region() string { return b.region }
 func (b *InMemoryBackend) AccountID() string { return b.accountID }
 
 // Reset reinitialises all maps to empty, clearing all stored resources.
+//
+//nolint:funlen // Reset must reinitialise all maps; splitting would obscure the invariant
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()

--- a/services/sagemaker/backend.go
+++ b/services/sagemaker/backend.go
@@ -411,6 +411,17 @@ type InMemoryBackend struct {
 	algorithms                 map[string]*Algorithm                       // key: algorithmName
 	clusters                   map[string]*Cluster                         // key: clusterName
 	modelPackages              map[string]*ModelPackage                    // key: modelPackageArn
+	modelPackageGroups         map[string]*ModelPackageGroup               // key: groupName
+	autoMLJobs                 map[string]*AutoMLJob                       // key: jobName
+	codeRepositories           map[string]*CodeRepository                  // key: name
+	projects                   map[string]*Project                         // key: projectName
+	spaces                     map[string]*Space                           // key: domainID+"/"+spaceName
+	smImages                   map[string]*SMImage                         // key: imageName
+	imageVersions              map[string]map[int]*ImageVersion            // imageName → version → ImageVersion
+	imageVersionCounts         map[string]int                              // imageName → latest version number
+	compilationJobs            map[string]*CompilationJob                  // key: jobName
+	monitoringSchedules        map[string]*MonitoringSchedule              // key: scheduleName
+	workteams                  map[string]*Workteam                        // key: workteamName
 	modelARNIndex              map[string]string                           // ARN → model name
 	endpointConfigARNIndex     map[string]string                           // ARN → endpoint config name
 	endpointARNIndex           map[string]string                           // ARN → endpoint name
@@ -460,6 +471,17 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		algorithms:                 make(map[string]*Algorithm),
 		clusters:                   make(map[string]*Cluster),
 		modelPackages:              make(map[string]*ModelPackage),
+		modelPackageGroups:         make(map[string]*ModelPackageGroup),
+		autoMLJobs:                 make(map[string]*AutoMLJob),
+		codeRepositories:           make(map[string]*CodeRepository),
+		projects:                   make(map[string]*Project),
+		spaces:                     make(map[string]*Space),
+		smImages:                   make(map[string]*SMImage),
+		imageVersions:              make(map[string]map[int]*ImageVersion),
+		imageVersionCounts:         make(map[string]int),
+		compilationJobs:            make(map[string]*CompilationJob),
+		monitoringSchedules:        make(map[string]*MonitoringSchedule),
+		workteams:                  make(map[string]*Workteam),
 		modelARNIndex:              make(map[string]string),
 		endpointConfigARNIndex:     make(map[string]string),
 		endpointARNIndex:           make(map[string]string),
@@ -519,6 +541,17 @@ func (b *InMemoryBackend) Reset() {
 	b.algorithms = make(map[string]*Algorithm)
 	b.clusters = make(map[string]*Cluster)
 	b.modelPackages = make(map[string]*ModelPackage)
+	b.modelPackageGroups = make(map[string]*ModelPackageGroup)
+	b.autoMLJobs = make(map[string]*AutoMLJob)
+	b.codeRepositories = make(map[string]*CodeRepository)
+	b.projects = make(map[string]*Project)
+	b.spaces = make(map[string]*Space)
+	b.smImages = make(map[string]*SMImage)
+	b.imageVersions = make(map[string]map[int]*ImageVersion)
+	b.imageVersionCounts = make(map[string]int)
+	b.compilationJobs = make(map[string]*CompilationJob)
+	b.monitoringSchedules = make(map[string]*MonitoringSchedule)
+	b.workteams = make(map[string]*Workteam)
 	b.modelARNIndex = make(map[string]string)
 	b.endpointConfigARNIndex = make(map[string]string)
 	b.endpointARNIndex = make(map[string]string)

--- a/services/sagemaker/backend_batch2.go
+++ b/services/sagemaker/backend_batch2.go
@@ -81,7 +81,7 @@ func (b *InMemoryBackend) CreateModelPackageGroup(
 		ModelPackageGroupName:        name,
 		ModelPackageGroupArn:         groupARN,
 		ModelPackageGroupDescription: description,
-		ModelPackageGroupStatus:      "Completed",
+		ModelPackageGroupStatus:      algorithmStatusCompleted,
 		Tags:                         mergeTags(nil, tags),
 		CreationTime:                 time.Now(),
 	}
@@ -118,6 +118,8 @@ func (b *InMemoryBackend) DeleteModelPackageGroup(name string) error {
 }
 
 // ListModelPackageGroups returns all model package groups, sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListModelPackageGroups(nextToken string) ([]*ModelPackageGroup, string) {
 	b.mu.RLock("ListModelPackageGroups")
 	defer b.mu.RUnlock()
@@ -140,10 +142,7 @@ func (b *InMemoryBackend) ListModelPackageGroups(nextToken string) ([]*ModelPack
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*ModelPackageGroup, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -207,7 +206,7 @@ func (b *InMemoryBackend) DescribeModelPackage(nameOrArn string) (*ModelPackage,
 
 	// Try name → ARN index.
 	if arnStr, ok := b.modelPackageARNIndex[nameOrArn]; ok {
-		if mp, ok := b.modelPackages[arnStr]; ok {
+		if mp, found := b.modelPackages[arnStr]; found {
 			return cloneModelPackage(mp), nil
 		}
 	}
@@ -262,10 +261,7 @@ func (b *InMemoryBackend) ListModelPackages(groupName, nextToken string) ([]*Mod
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(arns) {
-		end = len(arns)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(arns))
 
 	out := make([]*ModelPackage, 0, end-start)
 	for _, k := range arns[start:end] {
@@ -322,7 +318,7 @@ func (b *InMemoryBackend) CreateAutoMLJob(
 	j := &AutoMLJob{
 		AutoMLJobName:   name,
 		AutoMLJobArn:    jobARN,
-		AutoMLJobStatus: "Completed",
+		AutoMLJobStatus: algorithmStatusCompleted,
 		RoleArn:         roleArn,
 		Tags:            mergeTags(nil, tags),
 		CreationTime:    time.Now(),
@@ -355,12 +351,14 @@ func (b *InMemoryBackend) StopAutoMLJob(name string) error {
 		return fmt.Errorf("%w: AutoML job %q not found", ErrAutoMLJobNotFound, name)
 	}
 
-	j.AutoMLJobStatus = "Stopped"
+	j.AutoMLJobStatus = pipelineStatusStopped
 
 	return nil
 }
 
 // ListAutoMLJobs returns all AutoML jobs sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListAutoMLJobs(nextToken string) ([]*AutoMLJob, string) {
 	b.mu.RLock("ListAutoMLJobs")
 	defer b.mu.RUnlock()
@@ -383,10 +381,7 @@ func (b *InMemoryBackend) ListAutoMLJobs(nextToken string) ([]*AutoMLJob, string
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*AutoMLJob, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -506,6 +501,8 @@ func (b *InMemoryBackend) DeleteCodeRepository(name string) error {
 }
 
 // ListCodeRepositories returns all code repositories sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListCodeRepositories(nextToken string) ([]*CodeRepository, string) {
 	b.mu.RLock("ListCodeRepositories")
 	defer b.mu.RUnlock()
@@ -528,10 +525,7 @@ func (b *InMemoryBackend) ListCodeRepositories(nextToken string) ([]*CodeReposit
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*CodeRepository, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -556,7 +550,7 @@ type Project struct {
 	Tags               map[string]string `json:"Tags,omitempty"`
 	ProjectName        string            `json:"ProjectName"`
 	ProjectArn         string            `json:"ProjectArn"`
-	ProjectId          string            `json:"ProjectId"`
+	ProjectID          string            `json:"ProjectId"`
 	ProjectStatus      string            `json:"ProjectStatus"`
 	ProjectDescription string            `json:"ProjectDescription,omitempty"`
 }
@@ -589,7 +583,7 @@ func (b *InMemoryBackend) CreateProject(
 	p := &Project{
 		ProjectName:        name,
 		ProjectArn:         projectARN,
-		ProjectId:          generateID(),
+		ProjectID:          generateID(),
 		ProjectStatus:      "CreateCompleted",
 		ProjectDescription: description,
 		Tags:               mergeTags(nil, tags),
@@ -628,6 +622,8 @@ func (b *InMemoryBackend) DeleteProject(name string) error {
 }
 
 // ListProjects returns all projects sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListProjects(nextToken string) ([]*Project, string) {
 	b.mu.RLock("ListProjects")
 	defer b.mu.RUnlock()
@@ -650,10 +646,7 @@ func (b *InMemoryBackend) ListProjects(nextToken string) ([]*Project, string) {
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*Project, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -679,7 +672,7 @@ type Space struct {
 	Tags             map[string]string `json:"Tags,omitempty"`
 	SpaceName        string            `json:"SpaceName"`
 	SpaceArn         string            `json:"SpaceArn"`
-	DomainId         string            `json:"DomainId"`
+	DomainID         string            `json:"DomainId"`
 	SpaceStatus      string            `json:"SpaceStatus"`
 }
 
@@ -700,7 +693,7 @@ func (b *InMemoryBackend) CreateSpace(domainID, spaceName string, tags map[strin
 	defer b.mu.Unlock()
 
 	if domainID == "" {
-		return nil, fmt.Errorf("%w: DomainId is required", ErrValidation)
+		return nil, fmt.Errorf("%w: DomainID is required", ErrValidation)
 	}
 
 	if spaceName == "" {
@@ -719,7 +712,7 @@ func (b *InMemoryBackend) CreateSpace(domainID, spaceName string, tags map[strin
 	s := &Space{
 		SpaceName:        spaceName,
 		SpaceArn:         spaceARN,
-		DomainId:         domainID,
+		DomainID:         domainID,
 		SpaceStatus:      "InService",
 		Tags:             mergeTags(nil, tags),
 		CreationTime:     now,
@@ -766,7 +759,7 @@ func (b *InMemoryBackend) ListSpaces(domainID, nextToken string) ([]*Space, stri
 
 	var keys []string
 	for k, s := range b.spaces {
-		if domainID == "" || s.DomainId == domainID {
+		if domainID == "" || s.DomainID == domainID {
 			keys = append(keys, k)
 		}
 	}
@@ -784,10 +777,7 @@ func (b *InMemoryBackend) ListSpaces(domainID, nextToken string) ([]*Space, stri
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*Space, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -884,6 +874,8 @@ func (b *InMemoryBackend) DeleteImage(name string) error {
 }
 
 // ListImages returns all images sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListImages(nextToken string) ([]*SMImage, string) {
 	b.mu.RLock("ListImages")
 	defer b.mu.RUnlock()
@@ -906,10 +898,7 @@ func (b *InMemoryBackend) ListImages(nextToken string) ([]*SMImage, string) {
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*SMImage, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -1011,7 +1000,7 @@ func (b *InMemoryBackend) DeleteImageVersion(imageName string, version int) erro
 		return fmt.Errorf("%w: no versions found for image %q", ErrImageVersionNotFound, imageName)
 	}
 
-	if _, ok := versions[version]; !ok {
+	if _, exists := versions[version]; !exists {
 		return fmt.Errorf("%w: version %d not found for image %q", ErrImageVersionNotFound, version, imageName)
 	}
 
@@ -1047,10 +1036,7 @@ func (b *InMemoryBackend) ListImageVersions(imageName, nextToken string) ([]*Ima
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(nums) {
-		end = len(nums)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(nums))
 
 	out := make([]*ImageVersion, 0, end-start)
 	for _, n := range nums[start:end] {
@@ -1133,6 +1119,20 @@ func (b *InMemoryBackend) DescribeCompilationJob(name string) (*CompilationJob, 
 	return cloneCompilationJob(j), nil
 }
 
+// DeleteCompilationJob removes a compilation job by name.
+func (b *InMemoryBackend) DeleteCompilationJob(name string) error {
+	b.mu.Lock("DeleteCompilationJob")
+	defer b.mu.Unlock()
+
+	if _, ok := b.compilationJobs[name]; !ok {
+		return fmt.Errorf("%w: compilation job %q not found", ErrCompilationJobNotFound, name)
+	}
+
+	delete(b.compilationJobs, name)
+
+	return nil
+}
+
 // StopCompilationJob sets a compilation job status to "STOPPED".
 func (b *InMemoryBackend) StopCompilationJob(name string) error {
 	b.mu.Lock("StopCompilationJob")
@@ -1150,6 +1150,8 @@ func (b *InMemoryBackend) StopCompilationJob(name string) error {
 }
 
 // ListCompilationJobs returns all compilation jobs sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListCompilationJobs(nextToken string) ([]*CompilationJob, string) {
 	b.mu.RLock("ListCompilationJobs")
 	defer b.mu.RUnlock()
@@ -1172,10 +1174,7 @@ func (b *InMemoryBackend) ListCompilationJobs(nextToken string) ([]*CompilationJ
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*CompilationJob, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -1280,7 +1279,7 @@ func (b *InMemoryBackend) StopMonitoringSchedule(name string) error {
 		return fmt.Errorf("%w: monitoring schedule %q not found", ErrMonitoringScheduleNotFound, name)
 	}
 
-	ms.MonitoringScheduleStatus = "Stopped"
+	ms.MonitoringScheduleStatus = pipelineStatusStopped
 	ms.LastModifiedTime = time.Now()
 
 	return nil
@@ -1318,6 +1317,8 @@ func (b *InMemoryBackend) UpdateMonitoringSchedule(name string) (*MonitoringSche
 }
 
 // ListMonitoringSchedules returns all monitoring schedules sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListMonitoringSchedules(nextToken string) ([]*MonitoringSchedule, string) {
 	b.mu.RLock("ListMonitoringSchedules")
 	defer b.mu.RUnlock()
@@ -1340,10 +1341,7 @@ func (b *InMemoryBackend) ListMonitoringSchedules(nextToken string) ([]*Monitori
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*MonitoringSchedule, 0, end-start)
 	for _, k := range keys[start:end] {
@@ -1439,6 +1437,8 @@ func (b *InMemoryBackend) DeleteWorkteam(name string) error {
 }
 
 // ListWorkteams returns all workteams sorted by name.
+//
+//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListWorkteams(nextToken string) ([]*Workteam, string) {
 	b.mu.RLock("ListWorkteams")
 	defer b.mu.RUnlock()
@@ -1461,10 +1461,7 @@ func (b *InMemoryBackend) ListWorkteams(nextToken string) ([]*Workteam, string) 
 		}
 	}
 
-	end := start + sagemakerDefaultPageSize
-	if end > len(keys) {
-		end = len(keys)
-	}
+	end := min(start+sagemakerDefaultPageSize, len(keys))
 
 	out := make([]*Workteam, 0, end-start)
 	for _, k := range keys[start:end] {

--- a/services/sagemaker/backend_batch2.go
+++ b/services/sagemaker/backend_batch2.go
@@ -118,8 +118,6 @@ func (b *InMemoryBackend) DeleteModelPackageGroup(name string) error {
 }
 
 // ListModelPackageGroups returns all model package groups, sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListModelPackageGroups(nextToken string) ([]*ModelPackageGroup, string) {
 	b.mu.RLock("ListModelPackageGroups")
 	defer b.mu.RUnlock()
@@ -357,8 +355,6 @@ func (b *InMemoryBackend) StopAutoMLJob(name string) error {
 }
 
 // ListAutoMLJobs returns all AutoML jobs sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListAutoMLJobs(nextToken string) ([]*AutoMLJob, string) {
 	b.mu.RLock("ListAutoMLJobs")
 	defer b.mu.RUnlock()
@@ -501,8 +497,6 @@ func (b *InMemoryBackend) DeleteCodeRepository(name string) error {
 }
 
 // ListCodeRepositories returns all code repositories sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListCodeRepositories(nextToken string) ([]*CodeRepository, string) {
 	b.mu.RLock("ListCodeRepositories")
 	defer b.mu.RUnlock()
@@ -622,8 +616,6 @@ func (b *InMemoryBackend) DeleteProject(name string) error {
 }
 
 // ListProjects returns all projects sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListProjects(nextToken string) ([]*Project, string) {
 	b.mu.RLock("ListProjects")
 	defer b.mu.RUnlock()
@@ -874,8 +866,6 @@ func (b *InMemoryBackend) DeleteImage(name string) error {
 }
 
 // ListImages returns all images sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListImages(nextToken string) ([]*SMImage, string) {
 	b.mu.RLock("ListImages")
 	defer b.mu.RUnlock()
@@ -1150,8 +1140,6 @@ func (b *InMemoryBackend) StopCompilationJob(name string) error {
 }
 
 // ListCompilationJobs returns all compilation jobs sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListCompilationJobs(nextToken string) ([]*CompilationJob, string) {
 	b.mu.RLock("ListCompilationJobs")
 	defer b.mu.RUnlock()
@@ -1317,8 +1305,6 @@ func (b *InMemoryBackend) UpdateMonitoringSchedule(name string) (*MonitoringSche
 }
 
 // ListMonitoringSchedules returns all monitoring schedules sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListMonitoringSchedules(nextToken string) ([]*MonitoringSchedule, string) {
 	b.mu.RLock("ListMonitoringSchedules")
 	defer b.mu.RUnlock()
@@ -1437,8 +1423,6 @@ func (b *InMemoryBackend) DeleteWorkteam(name string) error {
 }
 
 // ListWorkteams returns all workteams sorted by name.
-//
-//nolint:dupl // List pagination pattern is identical by design; type-safe generics not available
 func (b *InMemoryBackend) ListWorkteams(nextToken string) ([]*Workteam, string) {
 	b.mu.RLock("ListWorkteams")
 	defer b.mu.RUnlock()

--- a/services/sagemaker/backend_batch2.go
+++ b/services/sagemaker/backend_batch2.go
@@ -1,0 +1,1480 @@
+package sagemaker
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/arn"
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+)
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+var (
+	// ErrModelPackageGroupNotFound is returned when a model package group does not exist.
+	ErrModelPackageGroupNotFound = awserr.New("ValidationException", awserr.ErrNotFound)
+	// ErrAutoMLJobNotFound is returned when an AutoML job does not exist.
+	ErrAutoMLJobNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrCodeRepositoryNotFound is returned when a code repository does not exist.
+	ErrCodeRepositoryNotFound = awserr.New("ValidationException", awserr.ErrNotFound)
+	// ErrProjectNotFound is returned when a project does not exist.
+	ErrProjectNotFound = awserr.New("ValidationException", awserr.ErrNotFound)
+	// ErrSpaceNotFound is returned when a space does not exist.
+	ErrSpaceNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrSMImageNotFound is returned when a SageMaker image does not exist.
+	ErrSMImageNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrImageVersionNotFound is returned when an image version does not exist.
+	ErrImageVersionNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrCompilationJobNotFound is returned when a compilation job does not exist.
+	ErrCompilationJobNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrMonitoringScheduleNotFound is returned when a monitoring schedule does not exist.
+	ErrMonitoringScheduleNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrWorkteamNotFound is returned when a workteam does not exist.
+	ErrWorkteamNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+)
+
+// ---------------------------------------------------------------------------
+// ModelPackageGroup
+// ---------------------------------------------------------------------------
+
+// ModelPackageGroup represents a SageMaker model package group.
+type ModelPackageGroup struct {
+	CreationTime                 time.Time         `json:"CreationTime"`
+	Tags                         map[string]string `json:"Tags,omitempty"`
+	ModelPackageGroupName        string            `json:"ModelPackageGroupName"`
+	ModelPackageGroupArn         string            `json:"ModelPackageGroupArn"`
+	ModelPackageGroupDescription string            `json:"ModelPackageGroupDescription,omitempty"`
+	ModelPackageGroupStatus      string            `json:"ModelPackageGroupStatus"`
+}
+
+func cloneModelPackageGroup(g *ModelPackageGroup) *ModelPackageGroup {
+	cp := *g
+	cp.Tags = maps.Clone(g.Tags)
+
+	return &cp
+}
+
+// CreateModelPackageGroup creates a new model package group.
+func (b *InMemoryBackend) CreateModelPackageGroup(
+	name, description string,
+	tags map[string]string,
+) (*ModelPackageGroup, error) {
+	b.mu.Lock("CreateModelPackageGroup")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: ModelPackageGroupName is required", ErrValidation)
+	}
+
+	if _, ok := b.modelPackageGroups[name]; ok {
+		return nil, fmt.Errorf("%w: model package group %q already exists", ErrValidation, name)
+	}
+
+	groupARN := arn.Build("sagemaker", b.region, b.accountID, "model-package-group/"+name)
+
+	g := &ModelPackageGroup{
+		ModelPackageGroupName:        name,
+		ModelPackageGroupArn:         groupARN,
+		ModelPackageGroupDescription: description,
+		ModelPackageGroupStatus:      "Completed",
+		Tags:                         mergeTags(nil, tags),
+		CreationTime:                 time.Now(),
+	}
+	b.modelPackageGroups[name] = g
+
+	return cloneModelPackageGroup(g), nil
+}
+
+// DescribeModelPackageGroup returns a model package group by name.
+func (b *InMemoryBackend) DescribeModelPackageGroup(name string) (*ModelPackageGroup, error) {
+	b.mu.RLock("DescribeModelPackageGroup")
+	defer b.mu.RUnlock()
+
+	g, ok := b.modelPackageGroups[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: model package group %q not found", ErrModelPackageGroupNotFound, name)
+	}
+
+	return cloneModelPackageGroup(g), nil
+}
+
+// DeleteModelPackageGroup removes a model package group by name.
+func (b *InMemoryBackend) DeleteModelPackageGroup(name string) error {
+	b.mu.Lock("DeleteModelPackageGroup")
+	defer b.mu.Unlock()
+
+	if _, ok := b.modelPackageGroups[name]; !ok {
+		return fmt.Errorf("%w: model package group %q not found", ErrModelPackageGroupNotFound, name)
+	}
+
+	delete(b.modelPackageGroups, name)
+
+	return nil
+}
+
+// ListModelPackageGroups returns all model package groups, sorted by name.
+func (b *InMemoryBackend) ListModelPackageGroups(nextToken string) ([]*ModelPackageGroup, string) {
+	b.mu.RLock("ListModelPackageGroups")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.modelPackageGroups))
+	for k := range b.modelPackageGroups {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*ModelPackageGroup, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneModelPackageGroup(b.modelPackageGroups[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// ModelPackage CRUD (name/ARN dual lookup)
+// ---------------------------------------------------------------------------
+
+// CreateModelPackage creates a model package.
+func (b *InMemoryBackend) CreateModelPackage(
+	name, groupName, description string,
+	tags map[string]string,
+) (*ModelPackage, error) {
+	b.mu.Lock("CreateModelPackage")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: ModelPackageName is required", ErrValidation)
+	}
+
+	mpARN := arn.Build("sagemaker", b.region, b.accountID, "model-package/"+name)
+
+	if _, ok := b.modelPackages[mpARN]; ok {
+		return nil, fmt.Errorf("%w: model package %q already exists", ErrValidation, name)
+	}
+
+	mp := &ModelPackage{
+		ModelPackageName:        name,
+		ModelPackageArn:         mpARN,
+		ModelPackageGroupName:   groupName,
+		ModelPackageStatus:      "Completed",
+		ModelPackageDescription: description,
+		Tags:                    mergeTags(nil, tags),
+		CreationTime:            time.Now(),
+	}
+	b.modelPackages[mpARN] = mp
+	b.modelPackageARNIndex[name] = mpARN
+
+	return cloneModelPackage(mp), nil
+}
+
+// DescribeModelPackage returns a model package by name or ARN.
+func (b *InMemoryBackend) DescribeModelPackage(nameOrArn string) (*ModelPackage, error) {
+	b.mu.RLock("DescribeModelPackage")
+	defer b.mu.RUnlock()
+
+	// Try direct ARN lookup first.
+	if mp, ok := b.modelPackages[nameOrArn]; ok {
+		return cloneModelPackage(mp), nil
+	}
+
+	// Try name → ARN index.
+	if arnStr, ok := b.modelPackageARNIndex[nameOrArn]; ok {
+		if mp, ok := b.modelPackages[arnStr]; ok {
+			return cloneModelPackage(mp), nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: model package %q not found", ErrModelPackageNotFound, nameOrArn)
+}
+
+// DeleteModelPackage removes a model package by name or ARN.
+func (b *InMemoryBackend) DeleteModelPackage(nameOrArn string) error {
+	b.mu.Lock("DeleteModelPackage")
+	defer b.mu.Unlock()
+
+	arnStr := nameOrArn
+	if v, ok := b.modelPackageARNIndex[nameOrArn]; ok {
+		arnStr = v
+	}
+
+	if _, ok := b.modelPackages[arnStr]; !ok {
+		return fmt.Errorf("%w: model package %q not found", ErrModelPackageNotFound, nameOrArn)
+	}
+
+	mp := b.modelPackages[arnStr]
+	delete(b.modelPackageARNIndex, mp.ModelPackageName)
+	delete(b.modelPackages, arnStr)
+
+	return nil
+}
+
+// ListModelPackages returns model packages, optionally filtered by group name.
+func (b *InMemoryBackend) ListModelPackages(groupName, nextToken string) ([]*ModelPackage, string) {
+	b.mu.RLock("ListModelPackages")
+	defer b.mu.RUnlock()
+
+	var arns []string
+	for k := range b.modelPackages {
+		mp := b.modelPackages[k]
+		if groupName == "" || mp.ModelPackageGroupName == groupName {
+			arns = append(arns, k)
+		}
+	}
+
+	sort.Strings(arns)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range arns {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(arns) {
+		end = len(arns)
+	}
+
+	out := make([]*ModelPackage, 0, end-start)
+	for _, k := range arns[start:end] {
+		out = append(out, cloneModelPackage(b.modelPackages[k]))
+	}
+
+	next := ""
+	if end < len(arns) {
+		next = arns[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// AutoMLJob
+// ---------------------------------------------------------------------------
+
+// AutoMLJob represents a SageMaker AutoML job.
+type AutoMLJob struct {
+	CreationTime    time.Time         `json:"CreationTime"`
+	Tags            map[string]string `json:"Tags,omitempty"`
+	AutoMLJobName   string            `json:"AutoMLJobName"`
+	AutoMLJobArn    string            `json:"AutoMLJobArn"`
+	AutoMLJobStatus string            `json:"AutoMLJobStatus"`
+	RoleArn         string            `json:"RoleArn,omitempty"`
+}
+
+func cloneAutoMLJob(j *AutoMLJob) *AutoMLJob {
+	cp := *j
+	cp.Tags = maps.Clone(j.Tags)
+
+	return &cp
+}
+
+// CreateAutoMLJob creates an AutoML job.
+func (b *InMemoryBackend) CreateAutoMLJob(
+	name, roleArn string,
+	tags map[string]string,
+) (*AutoMLJob, error) {
+	b.mu.Lock("CreateAutoMLJob")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: AutoMLJobName is required", ErrValidation)
+	}
+
+	if _, ok := b.autoMLJobs[name]; ok {
+		return nil, fmt.Errorf("%w: AutoML job %q already exists", ErrValidation, name)
+	}
+
+	jobARN := arn.Build("sagemaker", b.region, b.accountID, "automl-job/"+name)
+
+	j := &AutoMLJob{
+		AutoMLJobName:   name,
+		AutoMLJobArn:    jobARN,
+		AutoMLJobStatus: "Completed",
+		RoleArn:         roleArn,
+		Tags:            mergeTags(nil, tags),
+		CreationTime:    time.Now(),
+	}
+	b.autoMLJobs[name] = j
+
+	return cloneAutoMLJob(j), nil
+}
+
+// DescribeAutoMLJob returns an AutoML job by name.
+func (b *InMemoryBackend) DescribeAutoMLJob(name string) (*AutoMLJob, error) {
+	b.mu.RLock("DescribeAutoMLJob")
+	defer b.mu.RUnlock()
+
+	j, ok := b.autoMLJobs[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: AutoML job %q not found", ErrAutoMLJobNotFound, name)
+	}
+
+	return cloneAutoMLJob(j), nil
+}
+
+// StopAutoMLJob sets an AutoML job status to "Stopped".
+func (b *InMemoryBackend) StopAutoMLJob(name string) error {
+	b.mu.Lock("StopAutoMLJob")
+	defer b.mu.Unlock()
+
+	j, ok := b.autoMLJobs[name]
+	if !ok {
+		return fmt.Errorf("%w: AutoML job %q not found", ErrAutoMLJobNotFound, name)
+	}
+
+	j.AutoMLJobStatus = "Stopped"
+
+	return nil
+}
+
+// ListAutoMLJobs returns all AutoML jobs sorted by name.
+func (b *InMemoryBackend) ListAutoMLJobs(nextToken string) ([]*AutoMLJob, string) {
+	b.mu.RLock("ListAutoMLJobs")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.autoMLJobs))
+	for k := range b.autoMLJobs {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*AutoMLJob, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneAutoMLJob(b.autoMLJobs[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// CodeRepository
+// ---------------------------------------------------------------------------
+
+// CodeRepository represents a SageMaker code repository.
+type CodeRepository struct {
+	CreationTime       time.Time         `json:"CreationTime"`
+	LastModifiedTime   time.Time         `json:"LastModifiedTime"`
+	Tags               map[string]string `json:"Tags,omitempty"`
+	GitConfig          map[string]string `json:"GitConfig,omitempty"`
+	CodeRepositoryName string            `json:"CodeRepositoryName"`
+	CodeRepositoryArn  string            `json:"CodeRepositoryArn"`
+}
+
+func cloneCodeRepository(r *CodeRepository) *CodeRepository {
+	cp := *r
+	cp.Tags = maps.Clone(r.Tags)
+	cp.GitConfig = maps.Clone(r.GitConfig)
+
+	return &cp
+}
+
+// CreateCodeRepository creates a code repository.
+func (b *InMemoryBackend) CreateCodeRepository(
+	name string,
+	gitConfig map[string]string,
+	tags map[string]string,
+) (*CodeRepository, error) {
+	b.mu.Lock("CreateCodeRepository")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: CodeRepositoryName is required", ErrValidation)
+	}
+
+	if _, ok := b.codeRepositories[name]; ok {
+		return nil, fmt.Errorf("%w: code repository %q already exists", ErrValidation, name)
+	}
+
+	repoARN := arn.Build("sagemaker", b.region, b.accountID, "code-repository/"+name)
+	now := time.Now()
+
+	r := &CodeRepository{
+		CodeRepositoryName: name,
+		CodeRepositoryArn:  repoARN,
+		GitConfig:          maps.Clone(gitConfig),
+		Tags:               mergeTags(nil, tags),
+		CreationTime:       now,
+		LastModifiedTime:   now,
+	}
+	b.codeRepositories[name] = r
+
+	return cloneCodeRepository(r), nil
+}
+
+// DescribeCodeRepository returns a code repository by name.
+func (b *InMemoryBackend) DescribeCodeRepository(name string) (*CodeRepository, error) {
+	b.mu.RLock("DescribeCodeRepository")
+	defer b.mu.RUnlock()
+
+	r, ok := b.codeRepositories[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: code repository %q not found", ErrCodeRepositoryNotFound, name)
+	}
+
+	return cloneCodeRepository(r), nil
+}
+
+// UpdateCodeRepository updates the git config of a code repository.
+func (b *InMemoryBackend) UpdateCodeRepository(
+	name string,
+	gitConfig map[string]string,
+) (*CodeRepository, error) {
+	b.mu.Lock("UpdateCodeRepository")
+	defer b.mu.Unlock()
+
+	r, ok := b.codeRepositories[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: code repository %q not found", ErrCodeRepositoryNotFound, name)
+	}
+
+	if gitConfig != nil {
+		r.GitConfig = maps.Clone(gitConfig)
+	}
+
+	r.LastModifiedTime = time.Now()
+
+	return cloneCodeRepository(r), nil
+}
+
+// DeleteCodeRepository removes a code repository by name.
+func (b *InMemoryBackend) DeleteCodeRepository(name string) error {
+	b.mu.Lock("DeleteCodeRepository")
+	defer b.mu.Unlock()
+
+	if _, ok := b.codeRepositories[name]; !ok {
+		return fmt.Errorf("%w: code repository %q not found", ErrCodeRepositoryNotFound, name)
+	}
+
+	delete(b.codeRepositories, name)
+
+	return nil
+}
+
+// ListCodeRepositories returns all code repositories sorted by name.
+func (b *InMemoryBackend) ListCodeRepositories(nextToken string) ([]*CodeRepository, string) {
+	b.mu.RLock("ListCodeRepositories")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.codeRepositories))
+	for k := range b.codeRepositories {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*CodeRepository, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneCodeRepository(b.codeRepositories[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// Project
+// ---------------------------------------------------------------------------
+
+// Project represents a SageMaker project.
+type Project struct {
+	CreationTime       time.Time         `json:"CreationTime"`
+	Tags               map[string]string `json:"Tags,omitempty"`
+	ProjectName        string            `json:"ProjectName"`
+	ProjectArn         string            `json:"ProjectArn"`
+	ProjectId          string            `json:"ProjectId"`
+	ProjectStatus      string            `json:"ProjectStatus"`
+	ProjectDescription string            `json:"ProjectDescription,omitempty"`
+}
+
+func cloneProject(p *Project) *Project {
+	cp := *p
+	cp.Tags = maps.Clone(p.Tags)
+
+	return &cp
+}
+
+// CreateProject creates a SageMaker project.
+func (b *InMemoryBackend) CreateProject(
+	name, description string,
+	tags map[string]string,
+) (*Project, error) {
+	b.mu.Lock("CreateProject")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: ProjectName is required", ErrValidation)
+	}
+
+	if _, ok := b.projects[name]; ok {
+		return nil, fmt.Errorf("%w: project %q already exists", ErrValidation, name)
+	}
+
+	projectARN := arn.Build("sagemaker", b.region, b.accountID, "project/"+name)
+
+	p := &Project{
+		ProjectName:        name,
+		ProjectArn:         projectARN,
+		ProjectId:          generateID(),
+		ProjectStatus:      "CreateCompleted",
+		ProjectDescription: description,
+		Tags:               mergeTags(nil, tags),
+		CreationTime:       time.Now(),
+	}
+	b.projects[name] = p
+
+	return cloneProject(p), nil
+}
+
+// DescribeProject returns a project by name.
+func (b *InMemoryBackend) DescribeProject(name string) (*Project, error) {
+	b.mu.RLock("DescribeProject")
+	defer b.mu.RUnlock()
+
+	p, ok := b.projects[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: project %q not found", ErrProjectNotFound, name)
+	}
+
+	return cloneProject(p), nil
+}
+
+// DeleteProject removes a project by name.
+func (b *InMemoryBackend) DeleteProject(name string) error {
+	b.mu.Lock("DeleteProject")
+	defer b.mu.Unlock()
+
+	if _, ok := b.projects[name]; !ok {
+		return fmt.Errorf("%w: project %q not found", ErrProjectNotFound, name)
+	}
+
+	delete(b.projects, name)
+
+	return nil
+}
+
+// ListProjects returns all projects sorted by name.
+func (b *InMemoryBackend) ListProjects(nextToken string) ([]*Project, string) {
+	b.mu.RLock("ListProjects")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.projects))
+	for k := range b.projects {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*Project, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneProject(b.projects[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// Space
+// ---------------------------------------------------------------------------
+
+// Space represents a SageMaker Studio space.
+type Space struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	LastModifiedTime time.Time         `json:"LastModifiedTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	SpaceName        string            `json:"SpaceName"`
+	SpaceArn         string            `json:"SpaceArn"`
+	DomainId         string            `json:"DomainId"`
+	SpaceStatus      string            `json:"SpaceStatus"`
+}
+
+func cloneSpace(s *Space) *Space {
+	cp := *s
+	cp.Tags = maps.Clone(s.Tags)
+
+	return &cp
+}
+
+func spaceKey(domainID, spaceName string) string {
+	return domainID + "/" + spaceName
+}
+
+// CreateSpace creates a SageMaker Studio space.
+func (b *InMemoryBackend) CreateSpace(domainID, spaceName string, tags map[string]string) (*Space, error) {
+	b.mu.Lock("CreateSpace")
+	defer b.mu.Unlock()
+
+	if domainID == "" {
+		return nil, fmt.Errorf("%w: DomainId is required", ErrValidation)
+	}
+
+	if spaceName == "" {
+		return nil, fmt.Errorf("%w: SpaceName is required", ErrValidation)
+	}
+
+	key := spaceKey(domainID, spaceName)
+
+	if _, ok := b.spaces[key]; ok {
+		return nil, fmt.Errorf("%w: space %q already exists in domain %q", ErrValidation, spaceName, domainID)
+	}
+
+	spaceARN := arn.Build("sagemaker", b.region, b.accountID, "space/"+domainID+"/"+spaceName)
+	now := time.Now()
+
+	s := &Space{
+		SpaceName:        spaceName,
+		SpaceArn:         spaceARN,
+		DomainId:         domainID,
+		SpaceStatus:      "InService",
+		Tags:             mergeTags(nil, tags),
+		CreationTime:     now,
+		LastModifiedTime: now,
+	}
+	b.spaces[key] = s
+
+	return cloneSpace(s), nil
+}
+
+// DescribeSpace returns a space by domain ID and space name.
+func (b *InMemoryBackend) DescribeSpace(domainID, spaceName string) (*Space, error) {
+	b.mu.RLock("DescribeSpace")
+	defer b.mu.RUnlock()
+
+	s, ok := b.spaces[spaceKey(domainID, spaceName)]
+	if !ok {
+		return nil, fmt.Errorf("%w: space %q not found in domain %q", ErrSpaceNotFound, spaceName, domainID)
+	}
+
+	return cloneSpace(s), nil
+}
+
+// DeleteSpace removes a space.
+func (b *InMemoryBackend) DeleteSpace(domainID, spaceName string) error {
+	b.mu.Lock("DeleteSpace")
+	defer b.mu.Unlock()
+
+	key := spaceKey(domainID, spaceName)
+
+	if _, ok := b.spaces[key]; !ok {
+		return fmt.Errorf("%w: space %q not found in domain %q", ErrSpaceNotFound, spaceName, domainID)
+	}
+
+	delete(b.spaces, key)
+
+	return nil
+}
+
+// ListSpaces returns all spaces optionally filtered by domain ID.
+func (b *InMemoryBackend) ListSpaces(domainID, nextToken string) ([]*Space, string) {
+	b.mu.RLock("ListSpaces")
+	defer b.mu.RUnlock()
+
+	var keys []string
+	for k, s := range b.spaces {
+		if domainID == "" || s.DomainId == domainID {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*Space, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneSpace(b.spaces[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// SMImage
+// ---------------------------------------------------------------------------
+
+// SMImage represents a SageMaker image.
+type SMImage struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	LastModifiedTime time.Time         `json:"LastModifiedTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	ImageName        string            `json:"ImageName"`
+	ImageArn         string            `json:"ImageArn"`
+	ImageStatus      string            `json:"ImageStatus"`
+	Description      string            `json:"Description,omitempty"`
+	RoleArn          string            `json:"RoleArn,omitempty"`
+}
+
+func cloneSMImage(img *SMImage) *SMImage {
+	cp := *img
+	cp.Tags = maps.Clone(img.Tags)
+
+	return &cp
+}
+
+// CreateImage creates a SageMaker image.
+func (b *InMemoryBackend) CreateImage(name, description, roleArn string, tags map[string]string) (*SMImage, error) {
+	b.mu.Lock("CreateImage")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: ImageName is required", ErrValidation)
+	}
+
+	if _, ok := b.smImages[name]; ok {
+		return nil, fmt.Errorf("%w: image %q already exists", ErrValidation, name)
+	}
+
+	imageARN := arn.Build("sagemaker", b.region, b.accountID, "image/"+name)
+	now := time.Now()
+
+	img := &SMImage{
+		ImageName:        name,
+		ImageArn:         imageARN,
+		ImageStatus:      "CREATED",
+		Description:      description,
+		RoleArn:          roleArn,
+		Tags:             mergeTags(nil, tags),
+		CreationTime:     now,
+		LastModifiedTime: now,
+	}
+	b.smImages[name] = img
+
+	return cloneSMImage(img), nil
+}
+
+// DescribeImage returns a SageMaker image by name.
+func (b *InMemoryBackend) DescribeImage(name string) (*SMImage, error) {
+	b.mu.RLock("DescribeImage")
+	defer b.mu.RUnlock()
+
+	img, ok := b.smImages[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: image %q not found", ErrSMImageNotFound, name)
+	}
+
+	return cloneSMImage(img), nil
+}
+
+// DeleteImage removes a SageMaker image by name.
+func (b *InMemoryBackend) DeleteImage(name string) error {
+	b.mu.Lock("DeleteImage")
+	defer b.mu.Unlock()
+
+	if _, ok := b.smImages[name]; !ok {
+		return fmt.Errorf("%w: image %q not found", ErrSMImageNotFound, name)
+	}
+
+	delete(b.smImages, name)
+
+	return nil
+}
+
+// ListImages returns all images sorted by name.
+func (b *InMemoryBackend) ListImages(nextToken string) ([]*SMImage, string) {
+	b.mu.RLock("ListImages")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.smImages))
+	for k := range b.smImages {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*SMImage, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneSMImage(b.smImages[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// ImageVersion
+// ---------------------------------------------------------------------------
+
+// ImageVersion represents a version of a SageMaker image.
+type ImageVersion struct {
+	CreationTime       time.Time `json:"CreationTime"`
+	LastModifiedTime   time.Time `json:"LastModifiedTime"`
+	ImageArn           string    `json:"ImageArn"`
+	ImageVersionArn    string    `json:"ImageVersionArn"`
+	ImageVersionStatus string    `json:"ImageVersionStatus"`
+	Version            int       `json:"Version"`
+}
+
+func cloneImageVersion(v *ImageVersion) *ImageVersion {
+	cp := *v
+
+	return &cp
+}
+
+// CreateImageVersion creates a new version for an image.
+func (b *InMemoryBackend) CreateImageVersion(imageName string) (*ImageVersion, error) {
+	b.mu.Lock("CreateImageVersion")
+	defer b.mu.Unlock()
+
+	img, ok := b.smImages[imageName]
+	if !ok {
+		return nil, fmt.Errorf("%w: image %q not found", ErrSMImageNotFound, imageName)
+	}
+
+	b.imageVersionCounts[imageName]++
+	version := b.imageVersionCounts[imageName]
+
+	versionARN := arn.Build(
+		"sagemaker", b.region, b.accountID,
+		"image-version/"+imageName+"/"+strconv.Itoa(version),
+	)
+	now := time.Now()
+
+	iv := &ImageVersion{
+		ImageArn:           img.ImageArn,
+		ImageVersionArn:    versionARN,
+		ImageVersionStatus: "CREATED",
+		Version:            version,
+		CreationTime:       now,
+		LastModifiedTime:   now,
+	}
+
+	if b.imageVersions[imageName] == nil {
+		b.imageVersions[imageName] = make(map[int]*ImageVersion)
+	}
+
+	b.imageVersions[imageName][version] = iv
+
+	return cloneImageVersion(iv), nil
+}
+
+// DescribeImageVersion returns an image version by image name and version number.
+func (b *InMemoryBackend) DescribeImageVersion(imageName string, version int) (*ImageVersion, error) {
+	b.mu.RLock("DescribeImageVersion")
+	defer b.mu.RUnlock()
+
+	versions, ok := b.imageVersions[imageName]
+	if !ok {
+		return nil, fmt.Errorf("%w: no versions found for image %q", ErrImageVersionNotFound, imageName)
+	}
+
+	iv, ok := versions[version]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: version %d not found for image %q", ErrImageVersionNotFound, version, imageName,
+		)
+	}
+
+	return cloneImageVersion(iv), nil
+}
+
+// DeleteImageVersion removes an image version.
+func (b *InMemoryBackend) DeleteImageVersion(imageName string, version int) error {
+	b.mu.Lock("DeleteImageVersion")
+	defer b.mu.Unlock()
+
+	versions, ok := b.imageVersions[imageName]
+	if !ok {
+		return fmt.Errorf("%w: no versions found for image %q", ErrImageVersionNotFound, imageName)
+	}
+
+	if _, ok := versions[version]; !ok {
+		return fmt.Errorf("%w: version %d not found for image %q", ErrImageVersionNotFound, version, imageName)
+	}
+
+	delete(versions, version)
+
+	return nil
+}
+
+// ListImageVersions returns all versions for an image sorted by version number.
+func (b *InMemoryBackend) ListImageVersions(imageName, nextToken string) ([]*ImageVersion, string) {
+	b.mu.RLock("ListImageVersions")
+	defer b.mu.RUnlock()
+
+	versions := b.imageVersions[imageName]
+
+	nums := make([]int, 0, len(versions))
+	for v := range versions {
+		nums = append(nums, v)
+	}
+
+	sort.Ints(nums)
+
+	start := 0
+	if nextToken != "" {
+		if n, err := strconv.Atoi(nextToken); err == nil {
+			for i, v := range nums {
+				if v == n {
+					start = i
+
+					break
+				}
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(nums) {
+		end = len(nums)
+	}
+
+	out := make([]*ImageVersion, 0, end-start)
+	for _, n := range nums[start:end] {
+		out = append(out, cloneImageVersion(versions[n]))
+	}
+
+	next := ""
+	if end < len(nums) {
+		next = strconv.Itoa(nums[end])
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// CompilationJob
+// ---------------------------------------------------------------------------
+
+// CompilationJob represents a SageMaker Neo compilation job.
+type CompilationJob struct {
+	CreationTime         time.Time         `json:"CreationTime"`
+	LastModifiedTime     time.Time         `json:"LastModifiedTime"`
+	Tags                 map[string]string `json:"Tags,omitempty"`
+	CompilationJobName   string            `json:"CompilationJobName"`
+	CompilationJobArn    string            `json:"CompilationJobArn"`
+	CompilationJobStatus string            `json:"CompilationJobStatus"`
+	RoleArn              string            `json:"RoleArn,omitempty"`
+}
+
+func cloneCompilationJob(j *CompilationJob) *CompilationJob {
+	cp := *j
+	cp.Tags = maps.Clone(j.Tags)
+
+	return &cp
+}
+
+// CreateCompilationJob creates a compilation job.
+func (b *InMemoryBackend) CreateCompilationJob(
+	name, roleArn string,
+	tags map[string]string,
+) (*CompilationJob, error) {
+	b.mu.Lock("CreateCompilationJob")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: CompilationJobName is required", ErrValidation)
+	}
+
+	if _, ok := b.compilationJobs[name]; ok {
+		return nil, fmt.Errorf("%w: compilation job %q already exists", ErrValidation, name)
+	}
+
+	jobARN := arn.Build("sagemaker", b.region, b.accountID, "compilation-job/"+name)
+	now := time.Now()
+
+	j := &CompilationJob{
+		CompilationJobName:   name,
+		CompilationJobArn:    jobARN,
+		CompilationJobStatus: "COMPLETED",
+		RoleArn:              roleArn,
+		Tags:                 mergeTags(nil, tags),
+		CreationTime:         now,
+		LastModifiedTime:     now,
+	}
+	b.compilationJobs[name] = j
+
+	return cloneCompilationJob(j), nil
+}
+
+// DescribeCompilationJob returns a compilation job by name.
+func (b *InMemoryBackend) DescribeCompilationJob(name string) (*CompilationJob, error) {
+	b.mu.RLock("DescribeCompilationJob")
+	defer b.mu.RUnlock()
+
+	j, ok := b.compilationJobs[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: compilation job %q not found", ErrCompilationJobNotFound, name)
+	}
+
+	return cloneCompilationJob(j), nil
+}
+
+// StopCompilationJob sets a compilation job status to "STOPPED".
+func (b *InMemoryBackend) StopCompilationJob(name string) error {
+	b.mu.Lock("StopCompilationJob")
+	defer b.mu.Unlock()
+
+	j, ok := b.compilationJobs[name]
+	if !ok {
+		return fmt.Errorf("%w: compilation job %q not found", ErrCompilationJobNotFound, name)
+	}
+
+	j.CompilationJobStatus = "STOPPED"
+	j.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// ListCompilationJobs returns all compilation jobs sorted by name.
+func (b *InMemoryBackend) ListCompilationJobs(nextToken string) ([]*CompilationJob, string) {
+	b.mu.RLock("ListCompilationJobs")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.compilationJobs))
+	for k := range b.compilationJobs {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*CompilationJob, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneCompilationJob(b.compilationJobs[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// MonitoringSchedule
+// ---------------------------------------------------------------------------
+
+// MonitoringSchedule represents a SageMaker monitoring schedule.
+type MonitoringSchedule struct {
+	CreationTime             time.Time         `json:"CreationTime"`
+	LastModifiedTime         time.Time         `json:"LastModifiedTime"`
+	Tags                     map[string]string `json:"Tags,omitempty"`
+	MonitoringScheduleName   string            `json:"MonitoringScheduleName"`
+	MonitoringScheduleArn    string            `json:"MonitoringScheduleArn"`
+	MonitoringScheduleStatus string            `json:"MonitoringScheduleStatus"`
+}
+
+func cloneMonitoringSchedule(ms *MonitoringSchedule) *MonitoringSchedule {
+	cp := *ms
+	cp.Tags = maps.Clone(ms.Tags)
+
+	return &cp
+}
+
+// CreateMonitoringSchedule creates a monitoring schedule.
+func (b *InMemoryBackend) CreateMonitoringSchedule(
+	name string,
+	tags map[string]string,
+) (*MonitoringSchedule, error) {
+	b.mu.Lock("CreateMonitoringSchedule")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: MonitoringScheduleName is required", ErrValidation)
+	}
+
+	if _, ok := b.monitoringSchedules[name]; ok {
+		return nil, fmt.Errorf("%w: monitoring schedule %q already exists", ErrValidation, name)
+	}
+
+	schedARN := arn.Build("sagemaker", b.region, b.accountID, "monitoring-schedule/"+name)
+	now := time.Now()
+
+	ms := &MonitoringSchedule{
+		MonitoringScheduleName:   name,
+		MonitoringScheduleArn:    schedARN,
+		MonitoringScheduleStatus: "Scheduled",
+		Tags:                     mergeTags(nil, tags),
+		CreationTime:             now,
+		LastModifiedTime:         now,
+	}
+	b.monitoringSchedules[name] = ms
+
+	return cloneMonitoringSchedule(ms), nil
+}
+
+// DescribeMonitoringSchedule returns a monitoring schedule by name.
+func (b *InMemoryBackend) DescribeMonitoringSchedule(name string) (*MonitoringSchedule, error) {
+	b.mu.RLock("DescribeMonitoringSchedule")
+	defer b.mu.RUnlock()
+
+	ms, ok := b.monitoringSchedules[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: monitoring schedule %q not found", ErrMonitoringScheduleNotFound, name)
+	}
+
+	return cloneMonitoringSchedule(ms), nil
+}
+
+// DeleteMonitoringSchedule removes a monitoring schedule.
+func (b *InMemoryBackend) DeleteMonitoringSchedule(name string) error {
+	b.mu.Lock("DeleteMonitoringSchedule")
+	defer b.mu.Unlock()
+
+	if _, ok := b.monitoringSchedules[name]; !ok {
+		return fmt.Errorf("%w: monitoring schedule %q not found", ErrMonitoringScheduleNotFound, name)
+	}
+
+	delete(b.monitoringSchedules, name)
+
+	return nil
+}
+
+// StopMonitoringSchedule sets a monitoring schedule status to "Stopped".
+func (b *InMemoryBackend) StopMonitoringSchedule(name string) error {
+	b.mu.Lock("StopMonitoringSchedule")
+	defer b.mu.Unlock()
+
+	ms, ok := b.monitoringSchedules[name]
+	if !ok {
+		return fmt.Errorf("%w: monitoring schedule %q not found", ErrMonitoringScheduleNotFound, name)
+	}
+
+	ms.MonitoringScheduleStatus = "Stopped"
+	ms.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// StartMonitoringSchedule sets a monitoring schedule status to "Scheduled".
+func (b *InMemoryBackend) StartMonitoringSchedule(name string) error {
+	b.mu.Lock("StartMonitoringSchedule")
+	defer b.mu.Unlock()
+
+	ms, ok := b.monitoringSchedules[name]
+	if !ok {
+		return fmt.Errorf("%w: monitoring schedule %q not found", ErrMonitoringScheduleNotFound, name)
+	}
+
+	ms.MonitoringScheduleStatus = "Scheduled"
+	ms.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// UpdateMonitoringSchedule updates a monitoring schedule (marks it modified).
+func (b *InMemoryBackend) UpdateMonitoringSchedule(name string) (*MonitoringSchedule, error) {
+	b.mu.Lock("UpdateMonitoringSchedule")
+	defer b.mu.Unlock()
+
+	ms, ok := b.monitoringSchedules[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: monitoring schedule %q not found", ErrMonitoringScheduleNotFound, name)
+	}
+
+	ms.LastModifiedTime = time.Now()
+
+	return cloneMonitoringSchedule(ms), nil
+}
+
+// ListMonitoringSchedules returns all monitoring schedules sorted by name.
+func (b *InMemoryBackend) ListMonitoringSchedules(nextToken string) ([]*MonitoringSchedule, string) {
+	b.mu.RLock("ListMonitoringSchedules")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.monitoringSchedules))
+	for k := range b.monitoringSchedules {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*MonitoringSchedule, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneMonitoringSchedule(b.monitoringSchedules[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}
+
+// ---------------------------------------------------------------------------
+// Workteam
+// ---------------------------------------------------------------------------
+
+// Workteam represents a SageMaker Ground Truth workteam.
+type Workteam struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	LastModifiedTime time.Time         `json:"LastModifiedTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	WorkteamName     string            `json:"WorkteamName"`
+	WorkteamArn      string            `json:"WorkteamArn"`
+	Description      string            `json:"Description,omitempty"`
+}
+
+func cloneWorkteam(w *Workteam) *Workteam {
+	cp := *w
+	cp.Tags = maps.Clone(w.Tags)
+
+	return &cp
+}
+
+// CreateWorkteam creates a workteam.
+func (b *InMemoryBackend) CreateWorkteam(
+	name, description string,
+	tags map[string]string,
+) (*Workteam, error) {
+	b.mu.Lock("CreateWorkteam")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: WorkteamName is required", ErrValidation)
+	}
+
+	if _, ok := b.workteams[name]; ok {
+		return nil, fmt.Errorf("%w: workteam %q already exists", ErrValidation, name)
+	}
+
+	workteamARN := arn.Build("sagemaker", b.region, b.accountID, "workteam/"+name)
+	now := time.Now()
+
+	w := &Workteam{
+		WorkteamName:     name,
+		WorkteamArn:      workteamARN,
+		Description:      description,
+		Tags:             mergeTags(nil, tags),
+		CreationTime:     now,
+		LastModifiedTime: now,
+	}
+	b.workteams[name] = w
+
+	return cloneWorkteam(w), nil
+}
+
+// DescribeWorkteam returns a workteam by name.
+func (b *InMemoryBackend) DescribeWorkteam(name string) (*Workteam, error) {
+	b.mu.RLock("DescribeWorkteam")
+	defer b.mu.RUnlock()
+
+	w, ok := b.workteams[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: workteam %q not found", ErrWorkteamNotFound, name)
+	}
+
+	return cloneWorkteam(w), nil
+}
+
+// DeleteWorkteam removes a workteam.
+func (b *InMemoryBackend) DeleteWorkteam(name string) error {
+	b.mu.Lock("DeleteWorkteam")
+	defer b.mu.Unlock()
+
+	if _, ok := b.workteams[name]; !ok {
+		return fmt.Errorf("%w: workteam %q not found", ErrWorkteamNotFound, name)
+	}
+
+	delete(b.workteams, name)
+
+	return nil
+}
+
+// ListWorkteams returns all workteams sorted by name.
+func (b *InMemoryBackend) ListWorkteams(nextToken string) ([]*Workteam, string) {
+	b.mu.RLock("ListWorkteams")
+	defer b.mu.RUnlock()
+
+	keys := make([]string, 0, len(b.workteams))
+	for k := range b.workteams {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	start := 0
+	if nextToken != "" {
+		for i, k := range keys {
+			if k == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := start + sagemakerDefaultPageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*Workteam, 0, end-start)
+	for _, k := range keys[start:end] {
+		out = append(out, cloneWorkteam(b.workteams[k]))
+	}
+
+	next := ""
+	if end < len(keys) {
+		next = keys[end]
+	}
+
+	return out, next
+}

--- a/services/sagemaker/handler.go
+++ b/services/sagemaker/handler.go
@@ -241,12 +241,10 @@ func batch2OpsSupported() []string {
 		"CreateMonitoringSchedule",
 		"DescribeMonitoringSchedule",
 		"DeleteMonitoringSchedule",
-		"StopMonitoringSchedule",
+		opStopMonitoringSchedule,
 		"StartMonitoringSchedule",
 		"UpdateMonitoringSchedule",
 		"ListMonitoringSchedules",
-		// UpdateCodeRepository also goes to batch2
-		"UpdateCodeRepository",
 		// Workteam
 		"CreateWorkteam",
 		"DescribeWorkteam",

--- a/services/sagemaker/handler.go
+++ b/services/sagemaker/handler.go
@@ -68,7 +68,7 @@ func (h *Handler) Reset() {
 //
 //nolint:funlen
 func (h *Handler) GetSupportedOperations() []string {
-	core := []string{ //nolint:prealloc // literal initialization, not append loop
+	core := []string{
 		"AddAssociation",
 		"AddTags",
 		"AssociateTrialComponent",

--- a/services/sagemaker/handler.go
+++ b/services/sagemaker/handler.go
@@ -176,7 +176,83 @@ func (h *Handler) GetSupportedOperations() []string {
 		"UpdateTrialComponent",
 	}
 
-	return append(core, stubOpsSupported()...)
+	batch2 := batch2OpsSupported()
+
+	combined := make([]string, 0, len(core)+len(batch2)+len(stubOpsSupported()))
+	combined = append(combined, core...)
+	combined = append(combined, batch2...)
+
+	return append(combined, stubOpsSupported()...)
+}
+
+// batch2OpsSupported returns the 50 real stateful operations implemented in batch 2.
+func batch2OpsSupported() []string {
+	return []string{
+		// ModelPackage CRUD
+		"CreateModelPackage",
+		"DescribeModelPackage",
+		"DeleteModelPackage",
+		"ListModelPackages",
+		// ModelPackageGroup CRUD
+		"CreateModelPackageGroup",
+		"DescribeModelPackageGroup",
+		"DeleteModelPackageGroup",
+		"ListModelPackageGroups",
+		// AutoMLJob
+		"CreateAutoMLJob",
+		"CreateAutoMLJobV2",
+		"DescribeAutoMLJob",
+		"DescribeAutoMLJobV2",
+		"StopAutoMLJob",
+		"ListAutoMLJobs",
+		// CodeRepository
+		"CreateCodeRepository",
+		"DescribeCodeRepository",
+		"UpdateCodeRepository",
+		"DeleteCodeRepository",
+		"ListCodeRepositories",
+		// Project
+		"CreateProject",
+		"DescribeProject",
+		"DeleteProject",
+		"ListProjects",
+		// Space
+		"CreateSpace",
+		"DescribeSpace",
+		"DeleteSpace",
+		"ListSpaces",
+		// Image
+		"CreateImage",
+		"DescribeImage",
+		"DeleteImage",
+		"ListImages",
+		// ImageVersion
+		"CreateImageVersion",
+		"DescribeImageVersion",
+		"DeleteImageVersion",
+		"ListImageVersions",
+		// CompilationJob
+		"CreateCompilationJob",
+		"DescribeCompilationJob",
+		"DeleteCompilationJob",
+		"StopCompilationJob",
+		"ListCompilationJobs",
+		// MonitoringSchedule
+		"CreateMonitoringSchedule",
+		"DescribeMonitoringSchedule",
+		"DeleteMonitoringSchedule",
+		"StopMonitoringSchedule",
+		"StartMonitoringSchedule",
+		"UpdateMonitoringSchedule",
+		"ListMonitoringSchedules",
+		// UpdateCodeRepository also goes to batch2
+		"UpdateCodeRepository",
+		// Workteam
+		"CreateWorkteam",
+		"DescribeWorkteam",
+		"DeleteWorkteam",
+		"ListWorkteams",
+	}
 }
 
 // ChaosServiceName returns the lowercase AWS service name for fault rule matching.
@@ -320,6 +396,10 @@ func (h *Handler) dispatchNewOps(ctx context.Context, op string, body []byte) ([
 	}
 
 	if r, ok, err := h.dispatchStatefulOps(ctx, op, body); ok {
+		return r, err
+	}
+
+	if r, ok, err := h.dispatchBatch2Ops(ctx, op, body); ok {
 		return r, err
 	}
 

--- a/services/sagemaker/handler_batch2.go
+++ b/services/sagemaker/handler_batch2.go
@@ -1,0 +1,1325 @@
+package sagemaker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// dispatchBatch2Ops dispatches the 50 new real stateful operations (batch 2).
+//
+//nolint:cyclop,gocyclo // large switch is required for dispatching many operations
+func (h *Handler) dispatchBatch2Ops(
+	_ context.Context,
+	op string,
+	body []byte,
+) ([]byte, bool, error) {
+	switch op {
+	// ModelPackage
+	case "CreateModelPackage":
+		r, err := h.handleCreateModelPackage(body)
+
+		return r, true, err
+	case "DescribeModelPackage":
+		r, err := h.handleDescribeModelPackage(body)
+
+		return r, true, err
+	case "DeleteModelPackage":
+		return nil, true, h.handleDeleteModelPackage(body)
+	case "ListModelPackages":
+		r, err := h.handleListModelPackages(body)
+
+		return r, true, err
+
+	// ModelPackageGroup
+	case "CreateModelPackageGroup":
+		r, err := h.handleCreateModelPackageGroup(body)
+
+		return r, true, err
+	case "DescribeModelPackageGroup":
+		r, err := h.handleDescribeModelPackageGroup(body)
+
+		return r, true, err
+	case "DeleteModelPackageGroup":
+		return nil, true, h.handleDeleteModelPackageGroup(body)
+	case "ListModelPackageGroups":
+		r, err := h.handleListModelPackageGroups(body)
+
+		return r, true, err
+
+	// AutoMLJob
+	case "CreateAutoMLJob", "CreateAutoMLJobV2":
+		r, err := h.handleCreateAutoMLJob(body)
+
+		return r, true, err
+	case "DescribeAutoMLJob", "DescribeAutoMLJobV2":
+		r, err := h.handleDescribeAutoMLJob(body)
+
+		return r, true, err
+	case "StopAutoMLJob":
+		return nil, true, h.handleStopAutoMLJob(body)
+	case "ListAutoMLJobs":
+		r, err := h.handleListAutoMLJobs(body)
+
+		return r, true, err
+
+	// CodeRepository
+	case "CreateCodeRepository":
+		r, err := h.handleCreateCodeRepository(body)
+
+		return r, true, err
+	case "DescribeCodeRepository":
+		r, err := h.handleDescribeCodeRepository(body)
+
+		return r, true, err
+	case "UpdateCodeRepository":
+		r, err := h.handleUpdateCodeRepository(body)
+
+		return r, true, err
+	case "DeleteCodeRepository":
+		return nil, true, h.handleDeleteCodeRepository(body)
+	case "ListCodeRepositories":
+		r, err := h.handleListCodeRepositories(body)
+
+		return r, true, err
+
+	// Project
+	case "CreateProject":
+		r, err := h.handleCreateProject(body)
+
+		return r, true, err
+	case "DescribeProject":
+		r, err := h.handleDescribeProject(body)
+
+		return r, true, err
+	case "DeleteProject":
+		return nil, true, h.handleDeleteProject(body)
+	case "ListProjects":
+		r, err := h.handleListProjects(body)
+
+		return r, true, err
+
+	// Space
+	case "CreateSpace":
+		r, err := h.handleCreateSpace(body)
+
+		return r, true, err
+	case "DescribeSpace":
+		r, err := h.handleDescribeSpace(body)
+
+		return r, true, err
+	case "DeleteSpace":
+		return nil, true, h.handleDeleteSpace(body)
+	case "ListSpaces":
+		r, err := h.handleListSpaces(body)
+
+		return r, true, err
+
+	// Image
+	case "CreateImage":
+		r, err := h.handleCreateImage(body)
+
+		return r, true, err
+	case "DescribeImage":
+		r, err := h.handleDescribeImage(body)
+
+		return r, true, err
+	case "DeleteImage":
+		return nil, true, h.handleDeleteImage(body)
+	case "ListImages":
+		r, err := h.handleListImages(body)
+
+		return r, true, err
+
+	// ImageVersion
+	case "CreateImageVersion":
+		r, err := h.handleCreateImageVersion(body)
+
+		return r, true, err
+	case "DescribeImageVersion":
+		r, err := h.handleDescribeImageVersion(body)
+
+		return r, true, err
+	case "DeleteImageVersion":
+		return nil, true, h.handleDeleteImageVersion(body)
+	case "ListImageVersions":
+		r, err := h.handleListImageVersions(body)
+
+		return r, true, err
+
+	// CompilationJob
+	case "CreateCompilationJob":
+		r, err := h.handleCreateCompilationJob(body)
+
+		return r, true, err
+	case "DescribeCompilationJob":
+		r, err := h.handleDescribeCompilationJob(body)
+
+		return r, true, err
+	case "StopCompilationJob":
+		return nil, true, h.handleStopCompilationJob(body)
+	case "ListCompilationJobs":
+		r, err := h.handleListCompilationJobs(body)
+
+		return r, true, err
+
+	// MonitoringSchedule
+	case "CreateMonitoringSchedule":
+		r, err := h.handleCreateMonitoringSchedule(body)
+
+		return r, true, err
+	case "DescribeMonitoringSchedule":
+		r, err := h.handleDescribeMonitoringSchedule(body)
+
+		return r, true, err
+	case "DeleteMonitoringSchedule":
+		return nil, true, h.handleDeleteMonitoringSchedule(body)
+	case "StopMonitoringSchedule":
+		return nil, true, h.handleStopMonitoringSchedule(body)
+	case "StartMonitoringSchedule":
+		return nil, true, h.handleStartMonitoringSchedule(body)
+	case "UpdateMonitoringSchedule":
+		r, err := h.handleUpdateMonitoringSchedule(body)
+
+		return r, true, err
+	case "ListMonitoringSchedules":
+		r, err := h.handleListMonitoringSchedules(body)
+
+		return r, true, err
+
+	// Workteam
+	case "CreateWorkteam":
+		r, err := h.handleCreateWorkteam(body)
+
+		return r, true, err
+	case "DescribeWorkteam":
+		r, err := h.handleDescribeWorkteam(body)
+
+		return r, true, err
+	case "DeleteWorkteam":
+		return nil, true, h.handleDeleteWorkteam(body)
+	case "ListWorkteams":
+		r, err := h.handleListWorkteams(body)
+
+		return r, true, err
+	}
+
+	return nil, false, nil
+}
+
+// ---------------------------------------------------------------------------
+// ModelPackage handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateModelPackage(body []byte) ([]byte, error) {
+	var req struct {
+		ModelPackageName        string            `json:"ModelPackageName"`
+		ModelPackageGroupName   string            `json:"ModelPackageGroupName"`
+		ModelPackageDescription string            `json:"ModelPackageDescription"`
+		Tags                    map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelPackageName == "" {
+		return nil, fmt.Errorf("%w: ModelPackageName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateModelPackage(
+		req.ModelPackageName, req.ModelPackageGroupName, req.ModelPackageDescription, req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"ModelPackageArn": result.ModelPackageArn})
+}
+
+func (h *Handler) handleDescribeModelPackage(body []byte) ([]byte, error) {
+	var req struct {
+		ModelPackageName string `json:"ModelPackageName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelPackageName == "" {
+		return nil, fmt.Errorf("%w: ModelPackageName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeModelPackage(req.ModelPackageName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteModelPackage(body []byte) error {
+	var req struct {
+		ModelPackageName string `json:"ModelPackageName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelPackageName == "" {
+		return fmt.Errorf("%w: ModelPackageName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteModelPackage(req.ModelPackageName)
+}
+
+func (h *Handler) handleListModelPackages(body []byte) ([]byte, error) {
+	var req struct {
+		ModelPackageGroupName string `json:"ModelPackageGroupName"`
+		NextToken             string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListModelPackages(req.ModelPackageGroupName, req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, mp := range items {
+		summaries = append(summaries, map[string]any{
+			"ModelPackageName":   mp.ModelPackageName,
+			"ModelPackageArn":    mp.ModelPackageArn,
+			"ModelPackageStatus": mp.ModelPackageStatus,
+			"CreationTime":       mp.CreationTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"ModelPackageSummaryList": summaries,
+		"NextToken":               next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ModelPackageGroup handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateModelPackageGroup(body []byte) ([]byte, error) {
+	var req struct {
+		ModelPackageGroupName        string            `json:"ModelPackageGroupName"`
+		ModelPackageGroupDescription string            `json:"ModelPackageGroupDescription"`
+		Tags                         map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelPackageGroupName == "" {
+		return nil, fmt.Errorf("%w: ModelPackageGroupName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateModelPackageGroup(
+		req.ModelPackageGroupName, req.ModelPackageGroupDescription, req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"ModelPackageGroupArn": result.ModelPackageGroupArn})
+}
+
+func (h *Handler) handleDescribeModelPackageGroup(body []byte) ([]byte, error) {
+	var req struct {
+		ModelPackageGroupName string `json:"ModelPackageGroupName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelPackageGroupName == "" {
+		return nil, fmt.Errorf("%w: ModelPackageGroupName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeModelPackageGroup(req.ModelPackageGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteModelPackageGroup(body []byte) error {
+	var req struct {
+		ModelPackageGroupName string `json:"ModelPackageGroupName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelPackageGroupName == "" {
+		return fmt.Errorf("%w: ModelPackageGroupName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteModelPackageGroup(req.ModelPackageGroupName)
+}
+
+func (h *Handler) handleListModelPackageGroups(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListModelPackageGroups(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, g := range items {
+		summaries = append(summaries, map[string]any{
+			"ModelPackageGroupName":   g.ModelPackageGroupName,
+			"ModelPackageGroupArn":    g.ModelPackageGroupArn,
+			"ModelPackageGroupStatus": g.ModelPackageGroupStatus,
+			"CreationTime":            g.CreationTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"ModelPackageGroupSummaryList": summaries,
+		"NextToken":                   next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// AutoMLJob handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateAutoMLJob(body []byte) ([]byte, error) {
+	var req struct {
+		AutoMLJobName string            `json:"AutoMLJobName"`
+		RoleArn       string            `json:"RoleArn"`
+		Tags          map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AutoMLJobName == "" {
+		return nil, fmt.Errorf("%w: AutoMLJobName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateAutoMLJob(req.AutoMLJobName, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"AutoMLJobArn": result.AutoMLJobArn})
+}
+
+func (h *Handler) handleDescribeAutoMLJob(body []byte) ([]byte, error) {
+	var req struct {
+		AutoMLJobName string `json:"AutoMLJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AutoMLJobName == "" {
+		return nil, fmt.Errorf("%w: AutoMLJobName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeAutoMLJob(req.AutoMLJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleStopAutoMLJob(body []byte) error {
+	var req struct {
+		AutoMLJobName string `json:"AutoMLJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AutoMLJobName == "" {
+		return fmt.Errorf("%w: AutoMLJobName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StopAutoMLJob(req.AutoMLJobName)
+}
+
+func (h *Handler) handleListAutoMLJobs(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListAutoMLJobs(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, j := range items {
+		summaries = append(summaries, map[string]any{
+			"AutoMLJobName":   j.AutoMLJobName,
+			"AutoMLJobArn":    j.AutoMLJobArn,
+			"AutoMLJobStatus": j.AutoMLJobStatus,
+			"CreationTime":    j.CreationTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"AutoMLJobSummaries": summaries,
+		"NextToken":          next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CodeRepository handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateCodeRepository(body []byte) ([]byte, error) {
+	var req struct {
+		CodeRepositoryName string            `json:"CodeRepositoryName"`
+		GitConfig          map[string]string `json:"GitConfig"`
+		Tags               map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CodeRepositoryName == "" {
+		return nil, fmt.Errorf("%w: CodeRepositoryName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateCodeRepository(req.CodeRepositoryName, req.GitConfig, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"CodeRepositoryArn": result.CodeRepositoryArn})
+}
+
+func (h *Handler) handleDescribeCodeRepository(body []byte) ([]byte, error) {
+	var req struct {
+		CodeRepositoryName string `json:"CodeRepositoryName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CodeRepositoryName == "" {
+		return nil, fmt.Errorf("%w: CodeRepositoryName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeCodeRepository(req.CodeRepositoryName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleUpdateCodeRepository(body []byte) ([]byte, error) {
+	var req struct {
+		CodeRepositoryName string            `json:"CodeRepositoryName"`
+		GitConfig          map[string]string `json:"GitConfig"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CodeRepositoryName == "" {
+		return nil, fmt.Errorf("%w: CodeRepositoryName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.UpdateCodeRepository(req.CodeRepositoryName, req.GitConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"CodeRepositoryArn": result.CodeRepositoryArn})
+}
+
+func (h *Handler) handleDeleteCodeRepository(body []byte) error {
+	var req struct {
+		CodeRepositoryName string `json:"CodeRepositoryName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CodeRepositoryName == "" {
+		return fmt.Errorf("%w: CodeRepositoryName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteCodeRepository(req.CodeRepositoryName)
+}
+
+func (h *Handler) handleListCodeRepositories(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListCodeRepositories(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, r := range items {
+		summaries = append(summaries, map[string]any{
+			"CodeRepositoryName": r.CodeRepositoryName,
+			"CodeRepositoryArn":  r.CodeRepositoryArn,
+			"CreationTime":       r.CreationTime,
+			"LastModifiedTime":   r.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"CodeRepositorySummaryList": summaries,
+		"NextToken":                next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Project handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateProject(body []byte) ([]byte, error) {
+	var req struct {
+		ProjectName        string            `json:"ProjectName"`
+		ProjectDescription string            `json:"ProjectDescription"`
+		Tags               map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ProjectName == "" {
+		return nil, fmt.Errorf("%w: ProjectName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateProject(req.ProjectName, req.ProjectDescription, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{
+		"ProjectArn": result.ProjectArn,
+		"ProjectId":  result.ProjectId,
+	})
+}
+
+func (h *Handler) handleDescribeProject(body []byte) ([]byte, error) {
+	var req struct {
+		ProjectName string `json:"ProjectName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ProjectName == "" {
+		return nil, fmt.Errorf("%w: ProjectName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeProject(req.ProjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteProject(body []byte) error {
+	var req struct {
+		ProjectName string `json:"ProjectName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ProjectName == "" {
+		return fmt.Errorf("%w: ProjectName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteProject(req.ProjectName)
+}
+
+func (h *Handler) handleListProjects(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListProjects(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, p := range items {
+		summaries = append(summaries, map[string]any{
+			"ProjectName":   p.ProjectName,
+			"ProjectArn":    p.ProjectArn,
+			"ProjectId":     p.ProjectId,
+			"ProjectStatus": p.ProjectStatus,
+			"CreationTime":  p.CreationTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"ProjectSummaryList": summaries,
+		"NextToken":          next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Space handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateSpace(body []byte) ([]byte, error) {
+	var req struct {
+		DomainId  string            `json:"DomainId"`
+		SpaceName string            `json:"SpaceName"`
+		Tags      map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.DomainId == "" {
+		return nil, fmt.Errorf("%w: DomainId is required", errInvalidRequest)
+	}
+
+	if req.SpaceName == "" {
+		return nil, fmt.Errorf("%w: SpaceName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateSpace(req.DomainId, req.SpaceName, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"SpaceArn": result.SpaceArn})
+}
+
+func (h *Handler) handleDescribeSpace(body []byte) ([]byte, error) {
+	var req struct {
+		DomainId  string `json:"DomainId"`
+		SpaceName string `json:"SpaceName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.DomainId == "" {
+		return nil, fmt.Errorf("%w: DomainId is required", errInvalidRequest)
+	}
+
+	if req.SpaceName == "" {
+		return nil, fmt.Errorf("%w: SpaceName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeSpace(req.DomainId, req.SpaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteSpace(body []byte) error {
+	var req struct {
+		DomainId  string `json:"DomainId"`
+		SpaceName string `json:"SpaceName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.DomainId == "" {
+		return fmt.Errorf("%w: DomainId is required", errInvalidRequest)
+	}
+
+	if req.SpaceName == "" {
+		return fmt.Errorf("%w: SpaceName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteSpace(req.DomainId, req.SpaceName)
+}
+
+func (h *Handler) handleListSpaces(body []byte) ([]byte, error) {
+	var req struct {
+		DomainIdEquals string `json:"DomainIdEquals"`
+		NextToken      string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListSpaces(req.DomainIdEquals, req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, s := range items {
+		summaries = append(summaries, map[string]any{
+			"SpaceName":        s.SpaceName,
+			"SpaceArn":         s.SpaceArn,
+			"DomainId":         s.DomainId,
+			"SpaceStatus":      s.SpaceStatus,
+			"CreationTime":     s.CreationTime,
+			"LastModifiedTime": s.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"Spaces":    summaries,
+		"NextToken": next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Image handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateImage(body []byte) ([]byte, error) {
+	var req struct {
+		ImageName   string            `json:"ImageName"`
+		Description string            `json:"Description"`
+		RoleArn     string            `json:"RoleArn"`
+		Tags        map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return nil, fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateImage(req.ImageName, req.Description, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"ImageArn": result.ImageArn})
+}
+
+func (h *Handler) handleDescribeImage(body []byte) ([]byte, error) {
+	var req struct {
+		ImageName string `json:"ImageName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return nil, fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeImage(req.ImageName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteImage(body []byte) error {
+	var req struct {
+		ImageName string `json:"ImageName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteImage(req.ImageName)
+}
+
+func (h *Handler) handleListImages(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListImages(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, img := range items {
+		summaries = append(summaries, map[string]any{
+			"ImageName":        img.ImageName,
+			"ImageArn":         img.ImageArn,
+			"ImageStatus":      img.ImageStatus,
+			"CreationTime":     img.CreationTime,
+			"LastModifiedTime": img.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"Images":    summaries,
+		"NextToken": next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ImageVersion handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateImageVersion(body []byte) ([]byte, error) {
+	var req struct {
+		ImageName string `json:"ImageName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return nil, fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateImageVersion(req.ImageName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"ImageVersionArn": result.ImageVersionArn})
+}
+
+func (h *Handler) handleDescribeImageVersion(body []byte) ([]byte, error) {
+	var req struct {
+		ImageName string `json:"ImageName"`
+		Version   int    `json:"Version"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return nil, fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeImageVersion(req.ImageName, req.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteImageVersion(body []byte) error {
+	var req struct {
+		ImageName string `json:"ImageName"`
+		Version   int    `json:"Version"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteImageVersion(req.ImageName, req.Version)
+}
+
+func (h *Handler) handleListImageVersions(body []byte) ([]byte, error) {
+	var req struct {
+		ImageName string `json:"ImageName"`
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ImageName == "" {
+		return nil, fmt.Errorf("%w: ImageName is required", errInvalidRequest)
+	}
+
+	items, next := h.Backend.ListImageVersions(req.ImageName, req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, iv := range items {
+		summaries = append(summaries, map[string]any{
+			"ImageVersionArn":    iv.ImageVersionArn,
+			"ImageVersionStatus": iv.ImageVersionStatus,
+			"Version":            iv.Version,
+			"CreationTime":       iv.CreationTime,
+			"LastModifiedTime":   iv.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"ImageVersions": summaries,
+		"NextToken":     next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CompilationJob handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateCompilationJob(body []byte) ([]byte, error) {
+	var req struct {
+		CompilationJobName string            `json:"CompilationJobName"`
+		RoleArn            string            `json:"RoleArn"`
+		Tags               map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CompilationJobName == "" {
+		return nil, fmt.Errorf("%w: CompilationJobName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateCompilationJob(req.CompilationJobName, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"CompilationJobArn": result.CompilationJobArn})
+}
+
+func (h *Handler) handleDescribeCompilationJob(body []byte) ([]byte, error) {
+	var req struct {
+		CompilationJobName string `json:"CompilationJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CompilationJobName == "" {
+		return nil, fmt.Errorf("%w: CompilationJobName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeCompilationJob(req.CompilationJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleStopCompilationJob(body []byte) error {
+	var req struct {
+		CompilationJobName string `json:"CompilationJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CompilationJobName == "" {
+		return fmt.Errorf("%w: CompilationJobName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StopCompilationJob(req.CompilationJobName)
+}
+
+func (h *Handler) handleListCompilationJobs(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListCompilationJobs(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, j := range items {
+		summaries = append(summaries, map[string]any{
+			"CompilationJobName":   j.CompilationJobName,
+			"CompilationJobArn":    j.CompilationJobArn,
+			"CompilationJobStatus": j.CompilationJobStatus,
+			"CreationTime":         j.CreationTime,
+			"LastModifiedTime":     j.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"CompilationJobSummaries": summaries,
+		"NextToken":               next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// MonitoringSchedule handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateMonitoringSchedule(body []byte) ([]byte, error) {
+	var req struct {
+		MonitoringScheduleName string            `json:"MonitoringScheduleName"`
+		Tags                   map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MonitoringScheduleName == "" {
+		return nil, fmt.Errorf("%w: MonitoringScheduleName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateMonitoringSchedule(req.MonitoringScheduleName, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"MonitoringScheduleArn": result.MonitoringScheduleArn})
+}
+
+func (h *Handler) handleDescribeMonitoringSchedule(body []byte) ([]byte, error) {
+	var req struct {
+		MonitoringScheduleName string `json:"MonitoringScheduleName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MonitoringScheduleName == "" {
+		return nil, fmt.Errorf("%w: MonitoringScheduleName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeMonitoringSchedule(req.MonitoringScheduleName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteMonitoringSchedule(body []byte) error {
+	var req struct {
+		MonitoringScheduleName string `json:"MonitoringScheduleName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MonitoringScheduleName == "" {
+		return fmt.Errorf("%w: MonitoringScheduleName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteMonitoringSchedule(req.MonitoringScheduleName)
+}
+
+func (h *Handler) handleStopMonitoringSchedule(body []byte) error {
+	var req struct {
+		MonitoringScheduleName string `json:"MonitoringScheduleName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MonitoringScheduleName == "" {
+		return fmt.Errorf("%w: MonitoringScheduleName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StopMonitoringSchedule(req.MonitoringScheduleName)
+}
+
+func (h *Handler) handleStartMonitoringSchedule(body []byte) error {
+	var req struct {
+		MonitoringScheduleName string `json:"MonitoringScheduleName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MonitoringScheduleName == "" {
+		return fmt.Errorf("%w: MonitoringScheduleName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StartMonitoringSchedule(req.MonitoringScheduleName)
+}
+
+func (h *Handler) handleUpdateMonitoringSchedule(body []byte) ([]byte, error) {
+	var req struct {
+		MonitoringScheduleName string `json:"MonitoringScheduleName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.MonitoringScheduleName == "" {
+		return nil, fmt.Errorf("%w: MonitoringScheduleName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.UpdateMonitoringSchedule(req.MonitoringScheduleName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"MonitoringScheduleArn": result.MonitoringScheduleArn})
+}
+
+func (h *Handler) handleListMonitoringSchedules(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListMonitoringSchedules(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, ms := range items {
+		summaries = append(summaries, map[string]any{
+			"MonitoringScheduleName":   ms.MonitoringScheduleName,
+			"MonitoringScheduleArn":    ms.MonitoringScheduleArn,
+			"MonitoringScheduleStatus": ms.MonitoringScheduleStatus,
+			"CreationTime":             ms.CreationTime,
+			"LastModifiedTime":         ms.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"MonitoringScheduleSummaries": summaries,
+		"NextToken":                   next,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Workteam handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateWorkteam(body []byte) ([]byte, error) {
+	var req struct {
+		WorkteamName string            `json:"WorkteamName"`
+		Description  string            `json:"Description"`
+		Tags         map[string]string `json:"Tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.WorkteamName == "" {
+		return nil, fmt.Errorf("%w: WorkteamName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateWorkteam(req.WorkteamName, req.Description, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"WorkteamArn": result.WorkteamArn})
+}
+
+func (h *Handler) handleDescribeWorkteam(body []byte) ([]byte, error) {
+	var req struct {
+		WorkteamName string `json:"WorkteamName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.WorkteamName == "" {
+		return nil, fmt.Errorf("%w: WorkteamName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeWorkteam(req.WorkteamName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"Workteam": result})
+}
+
+func (h *Handler) handleDeleteWorkteam(body []byte) error {
+	var req struct {
+		WorkteamName string `json:"WorkteamName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.WorkteamName == "" {
+		return fmt.Errorf("%w: WorkteamName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteWorkteam(req.WorkteamName)
+}
+
+func (h *Handler) handleListWorkteams(body []byte) ([]byte, error) {
+	var req struct {
+		NextToken string `json:"NextToken"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	items, next := h.Backend.ListWorkteams(req.NextToken)
+
+	summaries := make([]map[string]any, 0, len(items))
+	for _, w := range items {
+		summaries = append(summaries, map[string]any{
+			"WorkteamName":     w.WorkteamName,
+			"WorkteamArn":      w.WorkteamArn,
+			"Description":      w.Description,
+			"CreationTime":     w.CreationTime,
+			"LastModifiedTime": w.LastModifiedTime,
+		})
+	}
+
+	return json.Marshal(map[string]any{
+		"Workteams": summaries,
+		"NextToken": next,
+	})
+}
+
+// ensure strconv is used (Version field in ImageVersion list handler uses it).
+var _ = strconv.Itoa

--- a/services/sagemaker/handler_batch2.go
+++ b/services/sagemaker/handler_batch2.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
+)
+
+// batch2 key constants to avoid goconst warnings.
+const (
+	keyNextToken             = "NextToken"
+	opStopMonitoringSchedule = "StopMonitoringSchedule"
 )
 
 // dispatchBatch2Ops dispatches the 50 new real stateful operations (batch 2).
 //
-//nolint:cyclop,gocyclo // large switch is required for dispatching many operations
+//nolint:cyclop,gocyclo,funlen // large switch is required for dispatching many operations
 func (h *Handler) dispatchBatch2Ops(
 	_ context.Context,
 	op string,
@@ -157,6 +162,8 @@ func (h *Handler) dispatchBatch2Ops(
 		r, err := h.handleDescribeCompilationJob(body)
 
 		return r, true, err
+	case "DeleteCompilationJob":
+		return nil, true, h.handleDeleteCompilationJob(body)
 	case "StopCompilationJob":
 		return nil, true, h.handleStopCompilationJob(body)
 	case "ListCompilationJobs":
@@ -175,7 +182,7 @@ func (h *Handler) dispatchBatch2Ops(
 		return r, true, err
 	case "DeleteMonitoringSchedule":
 		return nil, true, h.handleDeleteMonitoringSchedule(body)
-	case "StopMonitoringSchedule":
+	case opStopMonitoringSchedule:
 		return nil, true, h.handleStopMonitoringSchedule(body)
 	case "StartMonitoringSchedule":
 		return nil, true, h.handleStartMonitoringSchedule(body)
@@ -293,13 +300,13 @@ func (h *Handler) handleListModelPackages(body []byte) ([]byte, error) {
 			"ModelPackageName":   mp.ModelPackageName,
 			"ModelPackageArn":    mp.ModelPackageArn,
 			"ModelPackageStatus": mp.ModelPackageStatus,
-			"CreationTime":       mp.CreationTime,
+			keyCreationTime:      mp.CreationTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"ModelPackageSummaryList": summaries,
-		"NextToken":               next,
+		keyNextToken:              next,
 	})
 }
 
@@ -386,13 +393,13 @@ func (h *Handler) handleListModelPackageGroups(body []byte) ([]byte, error) {
 			"ModelPackageGroupName":   g.ModelPackageGroupName,
 			"ModelPackageGroupArn":    g.ModelPackageGroupArn,
 			"ModelPackageGroupStatus": g.ModelPackageGroupStatus,
-			"CreationTime":            g.CreationTime,
+			keyCreationTime:           g.CreationTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"ModelPackageGroupSummaryList": summaries,
-		"NextToken":                   next,
+		keyNextToken:                   next,
 	})
 }
 
@@ -477,13 +484,13 @@ func (h *Handler) handleListAutoMLJobs(body []byte) ([]byte, error) {
 			"AutoMLJobName":   j.AutoMLJobName,
 			"AutoMLJobArn":    j.AutoMLJobArn,
 			"AutoMLJobStatus": j.AutoMLJobStatus,
-			"CreationTime":    j.CreationTime,
+			keyCreationTime:   j.CreationTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"AutoMLJobSummaries": summaries,
-		"NextToken":          next,
+		keyNextToken:         next,
 	})
 }
 
@@ -511,7 +518,7 @@ func (h *Handler) handleCreateCodeRepository(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(map[string]any{"CodeRepositoryArn": result.CodeRepositoryArn})
+	return json.Marshal(map[string]any{keyCodeRepositoryArn: result.CodeRepositoryArn})
 }
 
 func (h *Handler) handleDescribeCodeRepository(body []byte) ([]byte, error) {
@@ -554,7 +561,7 @@ func (h *Handler) handleUpdateCodeRepository(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(map[string]any{"CodeRepositoryArn": result.CodeRepositoryArn})
+	return json.Marshal(map[string]any{keyCodeRepositoryArn: result.CodeRepositoryArn})
 }
 
 func (h *Handler) handleDeleteCodeRepository(body []byte) error {
@@ -588,15 +595,15 @@ func (h *Handler) handleListCodeRepositories(body []byte) ([]byte, error) {
 	for _, r := range items {
 		summaries = append(summaries, map[string]any{
 			"CodeRepositoryName": r.CodeRepositoryName,
-			"CodeRepositoryArn":  r.CodeRepositoryArn,
-			"CreationTime":       r.CreationTime,
-			"LastModifiedTime":   r.LastModifiedTime,
+			keyCodeRepositoryArn: r.CodeRepositoryArn,
+			keyCreationTime:      r.CreationTime,
+			keyLastModifiedTime:  r.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"CodeRepositorySummaryList": summaries,
-		"NextToken":                next,
+		keyNextToken:                next,
 	})
 }
 
@@ -626,7 +633,7 @@ func (h *Handler) handleCreateProject(body []byte) ([]byte, error) {
 
 	return json.Marshal(map[string]any{
 		"ProjectArn": result.ProjectArn,
-		"ProjectId":  result.ProjectId,
+		"ProjectId":  result.ProjectID,
 	})
 }
 
@@ -683,15 +690,15 @@ func (h *Handler) handleListProjects(body []byte) ([]byte, error) {
 		summaries = append(summaries, map[string]any{
 			"ProjectName":   p.ProjectName,
 			"ProjectArn":    p.ProjectArn,
-			"ProjectId":     p.ProjectId,
+			"ProjectId":     p.ProjectID,
 			"ProjectStatus": p.ProjectStatus,
-			"CreationTime":  p.CreationTime,
+			keyCreationTime: p.CreationTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"ProjectSummaryList": summaries,
-		"NextToken":          next,
+		keyNextToken:         next,
 	})
 }
 
@@ -701,7 +708,7 @@ func (h *Handler) handleListProjects(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateSpace(body []byte) ([]byte, error) {
 	var req struct {
-		DomainId  string            `json:"DomainId"`
+		DomainID  string            `json:"DomainId"`
 		SpaceName string            `json:"SpaceName"`
 		Tags      map[string]string `json:"Tags"`
 	}
@@ -710,15 +717,15 @@ func (h *Handler) handleCreateSpace(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	if req.DomainId == "" {
-		return nil, fmt.Errorf("%w: DomainId is required", errInvalidRequest)
+	if req.DomainID == "" {
+		return nil, fmt.Errorf("%w: DomainID is required", errInvalidRequest)
 	}
 
 	if req.SpaceName == "" {
 		return nil, fmt.Errorf("%w: SpaceName is required", errInvalidRequest)
 	}
 
-	result, err := h.Backend.CreateSpace(req.DomainId, req.SpaceName, req.Tags)
+	result, err := h.Backend.CreateSpace(req.DomainID, req.SpaceName, req.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -728,7 +735,7 @@ func (h *Handler) handleCreateSpace(body []byte) ([]byte, error) {
 
 func (h *Handler) handleDescribeSpace(body []byte) ([]byte, error) {
 	var req struct {
-		DomainId  string `json:"DomainId"`
+		DomainID  string `json:"DomainId"`
 		SpaceName string `json:"SpaceName"`
 	}
 
@@ -736,15 +743,15 @@ func (h *Handler) handleDescribeSpace(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	if req.DomainId == "" {
-		return nil, fmt.Errorf("%w: DomainId is required", errInvalidRequest)
+	if req.DomainID == "" {
+		return nil, fmt.Errorf("%w: DomainID is required", errInvalidRequest)
 	}
 
 	if req.SpaceName == "" {
 		return nil, fmt.Errorf("%w: SpaceName is required", errInvalidRequest)
 	}
 
-	result, err := h.Backend.DescribeSpace(req.DomainId, req.SpaceName)
+	result, err := h.Backend.DescribeSpace(req.DomainID, req.SpaceName)
 	if err != nil {
 		return nil, err
 	}
@@ -754,7 +761,7 @@ func (h *Handler) handleDescribeSpace(body []byte) ([]byte, error) {
 
 func (h *Handler) handleDeleteSpace(body []byte) error {
 	var req struct {
-		DomainId  string `json:"DomainId"`
+		DomainID  string `json:"DomainId"`
 		SpaceName string `json:"SpaceName"`
 	}
 
@@ -762,20 +769,20 @@ func (h *Handler) handleDeleteSpace(body []byte) error {
 		return fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	if req.DomainId == "" {
-		return fmt.Errorf("%w: DomainId is required", errInvalidRequest)
+	if req.DomainID == "" {
+		return fmt.Errorf("%w: DomainID is required", errInvalidRequest)
 	}
 
 	if req.SpaceName == "" {
 		return fmt.Errorf("%w: SpaceName is required", errInvalidRequest)
 	}
 
-	return h.Backend.DeleteSpace(req.DomainId, req.SpaceName)
+	return h.Backend.DeleteSpace(req.DomainID, req.SpaceName)
 }
 
 func (h *Handler) handleListSpaces(body []byte) ([]byte, error) {
 	var req struct {
-		DomainIdEquals string `json:"DomainIdEquals"`
+		DomainIDEquals string `json:"DomainIdEquals"`
 		NextToken      string `json:"NextToken"`
 	}
 
@@ -783,23 +790,23 @@ func (h *Handler) handleListSpaces(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	items, next := h.Backend.ListSpaces(req.DomainIdEquals, req.NextToken)
+	items, next := h.Backend.ListSpaces(req.DomainIDEquals, req.NextToken)
 
 	summaries := make([]map[string]any, 0, len(items))
 	for _, s := range items {
 		summaries = append(summaries, map[string]any{
-			"SpaceName":        s.SpaceName,
-			"SpaceArn":         s.SpaceArn,
-			"DomainId":         s.DomainId,
-			"SpaceStatus":      s.SpaceStatus,
-			"CreationTime":     s.CreationTime,
-			"LastModifiedTime": s.LastModifiedTime,
+			"SpaceName":         s.SpaceName,
+			"SpaceArn":          s.SpaceArn,
+			keyDomainID:         s.DomainID,
+			"SpaceStatus":       s.SpaceStatus,
+			keyCreationTime:     s.CreationTime,
+			keyLastModifiedTime: s.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
-		"Spaces":    summaries,
-		"NextToken": next,
+		"Spaces":     summaries,
+		keyNextToken: next,
 	})
 }
 
@@ -882,17 +889,17 @@ func (h *Handler) handleListImages(body []byte) ([]byte, error) {
 	summaries := make([]map[string]any, 0, len(items))
 	for _, img := range items {
 		summaries = append(summaries, map[string]any{
-			"ImageName":        img.ImageName,
-			"ImageArn":         img.ImageArn,
-			"ImageStatus":      img.ImageStatus,
-			"CreationTime":     img.CreationTime,
-			"LastModifiedTime": img.LastModifiedTime,
+			"ImageName":         img.ImageName,
+			"ImageArn":          img.ImageArn,
+			"ImageStatus":       img.ImageStatus,
+			keyCreationTime:     img.CreationTime,
+			keyLastModifiedTime: img.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
-		"Images":    summaries,
-		"NextToken": next,
+		"Images":     summaries,
+		keyNextToken: next,
 	})
 }
 
@@ -982,14 +989,14 @@ func (h *Handler) handleListImageVersions(body []byte) ([]byte, error) {
 			"ImageVersionArn":    iv.ImageVersionArn,
 			"ImageVersionStatus": iv.ImageVersionStatus,
 			"Version":            iv.Version,
-			"CreationTime":       iv.CreationTime,
-			"LastModifiedTime":   iv.LastModifiedTime,
+			keyCreationTime:      iv.CreationTime,
+			keyLastModifiedTime:  iv.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"ImageVersions": summaries,
-		"NextToken":     next,
+		keyNextToken:    next,
 	})
 }
 
@@ -1041,6 +1048,22 @@ func (h *Handler) handleDescribeCompilationJob(body []byte) ([]byte, error) {
 	return json.Marshal(result)
 }
 
+func (h *Handler) handleDeleteCompilationJob(body []byte) error {
+	var req struct {
+		CompilationJobName string `json:"CompilationJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.CompilationJobName == "" {
+		return fmt.Errorf("%w: CompilationJobName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteCompilationJob(req.CompilationJobName)
+}
+
 func (h *Handler) handleStopCompilationJob(body []byte) error {
 	var req struct {
 		CompilationJobName string `json:"CompilationJobName"`
@@ -1074,14 +1097,14 @@ func (h *Handler) handleListCompilationJobs(body []byte) ([]byte, error) {
 			"CompilationJobName":   j.CompilationJobName,
 			"CompilationJobArn":    j.CompilationJobArn,
 			"CompilationJobStatus": j.CompilationJobStatus,
-			"CreationTime":         j.CreationTime,
-			"LastModifiedTime":     j.LastModifiedTime,
+			keyCreationTime:        j.CreationTime,
+			keyLastModifiedTime:    j.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"CompilationJobSummaries": summaries,
-		"NextToken":               next,
+		keyNextToken:              next,
 	})
 }
 
@@ -1108,7 +1131,7 @@ func (h *Handler) handleCreateMonitoringSchedule(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(map[string]any{"MonitoringScheduleArn": result.MonitoringScheduleArn})
+	return json.Marshal(map[string]any{keyMonitoringScheduleArn: result.MonitoringScheduleArn})
 }
 
 func (h *Handler) handleDescribeMonitoringSchedule(body []byte) ([]byte, error) {
@@ -1198,7 +1221,7 @@ func (h *Handler) handleUpdateMonitoringSchedule(body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(map[string]any{"MonitoringScheduleArn": result.MonitoringScheduleArn})
+	return json.Marshal(map[string]any{keyMonitoringScheduleArn: result.MonitoringScheduleArn})
 }
 
 func (h *Handler) handleListMonitoringSchedules(body []byte) ([]byte, error) {
@@ -1216,16 +1239,16 @@ func (h *Handler) handleListMonitoringSchedules(body []byte) ([]byte, error) {
 	for _, ms := range items {
 		summaries = append(summaries, map[string]any{
 			"MonitoringScheduleName":   ms.MonitoringScheduleName,
-			"MonitoringScheduleArn":    ms.MonitoringScheduleArn,
+			keyMonitoringScheduleArn:   ms.MonitoringScheduleArn,
 			"MonitoringScheduleStatus": ms.MonitoringScheduleStatus,
-			"CreationTime":             ms.CreationTime,
-			"LastModifiedTime":         ms.LastModifiedTime,
+			keyCreationTime:            ms.CreationTime,
+			keyLastModifiedTime:        ms.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
 		"MonitoringScheduleSummaries": summaries,
-		"NextToken":                   next,
+		keyNextToken:                  next,
 	})
 }
 
@@ -1307,19 +1330,16 @@ func (h *Handler) handleListWorkteams(body []byte) ([]byte, error) {
 	summaries := make([]map[string]any, 0, len(items))
 	for _, w := range items {
 		summaries = append(summaries, map[string]any{
-			"WorkteamName":     w.WorkteamName,
-			"WorkteamArn":      w.WorkteamArn,
-			"Description":      w.Description,
-			"CreationTime":     w.CreationTime,
-			"LastModifiedTime": w.LastModifiedTime,
+			"WorkteamName":      w.WorkteamName,
+			"WorkteamArn":       w.WorkteamArn,
+			"Description":       w.Description,
+			keyCreationTime:     w.CreationTime,
+			keyLastModifiedTime: w.LastModifiedTime,
 		})
 	}
 
 	return json.Marshal(map[string]any{
-		"Workteams": summaries,
-		"NextToken": next,
+		"Workteams":  summaries,
+		keyNextToken: next,
 	})
 }
-
-// ensure strconv is used (Version field in ImageVersion list handler uses it).
-var _ = strconv.Itoa

--- a/services/sagemaker/handler_batch2.go
+++ b/services/sagemaker/handler_batch2.go
@@ -221,10 +221,10 @@ func (h *Handler) dispatchBatch2Ops(
 
 func (h *Handler) handleCreateModelPackage(body []byte) ([]byte, error) {
 	var req struct {
+		Tags                    map[string]string `json:"Tags"`
 		ModelPackageName        string            `json:"ModelPackageName"`
 		ModelPackageGroupName   string            `json:"ModelPackageGroupName"`
 		ModelPackageDescription string            `json:"ModelPackageDescription"`
-		Tags                    map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -316,9 +316,9 @@ func (h *Handler) handleListModelPackages(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateModelPackageGroup(body []byte) ([]byte, error) {
 	var req struct {
+		Tags                         map[string]string `json:"Tags"`
 		ModelPackageGroupName        string            `json:"ModelPackageGroupName"`
 		ModelPackageGroupDescription string            `json:"ModelPackageGroupDescription"`
-		Tags                         map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -409,9 +409,9 @@ func (h *Handler) handleListModelPackageGroups(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateAutoMLJob(body []byte) ([]byte, error) {
 	var req struct {
+		Tags          map[string]string `json:"Tags"`
 		AutoMLJobName string            `json:"AutoMLJobName"`
 		RoleArn       string            `json:"RoleArn"`
-		Tags          map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -500,9 +500,9 @@ func (h *Handler) handleListAutoMLJobs(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateCodeRepository(body []byte) ([]byte, error) {
 	var req struct {
-		CodeRepositoryName string            `json:"CodeRepositoryName"`
 		GitConfig          map[string]string `json:"GitConfig"`
 		Tags               map[string]string `json:"Tags"`
+		CodeRepositoryName string            `json:"CodeRepositoryName"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -544,8 +544,8 @@ func (h *Handler) handleDescribeCodeRepository(body []byte) ([]byte, error) {
 
 func (h *Handler) handleUpdateCodeRepository(body []byte) ([]byte, error) {
 	var req struct {
-		CodeRepositoryName string            `json:"CodeRepositoryName"`
 		GitConfig          map[string]string `json:"GitConfig"`
+		CodeRepositoryName string            `json:"CodeRepositoryName"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -613,9 +613,9 @@ func (h *Handler) handleListCodeRepositories(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateProject(body []byte) ([]byte, error) {
 	var req struct {
+		Tags               map[string]string `json:"Tags"`
 		ProjectName        string            `json:"ProjectName"`
 		ProjectDescription string            `json:"ProjectDescription"`
-		Tags               map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -708,9 +708,9 @@ func (h *Handler) handleListProjects(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateSpace(body []byte) ([]byte, error) {
 	var req struct {
+		Tags      map[string]string `json:"Tags"`
 		DomainID  string            `json:"DomainId"`
 		SpaceName string            `json:"SpaceName"`
-		Tags      map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -816,10 +816,10 @@ func (h *Handler) handleListSpaces(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateImage(body []byte) ([]byte, error) {
 	var req struct {
+		Tags        map[string]string `json:"Tags"`
 		ImageName   string            `json:"ImageName"`
 		Description string            `json:"Description"`
 		RoleArn     string            `json:"RoleArn"`
-		Tags        map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1006,9 +1006,9 @@ func (h *Handler) handleListImageVersions(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateCompilationJob(body []byte) ([]byte, error) {
 	var req struct {
+		Tags               map[string]string `json:"Tags"`
 		CompilationJobName string            `json:"CompilationJobName"`
 		RoleArn            string            `json:"RoleArn"`
-		Tags               map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1114,8 +1114,8 @@ func (h *Handler) handleListCompilationJobs(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateMonitoringSchedule(body []byte) ([]byte, error) {
 	var req struct {
-		MonitoringScheduleName string            `json:"MonitoringScheduleName"`
 		Tags                   map[string]string `json:"Tags"`
+		MonitoringScheduleName string            `json:"MonitoringScheduleName"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1258,9 +1258,9 @@ func (h *Handler) handleListMonitoringSchedules(body []byte) ([]byte, error) {
 
 func (h *Handler) handleCreateWorkteam(body []byte) ([]byte, error) {
 	var req struct {
+		Tags         map[string]string `json:"Tags"`
 		WorkteamName string            `json:"WorkteamName"`
 		Description  string            `json:"Description"`
-		Tags         map[string]string `json:"Tags"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {

--- a/services/sagemaker/handler_batch2_test.go
+++ b/services/sagemaker/handler_batch2_test.go
@@ -1,0 +1,797 @@
+package sagemaker_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ModelPackage
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateModelPackage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateModelPackage", map[string]any{
+		"ModelPackageName": "my-pkg",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["ModelPackageArn"], "my-pkg")
+}
+
+func TestHandler_DescribeModelPackage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelPackage", map[string]any{"ModelPackageName": "pkg-1"})
+
+	rec := doSageMakerRequest(t, h, "DescribeModelPackage", map[string]any{"ModelPackageName": "pkg-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "pkg-1", resp["ModelPackageName"])
+}
+
+func TestHandler_DeleteModelPackage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelPackage", map[string]any{"ModelPackageName": "pkg-del"})
+	rec := doSageMakerRequest(t, h, "DeleteModelPackage", map[string]any{"ModelPackageName": "pkg-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeModelPackage", map[string]any{"ModelPackageName": "pkg-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListModelPackages(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelPackage", map[string]any{"ModelPackageName": "pkg-a"})
+	doSageMakerRequest(t, h, "CreateModelPackage", map[string]any{"ModelPackageName": "pkg-b"})
+
+	rec := doSageMakerRequest(t, h, "ListModelPackages", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["ModelPackageSummaryList"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// ModelPackageGroup
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateModelPackageGroup(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateModelPackageGroup", map[string]any{
+		"ModelPackageGroupName": "my-group",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["ModelPackageGroupArn"], "my-group")
+}
+
+func TestHandler_DescribeModelPackageGroup(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-1"})
+
+	rec := doSageMakerRequest(t, h, "DescribeModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "grp-1", resp["ModelPackageGroupName"])
+	assert.Equal(t, "Completed", resp["ModelPackageGroupStatus"])
+}
+
+func TestHandler_DeleteModelPackageGroup(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-del"})
+	rec := doSageMakerRequest(t, h, "DeleteModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListModelPackageGroups(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-a"})
+	doSageMakerRequest(t, h, "CreateModelPackageGroup", map[string]any{"ModelPackageGroupName": "grp-b"})
+
+	rec := doSageMakerRequest(t, h, "ListModelPackageGroups", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["ModelPackageGroupSummaryList"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// AutoMLJob
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateAutoMLJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateAutoMLJob", map[string]any{
+		"AutoMLJobName": "my-job",
+		"RoleArn":       "arn:aws:iam::000000000000:role/test",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["AutoMLJobArn"], "my-job")
+}
+
+func TestHandler_DescribeAutoMLJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateAutoMLJob", map[string]any{"AutoMLJobName": "job-1", "RoleArn": "arn:test"})
+
+	rec := doSageMakerRequest(t, h, "DescribeAutoMLJob", map[string]any{"AutoMLJobName": "job-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "job-1", resp["AutoMLJobName"])
+	assert.Equal(t, "Completed", resp["AutoMLJobStatus"])
+}
+
+func TestHandler_StopAutoMLJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateAutoMLJob", map[string]any{"AutoMLJobName": "job-stop", "RoleArn": "arn:test"})
+	rec := doSageMakerRequest(t, h, "StopAutoMLJob", map[string]any{"AutoMLJobName": "job-stop"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeAutoMLJob", map[string]any{"AutoMLJobName": "job-stop"})
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "Stopped", resp["AutoMLJobStatus"])
+}
+
+func TestHandler_ListAutoMLJobs(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateAutoMLJob", map[string]any{"AutoMLJobName": "job-a", "RoleArn": "arn:test"})
+	doSageMakerRequest(t, h, "CreateAutoMLJob", map[string]any{"AutoMLJobName": "job-b", "RoleArn": "arn:test"})
+
+	rec := doSageMakerRequest(t, h, "ListAutoMLJobs", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["AutoMLJobSummaries"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// CodeRepository
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateCodeRepository(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateCodeRepository", map[string]any{
+		"CodeRepositoryName": "my-repo",
+		"GitConfig":          map[string]string{"RepositoryUrl": "https://github.com/test/repo"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["CodeRepositoryArn"], "my-repo")
+}
+
+func TestHandler_DescribeCodeRepository(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateCodeRepository", map[string]any{"CodeRepositoryName": "repo-1"})
+
+	rec := doSageMakerRequest(t, h, "DescribeCodeRepository", map[string]any{"CodeRepositoryName": "repo-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "repo-1", resp["CodeRepositoryName"])
+}
+
+func TestHandler_UpdateCodeRepository(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateCodeRepository", map[string]any{"CodeRepositoryName": "repo-upd"})
+	rec := doSageMakerRequest(t, h, "UpdateCodeRepository", map[string]any{
+		"CodeRepositoryName": "repo-upd",
+		"GitConfig":          map[string]string{"Branch": "main"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["CodeRepositoryArn"], "repo-upd")
+}
+
+func TestHandler_DeleteCodeRepository(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateCodeRepository", map[string]any{"CodeRepositoryName": "repo-del"})
+	rec := doSageMakerRequest(t, h, "DeleteCodeRepository", map[string]any{"CodeRepositoryName": "repo-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeCodeRepository", map[string]any{"CodeRepositoryName": "repo-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListCodeRepositories(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateCodeRepository", map[string]any{"CodeRepositoryName": "repo-x"})
+	doSageMakerRequest(t, h, "CreateCodeRepository", map[string]any{"CodeRepositoryName": "repo-y"})
+
+	rec := doSageMakerRequest(t, h, "ListCodeRepositories", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["CodeRepositorySummaryList"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Project
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateProject(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateProject", map[string]any{
+		"ProjectName": "my-project",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["ProjectArn"], "my-project")
+	assert.NotEmpty(t, resp["ProjectId"])
+}
+
+func TestHandler_DescribeProject(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateProject", map[string]any{"ProjectName": "proj-1"})
+
+	rec := doSageMakerRequest(t, h, "DescribeProject", map[string]any{"ProjectName": "proj-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "proj-1", resp["ProjectName"])
+	assert.Equal(t, "CreateCompleted", resp["ProjectStatus"])
+}
+
+func TestHandler_DeleteProject(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateProject", map[string]any{"ProjectName": "proj-del"})
+	rec := doSageMakerRequest(t, h, "DeleteProject", map[string]any{"ProjectName": "proj-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeProject", map[string]any{"ProjectName": "proj-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListProjects(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateProject", map[string]any{"ProjectName": "proj-a"})
+	doSageMakerRequest(t, h, "CreateProject", map[string]any{"ProjectName": "proj-b"})
+
+	rec := doSageMakerRequest(t, h, "ListProjects", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["ProjectSummaryList"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Space
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateSpace(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateSpace", map[string]any{
+		"DomainId":  "d-abc123",
+		"SpaceName": "my-space",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["SpaceArn"], "my-space")
+}
+
+func TestHandler_DescribeSpace(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateSpace", map[string]any{"DomainId": "d-1", "SpaceName": "space-1"})
+
+	rec := doSageMakerRequest(t, h, "DescribeSpace", map[string]any{"DomainId": "d-1", "SpaceName": "space-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "space-1", resp["SpaceName"])
+	assert.Equal(t, "InService", resp["SpaceStatus"])
+}
+
+func TestHandler_DeleteSpace(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateSpace", map[string]any{"DomainId": "d-1", "SpaceName": "space-del"})
+	rec := doSageMakerRequest(t, h, "DeleteSpace", map[string]any{"DomainId": "d-1", "SpaceName": "space-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeSpace", map[string]any{"DomainId": "d-1", "SpaceName": "space-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListSpaces(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateSpace", map[string]any{"DomainId": "d-1", "SpaceName": "sp-a"})
+	doSageMakerRequest(t, h, "CreateSpace", map[string]any{"DomainId": "d-1", "SpaceName": "sp-b"})
+	doSageMakerRequest(t, h, "CreateSpace", map[string]any{"DomainId": "d-2", "SpaceName": "sp-c"})
+
+	rec := doSageMakerRequest(t, h, "ListSpaces", map[string]any{"DomainIdEquals": "d-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["Spaces"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Image
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateImage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateImage", map[string]any{
+		"ImageName": "my-image",
+		"RoleArn":   "arn:aws:iam::000000000000:role/test",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["ImageArn"], "my-image")
+}
+
+func TestHandler_DescribeImage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-1", "RoleArn": "arn:test"})
+
+	rec := doSageMakerRequest(t, h, "DescribeImage", map[string]any{"ImageName": "img-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "img-1", resp["ImageName"])
+	assert.Equal(t, "CREATED", resp["ImageStatus"])
+}
+
+func TestHandler_DeleteImage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-del", "RoleArn": "arn:test"})
+	rec := doSageMakerRequest(t, h, "DeleteImage", map[string]any{"ImageName": "img-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeImage", map[string]any{"ImageName": "img-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListImages(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-a", "RoleArn": "arn:test"})
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-b", "RoleArn": "arn:test"})
+
+	rec := doSageMakerRequest(t, h, "ListImages", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["Images"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// ImageVersion
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateImageVersion(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-ver", "RoleArn": "arn:test"})
+
+	rec := doSageMakerRequest(t, h, "CreateImageVersion", map[string]any{"ImageName": "img-ver"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["ImageVersionArn"], "img-ver")
+}
+
+func TestHandler_DescribeImageVersion(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-v", "RoleArn": "arn:test"})
+	doSageMakerRequest(t, h, "CreateImageVersion", map[string]any{"ImageName": "img-v"})
+
+	rec := doSageMakerRequest(t, h, "DescribeImageVersion", map[string]any{"ImageName": "img-v", "Version": 1})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.InEpsilon(t, float64(1), resp["Version"], 0.001)
+	assert.Equal(t, "CREATED", resp["ImageVersionStatus"])
+}
+
+func TestHandler_ListImageVersions(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateImage", map[string]any{"ImageName": "img-lv", "RoleArn": "arn:test"})
+	doSageMakerRequest(t, h, "CreateImageVersion", map[string]any{"ImageName": "img-lv"})
+	doSageMakerRequest(t, h, "CreateImageVersion", map[string]any{"ImageName": "img-lv"})
+
+	rec := doSageMakerRequest(t, h, "ListImageVersions", map[string]any{"ImageName": "img-lv"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["ImageVersions"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// CompilationJob
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateCompilationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateCompilationJob", map[string]any{
+		"CompilationJobName": "my-compile",
+		"RoleArn":            "arn:test",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["CompilationJobArn"], "my-compile")
+}
+
+func TestHandler_DescribeCompilationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(
+		t,
+		h,
+		"CreateCompilationJob",
+		map[string]any{"CompilationJobName": "cj-1", "RoleArn": "arn:test"},
+	)
+
+	rec := doSageMakerRequest(t, h, "DescribeCompilationJob", map[string]any{"CompilationJobName": "cj-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "cj-1", resp["CompilationJobName"])
+	assert.Equal(t, "COMPLETED", resp["CompilationJobStatus"])
+}
+
+func TestHandler_StopCompilationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(
+		t,
+		h,
+		"CreateCompilationJob",
+		map[string]any{"CompilationJobName": "cj-stop", "RoleArn": "arn:test"},
+	)
+	rec := doSageMakerRequest(t, h, "StopCompilationJob", map[string]any{"CompilationJobName": "cj-stop"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeCompilationJob", map[string]any{"CompilationJobName": "cj-stop"})
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "STOPPED", resp["CompilationJobStatus"])
+}
+
+func TestHandler_ListCompilationJobs(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(
+		t,
+		h,
+		"CreateCompilationJob",
+		map[string]any{"CompilationJobName": "cj-a", "RoleArn": "arn:test"},
+	)
+	doSageMakerRequest(
+		t,
+		h,
+		"CreateCompilationJob",
+		map[string]any{"CompilationJobName": "cj-b", "RoleArn": "arn:test"},
+	)
+
+	rec := doSageMakerRequest(t, h, "ListCompilationJobs", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["CompilationJobSummaries"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// MonitoringSchedule
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateMonitoringSchedule(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{
+		"MonitoringScheduleName": "my-schedule",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["MonitoringScheduleArn"], "my-schedule")
+}
+
+func TestHandler_DescribeMonitoringSchedule(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-1"})
+
+	rec := doSageMakerRequest(t, h, "DescribeMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "sched-1", resp["MonitoringScheduleName"])
+	assert.Equal(t, "Scheduled", resp["MonitoringScheduleStatus"])
+}
+
+func TestHandler_StopMonitoringSchedule(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-stop"})
+	rec := doSageMakerRequest(t, h, "StopMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-stop"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-stop"})
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "Stopped", resp["MonitoringScheduleStatus"])
+}
+
+func TestHandler_StartMonitoringSchedule(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-start"})
+	doSageMakerRequest(t, h, "StopMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-start"})
+	rec := doSageMakerRequest(t, h, "StartMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-start"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(
+		t,
+		h,
+		"DescribeMonitoringSchedule",
+		map[string]any{"MonitoringScheduleName": "sched-start"},
+	)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "Scheduled", resp["MonitoringScheduleStatus"])
+}
+
+func TestHandler_DeleteMonitoringSchedule(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-del"})
+	rec := doSageMakerRequest(t, h, "DeleteMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListMonitoringSchedules(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-a"})
+	doSageMakerRequest(t, h, "CreateMonitoringSchedule", map[string]any{"MonitoringScheduleName": "sched-b"})
+
+	rec := doSageMakerRequest(t, h, "ListMonitoringSchedules", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["MonitoringScheduleSummaries"].([]any)
+	assert.Len(t, items, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Workteam
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateWorkteam(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateWorkteam", map[string]any{
+		"WorkteamName": "my-team",
+		"Description":  "Test team",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["WorkteamArn"], "my-team")
+}
+
+func TestHandler_DescribeWorkteam(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateWorkteam", map[string]any{"WorkteamName": "team-1", "Description": "desc"})
+
+	rec := doSageMakerRequest(t, h, "DescribeWorkteam", map[string]any{"WorkteamName": "team-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	wt := resp["Workteam"].(map[string]any)
+	assert.Equal(t, "team-1", wt["WorkteamName"])
+}
+
+func TestHandler_DeleteWorkteam(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateWorkteam", map[string]any{"WorkteamName": "team-del"})
+	rec := doSageMakerRequest(t, h, "DeleteWorkteam", map[string]any{"WorkteamName": "team-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeWorkteam", map[string]any{"WorkteamName": "team-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_ListWorkteams(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateWorkteam", map[string]any{"WorkteamName": "team-a"})
+	doSageMakerRequest(t, h, "CreateWorkteam", map[string]any{"WorkteamName": "team-b"})
+
+	rec := doSageMakerRequest(t, h, "ListWorkteams", map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items := resp["Workteams"].([]any)
+	assert.Len(t, items, 2)
+}

--- a/services/sagemaker/handler_stubs.go
+++ b/services/sagemaker/handler_stubs.go
@@ -91,12 +91,8 @@ func stubOpsSupported() []string {
 	return []string{
 		"CreateAppImageConfig",
 		"CreateArtifact",
-		"CreateAutoMLJob",
-		"CreateAutoMLJobV2",
 		"CreateCluster",
 		"CreateClusterSchedulerConfig",
-		"CreateCodeRepository",
-		"CreateCompilationJob",
 		"CreateComputeQuota",
 		"CreateContext",
 		"CreateDataQualityJobDefinition",
@@ -109,8 +105,6 @@ func stubOpsSupported() []string {
 		"CreateHubContentPresignedUrls",
 		"CreateHubContentReference",
 		"CreateHumanTaskUi",
-		"CreateImage",
-		"CreateImageVersion",
 		"CreateInferenceComponent",
 		"CreateInferenceExperiment",
 		"CreateInferenceRecommendationsJob",
@@ -121,22 +115,16 @@ func stubOpsSupported() []string {
 		"CreateModelCard",
 		"CreateModelCardExportJob",
 		"CreateModelExplainabilityJobDefinition",
-		"CreateModelPackage",
-		"CreateModelPackageGroup",
 		"CreateModelQualityJobDefinition",
-		"CreateMonitoringSchedule",
 		"CreateOptimizationJob",
 		"CreatePartnerApp",
 		"CreatePartnerAppPresignedUrl",
 		"CreatePresignedDomainUrl",
 		"CreatePresignedMlflowAppUrl",
 		"CreatePresignedMlflowTrackingServerUrl",
-		"CreateProject",
-		"CreateSpace",
 		"CreateStudioLifecycleConfig",
 		"CreateTrainingPlan",
 		"CreateWorkforce",
-		"CreateWorkteam",
 		"DeleteAction",
 		"DeleteAlgorithm",
 		"DeleteAppImageConfig",
@@ -144,8 +132,6 @@ func stubOpsSupported() []string {
 		"DeleteAssociation",
 		"DeleteCluster",
 		"DeleteClusterSchedulerConfig",
-		"DeleteCodeRepository",
-		"DeleteCompilationJob",
 		"DeleteComputeQuota",
 		"DeleteContext",
 		"DeleteDataQualityJobDefinition",
@@ -157,8 +143,6 @@ func stubOpsSupported() []string {
 		"DeleteHubContent",
 		"DeleteHubContentReference",
 		"DeleteHumanTaskUi",
-		"DeleteImage",
-		"DeleteImageVersion",
 		"DeleteInferenceComponent",
 		"DeleteInferenceExperiment",
 		"DeleteMlflowApp",
@@ -166,32 +150,22 @@ func stubOpsSupported() []string {
 		"DeleteModelBiasJobDefinition",
 		"DeleteModelCard",
 		"DeleteModelExplainabilityJobDefinition",
-		"DeleteModelPackage",
-		"DeleteModelPackageGroup",
 		"DeleteModelPackageGroupPolicy",
 		"DeleteModelQualityJobDefinition",
-		"DeleteMonitoringSchedule",
 		"DeleteOptimizationJob",
 		"DeletePartnerApp",
 		"DeleteProcessingJob",
-		"DeleteProject",
-		"DeleteSpace",
 		"DeleteStudioLifecycleConfig",
 		"DeleteWorkforce",
-		"DeleteWorkteam",
 		"DeregisterDevices",
 		"DescribeAction",
 		"DescribeAlgorithm",
 		"DescribeAppImageConfig",
 		"DescribeArtifact",
-		"DescribeAutoMLJob",
-		"DescribeAutoMLJobV2",
 		"DescribeCluster",
 		"DescribeClusterEvent",
 		"DescribeClusterNode",
 		"DescribeClusterSchedulerConfig",
-		"DescribeCodeRepository",
-		"DescribeCompilationJob",
 		"DescribeComputeQuota",
 		"DescribeContext",
 		"DescribeDataQualityJobDefinition",
@@ -204,8 +178,6 @@ func stubOpsSupported() []string {
 		"DescribeHub",
 		"DescribeHubContent",
 		"DescribeHumanTaskUi",
-		"DescribeImage",
-		"DescribeImageVersion",
 		"DescribeInferenceComponent",
 		"DescribeInferenceExperiment",
 		"DescribeInferenceRecommendationsJob",
@@ -217,22 +189,16 @@ func stubOpsSupported() []string {
 		"DescribeModelCard",
 		"DescribeModelCardExportJob",
 		"DescribeModelExplainabilityJobDefinition",
-		"DescribeModelPackage",
-		"DescribeModelPackageGroup",
 		"DescribeModelQualityJobDefinition",
-		"DescribeMonitoringSchedule",
 		"DescribeOptimizationJob",
 		"DescribePartnerApp",
 		"DescribePipelineDefinitionForExecution",
-		"DescribeProject",
 		"DescribeReservedCapacity",
-		"DescribeSpace",
 		"DescribeStudioLifecycleConfig",
 		"DescribeSubscribedWorkteam",
 		"DescribeTrainingPlan",
 		"DescribeTrainingPlanExtensionHistory",
 		"DescribeWorkforce",
-		"DescribeWorkteam",
 		"DetachClusterNodeVolume",
 		"DisableSagemakerServicecatalogPortfolio",
 		"DisassociateTrialComponent",
@@ -251,14 +217,11 @@ func stubOpsSupported() []string {
 		"ListAppImageConfigs",
 		"ListArtifacts",
 		"ListAssociations",
-		"ListAutoMLJobs",
 		"ListCandidatesForAutoMLJob",
 		"ListClusterEvents",
 		"ListClusterNodes",
 		"ListClusterSchedulerConfigs",
 		"ListClusters",
-		"ListCodeRepositories",
-		"ListCompilationJobs",
 		"ListComputeQuotas",
 		"ListContexts",
 		"ListDataQualityJobDefinitions",
@@ -271,8 +234,6 @@ func stubOpsSupported() []string {
 		"ListHubContents",
 		"ListHubs",
 		"ListHumanTaskUis",
-		"ListImageVersions",
-		"ListImages",
 		"ListInferenceComponents",
 		"ListInferenceExperiments",
 		"ListInferenceRecommendationsJobSteps",
@@ -288,20 +249,15 @@ func stubOpsSupported() []string {
 		"ListModelCards",
 		"ListModelExplainabilityJobDefinitions",
 		"ListModelMetadata",
-		"ListModelPackageGroups",
-		"ListModelPackages",
 		"ListModelQualityJobDefinitions",
 		"ListMonitoringAlertHistory",
 		"ListMonitoringAlerts",
 		"ListMonitoringExecutions",
-		"ListMonitoringSchedules",
 		"ListOptimizationJobs",
 		"ListPartnerApps",
 		// ListPipelineParametersForExecution — real implementation in handler_accuracy2.go
 		"ListPipelineVersions",
-		"ListProjects",
 		"ListResourceCatalogs",
-		"ListSpaces",
 		"ListStageDevices",
 		"ListStudioLifecycleConfigs",
 		"ListSubscribedWorkteams",
@@ -310,7 +266,6 @@ func stubOpsSupported() []string {
 		"ListTrialComponents",
 		"ListUltraServersByReservedCapacity",
 		"ListWorkforces",
-		"ListWorkteams",
 		"PutModelPackageGroupPolicy",
 		"QueryLineage",
 		"RegisterDevices",
@@ -320,17 +275,13 @@ func stubOpsSupported() []string {
 		"StartEdgeDeploymentStage",
 		"StartInferenceExperiment",
 		"StartMlflowTrackingServer",
-		"StartMonitoringSchedule",
 		"StartSession",
-		"StopAutoMLJob",
-		"StopCompilationJob",
 		"StopEdgeDeploymentStage",
 		"StopEdgePackagingJob",
 		"StopInferenceExperiment",
 		"StopInferenceRecommendationsJob",
 		"StopLabelingJob",
 		"StopMlflowTrackingServer",
-		"StopMonitoringSchedule",
 		"StopOptimizationJob",
 		"UpdateAction",
 		"UpdateAppImageConfig",
@@ -338,7 +289,6 @@ func stubOpsSupported() []string {
 		"UpdateCluster",
 		"UpdateClusterSchedulerConfig",
 		"UpdateClusterSoftware",
-		"UpdateCodeRepository",
 		"UpdateComputeQuota",
 		"UpdateContext",
 		"UpdateDeviceFleet",
@@ -357,7 +307,6 @@ func stubOpsSupported() []string {
 		"UpdateModelCard",
 		"UpdateModelPackage",
 		"UpdateMonitoringAlert",
-		"UpdateMonitoringSchedule",
 		"UpdatePartnerApp",
 		"UpdatePipelineExecution",
 		"UpdatePipelineVersion",
@@ -389,20 +338,11 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateArtifact":
 		return mustMarshal(m{keyArtifactArn: ""}), true
 
-	case "CreateAutoMLJob", "CreateAutoMLJobV2":
-		return mustMarshal(m{keyAutoMLJobArn: ""}), true
-
 	case "CreateCluster":
 		return mustMarshal(m{keyClusterArn: ""}), true
 
 	case "CreateClusterSchedulerConfig":
 		return mustMarshal(m{keyClusterSchedulerConfigArn: ""}), true
-
-	case "CreateCodeRepository":
-		return mustMarshal(m{keyCodeRepositoryArn: ""}), true
-
-	case "CreateCompilationJob":
-		return mustMarshal(m{keyCompilationJobArn: ""}), true
 
 	case "CreateComputeQuota":
 		return mustMarshal(m{keyComputeQuotaArn: ""}), true
@@ -449,12 +389,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateHumanTaskUi":
 		return mustMarshal(m{keyHumanTaskUIArn: ""}), true
 
-	case "CreateImage":
-		return mustMarshal(m{keyImageArn: ""}), true
-
-	case "CreateImageVersion":
-		return mustMarshal(m{keyImageVersionArn: ""}), true
-
 	case "CreateInferenceComponent":
 		return mustMarshal(m{keyInferenceComponentArn: ""}), true
 
@@ -479,15 +413,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateModelCardExportJob":
 		return mustMarshal(m{keyModelCardExportJobArn: ""}), true
 
-	case "CreateModelPackage":
-		return mustMarshal(m{keyModelPackageArn: ""}), true
-
-	case "CreateModelPackageGroup":
-		return mustMarshal(m{keyModelPackageGroupArn: ""}), true
-
-	case "CreateMonitoringSchedule":
-		return mustMarshal(m{keyMonitoringScheduleArn: ""}), true
-
 	case "CreateOptimizationJob":
 		return mustMarshal(m{keyOptimizationJobArn: ""}), true
 
@@ -499,12 +424,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "CreatePipeline":
 		return mustMarshal(m{keyPipelineArn: ""}), true
-
-	case "CreateProject":
-		return mustMarshal(m{keyProjectArn: "", "ProjectId": ""}), true
-
-	case "CreateSpace":
-		return mustMarshal(m{keySpaceArn: ""}), true
 
 	case "CreateStudioLifecycleConfig":
 		return mustMarshal(m{keyStudioLifecycleConfigArn: ""}), true
@@ -524,9 +443,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateWorkforce":
 		return mustMarshal(m{keyWorkforceArn: ""}), true
 
-	case "CreateWorkteam":
-		return mustMarshal(m{keyWorkteamArn: ""}), true
-
 	// -----------------------------------------------------------------------
 	// Delete / stop / misc — return empty object
 	// -----------------------------------------------------------------------
@@ -538,8 +454,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"DeleteAssociation",
 		"DeleteCluster",
 		"DeleteClusterSchedulerConfig",
-		"DeleteCodeRepository",
-		"DeleteCompilationJob",
 		"DeleteComputeQuota",
 		"DeleteContext",
 		"DeleteDataQualityJobDefinition",
@@ -554,8 +468,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"DeleteHubContent",
 		"DeleteHubContentReference",
 		"DeleteHumanTaskUi",
-		"DeleteImage",
-		"DeleteImageVersion",
 		"DeleteInferenceComponent",
 		"DeleteInferenceExperiment",
 		"DeleteMlflowApp",
@@ -563,23 +475,17 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"DeleteModelBiasJobDefinition",
 		"DeleteModelCard",
 		"DeleteModelExplainabilityJobDefinition",
-		"DeleteModelPackage",
-		"DeleteModelPackageGroup",
 		"DeleteModelPackageGroupPolicy",
 		"DeleteModelQualityJobDefinition",
-		"DeleteMonitoringSchedule",
 		"DeleteOptimizationJob",
 		"DeletePartnerApp",
 		"DeletePipeline",
 		"DeleteProcessingJob",
-		"DeleteProject",
-		"DeleteSpace",
 		"DeleteStudioLifecycleConfig",
 		"DeleteTrial",
 		"DeleteTrialComponent",
 		"DeleteUserProfile",
 		"DeleteWorkforce",
-		"DeleteWorkteam",
 		"DeregisterDevices",
 		"DetachClusterNodeVolume",
 		"DisableSagemakerServicecatalogPortfolio",
@@ -592,10 +498,7 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"RenderUiTemplate",
 		"StartEdgeDeploymentStage",
 		"StartMlflowTrackingServer",
-		"StartMonitoringSchedule",
 		"StartSession",
-		"StopAutoMLJob",
-		"StopCompilationJob",
 		"StopEdgeDeploymentStage",
 		"StopEdgePackagingJob",
 		"StopInferenceExperiment",
@@ -634,11 +537,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "DescribeArtifact":
 		return mustMarshal(m{keyArtifactArn: "", "ArtifactType": ""}), true
 
-	case "DescribeAutoMLJob", "DescribeAutoMLJobV2":
-		return mustMarshal(m{
-			keyAutoMLJobArn: "", "AutoMLJobName": "", "AutoMLJobStatus": statusCompleted,
-		}), true
-
 	case "DescribeCluster":
 		return mustMarshal(m{
 			keyClusterArn: "", "ClusterStatus": statusInService, "InstanceGroups": []any{},
@@ -652,14 +550,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "DescribeClusterSchedulerConfig":
 		return mustMarshal(m{keyClusterSchedulerConfigArn: "", keyStatus: "Creating"}), true
-
-	case "DescribeCodeRepository":
-		return mustMarshal(m{keyCodeRepositoryArn: "", "CodeRepositoryName": ""}), true
-
-	case "DescribeCompilationJob":
-		return mustMarshal(m{
-			keyCompilationJobArn: "", "CompilationJobName": "", "CompilationJobStatus": statusCompletedUpper,
-		}), true
 
 	case "DescribeComputeQuota":
 		return mustMarshal(m{keyComputeQuotaArn: "", keyStatus: statusCreated}), true
@@ -728,14 +618,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 			keyHumanTaskUIArn: "", "HumanTaskUiName": "", "HumanTaskUiStatus": statusActive,
 		}), true
 
-	case "DescribeImage":
-		return mustMarshal(m{keyImageArn: "", "ImageName": "", "ImageStatus": "CREATED"}), true
-
-	case "DescribeImageVersion":
-		return mustMarshal(m{
-			keyImageVersionArn: "", keyImageArn: "", "ImageVersionStatus": "CREATED", "Version": 0,
-		}), true
-
 	case "DescribeInferenceComponent":
 		return mustMarshal(m{
 			keyInferenceComponentArn: "", "InferenceComponentName": "", "InferenceComponentStatus": statusInService,
@@ -773,26 +655,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 			keyModelCardExportJobArn: "", "ModelCardExportJobName": "", keyStatus: statusCompleted,
 		}), true
 
-	case "DescribeModelPackage":
-		return mustMarshal(m{
-			keyModelPackageArn:     "",
-			"ModelPackageName":     "",
-			keyModelPackageStatus:  statusCompleted,
-			keyModelApprovalStatus: statusPendingManualApproval,
-		}), true
-
-	case "DescribeModelPackageGroup":
-		return mustMarshal(m{
-			keyModelPackageGroupArn: "", "ModelPackageGroupName": "", "ModelPackageGroupStatus": statusCompleted,
-		}), true
-
-	case "DescribeMonitoringSchedule":
-		return mustMarshal(m{
-			keyMonitoringScheduleArn:    "",
-			keyMonitoringScheduleName:   "",
-			keyMonitoringScheduleStatus: "Scheduled",
-		}), true
-
 	case "DescribeOptimizationJob":
 		return mustMarshal(m{
 			keyOptimizationJobArn: "", "OptimizationJobName": "", "OptimizationJobStatus": statusCompletedUpper,
@@ -814,16 +676,8 @@ func stubResponseFor(op string) ([]byte, bool) {
 			keyPipelineExecutionArn: "", keyPipelineExecutionStatus: pipelineStatusSucceeded,
 		}), true
 
-	case "DescribeProject":
-		return mustMarshal(m{
-			keyProjectArn: "", "ProjectId": "", "ProjectName": "", "ProjectStatus": "CreateCompleted",
-		}), true
-
 	case "DescribeReservedCapacity":
 		return mustMarshal(m{keyReservedCapacityArn: "", keyStatus: statusActive}), true
-
-	case "DescribeSpace":
-		return mustMarshal(m{keySpaceArn: "", "SpaceName": "", keyStatus: statusInService}), true
 
 	case "DescribeStudioLifecycleConfig":
 		return mustMarshal(m{
@@ -852,9 +706,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "DescribeWorkforce":
 		return mustMarshal(m{"Workforce": m{keyWorkforceArn: "", "WorkforceName": ""}}), true
-
-	case "DescribeWorkteam":
-		return mustMarshal(m{"Workteam": m{keyWorkteamArn: "", "WorkteamName": ""}}), true
 
 	// -----------------------------------------------------------------------
 	// Get ops
@@ -901,9 +752,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "ListAssociations":
 		return mustMarshal(m{"AssociationSummaries": []any{}}), true
 
-	case "ListAutoMLJobs":
-		return mustMarshal(m{"AutoMLJobSummaries": []any{}}), true
-
 	case "ListCandidatesForAutoMLJob":
 		return mustMarshal(m{"Candidates": []any{}}), true
 
@@ -918,12 +766,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "ListClusters":
 		return mustMarshal(m{"ClusterSummaries": []any{}}), true
-
-	case "ListCodeRepositories":
-		return mustMarshal(m{"CodeRepositorySummaryList": []any{}}), true
-
-	case "ListCompilationJobs":
-		return mustMarshal(m{"CompilationJobSummaries": []any{}}), true
 
 	case "ListComputeQuotas":
 		return mustMarshal(m{"ComputeQuotaSummaries": []any{}}), true
@@ -970,12 +812,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "ListHumanTaskUis":
 		return mustMarshal(m{"HumanTaskUiSummaries": []any{}}), true
 
-	case "ListImageVersions":
-		return mustMarshal(m{"ImageVersions": []any{}}), true
-
-	case "ListImages":
-		return mustMarshal(m{"Images": []any{}}), true
-
 	case "ListInferenceComponents":
 		return mustMarshal(m{"InferenceComponents": []any{}}), true
 
@@ -1009,12 +845,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "ListModelMetadata":
 		return mustMarshal(m{"ModelMetadataSummaries": []any{}}), true
 
-	case "ListModelPackageGroups":
-		return mustMarshal(m{"ModelPackageGroupSummaryList": []any{}}), true
-
-	case "ListModelPackages":
-		return mustMarshal(m{"ModelPackageSummaryList": []any{}}), true
-
 	case "ListMonitoringAlertHistory":
 		return mustMarshal(m{"MonitoringAlertHistory": []any{}}), true
 
@@ -1023,9 +853,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "ListMonitoringExecutions":
 		return mustMarshal(m{"MonitoringExecutionSummaries": []any{}}), true
-
-	case "ListMonitoringSchedules":
-		return mustMarshal(m{"MonitoringScheduleSummaries": []any{}}), true
 
 	case "ListOptimizationJobs":
 		return mustMarshal(m{"OptimizationJobSummaries": []any{}}), true
@@ -1042,14 +869,8 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "ListPipelines":
 		return mustMarshal(m{"PipelineSummaries": []any{}}), true
 
-	case "ListProjects":
-		return mustMarshal(m{"ProjectSummaryList": []any{}}), true
-
 	case "ListResourceCatalogs":
 		return mustMarshal(m{"ResourceCatalogs": []any{}}), true
-
-	case "ListSpaces":
-		return mustMarshal(m{"Spaces": []any{}}), true
 
 	case "ListStageDevices":
 		return mustMarshal(m{"DeviceDeploymentSummaries": []any{}}), true
@@ -1080,9 +901,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "ListWorkforces":
 		return mustMarshal(m{"Workforces": []any{}}), true
-
-	case "ListWorkteams":
-		return mustMarshal(m{"Workteams": []any{}}), true
 
 	// -----------------------------------------------------------------------
 	// Action / query / pipeline ops
@@ -1120,9 +938,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "UpdateClusterSchedulerConfig":
 		return mustMarshal(m{keyClusterSchedulerConfigArn: ""}), true
 
-	case "UpdateCodeRepository":
-		return mustMarshal(m{keyCodeRepositoryArn: ""}), true
-
 	case "UpdateComputeQuota":
 		return mustMarshal(m{keyComputeQuotaArn: ""}), true
 
@@ -1137,12 +952,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "UpdateHubContent", "UpdateHubContentReference":
 		return mustMarshal(m{keyHubArn: "", keyHubContentArn: ""}), true
-
-	case "UpdateImage":
-		return mustMarshal(m{keyImageArn: ""}), true
-
-	case "UpdateImageVersion":
-		return mustMarshal(m{keyImageVersionArn: ""}), true
 
 	case "UpdateInferenceComponent":
 		return mustMarshal(m{keyInferenceComponentArn: ""}), true
@@ -1167,9 +976,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "UpdateMonitoringAlert":
 		return mustMarshal(m{keyMonitoringScheduleArn: "", keyMonitoringAlertName: ""}), true
-
-	case "UpdateMonitoringSchedule":
-		return mustMarshal(m{keyMonitoringScheduleArn: ""}), true
 
 	case "UpdatePipeline", "UpdatePipelineVersion":
 		return mustMarshal(m{keyPipelineArn: ""}), true

--- a/services/sagemaker/handler_stubs.go
+++ b/services/sagemaker/handler_stubs.go
@@ -505,7 +505,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"StopInferenceRecommendationsJob",
 		"StopLabelingJob",
 		"StopMlflowTrackingServer",
-		"StopMonitoringSchedule",
 		"StopOptimizationJob",
 		"UpdateClusterSoftware",
 		"UpdateDeviceFleet",


### PR DESCRIPTION
## Summary

- Implements 50 real stateful SageMaker operations across 11 resource groups, replacing stub handlers that returned hardcoded empty responses
- Adds `backend_batch2.go` with full in-memory CRUD for: ModelPackage, ModelPackageGroup, AutoMLJob, CodeRepository, Project, Space, SMImage, ImageVersion, CompilationJob, MonitoringSchedule, Workteam
- Adds `handler_batch2.go` with HTTP handler functions and `dispatchBatch2Ops` dispatcher registered before the stub fallthrough

## Groups implemented

| Group | Ops |
|-------|-----|
| ModelPackage | Create, Describe, Delete, List (name/ARN dual lookup) |
| ModelPackageGroup | Create, Describe, Delete, List |
| AutoMLJob | CreateV1+V2, DescribeV1+V2, Stop, List |
| CodeRepository | Create, Describe, Update, Delete, List |
| Project | Create, Describe, Delete, List (with unique ProjectId) |
| Space | Create, Describe, Delete, List (keyed by domainID+spaceName) |
| Image | Create, Describe, Delete, List |
| ImageVersion | Create (auto-increment), Describe, Delete, List |
| CompilationJob | Create, Describe, Delete, Stop, List |
| MonitoringSchedule | Create, Describe, Delete, Stop, Start, Update, List |
| Workteam | Create, Describe, Delete, List |

## Test plan

- [x] `go test ./services/sagemaker/... -short -count=1` — all pass
- [x] `go vet ./services/sagemaker/` — clean
- [x] `goimports` — no changes
- [x] `golines` — no changes
- [x] `golangci-lint run ./services/sagemaker/` — 0 issues
- [x] TestSDKCompleteness — passes (no duplicates, no missing ops)
- [x] TestRefinement1_HandlerOpsLen — 381 ops maintained
- [x] handler_batch2_test.go covers all 11 groups with CRUD tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)