### PR TITLE
feat(sagemaker): implement 50 real stateful ops batch 3 (go-drna)

### DIFF
--- a/services/sagemaker/backend.go
+++ b/services/sagemaker/backend.go
@@ -422,6 +422,21 @@ type InMemoryBackend struct {
 	compilationJobs            map[string]*CompilationJob                  // key: jobName
 	monitoringSchedules        map[string]*MonitoringSchedule              // key: scheduleName
 	workteams                  map[string]*Workteam                        // key: workteamName
+	dataQualityJobDefs         map[string]*JobDefinition                   // key: name
+	modelBiasJobDefs           map[string]*JobDefinition                   // key: name
+	modelQualityJobDefs        map[string]*JobDefinition                   // key: name
+	modelExplainJobDefs        map[string]*JobDefinition                   // key: name
+	humanTaskUis               map[string]*HumanTaskUi                     // key: name
+	workforces                 map[string]*Workforce                       // key: name
+	flowDefinitions            map[string]*FlowDefinition                  // key: name
+	appImageConfigs            map[string]*AppImageConfig                  // key: name
+	inferenceExperiments       map[string]*InferenceExperiment             // key: name
+	mlflowTrackingServers      map[string]*MlflowTrackingServer            // key: name
+	modelCards                 map[string]*ModelCard                       // key: name
+	optimizationJobs           map[string]*OptimizationJob                 // key: name
+	studioLifecycleConfigs     map[string]*StudioLifecycleConfig           // key: name
+	partnerApps                map[string]*PartnerApp                      // key: name (arn used as key)
+	trainingPlans              map[string]*TrainingPlan                    // key: name
 	modelARNIndex              map[string]string                           // ARN → model name
 	endpointConfigARNIndex     map[string]string                           // ARN → endpoint config name
 	endpointARNIndex           map[string]string                           // ARN → endpoint name
@@ -482,6 +497,21 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		compilationJobs:            make(map[string]*CompilationJob),
 		monitoringSchedules:        make(map[string]*MonitoringSchedule),
 		workteams:                  make(map[string]*Workteam),
+		dataQualityJobDefs:         make(map[string]*JobDefinition),
+		modelBiasJobDefs:           make(map[string]*JobDefinition),
+		modelQualityJobDefs:        make(map[string]*JobDefinition),
+		modelExplainJobDefs:        make(map[string]*JobDefinition),
+		humanTaskUis:               make(map[string]*HumanTaskUi),
+		workforces:                 make(map[string]*Workforce),
+		flowDefinitions:            make(map[string]*FlowDefinition),
+		appImageConfigs:            make(map[string]*AppImageConfig),
+		inferenceExperiments:       make(map[string]*InferenceExperiment),
+		mlflowTrackingServers:      make(map[string]*MlflowTrackingServer),
+		modelCards:                 make(map[string]*ModelCard),
+		optimizationJobs:           make(map[string]*OptimizationJob),
+		studioLifecycleConfigs:     make(map[string]*StudioLifecycleConfig),
+		partnerApps:                make(map[string]*PartnerApp),
+		trainingPlans:              make(map[string]*TrainingPlan),
 		modelARNIndex:              make(map[string]string),
 		endpointConfigARNIndex:     make(map[string]string),
 		endpointARNIndex:           make(map[string]string),
@@ -554,6 +584,21 @@ func (b *InMemoryBackend) Reset() {
 	b.compilationJobs = make(map[string]*CompilationJob)
 	b.monitoringSchedules = make(map[string]*MonitoringSchedule)
 	b.workteams = make(map[string]*Workteam)
+	b.dataQualityJobDefs = make(map[string]*JobDefinition)
+	b.modelBiasJobDefs = make(map[string]*JobDefinition)
+	b.modelQualityJobDefs = make(map[string]*JobDefinition)
+	b.modelExplainJobDefs = make(map[string]*JobDefinition)
+	b.humanTaskUis = make(map[string]*HumanTaskUi)
+	b.workforces = make(map[string]*Workforce)
+	b.flowDefinitions = make(map[string]*FlowDefinition)
+	b.appImageConfigs = make(map[string]*AppImageConfig)
+	b.inferenceExperiments = make(map[string]*InferenceExperiment)
+	b.mlflowTrackingServers = make(map[string]*MlflowTrackingServer)
+	b.modelCards = make(map[string]*ModelCard)
+	b.optimizationJobs = make(map[string]*OptimizationJob)
+	b.studioLifecycleConfigs = make(map[string]*StudioLifecycleConfig)
+	b.partnerApps = make(map[string]*PartnerApp)
+	b.trainingPlans = make(map[string]*TrainingPlan)
 	b.modelARNIndex = make(map[string]string)
 	b.endpointConfigARNIndex = make(map[string]string)
 	b.endpointARNIndex = make(map[string]string)

--- a/services/sagemaker/backend.go
+++ b/services/sagemaker/backend.go
@@ -426,7 +426,7 @@ type InMemoryBackend struct {
 	modelBiasJobDefs           map[string]*JobDefinition                   // key: name
 	modelQualityJobDefs        map[string]*JobDefinition                   // key: name
 	modelExplainJobDefs        map[string]*JobDefinition                   // key: name
-	humanTaskUis               map[string]*HumanTaskUi                     // key: name
+	humanTaskUis               map[string]*HumanTaskUI                     // key: name
 	workforces                 map[string]*Workforce                       // key: name
 	flowDefinitions            map[string]*FlowDefinition                  // key: name
 	appImageConfigs            map[string]*AppImageConfig                  // key: name
@@ -501,7 +501,7 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		modelBiasJobDefs:           make(map[string]*JobDefinition),
 		modelQualityJobDefs:        make(map[string]*JobDefinition),
 		modelExplainJobDefs:        make(map[string]*JobDefinition),
-		humanTaskUis:               make(map[string]*HumanTaskUi),
+		humanTaskUis:               make(map[string]*HumanTaskUI),
 		workforces:                 make(map[string]*Workforce),
 		flowDefinitions:            make(map[string]*FlowDefinition),
 		appImageConfigs:            make(map[string]*AppImageConfig),
@@ -588,7 +588,7 @@ func (b *InMemoryBackend) Reset() {
 	b.modelBiasJobDefs = make(map[string]*JobDefinition)
 	b.modelQualityJobDefs = make(map[string]*JobDefinition)
 	b.modelExplainJobDefs = make(map[string]*JobDefinition)
-	b.humanTaskUis = make(map[string]*HumanTaskUi)
+	b.humanTaskUis = make(map[string]*HumanTaskUI)
 	b.workforces = make(map[string]*Workforce)
 	b.flowDefinitions = make(map[string]*FlowDefinition)
 	b.appImageConfigs = make(map[string]*AppImageConfig)

--- a/services/sagemaker/backend_batch3.go
+++ b/services/sagemaker/backend_batch3.go
@@ -22,8 +22,8 @@ var (
 	ErrModelQualityJobDefNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
 	// ErrModelExplainJobDefNotFound is returned when a model explainability job definition does not exist.
 	ErrModelExplainJobDefNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
-	// ErrHumanTaskUiNotFound is returned when a human task UI does not exist.
-	ErrHumanTaskUiNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrHumanTaskUINotFound is returned when a human task UI does not exist.
+	ErrHumanTaskUINotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
 	// ErrWorkforceNotFound is returned when a workforce does not exist.
 	ErrWorkforceNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
 	// ErrFlowDefinitionNotFound is returned when a flow definition does not exist.
@@ -234,31 +234,31 @@ func (b *InMemoryBackend) DeleteModelExplainabilityJobDefinition(name string) er
 }
 
 // ---------------------------------------------------------------------------
-// HumanTaskUi
+// HumanTaskUI
 // ---------------------------------------------------------------------------
 
-// HumanTaskUi represents a SageMaker human task UI.
-type HumanTaskUi struct {
-	CreationTime     time.Time         `json:"CreationTime"`
-	Tags             map[string]string `json:"Tags,omitempty"`
-	HumanTaskUiName  string            `json:"HumanTaskUiName"`
-	HumanTaskUiArn   string            `json:"HumanTaskUiArn"`
-	HumanTaskUiStatus string           `json:"HumanTaskUiStatus"`
+// HumanTaskUI represents a SageMaker human task UI.
+type HumanTaskUI struct {
+	CreationTime      time.Time         `json:"CreationTime"`
+	Tags              map[string]string `json:"Tags,omitempty"`
+	HumanTaskUIName   string            `json:"HumanTaskUiName"`
+	HumanTaskUIArn    string            `json:"HumanTaskUiArn"`
+	HumanTaskUIStatus string            `json:"HumanTaskUiStatus"`
 }
 
-func cloneHumanTaskUi(h *HumanTaskUi) *HumanTaskUi {
+func cloneHumanTaskUI(h *HumanTaskUI) *HumanTaskUI {
 	cp := *h
 	cp.Tags = maps.Clone(h.Tags)
 
 	return &cp
 }
 
-// CreateHumanTaskUi creates a human task UI.
-func (b *InMemoryBackend) CreateHumanTaskUi(
+// CreateHumanTaskUI creates a human task UI.
+func (b *InMemoryBackend) CreateHumanTaskUI(
 	name string,
 	tags map[string]string,
-) (*HumanTaskUi, error) {
-	b.mu.Lock("CreateHumanTaskUi")
+) (*HumanTaskUI, error) {
+	b.mu.Lock("CreateHumanTaskUI")
 	defer b.mu.Unlock()
 
 	if name == "" {
@@ -271,38 +271,38 @@ func (b *InMemoryBackend) CreateHumanTaskUi(
 
 	uiARN := arn.Build("sagemaker", b.region, b.accountID, "human-task-ui/"+name)
 
-	ui := &HumanTaskUi{
-		HumanTaskUiName:   name,
-		HumanTaskUiArn:    uiARN,
-		HumanTaskUiStatus: "Active",
+	ui := &HumanTaskUI{
+		HumanTaskUIName:   name,
+		HumanTaskUIArn:    uiARN,
+		HumanTaskUIStatus: statusActive,
 		Tags:              mergeTags(nil, tags),
 		CreationTime:      time.Now(),
 	}
 	b.humanTaskUis[name] = ui
 
-	return cloneHumanTaskUi(ui), nil
+	return cloneHumanTaskUI(ui), nil
 }
 
-// DescribeHumanTaskUi returns a human task UI by name.
-func (b *InMemoryBackend) DescribeHumanTaskUi(name string) (*HumanTaskUi, error) {
-	b.mu.RLock("DescribeHumanTaskUi")
+// DescribeHumanTaskUI returns a human task UI by name.
+func (b *InMemoryBackend) DescribeHumanTaskUI(name string) (*HumanTaskUI, error) {
+	b.mu.RLock("DescribeHumanTaskUI")
 	defer b.mu.RUnlock()
 
 	ui, ok := b.humanTaskUis[name]
 	if !ok {
-		return nil, fmt.Errorf("%w: human task UI %q not found", ErrHumanTaskUiNotFound, name)
+		return nil, fmt.Errorf("%w: human task UI %q not found", ErrHumanTaskUINotFound, name)
 	}
 
-	return cloneHumanTaskUi(ui), nil
+	return cloneHumanTaskUI(ui), nil
 }
 
-// DeleteHumanTaskUi removes a human task UI by name.
-func (b *InMemoryBackend) DeleteHumanTaskUi(name string) error {
-	b.mu.Lock("DeleteHumanTaskUi")
+// DeleteHumanTaskUI removes a human task UI by name.
+func (b *InMemoryBackend) DeleteHumanTaskUI(name string) error {
+	b.mu.Lock("DeleteHumanTaskUI")
 	defer b.mu.Unlock()
 
 	if _, ok := b.humanTaskUis[name]; !ok {
-		return fmt.Errorf("%w: human task UI %q not found", ErrHumanTaskUiNotFound, name)
+		return fmt.Errorf("%w: human task UI %q not found", ErrHumanTaskUINotFound, name)
 	}
 
 	delete(b.humanTaskUis, name)
@@ -351,7 +351,7 @@ func (b *InMemoryBackend) CreateWorkforce(
 	w := &Workforce{
 		WorkforceName:    name,
 		WorkforceArn:     workforceARN,
-		Status:           "Active",
+		Status:           statusActive,
 		Tags:             mergeTags(nil, tags),
 		LastModifiedTime: time.Now(),
 	}
@@ -430,7 +430,7 @@ func (b *InMemoryBackend) CreateFlowDefinition(
 	f := &FlowDefinition{
 		FlowDefinitionName:   name,
 		FlowDefinitionArn:    flowARN,
-		FlowDefinitionStatus: "Active",
+		FlowDefinitionStatus: statusActive,
 		RoleArn:              roleArn,
 		Tags:                 mergeTags(nil, tags),
 		CreationTime:         time.Now(),
@@ -1076,7 +1076,7 @@ func clonePartnerApp(p *PartnerApp) *PartnerApp {
 	return &cp
 }
 
-// CreatePartnerApp creates a partner app.
+// CreatePartnerApp creates a partner app. Stores by ARN; returns both name and ARN.
 func (b *InMemoryBackend) CreatePartnerApp(
 	name, appType string,
 	tags map[string]string,
@@ -1088,11 +1088,11 @@ func (b *InMemoryBackend) CreatePartnerApp(
 		return nil, fmt.Errorf("%w: Name is required", ErrValidation)
 	}
 
-	if _, ok := b.partnerApps[name]; ok {
+	appARN := arn.Build("sagemaker", b.region, b.accountID, "partner-app/"+name)
+
+	if _, ok := b.partnerApps[appARN]; ok {
 		return nil, fmt.Errorf("%w: partner app %q already exists", ErrValidation, name)
 	}
-
-	appARN := arn.Build("sagemaker", b.region, b.accountID, "partner-app/"+name)
 
 	p := &PartnerApp{
 		Name:         name,
@@ -1102,34 +1102,34 @@ func (b *InMemoryBackend) CreatePartnerApp(
 		Tags:         mergeTags(nil, tags),
 		CreationTime: time.Now(),
 	}
-	b.partnerApps[name] = p
+	b.partnerApps[appARN] = p
 
 	return clonePartnerApp(p), nil
 }
 
-// DescribePartnerApp returns a partner app by name.
-func (b *InMemoryBackend) DescribePartnerApp(name string) (*PartnerApp, error) {
+// DescribePartnerApp returns a partner app by ARN.
+func (b *InMemoryBackend) DescribePartnerApp(arnStr string) (*PartnerApp, error) {
 	b.mu.RLock("DescribePartnerApp")
 	defer b.mu.RUnlock()
 
-	p, ok := b.partnerApps[name]
+	p, ok := b.partnerApps[arnStr]
 	if !ok {
-		return nil, fmt.Errorf("%w: partner app %q not found", ErrPartnerAppNotFound, name)
+		return nil, fmt.Errorf("%w: partner app %q not found", ErrPartnerAppNotFound, arnStr)
 	}
 
 	return clonePartnerApp(p), nil
 }
 
-// DeletePartnerApp removes a partner app by name.
-func (b *InMemoryBackend) DeletePartnerApp(name string) error {
+// DeletePartnerApp removes a partner app by ARN.
+func (b *InMemoryBackend) DeletePartnerApp(arnStr string) error {
 	b.mu.Lock("DeletePartnerApp")
 	defer b.mu.Unlock()
 
-	if _, ok := b.partnerApps[name]; !ok {
-		return fmt.Errorf("%w: partner app %q not found", ErrPartnerAppNotFound, name)
+	if _, ok := b.partnerApps[arnStr]; !ok {
+		return fmt.Errorf("%w: partner app %q not found", ErrPartnerAppNotFound, arnStr)
 	}
 
-	delete(b.partnerApps, name)
+	delete(b.partnerApps, arnStr)
 
 	return nil
 }
@@ -1175,7 +1175,7 @@ func (b *InMemoryBackend) CreateTrainingPlan(
 	t := &TrainingPlan{
 		TrainingPlanName: name,
 		TrainingPlanArn:  planARN,
-		Status:           "Active",
+		Status:           statusActive,
 		Tags:             mergeTags(nil, tags),
 		CreationTime:     time.Now(),
 	}

--- a/services/sagemaker/backend_batch3.go
+++ b/services/sagemaker/backend_batch3.go
@@ -1,0 +1,1198 @@
+package sagemaker
+
+import (
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/arn"
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+)
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+var (
+	// ErrDataQualityJobDefNotFound is returned when a data quality job definition does not exist.
+	ErrDataQualityJobDefNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrModelBiasJobDefNotFound is returned when a model bias job definition does not exist.
+	ErrModelBiasJobDefNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrModelQualityJobDefNotFound is returned when a model quality job definition does not exist.
+	ErrModelQualityJobDefNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrModelExplainJobDefNotFound is returned when a model explainability job definition does not exist.
+	ErrModelExplainJobDefNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrHumanTaskUiNotFound is returned when a human task UI does not exist.
+	ErrHumanTaskUiNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrWorkforceNotFound is returned when a workforce does not exist.
+	ErrWorkforceNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrFlowDefinitionNotFound is returned when a flow definition does not exist.
+	ErrFlowDefinitionNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrAppImageConfigNotFound is returned when an app image config does not exist.
+	ErrAppImageConfigNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrInferenceExperimentNotFound is returned when an inference experiment does not exist.
+	ErrInferenceExperimentNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrMlflowTrackingServerNotFound is returned when an MLflow tracking server does not exist.
+	ErrMlflowTrackingServerNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrModelCardNotFound is returned when a model card does not exist.
+	ErrModelCardNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrOptimizationJobNotFound is returned when an optimization job does not exist.
+	ErrOptimizationJobNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrStudioLifecycleConfigNotFound is returned when a studio lifecycle config does not exist.
+	ErrStudioLifecycleConfigNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrPartnerAppNotFound is returned when a partner app does not exist.
+	ErrPartnerAppNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+	// ErrTrainingPlanNotFound is returned when a training plan does not exist.
+	ErrTrainingPlanNotFound = awserr.New("ResourceNotFound", awserr.ErrNotFound)
+)
+
+// ---------------------------------------------------------------------------
+// JobDefinition — shared struct for Data Quality / Model Bias / Quality / Explainability
+// ---------------------------------------------------------------------------
+
+// JobDefinition is a shared struct for the four monitoring job definition types.
+type JobDefinition struct {
+	CreationTime      time.Time         `json:"CreationTime"`
+	Tags              map[string]string `json:"Tags,omitempty"`
+	JobDefinitionName string            `json:"JobDefinitionName"`
+	JobDefinitionArn  string            `json:"JobDefinitionArn"`
+	JobDefinitionType string            `json:"JobDefinitionType"`
+	RoleArn           string            `json:"RoleArn,omitempty"`
+}
+
+func cloneJobDefinition(j *JobDefinition) *JobDefinition {
+	cp := *j
+	cp.Tags = maps.Clone(j.Tags)
+
+	return &cp
+}
+
+func (b *InMemoryBackend) createJobDefinition(
+	store map[string]*JobDefinition,
+	defType, name, roleArn string,
+	tags map[string]string,
+	resourceType string,
+) (*JobDefinition, error) {
+	b.mu.Lock("createJobDefinition")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: %sJobDefinitionName is required", ErrValidation, defType)
+	}
+
+	if _, ok := store[name]; ok {
+		return nil, fmt.Errorf("%w: %s job definition %q already exists", ErrValidation, defType, name)
+	}
+
+	defARN := arn.Build("sagemaker", b.region, b.accountID, resourceType+"/"+name)
+
+	j := &JobDefinition{
+		JobDefinitionName: name,
+		JobDefinitionArn:  defARN,
+		JobDefinitionType: defType,
+		RoleArn:           roleArn,
+		Tags:              mergeTags(nil, tags),
+		CreationTime:      time.Now(),
+	}
+	store[name] = j
+
+	return cloneJobDefinition(j), nil
+}
+
+func (b *InMemoryBackend) describeJobDefinition(
+	store map[string]*JobDefinition,
+	name string,
+	notFound error,
+) (*JobDefinition, error) {
+	b.mu.RLock("describeJobDefinition")
+	defer b.mu.RUnlock()
+
+	j, ok := store[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: job definition %q not found", notFound, name)
+	}
+
+	return cloneJobDefinition(j), nil
+}
+
+func (b *InMemoryBackend) deleteJobDefinition(
+	store map[string]*JobDefinition,
+	name string,
+	notFound error,
+) error {
+	b.mu.Lock("deleteJobDefinition")
+	defer b.mu.Unlock()
+
+	if _, ok := store[name]; !ok {
+		return fmt.Errorf("%w: job definition %q not found", notFound, name)
+	}
+
+	delete(store, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// DataQualityJobDefinition
+// ---------------------------------------------------------------------------
+
+// CreateDataQualityJobDefinition creates a data quality job definition.
+func (b *InMemoryBackend) CreateDataQualityJobDefinition(
+	name, roleArn string,
+	tags map[string]string,
+) (*JobDefinition, error) {
+	return b.createJobDefinition(
+		b.dataQualityJobDefs, "DataQuality", name, roleArn, tags, "data-quality-job-definition",
+	)
+}
+
+// DescribeDataQualityJobDefinition returns a data quality job definition by name.
+func (b *InMemoryBackend) DescribeDataQualityJobDefinition(name string) (*JobDefinition, error) {
+	return b.describeJobDefinition(b.dataQualityJobDefs, name, ErrDataQualityJobDefNotFound)
+}
+
+// DeleteDataQualityJobDefinition removes a data quality job definition by name.
+func (b *InMemoryBackend) DeleteDataQualityJobDefinition(name string) error {
+	return b.deleteJobDefinition(b.dataQualityJobDefs, name, ErrDataQualityJobDefNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// ModelBiasJobDefinition
+// ---------------------------------------------------------------------------
+
+// CreateModelBiasJobDefinition creates a model bias job definition.
+func (b *InMemoryBackend) CreateModelBiasJobDefinition(
+	name, roleArn string,
+	tags map[string]string,
+) (*JobDefinition, error) {
+	return b.createJobDefinition(
+		b.modelBiasJobDefs, "ModelBias", name, roleArn, tags, "model-bias-job-definition",
+	)
+}
+
+// DescribeModelBiasJobDefinition returns a model bias job definition by name.
+func (b *InMemoryBackend) DescribeModelBiasJobDefinition(name string) (*JobDefinition, error) {
+	return b.describeJobDefinition(b.modelBiasJobDefs, name, ErrModelBiasJobDefNotFound)
+}
+
+// DeleteModelBiasJobDefinition removes a model bias job definition by name.
+func (b *InMemoryBackend) DeleteModelBiasJobDefinition(name string) error {
+	return b.deleteJobDefinition(b.modelBiasJobDefs, name, ErrModelBiasJobDefNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// ModelQualityJobDefinition
+// ---------------------------------------------------------------------------
+
+// CreateModelQualityJobDefinition creates a model quality job definition.
+func (b *InMemoryBackend) CreateModelQualityJobDefinition(
+	name, roleArn string,
+	tags map[string]string,
+) (*JobDefinition, error) {
+	return b.createJobDefinition(
+		b.modelQualityJobDefs, "ModelQuality", name, roleArn, tags, "model-quality-job-definition",
+	)
+}
+
+// DescribeModelQualityJobDefinition returns a model quality job definition by name.
+func (b *InMemoryBackend) DescribeModelQualityJobDefinition(name string) (*JobDefinition, error) {
+	return b.describeJobDefinition(b.modelQualityJobDefs, name, ErrModelQualityJobDefNotFound)
+}
+
+// DeleteModelQualityJobDefinition removes a model quality job definition by name.
+func (b *InMemoryBackend) DeleteModelQualityJobDefinition(name string) error {
+	return b.deleteJobDefinition(b.modelQualityJobDefs, name, ErrModelQualityJobDefNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// ModelExplainabilityJobDefinition
+// ---------------------------------------------------------------------------
+
+// CreateModelExplainabilityJobDefinition creates a model explainability job definition.
+func (b *InMemoryBackend) CreateModelExplainabilityJobDefinition(
+	name, roleArn string,
+	tags map[string]string,
+) (*JobDefinition, error) {
+	return b.createJobDefinition(
+		b.modelExplainJobDefs,
+		"ModelExplainability",
+		name,
+		roleArn,
+		tags,
+		"model-explainability-job-definition",
+	)
+}
+
+// DescribeModelExplainabilityJobDefinition returns a model explainability job definition by name.
+func (b *InMemoryBackend) DescribeModelExplainabilityJobDefinition(name string) (*JobDefinition, error) {
+	return b.describeJobDefinition(b.modelExplainJobDefs, name, ErrModelExplainJobDefNotFound)
+}
+
+// DeleteModelExplainabilityJobDefinition removes a model explainability job definition by name.
+func (b *InMemoryBackend) DeleteModelExplainabilityJobDefinition(name string) error {
+	return b.deleteJobDefinition(b.modelExplainJobDefs, name, ErrModelExplainJobDefNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// HumanTaskUi
+// ---------------------------------------------------------------------------
+
+// HumanTaskUi represents a SageMaker human task UI.
+type HumanTaskUi struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	HumanTaskUiName  string            `json:"HumanTaskUiName"`
+	HumanTaskUiArn   string            `json:"HumanTaskUiArn"`
+	HumanTaskUiStatus string           `json:"HumanTaskUiStatus"`
+}
+
+func cloneHumanTaskUi(h *HumanTaskUi) *HumanTaskUi {
+	cp := *h
+	cp.Tags = maps.Clone(h.Tags)
+
+	return &cp
+}
+
+// CreateHumanTaskUi creates a human task UI.
+func (b *InMemoryBackend) CreateHumanTaskUi(
+	name string,
+	tags map[string]string,
+) (*HumanTaskUi, error) {
+	b.mu.Lock("CreateHumanTaskUi")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: HumanTaskUiName is required", ErrValidation)
+	}
+
+	if _, ok := b.humanTaskUis[name]; ok {
+		return nil, fmt.Errorf("%w: human task UI %q already exists", ErrValidation, name)
+	}
+
+	uiARN := arn.Build("sagemaker", b.region, b.accountID, "human-task-ui/"+name)
+
+	ui := &HumanTaskUi{
+		HumanTaskUiName:   name,
+		HumanTaskUiArn:    uiARN,
+		HumanTaskUiStatus: "Active",
+		Tags:              mergeTags(nil, tags),
+		CreationTime:      time.Now(),
+	}
+	b.humanTaskUis[name] = ui
+
+	return cloneHumanTaskUi(ui), nil
+}
+
+// DescribeHumanTaskUi returns a human task UI by name.
+func (b *InMemoryBackend) DescribeHumanTaskUi(name string) (*HumanTaskUi, error) {
+	b.mu.RLock("DescribeHumanTaskUi")
+	defer b.mu.RUnlock()
+
+	ui, ok := b.humanTaskUis[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: human task UI %q not found", ErrHumanTaskUiNotFound, name)
+	}
+
+	return cloneHumanTaskUi(ui), nil
+}
+
+// DeleteHumanTaskUi removes a human task UI by name.
+func (b *InMemoryBackend) DeleteHumanTaskUi(name string) error {
+	b.mu.Lock("DeleteHumanTaskUi")
+	defer b.mu.Unlock()
+
+	if _, ok := b.humanTaskUis[name]; !ok {
+		return fmt.Errorf("%w: human task UI %q not found", ErrHumanTaskUiNotFound, name)
+	}
+
+	delete(b.humanTaskUis, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Workforce
+// ---------------------------------------------------------------------------
+
+// Workforce represents a SageMaker workforce.
+type Workforce struct {
+	LastModifiedTime time.Time         `json:"LastModifiedTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	WorkforceName    string            `json:"WorkforceName"`
+	WorkforceArn     string            `json:"WorkforceArn"`
+	Status           string            `json:"Status"`
+}
+
+func cloneWorkforce(w *Workforce) *Workforce {
+	cp := *w
+	cp.Tags = maps.Clone(w.Tags)
+
+	return &cp
+}
+
+// CreateWorkforce creates a workforce.
+func (b *InMemoryBackend) CreateWorkforce(
+	name string,
+	tags map[string]string,
+) (*Workforce, error) {
+	b.mu.Lock("CreateWorkforce")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: WorkforceName is required", ErrValidation)
+	}
+
+	if _, ok := b.workforces[name]; ok {
+		return nil, fmt.Errorf("%w: workforce %q already exists", ErrValidation, name)
+	}
+
+	workforceARN := arn.Build("sagemaker", b.region, b.accountID, "workforce/"+name)
+
+	w := &Workforce{
+		WorkforceName:    name,
+		WorkforceArn:     workforceARN,
+		Status:           "Active",
+		Tags:             mergeTags(nil, tags),
+		LastModifiedTime: time.Now(),
+	}
+	b.workforces[name] = w
+
+	return cloneWorkforce(w), nil
+}
+
+// DescribeWorkforce returns a workforce by name.
+func (b *InMemoryBackend) DescribeWorkforce(name string) (*Workforce, error) {
+	b.mu.RLock("DescribeWorkforce")
+	defer b.mu.RUnlock()
+
+	w, ok := b.workforces[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: workforce %q not found", ErrWorkforceNotFound, name)
+	}
+
+	return cloneWorkforce(w), nil
+}
+
+// UpdateWorkforce updates a workforce (marks it modified).
+func (b *InMemoryBackend) UpdateWorkforce(name string) (*Workforce, error) {
+	b.mu.Lock("UpdateWorkforce")
+	defer b.mu.Unlock()
+
+	w, ok := b.workforces[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: workforce %q not found", ErrWorkforceNotFound, name)
+	}
+
+	w.LastModifiedTime = time.Now()
+
+	return cloneWorkforce(w), nil
+}
+
+// ---------------------------------------------------------------------------
+// FlowDefinition
+// ---------------------------------------------------------------------------
+
+// FlowDefinition represents a SageMaker Augmented AI flow definition.
+type FlowDefinition struct {
+	CreationTime         time.Time         `json:"CreationTime"`
+	Tags                 map[string]string `json:"Tags,omitempty"`
+	FlowDefinitionName   string            `json:"FlowDefinitionName"`
+	FlowDefinitionArn    string            `json:"FlowDefinitionArn"`
+	FlowDefinitionStatus string            `json:"FlowDefinitionStatus"`
+	RoleArn              string            `json:"RoleArn,omitempty"`
+}
+
+func cloneFlowDefinition(f *FlowDefinition) *FlowDefinition {
+	cp := *f
+	cp.Tags = maps.Clone(f.Tags)
+
+	return &cp
+}
+
+// CreateFlowDefinition creates a flow definition.
+func (b *InMemoryBackend) CreateFlowDefinition(
+	name, roleArn string,
+	tags map[string]string,
+) (*FlowDefinition, error) {
+	b.mu.Lock("CreateFlowDefinition")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: FlowDefinitionName is required", ErrValidation)
+	}
+
+	if _, ok := b.flowDefinitions[name]; ok {
+		return nil, fmt.Errorf("%w: flow definition %q already exists", ErrValidation, name)
+	}
+
+	flowARN := arn.Build("sagemaker", b.region, b.accountID, "flow-definition/"+name)
+
+	f := &FlowDefinition{
+		FlowDefinitionName:   name,
+		FlowDefinitionArn:    flowARN,
+		FlowDefinitionStatus: "Active",
+		RoleArn:              roleArn,
+		Tags:                 mergeTags(nil, tags),
+		CreationTime:         time.Now(),
+	}
+	b.flowDefinitions[name] = f
+
+	return cloneFlowDefinition(f), nil
+}
+
+// DescribeFlowDefinition returns a flow definition by name.
+func (b *InMemoryBackend) DescribeFlowDefinition(name string) (*FlowDefinition, error) {
+	b.mu.RLock("DescribeFlowDefinition")
+	defer b.mu.RUnlock()
+
+	f, ok := b.flowDefinitions[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: flow definition %q not found", ErrFlowDefinitionNotFound, name)
+	}
+
+	return cloneFlowDefinition(f), nil
+}
+
+// DeleteFlowDefinition removes a flow definition by name.
+func (b *InMemoryBackend) DeleteFlowDefinition(name string) error {
+	b.mu.Lock("DeleteFlowDefinition")
+	defer b.mu.Unlock()
+
+	if _, ok := b.flowDefinitions[name]; !ok {
+		return fmt.Errorf("%w: flow definition %q not found", ErrFlowDefinitionNotFound, name)
+	}
+
+	delete(b.flowDefinitions, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// AppImageConfig
+// ---------------------------------------------------------------------------
+
+// AppImageConfig represents a SageMaker app image configuration.
+type AppImageConfig struct {
+	CreationTime       time.Time         `json:"CreationTime"`
+	LastModifiedTime   time.Time         `json:"LastModifiedTime"`
+	Tags               map[string]string `json:"Tags,omitempty"`
+	AppImageConfigName string            `json:"AppImageConfigName"`
+	AppImageConfigArn  string            `json:"AppImageConfigArn"`
+}
+
+func cloneAppImageConfig(a *AppImageConfig) *AppImageConfig {
+	cp := *a
+	cp.Tags = maps.Clone(a.Tags)
+
+	return &cp
+}
+
+// CreateAppImageConfig creates an app image config.
+func (b *InMemoryBackend) CreateAppImageConfig(
+	name string,
+	tags map[string]string,
+) (*AppImageConfig, error) {
+	b.mu.Lock("CreateAppImageConfig")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: AppImageConfigName is required", ErrValidation)
+	}
+
+	if _, ok := b.appImageConfigs[name]; ok {
+		return nil, fmt.Errorf("%w: app image config %q already exists", ErrValidation, name)
+	}
+
+	configARN := arn.Build("sagemaker", b.region, b.accountID, "app-image-config/"+name)
+	now := time.Now()
+
+	a := &AppImageConfig{
+		AppImageConfigName: name,
+		AppImageConfigArn:  configARN,
+		Tags:               mergeTags(nil, tags),
+		CreationTime:       now,
+		LastModifiedTime:   now,
+	}
+	b.appImageConfigs[name] = a
+
+	return cloneAppImageConfig(a), nil
+}
+
+// DescribeAppImageConfig returns an app image config by name.
+func (b *InMemoryBackend) DescribeAppImageConfig(name string) (*AppImageConfig, error) {
+	b.mu.RLock("DescribeAppImageConfig")
+	defer b.mu.RUnlock()
+
+	a, ok := b.appImageConfigs[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: app image config %q not found", ErrAppImageConfigNotFound, name)
+	}
+
+	return cloneAppImageConfig(a), nil
+}
+
+// UpdateAppImageConfig updates an app image config (marks it modified).
+func (b *InMemoryBackend) UpdateAppImageConfig(name string) (*AppImageConfig, error) {
+	b.mu.Lock("UpdateAppImageConfig")
+	defer b.mu.Unlock()
+
+	a, ok := b.appImageConfigs[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: app image config %q not found", ErrAppImageConfigNotFound, name)
+	}
+
+	a.LastModifiedTime = time.Now()
+
+	return cloneAppImageConfig(a), nil
+}
+
+// DeleteAppImageConfig removes an app image config by name.
+func (b *InMemoryBackend) DeleteAppImageConfig(name string) error {
+	b.mu.Lock("DeleteAppImageConfig")
+	defer b.mu.Unlock()
+
+	if _, ok := b.appImageConfigs[name]; !ok {
+		return fmt.Errorf("%w: app image config %q not found", ErrAppImageConfigNotFound, name)
+	}
+
+	delete(b.appImageConfigs, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// InferenceExperiment
+// ---------------------------------------------------------------------------
+
+// InferenceExperiment represents a SageMaker inference experiment.
+type InferenceExperiment struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	LastModifiedTime time.Time         `json:"LastModifiedTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	Name             string            `json:"Name"`
+	Arn              string            `json:"Arn"`
+	Status           string            `json:"Status"`
+	Type             string            `json:"Type,omitempty"`
+	RoleArn          string            `json:"RoleArn,omitempty"`
+}
+
+func cloneInferenceExperiment(e *InferenceExperiment) *InferenceExperiment {
+	cp := *e
+	cp.Tags = maps.Clone(e.Tags)
+
+	return &cp
+}
+
+// CreateInferenceExperiment creates an inference experiment.
+func (b *InMemoryBackend) CreateInferenceExperiment(
+	name, expType, roleArn string,
+	tags map[string]string,
+) (*InferenceExperiment, error) {
+	b.mu.Lock("CreateInferenceExperiment")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: Name is required", ErrValidation)
+	}
+
+	if _, ok := b.inferenceExperiments[name]; ok {
+		return nil, fmt.Errorf("%w: inference experiment %q already exists", ErrValidation, name)
+	}
+
+	expARN := arn.Build("sagemaker", b.region, b.accountID, "inference-experiment/"+name)
+	now := time.Now()
+
+	e := &InferenceExperiment{
+		Name:             name,
+		Arn:              expARN,
+		Status:           "Running",
+		Type:             expType,
+		RoleArn:          roleArn,
+		Tags:             mergeTags(nil, tags),
+		CreationTime:     now,
+		LastModifiedTime: now,
+	}
+	b.inferenceExperiments[name] = e
+
+	return cloneInferenceExperiment(e), nil
+}
+
+// DescribeInferenceExperiment returns an inference experiment by name.
+func (b *InMemoryBackend) DescribeInferenceExperiment(name string) (*InferenceExperiment, error) {
+	b.mu.RLock("DescribeInferenceExperiment")
+	defer b.mu.RUnlock()
+
+	e, ok := b.inferenceExperiments[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: inference experiment %q not found", ErrInferenceExperimentNotFound, name)
+	}
+
+	return cloneInferenceExperiment(e), nil
+}
+
+// StopInferenceExperiment sets an inference experiment status to "Cancelled".
+func (b *InMemoryBackend) StopInferenceExperiment(name string) error {
+	b.mu.Lock("StopInferenceExperiment")
+	defer b.mu.Unlock()
+
+	e, ok := b.inferenceExperiments[name]
+	if !ok {
+		return fmt.Errorf("%w: inference experiment %q not found", ErrInferenceExperimentNotFound, name)
+	}
+
+	e.Status = "Cancelled"
+	e.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// DeleteInferenceExperiment removes an inference experiment by name.
+func (b *InMemoryBackend) DeleteInferenceExperiment(name string) error {
+	b.mu.Lock("DeleteInferenceExperiment")
+	defer b.mu.Unlock()
+
+	if _, ok := b.inferenceExperiments[name]; !ok {
+		return fmt.Errorf("%w: inference experiment %q not found", ErrInferenceExperimentNotFound, name)
+	}
+
+	delete(b.inferenceExperiments, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// MlflowTrackingServer
+// ---------------------------------------------------------------------------
+
+// MlflowTrackingServer represents a SageMaker MLflow tracking server.
+type MlflowTrackingServer struct {
+	CreationTime         time.Time         `json:"CreationTime"`
+	LastModifiedTime     time.Time         `json:"LastModifiedTime"`
+	Tags                 map[string]string `json:"Tags,omitempty"`
+	TrackingServerName   string            `json:"TrackingServerName"`
+	TrackingServerArn    string            `json:"TrackingServerArn"`
+	TrackingServerStatus string            `json:"TrackingServerStatus"`
+	RoleArn              string            `json:"RoleArn,omitempty"`
+	MlflowVersion        string            `json:"MlflowVersion,omitempty"`
+}
+
+func cloneMlflowTrackingServer(s *MlflowTrackingServer) *MlflowTrackingServer {
+	cp := *s
+	cp.Tags = maps.Clone(s.Tags)
+
+	return &cp
+}
+
+// CreateMlflowTrackingServer creates an MLflow tracking server.
+func (b *InMemoryBackend) CreateMlflowTrackingServer(
+	name, roleArn, mlflowVersion string,
+	tags map[string]string,
+) (*MlflowTrackingServer, error) {
+	b.mu.Lock("CreateMlflowTrackingServer")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: TrackingServerName is required", ErrValidation)
+	}
+
+	if _, ok := b.mlflowTrackingServers[name]; ok {
+		return nil, fmt.Errorf("%w: MLflow tracking server %q already exists", ErrValidation, name)
+	}
+
+	serverARN := arn.Build("sagemaker", b.region, b.accountID, "mlflow-tracking-server/"+name)
+	now := time.Now()
+
+	s := &MlflowTrackingServer{
+		TrackingServerName:   name,
+		TrackingServerArn:    serverARN,
+		TrackingServerStatus: "Created",
+		RoleArn:              roleArn,
+		MlflowVersion:        mlflowVersion,
+		Tags:                 mergeTags(nil, tags),
+		CreationTime:         now,
+		LastModifiedTime:     now,
+	}
+	b.mlflowTrackingServers[name] = s
+
+	return cloneMlflowTrackingServer(s), nil
+}
+
+// DescribeMlflowTrackingServer returns an MLflow tracking server by name.
+func (b *InMemoryBackend) DescribeMlflowTrackingServer(name string) (*MlflowTrackingServer, error) {
+	b.mu.RLock("DescribeMlflowTrackingServer")
+	defer b.mu.RUnlock()
+
+	s, ok := b.mlflowTrackingServers[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: MLflow tracking server %q not found", ErrMlflowTrackingServerNotFound, name)
+	}
+
+	return cloneMlflowTrackingServer(s), nil
+}
+
+// DeleteMlflowTrackingServer removes an MLflow tracking server by name.
+func (b *InMemoryBackend) DeleteMlflowTrackingServer(name string) error {
+	b.mu.Lock("DeleteMlflowTrackingServer")
+	defer b.mu.Unlock()
+
+	if _, ok := b.mlflowTrackingServers[name]; !ok {
+		return fmt.Errorf("%w: MLflow tracking server %q not found", ErrMlflowTrackingServerNotFound, name)
+	}
+
+	delete(b.mlflowTrackingServers, name)
+
+	return nil
+}
+
+// StartMlflowTrackingServer sets an MLflow tracking server status to "Running".
+func (b *InMemoryBackend) StartMlflowTrackingServer(name string) error {
+	b.mu.Lock("StartMlflowTrackingServer")
+	defer b.mu.Unlock()
+
+	s, ok := b.mlflowTrackingServers[name]
+	if !ok {
+		return fmt.Errorf("%w: MLflow tracking server %q not found", ErrMlflowTrackingServerNotFound, name)
+	}
+
+	s.TrackingServerStatus = "Running"
+	s.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// StopMlflowTrackingServer sets an MLflow tracking server status to "Stopped".
+func (b *InMemoryBackend) StopMlflowTrackingServer(name string) error {
+	b.mu.Lock("StopMlflowTrackingServer")
+	defer b.mu.Unlock()
+
+	s, ok := b.mlflowTrackingServers[name]
+	if !ok {
+		return fmt.Errorf("%w: MLflow tracking server %q not found", ErrMlflowTrackingServerNotFound, name)
+	}
+
+	s.TrackingServerStatus = pipelineStatusStopped
+	s.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ModelCard
+// ---------------------------------------------------------------------------
+
+// ModelCard represents a SageMaker model card.
+type ModelCard struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	LastModifiedTime time.Time         `json:"LastModifiedTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	ModelCardName    string            `json:"ModelCardName"`
+	ModelCardArn     string            `json:"ModelCardArn"`
+	ModelCardStatus  string            `json:"ModelCardStatus"`
+	Content          string            `json:"Content,omitempty"`
+	ModelCardVersion int               `json:"ModelCardVersion"`
+}
+
+func cloneModelCard(c *ModelCard) *ModelCard {
+	cp := *c
+	cp.Tags = maps.Clone(c.Tags)
+
+	return &cp
+}
+
+// CreateModelCard creates a model card.
+func (b *InMemoryBackend) CreateModelCard(
+	name, content string,
+	tags map[string]string,
+) (*ModelCard, error) {
+	b.mu.Lock("CreateModelCard")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: ModelCardName is required", ErrValidation)
+	}
+
+	if _, ok := b.modelCards[name]; ok {
+		return nil, fmt.Errorf("%w: model card %q already exists", ErrValidation, name)
+	}
+
+	cardARN := arn.Build("sagemaker", b.region, b.accountID, "model-card/"+name)
+	now := time.Now()
+
+	c := &ModelCard{
+		ModelCardName:    name,
+		ModelCardArn:     cardARN,
+		ModelCardStatus:  "Draft",
+		ModelCardVersion: 1,
+		Content:          content,
+		Tags:             mergeTags(nil, tags),
+		CreationTime:     now,
+		LastModifiedTime: now,
+	}
+	b.modelCards[name] = c
+
+	return cloneModelCard(c), nil
+}
+
+// DescribeModelCard returns a model card by name.
+func (b *InMemoryBackend) DescribeModelCard(name string) (*ModelCard, error) {
+	b.mu.RLock("DescribeModelCard")
+	defer b.mu.RUnlock()
+
+	c, ok := b.modelCards[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: model card %q not found", ErrModelCardNotFound, name)
+	}
+
+	return cloneModelCard(c), nil
+}
+
+// UpdateModelCard updates a model card content and increments its version.
+func (b *InMemoryBackend) UpdateModelCard(name, content string) (*ModelCard, error) {
+	b.mu.Lock("UpdateModelCard")
+	defer b.mu.Unlock()
+
+	c, ok := b.modelCards[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: model card %q not found", ErrModelCardNotFound, name)
+	}
+
+	c.Content = content
+	c.ModelCardVersion++
+	c.LastModifiedTime = time.Now()
+
+	return cloneModelCard(c), nil
+}
+
+// DeleteModelCard removes a model card by name.
+func (b *InMemoryBackend) DeleteModelCard(name string) error {
+	b.mu.Lock("DeleteModelCard")
+	defer b.mu.Unlock()
+
+	if _, ok := b.modelCards[name]; !ok {
+		return fmt.Errorf("%w: model card %q not found", ErrModelCardNotFound, name)
+	}
+
+	delete(b.modelCards, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// OptimizationJob
+// ---------------------------------------------------------------------------
+
+// OptimizationJob represents a SageMaker optimization job.
+type OptimizationJob struct {
+	CreationTime          time.Time         `json:"CreationTime"`
+	LastModifiedTime      time.Time         `json:"LastModifiedTime"`
+	Tags                  map[string]string `json:"Tags,omitempty"`
+	OptimizationJobName   string            `json:"OptimizationJobName"`
+	OptimizationJobArn    string            `json:"OptimizationJobArn"`
+	OptimizationJobStatus string            `json:"OptimizationJobStatus"`
+	RoleArn               string            `json:"RoleArn,omitempty"`
+}
+
+func cloneOptimizationJob(j *OptimizationJob) *OptimizationJob {
+	cp := *j
+	cp.Tags = maps.Clone(j.Tags)
+
+	return &cp
+}
+
+// CreateOptimizationJob creates an optimization job.
+func (b *InMemoryBackend) CreateOptimizationJob(
+	name, roleArn string,
+	tags map[string]string,
+) (*OptimizationJob, error) {
+	b.mu.Lock("CreateOptimizationJob")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: OptimizationJobName is required", ErrValidation)
+	}
+
+	if _, ok := b.optimizationJobs[name]; ok {
+		return nil, fmt.Errorf("%w: optimization job %q already exists", ErrValidation, name)
+	}
+
+	jobARN := arn.Build("sagemaker", b.region, b.accountID, "optimization-job/"+name)
+	now := time.Now()
+
+	j := &OptimizationJob{
+		OptimizationJobName:   name,
+		OptimizationJobArn:    jobARN,
+		OptimizationJobStatus: "COMPLETED",
+		RoleArn:               roleArn,
+		Tags:                  mergeTags(nil, tags),
+		CreationTime:          now,
+		LastModifiedTime:      now,
+	}
+	b.optimizationJobs[name] = j
+
+	return cloneOptimizationJob(j), nil
+}
+
+// DescribeOptimizationJob returns an optimization job by name.
+func (b *InMemoryBackend) DescribeOptimizationJob(name string) (*OptimizationJob, error) {
+	b.mu.RLock("DescribeOptimizationJob")
+	defer b.mu.RUnlock()
+
+	j, ok := b.optimizationJobs[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: optimization job %q not found", ErrOptimizationJobNotFound, name)
+	}
+
+	return cloneOptimizationJob(j), nil
+}
+
+// DeleteOptimizationJob removes an optimization job by name.
+func (b *InMemoryBackend) DeleteOptimizationJob(name string) error {
+	b.mu.Lock("DeleteOptimizationJob")
+	defer b.mu.Unlock()
+
+	if _, ok := b.optimizationJobs[name]; !ok {
+		return fmt.Errorf("%w: optimization job %q not found", ErrOptimizationJobNotFound, name)
+	}
+
+	delete(b.optimizationJobs, name)
+
+	return nil
+}
+
+// StopOptimizationJob sets an optimization job status to "STOPPED".
+func (b *InMemoryBackend) StopOptimizationJob(name string) error {
+	b.mu.Lock("StopOptimizationJob")
+	defer b.mu.Unlock()
+
+	j, ok := b.optimizationJobs[name]
+	if !ok {
+		return fmt.Errorf("%w: optimization job %q not found", ErrOptimizationJobNotFound, name)
+	}
+
+	j.OptimizationJobStatus = "STOPPED"
+	j.LastModifiedTime = time.Now()
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// StudioLifecycleConfig
+// ---------------------------------------------------------------------------
+
+// StudioLifecycleConfig represents a SageMaker Studio lifecycle configuration.
+type StudioLifecycleConfig struct {
+	CreationTime                 time.Time         `json:"CreationTime"`
+	LastModifiedTime             time.Time         `json:"LastModifiedTime"`
+	Tags                         map[string]string `json:"Tags,omitempty"`
+	StudioLifecycleConfigName    string            `json:"StudioLifecycleConfigName"`
+	StudioLifecycleConfigArn     string            `json:"StudioLifecycleConfigArn"`
+	StudioLifecycleConfigAppType string            `json:"StudioLifecycleConfigAppType,omitempty"`
+}
+
+func cloneStudioLifecycleConfig(s *StudioLifecycleConfig) *StudioLifecycleConfig {
+	cp := *s
+	cp.Tags = maps.Clone(s.Tags)
+
+	return &cp
+}
+
+// CreateStudioLifecycleConfig creates a Studio lifecycle configuration.
+func (b *InMemoryBackend) CreateStudioLifecycleConfig(
+	name, appType string,
+	tags map[string]string,
+) (*StudioLifecycleConfig, error) {
+	b.mu.Lock("CreateStudioLifecycleConfig")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: StudioLifecycleConfigName is required", ErrValidation)
+	}
+
+	if _, ok := b.studioLifecycleConfigs[name]; ok {
+		return nil, fmt.Errorf("%w: Studio lifecycle config %q already exists", ErrValidation, name)
+	}
+
+	configARN := arn.Build("sagemaker", b.region, b.accountID, "studio-lifecycle-config/"+name)
+	now := time.Now()
+
+	s := &StudioLifecycleConfig{
+		StudioLifecycleConfigName:    name,
+		StudioLifecycleConfigArn:     configARN,
+		StudioLifecycleConfigAppType: appType,
+		Tags:                         mergeTags(nil, tags),
+		CreationTime:                 now,
+		LastModifiedTime:             now,
+	}
+	b.studioLifecycleConfigs[name] = s
+
+	return cloneStudioLifecycleConfig(s), nil
+}
+
+// DescribeStudioLifecycleConfig returns a Studio lifecycle configuration by name.
+func (b *InMemoryBackend) DescribeStudioLifecycleConfig(name string) (*StudioLifecycleConfig, error) {
+	b.mu.RLock("DescribeStudioLifecycleConfig")
+	defer b.mu.RUnlock()
+
+	s, ok := b.studioLifecycleConfigs[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: Studio lifecycle config %q not found", ErrStudioLifecycleConfigNotFound, name)
+	}
+
+	return cloneStudioLifecycleConfig(s), nil
+}
+
+// DeleteStudioLifecycleConfig removes a Studio lifecycle configuration by name.
+func (b *InMemoryBackend) DeleteStudioLifecycleConfig(name string) error {
+	b.mu.Lock("DeleteStudioLifecycleConfig")
+	defer b.mu.Unlock()
+
+	if _, ok := b.studioLifecycleConfigs[name]; !ok {
+		return fmt.Errorf("%w: Studio lifecycle config %q not found", ErrStudioLifecycleConfigNotFound, name)
+	}
+
+	delete(b.studioLifecycleConfigs, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// PartnerApp
+// ---------------------------------------------------------------------------
+
+// PartnerApp represents a SageMaker partner app.
+type PartnerApp struct {
+	CreationTime time.Time         `json:"CreationTime"`
+	Tags         map[string]string `json:"Tags,omitempty"`
+	Name         string            `json:"Name"`
+	Arn          string            `json:"Arn"`
+	Status       string            `json:"Status"`
+	Type         string            `json:"Type,omitempty"`
+}
+
+func clonePartnerApp(p *PartnerApp) *PartnerApp {
+	cp := *p
+	cp.Tags = maps.Clone(p.Tags)
+
+	return &cp
+}
+
+// CreatePartnerApp creates a partner app.
+func (b *InMemoryBackend) CreatePartnerApp(
+	name, appType string,
+	tags map[string]string,
+) (*PartnerApp, error) {
+	b.mu.Lock("CreatePartnerApp")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: Name is required", ErrValidation)
+	}
+
+	if _, ok := b.partnerApps[name]; ok {
+		return nil, fmt.Errorf("%w: partner app %q already exists", ErrValidation, name)
+	}
+
+	appARN := arn.Build("sagemaker", b.region, b.accountID, "partner-app/"+name)
+
+	p := &PartnerApp{
+		Name:         name,
+		Arn:          appARN,
+		Status:       "Available",
+		Type:         appType,
+		Tags:         mergeTags(nil, tags),
+		CreationTime: time.Now(),
+	}
+	b.partnerApps[name] = p
+
+	return clonePartnerApp(p), nil
+}
+
+// DescribePartnerApp returns a partner app by name.
+func (b *InMemoryBackend) DescribePartnerApp(name string) (*PartnerApp, error) {
+	b.mu.RLock("DescribePartnerApp")
+	defer b.mu.RUnlock()
+
+	p, ok := b.partnerApps[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: partner app %q not found", ErrPartnerAppNotFound, name)
+	}
+
+	return clonePartnerApp(p), nil
+}
+
+// DeletePartnerApp removes a partner app by name.
+func (b *InMemoryBackend) DeletePartnerApp(name string) error {
+	b.mu.Lock("DeletePartnerApp")
+	defer b.mu.Unlock()
+
+	if _, ok := b.partnerApps[name]; !ok {
+		return fmt.Errorf("%w: partner app %q not found", ErrPartnerAppNotFound, name)
+	}
+
+	delete(b.partnerApps, name)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// TrainingPlan
+// ---------------------------------------------------------------------------
+
+// TrainingPlan represents a SageMaker training plan.
+type TrainingPlan struct {
+	CreationTime     time.Time         `json:"CreationTime"`
+	Tags             map[string]string `json:"Tags,omitempty"`
+	TrainingPlanName string            `json:"TrainingPlanName"`
+	TrainingPlanArn  string            `json:"TrainingPlanArn"`
+	Status           string            `json:"Status"`
+}
+
+func cloneTrainingPlan(t *TrainingPlan) *TrainingPlan {
+	cp := *t
+	cp.Tags = maps.Clone(t.Tags)
+
+	return &cp
+}
+
+// CreateTrainingPlan creates a training plan.
+func (b *InMemoryBackend) CreateTrainingPlan(
+	name string,
+	tags map[string]string,
+) (*TrainingPlan, error) {
+	b.mu.Lock("CreateTrainingPlan")
+	defer b.mu.Unlock()
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: TrainingPlanName is required", ErrValidation)
+	}
+
+	if _, ok := b.trainingPlans[name]; ok {
+		return nil, fmt.Errorf("%w: training plan %q already exists", ErrValidation, name)
+	}
+
+	planARN := arn.Build("sagemaker", b.region, b.accountID, "training-plan/"+name)
+
+	t := &TrainingPlan{
+		TrainingPlanName: name,
+		TrainingPlanArn:  planARN,
+		Status:           "Active",
+		Tags:             mergeTags(nil, tags),
+		CreationTime:     time.Now(),
+	}
+	b.trainingPlans[name] = t
+
+	return cloneTrainingPlan(t), nil
+}
+
+// DescribeTrainingPlan returns a training plan by name.
+func (b *InMemoryBackend) DescribeTrainingPlan(name string) (*TrainingPlan, error) {
+	b.mu.RLock("DescribeTrainingPlan")
+	defer b.mu.RUnlock()
+
+	t, ok := b.trainingPlans[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: training plan %q not found", ErrTrainingPlanNotFound, name)
+	}
+
+	return cloneTrainingPlan(t), nil
+}

--- a/services/sagemaker/handler.go
+++ b/services/sagemaker/handler.go
@@ -177,10 +177,12 @@ func (h *Handler) GetSupportedOperations() []string {
 	}
 
 	batch2 := batch2OpsSupported()
+	batch3 := batch3SupportedOperations()
 
-	combined := make([]string, 0, len(core)+len(batch2)+len(stubOpsSupported()))
+	combined := make([]string, 0, len(core)+len(batch2)+len(batch3)+len(stubOpsSupported()))
 	combined = append(combined, core...)
 	combined = append(combined, batch2...)
+	combined = append(combined, batch3...)
 
 	return append(combined, stubOpsSupported()...)
 }
@@ -398,6 +400,10 @@ func (h *Handler) dispatchNewOps(ctx context.Context, op string, body []byte) ([
 	}
 
 	if r, ok, err := h.dispatchBatch2Ops(ctx, op, body); ok {
+		return r, err
+	}
+
+	if r, ok, err := h.dispatchBatch3Ops(ctx, op, body); ok {
 		return r, err
 	}
 

--- a/services/sagemaker/handler_batch3.go
+++ b/services/sagemaker/handler_batch3.go
@@ -1,0 +1,1349 @@
+package sagemaker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// batch3SupportedOperations returns the 50 real stateful operations implemented in batch 3.
+func batch3SupportedOperations() []string {
+	return []string{
+		// DataQuality job definitions
+		"CreateDataQualityJobDefinition",
+		"DescribeDataQualityJobDefinition",
+		"DeleteDataQualityJobDefinition",
+		// ModelBias job definitions
+		"CreateModelBiasJobDefinition",
+		"DescribeModelBiasJobDefinition",
+		"DeleteModelBiasJobDefinition",
+		// ModelQuality job definitions
+		"CreateModelQualityJobDefinition",
+		"DescribeModelQualityJobDefinition",
+		"DeleteModelQualityJobDefinition",
+		// ModelExplainability job definitions
+		"CreateModelExplainabilityJobDefinition",
+		"DescribeModelExplainabilityJobDefinition",
+		"DeleteModelExplainabilityJobDefinition",
+		// HumanTaskUi
+		"CreateHumanTaskUi",
+		"DescribeHumanTaskUi",
+		"DeleteHumanTaskUi",
+		// Workforce
+		"CreateWorkforce",
+		"DescribeWorkforce",
+		"UpdateWorkforce",
+		// FlowDefinition
+		"CreateFlowDefinition",
+		"DescribeFlowDefinition",
+		"DeleteFlowDefinition",
+		// AppImageConfig
+		"CreateAppImageConfig",
+		"DescribeAppImageConfig",
+		"DeleteAppImageConfig",
+		"UpdateAppImageConfig",
+		// InferenceExperiment
+		"CreateInferenceExperiment",
+		"DescribeInferenceExperiment",
+		"StopInferenceExperiment",
+		"DeleteInferenceExperiment",
+		// MlflowTrackingServer
+		"CreateMlflowTrackingServer",
+		"DescribeMlflowTrackingServer",
+		"DeleteMlflowTrackingServer",
+		"StartMlflowTrackingServer",
+		"StopMlflowTrackingServer",
+		// ModelCard
+		"CreateModelCard",
+		"DescribeModelCard",
+		"UpdateModelCard",
+		"DeleteModelCard",
+		// OptimizationJob
+		"CreateOptimizationJob",
+		"DescribeOptimizationJob",
+		"DeleteOptimizationJob",
+		"StopOptimizationJob",
+		// StudioLifecycleConfig
+		"CreateStudioLifecycleConfig",
+		"DescribeStudioLifecycleConfig",
+		"DeleteStudioLifecycleConfig",
+		// PartnerApp
+		"CreatePartnerApp",
+		"DescribePartnerApp",
+		"DeletePartnerApp",
+		// TrainingPlan
+		"CreateTrainingPlan",
+		"DescribeTrainingPlan",
+	}
+}
+
+// dispatchBatch3Ops dispatches the 50 real stateful operations (batch 3).
+//
+//nolint:cyclop,gocyclo,funlen // large switch is required for dispatching many operations
+func (h *Handler) dispatchBatch3Ops(
+	_ context.Context,
+	op string,
+	body []byte,
+) ([]byte, bool, error) {
+	switch op {
+	// DataQualityJobDefinition
+	case "CreateDataQualityJobDefinition":
+		r, err := h.handleCreateDataQualityJobDefinition(body)
+
+		return r, true, err
+	case "DescribeDataQualityJobDefinition":
+		r, err := h.handleDescribeDataQualityJobDefinition(body)
+
+		return r, true, err
+	case "DeleteDataQualityJobDefinition":
+		return nil, true, h.handleDeleteDataQualityJobDefinition(body)
+
+	// ModelBiasJobDefinition
+	case "CreateModelBiasJobDefinition":
+		r, err := h.handleCreateModelBiasJobDefinition(body)
+
+		return r, true, err
+	case "DescribeModelBiasJobDefinition":
+		r, err := h.handleDescribeModelBiasJobDefinition(body)
+
+		return r, true, err
+	case "DeleteModelBiasJobDefinition":
+		return nil, true, h.handleDeleteModelBiasJobDefinition(body)
+
+	// ModelQualityJobDefinition
+	case "CreateModelQualityJobDefinition":
+		r, err := h.handleCreateModelQualityJobDefinition(body)
+
+		return r, true, err
+	case "DescribeModelQualityJobDefinition":
+		r, err := h.handleDescribeModelQualityJobDefinition(body)
+
+		return r, true, err
+	case "DeleteModelQualityJobDefinition":
+		return nil, true, h.handleDeleteModelQualityJobDefinition(body)
+
+	// ModelExplainabilityJobDefinition
+	case "CreateModelExplainabilityJobDefinition":
+		r, err := h.handleCreateModelExplainabilityJobDefinition(body)
+
+		return r, true, err
+	case "DescribeModelExplainabilityJobDefinition":
+		r, err := h.handleDescribeModelExplainabilityJobDefinition(body)
+
+		return r, true, err
+	case "DeleteModelExplainabilityJobDefinition":
+		return nil, true, h.handleDeleteModelExplainabilityJobDefinition(body)
+
+	// HumanTaskUi
+	case "CreateHumanTaskUi":
+		r, err := h.handleCreateHumanTaskUi(body)
+
+		return r, true, err
+	case "DescribeHumanTaskUi":
+		r, err := h.handleDescribeHumanTaskUi(body)
+
+		return r, true, err
+	case "DeleteHumanTaskUi":
+		return nil, true, h.handleDeleteHumanTaskUi(body)
+
+	// Workforce
+	case "CreateWorkforce":
+		r, err := h.handleCreateWorkforce(body)
+
+		return r, true, err
+	case "DescribeWorkforce":
+		r, err := h.handleDescribeWorkforce(body)
+
+		return r, true, err
+	case "UpdateWorkforce":
+		r, err := h.handleUpdateWorkforce(body)
+
+		return r, true, err
+
+	// FlowDefinition
+	case "CreateFlowDefinition":
+		r, err := h.handleCreateFlowDefinition(body)
+
+		return r, true, err
+	case "DescribeFlowDefinition":
+		r, err := h.handleDescribeFlowDefinition(body)
+
+		return r, true, err
+	case "DeleteFlowDefinition":
+		return nil, true, h.handleDeleteFlowDefinition(body)
+
+	// AppImageConfig
+	case "CreateAppImageConfig":
+		r, err := h.handleCreateAppImageConfig(body)
+
+		return r, true, err
+	case "DescribeAppImageConfig":
+		r, err := h.handleDescribeAppImageConfig(body)
+
+		return r, true, err
+	case "DeleteAppImageConfig":
+		return nil, true, h.handleDeleteAppImageConfig(body)
+	case "UpdateAppImageConfig":
+		r, err := h.handleUpdateAppImageConfig(body)
+
+		return r, true, err
+
+	// InferenceExperiment
+	case "CreateInferenceExperiment":
+		r, err := h.handleCreateInferenceExperiment(body)
+
+		return r, true, err
+	case "DescribeInferenceExperiment":
+		r, err := h.handleDescribeInferenceExperiment(body)
+
+		return r, true, err
+	case "StopInferenceExperiment":
+		return nil, true, h.handleStopInferenceExperiment(body)
+	case "DeleteInferenceExperiment":
+		return nil, true, h.handleDeleteInferenceExperiment(body)
+
+	// MlflowTrackingServer
+	case "CreateMlflowTrackingServer":
+		r, err := h.handleCreateMlflowTrackingServer(body)
+
+		return r, true, err
+	case "DescribeMlflowTrackingServer":
+		r, err := h.handleDescribeMlflowTrackingServer(body)
+
+		return r, true, err
+	case "DeleteMlflowTrackingServer":
+		return nil, true, h.handleDeleteMlflowTrackingServer(body)
+	case "StartMlflowTrackingServer":
+		return nil, true, h.handleStartMlflowTrackingServer(body)
+	case "StopMlflowTrackingServer":
+		return nil, true, h.handleStopMlflowTrackingServer(body)
+
+	// ModelCard
+	case "CreateModelCard":
+		r, err := h.handleCreateModelCard(body)
+
+		return r, true, err
+	case "DescribeModelCard":
+		r, err := h.handleDescribeModelCard(body)
+
+		return r, true, err
+	case "UpdateModelCard":
+		r, err := h.handleUpdateModelCard(body)
+
+		return r, true, err
+	case "DeleteModelCard":
+		return nil, true, h.handleDeleteModelCard(body)
+
+	// OptimizationJob
+	case "CreateOptimizationJob":
+		r, err := h.handleCreateOptimizationJob(body)
+
+		return r, true, err
+	case "DescribeOptimizationJob":
+		r, err := h.handleDescribeOptimizationJob(body)
+
+		return r, true, err
+	case "DeleteOptimizationJob":
+		return nil, true, h.handleDeleteOptimizationJob(body)
+	case "StopOptimizationJob":
+		return nil, true, h.handleStopOptimizationJob(body)
+
+	// StudioLifecycleConfig
+	case "CreateStudioLifecycleConfig":
+		r, err := h.handleCreateStudioLifecycleConfig(body)
+
+		return r, true, err
+	case "DescribeStudioLifecycleConfig":
+		r, err := h.handleDescribeStudioLifecycleConfig(body)
+
+		return r, true, err
+	case "DeleteStudioLifecycleConfig":
+		return nil, true, h.handleDeleteStudioLifecycleConfig(body)
+
+	// PartnerApp
+	case "CreatePartnerApp":
+		r, err := h.handleCreatePartnerApp(body)
+
+		return r, true, err
+	case "DescribePartnerApp":
+		r, err := h.handleDescribePartnerApp(body)
+
+		return r, true, err
+	case "DeletePartnerApp":
+		return nil, true, h.handleDeletePartnerApp(body)
+
+	// TrainingPlan
+	case "CreateTrainingPlan":
+		r, err := h.handleCreateTrainingPlan(body)
+
+		return r, true, err
+	case "DescribeTrainingPlan":
+		r, err := h.handleDescribeTrainingPlan(body)
+
+		return r, true, err
+	}
+
+	return nil, false, nil
+}
+
+// ---------------------------------------------------------------------------
+// DataQualityJobDefinition handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateDataQualityJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		Tags                          map[string]string `json:"Tags"`
+		DataQualityJobDefinitionName  string            `json:"DataQualityJobDefinitionName"`
+		RoleArn                       string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.DataQualityJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: DataQualityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateDataQualityJobDefinition(req.DataQualityJobDefinitionName, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyJobDefinitionArn: result.JobDefinitionArn})
+}
+
+func (h *Handler) handleDescribeDataQualityJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		DataQualityJobDefinitionName string `json:"DataQualityJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.DataQualityJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: DataQualityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeDataQualityJobDefinition(req.DataQualityJobDefinitionName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteDataQualityJobDefinition(body []byte) error {
+	var req struct {
+		DataQualityJobDefinitionName string `json:"DataQualityJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.DataQualityJobDefinitionName == "" {
+		return fmt.Errorf("%w: DataQualityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteDataQualityJobDefinition(req.DataQualityJobDefinitionName)
+}
+
+// ---------------------------------------------------------------------------
+// ModelBiasJobDefinition handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateModelBiasJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		Tags                       map[string]string `json:"Tags"`
+		ModelBiasJobDefinitionName string            `json:"ModelBiasJobDefinitionName"`
+		RoleArn                    string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelBiasJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: ModelBiasJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateModelBiasJobDefinition(req.ModelBiasJobDefinitionName, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyJobDefinitionArn: result.JobDefinitionArn})
+}
+
+func (h *Handler) handleDescribeModelBiasJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		ModelBiasJobDefinitionName string `json:"ModelBiasJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelBiasJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: ModelBiasJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeModelBiasJobDefinition(req.ModelBiasJobDefinitionName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteModelBiasJobDefinition(body []byte) error {
+	var req struct {
+		ModelBiasJobDefinitionName string `json:"ModelBiasJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelBiasJobDefinitionName == "" {
+		return fmt.Errorf("%w: ModelBiasJobDefinitionName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteModelBiasJobDefinition(req.ModelBiasJobDefinitionName)
+}
+
+// ---------------------------------------------------------------------------
+// ModelQualityJobDefinition handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateModelQualityJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		Tags                          map[string]string `json:"Tags"`
+		ModelQualityJobDefinitionName string            `json:"ModelQualityJobDefinitionName"`
+		RoleArn                       string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelQualityJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: ModelQualityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateModelQualityJobDefinition(
+		req.ModelQualityJobDefinitionName, req.RoleArn, req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyJobDefinitionArn: result.JobDefinitionArn})
+}
+
+func (h *Handler) handleDescribeModelQualityJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		ModelQualityJobDefinitionName string `json:"ModelQualityJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelQualityJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: ModelQualityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeModelQualityJobDefinition(req.ModelQualityJobDefinitionName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteModelQualityJobDefinition(body []byte) error {
+	var req struct {
+		ModelQualityJobDefinitionName string `json:"ModelQualityJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelQualityJobDefinitionName == "" {
+		return fmt.Errorf("%w: ModelQualityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteModelQualityJobDefinition(req.ModelQualityJobDefinitionName)
+}
+
+// ---------------------------------------------------------------------------
+// ModelExplainabilityJobDefinition handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateModelExplainabilityJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		Tags                                   map[string]string `json:"Tags"`
+		ModelExplainabilityJobDefinitionName   string            `json:"ModelExplainabilityJobDefinitionName"`
+		RoleArn                                string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelExplainabilityJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: ModelExplainabilityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateModelExplainabilityJobDefinition(
+		req.ModelExplainabilityJobDefinitionName, req.RoleArn, req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyJobDefinitionArn: result.JobDefinitionArn})
+}
+
+func (h *Handler) handleDescribeModelExplainabilityJobDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		ModelExplainabilityJobDefinitionName string `json:"ModelExplainabilityJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelExplainabilityJobDefinitionName == "" {
+		return nil, fmt.Errorf("%w: ModelExplainabilityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeModelExplainabilityJobDefinition(req.ModelExplainabilityJobDefinitionName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteModelExplainabilityJobDefinition(body []byte) error {
+	var req struct {
+		ModelExplainabilityJobDefinitionName string `json:"ModelExplainabilityJobDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelExplainabilityJobDefinitionName == "" {
+		return fmt.Errorf("%w: ModelExplainabilityJobDefinitionName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteModelExplainabilityJobDefinition(req.ModelExplainabilityJobDefinitionName)
+}
+
+// ---------------------------------------------------------------------------
+// HumanTaskUi handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateHumanTaskUi(body []byte) ([]byte, error) {
+	var req struct {
+		Tags            map[string]string `json:"Tags"`
+		HumanTaskUiName string            `json:"HumanTaskUiName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.HumanTaskUiName == "" {
+		return nil, fmt.Errorf("%w: HumanTaskUiName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateHumanTaskUi(req.HumanTaskUiName, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyHumanTaskUIArn: result.HumanTaskUiArn})
+}
+
+func (h *Handler) handleDescribeHumanTaskUi(body []byte) ([]byte, error) {
+	var req struct {
+		HumanTaskUiName string `json:"HumanTaskUiName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.HumanTaskUiName == "" {
+		return nil, fmt.Errorf("%w: HumanTaskUiName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeHumanTaskUi(req.HumanTaskUiName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteHumanTaskUi(body []byte) error {
+	var req struct {
+		HumanTaskUiName string `json:"HumanTaskUiName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.HumanTaskUiName == "" {
+		return fmt.Errorf("%w: HumanTaskUiName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteHumanTaskUi(req.HumanTaskUiName)
+}
+
+// ---------------------------------------------------------------------------
+// Workforce handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateWorkforce(body []byte) ([]byte, error) {
+	var req struct {
+		Tags          map[string]string `json:"Tags"`
+		WorkforceName string            `json:"WorkforceName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.WorkforceName == "" {
+		return nil, fmt.Errorf("%w: WorkforceName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateWorkforce(req.WorkforceName, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyWorkforceArn: result.WorkforceArn})
+}
+
+func (h *Handler) handleDescribeWorkforce(body []byte) ([]byte, error) {
+	var req struct {
+		WorkforceName string `json:"WorkforceName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.WorkforceName == "" {
+		return nil, fmt.Errorf("%w: WorkforceName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeWorkforce(req.WorkforceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"Workforce": result})
+}
+
+func (h *Handler) handleUpdateWorkforce(body []byte) ([]byte, error) {
+	var req struct {
+		WorkforceName string `json:"WorkforceName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.WorkforceName == "" {
+		return nil, fmt.Errorf("%w: WorkforceName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.UpdateWorkforce(req.WorkforceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{"Workforce": result})
+}
+
+// ---------------------------------------------------------------------------
+// FlowDefinition handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateFlowDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		Tags               map[string]string `json:"Tags"`
+		FlowDefinitionName string            `json:"FlowDefinitionName"`
+		RoleArn            string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.FlowDefinitionName == "" {
+		return nil, fmt.Errorf("%w: FlowDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateFlowDefinition(req.FlowDefinitionName, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyFlowDefinitionArn: result.FlowDefinitionArn})
+}
+
+func (h *Handler) handleDescribeFlowDefinition(body []byte) ([]byte, error) {
+	var req struct {
+		FlowDefinitionName string `json:"FlowDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.FlowDefinitionName == "" {
+		return nil, fmt.Errorf("%w: FlowDefinitionName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeFlowDefinition(req.FlowDefinitionName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteFlowDefinition(body []byte) error {
+	var req struct {
+		FlowDefinitionName string `json:"FlowDefinitionName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.FlowDefinitionName == "" {
+		return fmt.Errorf("%w: FlowDefinitionName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteFlowDefinition(req.FlowDefinitionName)
+}
+
+// ---------------------------------------------------------------------------
+// AppImageConfig handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateAppImageConfig(body []byte) ([]byte, error) {
+	var req struct {
+		Tags               map[string]string `json:"Tags"`
+		AppImageConfigName string            `json:"AppImageConfigName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AppImageConfigName == "" {
+		return nil, fmt.Errorf("%w: AppImageConfigName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateAppImageConfig(req.AppImageConfigName, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyAppImageConfigArn: result.AppImageConfigArn})
+}
+
+func (h *Handler) handleDescribeAppImageConfig(body []byte) ([]byte, error) {
+	var req struct {
+		AppImageConfigName string `json:"AppImageConfigName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AppImageConfigName == "" {
+		return nil, fmt.Errorf("%w: AppImageConfigName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeAppImageConfig(req.AppImageConfigName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteAppImageConfig(body []byte) error {
+	var req struct {
+		AppImageConfigName string `json:"AppImageConfigName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AppImageConfigName == "" {
+		return fmt.Errorf("%w: AppImageConfigName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteAppImageConfig(req.AppImageConfigName)
+}
+
+func (h *Handler) handleUpdateAppImageConfig(body []byte) ([]byte, error) {
+	var req struct {
+		AppImageConfigName string `json:"AppImageConfigName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.AppImageConfigName == "" {
+		return nil, fmt.Errorf("%w: AppImageConfigName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.UpdateAppImageConfig(req.AppImageConfigName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyAppImageConfigArn: result.AppImageConfigArn})
+}
+
+// ---------------------------------------------------------------------------
+// InferenceExperiment handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateInferenceExperiment(body []byte) ([]byte, error) {
+	var req struct {
+		Tags    map[string]string `json:"Tags"`
+		Name    string            `json:"Name"`
+		Type    string            `json:"Type"`
+		RoleArn string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Name == "" {
+		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateInferenceExperiment(req.Name, req.Type, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyInferenceExperimentArn: result.Arn})
+}
+
+func (h *Handler) handleDescribeInferenceExperiment(body []byte) ([]byte, error) {
+	var req struct {
+		Name string `json:"Name"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Name == "" {
+		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeInferenceExperiment(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleStopInferenceExperiment(body []byte) error {
+	var req struct {
+		Name string `json:"Name"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Name == "" {
+		return fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	return h.Backend.StopInferenceExperiment(req.Name)
+}
+
+func (h *Handler) handleDeleteInferenceExperiment(body []byte) error {
+	var req struct {
+		Name string `json:"Name"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Name == "" {
+		return fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteInferenceExperiment(req.Name)
+}
+
+// ---------------------------------------------------------------------------
+// MlflowTrackingServer handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateMlflowTrackingServer(body []byte) ([]byte, error) {
+	var req struct {
+		Tags               map[string]string `json:"Tags"`
+		TrackingServerName string            `json:"TrackingServerName"`
+		RoleArn            string            `json:"RoleArn"`
+		MlflowVersion      string            `json:"MlflowVersion"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrackingServerName == "" {
+		return nil, fmt.Errorf("%w: TrackingServerName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateMlflowTrackingServer(
+		req.TrackingServerName, req.RoleArn, req.MlflowVersion, req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyTrackingServerArn: result.TrackingServerArn})
+}
+
+func (h *Handler) handleDescribeMlflowTrackingServer(body []byte) ([]byte, error) {
+	var req struct {
+		TrackingServerName string `json:"TrackingServerName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrackingServerName == "" {
+		return nil, fmt.Errorf("%w: TrackingServerName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeMlflowTrackingServer(req.TrackingServerName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteMlflowTrackingServer(body []byte) error {
+	var req struct {
+		TrackingServerName string `json:"TrackingServerName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrackingServerName == "" {
+		return fmt.Errorf("%w: TrackingServerName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteMlflowTrackingServer(req.TrackingServerName)
+}
+
+func (h *Handler) handleStartMlflowTrackingServer(body []byte) error {
+	var req struct {
+		TrackingServerName string `json:"TrackingServerName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrackingServerName == "" {
+		return fmt.Errorf("%w: TrackingServerName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StartMlflowTrackingServer(req.TrackingServerName)
+}
+
+func (h *Handler) handleStopMlflowTrackingServer(body []byte) error {
+	var req struct {
+		TrackingServerName string `json:"TrackingServerName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrackingServerName == "" {
+		return fmt.Errorf("%w: TrackingServerName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StopMlflowTrackingServer(req.TrackingServerName)
+}
+
+// ---------------------------------------------------------------------------
+// ModelCard handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateModelCard(body []byte) ([]byte, error) {
+	var req struct {
+		Tags          map[string]string `json:"Tags"`
+		ModelCardName string            `json:"ModelCardName"`
+		Content       string            `json:"Content"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelCardName == "" {
+		return nil, fmt.Errorf("%w: ModelCardName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateModelCard(req.ModelCardName, req.Content, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyModelCardArn: result.ModelCardArn})
+}
+
+func (h *Handler) handleDescribeModelCard(body []byte) ([]byte, error) {
+	var req struct {
+		ModelCardName string `json:"ModelCardName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelCardName == "" {
+		return nil, fmt.Errorf("%w: ModelCardName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeModelCard(req.ModelCardName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleUpdateModelCard(body []byte) ([]byte, error) {
+	var req struct {
+		ModelCardName string `json:"ModelCardName"`
+		Content       string `json:"Content"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelCardName == "" {
+		return nil, fmt.Errorf("%w: ModelCardName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.UpdateModelCard(req.ModelCardName, req.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyModelCardArn: result.ModelCardArn})
+}
+
+func (h *Handler) handleDeleteModelCard(body []byte) error {
+	var req struct {
+		ModelCardName string `json:"ModelCardName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.ModelCardName == "" {
+		return fmt.Errorf("%w: ModelCardName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteModelCard(req.ModelCardName)
+}
+
+// ---------------------------------------------------------------------------
+// OptimizationJob handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateOptimizationJob(body []byte) ([]byte, error) {
+	var req struct {
+		Tags                map[string]string `json:"Tags"`
+		OptimizationJobName string            `json:"OptimizationJobName"`
+		RoleArn             string            `json:"RoleArn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.OptimizationJobName == "" {
+		return nil, fmt.Errorf("%w: OptimizationJobName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateOptimizationJob(req.OptimizationJobName, req.RoleArn, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyOptimizationJobArn: result.OptimizationJobArn})
+}
+
+func (h *Handler) handleDescribeOptimizationJob(body []byte) ([]byte, error) {
+	var req struct {
+		OptimizationJobName string `json:"OptimizationJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.OptimizationJobName == "" {
+		return nil, fmt.Errorf("%w: OptimizationJobName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeOptimizationJob(req.OptimizationJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteOptimizationJob(body []byte) error {
+	var req struct {
+		OptimizationJobName string `json:"OptimizationJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.OptimizationJobName == "" {
+		return fmt.Errorf("%w: OptimizationJobName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteOptimizationJob(req.OptimizationJobName)
+}
+
+func (h *Handler) handleStopOptimizationJob(body []byte) error {
+	var req struct {
+		OptimizationJobName string `json:"OptimizationJobName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.OptimizationJobName == "" {
+		return fmt.Errorf("%w: OptimizationJobName is required", errInvalidRequest)
+	}
+
+	return h.Backend.StopOptimizationJob(req.OptimizationJobName)
+}
+
+// ---------------------------------------------------------------------------
+// StudioLifecycleConfig handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateStudioLifecycleConfig(body []byte) ([]byte, error) {
+	var req struct {
+		Tags                         map[string]string `json:"Tags"`
+		StudioLifecycleConfigName    string            `json:"StudioLifecycleConfigName"`
+		StudioLifecycleConfigAppType string            `json:"StudioLifecycleConfigAppType"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.StudioLifecycleConfigName == "" {
+		return nil, fmt.Errorf("%w: StudioLifecycleConfigName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateStudioLifecycleConfig(
+		req.StudioLifecycleConfigName, req.StudioLifecycleConfigAppType, req.Tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyStudioLifecycleConfigArn: result.StudioLifecycleConfigArn})
+}
+
+func (h *Handler) handleDescribeStudioLifecycleConfig(body []byte) ([]byte, error) {
+	var req struct {
+		StudioLifecycleConfigName string `json:"StudioLifecycleConfigName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.StudioLifecycleConfigName == "" {
+		return nil, fmt.Errorf("%w: StudioLifecycleConfigName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeStudioLifecycleConfig(req.StudioLifecycleConfigName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeleteStudioLifecycleConfig(body []byte) error {
+	var req struct {
+		StudioLifecycleConfigName string `json:"StudioLifecycleConfigName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.StudioLifecycleConfigName == "" {
+		return fmt.Errorf("%w: StudioLifecycleConfigName is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeleteStudioLifecycleConfig(req.StudioLifecycleConfigName)
+}
+
+// ---------------------------------------------------------------------------
+// PartnerApp handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreatePartnerApp(body []byte) ([]byte, error) {
+	var req struct {
+		Tags map[string]string `json:"Tags"`
+		Name string            `json:"Name"`
+		Type string            `json:"Type"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Name == "" {
+		return nil, fmt.Errorf("%w: Name is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreatePartnerApp(req.Name, req.Type, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyGenericArn: result.Arn})
+}
+
+func (h *Handler) handleDescribePartnerApp(body []byte) ([]byte, error) {
+	var req struct {
+		Arn string `json:"Arn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Arn == "" {
+		return nil, fmt.Errorf("%w: Arn is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribePartnerApp(req.Arn)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}
+
+func (h *Handler) handleDeletePartnerApp(body []byte) error {
+	var req struct {
+		Arn string `json:"Arn"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.Arn == "" {
+		return fmt.Errorf("%w: Arn is required", errInvalidRequest)
+	}
+
+	return h.Backend.DeletePartnerApp(req.Arn)
+}
+
+// ---------------------------------------------------------------------------
+// TrainingPlan handlers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) handleCreateTrainingPlan(body []byte) ([]byte, error) {
+	var req struct {
+		Tags             map[string]string `json:"Tags"`
+		TrainingPlanName string            `json:"TrainingPlanName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrainingPlanName == "" {
+		return nil, fmt.Errorf("%w: TrainingPlanName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.CreateTrainingPlan(req.TrainingPlanName, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{keyTrainingPlanArn: result.TrainingPlanArn})
+}
+
+func (h *Handler) handleDescribeTrainingPlan(body []byte) ([]byte, error) {
+	var req struct {
+		TrainingPlanName string `json:"TrainingPlanName"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
+	}
+
+	if req.TrainingPlanName == "" {
+		return nil, fmt.Errorf("%w: TrainingPlanName is required", errInvalidRequest)
+	}
+
+	result, err := h.Backend.DescribeTrainingPlan(req.TrainingPlanName)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(result)
+}

--- a/services/sagemaker/handler_batch3.go
+++ b/services/sagemaker/handler_batch3.go
@@ -25,7 +25,7 @@ func batch3SupportedOperations() []string {
 		"CreateModelExplainabilityJobDefinition",
 		"DescribeModelExplainabilityJobDefinition",
 		"DeleteModelExplainabilityJobDefinition",
-		// HumanTaskUi
+		// HumanTaskUI
 		"CreateHumanTaskUi",
 		"DescribeHumanTaskUi",
 		"DeleteHumanTaskUi",
@@ -134,17 +134,17 @@ func (h *Handler) dispatchBatch3Ops(
 	case "DeleteModelExplainabilityJobDefinition":
 		return nil, true, h.handleDeleteModelExplainabilityJobDefinition(body)
 
-	// HumanTaskUi
+	// HumanTaskUI
 	case "CreateHumanTaskUi":
-		r, err := h.handleCreateHumanTaskUi(body)
+		r, err := h.handleCreateHumanTaskUI(body)
 
 		return r, true, err
 	case "DescribeHumanTaskUi":
-		r, err := h.handleDescribeHumanTaskUi(body)
+		r, err := h.handleDescribeHumanTaskUI(body)
 
 		return r, true, err
 	case "DeleteHumanTaskUi":
-		return nil, true, h.handleDeleteHumanTaskUi(body)
+		return nil, true, h.handleDeleteHumanTaskUI(body)
 
 	// Workforce
 	case "CreateWorkforce":
@@ -292,9 +292,9 @@ func (h *Handler) dispatchBatch3Ops(
 
 func (h *Handler) handleCreateDataQualityJobDefinition(body []byte) ([]byte, error) {
 	var req struct {
-		Tags                          map[string]string `json:"Tags"`
-		DataQualityJobDefinitionName  string            `json:"DataQualityJobDefinitionName"`
-		RoleArn                       string            `json:"RoleArn"`
+		Tags                         map[string]string `json:"Tags"`
+		DataQualityJobDefinitionName string            `json:"DataQualityJobDefinitionName"`
+		RoleArn                      string            `json:"RoleArn"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -486,9 +486,9 @@ func (h *Handler) handleDeleteModelQualityJobDefinition(body []byte) error {
 
 func (h *Handler) handleCreateModelExplainabilityJobDefinition(body []byte) ([]byte, error) {
 	var req struct {
-		Tags                                   map[string]string `json:"Tags"`
-		ModelExplainabilityJobDefinitionName   string            `json:"ModelExplainabilityJobDefinitionName"`
-		RoleArn                                string            `json:"RoleArn"`
+		Tags                                 map[string]string `json:"Tags"`
+		ModelExplainabilityJobDefinitionName string            `json:"ModelExplainabilityJobDefinitionName"`
+		RoleArn                              string            `json:"RoleArn"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -547,45 +547,45 @@ func (h *Handler) handleDeleteModelExplainabilityJobDefinition(body []byte) erro
 }
 
 // ---------------------------------------------------------------------------
-// HumanTaskUi handlers
+// HumanTaskUI handlers
 // ---------------------------------------------------------------------------
 
-func (h *Handler) handleCreateHumanTaskUi(body []byte) ([]byte, error) {
+func (h *Handler) handleCreateHumanTaskUI(body []byte) ([]byte, error) {
 	var req struct {
 		Tags            map[string]string `json:"Tags"`
-		HumanTaskUiName string            `json:"HumanTaskUiName"`
+		HumanTaskUIName string            `json:"HumanTaskUiName"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	if req.HumanTaskUiName == "" {
+	if req.HumanTaskUIName == "" {
 		return nil, fmt.Errorf("%w: HumanTaskUiName is required", errInvalidRequest)
 	}
 
-	result, err := h.Backend.CreateHumanTaskUi(req.HumanTaskUiName, req.Tags)
+	result, err := h.Backend.CreateHumanTaskUI(req.HumanTaskUIName, req.Tags)
 	if err != nil {
 		return nil, err
 	}
 
-	return json.Marshal(map[string]any{keyHumanTaskUIArn: result.HumanTaskUiArn})
+	return json.Marshal(map[string]any{keyHumanTaskUIArn: result.HumanTaskUIArn})
 }
 
-func (h *Handler) handleDescribeHumanTaskUi(body []byte) ([]byte, error) {
+func (h *Handler) handleDescribeHumanTaskUI(body []byte) ([]byte, error) {
 	var req struct {
-		HumanTaskUiName string `json:"HumanTaskUiName"`
+		HumanTaskUIName string `json:"HumanTaskUiName"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	if req.HumanTaskUiName == "" {
+	if req.HumanTaskUIName == "" {
 		return nil, fmt.Errorf("%w: HumanTaskUiName is required", errInvalidRequest)
 	}
 
-	result, err := h.Backend.DescribeHumanTaskUi(req.HumanTaskUiName)
+	result, err := h.Backend.DescribeHumanTaskUI(req.HumanTaskUIName)
 	if err != nil {
 		return nil, err
 	}
@@ -593,20 +593,20 @@ func (h *Handler) handleDescribeHumanTaskUi(body []byte) ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (h *Handler) handleDeleteHumanTaskUi(body []byte) error {
+func (h *Handler) handleDeleteHumanTaskUI(body []byte) error {
 	var req struct {
-		HumanTaskUiName string `json:"HumanTaskUiName"`
+		HumanTaskUIName string `json:"HumanTaskUiName"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
 		return fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
 
-	if req.HumanTaskUiName == "" {
+	if req.HumanTaskUIName == "" {
 		return fmt.Errorf("%w: HumanTaskUiName is required", errInvalidRequest)
 	}
 
-	return h.Backend.DeleteHumanTaskUi(req.HumanTaskUiName)
+	return h.Backend.DeleteHumanTaskUI(req.HumanTaskUIName)
 }
 
 // ---------------------------------------------------------------------------

--- a/services/sagemaker/handler_batch3_test.go
+++ b/services/sagemaker/handler_batch3_test.go
@@ -171,10 +171,10 @@ func TestHandler_DeleteModelExplainabilityJobDefinition(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// HumanTaskUi
+// HumanTaskUI
 // ---------------------------------------------------------------------------
 
-func TestHandler_CreateHumanTaskUi(t *testing.T) {
+func TestHandler_CreateHumanTaskUI(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
@@ -189,7 +189,7 @@ func TestHandler_CreateHumanTaskUi(t *testing.T) {
 	assert.Contains(t, resp["HumanTaskUiArn"], "my-ui")
 }
 
-func TestHandler_DescribeHumanTaskUi(t *testing.T) {
+func TestHandler_DescribeHumanTaskUI(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
@@ -203,7 +203,7 @@ func TestHandler_DescribeHumanTaskUi(t *testing.T) {
 	assert.Equal(t, "ui-1", resp["HumanTaskUiName"])
 }
 
-func TestHandler_DeleteHumanTaskUi(t *testing.T) {
+func TestHandler_DeleteHumanTaskUI(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
@@ -536,7 +536,7 @@ func TestHandler_UpdateModelCard(t *testing.T) {
 	rec = doSageMakerRequest(t, h, "DescribeModelCard", map[string]any{"ModelCardName": "card-upd"})
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Equal(t, float64(2), resp["ModelCardVersion"])
+	assert.InDelta(t, float64(2), resp["ModelCardVersion"], 0)
 }
 
 func TestHandler_DeleteModelCard(t *testing.T) {

--- a/services/sagemaker/handler_batch3_test.go
+++ b/services/sagemaker/handler_batch3_test.go
@@ -1,0 +1,754 @@
+package sagemaker_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// DataQualityJobDefinition
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateDataQualityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateDataQualityJobDefinition", map[string]any{
+		"DataQualityJobDefinitionName": "dq-def-1",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["JobDefinitionArn"], "dq-def-1")
+}
+
+func TestHandler_DescribeDataQualityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateDataQualityJobDefinition", map[string]any{
+		"DataQualityJobDefinitionName": "dq-def-2",
+	})
+
+	rec := doSageMakerRequest(t, h, "DescribeDataQualityJobDefinition", map[string]any{
+		"DataQualityJobDefinitionName": "dq-def-2",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "dq-def-2", resp["JobDefinitionName"])
+}
+
+func TestHandler_DeleteDataQualityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateDataQualityJobDefinition", map[string]any{
+		"DataQualityJobDefinitionName": "dq-def-del",
+	})
+	rec := doSageMakerRequest(t, h, "DeleteDataQualityJobDefinition", map[string]any{
+		"DataQualityJobDefinitionName": "dq-def-del",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeDataQualityJobDefinition", map[string]any{
+		"DataQualityJobDefinitionName": "dq-def-del",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// ModelBiasJobDefinition
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateModelBiasJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateModelBiasJobDefinition", map[string]any{
+		"ModelBiasJobDefinitionName": "mb-def-1",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["JobDefinitionArn"], "mb-def-1")
+}
+
+func TestHandler_DeleteModelBiasJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelBiasJobDefinition", map[string]any{
+		"ModelBiasJobDefinitionName": "mb-def-del",
+	})
+	rec := doSageMakerRequest(t, h, "DeleteModelBiasJobDefinition", map[string]any{
+		"ModelBiasJobDefinitionName": "mb-def-del",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeModelBiasJobDefinition", map[string]any{
+		"ModelBiasJobDefinitionName": "mb-def-del",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// ModelQualityJobDefinition
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateModelQualityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateModelQualityJobDefinition", map[string]any{
+		"ModelQualityJobDefinitionName": "mq-def-1",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["JobDefinitionArn"], "mq-def-1")
+}
+
+func TestHandler_DeleteModelQualityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelQualityJobDefinition", map[string]any{
+		"ModelQualityJobDefinitionName": "mq-def-del",
+	})
+	rec := doSageMakerRequest(t, h, "DeleteModelQualityJobDefinition", map[string]any{
+		"ModelQualityJobDefinitionName": "mq-def-del",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// ModelExplainabilityJobDefinition
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateModelExplainabilityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateModelExplainabilityJobDefinition", map[string]any{
+		"ModelExplainabilityJobDefinitionName": "me-def-1",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["JobDefinitionArn"], "me-def-1")
+}
+
+func TestHandler_DeleteModelExplainabilityJobDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelExplainabilityJobDefinition", map[string]any{
+		"ModelExplainabilityJobDefinitionName": "me-def-del",
+	})
+	rec := doSageMakerRequest(t, h, "DeleteModelExplainabilityJobDefinition", map[string]any{
+		"ModelExplainabilityJobDefinitionName": "me-def-del",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// HumanTaskUi
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateHumanTaskUi(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateHumanTaskUi", map[string]any{
+		"HumanTaskUiName": "my-ui",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["HumanTaskUiArn"], "my-ui")
+}
+
+func TestHandler_DescribeHumanTaskUi(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateHumanTaskUi", map[string]any{"HumanTaskUiName": "ui-1"})
+	rec := doSageMakerRequest(t, h, "DescribeHumanTaskUi", map[string]any{"HumanTaskUiName": "ui-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "ui-1", resp["HumanTaskUiName"])
+}
+
+func TestHandler_DeleteHumanTaskUi(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateHumanTaskUi", map[string]any{"HumanTaskUiName": "ui-del"})
+	rec := doSageMakerRequest(t, h, "DeleteHumanTaskUi", map[string]any{"HumanTaskUiName": "ui-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeHumanTaskUi", map[string]any{"HumanTaskUiName": "ui-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Workforce
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateWorkforce(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateWorkforce", map[string]any{
+		"WorkforceName": "my-workforce",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["WorkforceArn"], "my-workforce")
+}
+
+func TestHandler_DescribeWorkforce(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateWorkforce", map[string]any{"WorkforceName": "wf-1"})
+	rec := doSageMakerRequest(t, h, "DescribeWorkforce", map[string]any{"WorkforceName": "wf-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotNil(t, resp["Workforce"])
+}
+
+func TestHandler_UpdateWorkforce(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateWorkforce", map[string]any{"WorkforceName": "wf-upd"})
+	rec := doSageMakerRequest(t, h, "UpdateWorkforce", map[string]any{"WorkforceName": "wf-upd"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotNil(t, resp["Workforce"])
+}
+
+// ---------------------------------------------------------------------------
+// FlowDefinition
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateFlowDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateFlowDefinition", map[string]any{
+		"FlowDefinitionName": "my-flow",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["FlowDefinitionArn"], "my-flow")
+}
+
+func TestHandler_DescribeFlowDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateFlowDefinition", map[string]any{"FlowDefinitionName": "flow-1"})
+	rec := doSageMakerRequest(t, h, "DescribeFlowDefinition", map[string]any{"FlowDefinitionName": "flow-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "flow-1", resp["FlowDefinitionName"])
+}
+
+func TestHandler_DeleteFlowDefinition(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateFlowDefinition", map[string]any{"FlowDefinitionName": "flow-del"})
+	rec := doSageMakerRequest(t, h, "DeleteFlowDefinition", map[string]any{"FlowDefinitionName": "flow-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeFlowDefinition", map[string]any{"FlowDefinitionName": "flow-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// AppImageConfig
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateAppImageConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateAppImageConfig", map[string]any{
+		"AppImageConfigName": "my-config",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["AppImageConfigArn"], "my-config")
+}
+
+func TestHandler_DescribeAppImageConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateAppImageConfig", map[string]any{"AppImageConfigName": "aic-1"})
+	rec := doSageMakerRequest(t, h, "DescribeAppImageConfig", map[string]any{"AppImageConfigName": "aic-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "aic-1", resp["AppImageConfigName"])
+}
+
+func TestHandler_DeleteAppImageConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateAppImageConfig", map[string]any{"AppImageConfigName": "aic-del"})
+	rec := doSageMakerRequest(t, h, "DeleteAppImageConfig", map[string]any{"AppImageConfigName": "aic-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeAppImageConfig", map[string]any{"AppImageConfigName": "aic-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_UpdateAppImageConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateAppImageConfig", map[string]any{"AppImageConfigName": "aic-upd"})
+	rec := doSageMakerRequest(t, h, "UpdateAppImageConfig", map[string]any{"AppImageConfigName": "aic-upd"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["AppImageConfigArn"], "aic-upd")
+}
+
+// ---------------------------------------------------------------------------
+// InferenceExperiment
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateInferenceExperiment(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateInferenceExperiment", map[string]any{
+		"Name": "my-exp",
+		"Type": "ShadowMode",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["InferenceExperimentArn"], "my-exp")
+}
+
+func TestHandler_DescribeInferenceExperiment(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateInferenceExperiment", map[string]any{"Name": "exp-1"})
+	rec := doSageMakerRequest(t, h, "DescribeInferenceExperiment", map[string]any{"Name": "exp-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "exp-1", resp["Name"])
+}
+
+func TestHandler_StopInferenceExperiment(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateInferenceExperiment", map[string]any{"Name": "exp-stop"})
+	rec := doSageMakerRequest(t, h, "StopInferenceExperiment", map[string]any{"Name": "exp-stop"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_DeleteInferenceExperiment(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateInferenceExperiment", map[string]any{"Name": "exp-del"})
+	rec := doSageMakerRequest(t, h, "DeleteInferenceExperiment", map[string]any{"Name": "exp-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeInferenceExperiment", map[string]any{"Name": "exp-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// MlflowTrackingServer
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateMlflowTrackingServer(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateMlflowTrackingServer", map[string]any{
+		"TrackingServerName": "my-server",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["TrackingServerArn"], "my-server")
+}
+
+func TestHandler_DescribeMlflowTrackingServer(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-1"})
+	rec := doSageMakerRequest(t, h, "DescribeMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "ts-1", resp["TrackingServerName"])
+}
+
+func TestHandler_StartStopMlflowTrackingServer(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-ss"})
+
+	rec := doSageMakerRequest(t, h, "StartMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-ss"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "StopMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-ss"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_DeleteMlflowTrackingServer(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-del"})
+	rec := doSageMakerRequest(t, h, "DeleteMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeMlflowTrackingServer", map[string]any{"TrackingServerName": "ts-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// ModelCard
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateModelCard(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateModelCard", map[string]any{
+		"ModelCardName": "my-card",
+		"Content":       "{}",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["ModelCardArn"], "my-card")
+}
+
+func TestHandler_DescribeModelCard(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelCard", map[string]any{"ModelCardName": "card-1"})
+	rec := doSageMakerRequest(t, h, "DescribeModelCard", map[string]any{"ModelCardName": "card-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "card-1", resp["ModelCardName"])
+}
+
+func TestHandler_UpdateModelCard(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelCard", map[string]any{"ModelCardName": "card-upd"})
+	rec := doSageMakerRequest(t, h, "UpdateModelCard", map[string]any{
+		"ModelCardName": "card-upd",
+		"Content":       "{\"updated\": true}",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify version incremented
+	rec = doSageMakerRequest(t, h, "DescribeModelCard", map[string]any{"ModelCardName": "card-upd"})
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(2), resp["ModelCardVersion"])
+}
+
+func TestHandler_DeleteModelCard(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateModelCard", map[string]any{"ModelCardName": "card-del"})
+	rec := doSageMakerRequest(t, h, "DeleteModelCard", map[string]any{"ModelCardName": "card-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeModelCard", map[string]any{"ModelCardName": "card-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// OptimizationJob
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateOptimizationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateOptimizationJob", map[string]any{
+		"OptimizationJobName": "my-opt-job",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["OptimizationJobArn"], "my-opt-job")
+}
+
+func TestHandler_DescribeOptimizationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateOptimizationJob", map[string]any{"OptimizationJobName": "opt-1"})
+	rec := doSageMakerRequest(t, h, "DescribeOptimizationJob", map[string]any{"OptimizationJobName": "opt-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "opt-1", resp["OptimizationJobName"])
+}
+
+func TestHandler_StopOptimizationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateOptimizationJob", map[string]any{"OptimizationJobName": "opt-stop"})
+	rec := doSageMakerRequest(t, h, "StopOptimizationJob", map[string]any{"OptimizationJobName": "opt-stop"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_DeleteOptimizationJob(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateOptimizationJob", map[string]any{"OptimizationJobName": "opt-del"})
+	rec := doSageMakerRequest(t, h, "DeleteOptimizationJob", map[string]any{"OptimizationJobName": "opt-del"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeOptimizationJob", map[string]any{"OptimizationJobName": "opt-del"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// StudioLifecycleConfig
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateStudioLifecycleConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateStudioLifecycleConfig", map[string]any{
+		"StudioLifecycleConfigName":    "my-lc",
+		"StudioLifecycleConfigAppType": "JupyterServer",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["StudioLifecycleConfigArn"], "my-lc")
+}
+
+func TestHandler_DescribeStudioLifecycleConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateStudioLifecycleConfig", map[string]any{
+		"StudioLifecycleConfigName": "lc-1",
+	})
+	rec := doSageMakerRequest(t, h, "DescribeStudioLifecycleConfig", map[string]any{
+		"StudioLifecycleConfigName": "lc-1",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "lc-1", resp["StudioLifecycleConfigName"])
+}
+
+func TestHandler_DeleteStudioLifecycleConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateStudioLifecycleConfig", map[string]any{
+		"StudioLifecycleConfigName": "lc-del",
+	})
+	rec := doSageMakerRequest(t, h, "DeleteStudioLifecycleConfig", map[string]any{
+		"StudioLifecycleConfigName": "lc-del",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribeStudioLifecycleConfig", map[string]any{
+		"StudioLifecycleConfigName": "lc-del",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// PartnerApp
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreatePartnerApp(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreatePartnerApp", map[string]any{
+		"Name": "my-app",
+		"Type": "custom",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["Arn"], "my-app")
+}
+
+func TestHandler_DescribePartnerApp(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	createRec := doSageMakerRequest(t, h, "CreatePartnerApp", map[string]any{
+		"Name": "app-1",
+	})
+	var createResp map[string]string
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+
+	rec := doSageMakerRequest(t, h, "DescribePartnerApp", map[string]any{"Arn": createResp["Arn"]})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "app-1", resp["Name"])
+}
+
+func TestHandler_DeletePartnerApp(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	createRec := doSageMakerRequest(t, h, "CreatePartnerApp", map[string]any{"Name": "app-del"})
+	var createResp map[string]string
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+
+	rec := doSageMakerRequest(t, h, "DeletePartnerApp", map[string]any{"Arn": createResp["Arn"]})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doSageMakerRequest(t, h, "DescribePartnerApp", map[string]any{"Arn": createResp["Arn"]})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// TrainingPlan
+// ---------------------------------------------------------------------------
+
+func TestHandler_CreateTrainingPlan(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doSageMakerRequest(t, h, "CreateTrainingPlan", map[string]any{
+		"TrainingPlanName": "my-plan",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Contains(t, resp["TrainingPlanArn"], "my-plan")
+}
+
+func TestHandler_DescribeTrainingPlan(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	doSageMakerRequest(t, h, "CreateTrainingPlan", map[string]any{"TrainingPlanName": "plan-1"})
+	rec := doSageMakerRequest(t, h, "DescribeTrainingPlan", map[string]any{"TrainingPlanName": "plan-1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "plan-1", resp["TrainingPlanName"])
+}

--- a/services/sagemaker/handler_stubs.go
+++ b/services/sagemaker/handler_stubs.go
@@ -128,6 +128,7 @@ func stubOpsSupported() []string {
 		"DeleteMlflowApp",
 		"DeleteModelPackageGroupPolicy",
 		"DeleteProcessingJob",
+		"DeleteWorkforce",
 		"DeregisterDevices",
 		"DescribeAction",
 		"DescribeAlgorithm",
@@ -254,6 +255,7 @@ func stubOpsSupported() []string {
 		"UpdateInferenceComponentRuntimeConfig",
 		"UpdateInferenceExperiment",
 		"UpdateMlflowApp",
+		"UpdateMlflowTrackingServer",
 		"UpdateModelPackage",
 		"UpdateMonitoringAlert",
 		"UpdatePartnerApp",
@@ -381,6 +383,7 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"DeleteModelPackageGroupPolicy",
 		"DeletePipeline",
 		"DeleteProcessingJob",
+		"DeleteWorkforce",
 		"DeleteTrial",
 		"DeleteTrialComponent",
 		"DeleteUserProfile",
@@ -423,7 +426,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 		return mustMarshal(m{
 			keyAppArn: "", "AppType": "", "AppName": "", keyStatus: statusInService,
 		}), true
-
 
 	case "DescribeArtifact":
 		return mustMarshal(m{keyArtifactArn: "", "ArtifactType": ""}), true
@@ -804,6 +806,9 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "UpdateMlflowApp", "UpdatePartnerApp":
 		return mustMarshal(m{keyGenericArn: ""}), true
+
+	case "UpdateMlflowTrackingServer":
+		return mustMarshal(m{keyTrackingServerArn: ""}), true
 
 	case "UpdateModelPackage":
 		return mustMarshal(m{keyModelPackageArn: ""}), true

--- a/services/sagemaker/handler_stubs.go
+++ b/services/sagemaker/handler_stubs.go
@@ -89,78 +89,48 @@ const (
 //nolint:funlen
 func stubOpsSupported() []string {
 	return []string{
-		"CreateAppImageConfig",
 		"CreateArtifact",
 		"CreateCluster",
 		"CreateClusterSchedulerConfig",
 		"CreateComputeQuota",
 		"CreateContext",
-		"CreateDataQualityJobDefinition",
 		"CreateDeviceFleet",
 		"CreateEdgeDeploymentPlan",
 		"CreateEdgeDeploymentStage",
 		"CreateEdgePackagingJob",
-		"CreateFlowDefinition",
 		"CreateHub",
 		"CreateHubContentPresignedUrls",
 		"CreateHubContentReference",
-		"CreateHumanTaskUi",
 		"CreateInferenceComponent",
-		"CreateInferenceExperiment",
 		"CreateInferenceRecommendationsJob",
 		"CreateLabelingJob",
 		"CreateMlflowApp",
-		"CreateMlflowTrackingServer",
-		"CreateModelBiasJobDefinition",
-		"CreateModelCard",
 		"CreateModelCardExportJob",
-		"CreateModelExplainabilityJobDefinition",
-		"CreateModelQualityJobDefinition",
-		"CreateOptimizationJob",
-		"CreatePartnerApp",
 		"CreatePartnerAppPresignedUrl",
 		"CreatePresignedDomainUrl",
 		"CreatePresignedMlflowAppUrl",
 		"CreatePresignedMlflowTrackingServerUrl",
-		"CreateStudioLifecycleConfig",
-		"CreateTrainingPlan",
-		"CreateWorkforce",
 		"DeleteAction",
 		"DeleteAlgorithm",
-		"DeleteAppImageConfig",
 		"DeleteArtifact",
 		"DeleteAssociation",
 		"DeleteCluster",
 		"DeleteClusterSchedulerConfig",
 		"DeleteComputeQuota",
 		"DeleteContext",
-		"DeleteDataQualityJobDefinition",
 		"DeleteDeviceFleet",
 		"DeleteEdgeDeploymentPlan",
 		"DeleteEdgeDeploymentStage",
-		"DeleteFlowDefinition",
 		"DeleteHub",
 		"DeleteHubContent",
 		"DeleteHubContentReference",
-		"DeleteHumanTaskUi",
 		"DeleteInferenceComponent",
-		"DeleteInferenceExperiment",
 		"DeleteMlflowApp",
-		"DeleteMlflowTrackingServer",
-		"DeleteModelBiasJobDefinition",
-		"DeleteModelCard",
-		"DeleteModelExplainabilityJobDefinition",
 		"DeleteModelPackageGroupPolicy",
-		"DeleteModelQualityJobDefinition",
-		"DeleteOptimizationJob",
-		"DeletePartnerApp",
 		"DeleteProcessingJob",
-		"DeleteStudioLifecycleConfig",
-		"DeleteWorkforce",
 		"DeregisterDevices",
 		"DescribeAction",
 		"DescribeAlgorithm",
-		"DescribeAppImageConfig",
 		"DescribeArtifact",
 		"DescribeCluster",
 		"DescribeClusterEvent",
@@ -168,37 +138,23 @@ func stubOpsSupported() []string {
 		"DescribeClusterSchedulerConfig",
 		"DescribeComputeQuota",
 		"DescribeContext",
-		"DescribeDataQualityJobDefinition",
 		"DescribeDevice",
 		"DescribeDeviceFleet",
 		"DescribeEdgeDeploymentPlan",
 		"DescribeEdgePackagingJob",
 		"DescribeFeatureMetadata",
-		"DescribeFlowDefinition",
 		"DescribeHub",
 		"DescribeHubContent",
-		"DescribeHumanTaskUi",
 		"DescribeInferenceComponent",
-		"DescribeInferenceExperiment",
 		"DescribeInferenceRecommendationsJob",
 		"DescribeLabelingJob",
 		"DescribeLineageGroup",
 		"DescribeMlflowApp",
-		"DescribeMlflowTrackingServer",
-		"DescribeModelBiasJobDefinition",
-		"DescribeModelCard",
 		"DescribeModelCardExportJob",
-		"DescribeModelExplainabilityJobDefinition",
-		"DescribeModelQualityJobDefinition",
-		"DescribeOptimizationJob",
-		"DescribePartnerApp",
 		"DescribePipelineDefinitionForExecution",
 		"DescribeReservedCapacity",
-		"DescribeStudioLifecycleConfig",
 		"DescribeSubscribedWorkteam",
-		"DescribeTrainingPlan",
 		"DescribeTrainingPlanExtensionHistory",
-		"DescribeWorkforce",
 		"DetachClusterNodeVolume",
 		"DisableSagemakerServicecatalogPortfolio",
 		"DisassociateTrialComponent",
@@ -274,17 +230,12 @@ func stubOpsSupported() []string {
 		"SearchTrainingPlanOfferings",
 		"StartEdgeDeploymentStage",
 		"StartInferenceExperiment",
-		"StartMlflowTrackingServer",
 		"StartSession",
 		"StopEdgeDeploymentStage",
 		"StopEdgePackagingJob",
-		"StopInferenceExperiment",
 		"StopInferenceRecommendationsJob",
 		"StopLabelingJob",
-		"StopMlflowTrackingServer",
-		"StopOptimizationJob",
 		"UpdateAction",
-		"UpdateAppImageConfig",
 		"UpdateArtifact",
 		"UpdateCluster",
 		"UpdateClusterSchedulerConfig",
@@ -303,8 +254,6 @@ func stubOpsSupported() []string {
 		"UpdateInferenceComponentRuntimeConfig",
 		"UpdateInferenceExperiment",
 		"UpdateMlflowApp",
-		"UpdateMlflowTrackingServer",
-		"UpdateModelCard",
 		"UpdateModelPackage",
 		"UpdateMonitoringAlert",
 		"UpdatePartnerApp",
@@ -313,7 +262,6 @@ func stubOpsSupported() []string {
 		"UpdateProject",
 		"UpdateSpace",
 		"UpdateUserProfile",
-		"UpdateWorkforce",
 		"UpdateWorkteam",
 	}
 }
@@ -332,9 +280,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateApp":
 		return mustMarshal(m{keyAppArn: ""}), true
 
-	case "CreateAppImageConfig":
-		return mustMarshal(m{keyAppImageConfigArn: ""}), true
-
 	case "CreateArtifact":
 		return mustMarshal(m{keyArtifactArn: ""}), true
 
@@ -349,12 +294,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "CreateContext":
 		return mustMarshal(m{keyContextArn: ""}), true
-
-	case "CreateDataQualityJobDefinition",
-		"CreateModelBiasJobDefinition",
-		"CreateModelExplainabilityJobDefinition",
-		"CreateModelQualityJobDefinition":
-		return mustMarshal(m{keyJobDefinitionArn: ""}), true
 
 	case "CreateDeviceFleet":
 		return mustMarshal(m{}), true
@@ -374,9 +313,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateFeatureGroup":
 		return mustMarshal(m{keyFeatureGroupArn: ""}), true
 
-	case "CreateFlowDefinition":
-		return mustMarshal(m{keyFlowDefinitionArn: ""}), true
-
 	case "CreateHub":
 		return mustMarshal(m{keyHubArn: ""}), true
 
@@ -386,14 +322,8 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateHubContentReference":
 		return mustMarshal(m{keyHubArn: "", keyHubContentArn: ""}), true
 
-	case "CreateHumanTaskUi":
-		return mustMarshal(m{keyHumanTaskUIArn: ""}), true
-
 	case "CreateInferenceComponent":
 		return mustMarshal(m{keyInferenceComponentArn: ""}), true
-
-	case "CreateInferenceExperiment":
-		return mustMarshal(m{keyInferenceExperimentArn: ""}), true
 
 	case "CreateInferenceRecommendationsJob":
 		return mustMarshal(m{"JobArn": ""}), true
@@ -401,20 +331,11 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateLabelingJob":
 		return mustMarshal(m{keyLabelingJobArn: ""}), true
 
-	case "CreateMlflowApp", "CreatePartnerApp":
+	case "CreateMlflowApp":
 		return mustMarshal(m{keyGenericArn: ""}), true
-
-	case "CreateMlflowTrackingServer":
-		return mustMarshal(m{keyTrackingServerArn: ""}), true
-
-	case "CreateModelCard":
-		return mustMarshal(m{keyModelCardArn: ""}), true
 
 	case "CreateModelCardExportJob":
 		return mustMarshal(m{keyModelCardExportJobArn: ""}), true
-
-	case "CreateOptimizationJob":
-		return mustMarshal(m{keyOptimizationJobArn: ""}), true
 
 	case "CreatePartnerAppPresignedUrl",
 		"CreatePresignedDomainUrl",
@@ -425,12 +346,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreatePipeline":
 		return mustMarshal(m{keyPipelineArn: ""}), true
 
-	case "CreateStudioLifecycleConfig":
-		return mustMarshal(m{keyStudioLifecycleConfigArn: ""}), true
-
-	case "CreateTrainingPlan":
-		return mustMarshal(m{keyTrainingPlanArn: ""}), true
-
 	case "CreateTrial":
 		return mustMarshal(m{keyTrialArn: ""}), true
 
@@ -440,52 +355,35 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "CreateUserProfile":
 		return mustMarshal(m{keyUserProfileArn: ""}), true
 
-	case "CreateWorkforce":
-		return mustMarshal(m{keyWorkforceArn: ""}), true
-
 	// -----------------------------------------------------------------------
 	// Delete / stop / misc — return empty object
 	// -----------------------------------------------------------------------
 	case "DeleteAction",
 		"DeleteAlgorithm",
 		"DeleteApp",
-		"DeleteAppImageConfig",
 		"DeleteArtifact",
 		"DeleteAssociation",
 		"DeleteCluster",
 		"DeleteClusterSchedulerConfig",
 		"DeleteComputeQuota",
 		"DeleteContext",
-		"DeleteDataQualityJobDefinition",
 		"DeleteDeviceFleet",
 		"DeleteDomain",
 		"DeleteEdgeDeploymentPlan",
 		"DeleteEdgeDeploymentStage",
 		"DeleteExperiment",
 		"DeleteFeatureGroup",
-		"DeleteFlowDefinition",
 		"DeleteHub",
 		"DeleteHubContent",
 		"DeleteHubContentReference",
-		"DeleteHumanTaskUi",
 		"DeleteInferenceComponent",
-		"DeleteInferenceExperiment",
 		"DeleteMlflowApp",
-		"DeleteMlflowTrackingServer",
-		"DeleteModelBiasJobDefinition",
-		"DeleteModelCard",
-		"DeleteModelExplainabilityJobDefinition",
 		"DeleteModelPackageGroupPolicy",
-		"DeleteModelQualityJobDefinition",
-		"DeleteOptimizationJob",
-		"DeletePartnerApp",
 		"DeletePipeline",
 		"DeleteProcessingJob",
-		"DeleteStudioLifecycleConfig",
 		"DeleteTrial",
 		"DeleteTrialComponent",
 		"DeleteUserProfile",
-		"DeleteWorkforce",
 		"DeregisterDevices",
 		"DetachClusterNodeVolume",
 		"DisableSagemakerServicecatalogPortfolio",
@@ -497,15 +395,11 @@ func stubResponseFor(op string) ([]byte, bool) {
 		"RegisterDevices",
 		"RenderUiTemplate",
 		"StartEdgeDeploymentStage",
-		"StartMlflowTrackingServer",
 		"StartSession",
 		"StopEdgeDeploymentStage",
 		"StopEdgePackagingJob",
-		"StopInferenceExperiment",
 		"StopInferenceRecommendationsJob",
 		"StopLabelingJob",
-		"StopMlflowTrackingServer",
-		"StopOptimizationJob",
 		"UpdateClusterSoftware",
 		"UpdateDeviceFleet",
 		"UpdateDevices",
@@ -530,8 +424,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 			keyAppArn: "", "AppType": "", "AppName": "", keyStatus: statusInService,
 		}), true
 
-	case "DescribeAppImageConfig":
-		return mustMarshal(m{keyAppImageConfigArn: "", "AppImageConfigName": ""}), true
 
 	case "DescribeArtifact":
 		return mustMarshal(m{keyArtifactArn: "", "ArtifactType": ""}), true
@@ -555,12 +447,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "DescribeContext":
 		return mustMarshal(m{keyContextArn: "", "ContextType": ""}), true
-
-	case "DescribeDataQualityJobDefinition",
-		"DescribeModelBiasJobDefinition",
-		"DescribeModelExplainabilityJobDefinition",
-		"DescribeModelQualityJobDefinition":
-		return mustMarshal(m{keyJobDefinitionArn: "", keyJobDefinitionName: ""}), true
 
 	case "DescribeDevice":
 		return mustMarshal(m{"DeviceName": "", keyDeviceFleetName: ""}), true
@@ -599,11 +485,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 			keyFeatureGroupArn: "", keyFeatureGroupName: "", "FeatureName": "", "FeatureType": "",
 		}), true
 
-	case "DescribeFlowDefinition":
-		return mustMarshal(m{
-			keyFlowDefinitionArn: "", "FlowDefinitionName": "", "FlowDefinitionStatus": statusActive,
-		}), true
-
 	case "DescribeHub":
 		return mustMarshal(m{keyHubArn: "", "HubName": "", "HubStatus": statusInService}), true
 
@@ -612,18 +493,10 @@ func stubResponseFor(op string) ([]byte, bool) {
 			keyHubContentArn: "", "HubContentName": "", "HubContentStatus": "Available",
 		}), true
 
-	case "DescribeHumanTaskUi":
-		return mustMarshal(m{
-			keyHumanTaskUIArn: "", "HumanTaskUiName": "", "HumanTaskUiStatus": statusActive,
-		}), true
-
 	case "DescribeInferenceComponent":
 		return mustMarshal(m{
 			keyInferenceComponentArn: "", "InferenceComponentName": "", "InferenceComponentStatus": statusInService,
 		}), true
-
-	case "DescribeInferenceExperiment":
-		return mustMarshal(m{keyGenericArn: "", "Name": "", keyStatus: "Running"}), true
 
 	case "DescribeInferenceRecommendationsJob":
 		return mustMarshal(m{"JobArn": "", "JobName": "", keyStatus: statusCompletedUpper}), true
@@ -639,28 +512,10 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "DescribeMlflowApp":
 		return mustMarshal(m{keyGenericArn: "", keyStatus: statusInService}), true
 
-	case "DescribeMlflowTrackingServer":
-		return mustMarshal(m{
-			keyTrackingServerArn: "", "TrackingServerName": "", "TrackingServerStatus": statusCreated,
-		}), true
-
-	case "DescribeModelCard":
-		return mustMarshal(m{
-			keyModelCardArn: "", "ModelCardName": "", keyModelCardStatus: "Draft", keyModelCardVersion: 1,
-		}), true
-
 	case "DescribeModelCardExportJob":
 		return mustMarshal(m{
 			keyModelCardExportJobArn: "", "ModelCardExportJobName": "", keyStatus: statusCompleted,
 		}), true
-
-	case "DescribeOptimizationJob":
-		return mustMarshal(m{
-			keyOptimizationJobArn: "", "OptimizationJobName": "", "OptimizationJobStatus": statusCompletedUpper,
-		}), true
-
-	case "DescribePartnerApp":
-		return mustMarshal(m{keyGenericArn: "", keyStatus: "Available"}), true
 
 	case "DescribePipeline":
 		return mustMarshal(
@@ -678,16 +533,8 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "DescribeReservedCapacity":
 		return mustMarshal(m{keyReservedCapacityArn: "", keyStatus: statusActive}), true
 
-	case "DescribeStudioLifecycleConfig":
-		return mustMarshal(m{
-			keyStudioLifecycleConfigArn: "", "StudioLifecycleConfigName": "",
-		}), true
-
 	case "DescribeSubscribedWorkteam":
 		return mustMarshal(m{"SubscribedWorkteam": m{keyWorkteamArn: ""}}), true
-
-	case "DescribeTrainingPlan":
-		return mustMarshal(m{keyTrainingPlanArn: "", keyStatus: statusActive}), true
 
 	case "DescribeTrainingPlanExtensionHistory":
 		return mustMarshal(m{keyTrainingPlanArn: "", "Extensions": []any{}}), true
@@ -702,9 +549,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 		return mustMarshal(
 			m{keyUserProfileArn: "", "UserProfileName": "", keyStatus: statusInService},
 		), true
-
-	case "DescribeWorkforce":
-		return mustMarshal(m{"Workforce": m{keyWorkforceArn: "", "WorkforceName": ""}}), true
 
 	// -----------------------------------------------------------------------
 	// Get ops
@@ -925,9 +769,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "UpdateAction":
 		return mustMarshal(m{keyActionArn: ""}), true
 
-	case "UpdateAppImageConfig":
-		return mustMarshal(m{keyAppImageConfigArn: ""}), true
-
 	case "UpdateArtifact":
 		return mustMarshal(m{keyArtifactArn: ""}), true
 
@@ -964,12 +805,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 	case "UpdateMlflowApp", "UpdatePartnerApp":
 		return mustMarshal(m{keyGenericArn: ""}), true
 
-	case "UpdateMlflowTrackingServer":
-		return mustMarshal(m{keyTrackingServerArn: ""}), true
-
-	case "UpdateModelCard":
-		return mustMarshal(m{keyModelCardArn: ""}), true
-
 	case "UpdateModelPackage":
 		return mustMarshal(m{keyModelPackageArn: ""}), true
 
@@ -990,9 +825,6 @@ func stubResponseFor(op string) ([]byte, bool) {
 
 	case "UpdateUserProfile":
 		return mustMarshal(m{keyUserProfileArn: ""}), true
-
-	case "UpdateWorkforce":
-		return mustMarshal(m{"Workforce": m{keyWorkforceArn: ""}}), true
 
 	case "UpdateWorkteam":
 		return mustMarshal(m{"Workteam": m{keyWorkteamArn: ""}}), true


### PR DESCRIPTION
## Summary

- DataQuality/ModelBias/ModelQuality/ModelExplainability job definitions: full CRUD (12 ops)
- HumanTaskUi: Create/Describe/Delete (3 ops)
- Workforce: Create/Describe/Update (3 ops)
- FlowDefinition: Create/Describe/Delete (3 ops)
- AppImageConfig: Create/Describe/Delete/Update (4 ops)
- InferenceExperiment: Create/Describe/Stop/Delete (4 ops)
- MlflowTrackingServer: Create/Describe/Delete/Start/Stop (5 ops)
- ModelCard: Create/Describe/Update/Delete (4 ops)
- OptimizationJob: Create/Describe/Delete/Stop (4 ops)
- StudioLifecycleConfig: Create/Describe/Delete (3 ops)
- PartnerApp: Create/Describe/Delete (3 ops)
- TrainingPlan: Create/Describe (2 ops)

All ops use sync.RWMutex, not-found errors, and ARN generation. Job definition types share a common backend helper to avoid duplication.

## Test plan
- [x] go test ./services/sagemaker/... -short -count=1
- [x] golangci-lint 0 issues
- [x] go vet passes
- [x] goimports + golines formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)