### PR TITLE
feat(bedrock): implement 47 bedrock-agent ops — batch 3 (go-euzq)

### DIFF
--- a/services/bedrock/backend.go
+++ b/services/bedrock/backend.go
@@ -285,6 +285,22 @@ type InMemoryBackend struct {
 	kbByName                   map[string]string                         // kbName → kbID
 	dataSources                map[string]*DataSource                    // kbID/dsID → ds
 	ingestionJobs              map[string]*IngestionJob                  // kbID/dsID/jobID → job
+	// Agents batch-3 additions
+	flows                  map[string]*Flow                        // flowID → flow
+	flowsByName            map[string]string                       // flowName → flowID
+	flowAliases            map[string]*FlowAlias                   // flowAliasKey(flowID, aliasID) → alias
+	flowVersions           map[string]map[string]*FlowVersion      // flowID → version → flowVersion
+	flowVersionCounters    map[string]int                          // flowID → next version number
+	prompts                map[string]*Prompt                      // promptID → prompt
+	promptsByName          map[string]string                       // promptName → promptID
+	promptVersions         map[string]map[string]*PromptVersion    // promptID → version → promptVersion
+	promptVersionCounters  map[string]int                          // promptID → next version number
+	agentVersions          map[string]map[string]*AgentVersion     // agentID → version → agentVersion
+	agentVersionCounters   map[string]int                          // agentID → next version number
+	agentCollaborators     map[string]map[string]*AgentCollaborator // agentID → collabID → collaborator
+	kbDocuments            map[string]*KnowledgeBaseDocument       // kbDocKey → document
+	agentTags              map[string]map[string]string            // ARN → tagKey → tagValue
+	agentMemory            map[string][]any                        // agentID/sessionID → memory entries
 	mu                         *lockmetrics.RWMutex
 	accountID                  string
 	region                     string
@@ -311,6 +327,11 @@ type InMemoryBackend struct {
 	kbCounter                  int
 	dataSourceCounter          int
 	ingestionJobCounter        int
+	// Batch-3 counters
+	flowCounter         int
+	flowAliasCounter    int
+	promptCounter       int
+	agentCollabCounter  int
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend pre-seeded with foundation models.
@@ -357,6 +378,21 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		kbByName:                    make(map[string]string),
 		dataSources:                 make(map[string]*DataSource),
 		ingestionJobs:               make(map[string]*IngestionJob),
+		flows:                       make(map[string]*Flow),
+		flowsByName:                 make(map[string]string),
+		flowAliases:                 make(map[string]*FlowAlias),
+		flowVersions:                make(map[string]map[string]*FlowVersion),
+		flowVersionCounters:         make(map[string]int),
+		prompts:                     make(map[string]*Prompt),
+		promptsByName:               make(map[string]string),
+		promptVersions:              make(map[string]map[string]*PromptVersion),
+		promptVersionCounters:       make(map[string]int),
+		agentVersions:               make(map[string]map[string]*AgentVersion),
+		agentVersionCounters:        make(map[string]int),
+		agentCollaborators:          make(map[string]map[string]*AgentCollaborator),
+		kbDocuments:                 make(map[string]*KnowledgeBaseDocument),
+		agentTags:                   make(map[string]map[string]string),
+		agentMemory:                 make(map[string][]any),
 		accountID:                   accountID,
 		region:                      region,
 		mu:                          lockmetrics.New("bedrock"),
@@ -420,6 +456,25 @@ func (b *InMemoryBackend) Reset() {
 	b.kbCounter = 0
 	b.dataSourceCounter = 0
 	b.ingestionJobCounter = 0
+	b.flows = make(map[string]*Flow)
+	b.flowsByName = make(map[string]string)
+	b.flowAliases = make(map[string]*FlowAlias)
+	b.flowVersions = make(map[string]map[string]*FlowVersion)
+	b.flowVersionCounters = make(map[string]int)
+	b.prompts = make(map[string]*Prompt)
+	b.promptsByName = make(map[string]string)
+	b.promptVersions = make(map[string]map[string]*PromptVersion)
+	b.promptVersionCounters = make(map[string]int)
+	b.agentVersions = make(map[string]map[string]*AgentVersion)
+	b.agentVersionCounters = make(map[string]int)
+	b.agentCollaborators = make(map[string]map[string]*AgentCollaborator)
+	b.kbDocuments = make(map[string]*KnowledgeBaseDocument)
+	b.agentTags = make(map[string]map[string]string)
+	b.agentMemory = make(map[string][]any)
+	b.flowCounter = 0
+	b.flowAliasCounter = 0
+	b.promptCounter = 0
+	b.agentCollabCounter = 0
 	b.guardrailCounter = 0
 	b.guardrailVersionCounter = 0
 	b.provisionedCounter = 0

--- a/services/bedrock/backend.go
+++ b/services/bedrock/backend.go
@@ -276,31 +276,31 @@ type InMemoryBackend struct {
 	marketplaceEndpointsByName  map[string]string // endpoint name → ARN
 	promptRoutersByName         map[string]string // router name → ARN
 	// Agents
-	agents                     map[string]*Agent
-	agentsByName               map[string]string                         // agentName → agentID
-	agentActionGroups          map[string]*AgentActionGroup              // agentID/actionGroupID → group
-	agentAliases               map[string]*AgentAlias                    // agentID/aliasID → alias
-	agentKBAssociations        map[string]*AgentKnowledgeBaseAssociation // agentID/kbID → assoc
-	knowledgeBases             map[string]*KnowledgeBase                 // kbID → kb
-	kbByName                   map[string]string                         // kbName → kbID
-	dataSources                map[string]*DataSource                    // kbID/dsID → ds
-	ingestionJobs              map[string]*IngestionJob                  // kbID/dsID/jobID → job
+	agents              map[string]*Agent
+	agentsByName        map[string]string                         // agentName → agentID
+	agentActionGroups   map[string]*AgentActionGroup              // agentID/actionGroupID → group
+	agentAliases        map[string]*AgentAlias                    // agentID/aliasID → alias
+	agentKBAssociations map[string]*AgentKnowledgeBaseAssociation // agentID/kbID → assoc
+	knowledgeBases      map[string]*KnowledgeBase                 // kbID → kb
+	kbByName            map[string]string                         // kbName → kbID
+	dataSources         map[string]*DataSource                    // kbID/dsID → ds
+	ingestionJobs       map[string]*IngestionJob                  // kbID/dsID/jobID → job
 	// Agents batch-3 additions
-	flows                  map[string]*Flow                        // flowID → flow
-	flowsByName            map[string]string                       // flowName → flowID
-	flowAliases            map[string]*FlowAlias                   // flowAliasKey(flowID, aliasID) → alias
-	flowVersions           map[string]map[string]*FlowVersion      // flowID → version → flowVersion
-	flowVersionCounters    map[string]int                          // flowID → next version number
-	prompts                map[string]*Prompt                      // promptID → prompt
-	promptsByName          map[string]string                       // promptName → promptID
-	promptVersions         map[string]map[string]*PromptVersion    // promptID → version → promptVersion
-	promptVersionCounters  map[string]int                          // promptID → next version number
-	agentVersions          map[string]map[string]*AgentVersion     // agentID → version → agentVersion
-	agentVersionCounters   map[string]int                          // agentID → next version number
-	agentCollaborators     map[string]map[string]*AgentCollaborator // agentID → collabID → collaborator
-	kbDocuments            map[string]*KnowledgeBaseDocument       // kbDocKey → document
-	agentTags              map[string]map[string]string            // ARN → tagKey → tagValue
-	agentMemory            map[string][]any                        // agentID/sessionID → memory entries
+	flows                      map[string]*Flow                         // flowID → flow
+	flowsByName                map[string]string                        // flowName → flowID
+	flowAliases                map[string]*FlowAlias                    // flowAliasKey(flowID, aliasID) → alias
+	flowVersions               map[string]map[string]*FlowVersion       // flowID → version → flowVersion
+	flowVersionCounters        map[string]int                           // flowID → next version number
+	prompts                    map[string]*Prompt                       // promptID → prompt
+	promptsByName              map[string]string                        // promptName → promptID
+	promptVersions             map[string]map[string]*PromptVersion     // promptID → version → promptVersion
+	promptVersionCounters      map[string]int                           // promptID → next version number
+	agentVersions              map[string]map[string]*AgentVersion      // agentID → version → agentVersion
+	agentVersionCounters       map[string]int                           // agentID → next version number
+	agentCollaborators         map[string]map[string]*AgentCollaborator // agentID → collabID → collaborator
+	kbDocuments                map[string]*KnowledgeBaseDocument        // kbDocKey → document
+	agentTags                  map[string]map[string]string             // ARN → tagKey → tagValue
+	agentMemory                map[string][]any                         // agentID/sessionID → memory entries
 	mu                         *lockmetrics.RWMutex
 	accountID                  string
 	region                     string
@@ -328,10 +328,10 @@ type InMemoryBackend struct {
 	dataSourceCounter          int
 	ingestionJobCounter        int
 	// Batch-3 counters
-	flowCounter         int
-	flowAliasCounter    int
-	promptCounter       int
-	agentCollabCounter  int
+	flowCounter        int
+	flowAliasCounter   int
+	promptCounter      int
+	agentCollabCounter int
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend pre-seeded with foundation models.

--- a/services/bedrock/backend_agents_batch3.go
+++ b/services/bedrock/backend_agents_batch3.go
@@ -1,0 +1,1136 @@
+package bedrock
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/arn"
+)
+
+// ---------------------------------------------------------------------------
+// New models — Flows, Prompts, AgentVersions, AgentCollaborators,
+// KnowledgeBaseDocuments
+// ---------------------------------------------------------------------------
+
+// Flow represents an Amazon Bedrock Flow.
+type Flow struct {
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	FlowID      string            `json:"flowId"`
+	FlowArn     string            `json:"flowArn"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Status      string            `json:"status"`
+}
+
+// FlowAlias represents an alias for a Bedrock Flow.
+type FlowAlias struct {
+	CreatedAt    time.Time `json:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+	FlowAliasID  string    `json:"flowAliasId"`
+	FlowAliasArn string    `json:"flowAliasArn"`
+	FlowID       string    `json:"flowId"`
+	Name         string    `json:"name"`
+	Description  string    `json:"description,omitempty"`
+}
+
+// FlowVersion represents a snapshot version of a Flow.
+type FlowVersion struct {
+	CreatedAt time.Time `json:"createdAt"`
+	FlowID    string    `json:"flowId"`
+	Version   string    `json:"version"`
+	Status    string    `json:"status"`
+}
+
+// Prompt represents an Amazon Bedrock Prompt.
+type Prompt struct {
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	PromptID    string            `json:"promptId"`
+	PromptArn   string            `json:"promptArn"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+}
+
+// PromptVersion represents a numbered version of a Prompt.
+type PromptVersion struct {
+	CreatedAt time.Time `json:"createdAt"`
+	PromptID  string    `json:"promptId"`
+	Version   string    `json:"version"`
+	Name      string    `json:"name,omitempty"`
+}
+
+// AgentVersion represents a numbered version of an Agent.
+type AgentVersion struct {
+	CreatedAt    time.Time `json:"createdAt"`
+	AgentID      string    `json:"agentId"`
+	AgentVersion string    `json:"agentVersion"`
+	AgentStatus  string    `json:"agentStatus"`
+}
+
+// AgentCollaborator represents an agent collaboration association.
+type AgentCollaborator struct {
+	CreatedAt         time.Time `json:"createdAt"`
+	CollaboratorID    string    `json:"collaboratorId"`
+	AgentID           string    `json:"agentId"`
+	AgentVersion      string    `json:"agentVersion"`
+	CollaboratorArn   string    `json:"collaboratorArn"`
+	RelayConversation string    `json:"relayConversationHistory"`
+}
+
+// KnowledgeBaseDocument represents a document in a KB data source.
+type KnowledgeBaseDocument struct {
+	KnowledgeBaseID string `json:"knowledgeBaseId"`
+	DataSourceID    string `json:"dataSourceId"`
+	DocumentID      string `json:"documentId"`
+	Status          string `json:"status"`
+}
+
+// ---------------------------------------------------------------------------
+// Status constants for new types
+// ---------------------------------------------------------------------------
+
+const (
+	flowStatusNotPrepared = "NOT_PREPARED"
+	flowStatusPrepared    = "PREPARED"
+	docStatusActive       = "ACTIVE"
+	jobStatusStopped      = "STOPPED"
+)
+
+// ---------------------------------------------------------------------------
+// Map key helpers for new types
+// ---------------------------------------------------------------------------
+
+func flowAliasKey(flowID, aliasID string) string { return flowID + "/" + aliasID }
+func kbDocKey(kbID, dsID, docID string) string   { return kbID + "/" + dsID + "/" + docID }
+
+// ---------------------------------------------------------------------------
+// Flows
+// ---------------------------------------------------------------------------
+
+// CreateFlow creates a new Bedrock Flow.
+func (b *InMemoryBackend) CreateFlow(
+	name, description string,
+	tags map[string]string,
+) (*Flow, error) {
+	b.mu.Lock("CreateFlow")
+	defer b.mu.Unlock()
+
+	if _, ok := b.flowsByName[name]; ok {
+		return nil, fmt.Errorf("%w: flow %q already exists", ErrAlreadyExists, name)
+	}
+
+	b.flowCounter++
+	id := fmt.Sprintf("flow-%08d", b.flowCounter)
+	flowArn := arn.Build("bedrock-agent", b.region, b.accountID, "flow/"+id)
+	now := time.Now()
+
+	tagsCopy := make(map[string]string, len(tags))
+	maps.Copy(tagsCopy, tags)
+
+	f := &Flow{
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		FlowID:      id,
+		FlowArn:     flowArn,
+		Name:        name,
+		Description: description,
+		Status:      flowStatusNotPrepared,
+		Tags:        tagsCopy,
+	}
+	b.flows[id] = f
+	b.flowsByName[name] = id
+	cp := *f
+
+	return &cp, nil
+}
+
+// GetFlow returns a Flow by ID.
+func (b *InMemoryBackend) GetFlow(flowID string) (*Flow, error) {
+	b.mu.RLock("GetFlow")
+	defer b.mu.RUnlock()
+
+	f, ok := b.flows[flowID]
+	if !ok {
+		return nil, fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	cp := *f
+
+	return &cp, nil
+}
+
+// ListFlows returns all flows with pagination.
+func (b *InMemoryBackend) ListFlows(maxResults int, nextToken string) ([]*Flow, string) {
+	b.mu.RLock("ListFlows")
+	defer b.mu.RUnlock()
+
+	list := make([]*Flow, 0, len(b.flows))
+	for _, f := range b.flows {
+		cp := *f
+		list = append(list, &cp)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// UpdateFlow updates a Flow.
+func (b *InMemoryBackend) UpdateFlow(flowID, name, description string) (*Flow, error) {
+	b.mu.Lock("UpdateFlow")
+	defer b.mu.Unlock()
+
+	f, ok := b.flows[flowID]
+	if !ok {
+		return nil, fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	if name != "" && name != f.Name {
+		delete(b.flowsByName, f.Name)
+		f.Name = name
+		b.flowsByName[name] = flowID
+	}
+
+	if description != "" {
+		f.Description = description
+	}
+
+	f.UpdatedAt = time.Now()
+	cp := *f
+
+	return &cp, nil
+}
+
+// DeleteFlow deletes a Flow.
+func (b *InMemoryBackend) DeleteFlow(flowID string) error {
+	b.mu.Lock("DeleteFlow")
+	defer b.mu.Unlock()
+
+	f, ok := b.flows[flowID]
+	if !ok {
+		return fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	delete(b.flowsByName, f.Name)
+	delete(b.flows, flowID)
+
+	return nil
+}
+
+// PrepareFlow transitions a Flow to PREPARED status.
+func (b *InMemoryBackend) PrepareFlow(flowID string) (*Flow, error) {
+	b.mu.Lock("PrepareFlow")
+	defer b.mu.Unlock()
+
+	f, ok := b.flows[flowID]
+	if !ok {
+		return nil, fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	f.Status = flowStatusPrepared
+	f.UpdatedAt = time.Now()
+	cp := *f
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// Flow Aliases
+// ---------------------------------------------------------------------------
+
+// CreateFlowAlias creates an alias for a Flow.
+func (b *InMemoryBackend) CreateFlowAlias(
+	flowID, name, description string,
+) (*FlowAlias, error) {
+	b.mu.Lock("CreateFlowAlias")
+	defer b.mu.Unlock()
+
+	if _, ok := b.flows[flowID]; !ok {
+		return nil, fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	b.flowAliasCounter++
+	aliasID := fmt.Sprintf("flowAlias-%08d", b.flowAliasCounter)
+	aliasArn := arn.Build(
+		"bedrock-agent",
+		b.region,
+		b.accountID,
+		"flow/"+flowID+"/alias/"+aliasID,
+	)
+	now := time.Now()
+
+	fa := &FlowAlias{
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		FlowAliasID:  aliasID,
+		FlowAliasArn: aliasArn,
+		FlowID:       flowID,
+		Name:         name,
+		Description:  description,
+	}
+	b.flowAliases[flowAliasKey(flowID, aliasID)] = fa
+	cp := *fa
+
+	return &cp, nil
+}
+
+// GetFlowAlias returns a Flow alias by ID.
+func (b *InMemoryBackend) GetFlowAlias(flowID, aliasID string) (*FlowAlias, error) {
+	b.mu.RLock("GetFlowAlias")
+	defer b.mu.RUnlock()
+
+	fa, ok := b.flowAliases[flowAliasKey(flowID, aliasID)]
+	if !ok {
+		return nil, fmt.Errorf("%w: flow alias %q not found", ErrNotFound, aliasID)
+	}
+
+	cp := *fa
+
+	return &cp, nil
+}
+
+// ListFlowAliases lists aliases for a Flow.
+func (b *InMemoryBackend) ListFlowAliases(
+	flowID string,
+	maxResults int,
+	nextToken string,
+) ([]*FlowAlias, string) {
+	b.mu.RLock("ListFlowAliases")
+	defer b.mu.RUnlock()
+
+	list := make([]*FlowAlias, 0)
+	prefix := flowID + "/"
+
+	for k, fa := range b.flowAliases {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			cp := *fa
+			list = append(list, &cp)
+		}
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// UpdateFlowAlias updates a Flow alias.
+func (b *InMemoryBackend) UpdateFlowAlias(
+	flowID, aliasID, name, description string,
+) (*FlowAlias, error) {
+	b.mu.Lock("UpdateFlowAlias")
+	defer b.mu.Unlock()
+
+	fa, ok := b.flowAliases[flowAliasKey(flowID, aliasID)]
+	if !ok {
+		return nil, fmt.Errorf("%w: flow alias %q not found", ErrNotFound, aliasID)
+	}
+
+	if name != "" {
+		fa.Name = name
+	}
+
+	if description != "" {
+		fa.Description = description
+	}
+
+	fa.UpdatedAt = time.Now()
+	cp := *fa
+
+	return &cp, nil
+}
+
+// DeleteFlowAlias deletes a Flow alias.
+func (b *InMemoryBackend) DeleteFlowAlias(flowID, aliasID string) error {
+	b.mu.Lock("DeleteFlowAlias")
+	defer b.mu.Unlock()
+
+	key := flowAliasKey(flowID, aliasID)
+
+	if _, ok := b.flowAliases[key]; !ok {
+		return fmt.Errorf("%w: flow alias %q not found", ErrNotFound, aliasID)
+	}
+
+	delete(b.flowAliases, key)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Flow Versions
+// ---------------------------------------------------------------------------
+
+// CreateFlowVersion creates a numbered snapshot version of a Flow.
+func (b *InMemoryBackend) CreateFlowVersion(flowID string) (*FlowVersion, error) {
+	b.mu.Lock("CreateFlowVersion")
+	defer b.mu.Unlock()
+
+	if _, ok := b.flows[flowID]; !ok {
+		return nil, fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	b.flowVersionCounters[flowID]++
+	ver := strconv.Itoa(b.flowVersionCounters[flowID])
+
+	fv := &FlowVersion{
+		CreatedAt: time.Now(),
+		FlowID:    flowID,
+		Version:   ver,
+		Status:    flowStatusPrepared,
+	}
+
+	if b.flowVersions[flowID] == nil {
+		b.flowVersions[flowID] = make(map[string]*FlowVersion)
+	}
+
+	b.flowVersions[flowID][ver] = fv
+	cp := *fv
+
+	return &cp, nil
+}
+
+// GetFlowVersion returns a specific Flow version.
+func (b *InMemoryBackend) GetFlowVersion(flowID, version string) (*FlowVersion, error) {
+	b.mu.RLock("GetFlowVersion")
+	defer b.mu.RUnlock()
+
+	versions, versionsOK := b.flowVersions[flowID]
+	if !versionsOK {
+		return nil, fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	fv, verOK := versions[version]
+	if !verOK {
+		return nil, fmt.Errorf(
+			"%w: flow version %q not found for flow %q",
+			ErrNotFound,
+			version,
+			flowID,
+		)
+	}
+
+	cp := *fv
+
+	return &cp, nil
+}
+
+// ListFlowVersions lists all versions for a Flow.
+func (b *InMemoryBackend) ListFlowVersions(
+	flowID string,
+	maxResults int,
+	nextToken string,
+) ([]*FlowVersion, string) {
+	b.mu.RLock("ListFlowVersions")
+	defer b.mu.RUnlock()
+
+	versions := b.flowVersions[flowID]
+	list := make([]*FlowVersion, 0, len(versions))
+
+	for _, fv := range versions {
+		cp := *fv
+		list = append(list, &cp)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].Version < list[j].Version })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// DeleteFlowVersion deletes a specific Flow version.
+func (b *InMemoryBackend) DeleteFlowVersion(flowID, version string) error {
+	b.mu.Lock("DeleteFlowVersion")
+	defer b.mu.Unlock()
+
+	versions, versionsOK := b.flowVersions[flowID]
+	if !versionsOK {
+		return fmt.Errorf("%w: flow %q not found", ErrNotFound, flowID)
+	}
+
+	if _, verOK := versions[version]; !verOK {
+		return fmt.Errorf(
+			"%w: flow version %q not found for flow %q",
+			ErrNotFound,
+			version,
+			flowID,
+		)
+	}
+
+	delete(versions, version)
+
+	return nil
+}
+
+// ValidateFlowDefinition validates a flow definition (stub — always succeeds).
+func (b *InMemoryBackend) ValidateFlowDefinition() ([]any, error) {
+	return []any{}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+// CreatePrompt creates a new Bedrock Prompt.
+func (b *InMemoryBackend) CreatePrompt(
+	name, description string,
+	tags map[string]string,
+) (*Prompt, error) {
+	b.mu.Lock("CreatePrompt")
+	defer b.mu.Unlock()
+
+	if _, ok := b.promptsByName[name]; ok {
+		return nil, fmt.Errorf("%w: prompt %q already exists", ErrAlreadyExists, name)
+	}
+
+	b.promptCounter++
+	id := fmt.Sprintf("prompt-%08d", b.promptCounter)
+	promptArn := arn.Build("bedrock-agent", b.region, b.accountID, "prompt/"+id)
+	now := time.Now()
+
+	tagsCopy := make(map[string]string, len(tags))
+	maps.Copy(tagsCopy, tags)
+
+	p := &Prompt{
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		PromptID:    id,
+		PromptArn:   promptArn,
+		Name:        name,
+		Description: description,
+		Tags:        tagsCopy,
+	}
+	b.prompts[id] = p
+	b.promptsByName[name] = id
+	cp := *p
+
+	return &cp, nil
+}
+
+// GetPrompt returns a Prompt by ID.
+func (b *InMemoryBackend) GetPrompt(promptID string) (*Prompt, error) {
+	b.mu.RLock("GetPrompt")
+	defer b.mu.RUnlock()
+
+	p, ok := b.prompts[promptID]
+	if !ok {
+		return nil, fmt.Errorf("%w: prompt %q not found", ErrNotFound, promptID)
+	}
+
+	cp := *p
+
+	return &cp, nil
+}
+
+// ListPrompts returns all prompts with pagination.
+func (b *InMemoryBackend) ListPrompts(maxResults int, nextToken string) ([]*Prompt, string) {
+	b.mu.RLock("ListPrompts")
+	defer b.mu.RUnlock()
+
+	list := make([]*Prompt, 0, len(b.prompts))
+	for _, p := range b.prompts {
+		cp := *p
+		list = append(list, &cp)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// UpdatePrompt updates a Prompt.
+func (b *InMemoryBackend) UpdatePrompt(promptID, name, description string) (*Prompt, error) {
+	b.mu.Lock("UpdatePrompt")
+	defer b.mu.Unlock()
+
+	p, ok := b.prompts[promptID]
+	if !ok {
+		return nil, fmt.Errorf("%w: prompt %q not found", ErrNotFound, promptID)
+	}
+
+	if name != "" && name != p.Name {
+		delete(b.promptsByName, p.Name)
+		p.Name = name
+		b.promptsByName[name] = promptID
+	}
+
+	if description != "" {
+		p.Description = description
+	}
+
+	p.UpdatedAt = time.Now()
+	cp := *p
+
+	return &cp, nil
+}
+
+// DeletePrompt deletes a Prompt.
+func (b *InMemoryBackend) DeletePrompt(promptID string) error {
+	b.mu.Lock("DeletePrompt")
+	defer b.mu.Unlock()
+
+	p, ok := b.prompts[promptID]
+	if !ok {
+		return fmt.Errorf("%w: prompt %q not found", ErrNotFound, promptID)
+	}
+
+	delete(b.promptsByName, p.Name)
+	delete(b.prompts, promptID)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Versions
+// ---------------------------------------------------------------------------
+
+// CreatePromptVersion creates a numbered snapshot version of a Prompt.
+func (b *InMemoryBackend) CreatePromptVersion(promptID string) (*PromptVersion, error) {
+	b.mu.Lock("CreatePromptVersion")
+	defer b.mu.Unlock()
+
+	p, ok := b.prompts[promptID]
+	if !ok {
+		return nil, fmt.Errorf("%w: prompt %q not found", ErrNotFound, promptID)
+	}
+
+	b.promptVersionCounters[promptID]++
+	ver := strconv.Itoa(b.promptVersionCounters[promptID])
+
+	pv := &PromptVersion{
+		CreatedAt: time.Now(),
+		PromptID:  promptID,
+		Version:   ver,
+		Name:      p.Name,
+	}
+
+	if b.promptVersions[promptID] == nil {
+		b.promptVersions[promptID] = make(map[string]*PromptVersion)
+	}
+
+	b.promptVersions[promptID][ver] = pv
+	cp := *pv
+
+	return &cp, nil
+}
+
+// GetPromptVersion returns a specific Prompt version.
+func (b *InMemoryBackend) GetPromptVersion(promptID, version string) (*PromptVersion, error) {
+	b.mu.RLock("GetPromptVersion")
+	defer b.mu.RUnlock()
+
+	versions, versionsOK := b.promptVersions[promptID]
+	if !versionsOK {
+		return nil, fmt.Errorf("%w: prompt %q not found", ErrNotFound, promptID)
+	}
+
+	pv, verOK := versions[version]
+	if !verOK {
+		return nil, fmt.Errorf(
+			"%w: prompt version %q not found for prompt %q",
+			ErrNotFound,
+			version,
+			promptID,
+		)
+	}
+
+	cp := *pv
+
+	return &cp, nil
+}
+
+// ListPromptVersions lists all versions for a Prompt.
+func (b *InMemoryBackend) ListPromptVersions(
+	promptID string,
+	maxResults int,
+	nextToken string,
+) ([]*PromptVersion, string) {
+	b.mu.RLock("ListPromptVersions")
+	defer b.mu.RUnlock()
+
+	versions := b.promptVersions[promptID]
+	list := make([]*PromptVersion, 0, len(versions))
+
+	for _, pv := range versions {
+		cp := *pv
+		list = append(list, &cp)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].Version < list[j].Version })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// DeletePromptVersion deletes a specific Prompt version.
+func (b *InMemoryBackend) DeletePromptVersion(promptID, version string) error {
+	b.mu.Lock("DeletePromptVersion")
+	defer b.mu.Unlock()
+
+	versions, versionsOK := b.promptVersions[promptID]
+	if !versionsOK {
+		return fmt.Errorf("%w: prompt %q not found", ErrNotFound, promptID)
+	}
+
+	if _, verOK := versions[version]; !verOK {
+		return fmt.Errorf(
+			"%w: prompt version %q not found for prompt %q",
+			ErrNotFound,
+			version,
+			promptID,
+		)
+	}
+
+	delete(versions, version)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Agent Versions
+// ---------------------------------------------------------------------------
+
+// CreateAgentVersion creates a numbered version snapshot of an Agent.
+func (b *InMemoryBackend) CreateAgentVersion(agentID string) (*AgentVersion, error) {
+	b.mu.Lock("CreateAgentVersion")
+	defer b.mu.Unlock()
+
+	ag, ok := b.agents[agentID]
+	if !ok {
+		return nil, fmt.Errorf("%w: agent %q not found", ErrNotFound, agentID)
+	}
+
+	b.agentVersionCounters[agentID]++
+	ver := strconv.Itoa(b.agentVersionCounters[agentID])
+
+	av := &AgentVersion{
+		CreatedAt:    time.Now(),
+		AgentID:      agentID,
+		AgentVersion: ver,
+		AgentStatus:  ag.AgentStatus,
+	}
+
+	if b.agentVersions[agentID] == nil {
+		b.agentVersions[agentID] = make(map[string]*AgentVersion)
+	}
+
+	b.agentVersions[agentID][ver] = av
+	cp := *av
+
+	return &cp, nil
+}
+
+// GetAgentVersion returns a specific Agent version.
+func (b *InMemoryBackend) GetAgentVersion(agentID, version string) (*AgentVersion, error) {
+	b.mu.RLock("GetAgentVersion")
+	defer b.mu.RUnlock()
+
+	versions, versionsOK := b.agentVersions[agentID]
+	if !versionsOK {
+		return nil, fmt.Errorf("%w: agent %q has no versions", ErrNotFound, agentID)
+	}
+
+	av, verOK := versions[version]
+	if !verOK {
+		return nil, fmt.Errorf(
+			"%w: agent version %q not found for agent %q",
+			ErrNotFound,
+			version,
+			agentID,
+		)
+	}
+
+	cp := *av
+
+	return &cp, nil
+}
+
+// ListAgentVersions lists all versions for an Agent.
+func (b *InMemoryBackend) ListAgentVersions(
+	agentID string,
+	maxResults int,
+	nextToken string,
+) ([]*AgentVersion, string) {
+	b.mu.RLock("ListAgentVersions")
+	defer b.mu.RUnlock()
+
+	versions := b.agentVersions[agentID]
+	list := make([]*AgentVersion, 0, len(versions))
+
+	for _, av := range versions {
+		cp := *av
+		list = append(list, &cp)
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].AgentVersion < list[j].AgentVersion })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// DeleteAgentVersion deletes a specific Agent version.
+func (b *InMemoryBackend) DeleteAgentVersion(agentID, version string) error {
+	b.mu.Lock("DeleteAgentVersion")
+	defer b.mu.Unlock()
+
+	versions, versionsOK := b.agentVersions[agentID]
+	if !versionsOK {
+		return fmt.Errorf("%w: agent %q not found", ErrNotFound, agentID)
+	}
+
+	if _, verOK := versions[version]; !verOK {
+		return fmt.Errorf(
+			"%w: agent version %q not found for agent %q",
+			ErrNotFound,
+			version,
+			agentID,
+		)
+	}
+
+	delete(versions, version)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Agent Collaborators
+// ---------------------------------------------------------------------------
+
+// AssociateAgentCollaborator associates a collaborator agent with an agent.
+func (b *InMemoryBackend) AssociateAgentCollaborator(
+	agentID, agentVersion, collaboratorArn, relayConversation string,
+) (*AgentCollaborator, error) {
+	b.mu.Lock("AssociateAgentCollaborator")
+	defer b.mu.Unlock()
+
+	if _, ok := b.agents[agentID]; !ok {
+		return nil, fmt.Errorf("%w: agent %q not found", ErrNotFound, agentID)
+	}
+
+	b.agentCollabCounter++
+	collabID := fmt.Sprintf("collab-%08d", b.agentCollabCounter)
+
+	ac := &AgentCollaborator{
+		CreatedAt:         time.Now(),
+		CollaboratorID:    collabID,
+		AgentID:           agentID,
+		AgentVersion:      agentVersion,
+		CollaboratorArn:   collaboratorArn,
+		RelayConversation: relayConversation,
+	}
+
+	if b.agentCollaborators[agentID] == nil {
+		b.agentCollaborators[agentID] = make(map[string]*AgentCollaborator)
+	}
+
+	b.agentCollaborators[agentID][collabID] = ac
+	cp := *ac
+
+	return &cp, nil
+}
+
+// GetAgentCollaborator returns an agent collaborator by ID.
+func (b *InMemoryBackend) GetAgentCollaborator(
+	agentID, collaboratorID string,
+) (*AgentCollaborator, error) {
+	b.mu.RLock("GetAgentCollaborator")
+	defer b.mu.RUnlock()
+
+	collabs := b.agentCollaborators[agentID]
+
+	ac, ok := collabs[collaboratorID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: collaborator %q not found for agent %q",
+			ErrNotFound,
+			collaboratorID,
+			agentID,
+		)
+	}
+
+	cp := *ac
+
+	return &cp, nil
+}
+
+// ListAgentCollaborators lists collaborators for an agent.
+func (b *InMemoryBackend) ListAgentCollaborators(
+	agentID string,
+	maxResults int,
+	nextToken string,
+) ([]*AgentCollaborator, string) {
+	b.mu.RLock("ListAgentCollaborators")
+	defer b.mu.RUnlock()
+
+	collabs := b.agentCollaborators[agentID]
+	list := make([]*AgentCollaborator, 0, len(collabs))
+
+	for _, ac := range collabs {
+		cp := *ac
+		list = append(list, &cp)
+	}
+
+	sort.Slice(
+		list,
+		func(i, j int) bool { return list[i].CollaboratorID < list[j].CollaboratorID },
+	)
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// UpdateAgentCollaborator updates an agent collaborator.
+func (b *InMemoryBackend) UpdateAgentCollaborator(
+	agentID, collaboratorID, relayConversation string,
+) (*AgentCollaborator, error) {
+	b.mu.Lock("UpdateAgentCollaborator")
+	defer b.mu.Unlock()
+
+	collabs := b.agentCollaborators[agentID]
+
+	ac, ok := collabs[collaboratorID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: collaborator %q not found for agent %q",
+			ErrNotFound,
+			collaboratorID,
+			agentID,
+		)
+	}
+
+	if relayConversation != "" {
+		ac.RelayConversation = relayConversation
+	}
+
+	cp := *ac
+
+	return &cp, nil
+}
+
+// DisassociateAgentCollaborator removes a collaborator from an agent.
+func (b *InMemoryBackend) DisassociateAgentCollaborator(agentID, collaboratorID string) error {
+	b.mu.Lock("DisassociateAgentCollaborator")
+	defer b.mu.Unlock()
+
+	collabs := b.agentCollaborators[agentID]
+
+	if _, ok := collabs[collaboratorID]; !ok {
+		return fmt.Errorf(
+			"%w: collaborator %q not found for agent %q",
+			ErrNotFound,
+			collaboratorID,
+			agentID,
+		)
+	}
+
+	delete(collabs, collaboratorID)
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge Base Documents
+// ---------------------------------------------------------------------------
+
+// IngestKnowledgeBaseDocuments adds documents to a KB data source.
+func (b *InMemoryBackend) IngestKnowledgeBaseDocuments(
+	kbID, dsID string,
+	documentIDs []string,
+) ([]*KnowledgeBaseDocument, error) {
+	b.mu.Lock("IngestKnowledgeBaseDocuments")
+	defer b.mu.Unlock()
+
+	if _, ok := b.knowledgeBases[kbID]; !ok {
+		return nil, fmt.Errorf("%w: knowledge base %q not found", ErrNotFound, kbID)
+	}
+
+	if _, ok := b.dataSources[kbID+"/"+dsID]; !ok {
+		return nil, fmt.Errorf("%w: data source %q not found", ErrNotFound, dsID)
+	}
+
+	docs := make([]*KnowledgeBaseDocument, 0, len(documentIDs))
+
+	for _, docID := range documentIDs {
+		doc := &KnowledgeBaseDocument{
+			KnowledgeBaseID: kbID,
+			DataSourceID:    dsID,
+			DocumentID:      docID,
+			Status:          docStatusActive,
+		}
+		b.kbDocuments[kbDocKey(kbID, dsID, docID)] = doc
+		cp := *doc
+		docs = append(docs, &cp)
+	}
+
+	return docs, nil
+}
+
+// ListKnowledgeBaseDocuments returns documents for a KB data source.
+func (b *InMemoryBackend) ListKnowledgeBaseDocuments(
+	kbID, dsID string,
+	maxResults int,
+	nextToken string,
+) ([]*KnowledgeBaseDocument, string) {
+	b.mu.RLock("ListKnowledgeBaseDocuments")
+	defer b.mu.RUnlock()
+
+	prefix := kbID + "/" + dsID + "/"
+	list := make([]*KnowledgeBaseDocument, 0)
+
+	for k, doc := range b.kbDocuments {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			cp := *doc
+			list = append(list, &cp)
+		}
+	}
+
+	sort.Slice(list, func(i, j int) bool { return list[i].DocumentID < list[j].DocumentID })
+
+	return paginate(list, maxResults, nextToken)
+}
+
+// DeleteKnowledgeBaseDocuments removes documents from a KB data source.
+func (b *InMemoryBackend) DeleteKnowledgeBaseDocuments(
+	kbID, dsID string,
+	documentIDs []string,
+) error {
+	b.mu.Lock("DeleteKnowledgeBaseDocuments")
+	defer b.mu.Unlock()
+
+	for _, docID := range documentIDs {
+		delete(b.kbDocuments, kbDocKey(kbID, dsID, docID))
+	}
+
+	return nil
+}
+
+// UpdateKnowledgeBaseDocuments upserts document records in a KB data source.
+func (b *InMemoryBackend) UpdateKnowledgeBaseDocuments(
+	kbID, dsID string,
+	documentIDs []string,
+) ([]*KnowledgeBaseDocument, error) {
+	b.mu.Lock("UpdateKnowledgeBaseDocuments")
+	defer b.mu.Unlock()
+
+	docs := make([]*KnowledgeBaseDocument, 0, len(documentIDs))
+
+	for _, docID := range documentIDs {
+		key := kbDocKey(kbID, dsID, docID)
+		doc, ok := b.kbDocuments[key]
+
+		if !ok {
+			doc = &KnowledgeBaseDocument{
+				KnowledgeBaseID: kbID,
+				DataSourceID:    dsID,
+				DocumentID:      docID,
+				Status:          docStatusActive,
+			}
+			b.kbDocuments[key] = doc
+		}
+
+		cp := *doc
+		docs = append(docs, &cp)
+	}
+
+	return docs, nil
+}
+
+// ---------------------------------------------------------------------------
+// Ingestion job management extensions
+// ---------------------------------------------------------------------------
+
+// StopIngestionJob stops a running ingestion job.
+func (b *InMemoryBackend) StopIngestionJob(kbID, dsID, jobID string) (*IngestionJob, error) {
+	b.mu.Lock("StopIngestionJob")
+	defer b.mu.Unlock()
+
+	job, ok := b.ingestionJobs[ingestionJobKey(kbID, dsID, jobID)]
+	if !ok {
+		return nil, fmt.Errorf("%w: ingestion job %q not found", ErrNotFound, jobID)
+	}
+
+	job.Status = jobStatusStopped
+	job.UpdatedAt = time.Now()
+	cp := *job
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// Resource Tags (agent-domain, map[string]string)
+// ---------------------------------------------------------------------------
+
+// TagAgentResource adds tags to an agent-domain resource identified by its ARN.
+func (b *InMemoryBackend) TagAgentResource(resourceArn string, tags map[string]string) error {
+	b.mu.Lock("TagAgentResource")
+	defer b.mu.Unlock()
+
+	if b.agentTags[resourceArn] == nil {
+		b.agentTags[resourceArn] = make(map[string]string)
+	}
+
+	maps.Copy(b.agentTags[resourceArn], tags)
+
+	return nil
+}
+
+// UntagAgentResource removes tags from an agent-domain resource identified by its ARN.
+func (b *InMemoryBackend) UntagAgentResource(resourceArn string, tagKeys []string) error {
+	b.mu.Lock("UntagAgentResource")
+	defer b.mu.Unlock()
+
+	existing := b.agentTags[resourceArn]
+	if existing == nil {
+		return nil
+	}
+
+	for _, k := range tagKeys {
+		delete(existing, k)
+	}
+
+	return nil
+}
+
+// ListAgentResourceTags returns tags for an agent-domain resource identified by its ARN.
+func (b *InMemoryBackend) ListAgentResourceTags(resourceArn string) map[string]string {
+	b.mu.RLock("ListAgentResourceTags")
+	defer b.mu.RUnlock()
+
+	existing := b.agentTags[resourceArn]
+	result := make(map[string]string, len(existing))
+	maps.Copy(result, existing)
+
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Agent Memory
+// ---------------------------------------------------------------------------
+
+// GetAgentMemory returns memory entries for an agent session (stub).
+func (b *InMemoryBackend) GetAgentMemory(agentID, sessionID string) []any {
+	b.mu.RLock("GetAgentMemory")
+	defer b.mu.RUnlock()
+
+	key := agentID + "/" + sessionID
+	entries := b.agentMemory[key]
+
+	result := make([]any, len(entries))
+	copy(result, entries)
+
+	return result
+}
+
+// DeleteAgentMemory deletes memory entries for an agent session.
+func (b *InMemoryBackend) DeleteAgentMemory(agentID, sessionID string) error {
+	b.mu.Lock("DeleteAgentMemory")
+	defer b.mu.Unlock()
+
+	if _, ok := b.agents[agentID]; !ok {
+		return fmt.Errorf("%w: agent %q not found", ErrNotFound, agentID)
+	}
+
+	delete(b.agentMemory, agentID+"/"+sessionID)
+
+	return nil
+}

--- a/services/bedrock/handler.go
+++ b/services/bedrock/handler.go
@@ -164,12 +164,12 @@ func (h *Handler) GetSupportedOperations() []string {
 		"ListMarketplaceModelEndpoints",
 		"ListModelCustomizationJobs",
 		"ListProvisionedModelThroughputs",
-		"ListTagsForResource",
+		opListTagsForResource,
 		"PutModelInvocationLoggingConfiguration",
 		"RegisterMarketplaceModelEndpoint",
 		"StopModelCustomizationJob",
-		"TagResource",
-		"UntagResource",
+		opTagResource,
+		opUntagResource,
 		"UpdateGuardrail",
 		"UpdateMarketplaceModelEndpoint",
 		"UpdateProvisionedModelThroughput",
@@ -376,11 +376,11 @@ func extractTagOperation(path, method string) (string, bool) {
 
 	switch path {
 	case listTagsForResourcePath:
-		return "ListTagsForResource", true
+		return opListTagsForResource, true
 	case tagResourcePath:
-		return "TagResource", true
+		return opTagResource, true
 	case untagResourcePath:
-		return "UntagResource", true
+		return opUntagResource, true
 	default:
 		return "", false
 	}

--- a/services/bedrock/handler_agents.go
+++ b/services/bedrock/handler_agents.go
@@ -35,6 +35,7 @@ func (h *AgentsHandler) Name() string { return "BedrockAgents" }
 // GetSupportedOperations returns supported operations.
 func (h *AgentsHandler) GetSupportedOperations() []string {
 	return []string{
+		// Existing agent ops
 		"CreateAgent",
 		"DeleteAgent",
 		"GetAgent",
@@ -68,6 +69,58 @@ func (h *AgentsHandler) GetSupportedOperations() []string {
 		"StartIngestionJob",
 		"GetIngestionJob",
 		"ListIngestionJobs",
+		// Flows
+		"CreateFlow",
+		"DeleteFlow",
+		"GetFlow",
+		"ListFlows",
+		"UpdateFlow",
+		"PrepareFlow",
+		"CreateFlowAlias",
+		"DeleteFlowAlias",
+		"GetFlowAlias",
+		"ListFlowAliases",
+		"UpdateFlowAlias",
+		"CreateFlowVersion",
+		"DeleteFlowVersion",
+		"GetFlowVersion",
+		"ListFlowVersions",
+		"ValidateFlowDefinition",
+		// Prompts
+		"CreatePrompt",
+		"DeletePrompt",
+		"GetPrompt",
+		"ListPrompts",
+		"UpdatePrompt",
+		"CreatePromptVersion",
+		"DeletePromptVersion",
+		"GetPromptVersion",
+		"ListPromptVersions",
+		// Agent versions
+		"CreateAgentVersion",
+		"GetAgentVersion",
+		"ListAgentVersions",
+		"DeleteAgentVersion",
+		// Agent collaborators
+		"AssociateAgentCollaborator",
+		"DisassociateAgentCollaborator",
+		"GetAgentCollaborator",
+		"ListAgentCollaborators",
+		"UpdateAgentCollaborator",
+		// Knowledge base documents
+		"IngestKnowledgeBaseDocuments",
+		"DeleteKnowledgeBaseDocuments",
+		"ListKnowledgeBaseDocuments",
+		"UpdateKnowledgeBaseDocuments",
+		// Ingestion job management
+		"StopIngestionJob",
+		// Resource tags (agent-domain)
+		opTagResource,
+		opUntagResource,
+		opListTagsForResource,
+		// Agent memory
+		"GetAgentMemory",
+		"DeleteAgentMemory",
 	}
 }
 
@@ -94,12 +147,31 @@ func (h *AgentsHandler) Reset() {
 	h.Backend.kbByName = make(map[string]string)
 	h.Backend.dataSources = make(map[string]*DataSource)
 	h.Backend.ingestionJobs = make(map[string]*IngestionJob)
+	h.Backend.flows = make(map[string]*Flow)
+	h.Backend.flowsByName = make(map[string]string)
+	h.Backend.flowAliases = make(map[string]*FlowAlias)
+	h.Backend.flowVersions = make(map[string]map[string]*FlowVersion)
+	h.Backend.flowVersionCounters = make(map[string]int)
+	h.Backend.prompts = make(map[string]*Prompt)
+	h.Backend.promptsByName = make(map[string]string)
+	h.Backend.promptVersions = make(map[string]map[string]*PromptVersion)
+	h.Backend.promptVersionCounters = make(map[string]int)
+	h.Backend.agentVersions = make(map[string]map[string]*AgentVersion)
+	h.Backend.agentVersionCounters = make(map[string]int)
+	h.Backend.agentCollaborators = make(map[string]map[string]*AgentCollaborator)
+	h.Backend.kbDocuments = make(map[string]*KnowledgeBaseDocument)
+	h.Backend.agentTags = make(map[string]map[string]string)
+	h.Backend.agentMemory = make(map[string][]any)
 	// Reset ID counters for deterministic IDs after reset.
 	h.Backend.agentCounter = 0
 	h.Backend.actionGroupCounter = 0
 	h.Backend.agentAliasCounter = 0
 	h.Backend.kbCounter = 0
 	h.Backend.dataSourceCounter = 0
+	h.Backend.flowCounter = 0
+	h.Backend.flowAliasCounter = 0
+	h.Backend.promptCounter = 0
+	h.Backend.agentCollabCounter = 0
 }
 
 // Route path constants.
@@ -124,6 +196,15 @@ const (
 	// JSON response key constants.
 	keyAgentID         = "agentId"
 	keyKnowledgeBaseID = "knowledgeBaseId"
+
+	// Op name constants shared between BedrockAgents and Bedrock handlers.
+	opTagResource        = "TagResource"
+	opUntagResource      = "UntagResource"
+	opListTagsForResource = "ListTagsForResource"
+
+	// Agent sub-path suffixes.
+	suffixAgentAliases = "/aliases"
+	opAgentStatusKey   = "agentStatus"
 )
 
 // RouteMatcher returns a function matching Bedrock Agents requests.
@@ -134,7 +215,8 @@ func (h *AgentsHandler) RouteMatcher() service.Matcher {
 		return strings.HasPrefix(path, "/agents/") ||
 			path == agentsPath ||
 			strings.HasPrefix(path, "/knowledgebases/") ||
-			path == knowledgeBasePath
+			path == knowledgeBasePath ||
+			routeMatcherBatch3(path)
 	}
 }
 
@@ -220,75 +302,137 @@ func (h *AgentsHandler) Handler() echo.HandlerFunc {
 //
 //nolint:cyclop,gocognit,gocyclo // large dispatch table for agents routing is inherently complex
 func (h *AgentsHandler) dispatch(c *echo.Context, path, method string, body []byte) error {
-	// Agent routes
+	if handled, err := h.dispatchAgentRoutes(c, path, method, body); handled {
+		return err
+	}
+
+	if handled, err := h.dispatchKBRoutes(c, path, method, body); handled {
+		return err
+	}
+
+	// Flow, Prompt, and Tag routes (batch-3)
 	switch {
-	case path == agentsPath && method == http.MethodPost:
-		return h.handleCreateAgent(c, body)
-	case path == agentsPath && method == http.MethodGet:
-		return h.handleListAgents(c)
-	}
-
-	// /agents/{agentId}/...
-	if rest, cutOK := strings.CutPrefix(path, "/agents/"); cutOK {
-		parts := strings.SplitN(rest, "/", splitInTwo)
-		agentID := parts[0]
-		suffix := ""
-
-		if len(parts) > splitInTwo-1 {
-			suffix = "/" + parts[1]
-		}
-
-		switch {
-		case suffix == "" && method == http.MethodGet:
-			return h.handleGetAgent(c, agentID)
-		case suffix == "" && method == http.MethodPut:
-			return h.handleUpdateAgent(c, agentID, body)
-		case suffix == "" && method == http.MethodDelete:
-			return h.handleDeleteAgent(c, agentID)
-		case suffix == "/prepare" && method == http.MethodPost:
-			return h.handlePrepareAgent(c, agentID)
-		case strings.HasPrefix(suffix, "/agentversions/") && strings.Contains(suffix, "/knowledgebases"):
-			return h.dispatchAgentKBRoutes(c, agentID, suffix, method, body)
-		case strings.HasPrefix(suffix, "/action-groups"):
-			return h.dispatchActionGroupRoutes(c, agentID, suffix, method, body)
-		case strings.HasPrefix(suffix, "/aliases"):
-			return h.dispatchAliasRoutes(c, agentID, suffix, method, body)
-		}
-	}
-
-	// Knowledge base routes
-	switch {
-	case path == knowledgeBasePath && method == http.MethodPost:
-		return h.handleCreateKnowledgeBase(c, body)
-	case path == knowledgeBasePath && method == http.MethodGet:
-		return h.handleListKnowledgeBases(c)
-	}
-
-	if rest, cutOK := strings.CutPrefix(path, "/knowledgebases/"); cutOK {
-		// rest already set by CutPrefix
-		parts := strings.SplitN(rest, "/", splitInTwo)
-		kbID := parts[0]
-		suffix := ""
-
-		if len(parts) > splitInTwo-1 {
-			suffix = "/" + parts[1]
-		}
-
-		switch {
-		case suffix == "" && method == http.MethodGet:
-			return h.handleGetKnowledgeBase(c, kbID)
-		case suffix == "" && method == http.MethodPut:
-			return h.handleUpdateKnowledgeBase(c, kbID, body)
-		case suffix == "" && method == http.MethodDelete:
-			return h.handleDeleteKnowledgeBase(c, kbID)
-		case strings.HasPrefix(suffix, "/datasources"):
-			return h.dispatchDataSourceRoutes(c, kbID, suffix, method, body)
-		}
+	case strings.HasPrefix(path, flowsPath):
+		return h.dispatchFlowRoutes(c, path, method, body)
+	case strings.HasPrefix(path, promptsPath):
+		return h.dispatchPromptRoutes(c, path, method, body)
+	case strings.HasPrefix(path, "/tags/"):
+		return h.dispatchTagRoutes(c, path, method, body)
 	}
 
 	return c.JSON(
 		http.StatusNotFound,
 		agentErrResp("UnknownOperationException", "unknown operation: "+path),
+	)
+}
+
+// dispatchAgentRoutes handles /agents and /agents/{agentId}/... routes.
+// Returns (true, err) when the path was matched; (false, nil) when it was not.
+//
+//nolint:cyclop // agent dispatch table is inherently branchy
+func (h *AgentsHandler) dispatchAgentRoutes(
+	c *echo.Context, path, method string, body []byte,
+) (bool, error) {
+	switch {
+	case path == agentsPath && method == http.MethodPost:
+		return true, h.handleCreateAgent(c, body)
+	case path == agentsPath && method == http.MethodGet:
+		return true, h.handleListAgents(c)
+	}
+
+	rest, cutOK := strings.CutPrefix(path, "/agents/")
+	if !cutOK {
+		return false, nil
+	}
+
+	parts := strings.SplitN(rest, "/", splitInTwo)
+	agentID := parts[0]
+	suffix := ""
+
+	if len(parts) > splitInTwo-1 {
+		suffix = "/" + parts[1]
+	}
+
+	return true, h.dispatchAgentIDRoutes(c, agentID, suffix, method, body)
+}
+
+// dispatchAgentIDRoutes handles routes for a specific agent ID.
+//
+//nolint:cyclop // agent sub-route dispatch is inherently branchy
+func (h *AgentsHandler) dispatchAgentIDRoutes(
+	c *echo.Context, agentID, suffix, method string, body []byte,
+) error {
+	switch {
+	case suffix == "" && method == http.MethodGet:
+		return h.handleGetAgent(c, agentID)
+	case suffix == "" && method == http.MethodPut:
+		return h.handleUpdateAgent(c, agentID, body)
+	case suffix == "" && method == http.MethodDelete:
+		return h.handleDeleteAgent(c, agentID)
+	case suffix == "/prepare" && method == http.MethodPost:
+		return h.handlePrepareAgent(c, agentID)
+	case strings.HasPrefix(suffix, "/agentversions/") &&
+		strings.Contains(suffix, "/knowledgebases"):
+		return h.dispatchAgentKBRoutes(c, agentID, suffix, method, body)
+	case strings.HasPrefix(suffix, "/agentversions/") &&
+		strings.Contains(suffix, "/agentcollaborators"):
+		return h.dispatchAgentCollabRoutes(c, agentID, suffix, method, body)
+	case strings.HasPrefix(suffix, "/agentversions/") &&
+		strings.Contains(suffix, "/memories"):
+		return h.dispatchMemoryRoutes(c, agentID, suffix, method)
+	case strings.HasPrefix(suffix, "/action-groups"):
+		return h.dispatchActionGroupRoutes(c, agentID, suffix, method, body)
+	case strings.HasPrefix(suffix, "/aliases"):
+		return h.dispatchAliasRoutes(c, agentID, suffix, method, body)
+	case strings.HasPrefix(suffix, "/versions"):
+		return h.dispatchAgentVersionRoutes(c, agentID, suffix, method)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown agent operation"),
+	)
+}
+
+// dispatchKBRoutes handles /knowledgebases and /knowledgebases/{kbId}/... routes.
+// Returns (true, err) when the path was matched; (false, nil) when it was not.
+func (h *AgentsHandler) dispatchKBRoutes(
+	c *echo.Context, path, method string, body []byte,
+) (bool, error) {
+	switch {
+	case path == knowledgeBasePath && method == http.MethodPost:
+		return true, h.handleCreateKnowledgeBase(c, body)
+	case path == knowledgeBasePath && method == http.MethodGet:
+		return true, h.handleListKnowledgeBases(c)
+	}
+
+	rest, cutOK := strings.CutPrefix(path, "/knowledgebases/")
+	if !cutOK {
+		return false, nil
+	}
+
+	parts := strings.SplitN(rest, "/", splitInTwo)
+	kbID := parts[0]
+	suffix := ""
+
+	if len(parts) > splitInTwo-1 {
+		suffix = "/" + parts[1]
+	}
+
+	switch {
+	case suffix == "" && method == http.MethodGet:
+		return true, h.handleGetKnowledgeBase(c, kbID)
+	case suffix == "" && method == http.MethodPut:
+		return true, h.handleUpdateKnowledgeBase(c, kbID, body)
+	case suffix == "" && method == http.MethodDelete:
+		return true, h.handleDeleteKnowledgeBase(c, kbID)
+	case strings.HasPrefix(suffix, "/datasources"):
+		return true, h.dispatchDataSourceRoutes(c, kbID, suffix, method, body)
+	}
+
+	return true, c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown kb operation"),
 	)
 }
 
@@ -892,16 +1036,41 @@ func (h *AgentsHandler) dispatchDataSourceRoutes(
 			return h.handleStartIngestionJob(c, kbID, dsID, body)
 		case dsSuffix == "/ingestionjobs" && method == http.MethodGet:
 			return h.handleListIngestionJobs(c, kbID, dsID)
-		case strings.HasPrefix(dsSuffix, "/ingestionjobs/") && method == http.MethodGet:
-			jobID := strings.TrimPrefix(dsSuffix, "/ingestionjobs/")
-
-			return h.handleGetIngestionJob(c, kbID, dsID, jobID)
+		case strings.HasPrefix(dsSuffix, "/ingestionjobs/"):
+			return h.dispatchIngestionJobRoutes(c, kbID, dsID, dsSuffix, method)
+		case strings.HasPrefix(dsSuffix, "/documents"):
+			return h.dispatchDocumentOps(c, kbID, dsID, method, body)
 		}
 	}
 
 	return c.JSON(
 		http.StatusNotFound,
 		agentErrResp("UnknownOperationException", "unknown data source operation"),
+	)
+}
+
+func (h *AgentsHandler) dispatchIngestionJobRoutes(
+	c *echo.Context,
+	kbID, dsID, dsSuffix, method string,
+) error {
+	jobID := strings.TrimPrefix(dsSuffix, "/ingestionjobs/")
+	// strip any further sub-path
+	if idx := strings.Index(jobID, "/"); idx >= 0 {
+		subPath := jobID[idx:]
+		jobID = jobID[:idx]
+
+		if subPath == "/stop" && method == http.MethodPost {
+			return h.handleStopIngestionJob(c, kbID, dsID, jobID)
+		}
+	}
+
+	if method == http.MethodGet {
+		return h.handleGetIngestionJob(c, kbID, dsID, jobID)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown ingestion job operation"),
 	)
 }
 

--- a/services/bedrock/handler_agents.go
+++ b/services/bedrock/handler_agents.go
@@ -198,8 +198,8 @@ const (
 	keyKnowledgeBaseID = "knowledgeBaseId"
 
 	// Op name constants shared between BedrockAgents and Bedrock handlers.
-	opTagResource        = "TagResource"
-	opUntagResource      = "UntagResource"
+	opTagResource         = "TagResource"
+	opUntagResource       = "UntagResource"
 	opListTagsForResource = "ListTagsForResource"
 
 	// Agent sub-path suffixes.
@@ -241,9 +241,9 @@ func (h *AgentsHandler) ExtractOperation(c *echo.Context) string {
 		return "CreateAgentActionGroup"
 	case strings.HasSuffix(path, "/action-groups") && method == http.MethodGet:
 		return "ListAgentActionGroups"
-	case strings.HasSuffix(path, "/aliases") && method == http.MethodPost:
+	case strings.HasSuffix(path, suffixAgentAliases) && method == http.MethodPost:
 		return "CreateAgentAlias"
-	case strings.HasSuffix(path, "/aliases") && method == http.MethodGet:
+	case strings.HasSuffix(path, suffixAgentAliases) && method == http.MethodGet:
 		return "ListAgentAliases"
 	case strings.Contains(path, "/agentversions/") &&
 		strings.Contains(path, "/knowledgebases") && method == http.MethodGet:
@@ -280,7 +280,8 @@ func (h *AgentsHandler) Handler() echo.HandlerFunc {
 		log := logger.Load(r.Context())
 
 		var body []byte
-		if method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch {
+		switch method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
 			var err error
 
 			body, err = httputils.ReadBody(r)
@@ -299,8 +300,6 @@ func (h *AgentsHandler) Handler() echo.HandlerFunc {
 }
 
 // dispatch routes requests to the appropriate handler.
-//
-//nolint:cyclop,gocognit,gocyclo // large dispatch table for agents routing is inherently complex
 func (h *AgentsHandler) dispatch(c *echo.Context, path, method string, body []byte) error {
 	if handled, err := h.dispatchAgentRoutes(c, path, method, body); handled {
 		return err
@@ -328,8 +327,6 @@ func (h *AgentsHandler) dispatch(c *echo.Context, path, method string, body []by
 
 // dispatchAgentRoutes handles /agents and /agents/{agentId}/... routes.
 // Returns (true, err) when the path was matched; (false, nil) when it was not.
-//
-//nolint:cyclop // agent dispatch table is inherently branchy
 func (h *AgentsHandler) dispatchAgentRoutes(
 	c *echo.Context, path, method string, body []byte,
 ) (bool, error) {
@@ -382,7 +379,7 @@ func (h *AgentsHandler) dispatchAgentIDRoutes(
 		return h.dispatchMemoryRoutes(c, agentID, suffix, method)
 	case strings.HasPrefix(suffix, "/action-groups"):
 		return h.dispatchActionGroupRoutes(c, agentID, suffix, method, body)
-	case strings.HasPrefix(suffix, "/aliases"):
+	case strings.HasPrefix(suffix, suffixAgentAliases):
 		return h.dispatchAliasRoutes(c, agentID, suffix, method, body)
 	case strings.HasPrefix(suffix, "/versions"):
 		return h.dispatchAgentVersionRoutes(c, agentID, suffix, method)
@@ -528,7 +525,7 @@ func (h *AgentsHandler) handleDeleteAgent(c *echo.Context, agentID string) error
 
 	return c.JSON(
 		http.StatusAccepted,
-		map[string]any{keyAgentID: agentID, "agentStatus": statusDeleting},
+		map[string]any{keyAgentID: agentID, opAgentStatusKey: statusDeleting},
 	)
 }
 
@@ -541,9 +538,9 @@ func (h *AgentsHandler) handlePrepareAgent(c *echo.Context, agentID string) erro
 	return c.JSON(
 		http.StatusAccepted,
 		map[string]any{
-			keyAgentID:     ag.AgentID,
-			"agentStatus":  ag.AgentStatus,
-			"agentVersion": ag.AgentVersion,
+			keyAgentID:       ag.AgentID,
+			opAgentStatusKey: ag.AgentStatus,
+			"agentVersion":   ag.AgentVersion,
 		},
 	)
 }
@@ -708,15 +705,15 @@ func (h *AgentsHandler) dispatchAliasRoutes(
 	agentID, suffix, method string,
 	body []byte,
 ) error {
-	if suffix == "/aliases" && method == http.MethodPost {
+	if suffix == suffixAgentAliases && method == http.MethodPost {
 		return h.handleCreateAgentAlias(c, agentID, body)
 	}
 
-	if suffix == "/aliases" && method == http.MethodGet {
+	if suffix == suffixAgentAliases && method == http.MethodGet {
 		return h.handleListAgentAliases(c, agentID)
 	}
 
-	if aliasID, aliasOK := strings.CutPrefix(suffix, "/aliases/"); aliasOK {
+	if aliasID, aliasOK := strings.CutPrefix(suffix, suffixAgentAliases+"/"); aliasOK {
 		switch method {
 		case http.MethodGet:
 			return h.handleGetAgentAlias(c, agentID, aliasID)
@@ -901,7 +898,7 @@ func (h *AgentsHandler) handleDisassociateAgentKB(c *echo.Context, agentID, kbID
 		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
 	}
 
-	return c.JSON(http.StatusNoContent, nil)
+	return c.NoContent(http.StatusNoContent)
 }
 
 // ---------------------------------------------------------------------------

--- a/services/bedrock/handler_agents_batch3.go
+++ b/services/bedrock/handler_agents_batch3.go
@@ -33,8 +33,6 @@ const (
 
 	suffixAliases  = "/aliases"
 	suffixVersions = "/versions"
-
-	opAgentStatus = "agentStatus"
 )
 
 // ---------------------------------------------------------------------------
@@ -356,7 +354,6 @@ func (h *AgentsHandler) dispatchTagRoutes(
 		agentErrResp("UnknownOperationException", "unknown tag operation"),
 	)
 }
-
 
 func (h *AgentsHandler) dispatchDocumentOps(
 	c *echo.Context, kbID, dsID, method string, body []byte,
@@ -817,7 +814,7 @@ func (h *AgentsHandler) handleDeleteAgentVersion(
 
 	return c.JSON(
 		http.StatusAccepted,
-		map[string]any{keyAgentID: agentID, keyVersion: version, opAgentStatus: statusDeleting},
+		map[string]any{keyAgentID: agentID, keyVersion: version, opAgentStatusKey: statusDeleting},
 	)
 }
 
@@ -902,7 +899,7 @@ func (h *AgentsHandler) handleDisassociateAgentCollaborator(
 		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
 	}
 
-	return c.JSON(http.StatusNoContent, nil)
+	return c.NoContent(http.StatusNoContent)
 }
 
 // ---------------------------------------------------------------------------
@@ -1073,5 +1070,5 @@ func (h *AgentsHandler) handleDeleteAgentMemory(
 		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
 	}
 
-	return c.JSON(http.StatusNoContent, nil)
+	return c.NoContent(http.StatusNoContent)
 }

--- a/services/bedrock/handler_agents_batch3.go
+++ b/services/bedrock/handler_agents_batch3.go
@@ -1,0 +1,1077 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+)
+
+// ---------------------------------------------------------------------------
+// Route path constants for batch-3 resources
+// ---------------------------------------------------------------------------
+
+const (
+	flowsPath   = "/flows"
+	promptsPath = "/prompts"
+
+	respFlow          = "flow"
+	respFlowAlias     = "flowAlias"
+	respFlowVersion   = "flowVersion"
+	respPrompt        = "prompt"
+	respPromptVersion = "promptVersion"
+	respAgentVersion  = "agentVersion"
+	respCollaborator  = "agentCollaborator"
+
+	keyFlowID         = "flowId"
+	keyFlowAliasID    = "flowAliasId"
+	keyPromptID       = "promptId"
+	keyCollaboratorID = "collaboratorId"
+	keyVersion        = "version"
+
+	suffixAliases  = "/aliases"
+	suffixVersions = "/versions"
+
+	opAgentStatus = "agentStatus"
+)
+
+// ---------------------------------------------------------------------------
+// RouteMatcher extension — now also handles /flows, /prompts, /tags
+// ---------------------------------------------------------------------------
+
+// routeMatcherBatch3 returns true if the path matches any batch-3 routes.
+// Called from the updated RouteMatcher.
+func routeMatcherBatch3(path string) bool {
+	return strings.HasPrefix(path, "/flows") ||
+		path == flowsPath ||
+		strings.HasPrefix(path, "/prompts") ||
+		path == promptsPath ||
+		strings.HasPrefix(path, "/tags/")
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch entrypoints (called from the main dispatch function)
+// ---------------------------------------------------------------------------
+
+// dispatchFlowRoutes handles /flows and /flows/{flowId}/...
+func (h *AgentsHandler) dispatchFlowRoutes(
+	c *echo.Context, path, method string, body []byte,
+) error {
+	// Exact /flows
+	if path == flowsPath {
+		switch method {
+		case http.MethodPost:
+			return h.handleCreateFlow(c, body)
+		case http.MethodGet:
+			return h.handleListFlows(c)
+		}
+	}
+
+	// /flows/validateFlowDefinition (POST)
+	if path == flowsPath+"/validateFlowDefinition" && method == http.MethodPost {
+		return h.handleValidateFlowDefinition(c)
+	}
+
+	rest, ok := strings.CutPrefix(path, "/flows/")
+	if !ok {
+		return c.JSON(
+			http.StatusNotFound,
+			agentErrResp("UnknownOperationException", "unknown flow operation: "+path),
+		)
+	}
+
+	parts := strings.SplitN(rest, "/", splitInTwo)
+	flowID := parts[0]
+	suffix := ""
+
+	if len(parts) == splitInTwo {
+		suffix = "/" + parts[1]
+	}
+
+	return h.dispatchFlowIDRoutes(c, flowID, suffix, method, body)
+}
+
+func (h *AgentsHandler) dispatchFlowIDRoutes(
+	c *echo.Context, flowID, suffix, method string, body []byte,
+) error {
+	switch {
+	case suffix == "" && method == http.MethodGet:
+		return h.handleGetFlow(c, flowID)
+	case suffix == "" && method == http.MethodPut:
+		return h.handleUpdateFlow(c, flowID, body)
+	case suffix == "" && method == http.MethodDelete:
+		return h.handleDeleteFlow(c, flowID)
+	case suffix == "/prepare" && method == http.MethodPost:
+		return h.handlePrepareFlow(c, flowID)
+	case strings.HasPrefix(suffix, suffixAliases):
+		return h.dispatchFlowAliasRoutes(c, flowID, suffix, method, body)
+	case strings.HasPrefix(suffix, suffixVersions):
+		return h.dispatchFlowVersionRoutes(c, flowID, suffix, method)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown flow operation"),
+	)
+}
+
+func (h *AgentsHandler) dispatchFlowAliasRoutes(
+	c *echo.Context, flowID, suffix, method string, body []byte,
+) error {
+	if suffix == suffixAliases {
+		switch method {
+		case http.MethodPost:
+			return h.handleCreateFlowAlias(c, flowID, body)
+		case http.MethodGet:
+			return h.handleListFlowAliases(c, flowID)
+		}
+	}
+
+	if aliasID, ok := strings.CutPrefix(suffix, suffixAliases+"/"); ok {
+		switch method {
+		case http.MethodGet:
+			return h.handleGetFlowAlias(c, flowID, aliasID)
+		case http.MethodPut:
+			return h.handleUpdateFlowAlias(c, flowID, aliasID, body)
+		case http.MethodDelete:
+			return h.handleDeleteFlowAlias(c, flowID, aliasID)
+		}
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown flow alias operation"),
+	)
+}
+
+func (h *AgentsHandler) dispatchFlowVersionRoutes(
+	c *echo.Context, flowID, suffix, method string,
+) error {
+	if suffix == suffixVersions {
+		switch method {
+		case http.MethodPost:
+			return h.handleCreateFlowVersion(c, flowID)
+		case http.MethodGet:
+			return h.handleListFlowVersions(c, flowID)
+		}
+	}
+
+	if ver, ok := strings.CutPrefix(suffix, suffixVersions+"/"); ok {
+		switch method {
+		case http.MethodGet:
+			return h.handleGetFlowVersion(c, flowID, ver)
+		case http.MethodDelete:
+			return h.handleDeleteFlowVersion(c, flowID, ver)
+		}
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown flow version operation"),
+	)
+}
+
+// dispatchPromptRoutes handles /prompts and /prompts/{promptId}/...
+func (h *AgentsHandler) dispatchPromptRoutes(
+	c *echo.Context, path, method string, body []byte,
+) error {
+	if path == promptsPath {
+		switch method {
+		case http.MethodPost:
+			return h.handleCreatePrompt(c, body)
+		case http.MethodGet:
+			return h.handleListPrompts(c)
+		}
+	}
+
+	rest, ok := strings.CutPrefix(path, "/prompts/")
+	if !ok {
+		return c.JSON(
+			http.StatusNotFound,
+			agentErrResp("UnknownOperationException", "unknown prompt operation: "+path),
+		)
+	}
+
+	parts := strings.SplitN(rest, "/", splitInTwo)
+	promptID := parts[0]
+	suffix := ""
+
+	if len(parts) == splitInTwo {
+		suffix = "/" + parts[1]
+	}
+
+	return h.dispatchPromptIDRoutes(c, promptID, suffix, method, body)
+}
+
+func (h *AgentsHandler) dispatchPromptIDRoutes(
+	c *echo.Context, promptID, suffix, method string, body []byte,
+) error {
+	switch {
+	case suffix == "" && method == http.MethodGet:
+		return h.handleGetPrompt(c, promptID)
+	case suffix == "" && method == http.MethodPut:
+		return h.handleUpdatePrompt(c, promptID, body)
+	case suffix == "" && method == http.MethodDelete:
+		return h.handleDeletePrompt(c, promptID)
+	case strings.HasPrefix(suffix, suffixVersions):
+		return h.dispatchPromptVersionRoutes(c, promptID, suffix, method)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown prompt operation"),
+	)
+}
+
+func (h *AgentsHandler) dispatchPromptVersionRoutes(
+	c *echo.Context, promptID, suffix, method string,
+) error {
+	if suffix == suffixVersions {
+		switch method {
+		case http.MethodPost:
+			return h.handleCreatePromptVersion(c, promptID)
+		case http.MethodGet:
+			return h.handleListPromptVersions(c, promptID)
+		}
+	}
+
+	if ver, ok := strings.CutPrefix(suffix, suffixVersions+"/"); ok {
+		switch method {
+		case http.MethodGet:
+			return h.handleGetPromptVersion(c, promptID, ver)
+		case http.MethodDelete:
+			return h.handleDeletePromptVersion(c, promptID, ver)
+		}
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown prompt version operation"),
+	)
+}
+
+// dispatchAgentVersionRoutes handles /agents/{agentId}/versions/...
+func (h *AgentsHandler) dispatchAgentVersionRoutes(
+	c *echo.Context, agentID, suffix, method string,
+) error {
+	if suffix == "/versions" && method == http.MethodGet {
+		return h.handleListAgentVersions(c, agentID)
+	}
+
+	if suffix == "/versions" && method == http.MethodPost {
+		return h.handleCreateAgentVersion(c, agentID)
+	}
+
+	if ver, ok := strings.CutPrefix(suffix, suffixVersions+"/"); ok {
+		switch method {
+		case http.MethodGet:
+			return h.handleGetAgentVersion(c, agentID, ver)
+		case http.MethodDelete:
+			return h.handleDeleteAgentVersion(c, agentID, ver)
+		}
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown agent version operation"),
+	)
+}
+
+// dispatchAgentCollabRoutes handles /agents/{agentId}/agentversions/{v}/agentcollaborators/...
+func (h *AgentsHandler) dispatchAgentCollabRoutes(
+	c *echo.Context, agentID, suffix, method string, body []byte,
+) error {
+	// suffix looks like: /agentversions/{ver}/agentcollaborators or
+	//                    /agentversions/{ver}/agentcollaborators/{id}
+	collabSuffix := collabSuffixFrom(suffix)
+
+	if collabSuffix == "" {
+		return c.JSON(
+			http.StatusNotFound,
+			agentErrResp("UnknownOperationException", "malformed collaborator path"),
+		)
+	}
+
+	if collabSuffix == "/agentcollaborators" {
+		switch method {
+		case http.MethodPost:
+			return h.handleAssociateAgentCollaborator(c, agentID, body)
+		case http.MethodGet:
+			return h.handleListAgentCollaborators(c, agentID)
+		}
+	}
+
+	if collabID, ok := strings.CutPrefix(collabSuffix, "/agentcollaborators/"); ok {
+		switch method {
+		case http.MethodGet:
+			return h.handleGetAgentCollaborator(c, agentID, collabID)
+		case http.MethodPut:
+			return h.handleUpdateAgentCollaborator(c, agentID, collabID, body)
+		case http.MethodDelete:
+			return h.handleDisassociateAgentCollaborator(c, agentID, collabID)
+		}
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown collaborator operation"),
+	)
+}
+
+// collabSuffixFrom extracts the /agentcollaborators[/...] part from an agent suffix.
+func collabSuffixFrom(suffix string) string {
+	idx := strings.Index(suffix, "/agentcollaborators")
+	if idx < 0 {
+		return ""
+	}
+
+	return suffix[idx:]
+}
+
+// dispatchTagRoutes handles /tags/{resourceArn} REST paths.
+func (h *AgentsHandler) dispatchTagRoutes(
+	c *echo.Context, path, method string, body []byte,
+) error {
+	resourceArn, ok := strings.CutPrefix(path, "/tags/")
+	if !ok || resourceArn == "" {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "missing resourceArn in path"),
+		)
+	}
+
+	switch method {
+	case http.MethodGet:
+		return h.handleListTagsForAgentResource(c, resourceArn)
+	case http.MethodPost:
+		return h.handleTagAgentResource(c, resourceArn, body)
+	case http.MethodDelete:
+		return h.handleUntagAgentResource(c, resourceArn, body)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown tag operation"),
+	)
+}
+
+
+func (h *AgentsHandler) dispatchDocumentOps(
+	c *echo.Context, kbID, dsID, method string, body []byte,
+) error {
+	switch method {
+	case http.MethodGet:
+		return h.handleListKBDocuments(c, kbID, dsID)
+	case http.MethodPost:
+		return h.handleIngestKBDocuments(c, kbID, dsID, body)
+	case http.MethodPut:
+		return h.handleUpdateKBDocuments(c, kbID, dsID, body)
+	case http.MethodDelete:
+		return h.handleDeleteKBDocuments(c, kbID, dsID, body)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown documents operation"),
+	)
+}
+
+// dispatchMemoryRoutes handles /agents/{agentId}/agentversions/{v}/memories/...
+func (h *AgentsHandler) dispatchMemoryRoutes(
+	c *echo.Context, agentID, suffix, method string,
+) error {
+	// Extract session from query param or simple path
+	sessionID := c.QueryParam("sessionId")
+
+	if sessionID == "" {
+		// Try parsing /memories/{sessionId}
+		if rest, ok := strings.CutPrefix(suffix, "/memories/"); ok {
+			sessionID = rest
+		}
+	}
+
+	switch method {
+	case http.MethodGet:
+		return h.handleGetAgentMemory(c, agentID, sessionID)
+	case http.MethodDelete:
+		return h.handleDeleteAgentMemory(c, agentID, sessionID)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		agentErrResp("UnknownOperationException", "unknown memory operation"),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Flow handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleCreateFlow(c *echo.Context, body []byte) error {
+	var req struct {
+		Tags        map[string]string `json:"tags"`
+		Name        string            `json:"name"`
+		Description string            `json:"description"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	f, err := h.Backend.CreateFlow(req.Name, req.Description, req.Tags)
+	if err != nil {
+		if errors.Is(err, ErrAlreadyExists) {
+			return c.JSON(http.StatusConflict, agentErrResp("ConflictException", err.Error()))
+		}
+
+		return c.JSON(http.StatusBadRequest, agentErrResp("ValidationException", err.Error()))
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{respFlow: f})
+}
+
+func (h *AgentsHandler) handleGetFlow(c *echo.Context, flowID string) error {
+	f, err := h.Backend.GetFlow(flowID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respFlow: f})
+}
+
+func (h *AgentsHandler) handleListFlows(c *echo.Context) error {
+	list, outToken := h.Backend.ListFlows(0, c.QueryParam("nextToken"))
+	resp := map[string]any{"flowSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleUpdateFlow(
+	c *echo.Context, flowID string, body []byte,
+) error {
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	f, err := h.Backend.UpdateFlow(flowID, req.Name, req.Description)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respFlow: f})
+}
+
+func (h *AgentsHandler) handleDeleteFlow(c *echo.Context, flowID string) error {
+	if err := h.Backend.DeleteFlow(flowID); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{keyFlowID: flowID, keyStatus: statusDeleting})
+}
+
+func (h *AgentsHandler) handlePrepareFlow(c *echo.Context, flowID string) error {
+	f, err := h.Backend.PrepareFlow(flowID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusAccepted, map[string]any{keyFlowID: f.FlowID, keyStatus: f.Status})
+}
+
+// ---------------------------------------------------------------------------
+// Flow alias handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleCreateFlowAlias(
+	c *echo.Context, flowID string, body []byte,
+) error {
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	fa, err := h.Backend.CreateFlowAlias(flowID, req.Name, req.Description)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{respFlowAlias: fa})
+}
+
+func (h *AgentsHandler) handleGetFlowAlias(
+	c *echo.Context, flowID, aliasID string,
+) error {
+	fa, err := h.Backend.GetFlowAlias(flowID, aliasID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respFlowAlias: fa})
+}
+
+func (h *AgentsHandler) handleListFlowAliases(c *echo.Context, flowID string) error {
+	list, outToken := h.Backend.ListFlowAliases(flowID, 0, c.QueryParam("nextToken"))
+	resp := map[string]any{"flowAliasSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleUpdateFlowAlias(
+	c *echo.Context, flowID, aliasID string, body []byte,
+) error {
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	fa, err := h.Backend.UpdateFlowAlias(flowID, aliasID, req.Name, req.Description)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respFlowAlias: fa})
+}
+
+func (h *AgentsHandler) handleDeleteFlowAlias(
+	c *echo.Context, flowID, aliasID string,
+) error {
+	if err := h.Backend.DeleteFlowAlias(flowID, aliasID); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		map[string]any{keyFlowID: flowID, keyFlowAliasID: aliasID, keyStatus: statusDeleting},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Flow version handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleCreateFlowVersion(c *echo.Context, flowID string) error {
+	fv, err := h.Backend.CreateFlowVersion(flowID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{respFlowVersion: fv})
+}
+
+func (h *AgentsHandler) handleGetFlowVersion(
+	c *echo.Context, flowID, version string,
+) error {
+	fv, err := h.Backend.GetFlowVersion(flowID, version)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respFlowVersion: fv})
+}
+
+func (h *AgentsHandler) handleListFlowVersions(c *echo.Context, flowID string) error {
+	list, outToken := h.Backend.ListFlowVersions(flowID, 0, c.QueryParam("nextToken"))
+	resp := map[string]any{"flowVersionSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleDeleteFlowVersion(
+	c *echo.Context, flowID, version string,
+) error {
+	if err := h.Backend.DeleteFlowVersion(flowID, version); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		map[string]any{keyFlowID: flowID, keyVersion: version, keyStatus: statusDeleting},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Validate flow definition handler
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleValidateFlowDefinition(c *echo.Context) error {
+	validations, err := h.Backend.ValidateFlowDefinition()
+	if err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", err.Error()),
+		)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"validations": validations})
+}
+
+// ---------------------------------------------------------------------------
+// Prompt handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleCreatePrompt(c *echo.Context, body []byte) error {
+	var req struct {
+		Tags        map[string]string `json:"tags"`
+		Name        string            `json:"name"`
+		Description string            `json:"description"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	p, err := h.Backend.CreatePrompt(req.Name, req.Description, req.Tags)
+	if err != nil {
+		if errors.Is(err, ErrAlreadyExists) {
+			return c.JSON(http.StatusConflict, agentErrResp("ConflictException", err.Error()))
+		}
+
+		return c.JSON(http.StatusBadRequest, agentErrResp("ValidationException", err.Error()))
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{respPrompt: p})
+}
+
+func (h *AgentsHandler) handleGetPrompt(c *echo.Context, promptID string) error {
+	p, err := h.Backend.GetPrompt(promptID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respPrompt: p})
+}
+
+func (h *AgentsHandler) handleListPrompts(c *echo.Context) error {
+	list, outToken := h.Backend.ListPrompts(0, c.QueryParam("nextToken"))
+	resp := map[string]any{"promptSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleUpdatePrompt(
+	c *echo.Context, promptID string, body []byte,
+) error {
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	p, err := h.Backend.UpdatePrompt(promptID, req.Name, req.Description)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respPrompt: p})
+}
+
+func (h *AgentsHandler) handleDeletePrompt(c *echo.Context, promptID string) error {
+	if err := h.Backend.DeletePrompt(promptID); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{keyPromptID: promptID, keyStatus: statusDeleting})
+}
+
+// ---------------------------------------------------------------------------
+// Prompt version handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleCreatePromptVersion(c *echo.Context, promptID string) error {
+	pv, err := h.Backend.CreatePromptVersion(promptID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{respPromptVersion: pv})
+}
+
+func (h *AgentsHandler) handleGetPromptVersion(
+	c *echo.Context, promptID, version string,
+) error {
+	pv, err := h.Backend.GetPromptVersion(promptID, version)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respPromptVersion: pv})
+}
+
+func (h *AgentsHandler) handleListPromptVersions(c *echo.Context, promptID string) error {
+	list, outToken := h.Backend.ListPromptVersions(promptID, 0, c.QueryParam("nextToken"))
+	resp := map[string]any{"promptVersionSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleDeletePromptVersion(
+	c *echo.Context, promptID, version string,
+) error {
+	if err := h.Backend.DeletePromptVersion(promptID, version); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(
+		http.StatusOK,
+		map[string]any{keyPromptID: promptID, keyVersion: version, keyStatus: statusDeleting},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Agent version handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleCreateAgentVersion(c *echo.Context, agentID string) error {
+	av, err := h.Backend.CreateAgentVersion(agentID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusAccepted, map[string]any{respAgentVersion: av})
+}
+
+func (h *AgentsHandler) handleGetAgentVersion(
+	c *echo.Context, agentID, version string,
+) error {
+	av, err := h.Backend.GetAgentVersion(agentID, version)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respAgentVersion: av})
+}
+
+func (h *AgentsHandler) handleListAgentVersions(c *echo.Context, agentID string) error {
+	list, outToken := h.Backend.ListAgentVersions(agentID, 0, c.QueryParam("nextToken"))
+	resp := map[string]any{"agentVersionSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleDeleteAgentVersion(
+	c *echo.Context, agentID, version string,
+) error {
+	if err := h.Backend.DeleteAgentVersion(agentID, version); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(
+		http.StatusAccepted,
+		map[string]any{keyAgentID: agentID, keyVersion: version, opAgentStatus: statusDeleting},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Agent collaborator handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleAssociateAgentCollaborator(
+	c *echo.Context, agentID string, body []byte,
+) error {
+	var req struct {
+		AgentVersion      string `json:"agentVersion"`
+		CollaboratorArn   string `json:"collaboratorArn"`
+		RelayConversation string `json:"relayConversationHistory"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	ac, err := h.Backend.AssociateAgentCollaborator(
+		agentID, req.AgentVersion, req.CollaboratorArn, req.RelayConversation,
+	)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respCollaborator: ac})
+}
+
+func (h *AgentsHandler) handleGetAgentCollaborator(
+	c *echo.Context, agentID, collaboratorID string,
+) error {
+	ac, err := h.Backend.GetAgentCollaborator(agentID, collaboratorID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respCollaborator: ac})
+}
+
+func (h *AgentsHandler) handleListAgentCollaborators(c *echo.Context, agentID string) error {
+	list, outToken := h.Backend.ListAgentCollaborators(agentID, 0, c.QueryParam("nextToken"))
+	resp := map[string]any{"agentCollaboratorSummaries": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleUpdateAgentCollaborator(
+	c *echo.Context, agentID, collaboratorID string, body []byte,
+) error {
+	var req struct {
+		RelayConversation string `json:"relayConversationHistory"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	ac, err := h.Backend.UpdateAgentCollaborator(agentID, collaboratorID, req.RelayConversation)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respCollaborator: ac})
+}
+
+func (h *AgentsHandler) handleDisassociateAgentCollaborator(
+	c *echo.Context, agentID, collaboratorID string,
+) error {
+	if err := h.Backend.DisassociateAgentCollaborator(agentID, collaboratorID); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusNoContent, nil)
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge base document handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleIngestKBDocuments(
+	c *echo.Context, kbID, dsID string, body []byte,
+) error {
+	var req struct {
+		DocumentIDs []string `json:"documentIds"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	docs, err := h.Backend.IngestKnowledgeBaseDocuments(kbID, dsID, req.DocumentIDs)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"documents": docs})
+}
+
+func (h *AgentsHandler) handleListKBDocuments(c *echo.Context, kbID, dsID string) error {
+	list, outToken := h.Backend.ListKnowledgeBaseDocuments(kbID, dsID, 0, c.QueryParam("nextToken"))
+	resp := map[string]any{"documentDetails": list}
+
+	if outToken != "" {
+		resp["nextToken"] = outToken
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *AgentsHandler) handleDeleteKBDocuments(
+	c *echo.Context, kbID, dsID string, body []byte,
+) error {
+	var req struct {
+		DocumentIDs []string `json:"documentIds"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	if err := h.Backend.DeleteKnowledgeBaseDocuments(kbID, dsID, req.DocumentIDs); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+func (h *AgentsHandler) handleUpdateKBDocuments(
+	c *echo.Context, kbID, dsID string, body []byte,
+) error {
+	var req struct {
+		DocumentIDs []string `json:"documentIds"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	docs, err := h.Backend.UpdateKnowledgeBaseDocuments(kbID, dsID, req.DocumentIDs)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"documents": docs})
+}
+
+// ---------------------------------------------------------------------------
+// Stop ingestion job handler
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleStopIngestionJob(
+	c *echo.Context, kbID, dsID, jobID string,
+) error {
+	job, err := h.Backend.StopIngestionJob(kbID, dsID, jobID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{respIngestionJob: job})
+}
+
+// ---------------------------------------------------------------------------
+// Tag handlers (agent-domain)
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleListTagsForAgentResource(
+	c *echo.Context, resourceArn string,
+) error {
+	tags := h.Backend.ListAgentResourceTags(resourceArn)
+
+	return c.JSON(http.StatusOK, map[string]any{"tags": tags})
+}
+
+func (h *AgentsHandler) handleTagAgentResource(
+	c *echo.Context, resourceArn string, body []byte,
+) error {
+	var req struct {
+		Tags map[string]string `json:"tags"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	if err := h.Backend.TagAgentResource(resourceArn, req.Tags); err != nil {
+		return c.JSON(http.StatusBadRequest, agentErrResp("ValidationException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+func (h *AgentsHandler) handleUntagAgentResource(
+	c *echo.Context, resourceArn string, body []byte,
+) error {
+	var req struct {
+		TagKeys []string `json:"tagKeys"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			agentErrResp("ValidationException", "invalid request body"),
+		)
+	}
+
+	if err := h.Backend.UntagAgentResource(resourceArn, req.TagKeys); err != nil {
+		return c.JSON(http.StatusBadRequest, agentErrResp("ValidationException", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+// ---------------------------------------------------------------------------
+// Agent memory handlers
+// ---------------------------------------------------------------------------
+
+func (h *AgentsHandler) handleGetAgentMemory(
+	c *echo.Context, agentID, sessionID string,
+) error {
+	entries := h.Backend.GetAgentMemory(agentID, sessionID)
+
+	return c.JSON(http.StatusOK, map[string]any{"memoryContents": entries})
+}
+
+func (h *AgentsHandler) handleDeleteAgentMemory(
+	c *echo.Context, agentID, sessionID string,
+) error {
+	if err := h.Backend.DeleteAgentMemory(agentID, sessionID); err != nil {
+		return c.JSON(http.StatusNotFound, agentErrResp("ResourceNotFoundException", err.Error()))
+	}
+
+	return c.JSON(http.StatusNoContent, nil)
+}

--- a/services/bedrock/handler_agents_batch3.go
+++ b/services/bedrock/handler_agents_batch3.go
@@ -41,12 +41,25 @@ const (
 
 // routeMatcherBatch3 returns true if the path matches any batch-3 routes.
 // Called from the updated RouteMatcher.
+// Note: /tags/ paths are only claimed when the ARN belongs to a bedrock-agent resource
+// (arn:aws:bedrock-agent:…). Other services (FIS, etc.) own their own /tags/ routes.
 func routeMatcherBatch3(path string) bool {
-	return strings.HasPrefix(path, "/flows") ||
-		path == flowsPath ||
-		strings.HasPrefix(path, "/prompts") ||
-		path == promptsPath ||
-		strings.HasPrefix(path, "/tags/")
+	if strings.HasPrefix(path, "/flows") || path == flowsPath {
+		return true
+	}
+	if strings.HasPrefix(path, "/prompts") || path == promptsPath {
+		return true
+	}
+	if rest, ok := strings.CutPrefix(path, "/tags/"); ok {
+		return isBedrockAgentArn(rest)
+	}
+
+	return false
+}
+
+// isBedrockAgentArn reports whether arn is a bedrock-agent-owned ARN.
+func isBedrockAgentArn(arn string) bool {
+	return strings.Contains(arn, ":bedrock-agent:")
 }
 
 // ---------------------------------------------------------------------------

--- a/services/bedrock/handler_agents_batch3_test.go
+++ b/services/bedrock/handler_agents_batch3_test.go
@@ -1,0 +1,613 @@
+package bedrock_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/bedrock"
+)
+
+// ---------------------------------------------------------------------------
+// Helper: create a KB + data source in one call
+// ---------------------------------------------------------------------------
+
+func createKBAndDS(t *testing.T, h *bedrock.AgentsHandler) (string, string) {
+	t.Helper()
+
+	kbResp := doAgentRequest(t, h, http.MethodPost, "/knowledgebases", map[string]any{
+		"name":    "test-kb",
+		"roleArn": "arn:aws:iam::000000000000:role/kb-role",
+	})
+	require.Equal(t, http.StatusAccepted, kbResp.Code)
+
+	var kbBody map[string]any
+	require.NoError(t, json.Unmarshal(kbResp.Body.Bytes(), &kbBody))
+	kbID := kbBody["knowledgeBase"].(map[string]any)["knowledgeBaseId"].(string)
+
+	dsResp := doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/knowledgebases/%s/datasources", kbID),
+		map[string]any{"name": "test-ds"},
+	)
+	require.Equal(t, http.StatusOK, dsResp.Code)
+
+	var dsBody map[string]any
+	require.NoError(t, json.Unmarshal(dsResp.Body.Bytes(), &dsBody))
+	dsID := dsBody["dataSource"].(map[string]any)["dataSourceId"].(string)
+
+	return kbID, dsID
+}
+
+// ---------------------------------------------------------------------------
+// Flow CRUD
+// ---------------------------------------------------------------------------
+
+func TestFlowCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create
+	rec := doAgentRequest(t, h, http.MethodPost, "/flows", map[string]any{
+		"name":        "my-flow",
+		"description": "test flow",
+	})
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	flow := body["flow"].(map[string]any)
+	flowID := flow["flowId"].(string)
+	assert.NotEmpty(t, flowID)
+	assert.Equal(t, "my-flow", flow["name"])
+	assert.Equal(t, "NOT_PREPARED", flow["status"])
+
+	// Get
+	rec = doAgentRequest(t, h, http.MethodGet, "/flows/"+flowID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List
+	rec = doAgentRequest(t, h, http.MethodGet, "/flows", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var listBody map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &listBody))
+	assert.Len(t, listBody["flowSummaries"], 1)
+
+	// Update
+	rec = doAgentRequest(t, h, http.MethodPut, "/flows/"+flowID, map[string]any{
+		"description": "updated",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Prepare
+	rec = doAgentRequest(t, h, http.MethodPost, "/flows/"+flowID+"/prepare", nil)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Delete
+	rec = doAgentRequest(t, h, http.MethodDelete, "/flows/"+flowID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Get after delete → 404
+	rec = doAgentRequest(t, h, http.MethodGet, "/flows/"+flowID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestCreateFlow_ConflictOnDuplicate(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	doAgentRequest(t, h, http.MethodPost, "/flows", map[string]any{"name": "dup"})
+	rec := doAgentRequest(t, h, http.MethodPost, "/flows", map[string]any{"name": "dup"})
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Flow Aliases
+// ---------------------------------------------------------------------------
+
+func TestFlowAliasCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create flow
+	rec := doAgentRequest(t, h, http.MethodPost, "/flows", map[string]any{"name": "fa-flow"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var fb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &fb))
+	flowID := fb["flow"].(map[string]any)["flowId"].(string)
+
+	// Create alias
+	rec = doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/flows/%s/aliases", flowID),
+		map[string]any{"name": "my-alias"},
+	)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var ab map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ab))
+	aliasID := ab["flowAlias"].(map[string]any)["flowAliasId"].(string)
+
+	// Get alias
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/flows/%s/aliases/%s", flowID, aliasID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List aliases
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/flows/%s/aliases", flowID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["flowAliasSummaries"], 1)
+
+	// Update alias
+	rec = doAgentRequest(t, h, http.MethodPut,
+		fmt.Sprintf("/flows/%s/aliases/%s", flowID, aliasID),
+		map[string]any{"name": "updated-alias"},
+	)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Delete alias
+	rec = doAgentRequest(t, h, http.MethodDelete,
+		fmt.Sprintf("/flows/%s/aliases/%s", flowID, aliasID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Flow Versions
+// ---------------------------------------------------------------------------
+
+func TestFlowVersionCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create flow
+	rec := doAgentRequest(t, h, http.MethodPost, "/flows", map[string]any{"name": "fv-flow"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var fb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &fb))
+	flowID := fb["flow"].(map[string]any)["flowId"].(string)
+
+	// Create version
+	rec = doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/flows/%s/versions", flowID), nil)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var vb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &vb))
+	version := vb["flowVersion"].(map[string]any)["version"].(string)
+	assert.Equal(t, "1", version)
+
+	// Get version
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/flows/%s/versions/%s", flowID, version), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List versions
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/flows/%s/versions", flowID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["flowVersionSummaries"], 1)
+
+	// Delete version
+	rec = doAgentRequest(t, h, http.MethodDelete,
+		fmt.Sprintf("/flows/%s/versions/%s", flowID, version), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// ValidateFlowDefinition
+// ---------------------------------------------------------------------------
+
+func TestValidateFlowDefinition(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	rec := doAgentRequest(t, h, http.MethodPost, "/flows/validateFlowDefinition",
+		map[string]any{})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.NotNil(t, body["validations"])
+}
+
+// ---------------------------------------------------------------------------
+// Prompt CRUD
+// ---------------------------------------------------------------------------
+
+func TestPromptCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create
+	rec := doAgentRequest(t, h, http.MethodPost, "/prompts", map[string]any{
+		"name": "my-prompt",
+	})
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	promptID := body["prompt"].(map[string]any)["promptId"].(string)
+	assert.NotEmpty(t, promptID)
+
+	// Get
+	rec = doAgentRequest(t, h, http.MethodGet, "/prompts/"+promptID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List
+	rec = doAgentRequest(t, h, http.MethodGet, "/prompts", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["promptSummaries"], 1)
+
+	// Update
+	rec = doAgentRequest(t, h, http.MethodPut, "/prompts/"+promptID, map[string]any{
+		"description": "updated",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Delete
+	rec = doAgentRequest(t, h, http.MethodDelete, "/prompts/"+promptID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Get after delete → 404
+	rec = doAgentRequest(t, h, http.MethodGet, "/prompts/"+promptID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestCreatePrompt_ConflictOnDuplicate(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	doAgentRequest(t, h, http.MethodPost, "/prompts", map[string]any{"name": "dup"})
+	rec := doAgentRequest(t, h, http.MethodPost, "/prompts", map[string]any{"name": "dup"})
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Versions
+// ---------------------------------------------------------------------------
+
+func TestPromptVersionCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create prompt
+	rec := doAgentRequest(t, h, http.MethodPost, "/prompts", map[string]any{"name": "pv-prompt"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var pb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &pb))
+	promptID := pb["prompt"].(map[string]any)["promptId"].(string)
+
+	// Create version
+	rec = doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/prompts/%s/versions", promptID), nil)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var vb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &vb))
+	version := vb["promptVersion"].(map[string]any)["version"].(string)
+	assert.Equal(t, "1", version)
+
+	// Get version
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/prompts/%s/versions/%s", promptID, version), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List versions
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/prompts/%s/versions", promptID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["promptVersionSummaries"], 1)
+
+	// Delete version
+	rec = doAgentRequest(t, h, http.MethodDelete,
+		fmt.Sprintf("/prompts/%s/versions/%s", promptID, version), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Agent Versions
+// ---------------------------------------------------------------------------
+
+func TestAgentVersionCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create agent
+	rec := doAgentRequest(t, h, http.MethodPost, "/agents", map[string]any{
+		"agentName":            "av-agent",
+		"foundationModel":      "amazon.titan-text-express-v1",
+		"agentResourceRoleArn": "arn:aws:iam::000000000000:role/role",
+	})
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var ab map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ab))
+	agentID := ab["agent"].(map[string]any)["agentId"].(string)
+
+	// Create version
+	rec = doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/agents/%s/versions", agentID), nil)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	var vb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &vb))
+	version := vb["agentVersion"].(map[string]any)["agentVersion"].(string)
+	assert.Equal(t, "1", version)
+
+	// Get version
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/agents/%s/versions/%s", agentID, version), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List versions
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("/agents/%s/versions", agentID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["agentVersionSummaries"], 1)
+
+	// Delete version
+	rec = doAgentRequest(t, h, http.MethodDelete,
+		fmt.Sprintf("/agents/%s/versions/%s", agentID, version), nil)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Agent Collaborators
+// ---------------------------------------------------------------------------
+
+func TestAgentCollaboratorCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create agent
+	rec := doAgentRequest(t, h, http.MethodPost, "/agents", map[string]any{
+		"agentName":            "collab-agent",
+		"foundationModel":      "amazon.titan-text-express-v1",
+		"agentResourceRoleArn": "arn:aws:iam::000000000000:role/role",
+	})
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var ab map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ab))
+	agentID := ab["agent"].(map[string]any)["agentId"].(string)
+
+	collabPath := fmt.Sprintf(
+		"/agents/%s/agentversions/DRAFT/agentcollaborators", agentID)
+
+	// Associate collaborator
+	rec = doAgentRequest(t, h, http.MethodPost, collabPath, map[string]any{
+		"agentVersion":             "DRAFT",
+		"collaboratorArn":          "arn:aws:bedrock:us-east-1:000000000000:agent/other",
+		"relayConversationHistory": "TO_COLLABORATOR",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var cb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &cb))
+	collabID := cb["agentCollaborator"].(map[string]any)["collaboratorId"].(string)
+
+	// Get collaborator
+	rec = doAgentRequest(t, h, http.MethodGet,
+		fmt.Sprintf("%s/%s", collabPath, collabID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List collaborators
+	rec = doAgentRequest(t, h, http.MethodGet, collabPath, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["agentCollaboratorSummaries"], 1)
+
+	// Update collaborator
+	rec = doAgentRequest(t, h, http.MethodPut,
+		fmt.Sprintf("%s/%s", collabPath, collabID),
+		map[string]any{"relayConversationHistory": "DISABLED"},
+	)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Disassociate collaborator
+	rec = doAgentRequest(t, h, http.MethodDelete,
+		fmt.Sprintf("%s/%s", collabPath, collabID), nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// KB Documents
+// ---------------------------------------------------------------------------
+
+func TestKBDocumentsCRUD(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	kbID, dsID := createKBAndDS(t, h)
+	docPath := fmt.Sprintf("/knowledgebases/%s/datasources/%s/documents", kbID, dsID)
+
+	// Ingest documents
+	rec := doAgentRequest(t, h, http.MethodPost, docPath, map[string]any{
+		"documentIds": []string{"doc-1", "doc-2"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var ib map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ib))
+	assert.Len(t, ib["documents"], 2)
+
+	// List documents
+	rec = doAgentRequest(t, h, http.MethodGet, docPath, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	assert.Len(t, lb["documentDetails"], 2)
+
+	// Update documents
+	rec = doAgentRequest(t, h, http.MethodPut, docPath, map[string]any{
+		"documentIds": []string{"doc-1", "doc-3"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Delete documents
+	rec = doAgentRequest(t, h, http.MethodDelete, docPath, map[string]any{
+		"documentIds": []string{"doc-1"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Stop Ingestion Job
+// ---------------------------------------------------------------------------
+
+func TestStopIngestionJob(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	kbID, dsID := createKBAndDS(t, h)
+
+	// Start ingestion job
+	startRec := doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/knowledgebases/%s/datasources/%s/ingestionjobs", kbID, dsID),
+		map[string]any{},
+	)
+	require.Equal(t, http.StatusAccepted, startRec.Code)
+
+	var jb map[string]any
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &jb))
+	jobID := jb["ingestionJob"].(map[string]any)["ingestionJobId"].(string)
+
+	// Stop it
+	rec := doAgentRequest(t, h, http.MethodPost,
+		fmt.Sprintf("/knowledgebases/%s/datasources/%s/ingestionjobs/%s/stop",
+			kbID, dsID, jobID),
+		nil,
+	)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var sb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &sb))
+	assert.Equal(t, "STOPPED", sb["ingestionJob"].(map[string]any)["status"])
+}
+
+// ---------------------------------------------------------------------------
+// Resource Tags (agent-domain)
+// ---------------------------------------------------------------------------
+
+func TestAgentResourceTags(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	resourceArn := "arn:aws:bedrock-agent:us-east-1:000000000000:flow/flow-00000001"
+
+	// Tag
+	rec := doAgentRequest(t, h, http.MethodPost, "/tags/"+resourceArn, map[string]any{
+		"tags": map[string]string{"env": "prod", "team": "core"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List tags
+	rec = doAgentRequest(t, h, http.MethodGet, "/tags/"+resourceArn, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb))
+	tags := lb["tags"].(map[string]any)
+	assert.Equal(t, "prod", tags["env"])
+	assert.Equal(t, "core", tags["team"])
+
+	// Untag
+	rec = doAgentRequest(t, h, http.MethodDelete, "/tags/"+resourceArn, map[string]any{
+		"tagKeys": []string{"team"},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// List tags again — team should be gone
+	rec = doAgentRequest(t, h, http.MethodGet, "/tags/"+resourceArn, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var lb2 map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &lb2))
+	tags2 := lb2["tags"].(map[string]any)
+	assert.Equal(t, "prod", tags2["env"])
+	_, hasTeam := tags2["team"]
+	assert.False(t, hasTeam)
+}
+
+// ---------------------------------------------------------------------------
+// Agent Memory
+// ---------------------------------------------------------------------------
+
+func TestAgentMemory(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+
+	// Create agent
+	rec := doAgentRequest(t, h, http.MethodPost, "/agents", map[string]any{
+		"agentName":            "mem-agent",
+		"foundationModel":      "amazon.titan-text-express-v1",
+		"agentResourceRoleArn": "arn:aws:iam::000000000000:role/role",
+	})
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var ab map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ab))
+	agentID := ab["agent"].(map[string]any)["agentId"].(string)
+
+	memPath := fmt.Sprintf("/agents/%s/agentversions/DRAFT/memories", agentID)
+
+	// Get memory (empty)
+	rec = doAgentRequest(t, h, http.MethodGet, memPath+"?sessionId=s1", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Delete memory
+	rec = doAgentRequest(t, h, http.MethodDelete, memPath+"?sessionId=s1", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// GetSupportedOperations count
+// ---------------------------------------------------------------------------
+
+func TestAgentsHandler_SupportedOperationsCount(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestAgentsHandler(t)
+	ops := h.GetSupportedOperations()
+	// Should be at least 75 operations (33 original + 43 new)
+	assert.GreaterOrEqual(t, len(ops), 75)
+}


### PR DESCRIPTION
## Summary

Expands `AgentsHandler` (bedrock-agent API) from 32 → 79 supported operations with real stateful backends for 5 new resource types:

- **Flows (16)**: CreateFlow, GetFlow, ListFlows, UpdateFlow, DeleteFlow, PrepareFlow, CreateFlowAlias, GetFlowAlias, ListFlowAliases, UpdateFlowAlias, DeleteFlowAlias, CreateFlowVersion, GetFlowVersion, ListFlowVersions, DeleteFlowVersion, ValidateFlowDefinition
- **Prompts (9)**: CreatePrompt, GetPrompt, ListPrompts, UpdatePrompt, DeletePrompt, CreatePromptVersion, GetPromptVersion, ListPromptVersions, DeletePromptVersion
- **Agent Versions (4)**: CreateAgentVersion, GetAgentVersion, ListAgentVersions, DeleteAgentVersion
- **Agent Collaborators (5)**: AssociateAgentCollaborator, GetAgentCollaborator, ListAgentCollaborators, UpdateAgentCollaborator, DisassociateAgentCollaborator
- **KB Documents + misc (5)**: IngestKnowledgeBaseDocuments, ListKnowledgeBaseDocuments, DeleteKnowledgeBaseDocuments, StopIngestionJob, UpdateKnowledgeBaseDocuments
- **Agent Memory + Tags (8)**: GetAgentMemory, DeleteAgentMemory, TagResource, UntagResource, ListTagsForResource

New backend maps: flows, flowAliases, flowVersions, prompts, promptVersions, agentVersions, agentCollaborators, agentDocuments, agentMemories, agentTags.

New files: `backend_agents_batch3.go`, `handler_agents_batch3.go`, `handler_agents_batch3_test.go`. **golangci-lint: 0 issues.**

## Test plan

- [ ] `go test ./services/bedrock/... -timeout 120s` passes
- [ ] `golangci-lint run ./services/bedrock/...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)