### PR TITLE
feat(kms): AWS-accuracy audit batch-2 (go-78bt)

### DIFF
--- a/services/kms/backend.go
+++ b/services/kms/backend.go
@@ -343,6 +343,25 @@ func decryptData(blob []byte, encCtx map[string]string, km *keyMaterial) ([]byte
 	return decryptSymmetric(blob, encCtx, km)
 }
 
+// checkKeyMaterialExpiry returns ErrExpiredKeyMaterial if the key's imported material
+// has passed its ValidTo date. Must be called with at least a read lock held.
+func (*InMemoryBackend) checkKeyMaterialExpiry(key *Key) error {
+	if key.Origin != KeyOriginExternal {
+		return nil
+	}
+
+	if key.ExpirationModel != expirationModelExpires || key.ValidTo == 0 {
+		return nil
+	}
+
+	now := float64(time.Now().UnixNano()) / nanoToSeconds
+	if now >= key.ValidTo {
+		return fmt.Errorf("%w: key %q imported material has expired", ErrExpiredKeyMaterial, key.KeyID)
+	}
+
+	return nil
+}
+
 // requireKeyMaterial returns the key material for keyID or an error if absent.
 // Must be called with at least a read lock held.
 func (b *InMemoryBackend) requireKeyMaterial(keyID string) (*keyMaterial, error) {
@@ -618,6 +637,10 @@ func (b *InMemoryBackend) Encrypt(input *EncryptInput) (*EncryptOutput, error) {
 		return nil, fmt.Errorf("%w: key %q is not usable for encryption", ErrInvalidKeyUsage, key.KeyID)
 	}
 
+	if err = b.checkKeyMaterialExpiry(key); err != nil {
+		return nil, err
+	}
+
 	km, err := b.requireKeyMaterial(key.KeyID)
 	if err != nil {
 		return nil, err
@@ -707,6 +730,10 @@ func (b *InMemoryBackend) Decrypt(input *DecryptInput) (*DecryptOutput, error) {
 
 	if key.KeyUsage != KeyUsageEncryptDecrypt {
 		return nil, fmt.Errorf("%w: key %q is not usable for decryption", ErrInvalidKeyUsage, key.KeyID)
+	}
+
+	if err := b.checkKeyMaterialExpiry(key); err != nil {
+		return nil, err
 	}
 
 	km, err := b.requireKeyMaterial(key.KeyID)
@@ -2458,6 +2485,22 @@ func (b *InMemoryBackend) ImportKeyMaterial(input *ImportKeyMaterialInput) error
 	expModel := input.ExpirationModel
 	if expModel == "" {
 		expModel = expirationModelNoExpiry
+	}
+
+	// KEY_MATERIAL_EXPIRES requires a ValidTo timestamp.
+	if expModel == expirationModelExpires && input.ValidTo == 0 {
+		return fmt.Errorf(
+			"%w: ExpirationModel=%s requires ValidTo to be set",
+			ErrValidation, expirationModelExpires,
+		)
+	}
+
+	// KEY_MATERIAL_DOES_NOT_EXPIRE must not include a ValidTo timestamp.
+	if expModel == expirationModelNoExpiry && input.ValidTo > 0 {
+		return fmt.Errorf(
+			"%w: ExpirationModel=%s must not include ValidTo",
+			ErrValidation, expirationModelNoExpiry,
+		)
 	}
 
 	if input.ValidTo > 0 {

--- a/services/kms/backend.go
+++ b/services/kms/backend.go
@@ -2483,8 +2483,16 @@ func (b *InMemoryBackend) ImportKeyMaterial(input *ImportKeyMaterialInput) error
 
 	// Store expiration model and ValidTo for metadata and janitor enforcement.
 	expModel := input.ExpirationModel
+
+	// Infer default expiration model from context when not explicitly set:
+	// - if ValidTo is set but ExpirationModel is absent, default to KEY_MATERIAL_EXPIRES
+	// - if both are absent, default to KEY_MATERIAL_DOES_NOT_EXPIRE
 	if expModel == "" {
-		expModel = expirationModelNoExpiry
+		if input.ValidTo > 0 {
+			expModel = expirationModelExpires
+		} else {
+			expModel = expirationModelNoExpiry
+		}
 	}
 
 	// KEY_MATERIAL_EXPIRES requires a ValidTo timestamp.
@@ -2504,7 +2512,6 @@ func (b *InMemoryBackend) ImportKeyMaterial(input *ImportKeyMaterialInput) error
 	}
 
 	if input.ValidTo > 0 {
-		expModel = expirationModelExpires
 		key.ValidTo = input.ValidTo
 	} else {
 		key.ValidTo = 0

--- a/services/kms/batch2_audit_test.go
+++ b/services/kms/batch2_audit_test.go
@@ -1,0 +1,2466 @@
+package kms_test
+
+// batch2_audit_test.go — AWS-accuracy audit batch-2 for services/kms (go-78bt).
+// Covers edges beyond batch-1 (#1929): cross-region replica linkage, XKS lifecycle,
+// ECDH key agreement, ImportKeyMaterial ExpirationModel validation, GetParametersForImport,
+// multi-region state changes, rotation history, PendingDeletion lifecycle, ListAliases
+// by KeyId, retiring-principal grants, GrantTokens, and resource tagging.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/kms"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func b2newBackend(t *testing.T) *kms.InMemoryBackend {
+	t.Helper()
+
+	return kms.NewInMemoryBackend()
+}
+
+func b2newHandler(t *testing.T) *kms.Handler {
+	t.Helper()
+
+	return kms.NewHandler(kms.NewInMemoryBackend())
+}
+
+func b2mustCreateMultiRegionKey(t *testing.T, b *kms.InMemoryBackend) string {
+	t.Helper()
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		MultiRegion: true,
+		Description: "primary key",
+	})
+	require.NoError(t, err)
+
+	return out.KeyMetadata.KeyID
+}
+
+func b2mustCreateExternalKey(t *testing.T, b *kms.InMemoryBackend) string {
+	t.Helper()
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		Origin: "EXTERNAL",
+	})
+	require.NoError(t, err)
+
+	return out.KeyMetadata.KeyID
+}
+
+func b2mustCreateECKey(t *testing.T, b *kms.InMemoryBackend, spec string, usage string) string {
+	t.Helper()
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		KeySpec:  spec,
+		KeyUsage: usage,
+	})
+	require.NoError(t, err)
+
+	return out.KeyMetadata.KeyID
+}
+
+func b2importKeyMaterial(t *testing.T, b *kms.InMemoryBackend, keyID string) {
+	t.Helper()
+	mat := make([]byte, 32)
+	for i := range mat {
+		mat[i] = byte(i + 1)
+	}
+	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat,
+	}))
+}
+
+func b2postKMSOp(t *testing.T, h *kms.Handler, op, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "TrentService."+op)
+	c := e.NewContext(req, rec)
+	_ = h.Handler()(c)
+
+	return rec
+}
+
+// ── 1. ReplicateKey cross-region metadata sync ───────────────────────────────
+
+func TestBatch2_ReplicateKey_MetadataSync_Description(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         keyID,
+		ReplicaRegion: "us-west-2",
+		Description:   "replica description",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "replica description", out.ReplicaKeyMetadata.Description)
+}
+
+func TestBatch2_ReplicateKey_MetadataSync_InheritsDescription(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         keyID,
+		ReplicaRegion: "eu-west-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "primary key", out.ReplicaKeyMetadata.Description)
+}
+
+func TestBatch2_ReplicateKey_MetadataSync_KeySpecAndUsage(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         keyID,
+		ReplicaRegion: "ap-southeast-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "SYMMETRIC_DEFAULT", out.ReplicaKeyMetadata.KeySpec)
+	assert.Equal(t, kms.KeyUsageEncryptDecrypt, out.ReplicaKeyMetadata.KeyUsage)
+	assert.True(t, out.ReplicaKeyMetadata.MultiRegion)
+}
+
+func TestBatch2_ReplicateKey_SharedKeyMaterial_EncryptRoundtrip(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	replicaOut, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         primaryID,
+		ReplicaRegion: "us-east-2",
+	})
+	require.NoError(t, err)
+	replicaID := replicaOut.ReplicaKeyMetadata.KeyID
+
+	// Encrypt with primary key
+	enc, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:     primaryID,
+		Plaintext: []byte("shared secret"),
+	})
+	require.NoError(t, err)
+
+	// Decrypt with replica key (shared key material)
+	dec, err := b.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: enc.CiphertextBlob,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("shared secret"), dec.Plaintext)
+	_ = replicaID // used implicitly through shared material
+}
+
+func TestBatch2_ReplicateKey_PrimaryShowsReplica_InDescribeKey(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         primaryID,
+		ReplicaRegion: "eu-central-1",
+	})
+	require.NoError(t, err)
+	replicaID := out.ReplicaKeyMetadata.KeyID
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: primaryID})
+	require.NoError(t, err)
+	require.NotNil(t, desc.KeyMetadata.MultiRegionConfiguration)
+	assert.Equal(t, "PRIMARY", desc.KeyMetadata.MultiRegionConfiguration.MultiRegionKeyType)
+
+	replicaARNs := make([]string, 0)
+	for _, r := range desc.KeyMetadata.MultiRegionConfiguration.ReplicaKeys {
+		replicaARNs = append(replicaARNs, r.Arn)
+	}
+	assert.Contains(t, replicaARNs, out.ReplicaKeyMetadata.Arn)
+	_ = replicaID
+}
+
+func TestBatch2_ReplicateKey_ReplicaShowsPrimary_InDescribeKey(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         primaryID,
+		ReplicaRegion: "ap-northeast-1",
+	})
+	require.NoError(t, err)
+	replicaID := out.ReplicaKeyMetadata.KeyID
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: replicaID})
+	require.NoError(t, err)
+	assert.Equal(t, "REPLICA", desc.KeyMetadata.MultiRegionKeyType)
+}
+
+func TestBatch2_ReplicateKey_DisabledSource_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateMultiRegionKey(t, b)
+
+	require.NoError(t, b.DisableKey(&kms.DisableKeyInput{KeyID: keyID}))
+
+	_, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         keyID,
+		ReplicaRegion: "us-west-1",
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ReplicateKey_MultipleReplicas(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	regions := []string{"us-west-2", "eu-west-1", "ap-southeast-1"}
+	for _, region := range regions {
+		_, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+			KeyID:         primaryID,
+			ReplicaRegion: region,
+		})
+		require.NoError(t, err)
+	}
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: primaryID})
+	require.NoError(t, err)
+	assert.Len(t, desc.KeyMetadata.MultiRegionConfiguration.ReplicaKeys, 3)
+}
+
+// ── 2. ConnectCustomKeyStore + DisconnectCustomKeyStore edge cases ───────────
+
+func TestBatch2_ConnectCustomKeyStore_AlreadyConnected_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "my-hsm-store",
+	})
+	require.NoError(t, err)
+	storeID := out.CustomKeyStoreID
+
+	require.NoError(t, b.ConnectCustomKeyStore(&kms.ConnectCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	}))
+
+	err = b.ConnectCustomKeyStore(&kms.ConnectCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DisconnectCustomKeyStore_AlreadyDisconnected_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "my-hsm-store-2",
+	})
+	require.NoError(t, err)
+	storeID := out.CustomKeyStoreID
+
+	err = b.DisconnectCustomKeyStore(&kms.DisconnectCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ConnectCustomKeyStore_NotFound_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	err := b.ConnectCustomKeyStore(&kms.ConnectCustomKeyStoreInput{
+		CustomKeyStoreID: "nonexistent-id",
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DisconnectCustomKeyStore_NotFound_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	err := b.DisconnectCustomKeyStore(&kms.DisconnectCustomKeyStoreInput{
+		CustomKeyStoreID: "nonexistent-id",
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DeleteCustomKeyStore_WhileConnected_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "connected-store-delete-test",
+	})
+	require.NoError(t, err)
+	storeID := out.CustomKeyStoreID
+
+	require.NoError(t, b.ConnectCustomKeyStore(&kms.ConnectCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	}))
+
+	err = b.DeleteCustomKeyStore(&kms.DeleteCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_UpdateCustomKeyStore_RenameSucceeds(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "old-name",
+	})
+	require.NoError(t, err)
+	storeID := out.CustomKeyStoreID
+
+	require.NoError(t, b.UpdateCustomKeyStore(&kms.UpdateCustomKeyStoreInput{
+		CustomKeyStoreID:      storeID,
+		NewCustomKeyStoreName: "new-name",
+	}))
+
+	desc, err := b.DescribeCustomKeyStores(&kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.CustomKeyStores, 1)
+	assert.Equal(t, "new-name", desc.CustomKeyStores[0].CustomKeyStoreName)
+}
+
+// ── 3. External Key Store (XKS) lifecycle ────────────────────────────────────
+
+func TestBatch2_XKS_CreateWithExternalKeyStoreType(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "my-xks-store",
+		CustomKeyStoreType: "EXTERNAL_KEY_STORE",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.CustomKeyStoreID)
+}
+
+func TestBatch2_XKS_DescribeReturnsCorrectType(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "my-xks-describe",
+		CustomKeyStoreType: "EXTERNAL_KEY_STORE",
+	})
+	require.NoError(t, err)
+
+	desc, err := b.DescribeCustomKeyStores(&kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreID: out.CustomKeyStoreID,
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.CustomKeyStores, 1)
+	assert.Equal(t, "EXTERNAL_KEY_STORE", desc.CustomKeyStores[0].CustomKeyStoreType)
+}
+
+func TestBatch2_XKS_InvalidTypeRejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	_, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "bad-type-store",
+		CustomKeyStoreType: "INVALID_TYPE",
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_XKS_ConnectDisconnectLifecycle(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "xks-lifecycle",
+		CustomKeyStoreType: "EXTERNAL_KEY_STORE",
+	})
+	require.NoError(t, err)
+	storeID := out.CustomKeyStoreID
+
+	// Initial state is DISCONNECTED
+	desc, err := b.DescribeCustomKeyStores(&kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, kms.ConnectionStateDisconnected, desc.CustomKeyStores[0].ConnectionState)
+
+	require.NoError(t, b.ConnectCustomKeyStore(&kms.ConnectCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	}))
+
+	desc2, err := b.DescribeCustomKeyStores(&kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, kms.ConnectionStateConnected, desc2.CustomKeyStores[0].ConnectionState)
+
+	require.NoError(t, b.DisconnectCustomKeyStore(&kms.DisconnectCustomKeyStoreInput{
+		CustomKeyStoreID: storeID,
+	}))
+
+	desc3, err := b.DescribeCustomKeyStores(&kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreID: storeID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, kms.ConnectionStateDisconnected, desc3.CustomKeyStores[0].ConnectionState)
+}
+
+func TestBatch2_XKS_DescribeByName(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	_, err := b.CreateCustomKeyStore(&kms.CreateCustomKeyStoreInput{
+		CustomKeyStoreName: "my-xks-by-name",
+		CustomKeyStoreType: "EXTERNAL_KEY_STORE",
+	})
+	require.NoError(t, err)
+
+	desc, err := b.DescribeCustomKeyStores(&kms.DescribeCustomKeyStoresInput{
+		CustomKeyStoreName: "my-xks-by-name",
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.CustomKeyStores, 1)
+	assert.Equal(t, "my-xks-by-name", desc.CustomKeyStores[0].CustomKeyStoreName)
+}
+
+// ── 4. ECDH KeyAgreement / DeriveSharedSecret ────────────────────────────────
+
+func TestBatch2_DeriveSharedSecret_P256_Roundtrip(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	key1ID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+	key2ID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	pub1, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: key1ID})
+	require.NoError(t, err)
+	pub2, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: key2ID})
+	require.NoError(t, err)
+
+	// Derive shared secret from key1 with key2's public key
+	out1, err := b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 key1ID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             pub2.PublicKey,
+	})
+	require.NoError(t, err)
+
+	// Derive shared secret from key2 with key1's public key
+	out2, err := b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 key2ID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             pub1.PublicKey,
+	})
+	require.NoError(t, err)
+
+	// ECDH is commutative: both shared secrets must be identical
+	assert.Equal(t, out1.SharedSecret, out2.SharedSecret)
+}
+
+func TestBatch2_DeriveSharedSecret_P384_Roundtrip(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	key1ID := b2mustCreateECKey(t, b, "ECC_NIST_P384", kms.KeyUsageKeyAgreement)
+	key2ID := b2mustCreateECKey(t, b, "ECC_NIST_P384", kms.KeyUsageKeyAgreement)
+
+	pub2, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: key2ID})
+	require.NoError(t, err)
+
+	out, err := b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 key1ID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             pub2.PublicKey,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.SharedSecret)
+	assert.Equal(t, "ECDH", out.KeyAgreementAlgorithm)
+}
+
+func TestBatch2_DeriveSharedSecret_P521_Roundtrip(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	key1ID := b2mustCreateECKey(t, b, "ECC_NIST_P521", kms.KeyUsageKeyAgreement)
+	key2ID := b2mustCreateECKey(t, b, "ECC_NIST_P521", kms.KeyUsageKeyAgreement)
+
+	pub2, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: key2ID})
+	require.NoError(t, err)
+
+	out, err := b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 key1ID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             pub2.PublicKey,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.SharedSecret)
+}
+
+func TestBatch2_DeriveSharedSecret_WrongKeyUsage_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	// ECC SIGN_VERIFY key, not KEY_AGREEMENT
+	keyID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageSignVerify)
+	peerID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	pub, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: peerID})
+	require.NoError(t, err)
+
+	_, err = b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 keyID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             pub.PublicKey,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidKeyUsageException")
+}
+
+func TestBatch2_DeriveSharedSecret_DisabledKey_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	keyID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+	peerID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	require.NoError(t, b.DisableKey(&kms.DisableKeyInput{KeyID: keyID}))
+
+	pub, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: peerID})
+	require.NoError(t, err)
+
+	_, err = b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 keyID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             pub.PublicKey,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DeriveSharedSecret_InvalidPublicKey_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	keyID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	_, err := b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 keyID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             []byte("not a valid DER public key"),
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DeriveSharedSecret_WrongAlgorithm_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	keyID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+	peerID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	pub, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: peerID})
+	require.NoError(t, err)
+
+	_, err = b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 keyID,
+		KeyAgreementAlgorithm: "RSA_OAEP", // Wrong algorithm
+		PublicKey:             pub.PublicKey,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DeriveSharedSecret_EmptyPublicKey_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	keyID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	_, err := b.DeriveSharedSecret(&kms.DeriveSharedSecretInput{
+		KeyID:                 keyID,
+		KeyAgreementAlgorithm: "ECDH",
+		PublicKey:             nil,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_GetPublicKey_ReturnsKeyAgreementAlgorithms(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	keyID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	out, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Contains(t, out.KeyAgreementAlgorithms, "ECDH")
+	assert.Empty(t, out.SigningAlgorithms)
+	assert.Empty(t, out.EncryptionAlgorithms)
+}
+
+// ── 5. ImportKeyMaterial validation + ExpirationModel ────────────────────────
+
+func TestBatch2_ImportKeyMaterial_ExpiresModel_RequiresValidTo(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	mat := make([]byte, 32)
+	err := b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:           keyID,
+		KeyMaterial:     mat,
+		ExpirationModel: "KEY_MATERIAL_EXPIRES",
+		ValidTo:         0, // missing
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ValidationException")
+}
+
+func TestBatch2_ImportKeyMaterial_NoExpiryModel_RejectsValidTo(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	mat := make([]byte, 32)
+	futureTs := float64(time.Now().Add(24 * time.Hour).UnixNano()) / 1e9
+	err := b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:           keyID,
+		KeyMaterial:     mat,
+		ExpirationModel: "KEY_MATERIAL_DOES_NOT_EXPIRE",
+		ValidTo:         futureTs,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ValidationException")
+}
+
+func TestBatch2_ImportKeyMaterial_WithValidTo_ExpiresModel(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	mat := make([]byte, 32)
+	futureTs := float64(time.Now().Add(24 * time.Hour).UnixNano()) / 1e9
+	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat,
+		ValidTo:     futureTs,
+	}))
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, "KEY_MATERIAL_EXPIRES", desc.KeyMetadata.ExpirationModel)
+	assert.Greater(t, desc.KeyMetadata.ValidTo, float64(0))
+}
+
+func TestBatch2_ImportKeyMaterial_NoValidTo_NoExpiryModel(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	b2importKeyMaterial(t, b, keyID)
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, "KEY_MATERIAL_DOES_NOT_EXPIRE", desc.KeyMetadata.ExpirationModel)
+	assert.Equal(t, float64(0), desc.KeyMetadata.ValidTo)
+}
+
+func TestBatch2_ImportKeyMaterial_ReImport_ReplacesExisting(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	mat1 := make([]byte, 32)
+	for i := range mat1 {
+		mat1[i] = byte(i + 1)
+	}
+	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat1,
+	}))
+
+	// Delete imported material
+	require.NoError(t, b.DeleteImportedKeyMaterial(&kms.DeleteImportedKeyMaterialInput{
+		KeyID: keyID,
+	}))
+
+	// Re-import with different material
+	mat2 := make([]byte, 32)
+	for i := range mat2 {
+		mat2[i] = byte(i + 100)
+	}
+	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat2,
+	}))
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, kms.KeyStateEnabled, desc.KeyMetadata.KeyState)
+}
+
+func TestBatch2_ImportKeyMaterial_ExpiredMaterial_BlocksEncrypt(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	// Import with past ValidTo (already expired)
+	pastTs := float64(time.Now().Add(-1 * time.Hour).UnixNano()) / 1e9
+
+	// Import must succeed (we allow setting past ValidTo for testing)
+	mat := make([]byte, 32)
+	for i := range mat {
+		mat[i] = byte(i + 1)
+	}
+	// The backend's expiry check is inline on Encrypt, not on Import.
+	// So first import successfully with a past-time ValidTo via direct struct manipulation.
+	// AWS validates ValidTo > now on import; our mock doesn't to stay testable.
+	// We test the inline expiry check by first importing with future ts, then time-rolling.
+	// Instead: import with explicit expires model + past ValidTo to verify Encrypt blocks.
+
+	// Use backdated timestamp so it looks expired
+	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat,
+		ValidTo:     pastTs,
+	}))
+
+	// Encrypt should fail because the material is past its ValidTo
+	_, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("test"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestBatch2_ImportKeyMaterial_NonExternalOrigin_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	mat := make([]byte, 32)
+	err = b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ImportKeyMaterial_WrongSize_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	mat := make([]byte, 16) // too short, need 32
+	err := b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
+		KeyID:       keyID,
+		KeyMaterial: mat,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_DeleteImportedKeyMaterial_TransitionsToPendingImport(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	b2importKeyMaterial(t, b, keyID)
+
+	require.NoError(t, b.DeleteImportedKeyMaterial(&kms.DeleteImportedKeyMaterialInput{
+		KeyID: keyID,
+	}))
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, kms.KeyStatePendingImport, desc.KeyMetadata.KeyState)
+	assert.False(t, desc.KeyMetadata.Enabled)
+}
+
+// ── 6. GetParametersForImport ─────────────────────────────────────────────────
+
+func TestBatch2_GetParametersForImport_ReturnsTokenAndKey(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	out, err := b.GetParametersForImport(&kms.GetParametersForImportInput{
+		KeyID: keyID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, keyID, out.KeyID)
+	assert.NotEmpty(t, out.ImportToken)
+	assert.NotEmpty(t, out.PublicKey)
+	assert.Greater(t, out.ParametersValidTo, float64(0))
+}
+
+func TestBatch2_GetParametersForImport_AWSOriginKey_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.GetParametersForImport(&kms.GetParametersForImportInput{
+		KeyID: keyID,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_GetParametersForImport_InvalidWrappingAlgorithm_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	_, err := b.GetParametersForImport(&kms.GetParametersForImportInput{
+		KeyID:             keyID,
+		WrappingAlgorithm: "INVALID_ALGO",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ValidationException")
+}
+
+func TestBatch2_GetParametersForImport_InvalidWrappingKeySpec_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	_, err := b.GetParametersForImport(&kms.GetParametersForImportInput{
+		KeyID:           keyID,
+		WrappingKeySpec: "ECC_NIST_P256",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ValidationException")
+}
+
+func TestBatch2_GetParametersForImport_ValidWrappingAlgorithms(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	algorithms := []string{
+		"RSAES_PKCS1_V1_5",
+		"RSAES_OAEP_SHA_1",
+		"RSAES_OAEP_SHA_256",
+		"RSA_AES_KEY_WRAP_SHA_1",
+		"RSA_AES_KEY_WRAP_SHA_256",
+	}
+
+	for _, algo := range algorithms {
+		algo := algo
+		t.Run(algo, func(t *testing.T) {
+			t.Parallel()
+			keyID := b2mustCreateExternalKey(t, b)
+			out, err := b.GetParametersForImport(&kms.GetParametersForImportInput{
+				KeyID:             keyID,
+				WrappingAlgorithm: algo,
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, out.ImportToken)
+		})
+	}
+}
+
+func TestBatch2_GetParametersForImport_ValidWrappingKeySpecs(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	specs := []string{"RSA_2048", "RSA_3072", "RSA_4096"}
+	for _, spec := range specs {
+		spec := spec
+		t.Run(spec, func(t *testing.T) {
+			t.Parallel()
+			keyID := b2mustCreateExternalKey(t, b)
+			out, err := b.GetParametersForImport(&kms.GetParametersForImportInput{
+				KeyID:           keyID,
+				WrappingKeySpec: spec,
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, out.PublicKey)
+		})
+	}
+}
+
+func TestBatch2_GetParametersForImport_ParametersValidToIsFuture(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	now := float64(time.Now().UnixNano()) / 1e9
+	out, err := b.GetParametersForImport(&kms.GetParametersForImportInput{
+		KeyID: keyID,
+	})
+	require.NoError(t, err)
+	assert.Greater(t, out.ParametersValidTo, now)
+}
+
+// ── 7. Multi-region primary/replica state changes ─────────────────────────────
+
+func TestBatch2_MultiRegion_PrimaryType_InDescribeKey(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateMultiRegionKey(t, b)
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, "PRIMARY", desc.KeyMetadata.MultiRegionKeyType)
+	assert.True(t, desc.KeyMetadata.MultiRegion)
+}
+
+func TestBatch2_MultiRegion_ReplicaType_AfterReplicate(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         primaryID,
+		ReplicaRegion: "us-west-2",
+	})
+	require.NoError(t, err)
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: out.ReplicaKeyMetadata.KeyID})
+	require.NoError(t, err)
+	assert.Equal(t, "REPLICA", desc.KeyMetadata.MultiRegionKeyType)
+}
+
+func TestBatch2_MultiRegion_PrimaryConfig_HasPrimaryAndReplicas(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         primaryID,
+		ReplicaRegion: "ap-east-1",
+	})
+	require.NoError(t, err)
+	_ = out
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: primaryID})
+	require.NoError(t, err)
+	mrConfig := desc.KeyMetadata.MultiRegionConfiguration
+	require.NotNil(t, mrConfig)
+	assert.NotNil(t, mrConfig.PrimaryKey)
+	assert.NotEmpty(t, mrConfig.ReplicaKeys)
+}
+
+func TestBatch2_MultiRegion_UpdatePrimaryRegion_ChangesType(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateMultiRegionKey(t, b)
+
+	require.NoError(t, b.UpdatePrimaryRegion(&kms.UpdatePrimaryRegionInput{
+		KeyID:         keyID,
+		PrimaryRegion: "us-west-2",
+	}))
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, "REPLICA", desc.KeyMetadata.MultiRegionKeyType)
+}
+
+func TestBatch2_MultiRegion_ReplicaEnableDisable_Independent(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+
+	out, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+		KeyID:         primaryID,
+		ReplicaRegion: "sa-east-1",
+	})
+	require.NoError(t, err)
+	replicaID := out.ReplicaKeyMetadata.KeyID
+
+	// Disable primary; replica should still be enabled
+	require.NoError(t, b.DisableKey(&kms.DisableKeyInput{KeyID: primaryID}))
+
+	replicaDesc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: replicaID})
+	require.NoError(t, err)
+	assert.Equal(t, kms.KeyStateEnabled, replicaDesc.KeyMetadata.KeyState)
+}
+
+// ── 8. Rotation history (Enable/Disable/GetStatus/ListKeyRotations) ──────────
+
+func TestBatch2_Rotation_CustomPeriodPreserved(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	period := int32(90)
+	require.NoError(t, b.EnableKeyRotation(&kms.EnableKeyRotationInput{
+		KeyID:                keyID,
+		RotationPeriodInDays: &period,
+	}))
+
+	status, err := b.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.True(t, status.KeyRotationEnabled)
+	assert.Equal(t, int32(90), status.RotationPeriodInDays)
+}
+
+func TestBatch2_Rotation_DisableKeyRotation_ClearsStatus(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	require.NoError(t, b.EnableKeyRotation(&kms.EnableKeyRotationInput{KeyID: keyID}))
+	require.NoError(t, b.DisableKeyRotation(&kms.DisableKeyRotationInput{KeyID: keyID}))
+
+	status, err := b.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.False(t, status.KeyRotationEnabled)
+}
+
+func TestBatch2_Rotation_NextRotationDate_SetAfterEnable(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	require.NoError(t, b.EnableKeyRotation(&kms.EnableKeyRotationInput{KeyID: keyID}))
+
+	now := float64(time.Now().UnixNano()) / 1e9
+	status, err := b.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Greater(t, status.NextRotationDate, now)
+}
+
+func TestBatch2_Rotation_ListKeyRotations_ContainsAutoRotationType(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	require.NoError(t, b.EnableKeyRotation(&kms.EnableKeyRotationInput{KeyID: keyID}))
+	_, err = b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
+	require.NoError(t, err)
+
+	rotList, err := b.ListKeyRotations(&kms.ListKeyRotationsInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.NotEmpty(t, rotList.Rotations)
+
+	types := make(map[string]bool)
+	for _, r := range rotList.Rotations {
+		types[r.RotationType] = true
+	}
+	assert.True(t, types["IMPORTED"], "on-demand rotation type should be present")
+}
+
+func TestBatch2_Rotation_ListKeyRotations_Pagination(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	// Perform multiple on-demand rotations
+	for i := 0; i < 5; i++ {
+		_, err := b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
+		require.NoError(t, err)
+	}
+
+	limit := int32(2)
+	first, err := b.ListKeyRotations(&kms.ListKeyRotationsInput{
+		KeyID: keyID,
+		Limit: &limit,
+	})
+	require.NoError(t, err)
+	assert.Len(t, first.Rotations, 2)
+	assert.True(t, first.Truncated)
+	assert.NotEmpty(t, first.NextMarker)
+
+	second, err := b.ListKeyRotations(&kms.ListKeyRotationsInput{
+		KeyID:  keyID,
+		Limit:  &limit,
+		Marker: first.NextMarker,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, second.Rotations)
+}
+
+func TestBatch2_Rotation_ExternalOriginKey_RotationRejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+	keyID := b2mustCreateExternalKey(t, b)
+
+	err := b.EnableKeyRotation(&kms.EnableKeyRotationInput{KeyID: keyID})
+	require.Error(t, err)
+}
+
+// ── 9. RotateKeyOnDemand ──────────────────────────────────────────────────────
+
+func TestBatch2_RotateKeyOnDemand_OldCiphertext_Decryptable(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	// Encrypt before rotation
+	enc, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("pre-rotation data"),
+	})
+	require.NoError(t, err)
+
+	_, err = b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
+	require.NoError(t, err)
+
+	// Should still decrypt after rotation
+	dec, err := b.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: enc.CiphertextBlob,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("pre-rotation data"), dec.Plaintext)
+}
+
+func TestBatch2_RotateKeyOnDemand_HMACKey_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		KeySpec:  "HMAC_256",
+		KeyUsage: kms.KeyUsageGenerateMac,
+	})
+	require.NoError(t, err)
+
+	_, err = b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: out.KeyMetadata.KeyID})
+	require.Error(t, err)
+}
+
+func TestBatch2_RotateKeyOnDemand_ReturnsKeyID(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	rotOut, err := b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, keyID, rotOut.KeyID)
+}
+
+func TestBatch2_RotateKeyOnDemand_GetKeyRotationStatus_HasOnDemandDate(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
+	require.NoError(t, err)
+
+	status, err := b.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Greater(t, status.OnDemandRotationStartDate, float64(0))
+}
+
+// ── 10. ScheduleKeyDeletion + CancelKeyDeletion lifecycle ────────────────────
+
+func TestBatch2_ScheduleKeyDeletion_BlocksEncrypt(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+
+	_, err = b.Encrypt(&kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("test"),
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ScheduleKeyDeletion_BlocksDecrypt(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	enc, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("test"),
+	})
+	require.NoError(t, err)
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+
+	_, err = b.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: enc.CiphertextBlob,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ScheduleKeyDeletion_MinWindow_7Days(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 6,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ScheduleKeyDeletion_MaxWindow_30Days(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 31,
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_ScheduleKeyDeletion_DeletionDateInFuture(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	now := float64(time.Now().UnixNano()) / 1e9
+	schedOut, err := b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+	assert.Greater(t, schedOut.DeletionDate, now)
+	assert.Equal(t, kms.KeyStatePendingDeletion, schedOut.KeyState)
+}
+
+func TestBatch2_CancelKeyDeletion_RestoresToDisabled(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+
+	cancelOut, err := b.CancelKeyDeletion(&kms.CancelKeyDeletionInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, kms.KeyStateDisabled, cancelOut.KeyState)
+}
+
+func TestBatch2_CancelKeyDeletion_AllowsReEnableAndEncrypt(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+
+	_, err = b.CancelKeyDeletion(&kms.CancelKeyDeletionInput{KeyID: keyID})
+	require.NoError(t, err)
+
+	require.NoError(t, b.EnableKey(&kms.EnableKeyInput{KeyID: keyID}))
+
+	_, err = b.Encrypt(&kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("after cancel"),
+	})
+	require.NoError(t, err)
+}
+
+func TestBatch2_ScheduleKeyDeletion_DefaultWindow_30Days(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	schedOut, err := b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID: keyID,
+		// No PendingWindowInDays → defaults to 30
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 30, schedOut.PendingWindowInDays)
+}
+
+func TestBatch2_ScheduleKeyDeletion_BlocksSign(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		KeySpec:  "RSA_2048",
+		KeyUsage: kms.KeyUsageSignVerify,
+	})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	_, err = b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+
+	_, err = b.Sign(&kms.SignInput{
+		KeyID:            keyID,
+		Message:          []byte("message"),
+		SigningAlgorithm: "RSASSA_PKCS1_V1_5_SHA_256",
+	})
+	require.Error(t, err)
+}
+
+// ── 11. UpdateKeyDescription ──────────────────────────────────────────────────
+
+func TestBatch2_UpdateKeyDescription_EmptyDescriptionAllowed(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{Description: "original"})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	require.NoError(t, b.UpdateKeyDescription(&kms.UpdateKeyDescriptionInput{
+		KeyID:       keyID,
+		Description: "",
+	}))
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, "", desc.KeyMetadata.Description)
+}
+
+func TestBatch2_UpdateKeyDescription_MaxLength_Accepted(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	maxDesc := make([]byte, 8192)
+	for i := range maxDesc {
+		maxDesc[i] = 'a'
+	}
+	require.NoError(t, b.UpdateKeyDescription(&kms.UpdateKeyDescriptionInput{
+		KeyID:       keyID,
+		Description: string(maxDesc),
+	}))
+}
+
+func TestBatch2_UpdateKeyDescription_ExceedsMaxLength_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	tooLong := make([]byte, 8193)
+	err = b.UpdateKeyDescription(&kms.UpdateKeyDescriptionInput{
+		KeyID:       keyID,
+		Description: string(tooLong),
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_UpdateKeyDescription_DescribeKeyReturnsUpdated(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	require.NoError(t, b.UpdateKeyDescription(&kms.UpdateKeyDescriptionInput{
+		KeyID:       keyID,
+		Description: "updated description",
+	}))
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Equal(t, "updated description", desc.KeyMetadata.Description)
+}
+
+// ── 12. ListAliases by KeyId ──────────────────────────────────────────────────
+
+func TestBatch2_ListAliases_FilterByKeyID_ReturnsOnlyMatching(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out1, _ := b.CreateKey(&kms.CreateKeyInput{})
+	out2, _ := b.CreateKey(&kms.CreateKeyInput{})
+	key1 := out1.KeyMetadata.KeyID
+	key2 := out2.KeyMetadata.KeyID
+
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/key1-a", TargetKeyID: key1}))
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/key1-b", TargetKeyID: key1}))
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/key2-a", TargetKeyID: key2}))
+
+	aliases, err := b.ListAliases(&kms.ListAliasesInput{KeyID: key1})
+	require.NoError(t, err)
+	assert.Len(t, aliases.Aliases, 2)
+	for _, a := range aliases.Aliases {
+		assert.Equal(t, key1, a.TargetKeyID)
+	}
+}
+
+func TestBatch2_ListAliases_NoFilter_ReturnsAll(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out1, _ := b.CreateKey(&kms.CreateKeyInput{})
+	out2, _ := b.CreateKey(&kms.CreateKeyInput{})
+
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/one", TargetKeyID: out1.KeyMetadata.KeyID}))
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/two", TargetKeyID: out2.KeyMetadata.KeyID}))
+
+	aliases, err := b.ListAliases(&kms.ListAliasesInput{})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(aliases.Aliases), 2)
+}
+
+func TestBatch2_ListAliases_NonMatchingKeyID_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	key1 := out.KeyMetadata.KeyID
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/unrelated", TargetKeyID: key1}))
+
+	out2, _ := b.CreateKey(&kms.CreateKeyInput{})
+	key2 := out2.KeyMetadata.KeyID // no aliases
+
+	aliases, err := b.ListAliases(&kms.ListAliasesInput{KeyID: key2})
+	require.NoError(t, err)
+	assert.Empty(t, aliases.Aliases)
+}
+
+func TestBatch2_ListAliases_Pagination(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("alias/pagtest-%d", i)
+		require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: name, TargetKeyID: keyID}))
+	}
+
+	limit := int32(2)
+	first, err := b.ListAliases(&kms.ListAliasesInput{Limit: &limit})
+	require.NoError(t, err)
+	assert.Len(t, first.Aliases, 2)
+	assert.True(t, first.Truncated)
+	assert.NotEmpty(t, first.NextMarker)
+
+	second, err := b.ListAliases(&kms.ListAliasesInput{Limit: &limit, Marker: first.NextMarker})
+	require.NoError(t, err)
+	assert.NotEmpty(t, second.Aliases)
+}
+
+func TestBatch2_ListAliases_ReturnsCreationAndUpdateDates(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/dated", TargetKeyID: keyID}))
+
+	aliases, err := b.ListAliases(&kms.ListAliasesInput{})
+	require.NoError(t, err)
+	require.NotEmpty(t, aliases.Aliases)
+	for _, a := range aliases.Aliases {
+		if a.AliasName == "alias/dated" {
+			assert.Greater(t, a.CreationDate, float64(0))
+		}
+	}
+}
+
+// ── 13. Grants with retiring principal ───────────────────────────────────────
+
+func TestBatch2_CreateGrant_WithRetiringPrincipal(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	grantOut, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:             keyID,
+		GranteePrincipal:  "arn:aws:iam::123456789012:role/grantee",
+		RetiringPrincipal: "arn:aws:iam::123456789012:role/retiree",
+		Operations:        []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, grantOut.GrantID)
+	assert.NotEmpty(t, grantOut.GrantToken)
+}
+
+func TestBatch2_ListRetirableGrants_ReturnsMatchingGrants(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	retiringPrincipal := "arn:aws:iam::123456789012:role/retiree"
+	_, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:             keyID,
+		GranteePrincipal:  "arn:aws:iam::123456789012:role/grantee",
+		RetiringPrincipal: retiringPrincipal,
+		Operations:        []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+
+	retList, err := b.ListRetirableGrants(&kms.ListRetirableGrantsInput{
+		RetiringPrincipal: retiringPrincipal,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, retList.Grants)
+	for _, g := range retList.Grants {
+		assert.Equal(t, retiringPrincipal, g.RetiringPrincipal)
+	}
+}
+
+func TestBatch2_ListRetirableGrants_DifferentPrincipal_NotReturned(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	_, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:             keyID,
+		GranteePrincipal:  "arn:aws:iam::123456789012:role/grantee",
+		RetiringPrincipal: "arn:aws:iam::123456789012:role/retiree-A",
+		Operations:        []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+
+	retList, err := b.ListRetirableGrants(&kms.ListRetirableGrantsInput{
+		RetiringPrincipal: "arn:aws:iam::123456789012:role/retiree-B",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, retList.Grants)
+}
+
+func TestBatch2_RetireGrant_ByGrantToken(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	grantOut, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:             keyID,
+		GranteePrincipal:  "arn:aws:iam::123456789012:role/grantee",
+		RetiringPrincipal: "arn:aws:iam::123456789012:role/retiree",
+		Operations:        []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, b.RetireGrant(&kms.RetireGrantInput{
+		GrantToken: grantOut.GrantToken,
+	}))
+
+	grants, err := b.ListGrants(&kms.ListGrantsInput{KeyID: keyID})
+	require.NoError(t, err)
+	for _, g := range grants.Grants {
+		assert.NotEqual(t, grantOut.GrantID, g.GrantID)
+	}
+}
+
+func TestBatch2_RetireGrant_ByGrantIDAndKeyID(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	grantOut, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:            keyID,
+		GranteePrincipal: "arn:aws:iam::123456789012:role/grantee",
+		Operations:       []string{"Decrypt"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, b.RetireGrant(&kms.RetireGrantInput{
+		KeyID:   keyID,
+		GrantID: grantOut.GrantID,
+	}))
+
+	grants, err := b.ListGrants(&kms.ListGrantsInput{KeyID: keyID})
+	require.NoError(t, err)
+	for _, g := range grants.Grants {
+		assert.NotEqual(t, grantOut.GrantID, g.GrantID)
+	}
+}
+
+func TestBatch2_ListGrants_FilterByGrantID(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	g1, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:            keyID,
+		GranteePrincipal: "arn:aws:iam::123456789012:role/grantee1",
+		Operations:       []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+	_, err = b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:            keyID,
+		GranteePrincipal: "arn:aws:iam::123456789012:role/grantee2",
+		Operations:       []string{"Decrypt"},
+	})
+	require.NoError(t, err)
+
+	grants, err := b.ListGrants(&kms.ListGrantsInput{
+		KeyID:   keyID,
+		GrantID: g1.GrantID,
+	})
+	require.NoError(t, err)
+	require.Len(t, grants.Grants, 1)
+	assert.Equal(t, g1.GrantID, grants.Grants[0].GrantID)
+}
+
+func TestBatch2_GrantName_Preserved(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	grantOut, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:            keyID,
+		GranteePrincipal: "arn:aws:iam::123456789012:role/grantee",
+		Name:             "my-named-grant",
+		Operations:       []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+
+	grants, err := b.ListGrants(&kms.ListGrantsInput{
+		KeyID:   keyID,
+		GrantID: grantOut.GrantID,
+	})
+	require.NoError(t, err)
+	require.Len(t, grants.Grants, 1)
+	assert.Equal(t, "my-named-grant", grants.Grants[0].Name)
+}
+
+// ── 14. GrantTokens in crypto operations ─────────────────────────────────────
+
+func TestBatch2_GrantTokens_ValidToken_Encrypt_Accepted(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	grantOut, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:            keyID,
+		GranteePrincipal: "arn:aws:iam::123456789012:role/grantee",
+		Operations:       []string{"Encrypt"},
+	})
+	require.NoError(t, err)
+
+	_, err = b.Encrypt(&kms.EncryptInput{
+		KeyID:       keyID,
+		Plaintext:   []byte("token test"),
+		GrantTokens: []string{grantOut.GrantToken},
+	})
+	require.NoError(t, err)
+}
+
+func TestBatch2_GrantTokens_ExpiredToken_Rejected(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	// Use an obviously invalid/expired token
+	_, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:       keyID,
+		Plaintext:   []byte("token test"),
+		GrantTokens: []string{"definitely-not-a-real-grant-token"},
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_GrantTokens_ValidToken_Decrypt_Accepted(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	enc, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("decrypt with token"),
+	})
+	require.NoError(t, err)
+
+	grantOut, err := b.CreateGrant(&kms.CreateGrantInput{
+		KeyID:            keyID,
+		GranteePrincipal: "arn:aws:iam::123456789012:role/grantee",
+		Operations:       []string{"Decrypt"},
+	})
+	require.NoError(t, err)
+
+	dec, err := b.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: enc.CiphertextBlob,
+		GrantTokens:    []string{grantOut.GrantToken},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("decrypt with token"), dec.Plaintext)
+}
+
+// ── 15. ResourceTagging ───────────────────────────────────────────────────────
+
+func TestBatch2_TagResource_AndListResourceTags_Roundtrip(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s","Tags":[{"TagKey":"env","TagValue":"prod"},{"TagKey":"team","TagValue":"platform"}]}`, keyID)
+	rec := b2postKMSOp(t, h, "TagResource", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	listBody := fmt.Sprintf(`{"KeyId":"%s"}`, keyID)
+	rec2 := b2postKMSOp(t, h, "ListResourceTags", listBody)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	var tagsResp struct {
+		Tags []struct {
+			TagKey   string `json:"TagKey"`
+			TagValue string `json:"TagValue"`
+		} `json:"Tags"`
+	}
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &tagsResp))
+	assert.Len(t, tagsResp.Tags, 2)
+}
+
+func TestBatch2_UntagResource_RemovesSpecifiedTags(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	tagBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[{"TagKey":"env","TagValue":"prod"},{"TagKey":"owner","TagValue":"alice"}]}`, keyID)
+	b2postKMSOp(t, h, "TagResource", tagBody)
+
+	untagBody := fmt.Sprintf(`{"KeyId":"%s","TagKeys":["owner"]}`, keyID)
+	rec := b2postKMSOp(t, h, "UntagResource", untagBody)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	listBody := fmt.Sprintf(`{"KeyId":"%s"}`, keyID)
+	rec2 := b2postKMSOp(t, h, "ListResourceTags", listBody)
+	var tagsResp struct {
+		Tags []struct {
+			TagKey string `json:"TagKey"`
+		} `json:"Tags"`
+	}
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &tagsResp))
+	keys := make([]string, 0, len(tagsResp.Tags))
+	for _, t := range tagsResp.Tags {
+		keys = append(keys, t.TagKey)
+	}
+	assert.Contains(t, keys, "env")
+	assert.NotContains(t, keys, "owner")
+}
+
+func TestBatch2_TagResource_AWSPrefixRejected(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s","Tags":[{"TagKey":"aws:reserved","TagValue":"x"}]}`, keyID)
+	rec := b2postKMSOp(t, h, "TagResource", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestBatch2_TagResource_MaxTagsLimit_Enforced(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	// Add 50 tags (the max)
+	tags := make([]string, 0, 50)
+	for i := 0; i < 50; i++ {
+		tags = append(tags, fmt.Sprintf(`{"TagKey":"key-%d","TagValue":"val"}`, i))
+	}
+	firstBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[%s]}`, keyID, strings.Join(tags, ","))
+	rec := b2postKMSOp(t, h, "TagResource", firstBody)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Adding one more should fail
+	overBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[{"TagKey":"overflow","TagValue":"x"}]}`, keyID)
+	rec2 := b2postKMSOp(t, h, "TagResource", overBody)
+	assert.Equal(t, http.StatusBadRequest, rec2.Code)
+}
+
+func TestBatch2_ListResourceTags_Pagination(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	// Add 10 tags
+	tags := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		tags = append(tags, fmt.Sprintf(`{"TagKey":"t-%d","TagValue":"v"}`, i))
+	}
+	addBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[%s]}`, keyID, strings.Join(tags, ","))
+	b2postKMSOp(t, h, "TagResource", addBody)
+
+	// Page with limit 3
+	listBody := fmt.Sprintf(`{"KeyId":"%s","Limit":3}`, keyID)
+	rec := b2postKMSOp(t, h, "ListResourceTags", listBody)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Tags      []interface{} `json:"Tags"`
+		Truncated bool          `json:"Truncated"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp.Tags, 3)
+	assert.True(t, resp.Truncated)
+}
+
+func TestBatch2_TagResource_NonExistentKey_Rejected(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+
+	body := `{"KeyId":"nonexistent-key","Tags":[{"TagKey":"k","TagValue":"v"}]}`
+	rec := b2postKMSOp(t, h, "TagResource", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestBatch2_UntagResource_NonExistentKey_Rejected(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+
+	body := `{"KeyId":"nonexistent-key","TagKeys":["k"]}`
+	rec := b2postKMSOp(t, h, "UntagResource", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ── 16. Handler-level tests ───────────────────────────────────────────────────
+
+func TestBatch2_Handler_XKS_CreateDescribeViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+
+	// Create XKS store
+	rec := b2postKMSOp(t, h, "CreateCustomKeyStore",
+		`{"CustomKeyStoreName":"xks-http","CustomKeyStoreType":"EXTERNAL_KEY_STORE"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var createResp struct {
+		CustomKeyStoreID string `json:"CustomKeyStoreId"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createResp))
+	assert.NotEmpty(t, createResp.CustomKeyStoreID)
+
+	// Describe the XKS store
+	descBody := fmt.Sprintf(`{"CustomKeyStoreId":"%s"}`, createResp.CustomKeyStoreID)
+	rec2 := b2postKMSOp(t, h, "DescribeCustomKeyStores", descBody)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	var descResp struct {
+		CustomKeyStores []struct {
+			CustomKeyStoreType string `json:"CustomKeyStoreType"`
+			ConnectionState    string `json:"ConnectionState"`
+		} `json:"CustomKeyStores"`
+	}
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &descResp))
+	require.Len(t, descResp.CustomKeyStores, 1)
+	assert.Equal(t, "EXTERNAL_KEY_STORE", descResp.CustomKeyStores[0].CustomKeyStoreType)
+	assert.Equal(t, kms.ConnectionStateDisconnected, descResp.CustomKeyStores[0].ConnectionState)
+}
+
+func TestBatch2_Handler_ReplicateKey_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	createOut, _ := b.CreateKey(&kms.CreateKeyInput{MultiRegion: true})
+	keyID := createOut.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s","ReplicaRegion":"eu-west-1"}`, keyID)
+	rec := b2postKMSOp(t, h, "ReplicateKey", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestBatch2_Handler_ScheduleKeyDeletion_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s","PendingWindowInDays":7}`, keyID)
+	rec := b2postKMSOp(t, h, "ScheduleKeyDeletion", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		KeyState string `json:"KeyState"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, kms.KeyStatePendingDeletion, resp.KeyState)
+}
+
+func TestBatch2_Handler_CancelKeyDeletion_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	_, err := b.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyID:               keyID,
+		PendingWindowInDays: 7,
+	})
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"KeyId":"%s"}`, keyID)
+	rec := b2postKMSOp(t, h, "CancelKeyDeletion", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		KeyState string `json:"KeyState"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, kms.KeyStateDisabled, resp.KeyState)
+}
+
+func TestBatch2_Handler_DeriveSharedSecret_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	key1ID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+	key2ID := b2mustCreateECKey(t, b, "ECC_NIST_P256", kms.KeyUsageKeyAgreement)
+
+	pub2, err := b.GetPublicKey(&kms.GetPublicKeyInput{KeyID: key2ID})
+	require.NoError(t, err)
+
+	// Encode public key as base64 for JSON
+	pubKeyB64 := encodeBase64(pub2.PublicKey)
+	body := fmt.Sprintf(`{"KeyId":"%s","KeyAgreementAlgorithm":"ECDH","PublicKey":"%s"}`, key1ID, pubKeyB64)
+	rec := b2postKMSOp(t, h, "DeriveSharedSecret", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestBatch2_Handler_ListAliases_FilterByKeyID_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{
+		AliasName:   "alias/filter-test",
+		TargetKeyID: keyID,
+	}))
+
+	body := fmt.Sprintf(`{"KeyId":"%s"}`, keyID)
+	rec := b2postKMSOp(t, h, "ListAliases", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Aliases []struct {
+			AliasName string `json:"AliasName"`
+		} `json:"Aliases"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Aliases)
+	for _, a := range resp.Aliases {
+		assert.Equal(t, "alias/filter-test", a.AliasName)
+	}
+}
+
+func TestBatch2_Handler_GetParametersForImport_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	keyID := b2mustCreateExternalKey(t, b)
+
+	body := fmt.Sprintf(`{"KeyId":"%s","WrappingAlgorithm":"RSAES_OAEP_SHA_256","WrappingKeySpec":"RSA_2048"}`, keyID)
+	rec := b2postKMSOp(t, h, "GetParametersForImport", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		KeyID             string  `json:"KeyId"`
+		ParametersValidTo float64 `json:"ParametersValidTo"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, keyID, resp.KeyID)
+	assert.Greater(t, resp.ParametersValidTo, float64(0))
+}
+
+func TestBatch2_Handler_ImportKeyMaterial_ExpirationValidation_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	keyID := b2mustCreateExternalKey(t, b)
+
+	mat := make([]byte, 32)
+	for i := range mat {
+		mat[i] = byte(i + 1)
+	}
+	matB64 := encodeBase64(mat)
+
+	// KEY_MATERIAL_EXPIRES without ValidTo should fail
+	body := fmt.Sprintf(`{"KeyId":"%s","KeyMaterial":"%s","ExpirationModel":"KEY_MATERIAL_EXPIRES"}`, keyID, matB64)
+	rec := b2postKMSOp(t, h, "ImportKeyMaterial", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestBatch2_Handler_RotateKeyOnDemand_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s"}`, keyID)
+	rec := b2postKMSOp(t, h, "RotateKeyOnDemand", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		KeyID string `json:"KeyId"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, keyID, resp.KeyID)
+}
+
+func TestBatch2_Handler_EnableKeyRotation_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s","RotationPeriodInDays":90}`, keyID)
+	rec := b2postKMSOp(t, h, "EnableKeyRotation", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify via GetKeyRotationStatus
+	statusBody := fmt.Sprintf(`{"KeyId":"%s"}`, keyID)
+	rec2 := b2postKMSOp(t, h, "GetKeyRotationStatus", statusBody)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	var status struct {
+		KeyRotationEnabled  bool  `json:"KeyRotationEnabled"`
+		RotationPeriodInDays int32 `json:"RotationPeriodInDays"`
+	}
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &status))
+	assert.True(t, status.KeyRotationEnabled)
+	assert.Equal(t, int32(90), status.RotationPeriodInDays)
+}
+
+func TestBatch2_Handler_CreateGrant_WithRetiringPrincipal_ViaHTTP(t *testing.T) {
+	t.Parallel()
+	h := b2newHandler(t)
+	b := h.Backend.(*kms.InMemoryBackend)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	body := fmt.Sprintf(`{"KeyId":"%s","GranteePrincipal":"arn:aws:iam::123456789012:role/grantee","RetiringPrincipal":"arn:aws:iam::123456789012:role/retiree","Operations":["Encrypt"]}`, keyID)
+	rec := b2postKMSOp(t, h, "CreateGrant", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		GrantID    string `json:"GrantId"`
+		GrantToken string `json:"GrantToken"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.GrantID)
+	assert.NotEmpty(t, resp.GrantToken)
+}
+
+// ── 17. Additional edge cases ─────────────────────────────────────────────────
+
+func TestBatch2_DescribeKey_AllFields_Populated(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		Description: "test key",
+		MultiRegion: true,
+	})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
+	require.NoError(t, err)
+	meta := desc.KeyMetadata
+	assert.NotEmpty(t, meta.KeyID)
+	assert.NotEmpty(t, meta.Arn)
+	assert.Equal(t, "test key", meta.Description)
+	assert.Equal(t, kms.KeyStateEnabled, meta.KeyState)
+	assert.Equal(t, kms.KeyUsageEncryptDecrypt, meta.KeyUsage)
+	assert.Equal(t, "CUSTOMER", meta.KeyManager)
+	assert.Equal(t, kms.KeyOriginAWSKMS, meta.Origin)
+	assert.Greater(t, meta.CreationDate, float64(0))
+	assert.True(t, meta.MultiRegion)
+}
+
+func TestBatch2_CreateKey_ECC_P384_KeyAgreement(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		KeySpec:  "ECC_NIST_P384",
+		KeyUsage: kms.KeyUsageKeyAgreement,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ECC_NIST_P384", out.KeyMetadata.KeySpec)
+	assert.Equal(t, kms.KeyUsageKeyAgreement, out.KeyMetadata.KeyUsage)
+}
+
+func TestBatch2_CreateKey_ECC_P521_KeyAgreement(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		KeySpec:  "ECC_NIST_P521",
+		KeyUsage: kms.KeyUsageKeyAgreement,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ECC_NIST_P521", out.KeyMetadata.KeySpec)
+}
+
+func TestBatch2_CreateKey_SignVerify_DefaultsToRSA2048(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, err := b.CreateKey(&kms.CreateKeyInput{
+		KeyUsage: kms.KeyUsageSignVerify,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "RSA_2048", out.KeyMetadata.KeySpec)
+}
+
+func TestBatch2_ListKeys_Pagination_MultiplePages(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	for i := 0; i < 5; i++ {
+		_, err := b.CreateKey(&kms.CreateKeyInput{})
+		require.NoError(t, err)
+	}
+
+	limit := int32(2)
+	first, err := b.ListKeys(&kms.ListKeysInput{Limit: &limit})
+	require.NoError(t, err)
+	assert.Len(t, first.Keys, 2)
+	assert.True(t, first.Truncated)
+
+	second, err := b.ListKeys(&kms.ListKeysInput{Limit: &limit, Marker: first.NextMarker})
+	require.NoError(t, err)
+	assert.NotEmpty(t, second.Keys)
+}
+
+func TestBatch2_RevokeGrant_NotFound_Error(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	err := b.RevokeGrant(&kms.RevokeGrantInput{
+		KeyID:   keyID,
+		GrantID: "nonexistent-grant-id",
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_PutKeyPolicy_AndGetKeyPolicy_Roundtrip(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"kms:*","Resource":"*"}]}`
+	require.NoError(t, b.PutKeyPolicy(&kms.PutKeyPolicyInput{
+		KeyID:      keyID,
+		PolicyName: "default",
+		Policy:     policy,
+	}))
+
+	policyOut, err := b.GetKeyPolicy(&kms.GetKeyPolicyInput{
+		KeyID:      keyID,
+		PolicyName: "default",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, policy, policyOut.Policy)
+}
+
+func TestBatch2_ListKeyPolicies_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	policies, err := b.ListKeyPolicies(&kms.ListKeyPoliciesInput{KeyID: keyID})
+	require.NoError(t, err)
+	assert.Contains(t, policies.PolicyNames, "default")
+}
+
+func TestBatch2_GenerateDataKeyPair_AllSpecs(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	specs := []string{"RSA_2048", "RSA_3072", "RSA_4096", "ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521"}
+	for _, spec := range specs {
+		spec := spec
+		t.Run(spec, func(t *testing.T) {
+			t.Parallel()
+			pairOut, err := b.GenerateDataKeyPair(&kms.GenerateDataKeyPairInput{
+				KeyID:       keyID,
+				KeyPairSpec: spec,
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, pairOut.PublicKey)
+			assert.NotEmpty(t, pairOut.PrivateKeyPlaintext)
+			assert.NotEmpty(t, pairOut.PrivateKeyCiphertextBlob)
+			assert.Equal(t, spec, pairOut.KeyPairSpec)
+		})
+	}
+}
+
+func TestBatch2_EncryptDecrypt_WithEncryptionContext_Roundtrip(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	ctx := map[string]string{"purpose": "batch2-test", "env": "staging"}
+	enc, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:             keyID,
+		Plaintext:         []byte("context-bound data"),
+		EncryptionContext: ctx,
+	})
+	require.NoError(t, err)
+
+	dec, err := b.Decrypt(&kms.DecryptInput{
+		CiphertextBlob:    enc.CiphertextBlob,
+		EncryptionContext: ctx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("context-bound data"), dec.Plaintext)
+}
+
+func TestBatch2_EncryptDecrypt_WrongContext_Fails(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	ctx := map[string]string{"purpose": "correct"}
+	enc, err := b.Encrypt(&kms.EncryptInput{
+		KeyID:             keyID,
+		Plaintext:         []byte("secret"),
+		EncryptionContext: ctx,
+	})
+	require.NoError(t, err)
+
+	_, err = b.Decrypt(&kms.DecryptInput{
+		CiphertextBlob:    enc.CiphertextBlob,
+		EncryptionContext: map[string]string{"purpose": "wrong"},
+	})
+	require.Error(t, err)
+}
+
+func TestBatch2_Concurrent_CreateGrant_And_ListGrants(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	out, _ := b.CreateKey(&kms.CreateKeyInput{})
+	keyID := out.KeyMetadata.KeyID
+
+	const workers = 5
+	errCh := make(chan error, workers*2)
+
+	for i := 0; i < workers; i++ {
+		go func(n int) {
+			_, err := b.CreateGrant(&kms.CreateGrantInput{
+				KeyID:            keyID,
+				GranteePrincipal: fmt.Sprintf("arn:aws:iam::123456789012:role/grantee-%d", n),
+				Operations:       []string{"Encrypt"},
+			})
+			errCh <- err
+		}(i)
+		go func() {
+			_, err := b.ListGrants(&kms.ListGrantsInput{KeyID: keyID})
+			errCh <- err
+		}()
+	}
+
+	for i := 0; i < workers*2; i++ {
+		err := <-errCh
+		assert.NoError(t, err)
+	}
+}
+
+func TestBatch2_Concurrent_ReplicateKey(t *testing.T) {
+	t.Parallel()
+	b := b2newBackend(t)
+
+	primaryID := b2mustCreateMultiRegionKey(t, b)
+	regions := []string{"us-west-2", "eu-west-1", "ap-southeast-1", "sa-east-1", "ca-central-1"}
+
+	errCh := make(chan error, len(regions))
+	for _, region := range regions {
+		region := region
+		go func() {
+			_, err := b.ReplicateKey(&kms.ReplicateKeyInput{
+				KeyID:         primaryID,
+				ReplicaRegion: region,
+			})
+			errCh <- err
+		}()
+	}
+
+	for range regions {
+		err := <-errCh
+		assert.NoError(t, err)
+	}
+
+	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: primaryID})
+	require.NoError(t, err)
+	assert.Len(t, desc.KeyMetadata.MultiRegionConfiguration.ReplicaKeys, len(regions))
+}
+
+// ── helpers for handler tests ─────────────────────────────────────────────────
+
+// encodeBase64 returns the standard base64-encoded string for a byte slice.
+func encodeBase64(data []byte) string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	if len(data) == 0 {
+		return ""
+	}
+
+	encoded := make([]byte, 0, ((len(data)+2)/3)*4)
+	for i := 0; i < len(data); i += 3 {
+		b0 := data[i]
+		var b1, b2 byte
+		if i+1 < len(data) {
+			b1 = data[i+1]
+		}
+		if i+2 < len(data) {
+			b2 = data[i+2]
+		}
+		encoded = append(encoded,
+			alphabet[b0>>2],
+			alphabet[((b0&0x3)<<4)|(b1>>4)],
+			alphabet[((b1&0xF)<<2)|(b2>>6)],
+			alphabet[b2&0x3F],
+		)
+	}
+	// Add padding
+	switch len(data) % 3 {
+	case 1:
+		encoded[len(encoded)-2] = '='
+		encoded[len(encoded)-1] = '='
+	case 2:
+		encoded[len(encoded)-1] = '='
+	}
+
+	return string(encoded)
+}
+

--- a/services/kms/batch2_audit_test.go
+++ b/services/kms/batch2_audit_test.go
@@ -183,7 +183,7 @@ func TestBatch2_ReplicateKey_PrimaryShowsReplica_InDescribeKey(t *testing.T) {
 	require.NotNil(t, desc.KeyMetadata.MultiRegionConfiguration)
 	assert.Equal(t, "PRIMARY", desc.KeyMetadata.MultiRegionConfiguration.MultiRegionKeyType)
 
-	replicaARNs := make([]string, 0)
+	replicaARNs := make([]string, 0, len(desc.KeyMetadata.MultiRegionConfiguration.ReplicaKeys))
 	for _, r := range desc.KeyMetadata.MultiRegionConfiguration.ReplicaKeys {
 		replicaARNs = append(replicaARNs, r.Arn)
 	}
@@ -638,12 +638,12 @@ func TestBatch2_ImportKeyMaterial_NoExpiryModel_RejectsValidTo(t *testing.T) {
 	keyID := b2mustCreateExternalKey(t, b)
 
 	mat := make([]byte, 32)
-	futureTs := float64(time.Now().Add(24 * time.Hour).UnixNano()) / 1e9
+	futureTS := float64(time.Now().Add(24*time.Hour).UnixNano()) / 1e9
 	err := b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
 		KeyID:           keyID,
 		KeyMaterial:     mat,
 		ExpirationModel: "KEY_MATERIAL_DOES_NOT_EXPIRE",
-		ValidTo:         futureTs,
+		ValidTo:         futureTS,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ValidationException")
@@ -655,11 +655,11 @@ func TestBatch2_ImportKeyMaterial_WithValidTo_ExpiresModel(t *testing.T) {
 	keyID := b2mustCreateExternalKey(t, b)
 
 	mat := make([]byte, 32)
-	futureTs := float64(time.Now().Add(24 * time.Hour).UnixNano()) / 1e9
+	futureTS := float64(time.Now().Add(24*time.Hour).UnixNano()) / 1e9
 	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
 		KeyID:       keyID,
 		KeyMaterial: mat,
-		ValidTo:     futureTs,
+		ValidTo:     futureTS,
 	}))
 
 	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
@@ -678,7 +678,7 @@ func TestBatch2_ImportKeyMaterial_NoValidTo_NoExpiryModel(t *testing.T) {
 	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
 	require.NoError(t, err)
 	assert.Equal(t, "KEY_MATERIAL_DOES_NOT_EXPIRE", desc.KeyMetadata.ExpirationModel)
-	assert.Equal(t, float64(0), desc.KeyMetadata.ValidTo)
+	assert.InDelta(t, float64(0), desc.KeyMetadata.ValidTo, 0)
 }
 
 func TestBatch2_ImportKeyMaterial_ReImport_ReplacesExisting(t *testing.T) {
@@ -721,7 +721,7 @@ func TestBatch2_ImportKeyMaterial_ExpiredMaterial_BlocksEncrypt(t *testing.T) {
 	keyID := b2mustCreateExternalKey(t, b)
 
 	// Import with past ValidTo (already expired)
-	pastTs := float64(time.Now().Add(-1 * time.Hour).UnixNano()) / 1e9
+	pastTS := float64(time.Now().Add(-1*time.Hour).UnixNano()) / 1e9
 
 	// Import must succeed (we allow setting past ValidTo for testing)
 	mat := make([]byte, 32)
@@ -738,7 +738,7 @@ func TestBatch2_ImportKeyMaterial_ExpiredMaterial_BlocksEncrypt(t *testing.T) {
 	require.NoError(t, b.ImportKeyMaterial(&kms.ImportKeyMaterialInput{
 		KeyID:       keyID,
 		KeyMaterial: mat,
-		ValidTo:     pastTs,
+		ValidTo:     pastTS,
 	}))
 
 	// Encrypt should fail because the material is past its ValidTo
@@ -866,7 +866,6 @@ func TestBatch2_GetParametersForImport_ValidWrappingAlgorithms(t *testing.T) {
 	}
 
 	for _, algo := range algorithms {
-		algo := algo
 		t.Run(algo, func(t *testing.T) {
 			t.Parallel()
 			keyID := b2mustCreateExternalKey(t, b)
@@ -886,7 +885,6 @@ func TestBatch2_GetParametersForImport_ValidWrappingKeySpecs(t *testing.T) {
 
 	specs := []string{"RSA_2048", "RSA_3072", "RSA_4096"}
 	for _, spec := range specs {
-		spec := spec
 		t.Run(spec, func(t *testing.T) {
 			t.Parallel()
 			keyID := b2mustCreateExternalKey(t, b)
@@ -1083,9 +1081,9 @@ func TestBatch2_Rotation_ListKeyRotations_Pagination(t *testing.T) {
 	keyID := out.KeyMetadata.KeyID
 
 	// Perform multiple on-demand rotations
-	for i := 0; i < 5; i++ {
-		_, err := b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
-		require.NoError(t, err)
+	for range 5 {
+		_, rotErr := b.RotateKeyOnDemand(&kms.RotateKeyOnDemandInput{KeyID: keyID})
+		require.NoError(t, rotErr)
 	}
 
 	limit := int32(2)
@@ -1387,7 +1385,7 @@ func TestBatch2_UpdateKeyDescription_EmptyDescriptionAllowed(t *testing.T) {
 
 	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: keyID})
 	require.NoError(t, err)
-	assert.Equal(t, "", desc.KeyMetadata.Description)
+	assert.Empty(t, desc.KeyMetadata.Description)
 }
 
 func TestBatch2_UpdateKeyDescription_MaxLength_Accepted(t *testing.T) {
@@ -1472,8 +1470,14 @@ func TestBatch2_ListAliases_NoFilter_ReturnsAll(t *testing.T) {
 	out1, _ := b.CreateKey(&kms.CreateKeyInput{})
 	out2, _ := b.CreateKey(&kms.CreateKeyInput{})
 
-	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/one", TargetKeyID: out1.KeyMetadata.KeyID}))
-	require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/two", TargetKeyID: out2.KeyMetadata.KeyID}))
+	require.NoError(
+		t,
+		b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/one", TargetKeyID: out1.KeyMetadata.KeyID}),
+	)
+	require.NoError(
+		t,
+		b.CreateAlias(&kms.CreateAliasInput{AliasName: "alias/two", TargetKeyID: out2.KeyMetadata.KeyID}),
+	)
 
 	aliases, err := b.ListAliases(&kms.ListAliasesInput{})
 	require.NoError(t, err)
@@ -1503,7 +1507,7 @@ func TestBatch2_ListAliases_Pagination(t *testing.T) {
 	out, _ := b.CreateKey(&kms.CreateKeyInput{})
 	keyID := out.KeyMetadata.KeyID
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		name := fmt.Sprintf("alias/pagtest-%d", i)
 		require.NoError(t, b.CreateAlias(&kms.CreateAliasInput{AliasName: name, TargetKeyID: keyID}))
 	}
@@ -1789,7 +1793,10 @@ func TestBatch2_TagResource_AndListResourceTags_Roundtrip(t *testing.T) {
 	out, _ := b.CreateKey(&kms.CreateKeyInput{})
 	keyID := out.KeyMetadata.KeyID
 
-	body := fmt.Sprintf(`{"KeyId":"%s","Tags":[{"TagKey":"env","TagValue":"prod"},{"TagKey":"team","TagValue":"platform"}]}`, keyID)
+	body := fmt.Sprintf(
+		`{"KeyId":"%s","Tags":[{"TagKey":"env","TagValue":"prod"},{"TagKey":"team","TagValue":"platform"}]}`,
+		keyID,
+	)
 	rec := b2postKMSOp(t, h, "TagResource", body)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -1815,7 +1822,10 @@ func TestBatch2_UntagResource_RemovesSpecifiedTags(t *testing.T) {
 	out, _ := b.CreateKey(&kms.CreateKeyInput{})
 	keyID := out.KeyMetadata.KeyID
 
-	tagBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[{"TagKey":"env","TagValue":"prod"},{"TagKey":"owner","TagValue":"alice"}]}`, keyID)
+	tagBody := fmt.Sprintf(
+		`{"KeyId":"%s","Tags":[{"TagKey":"env","TagValue":"prod"},{"TagKey":"owner","TagValue":"alice"}]}`,
+		keyID,
+	)
 	b2postKMSOp(t, h, "TagResource", tagBody)
 
 	untagBody := fmt.Sprintf(`{"KeyId":"%s","TagKeys":["owner"]}`, keyID)
@@ -1861,7 +1871,7 @@ func TestBatch2_TagResource_MaxTagsLimit_Enforced(t *testing.T) {
 
 	// Add 50 tags (the max)
 	tags := make([]string, 0, 50)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		tags = append(tags, fmt.Sprintf(`{"TagKey":"key-%d","TagValue":"val"}`, i))
 	}
 	firstBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[%s]}`, keyID, strings.Join(tags, ","))
@@ -1884,7 +1894,7 @@ func TestBatch2_ListResourceTags_Pagination(t *testing.T) {
 
 	// Add 10 tags
 	tags := make([]string, 0, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tags = append(tags, fmt.Sprintf(`{"TagKey":"t-%d","TagValue":"v"}`, i))
 	}
 	addBody := fmt.Sprintf(`{"KeyId":"%s","Tags":[%s]}`, keyID, strings.Join(tags, ","))
@@ -1896,8 +1906,8 @@ func TestBatch2_ListResourceTags_Pagination(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var resp struct {
-		Tags      []interface{} `json:"Tags"`
-		Truncated bool          `json:"Truncated"`
+		Tags      []any `json:"Tags"`
+		Truncated bool  `json:"Truncated"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp.Tags, 3)
@@ -2136,7 +2146,7 @@ func TestBatch2_Handler_EnableKeyRotation_ViaHTTP(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec2.Code)
 
 	var status struct {
-		KeyRotationEnabled  bool  `json:"KeyRotationEnabled"`
+		KeyRotationEnabled   bool  `json:"KeyRotationEnabled"`
 		RotationPeriodInDays int32 `json:"RotationPeriodInDays"`
 	}
 	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &status))
@@ -2152,7 +2162,11 @@ func TestBatch2_Handler_CreateGrant_WithRetiringPrincipal_ViaHTTP(t *testing.T) 
 	out, _ := b.CreateKey(&kms.CreateKeyInput{})
 	keyID := out.KeyMetadata.KeyID
 
-	body := fmt.Sprintf(`{"KeyId":"%s","GranteePrincipal":"arn:aws:iam::123456789012:role/grantee","RetiringPrincipal":"arn:aws:iam::123456789012:role/retiree","Operations":["Encrypt"]}`, keyID)
+	body := fmt.Sprintf(
+		`{"KeyId":"%s","GranteePrincipal":"arn:aws:iam::123456789012:role/grantee",`+
+			`"RetiringPrincipal":"arn:aws:iam::123456789012:role/retiree","Operations":["Encrypt"]}`,
+		keyID,
+	)
 	rec := b2postKMSOp(t, h, "CreateGrant", body)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -2232,7 +2246,7 @@ func TestBatch2_ListKeys_Pagination_MultiplePages(t *testing.T) {
 	t.Parallel()
 	b := b2newBackend(t)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_, err := b.CreateKey(&kms.CreateKeyInput{})
 		require.NoError(t, err)
 	}
@@ -2305,7 +2319,6 @@ func TestBatch2_GenerateDataKeyPair_AllSpecs(t *testing.T) {
 
 	specs := []string{"RSA_2048", "RSA_3072", "RSA_4096", "ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521"}
 	for _, spec := range specs {
-		spec := spec
 		t.Run(spec, func(t *testing.T) {
 			t.Parallel()
 			pairOut, err := b.GenerateDataKeyPair(&kms.GenerateDataKeyPairInput{
@@ -2376,7 +2389,7 @@ func TestBatch2_Concurrent_CreateGrant_And_ListGrants(t *testing.T) {
 	const workers = 5
 	errCh := make(chan error, workers*2)
 
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		go func(n int) {
 			_, err := b.CreateGrant(&kms.CreateGrantInput{
 				KeyID:            keyID,
@@ -2391,9 +2404,9 @@ func TestBatch2_Concurrent_CreateGrant_And_ListGrants(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < workers*2; i++ {
+	for range workers * 2 {
 		err := <-errCh
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -2406,7 +2419,6 @@ func TestBatch2_Concurrent_ReplicateKey(t *testing.T) {
 
 	errCh := make(chan error, len(regions))
 	for _, region := range regions {
-		region := region
 		go func() {
 			_, err := b.ReplicateKey(&kms.ReplicateKeyInput{
 				KeyID:         primaryID,
@@ -2418,7 +2430,7 @@ func TestBatch2_Concurrent_ReplicateKey(t *testing.T) {
 
 	for range regions {
 		err := <-errCh
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	desc, err := b.DescribeKey(&kms.DescribeKeyInput{KeyID: primaryID})
@@ -2463,4 +2475,3 @@ func encodeBase64(data []byte) string {
 
 	return string(encoded)
 }
-


### PR DESCRIPTION
KMS audit batch-2.

Closes #1680

- Replicate cross-region, CustomKeyStore, XKS, KeyAgreement, rotation history, asymmetric ECDH (sync.RWMutex)
- 2520 changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)