### PR TITLE
feat(cognitoidp): AWS-accuracy audit batch-2 (go-y4ew)

### DIFF
--- a/services/cognitoidp/accuracy_backend.go
+++ b/services/cognitoidp/accuracy_backend.go
@@ -378,7 +378,7 @@ func (b *InMemoryBackend) SignUpWithValidation(
 
 	for _, attr := range pool.AutoVerifiedAttributes {
 		if _, hasAttr := attrs[attr]; hasAttr {
-			attrs[attr+"_verified"] = "true"
+			attrs[attr+"_verified"] = attrVerifiedTrue
 			autoConfirmed = true
 		}
 	}

--- a/services/cognitoidp/backend.go
+++ b/services/cognitoidp/backend.go
@@ -124,6 +124,7 @@ type Group struct {
 	GroupName   string    `json:"groupName"`
 	UserPoolID  string    `json:"userPoolId"`
 	Description string    `json:"description,omitempty"`
+	RoleArn     string    `json:"roleArn,omitempty"`
 	Precedence  int32     `json:"precedence"`
 }
 
@@ -173,9 +174,15 @@ type InMemoryBackend struct {
 	terms map[string]*Terms
 	// userImportJobs maps poolID → jobID → UserImportJob
 	userImportJobs map[string]map[string]*UserImportJob
-	accountID      string
-	region         string
-	endpoint       string
+	// poolMfaConfigs maps poolID → full MFA config (SMS/TOTP/Email sub-configs)
+	poolMfaConfigs map[string]*UserPoolMfaFullConfig
+	// attrVerificationCodes maps poolID+":"+username+":"+attrName → pending verification entry
+	attrVerificationCodes map[string]*attrVerificationEntry
+	// typedRiskConfigurations maps poolID+":"+clientID → typed risk configuration
+	typedRiskConfigurations map[string]*TypedRiskConfiguration
+	accountID               string
+	region                  string
+	endpoint                string
 }
 
 // refreshTokenEntry holds the pool/user context for a refresh token.
@@ -240,12 +247,15 @@ func NewInMemoryBackend(accountID, region, endpoint string) *InMemoryBackend {
 		riskConfigurations:    make(map[string]*RiskConfiguration),
 		logDeliveryConfigs:    make(map[string]*LogDeliveryConfig),
 		uiCustomizations:      make(map[string]*UICustomization),
-		managedLoginBrandings: make(map[string]map[string]*ManagedLoginBranding),
-		terms:                 make(map[string]*Terms),
-		userImportJobs:        make(map[string]map[string]*UserImportJob),
-		accountID:             accountID,
-		region:                region,
-		endpoint:              endpoint,
+		managedLoginBrandings:   make(map[string]map[string]*ManagedLoginBranding),
+		terms:                   make(map[string]*Terms),
+		userImportJobs:          make(map[string]map[string]*UserImportJob),
+		poolMfaConfigs:          make(map[string]*UserPoolMfaFullConfig),
+		attrVerificationCodes:   make(map[string]*attrVerificationEntry),
+		typedRiskConfigurations: make(map[string]*TypedRiskConfiguration),
+		accountID:               accountID,
+		region:                  region,
+		endpoint:                endpoint,
 	}
 }
 

--- a/services/cognitoidp/backend.go
+++ b/services/cognitoidp/backend.go
@@ -226,27 +226,27 @@ const totpCodeLen = 6
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region, endpoint string) *InMemoryBackend {
 	return &InMemoryBackend{
-		mu:                    lockmetrics.New("cognitoidp"),
-		pools:                 make(map[string]*UserPool),
-		poolsByName:           make(map[string]*UserPool),
-		clients:               make(map[string]*UserPoolClient),
-		clientsByPool:         make(map[string]map[string]*UserPoolClient),
-		users:                 make(map[string]map[string]*User),
-		usersBySub:            make(map[string]string),
-		refreshTokens:         make(map[string]*refreshTokenEntry),
-		refreshTokensByClient: make(map[string]map[string]struct{}),
-		refreshTokensByUser:   make(map[string]map[string]struct{}),
-		mfaSessions:           make(map[string]*mfaSessionEntry),
-		groups:                make(map[string]map[string]*Group),
-		groupMembers:          make(map[string]map[string]map[string]struct{}),
-		resourceServers:       make(map[string]map[string]*ResourceServer),
-		tokenRevokedBefore:    make(map[string]time.Time),
-		identityProviders:     make(map[string]map[string]*IdentityProvider),
-		domains:               make(map[string]*UserPoolDomain),
-		resourceTags:          make(map[string]map[string]string),
-		riskConfigurations:    make(map[string]*RiskConfiguration),
-		logDeliveryConfigs:    make(map[string]*LogDeliveryConfig),
-		uiCustomizations:      make(map[string]*UICustomization),
+		mu:                      lockmetrics.New("cognitoidp"),
+		pools:                   make(map[string]*UserPool),
+		poolsByName:             make(map[string]*UserPool),
+		clients:                 make(map[string]*UserPoolClient),
+		clientsByPool:           make(map[string]map[string]*UserPoolClient),
+		users:                   make(map[string]map[string]*User),
+		usersBySub:              make(map[string]string),
+		refreshTokens:           make(map[string]*refreshTokenEntry),
+		refreshTokensByClient:   make(map[string]map[string]struct{}),
+		refreshTokensByUser:     make(map[string]map[string]struct{}),
+		mfaSessions:             make(map[string]*mfaSessionEntry),
+		groups:                  make(map[string]map[string]*Group),
+		groupMembers:            make(map[string]map[string]map[string]struct{}),
+		resourceServers:         make(map[string]map[string]*ResourceServer),
+		tokenRevokedBefore:      make(map[string]time.Time),
+		identityProviders:       make(map[string]map[string]*IdentityProvider),
+		domains:                 make(map[string]*UserPoolDomain),
+		resourceTags:            make(map[string]map[string]string),
+		riskConfigurations:      make(map[string]*RiskConfiguration),
+		logDeliveryConfigs:      make(map[string]*LogDeliveryConfig),
+		uiCustomizations:        make(map[string]*UICustomization),
 		managedLoginBrandings:   make(map[string]map[string]*ManagedLoginBranding),
 		terms:                   make(map[string]*Terms),
 		userImportJobs:          make(map[string]map[string]*UserImportJob),
@@ -1889,7 +1889,7 @@ func (b *InMemoryBackend) VerifyUserAttribute(accessToken, attributeName, _ stri
 
 	// Attribute name validation: must be a known verifiable attribute.
 	switch attributeName {
-	case attrEmail, "phone_number":
+	case attrEmail, attrPhoneNumber:
 		// valid
 	default:
 		return fmt.Errorf("%w: attribute %q is not verifiable", ErrInvalidUserPoolConfig, attributeName)

--- a/services/cognitoidp/batch2_backend.go
+++ b/services/cognitoidp/batch2_backend.go
@@ -116,7 +116,7 @@ type AccountTakeoverActions struct {
 
 // NotifyEmailType holds an email template for notifications.
 type NotifyEmailType struct {
-	HtmlBody string `json:"HtmlBody,omitempty"`
+	HTMLBody string `json:"HtmlBody,omitempty"`
 	Subject  string `json:"Subject,omitempty"`
 	TextBody string `json:"TextBody,omitempty"`
 }
@@ -204,7 +204,7 @@ func (b *InMemoryBackend) GetUserPoolMfaConfigFull(userPoolID string) (*UserPool
 // and stores it for later validation via VerifyUserAttributeWithCode.
 func (b *InMemoryBackend) GetUserAttributeVerificationCode(
 	accessToken, attributeName string,
-) (code, deliveryDest, deliveryMedium string, err error) {
+) (string, string, string, error) {
 	b.mu.Lock("GetUserAttributeVerificationCode")
 	defer b.mu.Unlock()
 
@@ -220,7 +220,7 @@ func (b *InMemoryBackend) GetUserAttributeVerificationCode(
 		return "", "", "", fmt.Errorf("%w: attribute %q is not verifiable", ErrInvalidParameter, attributeName)
 	}
 
-	code = randomAlphanumeric(attrVerificationCodeLen)
+	code := randomAlphanumeric(attrVerificationCodeLen)
 	key := user.UserPoolID + ":" + user.Username + ":" + attributeName
 
 	b.attrVerificationCodes[key] = &attrVerificationEntry{
@@ -236,6 +236,7 @@ func (b *InMemoryBackend) GetUserAttributeVerificationCode(
 		}
 		// Mask email: show first 2 chars + *** + domain.
 		dest = maskEmail(dest)
+
 		return code, dest, "EMAIL", nil
 	}
 
@@ -299,6 +300,7 @@ func maskEmail(email string) string {
 	for i, c := range email {
 		if c == '@' {
 			at = i
+
 			break
 		}
 	}
@@ -393,7 +395,7 @@ func (b *InMemoryBackend) SetUICustomizationFull(poolID, clientID, css, imageURL
 	}
 
 	existing.CSS = css
-	existing.ImageUrl = imageURL
+	existing.ImageURL = imageURL
 	existing.LastModifiedAt = now
 
 	cp := *existing

--- a/services/cognitoidp/batch2_backend.go
+++ b/services/cognitoidp/batch2_backend.go
@@ -1,0 +1,910 @@
+package cognitoidp
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ---------------------------------------------------------------------------
+// MFA Configuration Types
+// ---------------------------------------------------------------------------
+
+// SmsConfiguration holds the SNS topic ARN for SMS delivery.
+type SmsConfiguration struct {
+	SnsCallerArn string `json:"SnsCallerArn,omitempty"`
+	SnsRegion    string `json:"SnsRegion,omitempty"`
+	ExternalID   string `json:"ExternalId,omitempty"`
+}
+
+// SmsMfaConfiguration holds SMS MFA settings for a user pool.
+type SmsMfaConfiguration struct {
+	SmsAuthenticationMessage string            `json:"SmsAuthenticationMessage,omitempty"`
+	SmsConfiguration         *SmsConfiguration `json:"SmsConfiguration,omitempty"`
+}
+
+// SoftwareTokenMfaConfiguration holds TOTP MFA settings for a user pool.
+type SoftwareTokenMfaConfiguration struct {
+	Enabled bool `json:"Enabled"`
+}
+
+// EmailMfaConfiguration holds email OTP MFA settings for a user pool.
+type EmailMfaConfiguration struct {
+	Message string `json:"Message,omitempty"`
+	Subject string `json:"Subject,omitempty"`
+}
+
+// UserPoolMfaFullConfig holds the complete MFA configuration for a pool.
+type UserPoolMfaFullConfig struct {
+	MfaConfiguration       string
+	SmsMfaConfiguration    *SmsMfaConfiguration
+	SoftwareTokenMfa       *SoftwareTokenMfaConfiguration
+	EmailMfaConfiguration  *EmailMfaConfiguration
+}
+
+// ---------------------------------------------------------------------------
+// Attribute Verification Types
+// ---------------------------------------------------------------------------
+
+// attrVerificationEntry stores a pending attribute verification code.
+type attrVerificationEntry struct {
+	ExpiresAt time.Time
+	Code      string
+}
+
+// attrVerificationTTL is how long attribute verification codes remain valid.
+const attrVerificationTTL = 24 * time.Hour
+
+// attrVerificationCodeLen is the length of attribute verification codes.
+const attrVerificationCodeLen = 6
+
+// ---------------------------------------------------------------------------
+// Typed Risk Configuration
+// ---------------------------------------------------------------------------
+
+// CompromisedCredentialsActions defines what action to take for compromised credentials.
+type CompromisedCredentialsActions struct {
+	EventAction string `json:"EventAction"` // "BLOCK" | "NO_ACTION"
+}
+
+// CompromisedCredentialsRiskConfig holds the compromised credentials risk configuration.
+type CompromisedCredentialsRiskConfig struct {
+	EventFilter []string                       `json:"EventFilter,omitempty"`
+	Actions     *CompromisedCredentialsActions `json:"Actions,omitempty"`
+}
+
+// AccountTakeoverActionType defines an action for a specific risk level.
+type AccountTakeoverActionType struct {
+	Notify      bool   `json:"Notify"`
+	EventAction string `json:"EventAction"` // "BLOCK"|"MFA_IF_CONFIGURED"|"MFA_REQUIRED"|"NO_ACTION"
+}
+
+// AccountTakeoverActions defines actions per risk level.
+type AccountTakeoverActions struct {
+	LowAction    *AccountTakeoverActionType `json:"LowAction,omitempty"`
+	MediumAction *AccountTakeoverActionType `json:"MediumAction,omitempty"`
+	HighAction   *AccountTakeoverActionType `json:"HighAction,omitempty"`
+}
+
+// NotifyEmailType holds an email template for notifications.
+type NotifyEmailType struct {
+	HtmlBody string `json:"HtmlBody,omitempty"`
+	Subject  string `json:"Subject,omitempty"`
+	TextBody string `json:"TextBody,omitempty"`
+}
+
+// NotifyConfigurationType holds notification settings for account takeover.
+type NotifyConfigurationType struct {
+	From          string           `json:"From,omitempty"`
+	ReplyTo       string           `json:"ReplyTo,omitempty"`
+	SourceArn     string           `json:"SourceArn,omitempty"`
+	BlockEmail    *NotifyEmailType `json:"BlockEmail,omitempty"`
+	MfaEmail      *NotifyEmailType `json:"MfaEmail,omitempty"`
+	NoActionEmail *NotifyEmailType `json:"NoActionEmail,omitempty"`
+}
+
+// AccountTakeoverRiskConfig holds account takeover risk configuration.
+type AccountTakeoverRiskConfig struct {
+	Actions              *AccountTakeoverActions  `json:"Actions,omitempty"`
+	NotifyConfiguration  *NotifyConfigurationType `json:"NotifyConfiguration,omitempty"`
+}
+
+// TypedRiskConfiguration holds fully typed risk config fields.
+type TypedRiskConfiguration struct {
+	UserPoolID                            string
+	ClientID                              string
+	CompromisedCredentialsRiskConfig      *CompromisedCredentialsRiskConfig
+	AccountTakeoverRiskConfig             *AccountTakeoverRiskConfig
+	RiskExceptionConfiguration            map[string]any
+}
+
+// ---------------------------------------------------------------------------
+// UserPool extended MFA fields — added to UserPool struct via separate backing map
+// ---------------------------------------------------------------------------
+// We store MFA sub-configs in a separate map on the backend keyed by poolID
+// to avoid modifying the frozen UserPool struct in backend.go.
+
+// SetUserPoolMfaConfigFull stores the full MFA configuration for a pool.
+func (b *InMemoryBackend) SetUserPoolMfaConfigFull(userPoolID string, cfg UserPoolMfaFullConfig) error {
+	b.mu.Lock("SetUserPoolMfaConfigFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	pool := b.pools[userPoolID]
+	if cfg.MfaConfiguration != "" {
+		pool.MfaConfiguration = cfg.MfaConfiguration
+	}
+
+	b.poolMfaConfigs[userPoolID] = &cfg
+
+	return nil
+}
+
+// GetUserPoolMfaConfigFull returns the full MFA configuration for a pool.
+func (b *InMemoryBackend) GetUserPoolMfaConfigFull(userPoolID string) (*UserPoolMfaFullConfig, error) {
+	b.mu.RLock("GetUserPoolMfaConfigFull")
+	defer b.mu.RUnlock()
+
+	pool, ok := b.pools[userPoolID]
+	if !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	cfg, ok := b.poolMfaConfigs[userPoolID]
+	if !ok {
+		mfaVal := pool.MfaConfiguration
+		if mfaVal == "" {
+			mfaVal = "OFF"
+		}
+
+		return &UserPoolMfaFullConfig{MfaConfiguration: mfaVal}, nil
+	}
+
+	cp := *cfg
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// Attribute Verification — stateful
+// ---------------------------------------------------------------------------
+
+// GetUserAttributeVerificationCode generates a verification code for a user attribute
+// and stores it for later validation via VerifyUserAttributeWithCode.
+func (b *InMemoryBackend) GetUserAttributeVerificationCode(
+	accessToken, attributeName string,
+) (code, deliveryDest, deliveryMedium string, err error) {
+	b.mu.Lock("GetUserAttributeVerificationCode")
+	defer b.mu.Unlock()
+
+	user, verr := b.findUserByAccessTokenLocked(accessToken)
+	if verr != nil {
+		return "", "", "", verr
+	}
+
+	switch attributeName {
+	case attrEmail, "phone_number":
+		// valid verifiable attributes
+	default:
+		return "", "", "", fmt.Errorf("%w: attribute %q is not verifiable", ErrInvalidParameter, attributeName)
+	}
+
+	code = randomAlphanumeric(attrVerificationCodeLen)
+	key := user.UserPoolID + ":" + user.Username + ":" + attributeName
+
+	b.attrVerificationCodes[key] = &attrVerificationEntry{
+		Code:      code,
+		ExpiresAt: time.Now().Add(attrVerificationTTL),
+	}
+
+	// Determine delivery destination and medium.
+	if attributeName == attrEmail {
+		dest := user.Attributes[attrEmail]
+		if dest == "" {
+			dest = "unknown@example.com"
+		}
+		// Mask email: show first 2 chars + *** + domain.
+		dest = maskEmail(dest)
+		return code, dest, "EMAIL", nil
+	}
+
+	// phone_number
+	dest := user.Attributes["phone_number"]
+	if dest == "" {
+		dest = "+*******1234"
+	}
+
+	dest = maskPhone(dest)
+
+	return code, dest, "SMS", nil
+}
+
+// VerifyUserAttributeWithCode validates the code stored by GetUserAttributeVerificationCode
+// and marks the attribute as verified in the user record.
+func (b *InMemoryBackend) VerifyUserAttributeWithCode(accessToken, attributeName, code string) error {
+	b.mu.Lock("VerifyUserAttributeWithCode")
+	defer b.mu.Unlock()
+
+	user, err := b.findUserByAccessTokenLocked(accessToken)
+	if err != nil {
+		return err
+	}
+
+	switch attributeName {
+	case attrEmail, "phone_number":
+	default:
+		return fmt.Errorf("%w: attribute %q is not verifiable", ErrInvalidParameter, attributeName)
+	}
+
+	key := user.UserPoolID + ":" + user.Username + ":" + attributeName
+
+	entry, ok := b.attrVerificationCodes[key]
+	if !ok {
+		return fmt.Errorf("%w: no verification code found for attribute %q", ErrCodeMismatch, attributeName)
+	}
+
+	if time.Now().After(entry.ExpiresAt) {
+		delete(b.attrVerificationCodes, key)
+
+		return fmt.Errorf("%w: verification code for attribute %q has expired", ErrExpiredCode, attributeName)
+	}
+
+	if entry.Code != code {
+		return fmt.Errorf("%w: incorrect verification code for attribute %q", ErrCodeMismatch, attributeName)
+	}
+
+	delete(b.attrVerificationCodes, key)
+
+	// Mark attribute as verified.
+	user.Attributes[attributeName+"_verified"] = "true"
+	user.UpdatedAt = time.Now()
+
+	return nil
+}
+
+// maskEmail masks most of an email address for privacy.
+func maskEmail(email string) string {
+	at := -1
+	for i, c := range email {
+		if c == '@' {
+			at = i
+			break
+		}
+	}
+
+	if at <= 0 {
+		return "***@***"
+	}
+
+	prefix := email[:at]
+	domain := email[at:]
+
+	if len(prefix) <= 2 {
+		return prefix + "***" + domain
+	}
+
+	return prefix[:2] + "***" + domain
+}
+
+// maskPhone masks most of a phone number for privacy.
+func maskPhone(phone string) string {
+	if len(phone) <= 4 {
+		return "+*******"
+	}
+
+	return "+*******" + phone[len(phone)-4:]
+}
+
+// ---------------------------------------------------------------------------
+// Typed RiskConfiguration
+// ---------------------------------------------------------------------------
+
+// SetTypedRiskConfiguration stores a fully typed risk configuration for a pool or client.
+func (b *InMemoryBackend) SetTypedRiskConfiguration(cfg *TypedRiskConfiguration) error {
+	b.mu.Lock("SetTypedRiskConfiguration")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[cfg.UserPoolID]; !ok {
+		return fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, cfg.UserPoolID)
+	}
+
+	key := cfg.UserPoolID + ":" + cfg.ClientID
+	b.typedRiskConfigurations[key] = cfg
+
+	return nil
+}
+
+// GetTypedRiskConfiguration returns the typed risk configuration for a pool or client.
+func (b *InMemoryBackend) GetTypedRiskConfiguration(poolID, clientID string) (*TypedRiskConfiguration, error) {
+	b.mu.RLock("GetTypedRiskConfiguration")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.pools[poolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, poolID)
+	}
+
+	key := poolID + ":" + clientID
+
+	cfg, ok := b.typedRiskConfigurations[key]
+	if !ok {
+		return &TypedRiskConfiguration{UserPoolID: poolID, ClientID: clientID}, nil
+	}
+
+	cp := *cfg
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// UICustomization extended
+// ---------------------------------------------------------------------------
+
+// SetUICustomizationFull stores extended UI customization including image URL.
+func (b *InMemoryBackend) SetUICustomizationFull(poolID, clientID, css, imageURL string) (*UICustomization, error) {
+	b.mu.Lock("SetUICustomizationFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[poolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, poolID)
+	}
+
+	key := poolID + ":" + clientID
+	now := time.Now()
+
+	existing, ok := b.uiCustomizations[key]
+	if !ok {
+		existing = &UICustomization{
+			UserPoolID: poolID,
+			ClientID:   clientID,
+			CreatedAt:  now,
+		}
+		b.uiCustomizations[key] = existing
+	}
+
+	existing.CSS = css
+	existing.ImageUrl = imageURL
+	existing.LastModifiedAt = now
+
+	cp := *existing
+
+	return &cp, nil
+}
+
+// GetUICustomizationFull returns extended UI customization.
+func (b *InMemoryBackend) GetUICustomizationFull(poolID, clientID string) (*UICustomization, error) {
+	b.mu.RLock("GetUICustomizationFull")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.pools[poolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, poolID)
+	}
+
+	key := poolID + ":" + clientID
+
+	existing, ok := b.uiCustomizations[key]
+	if !ok {
+		return &UICustomization{UserPoolID: poolID, ClientID: clientID}, nil
+	}
+
+	cp := *existing
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// IdentityProvider extended — AttributeMapping and IdpIdentifiers
+// ---------------------------------------------------------------------------
+
+// CreateIdentityProviderFull creates an identity provider with AttributeMapping and IdpIdentifiers.
+func (b *InMemoryBackend) CreateIdentityProviderFull(
+	userPoolID, providerName, providerType string,
+	providerDetails map[string]string,
+	attributeMapping map[string]string,
+	idpIdentifiers []string,
+) (*IdentityProvider, error) {
+	b.mu.Lock("CreateIdentityProviderFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	if b.identityProviders[userPoolID] == nil {
+		b.identityProviders[userPoolID] = make(map[string]*IdentityProvider)
+	}
+
+	if _, exists := b.identityProviders[userPoolID][providerName]; exists {
+		return nil, fmt.Errorf("%w: identity provider %q already exists in pool %q",
+			ErrAlreadyExists, providerName, userPoolID)
+	}
+
+	now := time.Now()
+
+	details := make(map[string]string, len(providerDetails))
+	for k, v := range providerDetails {
+		details[k] = v
+	}
+
+	attrMap := make(map[string]string, len(attributeMapping))
+	for k, v := range attributeMapping {
+		attrMap[k] = v
+	}
+
+	ids := make([]string, len(idpIdentifiers))
+	copy(ids, idpIdentifiers)
+
+	idp := &IdentityProvider{
+		UserPoolID:       userPoolID,
+		ProviderName:     providerName,
+		ProviderType:     providerType,
+		ProviderDetails:  details,
+		AttributeMapping: attrMap,
+		IdpIdentifiers:   ids,
+		CreatedAt:        now,
+		LastModifiedAt:   now,
+	}
+
+	b.identityProviders[userPoolID][providerName] = idp
+
+	cp := *idp
+
+	return &cp, nil
+}
+
+// UpdateIdentityProviderFull updates an identity provider with AttributeMapping and IdpIdentifiers.
+func (b *InMemoryBackend) UpdateIdentityProviderFull(
+	userPoolID, providerName string,
+	providerDetails map[string]string,
+	attributeMapping map[string]string,
+	idpIdentifiers []string,
+) (*IdentityProvider, error) {
+	b.mu.Lock("UpdateIdentityProviderFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	idp, ok := b.identityProviders[userPoolID][providerName]
+	if !ok {
+		return nil, fmt.Errorf("%w: identity provider %q not found in pool %q",
+			ErrUserPoolNotFound, providerName, userPoolID)
+	}
+
+	if providerDetails != nil {
+		for k, v := range providerDetails {
+			idp.ProviderDetails[k] = v
+		}
+	}
+
+	if attributeMapping != nil {
+		if idp.AttributeMapping == nil {
+			idp.AttributeMapping = make(map[string]string)
+		}
+
+		for k, v := range attributeMapping {
+			idp.AttributeMapping[k] = v
+		}
+	}
+
+	if idpIdentifiers != nil {
+		ids := make([]string, len(idpIdentifiers))
+		copy(ids, idpIdentifiers)
+		idp.IdpIdentifiers = ids
+	}
+
+	idp.LastModifiedAt = time.Now()
+
+	cp := *idp
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// UserPoolDomain extended — CertificateArn for custom domains
+// ---------------------------------------------------------------------------
+
+// CreateUserPoolDomainFull creates a user pool domain with optional custom domain cert.
+func (b *InMemoryBackend) CreateUserPoolDomainFull(userPoolID, domain, certificateArn string) (*UserPoolDomain, error) {
+	b.mu.Lock("CreateUserPoolDomainFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	if _, exists := b.domains[domain]; exists {
+		return nil, fmt.Errorf("%w: domain %q already exists", ErrAlreadyExists, domain)
+	}
+
+	cfDomain := domain + ".auth." + b.region + ".amazoncognito.com"
+	if certificateArn != "" {
+		// Custom domain: generate a CloudFront distribution domain.
+		cfDomain = "d" + randomAlphanumeric(13) + ".cloudfront.net"
+	}
+
+	d := &UserPoolDomain{
+		Domain:                 domain,
+		UserPoolID:             userPoolID,
+		CloudFrontDistribution: cfDomain,
+		CertificateArn:         certificateArn,
+		Status:                 "ACTIVE",
+	}
+	b.domains[domain] = d
+
+	cp := *d
+
+	return &cp, nil
+}
+
+// UpdateUserPoolDomainFull updates a domain's certificate ARN and returns the CloudFront domain.
+func (b *InMemoryBackend) UpdateUserPoolDomainFull(userPoolID, domain, certificateArn string) (string, error) {
+	b.mu.Lock("UpdateUserPoolDomainFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return "", fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	d, ok := b.domains[domain]
+	if !ok {
+		return "", fmt.Errorf("%w: domain %q not found", ErrUserPoolNotFound, domain)
+	}
+
+	if certificateArn != "" {
+		d.CertificateArn = certificateArn
+		d.CloudFrontDistribution = "d" + randomAlphanumeric(13) + ".cloudfront.net"
+	}
+
+	return d.CloudFrontDistribution, nil
+}
+
+// ---------------------------------------------------------------------------
+// Group with RoleArn
+// ---------------------------------------------------------------------------
+
+// CreateGroupFull creates a group with a RoleArn.
+func (b *InMemoryBackend) CreateGroupFull(userPoolID, groupName, description, roleArn string, precedence int32) (*Group, error) {
+	b.mu.Lock("CreateGroupFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	if b.groups[userPoolID] == nil {
+		b.groups[userPoolID] = make(map[string]*Group)
+	}
+
+	if _, exists := b.groups[userPoolID][groupName]; exists {
+		return nil, fmt.Errorf("%w: group %q already exists in pool %q", ErrAlreadyExists, groupName, userPoolID)
+	}
+
+	g := &Group{
+		GroupName:   groupName,
+		UserPoolID:  userPoolID,
+		Description: description,
+		RoleArn:     roleArn,
+		Precedence:  precedence,
+		CreatedAt:   time.Now(),
+	}
+
+	b.groups[userPoolID][groupName] = g
+
+	if b.groupMembers[userPoolID] == nil {
+		b.groupMembers[userPoolID] = make(map[string]map[string]struct{})
+	}
+
+	b.groupMembers[userPoolID][groupName] = make(map[string]struct{})
+
+	cp := *g
+
+	return &cp, nil
+}
+
+// UpdateGroupFull updates group with description, roleArn, and precedence.
+func (b *InMemoryBackend) UpdateGroupFull(userPoolID, groupName, description, roleArn string, precedence int32) (*Group, error) {
+	b.mu.Lock("UpdateGroupFull")
+	defer b.mu.Unlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	g, ok := b.groups[userPoolID][groupName]
+	if !ok {
+		return nil, fmt.Errorf("%w: group %q not found in pool %q", ErrGroupNotFound, groupName, userPoolID)
+	}
+
+	if description != "" {
+		g.Description = description
+	}
+
+	if roleArn != "" {
+		g.RoleArn = roleArn
+	}
+
+	g.Precedence = precedence
+
+	cp := *g
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// AdminCreateUser with MessageAction
+// ---------------------------------------------------------------------------
+
+// AdminCreateUserFull creates a user with optional MessageAction (SUPPRESS/RESEND) and delivery mediums.
+func (b *InMemoryBackend) AdminCreateUserFull(
+	userPoolID, username, tempPassword string,
+	userAttributes map[string]string,
+	messageAction string,
+	desiredDeliveryMediums []string,
+	forceAliasCreation bool,
+) (*User, error) {
+	b.mu.Lock("AdminCreateUserFull")
+	defer b.mu.Unlock()
+
+	pool, ok := b.pools[userPoolID]
+	if !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	poolUsers, ok := b.users[userPoolID]
+	if !ok {
+		return nil, fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	if existing, exists := poolUsers[username]; exists {
+		if messageAction == "RESEND" {
+			// Re-send temp password to existing FORCE_CHANGE_PASSWORD user.
+			if existing.Status != UserStatusForceChangePassword {
+				return nil, fmt.Errorf("%w: user %q is not in FORCE_CHANGE_PASSWORD state", ErrInvalidParameter, username)
+			}
+
+			cp := *existing
+
+			return &cp, nil
+		}
+
+		return nil, fmt.Errorf("%w: user %q already exists", ErrUserAlreadyExists, username)
+	}
+
+	if tempPassword != "" {
+		if err := validatePassword(pool.PasswordPolicy, tempPassword); err != nil {
+			return nil, err
+		}
+	} else {
+		// Generate a temporary password.
+		tempPassword = randomAlphanumeric(12) + "Aa1!"
+	}
+
+	importHash, err := bcryptHashPassword(tempPassword)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := make(map[string]string, len(userAttributes))
+	for k, v := range userAttributes {
+		attrs[k] = v
+	}
+
+	if messageAction != "SUPPRESS" && tempPassword != "" {
+		attrs["custom:temporaryPassword"] = tempPassword
+	}
+
+	// Auto-verify attributes configured on the pool.
+	for _, attr := range pool.AutoVerifiedAttributes {
+		if _, hasAttr := attrs[attr]; hasAttr {
+			attrs[attr+"_verified"] = "true"
+		}
+	}
+
+	_ = desiredDeliveryMediums
+	_ = forceAliasCreation
+
+	user := &User{
+		Sub:          uuid.New().String(),
+		Username:     username,
+		UserPoolID:   userPoolID,
+		PasswordHash: importHash,
+		Status:       UserStatusForceChangePassword,
+		Attributes:   attrs,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+		Enabled:      true,
+	}
+
+	poolUsers[username] = user
+	b.usersBySub[userPoolID+":"+user.Sub] = username
+
+	cp := *user
+
+	return &cp, nil
+}
+
+// ---------------------------------------------------------------------------
+// AdminSetUserPassword — accurate permanent/temporary
+// ---------------------------------------------------------------------------
+
+// AdminSetUserPasswordFull sets password with proper status handling.
+// If permanent=true, status becomes CONFIRMED. If permanent=false, status remains FORCE_CHANGE_PASSWORD.
+func (b *InMemoryBackend) AdminSetUserPasswordFull(userPoolID, username, password string, permanent bool) error {
+	b.mu.Lock("AdminSetUserPasswordFull")
+	defer b.mu.Unlock()
+
+	pool, ok := b.pools[userPoolID]
+	if !ok {
+		return fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	if err := validatePassword(pool.PasswordPolicy, password); err != nil {
+		return err
+	}
+
+	user, ok := b.users[userPoolID][username]
+	if !ok {
+		return fmt.Errorf("%w: user %q not found", ErrUserNotFound, username)
+	}
+
+	hash, err := bcryptHashPassword(password)
+	if err != nil {
+		return err
+	}
+
+	user.PasswordHash = hash
+	user.UpdatedAt = time.Now()
+
+	if permanent {
+		user.Status = UserStatusConfirmed
+	} else {
+		user.Status = UserStatusForceChangePassword
+		user.Attributes["custom:temporaryPassword"] = password
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ListGroups with pagination
+// ---------------------------------------------------------------------------
+
+// ListGroupsPage returns a page of groups with optional NextToken pagination.
+func (b *InMemoryBackend) ListGroupsPage(userPoolID string, limit int, nextToken string) ([]*Group, string, error) {
+	b.mu.RLock("ListGroupsPage")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, "", fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	poolGroups := b.groups[userPoolID]
+	all := make([]*Group, 0, len(poolGroups))
+
+	for _, g := range poolGroups {
+		cp := *g
+		all = append(all, &cp)
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].GroupName < all[j].GroupName })
+
+	// Apply token-based pagination.
+	startIdx := 0
+
+	if nextToken != "" {
+		for i, g := range all {
+			if g.GroupName == nextToken {
+				startIdx = i
+
+				break
+			}
+		}
+	}
+
+	all = all[startIdx:]
+
+	if limit <= 0 || limit > len(all) {
+		return all, "", nil
+	}
+
+	page := all[:limit]
+	newToken := ""
+
+	if limit < len(all) {
+		newToken = all[limit].GroupName
+	}
+
+	return page, newToken, nil
+}
+
+// ListUsersInGroupPage returns a page of users in a group with optional NextToken pagination.
+func (b *InMemoryBackend) ListUsersInGroupPage(userPoolID, groupName string, limit int, nextToken string) ([]*User, string, error) {
+	b.mu.RLock("ListUsersInGroupPage")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.pools[userPoolID]; !ok {
+		return nil, "", fmt.Errorf("%w: pool %q not found", ErrUserPoolNotFound, userPoolID)
+	}
+
+	if _, ok := b.groups[userPoolID][groupName]; !ok {
+		return nil, "", fmt.Errorf("%w: group %q not found", ErrGroupNotFound, groupName)
+	}
+
+	members := b.groupMembers[userPoolID][groupName]
+	all := make([]*User, 0, len(members))
+
+	for username := range members {
+		if u, ok := b.users[userPoolID][username]; ok {
+			cp := *u
+			all = append(all, &cp)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].Username < all[j].Username })
+
+	startIdx := 0
+
+	if nextToken != "" {
+		for i, u := range all {
+			if u.Username == nextToken {
+				startIdx = i
+
+				break
+			}
+		}
+	}
+
+	all = all[startIdx:]
+
+	if limit <= 0 || limit > len(all) {
+		return all, "", nil
+	}
+
+	page := all[:limit]
+	newToken := ""
+
+	if limit < len(all) {
+		newToken = all[limit].Username
+	}
+
+	return page, newToken, nil
+}
+
+// ---------------------------------------------------------------------------
+// EvictExpiredAttrVerificationCodes removes expired attribute verification codes.
+// Called by the janitor.
+// ---------------------------------------------------------------------------
+
+func (b *InMemoryBackend) EvictExpiredAttrVerificationCodes() {
+	b.mu.Lock("EvictExpiredAttrVerificationCodes")
+	defer b.mu.Unlock()
+
+	now := time.Now()
+
+	for key, entry := range b.attrVerificationCodes {
+		if now.After(entry.ExpiresAt) {
+			delete(b.attrVerificationCodes, key)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// bcryptHashPassword hashes a password with bcrypt.
+func bcryptHashPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
+	if err != nil {
+		return "", fmt.Errorf("hashing password: %w", err)
+	}
+
+	return string(hash), nil
+}

--- a/services/cognitoidp/batch2_backend.go
+++ b/services/cognitoidp/batch2_backend.go
@@ -2,12 +2,19 @@ package cognitoidp
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// defaultTempPasswordSuffix is appended to ensure temp password meets basic complexity.
+const defaultTempPasswordSuffix = "Aa1!"
+
+// defaultTempPasswordPrefixLen is the length of the random prefix in generated temp passwords.
+const defaultTempPasswordPrefixLen = 12
 
 // ---------------------------------------------------------------------------
 // MFA Configuration Types
@@ -22,8 +29,8 @@ type SmsConfiguration struct {
 
 // SmsMfaConfiguration holds SMS MFA settings for a user pool.
 type SmsMfaConfiguration struct {
-	SmsAuthenticationMessage string            `json:"SmsAuthenticationMessage,omitempty"`
 	SmsConfiguration         *SmsConfiguration `json:"SmsConfiguration,omitempty"`
+	SmsAuthenticationMessage string            `json:"SmsAuthenticationMessage,omitempty"`
 }
 
 // SoftwareTokenMfaConfiguration holds TOTP MFA settings for a user pool.
@@ -39,10 +46,10 @@ type EmailMfaConfiguration struct {
 
 // UserPoolMfaFullConfig holds the complete MFA configuration for a pool.
 type UserPoolMfaFullConfig struct {
-	MfaConfiguration       string
-	SmsMfaConfiguration    *SmsMfaConfiguration
-	SoftwareTokenMfa       *SoftwareTokenMfaConfiguration
-	EmailMfaConfiguration  *EmailMfaConfiguration
+	SmsMfaConfiguration   *SmsMfaConfiguration
+	SoftwareTokenMfa      *SoftwareTokenMfaConfiguration
+	EmailMfaConfiguration *EmailMfaConfiguration
+	MfaConfiguration      string
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +68,24 @@ const attrVerificationTTL = 24 * time.Hour
 // attrVerificationCodeLen is the length of attribute verification codes.
 const attrVerificationCodeLen = 6
 
+// mfaConfigOFF is the default MFA configuration value when none is set.
+const mfaConfigOFF = "OFF"
+
+// attrPhoneNumber is the standard Cognito phone_number attribute name.
+const attrPhoneNumber = "phone_number"
+
+// attrVerifiedTrue is the string value for a verified attribute.
+const attrVerifiedTrue = "true"
+
+// maskEmailPrefixLen is the number of chars shown unmasked in an email prefix.
+const maskEmailPrefixLen = 2
+
+// maskPhoneVisibleSuffix is the number of phone digits shown unmasked at the end.
+const maskPhoneVisibleSuffix = 4
+
+// cloudFrontDistIDLen is the length of the random part in generated CloudFront distribution IDs.
+const cloudFrontDistIDLen = 13
+
 // ---------------------------------------------------------------------------
 // Typed Risk Configuration
 // ---------------------------------------------------------------------------
@@ -72,14 +97,14 @@ type CompromisedCredentialsActions struct {
 
 // CompromisedCredentialsRiskConfig holds the compromised credentials risk configuration.
 type CompromisedCredentialsRiskConfig struct {
-	EventFilter []string                       `json:"EventFilter,omitempty"`
 	Actions     *CompromisedCredentialsActions `json:"Actions,omitempty"`
+	EventFilter []string                       `json:"EventFilter,omitempty"`
 }
 
 // AccountTakeoverActionType defines an action for a specific risk level.
 type AccountTakeoverActionType struct {
+	EventAction string `json:"EventAction"`
 	Notify      bool   `json:"Notify"`
-	EventAction string `json:"EventAction"` // "BLOCK"|"MFA_IF_CONFIGURED"|"MFA_REQUIRED"|"NO_ACTION"
 }
 
 // AccountTakeoverActions defines actions per risk level.
@@ -98,27 +123,27 @@ type NotifyEmailType struct {
 
 // NotifyConfigurationType holds notification settings for account takeover.
 type NotifyConfigurationType struct {
-	From          string           `json:"From,omitempty"`
-	ReplyTo       string           `json:"ReplyTo,omitempty"`
-	SourceArn     string           `json:"SourceArn,omitempty"`
 	BlockEmail    *NotifyEmailType `json:"BlockEmail,omitempty"`
 	MfaEmail      *NotifyEmailType `json:"MfaEmail,omitempty"`
 	NoActionEmail *NotifyEmailType `json:"NoActionEmail,omitempty"`
+	From          string           `json:"From,omitempty"`
+	ReplyTo       string           `json:"ReplyTo,omitempty"`
+	SourceArn     string           `json:"SourceArn,omitempty"`
 }
 
 // AccountTakeoverRiskConfig holds account takeover risk configuration.
 type AccountTakeoverRiskConfig struct {
-	Actions              *AccountTakeoverActions  `json:"Actions,omitempty"`
-	NotifyConfiguration  *NotifyConfigurationType `json:"NotifyConfiguration,omitempty"`
+	Actions             *AccountTakeoverActions  `json:"Actions,omitempty"`
+	NotifyConfiguration *NotifyConfigurationType `json:"NotifyConfiguration,omitempty"`
 }
 
 // TypedRiskConfiguration holds fully typed risk config fields.
 type TypedRiskConfiguration struct {
-	UserPoolID                            string
-	ClientID                              string
-	CompromisedCredentialsRiskConfig      *CompromisedCredentialsRiskConfig
-	AccountTakeoverRiskConfig             *AccountTakeoverRiskConfig
-	RiskExceptionConfiguration            map[string]any
+	CompromisedCredentialsRiskConfig *CompromisedCredentialsRiskConfig
+	AccountTakeoverRiskConfig        *AccountTakeoverRiskConfig
+	RiskExceptionConfiguration       map[string]any
+	UserPoolID                       string
+	ClientID                         string
 }
 
 // ---------------------------------------------------------------------------
@@ -160,7 +185,7 @@ func (b *InMemoryBackend) GetUserPoolMfaConfigFull(userPoolID string) (*UserPool
 	if !ok {
 		mfaVal := pool.MfaConfiguration
 		if mfaVal == "" {
-			mfaVal = "OFF"
+			mfaVal = mfaConfigOFF
 		}
 
 		return &UserPoolMfaFullConfig{MfaConfiguration: mfaVal}, nil
@@ -189,7 +214,7 @@ func (b *InMemoryBackend) GetUserAttributeVerificationCode(
 	}
 
 	switch attributeName {
-	case attrEmail, "phone_number":
+	case attrEmail, attrPhoneNumber:
 		// valid verifiable attributes
 	default:
 		return "", "", "", fmt.Errorf("%w: attribute %q is not verifiable", ErrInvalidParameter, attributeName)
@@ -215,7 +240,7 @@ func (b *InMemoryBackend) GetUserAttributeVerificationCode(
 	}
 
 	// phone_number
-	dest := user.Attributes["phone_number"]
+	dest := user.Attributes[attrPhoneNumber]
 	if dest == "" {
 		dest = "+*******1234"
 	}
@@ -237,7 +262,7 @@ func (b *InMemoryBackend) VerifyUserAttributeWithCode(accessToken, attributeName
 	}
 
 	switch attributeName {
-	case attrEmail, "phone_number":
+	case attrEmail, attrPhoneNumber:
 	default:
 		return fmt.Errorf("%w: attribute %q is not verifiable", ErrInvalidParameter, attributeName)
 	}
@@ -262,7 +287,7 @@ func (b *InMemoryBackend) VerifyUserAttributeWithCode(accessToken, attributeName
 	delete(b.attrVerificationCodes, key)
 
 	// Mark attribute as verified.
-	user.Attributes[attributeName+"_verified"] = "true"
+	user.Attributes[attributeName+"_verified"] = attrVerifiedTrue
 	user.UpdatedAt = time.Now()
 
 	return nil
@@ -285,20 +310,20 @@ func maskEmail(email string) string {
 	prefix := email[:at]
 	domain := email[at:]
 
-	if len(prefix) <= 2 {
+	if len(prefix) <= maskEmailPrefixLen {
 		return prefix + "***" + domain
 	}
 
-	return prefix[:2] + "***" + domain
+	return prefix[:maskEmailPrefixLen] + "***" + domain
 }
 
 // maskPhone masks most of a phone number for privacy.
 func maskPhone(phone string) string {
-	if len(phone) <= 4 {
+	if len(phone) <= maskPhoneVisibleSuffix {
 		return "+*******"
 	}
 
-	return "+*******" + phone[len(phone)-4:]
+	return "+*******" + phone[len(phone)-maskPhoneVisibleSuffix:]
 }
 
 // ---------------------------------------------------------------------------
@@ -427,14 +452,10 @@ func (b *InMemoryBackend) CreateIdentityProviderFull(
 	now := time.Now()
 
 	details := make(map[string]string, len(providerDetails))
-	for k, v := range providerDetails {
-		details[k] = v
-	}
+	maps.Copy(details, providerDetails)
 
 	attrMap := make(map[string]string, len(attributeMapping))
-	for k, v := range attributeMapping {
-		attrMap[k] = v
-	}
+	maps.Copy(attrMap, attributeMapping)
 
 	ids := make([]string, len(idpIdentifiers))
 	copy(ids, idpIdentifiers)
@@ -478,9 +499,7 @@ func (b *InMemoryBackend) UpdateIdentityProviderFull(
 	}
 
 	if providerDetails != nil {
-		for k, v := range providerDetails {
-			idp.ProviderDetails[k] = v
-		}
+		maps.Copy(idp.ProviderDetails, providerDetails)
 	}
 
 	if attributeMapping != nil {
@@ -488,9 +507,7 @@ func (b *InMemoryBackend) UpdateIdentityProviderFull(
 			idp.AttributeMapping = make(map[string]string)
 		}
 
-		for k, v := range attributeMapping {
-			idp.AttributeMapping[k] = v
-		}
+		maps.Copy(idp.AttributeMapping, attributeMapping)
 	}
 
 	if idpIdentifiers != nil {
@@ -526,7 +543,7 @@ func (b *InMemoryBackend) CreateUserPoolDomainFull(userPoolID, domain, certifica
 	cfDomain := domain + ".auth." + b.region + ".amazoncognito.com"
 	if certificateArn != "" {
 		// Custom domain: generate a CloudFront distribution domain.
-		cfDomain = "d" + randomAlphanumeric(13) + ".cloudfront.net"
+		cfDomain = "d" + randomAlphanumeric(cloudFrontDistIDLen) + ".cloudfront.net"
 	}
 
 	d := &UserPoolDomain{
@@ -559,7 +576,7 @@ func (b *InMemoryBackend) UpdateUserPoolDomainFull(userPoolID, domain, certifica
 
 	if certificateArn != "" {
 		d.CertificateArn = certificateArn
-		d.CloudFrontDistribution = "d" + randomAlphanumeric(13) + ".cloudfront.net"
+		d.CloudFrontDistribution = "d" + randomAlphanumeric(cloudFrontDistIDLen) + ".cloudfront.net"
 	}
 
 	return d.CloudFrontDistribution, nil
@@ -570,7 +587,10 @@ func (b *InMemoryBackend) UpdateUserPoolDomainFull(userPoolID, domain, certifica
 // ---------------------------------------------------------------------------
 
 // CreateGroupFull creates a group with a RoleArn.
-func (b *InMemoryBackend) CreateGroupFull(userPoolID, groupName, description, roleArn string, precedence int32) (*Group, error) {
+func (b *InMemoryBackend) CreateGroupFull(
+	userPoolID, groupName, description, roleArn string,
+	precedence int32,
+) (*Group, error) {
 	b.mu.Lock("CreateGroupFull")
 	defer b.mu.Unlock()
 
@@ -609,7 +629,10 @@ func (b *InMemoryBackend) CreateGroupFull(userPoolID, groupName, description, ro
 }
 
 // UpdateGroupFull updates group with description, roleArn, and precedence.
-func (b *InMemoryBackend) UpdateGroupFull(userPoolID, groupName, description, roleArn string, precedence int32) (*Group, error) {
+func (b *InMemoryBackend) UpdateGroupFull(
+	userPoolID, groupName, description, roleArn string,
+	precedence int32,
+) (*Group, error) {
 	b.mu.Lock("UpdateGroupFull")
 	defer b.mu.Unlock()
 
@@ -666,7 +689,11 @@ func (b *InMemoryBackend) AdminCreateUserFull(
 		if messageAction == "RESEND" {
 			// Re-send temp password to existing FORCE_CHANGE_PASSWORD user.
 			if existing.Status != UserStatusForceChangePassword {
-				return nil, fmt.Errorf("%w: user %q is not in FORCE_CHANGE_PASSWORD state", ErrInvalidParameter, username)
+				return nil, fmt.Errorf(
+					"%w: user %q is not in FORCE_CHANGE_PASSWORD state",
+					ErrInvalidParameter,
+					username,
+				)
 			}
 
 			cp := *existing
@@ -683,7 +710,7 @@ func (b *InMemoryBackend) AdminCreateUserFull(
 		}
 	} else {
 		// Generate a temporary password.
-		tempPassword = randomAlphanumeric(12) + "Aa1!"
+		tempPassword = randomAlphanumeric(defaultTempPasswordPrefixLen) + defaultTempPasswordSuffix
 	}
 
 	importHash, err := bcryptHashPassword(tempPassword)
@@ -692,9 +719,7 @@ func (b *InMemoryBackend) AdminCreateUserFull(
 	}
 
 	attrs := make(map[string]string, len(userAttributes))
-	for k, v := range userAttributes {
-		attrs[k] = v
-	}
+	maps.Copy(attrs, userAttributes)
 
 	if messageAction != "SUPPRESS" && tempPassword != "" {
 		attrs["custom:temporaryPassword"] = tempPassword
@@ -703,7 +728,7 @@ func (b *InMemoryBackend) AdminCreateUserFull(
 	// Auto-verify attributes configured on the pool.
 	for _, attr := range pool.AutoVerifiedAttributes {
 		if _, hasAttr := attrs[attr]; hasAttr {
-			attrs[attr+"_verified"] = "true"
+			attrs[attr+"_verified"] = attrVerifiedTrue
 		}
 	}
 
@@ -825,7 +850,11 @@ func (b *InMemoryBackend) ListGroupsPage(userPoolID string, limit int, nextToken
 }
 
 // ListUsersInGroupPage returns a page of users in a group with optional NextToken pagination.
-func (b *InMemoryBackend) ListUsersInGroupPage(userPoolID, groupName string, limit int, nextToken string) ([]*User, string, error) {
+func (b *InMemoryBackend) ListUsersInGroupPage(
+	userPoolID, groupName string,
+	limit int,
+	nextToken string,
+) ([]*User, string, error) {
 	b.mu.RLock("ListUsersInGroupPage")
 	defer b.mu.RUnlock()
 

--- a/services/cognitoidp/batch2_handler.go
+++ b/services/cognitoidp/batch2_handler.go
@@ -217,7 +217,7 @@ type uiCustomizationJSON struct {
 	UserPoolID       string  `json:"UserPoolId"`
 	ClientID         string  `json:"ClientId,omitempty"`
 	CSS              string  `json:"CSS,omitempty"`
-	ImageUrl         string  `json:"ImageUrl,omitempty"`
+	ImageURL         string  `json:"ImageUrl,omitempty"`
 	CreationDate     float64 `json:"CreationDate,omitempty"`
 	LastModifiedDate float64 `json:"LastModifiedDate,omitempty"`
 }
@@ -264,7 +264,7 @@ func toUICustomizationJSON(ui *UICustomization) *uiCustomizationJSON {
 		UserPoolID: ui.UserPoolID,
 		ClientID:   ui.ClientID,
 		CSS:        ui.CSS,
-		ImageUrl:   ui.ImageUrl,
+		ImageURL:   ui.ImageURL,
 	}
 
 	if !ui.CreatedAt.IsZero() {
@@ -608,7 +608,7 @@ type accountTakeoverActionsJSON struct {
 }
 
 type notifyEmailTypeJSON struct {
-	HtmlBody string `json:"HtmlBody,omitempty"`
+	HTMLBody string `json:"HtmlBody,omitempty"`
 	Subject  string `json:"Subject,omitempty"`
 	TextBody string `json:"TextBody,omitempty"`
 }
@@ -816,7 +816,7 @@ func toNotifyConfigJSON(n *NotifyConfigurationType) *notifyConfigJSON {
 
 	if n.BlockEmail != nil {
 		out.BlockEmail = &notifyEmailTypeJSON{
-			HtmlBody: n.BlockEmail.HtmlBody,
+			HTMLBody: n.BlockEmail.HTMLBody,
 			Subject:  n.BlockEmail.Subject,
 			TextBody: n.BlockEmail.TextBody,
 		}
@@ -824,7 +824,7 @@ func toNotifyConfigJSON(n *NotifyConfigurationType) *notifyConfigJSON {
 
 	if n.MfaEmail != nil {
 		out.MfaEmail = &notifyEmailTypeJSON{
-			HtmlBody: n.MfaEmail.HtmlBody,
+			HTMLBody: n.MfaEmail.HTMLBody,
 			Subject:  n.MfaEmail.Subject,
 			TextBody: n.MfaEmail.TextBody,
 		}
@@ -832,7 +832,7 @@ func toNotifyConfigJSON(n *NotifyConfigurationType) *notifyConfigJSON {
 
 	if n.NoActionEmail != nil {
 		out.NoActionEmail = &notifyEmailTypeJSON{
-			HtmlBody: n.NoActionEmail.HtmlBody,
+			HTMLBody: n.NoActionEmail.HTMLBody,
 			Subject:  n.NoActionEmail.Subject,
 			TextBody: n.NoActionEmail.TextBody,
 		}
@@ -850,7 +850,7 @@ func fromNotifyConfigJSON(in *notifyConfigJSON) *NotifyConfigurationType {
 
 	if in.BlockEmail != nil {
 		out.BlockEmail = &NotifyEmailType{
-			HtmlBody: in.BlockEmail.HtmlBody,
+			HTMLBody: in.BlockEmail.HTMLBody,
 			Subject:  in.BlockEmail.Subject,
 			TextBody: in.BlockEmail.TextBody,
 		}
@@ -858,7 +858,7 @@ func fromNotifyConfigJSON(in *notifyConfigJSON) *NotifyConfigurationType {
 
 	if in.MfaEmail != nil {
 		out.MfaEmail = &NotifyEmailType{
-			HtmlBody: in.MfaEmail.HtmlBody,
+			HTMLBody: in.MfaEmail.HTMLBody,
 			Subject:  in.MfaEmail.Subject,
 			TextBody: in.MfaEmail.TextBody,
 		}
@@ -866,7 +866,7 @@ func fromNotifyConfigJSON(in *notifyConfigJSON) *NotifyConfigurationType {
 
 	if in.NoActionEmail != nil {
 		out.NoActionEmail = &NotifyEmailType{
-			HtmlBody: in.NoActionEmail.HtmlBody,
+			HTMLBody: in.NoActionEmail.HTMLBody,
 			Subject:  in.NoActionEmail.Subject,
 			TextBody: in.NoActionEmail.TextBody,
 		}

--- a/services/cognitoidp/batch2_handler.go
+++ b/services/cognitoidp/batch2_handler.go
@@ -12,28 +12,28 @@ import (
 // batch2DispatchTable returns dispatch entries that override the base table.
 func (h *Handler) batch2DispatchTable() map[string]service.JSONOpFunc {
 	return map[string]service.JSONOpFunc{
-		opGetUserPoolMfaConfig:         wrapAccuracy(h.handleGetUserPoolMfaConfigFull),
-		opSetUserPoolMfaConfig:         wrapAccuracy(h.handleSetUserPoolMfaConfigFull),
-		opGetUICustomization:           wrapAccuracy(h.handleGetUICustomizationFull),
-		opSetUICustomization:           wrapAccuracy(h.handleSetUICustomizationFull),
-		opGetUserAttributeVerifCode:    wrapAccuracy(h.handleGetUserAttributeVerificationCodeFull),
-		opVerifyUserAttribute:          wrapAccuracy(h.handleVerifyUserAttributeFull),
-		opCreateIdentityProvider:       wrapAccuracy(h.handleCreateIdentityProviderFull),
-		opUpdateIdentityProvider:       wrapAccuracy(h.handleUpdateIdentityProviderFull),
-		opDescribeIdentityProvider:     wrapAccuracy(h.handleDescribeIdentityProviderFull),
-		opGetIdentityProviderByIdent:   wrapAccuracy(h.handleGetIdentityProviderByIdentifierFull),
-		opListIdentityProviders:        wrapAccuracy(h.handleListIdentityProvidersFull),
-		opCreateUserPoolDomain:         wrapAccuracy(h.handleCreateUserPoolDomainFull),
-		opUpdateUserPoolDomain:         wrapAccuracy(h.handleUpdateUserPoolDomainFull),
-		opDescribeRiskConfiguration:    wrapAccuracy(h.handleDescribeRiskConfigurationFull),
-		opSetRiskConfiguration:         wrapAccuracy(h.handleSetRiskConfigurationFull),
-		opAdminCreateUser:              wrapAccuracy(h.handleAdminCreateUserFull),
-		opAdminSetUserPassword:         wrapAccuracy(h.handleAdminSetUserPasswordFull),
-		opCreateGroup:                  wrapAccuracy(h.handleCreateGroupFull),
-		opUpdateGroup:                  wrapAccuracy(h.handleUpdateGroupFull),
-		opGetGroup:                     wrapAccuracy(h.handleGetGroupFull),
-		opListGroups:                   wrapAccuracy(h.handleListGroupsFull),
-		opListUsersInGroup:             wrapAccuracy(h.handleListUsersInGroupFull),
+		opGetUserPoolMfaConfig:       wrapAccuracy(h.handleGetUserPoolMfaConfigFull),
+		opSetUserPoolMfaConfig:       wrapAccuracy(h.handleSetUserPoolMfaConfigFull),
+		opGetUICustomization:         wrapAccuracy(h.handleGetUICustomizationFull),
+		opSetUICustomization:         wrapAccuracy(h.handleSetUICustomizationFull),
+		opGetUserAttributeVerifCode:  wrapAccuracy(h.handleGetUserAttributeVerificationCodeFull),
+		opVerifyUserAttribute:        wrapAccuracy(h.handleVerifyUserAttributeFull),
+		opCreateIdentityProvider:     wrapAccuracy(h.handleCreateIdentityProviderFull),
+		opUpdateIdentityProvider:     wrapAccuracy(h.handleUpdateIdentityProviderFull),
+		opDescribeIdentityProvider:   wrapAccuracy(h.handleDescribeIdentityProviderFull),
+		opGetIdentityProviderByIdent: wrapAccuracy(h.handleGetIdentityProviderByIdentifierFull),
+		opListIdentityProviders:      wrapAccuracy(h.handleListIdentityProvidersFull),
+		opCreateUserPoolDomain:       wrapAccuracy(h.handleCreateUserPoolDomainFull),
+		opUpdateUserPoolDomain:       wrapAccuracy(h.handleUpdateUserPoolDomainFull),
+		opDescribeRiskConfiguration:  wrapAccuracy(h.handleDescribeRiskConfigurationFull),
+		opSetRiskConfiguration:       wrapAccuracy(h.handleSetRiskConfigurationFull),
+		opAdminCreateUser:            wrapAccuracy(h.handleAdminCreateUserFull),
+		opAdminSetUserPassword:       wrapAccuracy(h.handleAdminSetUserPasswordFull),
+		opCreateGroup:                wrapAccuracy(h.handleCreateGroupFull),
+		opUpdateGroup:                wrapAccuracy(h.handleUpdateGroupFull),
+		opGetGroup:                   wrapAccuracy(h.handleGetGroupFull),
+		opListGroups:                 wrapAccuracy(h.handleListGroupsFull),
+		opListUsersInGroup:           wrapAccuracy(h.handleListUsersInGroupFull),
 	}
 }
 
@@ -68,8 +68,8 @@ const (
 // ---------------------------------------------------------------------------
 
 type smsMfaConfigJSON struct {
-	SmsAuthenticationMessage string            `json:"SmsAuthenticationMessage,omitempty"`
-	SmsConfiguration         *smsConfigJSON    `json:"SmsConfiguration,omitempty"`
+	SmsConfiguration         *smsConfigJSON `json:"SmsConfiguration,omitempty"`
+	SmsAuthenticationMessage string         `json:"SmsAuthenticationMessage,omitempty"`
 }
 
 type smsConfigJSON struct {
@@ -92,10 +92,10 @@ type getUserPoolMfaConfigFullInput struct {
 }
 
 type getUserPoolMfaConfigFullOutput struct {
-	MfaConfiguration            string                      `json:"MfaConfiguration"`
-	SmsMfaConfiguration         *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
+	SmsMfaConfiguration           *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
 	SoftwareTokenMfaConfiguration *softwareTokenMfaConfigJSON `json:"SoftwareTokenMfaConfiguration,omitempty"`
-	EmailMfaConfiguration       *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+	EmailMfaConfiguration         *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+	MfaConfiguration              string                      `json:"MfaConfiguration"`
 }
 
 func (h *Handler) handleGetUserPoolMfaConfigFull(
@@ -109,7 +109,7 @@ func (h *Handler) handleGetUserPoolMfaConfigFull(
 
 	out := &getUserPoolMfaConfigFullOutput{MfaConfiguration: cfg.MfaConfiguration}
 	if out.MfaConfiguration == "" {
-		out.MfaConfiguration = "OFF"
+		out.MfaConfiguration = mfaConfigOFF
 	}
 
 	if cfg.SmsMfaConfiguration != nil {
@@ -141,18 +141,18 @@ func (h *Handler) handleGetUserPoolMfaConfigFull(
 }
 
 type setUserPoolMfaConfigFullInput struct {
-	UserPoolID                    string                      `json:"UserPoolId"`
-	MfaConfiguration              string                      `json:"MfaConfiguration"`
 	SmsMfaConfiguration           *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
 	SoftwareTokenMfaConfiguration *softwareTokenMfaConfigJSON `json:"SoftwareTokenMfaConfiguration,omitempty"`
 	EmailMfaConfiguration         *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+	UserPoolID                    string                      `json:"UserPoolId"`
+	MfaConfiguration              string                      `json:"MfaConfiguration"`
 }
 
 type setUserPoolMfaConfigFullOutput struct {
-	MfaConfiguration              string                      `json:"MfaConfiguration"`
 	SmsMfaConfiguration           *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
 	SoftwareTokenMfaConfiguration *softwareTokenMfaConfigJSON `json:"SoftwareTokenMfaConfiguration,omitempty"`
 	EmailMfaConfiguration         *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+	MfaConfiguration              string                      `json:"MfaConfiguration"`
 }
 
 func (h *Handler) handleSetUserPoolMfaConfigFull(
@@ -453,13 +453,13 @@ func (h *Handler) handleGetIdentityProviderByIdentifierFull(
 
 type listIdentityProvidersFullInput struct {
 	UserPoolID string `json:"UserPoolId"`
-	MaxResults int    `json:"MaxResults,omitempty"`
 	NextToken  string `json:"NextToken,omitempty"`
+	MaxResults int    `json:"MaxResults,omitempty"`
 }
 
 type listIdentityProvidersFullOutput struct {
-	Providers []identityProviderSummaryJSON `json:"Providers"`
 	NextToken string                        `json:"NextToken,omitempty"`
+	Providers []identityProviderSummaryJSON `json:"Providers"`
 }
 
 type identityProviderSummaryJSON struct {
@@ -530,9 +530,9 @@ type customDomainConfigJSON struct {
 }
 
 type createUserPoolDomainFullInput struct {
+	CustomDomainConfig *customDomainConfigJSON `json:"CustomDomainConfig,omitempty"`
 	UserPoolID         string                  `json:"UserPoolId"`
 	Domain             string                  `json:"Domain"`
-	CustomDomainConfig *customDomainConfigJSON `json:"CustomDomainConfig,omitempty"`
 }
 
 type createUserPoolDomainFullOutput struct {
@@ -557,9 +557,9 @@ func (h *Handler) handleCreateUserPoolDomainFull(
 }
 
 type updateUserPoolDomainFullInput struct {
+	CustomDomainConfig *customDomainConfigJSON `json:"CustomDomainConfig,omitempty"`
 	UserPoolID         string                  `json:"UserPoolId"`
 	Domain             string                  `json:"Domain"`
-	CustomDomainConfig *customDomainConfigJSON `json:"CustomDomainConfig,omitempty"`
 }
 
 type updateUserPoolDomainFullOutput struct {
@@ -592,13 +592,13 @@ type compromisedCredActionsJSON struct {
 }
 
 type compromisedCredRiskConfigJSON struct {
-	EventFilter []string                    `json:"EventFilter,omitempty"`
 	Actions     *compromisedCredActionsJSON `json:"Actions,omitempty"`
+	EventFilter []string                    `json:"EventFilter,omitempty"`
 }
 
 type accountTakeoverActionTypeJSON struct {
-	Notify      bool   `json:"Notify"`
 	EventAction string `json:"EventAction"`
+	Notify      bool   `json:"Notify"`
 }
 
 type accountTakeoverActionsJSON struct {
@@ -614,12 +614,12 @@ type notifyEmailTypeJSON struct {
 }
 
 type notifyConfigJSON struct {
-	From          string               `json:"From,omitempty"`
-	ReplyTo       string               `json:"ReplyTo,omitempty"`
-	SourceArn     string               `json:"SourceArn,omitempty"`
 	BlockEmail    *notifyEmailTypeJSON `json:"BlockEmail,omitempty"`
 	MfaEmail      *notifyEmailTypeJSON `json:"MfaEmail,omitempty"`
 	NoActionEmail *notifyEmailTypeJSON `json:"NoActionEmail,omitempty"`
+	From          string               `json:"From,omitempty"`
+	ReplyTo       string               `json:"ReplyTo,omitempty"`
+	SourceArn     string               `json:"SourceArn,omitempty"`
 }
 
 type accountTakeoverRiskConfigJSON struct {
@@ -628,8 +628,8 @@ type accountTakeoverRiskConfigJSON struct {
 }
 
 type riskExceptionConfigJSON struct {
-	BlockedIPRangeList  []string `json:"BlockedIPRangeList,omitempty"`
-	SkippedIPRangeList  []string `json:"SkippedIPRangeList,omitempty"`
+	BlockedIPRangeList []string `json:"BlockedIPRangeList,omitempty"`
+	SkippedIPRangeList []string `json:"SkippedIPRangeList,omitempty"`
 }
 
 type describeRiskConfigFullInput struct {
@@ -638,11 +638,11 @@ type describeRiskConfigFullInput struct {
 }
 
 type riskConfigurationJSON struct {
-	UserPoolID                            string                         `json:"UserPoolId,omitempty"`
-	ClientID                              string                         `json:"ClientId,omitempty"`
-	CompromisedCredentialsRiskConfiguration *compromisedCredRiskConfigJSON `json:"CompromisedCredentialsRiskConfiguration,omitempty"`
-	AccountTakeoverRiskConfiguration      *accountTakeoverRiskConfigJSON `json:"AccountTakeoverRiskConfiguration,omitempty"`
-	RiskExceptionConfiguration            *riskExceptionConfigJSON       `json:"RiskExceptionConfiguration,omitempty"`
+	CompromisedCredentialsRiskConfiguration *compromisedCredRiskConfigJSON `json:"CompromisedCredentialsRiskConfiguration,omitempty"` //nolint:lll // AWS field name
+	AccountTakeoverRiskConfiguration        *accountTakeoverRiskConfigJSON `json:"AccountTakeoverRiskConfiguration,omitempty"`        //nolint:lll // AWS field name
+	RiskExceptionConfiguration              *riskExceptionConfigJSON       `json:"RiskExceptionConfiguration,omitempty"`
+	UserPoolID                              string                         `json:"UserPoolId,omitempty"`
+	ClientID                                string                         `json:"ClientId,omitempty"`
 }
 
 type describeRiskConfigFullOutput struct {
@@ -662,11 +662,11 @@ func (h *Handler) handleDescribeRiskConfigurationFull(
 }
 
 type setRiskConfigFullInput struct {
-	UserPoolID                            string                         `json:"UserPoolId"`
-	ClientID                              string                         `json:"ClientId,omitempty"`
-	CompromisedCredentialsRiskConfiguration *compromisedCredRiskConfigJSON `json:"CompromisedCredentialsRiskConfiguration,omitempty"`
-	AccountTakeoverRiskConfiguration      *accountTakeoverRiskConfigJSON `json:"AccountTakeoverRiskConfiguration,omitempty"`
-	RiskExceptionConfiguration            *riskExceptionConfigJSON       `json:"RiskExceptionConfiguration,omitempty"`
+	CompromisedCredentialsRiskConfiguration *compromisedCredRiskConfigJSON `json:"CompromisedCredentialsRiskConfiguration,omitempty"` //nolint:lll // AWS field name
+	AccountTakeoverRiskConfiguration        *accountTakeoverRiskConfigJSON `json:"AccountTakeoverRiskConfiguration,omitempty"`        //nolint:lll // AWS field name
+	RiskExceptionConfiguration              *riskExceptionConfigJSON       `json:"RiskExceptionConfiguration,omitempty"`
+	UserPoolID                              string                         `json:"UserPoolId"`
+	ClientID                                string                         `json:"ClientId,omitempty"`
 }
 
 type setRiskConfigFullOutput struct {
@@ -767,11 +767,17 @@ func toAccountTakeoverActionsJSON(a *AccountTakeoverActions) *accountTakeoverAct
 	}
 
 	if a.MediumAction != nil {
-		out.MediumAction = &accountTakeoverActionTypeJSON{Notify: a.MediumAction.Notify, EventAction: a.MediumAction.EventAction}
+		out.MediumAction = &accountTakeoverActionTypeJSON{
+			Notify:      a.MediumAction.Notify,
+			EventAction: a.MediumAction.EventAction,
+		}
 	}
 
 	if a.HighAction != nil {
-		out.HighAction = &accountTakeoverActionTypeJSON{Notify: a.HighAction.Notify, EventAction: a.HighAction.EventAction}
+		out.HighAction = &accountTakeoverActionTypeJSON{
+			Notify:      a.HighAction.Notify,
+			EventAction: a.HighAction.EventAction,
+		}
 	}
 
 	return out
@@ -785,11 +791,17 @@ func fromAccountTakeoverActionsJSON(in *accountTakeoverActionsJSON) *AccountTake
 	}
 
 	if in.MediumAction != nil {
-		out.MediumAction = &AccountTakeoverActionType{Notify: in.MediumAction.Notify, EventAction: in.MediumAction.EventAction}
+		out.MediumAction = &AccountTakeoverActionType{
+			Notify:      in.MediumAction.Notify,
+			EventAction: in.MediumAction.EventAction,
+		}
 	}
 
 	if in.HighAction != nil {
-		out.HighAction = &AccountTakeoverActionType{Notify: in.HighAction.Notify, EventAction: in.HighAction.EventAction}
+		out.HighAction = &AccountTakeoverActionType{
+			Notify:      in.HighAction.Notify,
+			EventAction: in.HighAction.EventAction,
+		}
 	}
 
 	return out
@@ -803,15 +815,27 @@ func toNotifyConfigJSON(n *NotifyConfigurationType) *notifyConfigJSON {
 	}
 
 	if n.BlockEmail != nil {
-		out.BlockEmail = &notifyEmailTypeJSON{HtmlBody: n.BlockEmail.HtmlBody, Subject: n.BlockEmail.Subject, TextBody: n.BlockEmail.TextBody}
+		out.BlockEmail = &notifyEmailTypeJSON{
+			HtmlBody: n.BlockEmail.HtmlBody,
+			Subject:  n.BlockEmail.Subject,
+			TextBody: n.BlockEmail.TextBody,
+		}
 	}
 
 	if n.MfaEmail != nil {
-		out.MfaEmail = &notifyEmailTypeJSON{HtmlBody: n.MfaEmail.HtmlBody, Subject: n.MfaEmail.Subject, TextBody: n.MfaEmail.TextBody}
+		out.MfaEmail = &notifyEmailTypeJSON{
+			HtmlBody: n.MfaEmail.HtmlBody,
+			Subject:  n.MfaEmail.Subject,
+			TextBody: n.MfaEmail.TextBody,
+		}
 	}
 
 	if n.NoActionEmail != nil {
-		out.NoActionEmail = &notifyEmailTypeJSON{HtmlBody: n.NoActionEmail.HtmlBody, Subject: n.NoActionEmail.Subject, TextBody: n.NoActionEmail.TextBody}
+		out.NoActionEmail = &notifyEmailTypeJSON{
+			HtmlBody: n.NoActionEmail.HtmlBody,
+			Subject:  n.NoActionEmail.Subject,
+			TextBody: n.NoActionEmail.TextBody,
+		}
 	}
 
 	return out
@@ -825,15 +849,27 @@ func fromNotifyConfigJSON(in *notifyConfigJSON) *NotifyConfigurationType {
 	}
 
 	if in.BlockEmail != nil {
-		out.BlockEmail = &NotifyEmailType{HtmlBody: in.BlockEmail.HtmlBody, Subject: in.BlockEmail.Subject, TextBody: in.BlockEmail.TextBody}
+		out.BlockEmail = &NotifyEmailType{
+			HtmlBody: in.BlockEmail.HtmlBody,
+			Subject:  in.BlockEmail.Subject,
+			TextBody: in.BlockEmail.TextBody,
+		}
 	}
 
 	if in.MfaEmail != nil {
-		out.MfaEmail = &NotifyEmailType{HtmlBody: in.MfaEmail.HtmlBody, Subject: in.MfaEmail.Subject, TextBody: in.MfaEmail.TextBody}
+		out.MfaEmail = &NotifyEmailType{
+			HtmlBody: in.MfaEmail.HtmlBody,
+			Subject:  in.MfaEmail.Subject,
+			TextBody: in.MfaEmail.TextBody,
+		}
 	}
 
 	if in.NoActionEmail != nil {
-		out.NoActionEmail = &NotifyEmailType{HtmlBody: in.NoActionEmail.HtmlBody, Subject: in.NoActionEmail.Subject, TextBody: in.NoActionEmail.TextBody}
+		out.NoActionEmail = &NotifyEmailType{
+			HtmlBody: in.NoActionEmail.HtmlBody,
+			Subject:  in.NoActionEmail.Subject,
+			TextBody: in.NoActionEmail.TextBody,
+		}
 	}
 
 	return out
@@ -1007,13 +1043,13 @@ func (h *Handler) handleGetGroupFull(
 
 type listGroupsFullInput struct {
 	UserPoolID string `json:"UserPoolId"`
-	Limit      int    `json:"Limit,omitempty"`
 	NextToken  string `json:"NextToken,omitempty"`
+	Limit      int    `json:"Limit,omitempty"`
 }
 
 type listGroupsFullOutput struct {
-	Groups    []*groupFullSummary `json:"Groups"`
 	NextToken string              `json:"NextToken,omitempty"`
+	Groups    []*groupFullSummary `json:"Groups"`
 }
 
 func (h *Handler) handleListGroupsFull(
@@ -1037,13 +1073,13 @@ func (h *Handler) handleListGroupsFull(
 type listUsersInGroupFullInput struct {
 	UserPoolID string `json:"UserPoolId"`
 	GroupName  string `json:"GroupName"`
-	Limit      int    `json:"Limit,omitempty"`
 	NextToken  string `json:"NextToken,omitempty"`
+	Limit      int    `json:"Limit,omitempty"`
 }
 
 type listUsersInGroupFullOutput struct {
-	Users     []adminUserJSON `json:"Users"`
 	NextToken string          `json:"NextToken,omitempty"`
+	Users     []adminUserJSON `json:"Users"`
 }
 
 func (h *Handler) handleListUsersInGroupFull(

--- a/services/cognitoidp/batch2_handler.go
+++ b/services/cognitoidp/batch2_handler.go
@@ -1,0 +1,1076 @@
+package cognitoidp
+
+// batch2_handler.go wires batch-2 accuracy improvements into the Cognito IDP HTTP handler.
+// Overrides selected ops with stateful, AWS-accurate implementations.
+
+import (
+	"context"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/service"
+)
+
+// batch2DispatchTable returns dispatch entries that override the base table.
+func (h *Handler) batch2DispatchTable() map[string]service.JSONOpFunc {
+	return map[string]service.JSONOpFunc{
+		opGetUserPoolMfaConfig:         wrapAccuracy(h.handleGetUserPoolMfaConfigFull),
+		opSetUserPoolMfaConfig:         wrapAccuracy(h.handleSetUserPoolMfaConfigFull),
+		opGetUICustomization:           wrapAccuracy(h.handleGetUICustomizationFull),
+		opSetUICustomization:           wrapAccuracy(h.handleSetUICustomizationFull),
+		opGetUserAttributeVerifCode:    wrapAccuracy(h.handleGetUserAttributeVerificationCodeFull),
+		opVerifyUserAttribute:          wrapAccuracy(h.handleVerifyUserAttributeFull),
+		opCreateIdentityProvider:       wrapAccuracy(h.handleCreateIdentityProviderFull),
+		opUpdateIdentityProvider:       wrapAccuracy(h.handleUpdateIdentityProviderFull),
+		opDescribeIdentityProvider:     wrapAccuracy(h.handleDescribeIdentityProviderFull),
+		opGetIdentityProviderByIdent:   wrapAccuracy(h.handleGetIdentityProviderByIdentifierFull),
+		opListIdentityProviders:        wrapAccuracy(h.handleListIdentityProvidersFull),
+		opCreateUserPoolDomain:         wrapAccuracy(h.handleCreateUserPoolDomainFull),
+		opUpdateUserPoolDomain:         wrapAccuracy(h.handleUpdateUserPoolDomainFull),
+		opDescribeRiskConfiguration:    wrapAccuracy(h.handleDescribeRiskConfigurationFull),
+		opSetRiskConfiguration:         wrapAccuracy(h.handleSetRiskConfigurationFull),
+		opAdminCreateUser:              wrapAccuracy(h.handleAdminCreateUserFull),
+		opAdminSetUserPassword:         wrapAccuracy(h.handleAdminSetUserPasswordFull),
+		opCreateGroup:                  wrapAccuracy(h.handleCreateGroupFull),
+		opUpdateGroup:                  wrapAccuracy(h.handleUpdateGroupFull),
+		opGetGroup:                     wrapAccuracy(h.handleGetGroupFull),
+		opListGroups:                   wrapAccuracy(h.handleListGroupsFull),
+		opListUsersInGroup:             wrapAccuracy(h.handleListUsersInGroupFull),
+	}
+}
+
+// Additional op name constants for batch-2.
+const (
+	opGetUserPoolMfaConfig       = "GetUserPoolMfaConfig"
+	opSetUserPoolMfaConfig       = "SetUserPoolMfaConfig"
+	opGetUICustomization         = "GetUICustomization"
+	opSetUICustomization         = "SetUICustomization"
+	opGetUserAttributeVerifCode  = "GetUserAttributeVerificationCode"
+	opVerifyUserAttribute        = "VerifyUserAttribute"
+	opCreateIdentityProvider     = "CreateIdentityProvider"
+	opUpdateIdentityProvider     = "UpdateIdentityProvider"
+	opDescribeIdentityProvider   = "DescribeIdentityProvider"
+	opGetIdentityProviderByIdent = "GetIdentityProviderByIdentifier"
+	opListIdentityProviders      = "ListIdentityProviders"
+	opCreateUserPoolDomain       = "CreateUserPoolDomain"
+	opUpdateUserPoolDomain       = "UpdateUserPoolDomain"
+	opDescribeRiskConfiguration  = "DescribeRiskConfiguration"
+	opSetRiskConfiguration       = "SetRiskConfiguration"
+	opAdminCreateUser            = "AdminCreateUser"
+	opAdminSetUserPassword       = "AdminSetUserPassword"
+	opCreateGroup                = "CreateGroup"
+	opUpdateGroup                = "UpdateGroup"
+	opGetGroup                   = "GetGroup"
+	opListGroups                 = "ListGroups"
+	opListUsersInGroup           = "ListUsersInGroup"
+)
+
+// ---------------------------------------------------------------------------
+// MFA Configuration — full SMS/TOTP/Email sub-config
+// ---------------------------------------------------------------------------
+
+type smsMfaConfigJSON struct {
+	SmsAuthenticationMessage string            `json:"SmsAuthenticationMessage,omitempty"`
+	SmsConfiguration         *smsConfigJSON    `json:"SmsConfiguration,omitempty"`
+}
+
+type smsConfigJSON struct {
+	SnsCallerArn string `json:"SnsCallerArn,omitempty"`
+	SnsRegion    string `json:"SnsRegion,omitempty"`
+	ExternalID   string `json:"ExternalId,omitempty"`
+}
+
+type softwareTokenMfaConfigJSON struct {
+	Enabled bool `json:"Enabled"`
+}
+
+type emailMfaConfigJSON struct {
+	Message string `json:"Message,omitempty"`
+	Subject string `json:"Subject,omitempty"`
+}
+
+type getUserPoolMfaConfigFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+}
+
+type getUserPoolMfaConfigFullOutput struct {
+	MfaConfiguration            string                      `json:"MfaConfiguration"`
+	SmsMfaConfiguration         *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
+	SoftwareTokenMfaConfiguration *softwareTokenMfaConfigJSON `json:"SoftwareTokenMfaConfiguration,omitempty"`
+	EmailMfaConfiguration       *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+}
+
+func (h *Handler) handleGetUserPoolMfaConfigFull(
+	_ context.Context,
+	in *getUserPoolMfaConfigFullInput,
+) (*getUserPoolMfaConfigFullOutput, error) {
+	cfg, err := h.Backend.GetUserPoolMfaConfigFull(in.UserPoolID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &getUserPoolMfaConfigFullOutput{MfaConfiguration: cfg.MfaConfiguration}
+	if out.MfaConfiguration == "" {
+		out.MfaConfiguration = "OFF"
+	}
+
+	if cfg.SmsMfaConfiguration != nil {
+		out.SmsMfaConfiguration = &smsMfaConfigJSON{
+			SmsAuthenticationMessage: cfg.SmsMfaConfiguration.SmsAuthenticationMessage,
+		}
+
+		if cfg.SmsMfaConfiguration.SmsConfiguration != nil {
+			out.SmsMfaConfiguration.SmsConfiguration = &smsConfigJSON{
+				SnsCallerArn: cfg.SmsMfaConfiguration.SmsConfiguration.SnsCallerArn,
+				SnsRegion:    cfg.SmsMfaConfiguration.SmsConfiguration.SnsRegion,
+				ExternalID:   cfg.SmsMfaConfiguration.SmsConfiguration.ExternalID,
+			}
+		}
+	}
+
+	if cfg.SoftwareTokenMfa != nil {
+		out.SoftwareTokenMfaConfiguration = &softwareTokenMfaConfigJSON{Enabled: cfg.SoftwareTokenMfa.Enabled}
+	}
+
+	if cfg.EmailMfaConfiguration != nil {
+		out.EmailMfaConfiguration = &emailMfaConfigJSON{
+			Message: cfg.EmailMfaConfiguration.Message,
+			Subject: cfg.EmailMfaConfiguration.Subject,
+		}
+	}
+
+	return out, nil
+}
+
+type setUserPoolMfaConfigFullInput struct {
+	UserPoolID                    string                      `json:"UserPoolId"`
+	MfaConfiguration              string                      `json:"MfaConfiguration"`
+	SmsMfaConfiguration           *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
+	SoftwareTokenMfaConfiguration *softwareTokenMfaConfigJSON `json:"SoftwareTokenMfaConfiguration,omitempty"`
+	EmailMfaConfiguration         *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+}
+
+type setUserPoolMfaConfigFullOutput struct {
+	MfaConfiguration              string                      `json:"MfaConfiguration"`
+	SmsMfaConfiguration           *smsMfaConfigJSON           `json:"SmsMfaConfiguration,omitempty"`
+	SoftwareTokenMfaConfiguration *softwareTokenMfaConfigJSON `json:"SoftwareTokenMfaConfiguration,omitempty"`
+	EmailMfaConfiguration         *emailMfaConfigJSON         `json:"EmailMfaConfiguration,omitempty"`
+}
+
+func (h *Handler) handleSetUserPoolMfaConfigFull(
+	_ context.Context,
+	in *setUserPoolMfaConfigFullInput,
+) (*setUserPoolMfaConfigFullOutput, error) {
+	cfg := UserPoolMfaFullConfig{
+		MfaConfiguration: in.MfaConfiguration,
+	}
+
+	if in.SmsMfaConfiguration != nil {
+		smsCfg := &SmsMfaConfiguration{
+			SmsAuthenticationMessage: in.SmsMfaConfiguration.SmsAuthenticationMessage,
+		}
+
+		if in.SmsMfaConfiguration.SmsConfiguration != nil {
+			smsCfg.SmsConfiguration = &SmsConfiguration{
+				SnsCallerArn: in.SmsMfaConfiguration.SmsConfiguration.SnsCallerArn,
+				SnsRegion:    in.SmsMfaConfiguration.SmsConfiguration.SnsRegion,
+				ExternalID:   in.SmsMfaConfiguration.SmsConfiguration.ExternalID,
+			}
+		}
+
+		cfg.SmsMfaConfiguration = smsCfg
+	}
+
+	if in.SoftwareTokenMfaConfiguration != nil {
+		cfg.SoftwareTokenMfa = &SoftwareTokenMfaConfiguration{Enabled: in.SoftwareTokenMfaConfiguration.Enabled}
+	}
+
+	if in.EmailMfaConfiguration != nil {
+		cfg.EmailMfaConfiguration = &EmailMfaConfiguration{
+			Message: in.EmailMfaConfiguration.Message,
+			Subject: in.EmailMfaConfiguration.Subject,
+		}
+	}
+
+	if err := h.Backend.SetUserPoolMfaConfigFull(in.UserPoolID, cfg); err != nil {
+		return nil, err
+	}
+
+	out := &setUserPoolMfaConfigFullOutput{MfaConfiguration: in.MfaConfiguration}
+	out.SmsMfaConfiguration = in.SmsMfaConfiguration
+	out.SoftwareTokenMfaConfiguration = in.SoftwareTokenMfaConfiguration
+	out.EmailMfaConfiguration = in.EmailMfaConfiguration
+
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// UICustomization — extended with ImageUrl and timestamps
+// ---------------------------------------------------------------------------
+
+type setUICustomizationFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	ClientID   string `json:"ClientId,omitempty"`
+	CSS        string `json:"CSS,omitempty"`
+	ImageData  string `json:"ImageData,omitempty"`
+}
+
+type uiCustomizationJSON struct {
+	UserPoolID       string  `json:"UserPoolId"`
+	ClientID         string  `json:"ClientId,omitempty"`
+	CSS              string  `json:"CSS,omitempty"`
+	ImageUrl         string  `json:"ImageUrl,omitempty"`
+	CreationDate     float64 `json:"CreationDate,omitempty"`
+	LastModifiedDate float64 `json:"LastModifiedDate,omitempty"`
+}
+
+type setUICustomizationFullOutput struct {
+	UICustomization *uiCustomizationJSON `json:"UICustomization"`
+}
+
+func (h *Handler) handleSetUICustomizationFull(
+	_ context.Context,
+	in *setUICustomizationFullInput,
+) (*setUICustomizationFullOutput, error) {
+	ui, err := h.Backend.SetUICustomizationFull(in.UserPoolID, in.ClientID, in.CSS, in.ImageData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &setUICustomizationFullOutput{UICustomization: toUICustomizationJSON(ui)}, nil
+}
+
+type getUICustomizationFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	ClientID   string `json:"ClientId,omitempty"`
+}
+
+type getUICustomizationFullOutput struct {
+	UICustomization *uiCustomizationJSON `json:"UICustomization"`
+}
+
+func (h *Handler) handleGetUICustomizationFull(
+	_ context.Context,
+	in *getUICustomizationFullInput,
+) (*getUICustomizationFullOutput, error) {
+	ui, err := h.Backend.GetUICustomizationFull(in.UserPoolID, in.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getUICustomizationFullOutput{UICustomization: toUICustomizationJSON(ui)}, nil
+}
+
+func toUICustomizationJSON(ui *UICustomization) *uiCustomizationJSON {
+	out := &uiCustomizationJSON{
+		UserPoolID: ui.UserPoolID,
+		ClientID:   ui.ClientID,
+		CSS:        ui.CSS,
+		ImageUrl:   ui.ImageUrl,
+	}
+
+	if !ui.CreatedAt.IsZero() {
+		out.CreationDate = float64(ui.CreatedAt.Unix())
+	}
+
+	if !ui.LastModifiedAt.IsZero() {
+		out.LastModifiedDate = float64(ui.LastModifiedAt.Unix())
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// GetUserAttributeVerificationCode — stateful
+// ---------------------------------------------------------------------------
+
+type getUserAttributeVerifCodeFullInput struct {
+	AccessToken   string `json:"AccessToken"`
+	AttributeName string `json:"AttributeName"`
+}
+
+type getUserAttributeVerifCodeFullOutput struct {
+	CodeDeliveryDetails map[string]string `json:"CodeDeliveryDetails"`
+}
+
+func (h *Handler) handleGetUserAttributeVerificationCodeFull(
+	_ context.Context,
+	in *getUserAttributeVerifCodeFullInput,
+) (*getUserAttributeVerifCodeFullOutput, error) {
+	_, dest, medium, err := h.Backend.GetUserAttributeVerificationCode(in.AccessToken, in.AttributeName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getUserAttributeVerifCodeFullOutput{
+		CodeDeliveryDetails: map[string]string{
+			keyDeliveryMedium: medium,
+			keyDestination:    dest,
+			keyAttributeName:  in.AttributeName,
+		},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// VerifyUserAttribute — stateful code validation
+// ---------------------------------------------------------------------------
+
+type verifyUserAttributeFullInput struct {
+	AccessToken   string `json:"AccessToken"`
+	AttributeName string `json:"AttributeName"`
+	Code          string `json:"Code"`
+}
+
+type verifyUserAttributeFullOutput struct{}
+
+func (h *Handler) handleVerifyUserAttributeFull(
+	_ context.Context,
+	in *verifyUserAttributeFullInput,
+) (*verifyUserAttributeFullOutput, error) {
+	if err := h.Backend.VerifyUserAttributeWithCode(in.AccessToken, in.AttributeName, in.Code); err != nil {
+		return nil, err
+	}
+
+	return &verifyUserAttributeFullOutput{}, nil
+}
+
+// ---------------------------------------------------------------------------
+// IdentityProvider — full with AttributeMapping and IdpIdentifiers
+// ---------------------------------------------------------------------------
+
+type idpProviderDetails map[string]string
+type idpAttributeMapping map[string]string
+
+type createIdentityProviderFullInput struct {
+	UserPoolID       string              `json:"UserPoolId"`
+	ProviderName     string              `json:"ProviderName"`
+	ProviderType     string              `json:"ProviderType"`
+	ProviderDetails  idpProviderDetails  `json:"ProviderDetails,omitempty"`
+	AttributeMapping idpAttributeMapping `json:"AttributeMapping,omitempty"`
+	IdpIdentifiers   []string            `json:"IdpIdentifiers,omitempty"`
+}
+
+type identityProviderJSON struct {
+	UserPoolID       string              `json:"UserPoolId"`
+	ProviderName     string              `json:"ProviderName"`
+	ProviderType     string              `json:"ProviderType,omitempty"`
+	ProviderDetails  idpProviderDetails  `json:"ProviderDetails,omitempty"`
+	AttributeMapping idpAttributeMapping `json:"AttributeMapping,omitempty"`
+	IdpIdentifiers   []string            `json:"IdpIdentifiers,omitempty"`
+	CreationDate     float64             `json:"CreationDate,omitempty"`
+	LastModifiedDate float64             `json:"LastModifiedDate,omitempty"`
+}
+
+type createIdentityProviderFullOutput struct {
+	IdentityProvider *identityProviderJSON `json:"IdentityProvider"`
+}
+
+func (h *Handler) handleCreateIdentityProviderFull(
+	_ context.Context,
+	in *createIdentityProviderFullInput,
+) (*createIdentityProviderFullOutput, error) {
+	idp, err := h.Backend.CreateIdentityProviderFull(
+		in.UserPoolID, in.ProviderName, in.ProviderType,
+		map[string]string(in.ProviderDetails),
+		map[string]string(in.AttributeMapping),
+		in.IdpIdentifiers,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createIdentityProviderFullOutput{IdentityProvider: toIdentityProviderJSON(idp)}, nil
+}
+
+type updateIdentityProviderFullInput struct {
+	UserPoolID       string              `json:"UserPoolId"`
+	ProviderName     string              `json:"ProviderName"`
+	ProviderDetails  idpProviderDetails  `json:"ProviderDetails,omitempty"`
+	AttributeMapping idpAttributeMapping `json:"AttributeMapping,omitempty"`
+	IdpIdentifiers   []string            `json:"IdpIdentifiers,omitempty"`
+}
+
+type updateIdentityProviderFullOutput struct {
+	IdentityProvider *identityProviderJSON `json:"IdentityProvider"`
+}
+
+func (h *Handler) handleUpdateIdentityProviderFull(
+	_ context.Context,
+	in *updateIdentityProviderFullInput,
+) (*updateIdentityProviderFullOutput, error) {
+	idp, err := h.Backend.UpdateIdentityProviderFull(
+		in.UserPoolID, in.ProviderName,
+		map[string]string(in.ProviderDetails),
+		map[string]string(in.AttributeMapping),
+		in.IdpIdentifiers,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateIdentityProviderFullOutput{IdentityProvider: toIdentityProviderJSON(idp)}, nil
+}
+
+type describeIdentityProviderFullInput struct {
+	UserPoolID   string `json:"UserPoolId"`
+	ProviderName string `json:"ProviderName"`
+}
+
+type describeIdentityProviderFullOutput struct {
+	IdentityProvider *identityProviderJSON `json:"IdentityProvider"`
+}
+
+func (h *Handler) handleDescribeIdentityProviderFull(
+	_ context.Context,
+	in *describeIdentityProviderFullInput,
+) (*describeIdentityProviderFullOutput, error) {
+	idp, err := h.Backend.DescribeIdentityProvider(in.UserPoolID, in.ProviderName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &describeIdentityProviderFullOutput{IdentityProvider: toIdentityProviderJSON(idp)}, nil
+}
+
+type getIdentityProviderByIdentFullInput struct {
+	UserPoolID    string `json:"UserPoolId"`
+	IdpIdentifier string `json:"IdpIdentifier"`
+}
+
+type getIdentityProviderByIdentFullOutput struct {
+	IdentityProvider *identityProviderJSON `json:"IdentityProvider"`
+}
+
+func (h *Handler) handleGetIdentityProviderByIdentifierFull(
+	_ context.Context,
+	in *getIdentityProviderByIdentFullInput,
+) (*getIdentityProviderByIdentFullOutput, error) {
+	idp, err := h.Backend.GetIdentityProviderByIdentifier(in.UserPoolID, in.IdpIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getIdentityProviderByIdentFullOutput{IdentityProvider: toIdentityProviderJSON(idp)}, nil
+}
+
+type listIdentityProvidersFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	MaxResults int    `json:"MaxResults,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+}
+
+type listIdentityProvidersFullOutput struct {
+	Providers []identityProviderSummaryJSON `json:"Providers"`
+	NextToken string                        `json:"NextToken,omitempty"`
+}
+
+type identityProviderSummaryJSON struct {
+	ProviderName     string  `json:"ProviderName"`
+	ProviderType     string  `json:"ProviderType,omitempty"`
+	CreationDate     float64 `json:"CreationDate,omitempty"`
+	LastModifiedDate float64 `json:"LastModifiedDate,omitempty"`
+}
+
+func (h *Handler) handleListIdentityProvidersFull(
+	_ context.Context,
+	in *listIdentityProvidersFullInput,
+) (*listIdentityProvidersFullOutput, error) {
+	idps, err := h.Backend.ListIdentityProviders(in.UserPoolID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]identityProviderSummaryJSON, 0, len(idps))
+
+	for _, idp := range idps {
+		s := identityProviderSummaryJSON{
+			ProviderName: idp.ProviderName,
+			ProviderType: idp.ProviderType,
+		}
+
+		if !idp.CreatedAt.IsZero() {
+			s.CreationDate = float64(idp.CreatedAt.Unix())
+		}
+
+		if !idp.LastModifiedAt.IsZero() {
+			s.LastModifiedDate = float64(idp.LastModifiedAt.Unix())
+		}
+
+		out = append(out, s)
+	}
+
+	return &listIdentityProvidersFullOutput{Providers: out}, nil
+}
+
+func toIdentityProviderJSON(idp *IdentityProvider) *identityProviderJSON {
+	out := &identityProviderJSON{
+		UserPoolID:       idp.UserPoolID,
+		ProviderName:     idp.ProviderName,
+		ProviderType:     idp.ProviderType,
+		ProviderDetails:  idpProviderDetails(idp.ProviderDetails),
+		AttributeMapping: idpAttributeMapping(idp.AttributeMapping),
+		IdpIdentifiers:   idp.IdpIdentifiers,
+	}
+
+	if !idp.CreatedAt.IsZero() {
+		out.CreationDate = float64(idp.CreatedAt.Unix())
+	}
+
+	if !idp.LastModifiedAt.IsZero() {
+		out.LastModifiedDate = float64(idp.LastModifiedAt.Unix())
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// UserPoolDomain — with CustomDomainConfig (CertificateArn)
+// ---------------------------------------------------------------------------
+
+type customDomainConfigJSON struct {
+	CertificateArn string `json:"CertificateArn,omitempty"`
+}
+
+type createUserPoolDomainFullInput struct {
+	UserPoolID         string                  `json:"UserPoolId"`
+	Domain             string                  `json:"Domain"`
+	CustomDomainConfig *customDomainConfigJSON `json:"CustomDomainConfig,omitempty"`
+}
+
+type createUserPoolDomainFullOutput struct {
+	CloudFrontDomain string `json:"CloudFrontDomain,omitempty"`
+}
+
+func (h *Handler) handleCreateUserPoolDomainFull(
+	_ context.Context,
+	in *createUserPoolDomainFullInput,
+) (*createUserPoolDomainFullOutput, error) {
+	certArn := ""
+	if in.CustomDomainConfig != nil {
+		certArn = in.CustomDomainConfig.CertificateArn
+	}
+
+	d, err := h.Backend.CreateUserPoolDomainFull(in.UserPoolID, in.Domain, certArn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createUserPoolDomainFullOutput{CloudFrontDomain: d.CloudFrontDistribution}, nil
+}
+
+type updateUserPoolDomainFullInput struct {
+	UserPoolID         string                  `json:"UserPoolId"`
+	Domain             string                  `json:"Domain"`
+	CustomDomainConfig *customDomainConfigJSON `json:"CustomDomainConfig,omitempty"`
+}
+
+type updateUserPoolDomainFullOutput struct {
+	CloudFrontDomain string `json:"CloudFrontDomain,omitempty"`
+}
+
+func (h *Handler) handleUpdateUserPoolDomainFull(
+	_ context.Context,
+	in *updateUserPoolDomainFullInput,
+) (*updateUserPoolDomainFullOutput, error) {
+	certArn := ""
+	if in.CustomDomainConfig != nil {
+		certArn = in.CustomDomainConfig.CertificateArn
+	}
+
+	cfDomain, err := h.Backend.UpdateUserPoolDomainFull(in.UserPoolID, in.Domain, certArn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateUserPoolDomainFullOutput{CloudFrontDomain: cfDomain}, nil
+}
+
+// ---------------------------------------------------------------------------
+// RiskConfiguration — fully typed
+// ---------------------------------------------------------------------------
+
+type compromisedCredActionsJSON struct {
+	EventAction string `json:"EventAction"`
+}
+
+type compromisedCredRiskConfigJSON struct {
+	EventFilter []string                    `json:"EventFilter,omitempty"`
+	Actions     *compromisedCredActionsJSON `json:"Actions,omitempty"`
+}
+
+type accountTakeoverActionTypeJSON struct {
+	Notify      bool   `json:"Notify"`
+	EventAction string `json:"EventAction"`
+}
+
+type accountTakeoverActionsJSON struct {
+	LowAction    *accountTakeoverActionTypeJSON `json:"LowAction,omitempty"`
+	MediumAction *accountTakeoverActionTypeJSON `json:"MediumAction,omitempty"`
+	HighAction   *accountTakeoverActionTypeJSON `json:"HighAction,omitempty"`
+}
+
+type notifyEmailTypeJSON struct {
+	HtmlBody string `json:"HtmlBody,omitempty"`
+	Subject  string `json:"Subject,omitempty"`
+	TextBody string `json:"TextBody,omitempty"`
+}
+
+type notifyConfigJSON struct {
+	From          string               `json:"From,omitempty"`
+	ReplyTo       string               `json:"ReplyTo,omitempty"`
+	SourceArn     string               `json:"SourceArn,omitempty"`
+	BlockEmail    *notifyEmailTypeJSON `json:"BlockEmail,omitempty"`
+	MfaEmail      *notifyEmailTypeJSON `json:"MfaEmail,omitempty"`
+	NoActionEmail *notifyEmailTypeJSON `json:"NoActionEmail,omitempty"`
+}
+
+type accountTakeoverRiskConfigJSON struct {
+	Actions             *accountTakeoverActionsJSON `json:"Actions,omitempty"`
+	NotifyConfiguration *notifyConfigJSON           `json:"NotifyConfiguration,omitempty"`
+}
+
+type riskExceptionConfigJSON struct {
+	BlockedIPRangeList  []string `json:"BlockedIPRangeList,omitempty"`
+	SkippedIPRangeList  []string `json:"SkippedIPRangeList,omitempty"`
+}
+
+type describeRiskConfigFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	ClientID   string `json:"ClientId,omitempty"`
+}
+
+type riskConfigurationJSON struct {
+	UserPoolID                            string                         `json:"UserPoolId,omitempty"`
+	ClientID                              string                         `json:"ClientId,omitempty"`
+	CompromisedCredentialsRiskConfiguration *compromisedCredRiskConfigJSON `json:"CompromisedCredentialsRiskConfiguration,omitempty"`
+	AccountTakeoverRiskConfiguration      *accountTakeoverRiskConfigJSON `json:"AccountTakeoverRiskConfiguration,omitempty"`
+	RiskExceptionConfiguration            *riskExceptionConfigJSON       `json:"RiskExceptionConfiguration,omitempty"`
+}
+
+type describeRiskConfigFullOutput struct {
+	RiskConfiguration *riskConfigurationJSON `json:"RiskConfiguration"`
+}
+
+func (h *Handler) handleDescribeRiskConfigurationFull(
+	_ context.Context,
+	in *describeRiskConfigFullInput,
+) (*describeRiskConfigFullOutput, error) {
+	cfg, err := h.Backend.GetTypedRiskConfiguration(in.UserPoolID, in.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &describeRiskConfigFullOutput{RiskConfiguration: toRiskConfigJSON(cfg)}, nil
+}
+
+type setRiskConfigFullInput struct {
+	UserPoolID                            string                         `json:"UserPoolId"`
+	ClientID                              string                         `json:"ClientId,omitempty"`
+	CompromisedCredentialsRiskConfiguration *compromisedCredRiskConfigJSON `json:"CompromisedCredentialsRiskConfiguration,omitempty"`
+	AccountTakeoverRiskConfiguration      *accountTakeoverRiskConfigJSON `json:"AccountTakeoverRiskConfiguration,omitempty"`
+	RiskExceptionConfiguration            *riskExceptionConfigJSON       `json:"RiskExceptionConfiguration,omitempty"`
+}
+
+type setRiskConfigFullOutput struct {
+	RiskConfiguration *riskConfigurationJSON `json:"RiskConfiguration"`
+}
+
+func (h *Handler) handleSetRiskConfigurationFull(
+	_ context.Context,
+	in *setRiskConfigFullInput,
+) (*setRiskConfigFullOutput, error) {
+	cfg := &TypedRiskConfiguration{
+		UserPoolID: in.UserPoolID,
+		ClientID:   in.ClientID,
+	}
+
+	if in.CompromisedCredentialsRiskConfiguration != nil {
+		c := &CompromisedCredentialsRiskConfig{
+			EventFilter: in.CompromisedCredentialsRiskConfiguration.EventFilter,
+		}
+
+		if in.CompromisedCredentialsRiskConfiguration.Actions != nil {
+			c.Actions = &CompromisedCredentialsActions{
+				EventAction: in.CompromisedCredentialsRiskConfiguration.Actions.EventAction,
+			}
+		}
+
+		cfg.CompromisedCredentialsRiskConfig = c
+	}
+
+	if in.AccountTakeoverRiskConfiguration != nil {
+		at := &AccountTakeoverRiskConfig{}
+
+		if in.AccountTakeoverRiskConfiguration.Actions != nil {
+			at.Actions = fromAccountTakeoverActionsJSON(in.AccountTakeoverRiskConfiguration.Actions)
+		}
+
+		if in.AccountTakeoverRiskConfiguration.NotifyConfiguration != nil {
+			at.NotifyConfiguration = fromNotifyConfigJSON(in.AccountTakeoverRiskConfiguration.NotifyConfiguration)
+		}
+
+		cfg.AccountTakeoverRiskConfig = at
+	}
+
+	if err := h.Backend.SetTypedRiskConfiguration(cfg); err != nil {
+		return nil, err
+	}
+
+	stored, err := h.Backend.GetTypedRiskConfiguration(in.UserPoolID, in.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &setRiskConfigFullOutput{RiskConfiguration: toRiskConfigJSON(stored)}, nil
+}
+
+func toRiskConfigJSON(cfg *TypedRiskConfiguration) *riskConfigurationJSON {
+	out := &riskConfigurationJSON{
+		UserPoolID: cfg.UserPoolID,
+		ClientID:   cfg.ClientID,
+	}
+
+	if cfg.CompromisedCredentialsRiskConfig != nil {
+		c := &compromisedCredRiskConfigJSON{
+			EventFilter: cfg.CompromisedCredentialsRiskConfig.EventFilter,
+		}
+
+		if cfg.CompromisedCredentialsRiskConfig.Actions != nil {
+			c.Actions = &compromisedCredActionsJSON{
+				EventAction: cfg.CompromisedCredentialsRiskConfig.Actions.EventAction,
+			}
+		}
+
+		out.CompromisedCredentialsRiskConfiguration = c
+	}
+
+	if cfg.AccountTakeoverRiskConfig != nil {
+		at := &accountTakeoverRiskConfigJSON{}
+
+		if cfg.AccountTakeoverRiskConfig.Actions != nil {
+			at.Actions = toAccountTakeoverActionsJSON(cfg.AccountTakeoverRiskConfig.Actions)
+		}
+
+		if cfg.AccountTakeoverRiskConfig.NotifyConfiguration != nil {
+			at.NotifyConfiguration = toNotifyConfigJSON(cfg.AccountTakeoverRiskConfig.NotifyConfiguration)
+		}
+
+		out.AccountTakeoverRiskConfiguration = at
+	}
+
+	return out
+}
+
+func toAccountTakeoverActionsJSON(a *AccountTakeoverActions) *accountTakeoverActionsJSON {
+	out := &accountTakeoverActionsJSON{}
+
+	if a.LowAction != nil {
+		out.LowAction = &accountTakeoverActionTypeJSON{Notify: a.LowAction.Notify, EventAction: a.LowAction.EventAction}
+	}
+
+	if a.MediumAction != nil {
+		out.MediumAction = &accountTakeoverActionTypeJSON{Notify: a.MediumAction.Notify, EventAction: a.MediumAction.EventAction}
+	}
+
+	if a.HighAction != nil {
+		out.HighAction = &accountTakeoverActionTypeJSON{Notify: a.HighAction.Notify, EventAction: a.HighAction.EventAction}
+	}
+
+	return out
+}
+
+func fromAccountTakeoverActionsJSON(in *accountTakeoverActionsJSON) *AccountTakeoverActions {
+	out := &AccountTakeoverActions{}
+
+	if in.LowAction != nil {
+		out.LowAction = &AccountTakeoverActionType{Notify: in.LowAction.Notify, EventAction: in.LowAction.EventAction}
+	}
+
+	if in.MediumAction != nil {
+		out.MediumAction = &AccountTakeoverActionType{Notify: in.MediumAction.Notify, EventAction: in.MediumAction.EventAction}
+	}
+
+	if in.HighAction != nil {
+		out.HighAction = &AccountTakeoverActionType{Notify: in.HighAction.Notify, EventAction: in.HighAction.EventAction}
+	}
+
+	return out
+}
+
+func toNotifyConfigJSON(n *NotifyConfigurationType) *notifyConfigJSON {
+	out := &notifyConfigJSON{
+		From:      n.From,
+		ReplyTo:   n.ReplyTo,
+		SourceArn: n.SourceArn,
+	}
+
+	if n.BlockEmail != nil {
+		out.BlockEmail = &notifyEmailTypeJSON{HtmlBody: n.BlockEmail.HtmlBody, Subject: n.BlockEmail.Subject, TextBody: n.BlockEmail.TextBody}
+	}
+
+	if n.MfaEmail != nil {
+		out.MfaEmail = &notifyEmailTypeJSON{HtmlBody: n.MfaEmail.HtmlBody, Subject: n.MfaEmail.Subject, TextBody: n.MfaEmail.TextBody}
+	}
+
+	if n.NoActionEmail != nil {
+		out.NoActionEmail = &notifyEmailTypeJSON{HtmlBody: n.NoActionEmail.HtmlBody, Subject: n.NoActionEmail.Subject, TextBody: n.NoActionEmail.TextBody}
+	}
+
+	return out
+}
+
+func fromNotifyConfigJSON(in *notifyConfigJSON) *NotifyConfigurationType {
+	out := &NotifyConfigurationType{
+		From:      in.From,
+		ReplyTo:   in.ReplyTo,
+		SourceArn: in.SourceArn,
+	}
+
+	if in.BlockEmail != nil {
+		out.BlockEmail = &NotifyEmailType{HtmlBody: in.BlockEmail.HtmlBody, Subject: in.BlockEmail.Subject, TextBody: in.BlockEmail.TextBody}
+	}
+
+	if in.MfaEmail != nil {
+		out.MfaEmail = &NotifyEmailType{HtmlBody: in.MfaEmail.HtmlBody, Subject: in.MfaEmail.Subject, TextBody: in.MfaEmail.TextBody}
+	}
+
+	if in.NoActionEmail != nil {
+		out.NoActionEmail = &NotifyEmailType{HtmlBody: in.NoActionEmail.HtmlBody, Subject: in.NoActionEmail.Subject, TextBody: in.NoActionEmail.TextBody}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// AdminCreateUser — full with MessageAction and DesiredDeliveryMediums
+// ---------------------------------------------------------------------------
+
+type adminCreateUserFullInput struct {
+	UserPoolID             string          `json:"UserPoolId"`
+	Username               string          `json:"Username"`
+	TemporaryPassword      string          `json:"TemporaryPassword,omitempty"`
+	UserAttributes         []attributeType `json:"UserAttributes,omitempty"`
+	MessageAction          string          `json:"MessageAction,omitempty"`
+	DesiredDeliveryMediums []string        `json:"DesiredDeliveryMediums,omitempty"`
+	ForceAliasCreation     bool            `json:"ForceAliasCreation,omitempty"`
+}
+
+type adminCreateUserFullOutput struct {
+	User *adminUserJSON `json:"User"`
+}
+
+type adminUserJSON struct {
+	Username             string          `json:"Username"`
+	UserStatus           string          `json:"UserStatus"`
+	UserAttributes       []attributeType `json:"UserAttributes"`
+	UserCreateDate       float64         `json:"UserCreateDate"`
+	UserLastModifiedDate float64         `json:"UserLastModifiedDate"`
+	Enabled              bool            `json:"Enabled"`
+}
+
+func (h *Handler) handleAdminCreateUserFull(
+	_ context.Context,
+	in *adminCreateUserFullInput,
+) (*adminCreateUserFullOutput, error) {
+	attrs := attributeListToMap(in.UserAttributes)
+
+	user, err := h.Backend.AdminCreateUserFull(
+		in.UserPoolID,
+		in.Username,
+		in.TemporaryPassword,
+		attrs,
+		in.MessageAction,
+		in.DesiredDeliveryMediums,
+		in.ForceAliasCreation,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &adminCreateUserFullOutput{User: toAdminUserJSON(user)}, nil
+}
+
+func toAdminUserJSON(u *User) *adminUserJSON {
+	return &adminUserJSON{
+		Username:             u.Username,
+		UserStatus:           u.Status,
+		UserAttributes:       sortedAttributeList(u.Attributes),
+		UserCreateDate:       float64(u.CreatedAt.Unix()),
+		UserLastModifiedDate: float64(u.UpdatedAt.Unix()),
+		Enabled:              u.Enabled,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AdminSetUserPassword — with policy enforcement
+// ---------------------------------------------------------------------------
+
+type adminSetUserPasswordFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	Username   string `json:"Username"`
+	Password   string `json:"Password"`
+	Permanent  bool   `json:"Permanent"`
+}
+
+type adminSetUserPasswordFullOutput struct{}
+
+func (h *Handler) handleAdminSetUserPasswordFull(
+	_ context.Context,
+	in *adminSetUserPasswordFullInput,
+) (*adminSetUserPasswordFullOutput, error) {
+	if err := h.Backend.AdminSetUserPasswordFull(in.UserPoolID, in.Username, in.Password, in.Permanent); err != nil {
+		return nil, err
+	}
+
+	return &adminSetUserPasswordFullOutput{}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Group — full with RoleArn and pagination
+// ---------------------------------------------------------------------------
+
+type createGroupFullInput struct {
+	UserPoolID  string `json:"UserPoolId"`
+	GroupName   string `json:"GroupName"`
+	Description string `json:"Description,omitempty"`
+	RoleArn     string `json:"RoleArn,omitempty"`
+	Precedence  int32  `json:"Precedence,omitempty"`
+}
+
+type groupFullSummary struct {
+	GroupName    string  `json:"GroupName"`
+	UserPoolID   string  `json:"UserPoolId"`
+	Description  string  `json:"Description,omitempty"`
+	RoleArn      string  `json:"RoleArn,omitempty"`
+	Precedence   int32   `json:"Precedence"`
+	CreationDate float64 `json:"CreationDate,omitempty"`
+}
+
+type createGroupFullOutput struct {
+	Group *groupFullSummary `json:"Group"`
+}
+
+func (h *Handler) handleCreateGroupFull(
+	_ context.Context,
+	in *createGroupFullInput,
+) (*createGroupFullOutput, error) {
+	g, err := h.Backend.CreateGroupFull(in.UserPoolID, in.GroupName, in.Description, in.RoleArn, in.Precedence)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createGroupFullOutput{Group: toGroupFullSummary(g)}, nil
+}
+
+type updateGroupFullInput struct {
+	UserPoolID  string `json:"UserPoolId"`
+	GroupName   string `json:"GroupName"`
+	Description string `json:"Description,omitempty"`
+	RoleArn     string `json:"RoleArn,omitempty"`
+	Precedence  int32  `json:"Precedence,omitempty"`
+}
+
+type updateGroupFullOutput struct {
+	Group *groupFullSummary `json:"Group"`
+}
+
+func (h *Handler) handleUpdateGroupFull(
+	_ context.Context,
+	in *updateGroupFullInput,
+) (*updateGroupFullOutput, error) {
+	g, err := h.Backend.UpdateGroupFull(in.UserPoolID, in.GroupName, in.Description, in.RoleArn, in.Precedence)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateGroupFullOutput{Group: toGroupFullSummary(g)}, nil
+}
+
+type getGroupFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	GroupName  string `json:"GroupName"`
+}
+
+type getGroupFullOutput struct {
+	Group *groupFullSummary `json:"Group"`
+}
+
+func (h *Handler) handleGetGroupFull(
+	_ context.Context,
+	in *getGroupFullInput,
+) (*getGroupFullOutput, error) {
+	g, err := h.Backend.GetGroup(in.UserPoolID, in.GroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getGroupFullOutput{Group: toGroupFullSummary(g)}, nil
+}
+
+type listGroupsFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	Limit      int    `json:"Limit,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+}
+
+type listGroupsFullOutput struct {
+	Groups    []*groupFullSummary `json:"Groups"`
+	NextToken string              `json:"NextToken,omitempty"`
+}
+
+func (h *Handler) handleListGroupsFull(
+	_ context.Context,
+	in *listGroupsFullInput,
+) (*listGroupsFullOutput, error) {
+	groups, nextToken, err := h.Backend.ListGroupsPage(in.UserPoolID, in.Limit, in.NextToken)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*groupFullSummary, 0, len(groups))
+
+	for _, g := range groups {
+		out = append(out, toGroupFullSummary(g))
+	}
+
+	return &listGroupsFullOutput{Groups: out, NextToken: nextToken}, nil
+}
+
+type listUsersInGroupFullInput struct {
+	UserPoolID string `json:"UserPoolId"`
+	GroupName  string `json:"GroupName"`
+	Limit      int    `json:"Limit,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+}
+
+type listUsersInGroupFullOutput struct {
+	Users     []adminUserJSON `json:"Users"`
+	NextToken string          `json:"NextToken,omitempty"`
+}
+
+func (h *Handler) handleListUsersInGroupFull(
+	_ context.Context,
+	in *listUsersInGroupFullInput,
+) (*listUsersInGroupFullOutput, error) {
+	users, nextToken, err := h.Backend.ListUsersInGroupPage(in.UserPoolID, in.GroupName, in.Limit, in.NextToken)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]adminUserJSON, 0, len(users))
+
+	for _, u := range users {
+		out = append(out, *toAdminUserJSON(u))
+	}
+
+	return &listUsersInGroupFullOutput{Users: out, NextToken: nextToken}, nil
+}
+
+func toGroupFullSummary(g *Group) *groupFullSummary {
+	return &groupFullSummary{
+		GroupName:    g.GroupName,
+		UserPoolID:   g.UserPoolID,
+		Description:  g.Description,
+		RoleArn:      g.RoleArn,
+		Precedence:   g.Precedence,
+		CreationDate: float64(g.CreatedAt.Unix()),
+	}
+}

--- a/services/cognitoidp/batch2_test.go
+++ b/services/cognitoidp/batch2_test.go
@@ -1,0 +1,1765 @@
+package cognitoidp_test
+
+// batch2_test.go covers the batch-2 AWS-accuracy improvements for Cognito IDP.
+// Targets: MFA config sub-types, UICustomization timestamps, IdentityProvider
+// AttributeMapping/IdpIdentifiers, UserPoolDomain CertificateArn, typed
+// RiskConfiguration, stateful attribute verification, Group RoleArn + pagination,
+// AdminCreateUser MessageAction, AdminSetUserPassword policy enforcement.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/cognitoidp"
+)
+
+// ---------------------------------------------------------------------------
+// MFA Configuration — full sub-type support
+// ---------------------------------------------------------------------------
+
+func TestBatch2_GetUserPoolMfaConfig_DefaultsToOFF(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "mfa-default-pool")
+
+	rec := doCognitoRequest(t, h, "GetUserPoolMfaConfig", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		MfaConfiguration string `json:"MfaConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "OFF", out.MfaConfiguration)
+}
+
+func TestBatch2_SetGetMfaConfig_SmsMfaConfiguration(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "mfa-sms-pool")
+
+	rec := doCognitoRequest(t, h, "SetUserPoolMfaConfig", map[string]any{
+		"UserPoolId":       poolID,
+		"MfaConfiguration": "ON",
+		"SmsMfaConfiguration": map[string]any{
+			"SmsAuthenticationMessage": "Your code is {####}",
+			"SmsConfiguration": map[string]any{
+				"SnsCallerArn": "arn:aws:iam::123456789:role/cognito-sms",
+				"SnsRegion":    "us-east-1",
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var setOut struct {
+		SmsMfaConfiguration *struct {
+			SmsConfiguration *struct {
+				SnsCallerArn string `json:"SnsCallerArn"`
+			} `json:"SmsConfiguration"`
+			SmsAuthenticationMessage string `json:"SmsAuthenticationMessage"`
+		} `json:"SmsMfaConfiguration"`
+		MfaConfiguration string `json:"MfaConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &setOut))
+	assert.Equal(t, "ON", setOut.MfaConfiguration)
+	require.NotNil(t, setOut.SmsMfaConfiguration)
+	assert.Equal(t, "Your code is {####}", setOut.SmsMfaConfiguration.SmsAuthenticationMessage)
+	require.NotNil(t, setOut.SmsMfaConfiguration.SmsConfiguration)
+	assert.Equal(t, "arn:aws:iam::123456789:role/cognito-sms", setOut.SmsMfaConfiguration.SmsConfiguration.SnsCallerArn)
+
+	// Get and verify persisted.
+	rec = doCognitoRequest(t, h, "GetUserPoolMfaConfig", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getOut struct {
+		SmsMfaConfiguration *struct {
+			SmsAuthenticationMessage string `json:"SmsAuthenticationMessage"`
+		} `json:"SmsMfaConfiguration"`
+		MfaConfiguration string `json:"MfaConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &getOut))
+	assert.Equal(t, "ON", getOut.MfaConfiguration)
+	require.NotNil(t, getOut.SmsMfaConfiguration)
+	assert.Equal(t, "Your code is {####}", getOut.SmsMfaConfiguration.SmsAuthenticationMessage)
+}
+
+func TestBatch2_SetGetMfaConfig_SoftwareTokenMfa(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "mfa-totp-pool")
+
+	rec := doCognitoRequest(t, h, "SetUserPoolMfaConfig", map[string]any{
+		"UserPoolId":       poolID,
+		"MfaConfiguration": "OPTIONAL",
+		"SoftwareTokenMfaConfiguration": map[string]any{
+			"Enabled": true,
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var setOut struct {
+		SoftwareTokenMfaConfiguration *struct {
+			Enabled bool `json:"Enabled"`
+		} `json:"SoftwareTokenMfaConfiguration"`
+		MfaConfiguration string `json:"MfaConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &setOut))
+	assert.Equal(t, "OPTIONAL", setOut.MfaConfiguration)
+	require.NotNil(t, setOut.SoftwareTokenMfaConfiguration)
+	assert.True(t, setOut.SoftwareTokenMfaConfiguration.Enabled)
+
+	// Verify Get returns the same.
+	rec = doCognitoRequest(t, h, "GetUserPoolMfaConfig", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getOut struct {
+		SoftwareTokenMfaConfiguration *struct {
+			Enabled bool `json:"Enabled"`
+		} `json:"SoftwareTokenMfaConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &getOut))
+	require.NotNil(t, getOut.SoftwareTokenMfaConfiguration)
+	assert.True(t, getOut.SoftwareTokenMfaConfiguration.Enabled)
+}
+
+func TestBatch2_SetGetMfaConfig_EmailMfa(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "mfa-email-pool")
+
+	rec := doCognitoRequest(t, h, "SetUserPoolMfaConfig", map[string]any{
+		"UserPoolId":       poolID,
+		"MfaConfiguration": "ON",
+		"EmailMfaConfiguration": map[string]any{
+			"Message": "Your login code is {####}",
+			"Subject": "Login verification",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var setOut struct {
+		EmailMfaConfiguration *struct {
+			Message string `json:"Message"`
+			Subject string `json:"Subject"`
+		} `json:"EmailMfaConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &setOut))
+	require.NotNil(t, setOut.EmailMfaConfiguration)
+	assert.Equal(t, "Your login code is {####}", setOut.EmailMfaConfiguration.Message)
+	assert.Equal(t, "Login verification", setOut.EmailMfaConfiguration.Subject)
+}
+
+func TestBatch2_MfaConfig_InvalidPool(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doCognitoRequest(t, h, "GetUserPoolMfaConfig", map[string]any{
+		"UserPoolId": "invalid-pool-id",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = doCognitoRequest(t, h, "SetUserPoolMfaConfig", map[string]any{
+		"UserPoolId":       "invalid-pool-id",
+		"MfaConfiguration": "ON",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestBatch2_MfaConfig_Backend_Full(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("mfa-full-pool")
+	require.NoError(t, err)
+
+	cfg := cognitoidp.UserPoolMfaFullConfig{
+		MfaConfiguration: "ON",
+		SmsMfaConfiguration: &cognitoidp.SmsMfaConfiguration{
+			SmsAuthenticationMessage: "Code: {####}",
+			SmsConfiguration: &cognitoidp.SmsConfiguration{
+				SnsCallerArn: "arn:aws:iam::111:role/role",
+				SnsRegion:    "us-west-2",
+				ExternalID:   "ext-id-123",
+			},
+		},
+		SoftwareTokenMfa: &cognitoidp.SoftwareTokenMfaConfiguration{Enabled: true},
+	}
+
+	require.NoError(t, b.SetUserPoolMfaConfigFull(pool.ID, cfg))
+
+	got, err := b.GetUserPoolMfaConfigFull(pool.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ON", got.MfaConfiguration)
+	require.NotNil(t, got.SmsMfaConfiguration)
+	assert.Equal(t, "Code: {####}", got.SmsMfaConfiguration.SmsAuthenticationMessage)
+	require.NotNil(t, got.SmsMfaConfiguration.SmsConfiguration)
+	assert.Equal(t, "us-west-2", got.SmsMfaConfiguration.SmsConfiguration.SnsRegion)
+	assert.Equal(t, "ext-id-123", got.SmsMfaConfiguration.SmsConfiguration.ExternalID)
+	require.NotNil(t, got.SoftwareTokenMfa)
+	assert.True(t, got.SoftwareTokenMfa.Enabled)
+}
+
+func TestBatch2_MfaConfig_Backend_InvalidPool(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+
+	_, err := b.GetUserPoolMfaConfigFull("bad-pool")
+	require.Error(t, err)
+
+	err = b.SetUserPoolMfaConfigFull("bad-pool", cognitoidp.UserPoolMfaFullConfig{})
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// UICustomization — extended with timestamps and ImageUrl
+// ---------------------------------------------------------------------------
+
+func TestBatch2_UICustomization_SetGet_WithImageUrl(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, clientID := setupHandlerPoolAndClient(t, h, "ui-custom-pool")
+
+	rec := doCognitoRequest(t, h, "SetUICustomization", map[string]any{
+		"UserPoolId": poolID,
+		"ClientId":   clientID,
+		"CSS":        ".banner { background: blue; }",
+		"ImageData":  "https://example.com/logo.png",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var setOut struct {
+		UICustomization *struct {
+			UserPoolId       string  `json:"UserPoolId"`
+			ClientId         string  `json:"ClientId"`
+			CSS              string  `json:"CSS"`
+			ImageUrl         string  `json:"ImageUrl"`
+			CreationDate     float64 `json:"CreationDate"`
+			LastModifiedDate float64 `json:"LastModifiedDate"`
+		} `json:"UICustomization"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &setOut))
+	require.NotNil(t, setOut.UICustomization)
+	assert.Equal(t, poolID, setOut.UICustomization.UserPoolId)
+	assert.Equal(t, clientID, setOut.UICustomization.ClientId)
+	assert.Equal(t, ".banner { background: blue; }", setOut.UICustomization.CSS)
+	assert.Equal(t, "https://example.com/logo.png", setOut.UICustomization.ImageUrl)
+	assert.Greater(t, setOut.UICustomization.CreationDate, float64(0))
+	assert.Greater(t, setOut.UICustomization.LastModifiedDate, float64(0))
+
+	// Get and verify.
+	rec = doCognitoRequest(t, h, "GetUICustomization", map[string]any{
+		"UserPoolId": poolID,
+		"ClientId":   clientID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getOut struct {
+		UICustomization *struct {
+			CSS              string  `json:"CSS"`
+			ImageUrl         string  `json:"ImageUrl"`
+			LastModifiedDate float64 `json:"LastModifiedDate"`
+		} `json:"UICustomization"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &getOut))
+	require.NotNil(t, getOut.UICustomization)
+	assert.Equal(t, ".banner { background: blue; }", getOut.UICustomization.CSS)
+	assert.Equal(t, "https://example.com/logo.png", getOut.UICustomization.ImageUrl)
+	assert.Greater(t, getOut.UICustomization.LastModifiedDate, float64(0))
+}
+
+func TestBatch2_UICustomization_Get_Empty(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "ui-empty-pool")
+
+	rec := doCognitoRequest(t, h, "GetUICustomization", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		UICustomization *struct {
+			UserPoolId string `json:"UserPoolId"`
+			CSS        string `json:"CSS"`
+		} `json:"UICustomization"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.UICustomization)
+	assert.Empty(t, out.UICustomization.CSS)
+}
+
+func TestBatch2_UICustomization_InvalidPool(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doCognitoRequest(t, h, "GetUICustomization", map[string]any{
+		"UserPoolId": "bad-pool",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = doCognitoRequest(t, h, "SetUICustomization", map[string]any{
+		"UserPoolId": "bad-pool",
+		"CSS":        ".foo {}",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestBatch2_UICustomization_Backend_Direct(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("ui-backend-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "ui-client")
+	require.NoError(t, err)
+
+	ui, err := b.SetUICustomizationFull(
+		pool.ID,
+		client.ClientID,
+		".body { color: red; }",
+		"https://img.example.com/logo.png",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, ".body { color: red; }", ui.CSS)
+	assert.Equal(t, "https://img.example.com/logo.png", ui.ImageUrl)
+	assert.False(t, ui.CreatedAt.IsZero())
+	assert.False(t, ui.LastModifiedAt.IsZero())
+
+	got, err := b.GetUICustomizationFull(pool.ID, client.ClientID)
+	require.NoError(t, err)
+	assert.Equal(t, ui.CSS, got.CSS)
+	assert.Equal(t, ui.ImageUrl, got.ImageUrl)
+}
+
+// ---------------------------------------------------------------------------
+// IdentityProvider — with AttributeMapping and IdpIdentifiers
+// ---------------------------------------------------------------------------
+
+func TestBatch2_IdentityProvider_SAML_WithAttributeMapping(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "idp-saml-pool")
+
+	rec := doCognitoRequest(t, h, "CreateIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "MySAML",
+		"ProviderType": "SAML",
+		"ProviderDetails": map[string]string{
+			"MetadataURL": "https://idp.example.com/metadata",
+		},
+		"AttributeMapping": map[string]string{
+			"email":      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+			"given_name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+		},
+		"IdpIdentifiers": []string{"idp.example.com"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var createOut struct {
+		IdentityProvider *struct {
+			ProviderName     string            `json:"ProviderName"`
+			ProviderType     string            `json:"ProviderType"`
+			AttributeMapping map[string]string `json:"AttributeMapping"`
+			IdpIdentifiers   []string          `json:"IdpIdentifiers"`
+			CreationDate     float64           `json:"CreationDate"`
+		} `json:"IdentityProvider"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createOut))
+	require.NotNil(t, createOut.IdentityProvider)
+	assert.Equal(t, "MySAML", createOut.IdentityProvider.ProviderName)
+	assert.Equal(t, "SAML", createOut.IdentityProvider.ProviderType)
+	assert.Equal(t, "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+		createOut.IdentityProvider.AttributeMapping["email"])
+	assert.Contains(t, createOut.IdentityProvider.IdpIdentifiers, "idp.example.com")
+	assert.Greater(t, createOut.IdentityProvider.CreationDate, float64(0))
+}
+
+func TestBatch2_IdentityProvider_OIDC_WithScopes(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "idp-oidc-pool")
+
+	rec := doCognitoRequest(t, h, "CreateIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "MyOIDC",
+		"ProviderType": "OIDC",
+		"ProviderDetails": map[string]string{
+			"client_id":        "oidc-client-id",
+			"client_secret":    "oidc-secret",
+			"authorize_scopes": "openid email profile",
+			"oidc_issuer":      "https://oidc.example.com",
+		},
+		"AttributeMapping": map[string]string{
+			"email":    "email",
+			"username": "sub",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		IdentityProvider *struct {
+			AttributeMapping map[string]string `json:"AttributeMapping"`
+			ProviderName     string            `json:"ProviderName"`
+			ProviderType     string            `json:"ProviderType"`
+		} `json:"IdentityProvider"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.IdentityProvider)
+	assert.Equal(t, "MyOIDC", out.IdentityProvider.ProviderName)
+	assert.Equal(t, "email", out.IdentityProvider.AttributeMapping["email"])
+	assert.Equal(t, "sub", out.IdentityProvider.AttributeMapping["username"])
+}
+
+func TestBatch2_IdentityProvider_Social_Google(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "idp-google-pool")
+
+	rec := doCognitoRequest(t, h, "CreateIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "Google",
+		"ProviderType": "Google",
+		"ProviderDetails": map[string]string{
+			"client_id":        "google-app-id",
+			"client_secret":    "google-secret",
+			"authorize_scopes": "profile email openid",
+		},
+		"AttributeMapping": map[string]string{
+			"email":       "email",
+			"name":        "name",
+			"given_name":  "given_name",
+			"family_name": "family_name",
+			"picture":     "picture",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Describe should return AttributeMapping.
+	rec = doCognitoRequest(t, h, "DescribeIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "Google",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var descOut struct {
+		IdentityProvider *struct {
+			AttributeMapping map[string]string `json:"AttributeMapping"`
+			ProviderDetails  map[string]string `json:"ProviderDetails"`
+		} `json:"IdentityProvider"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &descOut))
+	require.NotNil(t, descOut.IdentityProvider)
+	assert.Equal(t, "email", descOut.IdentityProvider.AttributeMapping["email"])
+	assert.Equal(t, "google-app-id", descOut.IdentityProvider.ProviderDetails["client_id"])
+}
+
+func TestBatch2_IdentityProvider_Update_AttributeMapping(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "idp-update-pool")
+
+	// Create.
+	rec := doCognitoRequest(t, h, "CreateIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "Facebook",
+		"ProviderType": "Facebook",
+		"ProviderDetails": map[string]string{
+			"client_id":        "fb-app-id",
+			"client_secret":    "fb-secret",
+			"authorize_scopes": "public_profile,email",
+		},
+		"AttributeMapping": map[string]string{"email": "email"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Update with new AttributeMapping.
+	rec = doCognitoRequest(t, h, "UpdateIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "Facebook",
+		"AttributeMapping": map[string]string{
+			"email":    "email",
+			"username": "id",
+		},
+		"IdpIdentifiers": []string{"facebook.com"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var updOut struct {
+		IdentityProvider *struct {
+			AttributeMapping map[string]string `json:"AttributeMapping"`
+			IdpIdentifiers   []string          `json:"IdpIdentifiers"`
+		} `json:"IdentityProvider"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &updOut))
+	require.NotNil(t, updOut.IdentityProvider)
+	assert.Equal(t, "id", updOut.IdentityProvider.AttributeMapping["username"])
+	assert.Contains(t, updOut.IdentityProvider.IdpIdentifiers, "facebook.com")
+}
+
+func TestBatch2_IdentityProvider_GetByIdentifier(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "idp-byident-pool")
+
+	rec := doCognitoRequest(t, h, "CreateIdentityProvider", map[string]any{
+		"UserPoolId":   poolID,
+		"ProviderName": "LoginWithAmazon",
+		"ProviderType": "LoginWithAmazon",
+		"ProviderDetails": map[string]string{
+			"client_id":        "amzn-id",
+			"client_secret":    "amzn-sec",
+			"authorize_scopes": "profile",
+		},
+		"IdpIdentifiers": []string{"amazon.com"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doCognitoRequest(t, h, "GetIdentityProviderByIdentifier", map[string]any{
+		"UserPoolId":    poolID,
+		"IdpIdentifier": "amazon.com",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		IdentityProvider *struct {
+			ProviderName string `json:"ProviderName"`
+		} `json:"IdentityProvider"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.IdentityProvider)
+	assert.Equal(t, "LoginWithAmazon", out.IdentityProvider.ProviderName)
+}
+
+func TestBatch2_IdentityProvider_List_WithTimestamps(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "idp-list-ts-pool")
+
+	for _, name := range []string{"Google", "Facebook", "SignInWithApple"} {
+		provType := name
+		if name == "SignInWithApple" {
+			provType = "SignInWithApple"
+		}
+
+		rec := doCognitoRequest(t, h, "CreateIdentityProvider", map[string]any{
+			"UserPoolId":   poolID,
+			"ProviderName": name,
+			"ProviderType": provType,
+			"ProviderDetails": map[string]string{
+				"client_id":        name + "-id",
+				"client_secret":    name + "-secret",
+				"authorize_scopes": "email",
+			},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	rec := doCognitoRequest(t, h, "ListIdentityProviders", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Providers []struct {
+			ProviderName     string  `json:"ProviderName"`
+			ProviderType     string  `json:"ProviderType"`
+			CreationDate     float64 `json:"CreationDate"`
+			LastModifiedDate float64 `json:"LastModifiedDate"`
+		} `json:"Providers"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out.Providers, 3)
+
+	for _, p := range out.Providers {
+		assert.Greater(t, p.CreationDate, float64(0), "CreationDate should be set for %s", p.ProviderName)
+		assert.Greater(t, p.LastModifiedDate, float64(0), "LastModifiedDate should be set for %s", p.ProviderName)
+	}
+}
+
+func TestBatch2_IdentityProvider_Backend_Direct(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("idp-backend-pool")
+	require.NoError(t, err)
+
+	idp, err := b.CreateIdentityProviderFull(
+		pool.ID, "MySAML", "SAML",
+		map[string]string{"MetadataURL": "https://idp.test/metadata"},
+		map[string]string{"email": "urn:email"},
+		[]string{"saml.example.com"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "urn:email", idp.AttributeMapping["email"])
+	assert.Contains(t, idp.IdpIdentifiers, "saml.example.com")
+
+	// Duplicate should fail.
+	_, err = b.CreateIdentityProviderFull(pool.ID, "MySAML", "SAML", nil, nil, nil)
+	require.Error(t, err)
+
+	// Update AttributeMapping.
+	updated, err := b.UpdateIdentityProviderFull(
+		pool.ID, "MySAML",
+		map[string]string{"MetadataURL": "https://new-idp.test/metadata"},
+		map[string]string{"email": "urn:new-email", "username": "urn:username"},
+		[]string{"new-saml.example.com"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "urn:new-email", updated.AttributeMapping["email"])
+	assert.Equal(t, "urn:username", updated.AttributeMapping["username"])
+}
+
+// ---------------------------------------------------------------------------
+// UserPoolDomain — with CertificateArn for custom domains
+// ---------------------------------------------------------------------------
+
+func TestBatch2_UserPoolDomain_Managed(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "domain-managed-pool")
+
+	rec := doCognitoRequest(t, h, "CreateUserPoolDomain", map[string]any{
+		"UserPoolId": poolID,
+		"Domain":     "myapp-managed",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		CloudFrontDomain string `json:"CloudFrontDomain"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Contains(t, out.CloudFrontDomain, "amazoncognito.com")
+}
+
+func TestBatch2_UserPoolDomain_Custom_WithCertArn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "domain-custom-pool")
+
+	certArn := "arn:aws:acm:us-east-1:123456789012:certificate/abc123"
+
+	rec := doCognitoRequest(t, h, "CreateUserPoolDomain", map[string]any{
+		"UserPoolId": poolID,
+		"Domain":     "auth.mycompany.com",
+		"CustomDomainConfig": map[string]any{
+			"CertificateArn": certArn,
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var createOut struct {
+		CloudFrontDomain string `json:"CloudFrontDomain"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createOut))
+	assert.Contains(t, createOut.CloudFrontDomain, "cloudfront.net")
+
+	// Describe should return the domain with status.
+	rec = doCognitoRequest(t, h, "DescribeUserPoolDomain", map[string]any{
+		"Domain": "auth.mycompany.com",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var descOut struct {
+		DomainDescription *struct {
+			Domain                 string `json:"Domain"`
+			UserPoolID             string `json:"UserPoolId"`
+			Status                 string `json:"Status"`
+			CloudFrontDistribution string `json:"CloudFrontDistribution"`
+		} `json:"DomainDescription"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &descOut))
+	require.NotNil(t, descOut.DomainDescription)
+	assert.Equal(t, "auth.mycompany.com", descOut.DomainDescription.Domain)
+	assert.Equal(t, "ACTIVE", descOut.DomainDescription.Status)
+}
+
+func TestBatch2_UserPoolDomain_Update_WithCertArn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "domain-update-pool")
+
+	// Create managed domain first.
+	rec := doCognitoRequest(t, h, "CreateUserPoolDomain", map[string]any{
+		"UserPoolId": poolID,
+		"Domain":     "auth-update.mycompany.com",
+		"CustomDomainConfig": map[string]any{
+			"CertificateArn": "arn:aws:acm:us-east-1:123:certificate/old",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Update with new cert.
+	rec = doCognitoRequest(t, h, "UpdateUserPoolDomain", map[string]any{
+		"UserPoolId": poolID,
+		"Domain":     "auth-update.mycompany.com",
+		"CustomDomainConfig": map[string]any{
+			"CertificateArn": "arn:aws:acm:us-east-1:123:certificate/new",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		CloudFrontDomain string `json:"CloudFrontDomain"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Contains(t, out.CloudFrontDomain, "cloudfront.net")
+}
+
+func TestBatch2_UserPoolDomain_Backend_Direct(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("domain-direct-pool")
+	require.NoError(t, err)
+
+	// Managed domain (no cert).
+	d, err := b.CreateUserPoolDomainFull(pool.ID, "my-managed-domain", "")
+	require.NoError(t, err)
+	assert.Contains(t, d.CloudFrontDistribution, "amazoncognito.com")
+	assert.Empty(t, d.CertificateArn)
+
+	// Custom domain with cert.
+	certArn := "arn:aws:acm:us-east-1:123:certificate/xyz"
+	d2, err := b.CreateUserPoolDomainFull(pool.ID, "auth.example.com", certArn)
+	require.NoError(t, err)
+	assert.Contains(t, d2.CloudFrontDistribution, "cloudfront.net")
+	assert.Equal(t, certArn, d2.CertificateArn)
+
+	// Update cert.
+	newCert := "arn:aws:acm:us-east-1:123:certificate/new"
+	cfDomain, err := b.UpdateUserPoolDomainFull(pool.ID, "auth.example.com", newCert)
+	require.NoError(t, err)
+	assert.Contains(t, cfDomain, "cloudfront.net")
+
+	// Delete.
+	require.NoError(t, b.DeleteUserPoolDomain(pool.ID, "auth.example.com"))
+	d3 := b.FindUserPoolDomain("auth.example.com")
+	assert.Nil(t, d3)
+}
+
+// ---------------------------------------------------------------------------
+// Typed RiskConfiguration
+// ---------------------------------------------------------------------------
+
+func TestBatch2_RiskConfiguration_CompromisedCredentials(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "risk-cc-pool")
+
+	rec := doCognitoRequest(t, h, "SetRiskConfiguration", map[string]any{
+		"UserPoolId": poolID,
+		"CompromisedCredentialsRiskConfiguration": map[string]any{
+			"EventFilter": []string{"SIGN_IN", "PASSWORD_CHANGE"},
+			"Actions": map[string]any{
+				"EventAction": "BLOCK",
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var setOut struct {
+		RiskConfiguration *struct {
+			CompromisedCredentialsRiskConfiguration *struct {
+				Actions *struct {
+					EventAction string `json:"EventAction"`
+				} `json:"Actions"`
+				EventFilter []string `json:"EventFilter"`
+			} `json:"CompromisedCredentialsRiskConfiguration"`
+		} `json:"RiskConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &setOut))
+	require.NotNil(t, setOut.RiskConfiguration)
+	require.NotNil(t, setOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration)
+	assert.Contains(t, setOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration.EventFilter, "SIGN_IN")
+	require.NotNil(t, setOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration.Actions)
+	assert.Equal(t, "BLOCK", setOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration.Actions.EventAction)
+
+	// Describe and verify persisted.
+	rec = doCognitoRequest(t, h, "DescribeRiskConfiguration", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var descOut struct {
+		RiskConfiguration *struct {
+			CompromisedCredentialsRiskConfiguration *struct {
+				Actions *struct {
+					EventAction string `json:"EventAction"`
+				} `json:"Actions"`
+			} `json:"CompromisedCredentialsRiskConfiguration"`
+		} `json:"RiskConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &descOut))
+	require.NotNil(t, descOut.RiskConfiguration)
+	require.NotNil(t, descOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration)
+	assert.Equal(t, "BLOCK", descOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration.Actions.EventAction)
+}
+
+func TestBatch2_RiskConfiguration_AccountTakeover(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "risk-at-pool")
+
+	rec := doCognitoRequest(t, h, "SetRiskConfiguration", map[string]any{
+		"UserPoolId": poolID,
+		"AccountTakeoverRiskConfiguration": map[string]any{
+			"Actions": map[string]any{
+				"HighAction": map[string]any{
+					"Notify":      true,
+					"EventAction": "BLOCK",
+				},
+				"MediumAction": map[string]any{
+					"Notify":      true,
+					"EventAction": "MFA_IF_CONFIGURED",
+				},
+				"LowAction": map[string]any{
+					"Notify":      false,
+					"EventAction": "NO_ACTION",
+				},
+			},
+			"NotifyConfiguration": map[string]any{
+				"From":      "noreply@example.com",
+				"SourceArn": "arn:aws:ses:us-east-1:123:identity/example.com",
+				"BlockEmail": map[string]any{
+					"Subject":  "Your account has been blocked",
+					"HtmlBody": "<html>Your account was blocked.</html>",
+					"TextBody": "Your account was blocked.",
+				},
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		RiskConfiguration *struct {
+			AccountTakeoverRiskConfiguration *struct {
+				Actions *struct {
+					HighAction *struct {
+						EventAction string `json:"EventAction"`
+						Notify      bool   `json:"Notify"`
+					} `json:"HighAction"`
+					MediumAction *struct {
+						EventAction string `json:"EventAction"`
+					} `json:"MediumAction"`
+					LowAction *struct {
+						Notify bool `json:"Notify"`
+					} `json:"LowAction"`
+				} `json:"Actions"`
+				NotifyConfiguration *struct {
+					BlockEmail *struct {
+						Subject string `json:"Subject"`
+					} `json:"BlockEmail"`
+					From string `json:"From"`
+				} `json:"NotifyConfiguration"`
+			} `json:"AccountTakeoverRiskConfiguration"`
+		} `json:"RiskConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.RiskConfiguration)
+	require.NotNil(t, out.RiskConfiguration.AccountTakeoverRiskConfiguration)
+	require.NotNil(t, out.RiskConfiguration.AccountTakeoverRiskConfiguration.Actions)
+
+	a := out.RiskConfiguration.AccountTakeoverRiskConfiguration.Actions
+	require.NotNil(t, a.HighAction)
+	assert.True(t, a.HighAction.Notify)
+	assert.Equal(t, "BLOCK", a.HighAction.EventAction)
+	require.NotNil(t, a.MediumAction)
+	assert.Equal(t, "MFA_IF_CONFIGURED", a.MediumAction.EventAction)
+	require.NotNil(t, a.LowAction)
+	assert.False(t, a.LowAction.Notify)
+
+	nc := out.RiskConfiguration.AccountTakeoverRiskConfiguration.NotifyConfiguration
+	require.NotNil(t, nc)
+	assert.Equal(t, "noreply@example.com", nc.From)
+	require.NotNil(t, nc.BlockEmail)
+	assert.Equal(t, "Your account has been blocked", nc.BlockEmail.Subject)
+}
+
+func TestBatch2_RiskConfiguration_PerClient(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, clientID := setupHandlerPoolAndClient(t, h, "risk-perclient-pool")
+
+	rec := doCognitoRequest(t, h, "SetRiskConfiguration", map[string]any{
+		"UserPoolId": poolID,
+		"ClientId":   clientID,
+		"CompromisedCredentialsRiskConfiguration": map[string]any{
+			"EventFilter": []string{"SIGN_IN"},
+			"Actions":     map[string]any{"EventAction": "NO_ACTION"},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Pool-level should still be empty.
+	rec = doCognitoRequest(t, h, "DescribeRiskConfiguration", map[string]any{
+		"UserPoolId": poolID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var poolOut struct {
+		RiskConfiguration *struct {
+			CompromisedCredentialsRiskConfiguration *struct{} `json:"CompromisedCredentialsRiskConfiguration"`
+		} `json:"RiskConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &poolOut))
+	assert.Nil(t, poolOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration)
+
+	// Client-level should be set.
+	rec = doCognitoRequest(t, h, "DescribeRiskConfiguration", map[string]any{
+		"UserPoolId": poolID,
+		"ClientId":   clientID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var clientOut struct {
+		RiskConfiguration *struct {
+			CompromisedCredentialsRiskConfiguration *struct {
+				Actions *struct {
+					EventAction string `json:"EventAction"`
+				} `json:"Actions"`
+			} `json:"CompromisedCredentialsRiskConfiguration"`
+		} `json:"RiskConfiguration"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &clientOut))
+	require.NotNil(t, clientOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration)
+	assert.Equal(
+		t,
+		"NO_ACTION",
+		clientOut.RiskConfiguration.CompromisedCredentialsRiskConfiguration.Actions.EventAction,
+	)
+}
+
+func TestBatch2_RiskConfiguration_Backend_Direct(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("risk-backend-pool")
+	require.NoError(t, err)
+
+	cfg := &cognitoidp.TypedRiskConfiguration{
+		UserPoolID: pool.ID,
+		ClientID:   "",
+		CompromisedCredentialsRiskConfig: &cognitoidp.CompromisedCredentialsRiskConfig{
+			EventFilter: []string{"SIGN_IN", "SIGN_UP"},
+			Actions:     &cognitoidp.CompromisedCredentialsActions{EventAction: "BLOCK"},
+		},
+		AccountTakeoverRiskConfig: &cognitoidp.AccountTakeoverRiskConfig{
+			Actions: &cognitoidp.AccountTakeoverActions{
+				HighAction: &cognitoidp.AccountTakeoverActionType{Notify: true, EventAction: "BLOCK"},
+			},
+		},
+	}
+
+	require.NoError(t, b.SetTypedRiskConfiguration(cfg))
+
+	got, err := b.GetTypedRiskConfiguration(pool.ID, "")
+	require.NoError(t, err)
+	require.NotNil(t, got.CompromisedCredentialsRiskConfig)
+	assert.Equal(t, "BLOCK", got.CompromisedCredentialsRiskConfig.Actions.EventAction)
+	require.NotNil(t, got.AccountTakeoverRiskConfig)
+	require.NotNil(t, got.AccountTakeoverRiskConfig.Actions.HighAction)
+	assert.True(t, got.AccountTakeoverRiskConfig.Actions.HighAction.Notify)
+
+	// Invalid pool should fail.
+	err = b.SetTypedRiskConfiguration(&cognitoidp.TypedRiskConfiguration{UserPoolID: "bad-pool"})
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Stateful attribute verification
+// ---------------------------------------------------------------------------
+
+func TestBatch2_AttrVerification_GetAndVerify(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("attr-verify-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "attr-client")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "attr-user", "Pass1234!", map[string]string{
+		"email": "attr@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "attr-user", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "attr-user", "Pass1234!")
+	require.NoError(t, err)
+	accessToken := result.Tokens.AccessToken
+
+	// Generate code.
+	code, dest, medium, err := b.GetUserAttributeVerificationCode(accessToken, "email")
+	require.NoError(t, err)
+	assert.NotEmpty(t, code)
+	assert.NotEmpty(t, dest)
+	assert.Equal(t, "EMAIL", medium)
+	assert.Contains(t, dest, "***")
+
+	// Verify with code.
+	require.NoError(t, b.VerifyUserAttributeWithCode(accessToken, "email", code))
+
+	// User attribute should be verified.
+	u, err := b.GetUser(accessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "true", u.Attributes["email_verified"])
+}
+
+func TestBatch2_AttrVerification_WrongCode(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("attr-verify-wrong-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "attr-client2")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "attr-user2", "Pass1234!", map[string]string{
+		"email": "wrong@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "attr-user2", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "attr-user2", "Pass1234!")
+	require.NoError(t, err)
+
+	_, _, _, err = b.GetUserAttributeVerificationCode(result.Tokens.AccessToken, "email")
+	require.NoError(t, err)
+
+	// Wrong code.
+	err = b.VerifyUserAttributeWithCode(result.Tokens.AccessToken, "email", "WRONG!")
+	require.Error(t, err)
+}
+
+func TestBatch2_AttrVerification_NoCodeGenerated(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("attr-nocode-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "attr-nocode-client")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "attr-nocode-user", "Pass1234!", map[string]string{
+		"email": "nocode@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "attr-nocode-user", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "attr-nocode-user", "Pass1234!")
+	require.NoError(t, err)
+
+	// No code generated — verify should fail.
+	err = b.VerifyUserAttributeWithCode(result.Tokens.AccessToken, "email", "123456")
+	require.Error(t, err)
+}
+
+func TestBatch2_AttrVerification_PhoneNumber(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("attr-phone-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "phone-client")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "phone-user", "Pass1234!", map[string]string{
+		"phone_number": "+14155551234",
+		"email":        "phone@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "phone-user", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "phone-user", "Pass1234!")
+	require.NoError(t, err)
+
+	code, dest, medium, err := b.GetUserAttributeVerificationCode(result.Tokens.AccessToken, "phone_number")
+	require.NoError(t, err)
+	assert.NotEmpty(t, code)
+	assert.Equal(t, "SMS", medium)
+	assert.Contains(t, dest, "+*******")
+	assert.Contains(t, dest, "1234")
+}
+
+func TestBatch2_AttrVerification_InvalidAttribute(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("attr-invalid-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "attr-inv-client")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "attr-inv-user", "Pass1234!", map[string]string{
+		"email": "inv@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "attr-inv-user", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "attr-inv-user", "Pass1234!")
+	require.NoError(t, err)
+
+	// "name" is not verifiable.
+	_, _, _, err = b.GetUserAttributeVerificationCode(result.Tokens.AccessToken, "name")
+	require.Error(t, err)
+}
+
+func TestBatch2_AttrVerification_Handler_GetAndVerify(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, clientID := setupHandlerPoolAndClient(t, h, "attr-handler-pool")
+
+	rec := doCognitoRequest(t, h, "SignUp", map[string]any{
+		"ClientId": clientID,
+		"Username": "attr-handler-user",
+		"Password": "Pass1234!",
+		"UserAttributes": []map[string]string{
+			{"Name": "email", "Value": "handler@example.com"},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var signUpResp struct {
+		CodeDeliveryDetails map[string]string `json:"CodeDeliveryDetails"`
+		UserConfirmed       bool              `json:"UserConfirmed"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &signUpResp))
+
+	if !signUpResp.UserConfirmed {
+		confirmRec := doCognitoRequest(t, h, "ConfirmSignUp", map[string]any{
+			"ClientId":         clientID,
+			"Username":         "attr-handler-user",
+			"ConfirmationCode": signUpResp.CodeDeliveryDetails["ConfirmationCode"],
+		})
+		require.Equal(t, http.StatusOK, confirmRec.Code)
+	}
+
+	accessToken := loginViaHandler(t, h, clientID, "attr-handler-user")
+
+	// GetUserAttributeVerificationCode.
+	rec = doCognitoRequest(t, h, "GetUserAttributeVerificationCode", map[string]any{
+		"AccessToken":   accessToken,
+		"AttributeName": "email",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var codeOut struct {
+		CodeDeliveryDetails map[string]string `json:"CodeDeliveryDetails"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &codeOut))
+	assert.Equal(t, "EMAIL", codeOut.CodeDeliveryDetails["DeliveryMedium"])
+	assert.NotEmpty(t, codeOut.CodeDeliveryDetails["Destination"])
+
+	// Get code from backend for test.
+	code := h.Backend.GetAttrVerificationCodeForTest(poolID, "attr-handler-user", "email")
+	require.NotEmpty(t, code)
+
+	// VerifyUserAttribute with real code.
+	rec = doCognitoRequest(t, h, "VerifyUserAttribute", map[string]any{
+		"AccessToken":   accessToken,
+		"AttributeName": "email",
+		"Code":          code,
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Group — RoleArn and pagination
+// ---------------------------------------------------------------------------
+
+func TestBatch2_Group_Create_WithRoleArn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "group-role-pool")
+
+	roleArn := "arn:aws:iam::123456789:role/CognitoAdminRole"
+
+	rec := doCognitoRequest(t, h, "CreateGroup", map[string]any{
+		"UserPoolId":  poolID,
+		"GroupName":   "admins",
+		"Description": "Admin users",
+		"RoleArn":     roleArn,
+		"Precedence":  int32(1),
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Group *struct {
+			GroupName    string  `json:"GroupName"`
+			RoleArn      string  `json:"RoleArn"`
+			Precedence   int32   `json:"Precedence"`
+			CreationDate float64 `json:"CreationDate"`
+		} `json:"Group"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.Group)
+	assert.Equal(t, "admins", out.Group.GroupName)
+	assert.Equal(t, roleArn, out.Group.RoleArn)
+	assert.Equal(t, int32(1), out.Group.Precedence)
+	assert.Greater(t, out.Group.CreationDate, float64(0))
+}
+
+func TestBatch2_Group_Update_WithRoleArn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "group-upd-role-pool")
+
+	// Create without role.
+	rec := doCognitoRequest(t, h, "CreateGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "editors",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Update with role.
+	roleArn := "arn:aws:iam::123:role/EditorRole"
+	rec = doCognitoRequest(t, h, "UpdateGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "editors",
+		"RoleArn":    roleArn,
+		"Precedence": int32(10),
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Group *struct {
+			RoleArn    string `json:"RoleArn"`
+			Precedence int32  `json:"Precedence"`
+		} `json:"Group"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.Group)
+	assert.Equal(t, roleArn, out.Group.RoleArn)
+	assert.Equal(t, int32(10), out.Group.Precedence)
+}
+
+func TestBatch2_Group_GetGroup_WithRoleArn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "group-get-role-pool")
+
+	roleArn := "arn:aws:iam::123:role/MyRole"
+	rec := doCognitoRequest(t, h, "CreateGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "viewers",
+		"RoleArn":    roleArn,
+		"Precedence": int32(5),
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doCognitoRequest(t, h, "GetGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "viewers",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Group *struct {
+			GroupName  string `json:"GroupName"`
+			RoleArn    string `json:"RoleArn"`
+			Precedence int32  `json:"Precedence"`
+		} `json:"Group"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.Group)
+	assert.Equal(t, "viewers", out.Group.GroupName)
+	assert.Equal(t, roleArn, out.Group.RoleArn)
+}
+
+func TestBatch2_Group_ListGroups_Pagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "group-page-pool")
+
+	// Create 5 groups.
+	for i := range 5 {
+		rec := doCognitoRequest(t, h, "CreateGroup", map[string]any{
+			"UserPoolId": poolID,
+			"GroupName":  fmt.Sprintf("group-%02d", i),
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// Page 1 — 3 items.
+	rec := doCognitoRequest(t, h, "ListGroups", map[string]any{
+		"UserPoolId": poolID,
+		"Limit":      3,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page1 struct {
+		NextToken string `json:"NextToken"`
+		Groups    []struct {
+			GroupName string `json:"GroupName"`
+		} `json:"Groups"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page1))
+	assert.Len(t, page1.Groups, 3)
+	assert.NotEmpty(t, page1.NextToken)
+
+	// Page 2 — remaining items.
+	rec = doCognitoRequest(t, h, "ListGroups", map[string]any{
+		"UserPoolId": poolID,
+		"Limit":      3,
+		"NextToken":  page1.NextToken,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page2 struct {
+		NextToken string `json:"NextToken"`
+		Groups    []struct {
+			GroupName string `json:"GroupName"`
+		} `json:"Groups"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page2))
+	assert.Len(t, page2.Groups, 2)
+	assert.Empty(t, page2.NextToken)
+}
+
+func TestBatch2_Group_ListUsersInGroup_Pagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, clientID := setupHandlerPoolAndClient(t, h, "group-users-page-pool")
+
+	rec := doCognitoRequest(t, h, "CreateGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "members",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Create and add 4 users to group.
+	for i := range 4 {
+		username := fmt.Sprintf("member-%02d", i)
+		signUpAndConfirmViaHandler(t, h, clientID, username)
+		addRec := doCognitoRequest(t, h, "AdminAddUserToGroup", map[string]any{
+			"UserPoolId": poolID,
+			"Username":   username,
+			"GroupName":  "members",
+		})
+		require.Equal(t, http.StatusOK, addRec.Code)
+	}
+
+	// Page 1 — 2 users.
+	rec = doCognitoRequest(t, h, "ListUsersInGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "members",
+		"Limit":      2,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page1 struct {
+		NextToken string `json:"NextToken"`
+		Users     []struct {
+			Username string `json:"Username"`
+		} `json:"Users"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page1))
+	assert.Len(t, page1.Users, 2)
+	assert.NotEmpty(t, page1.NextToken)
+
+	// Page 2.
+	rec = doCognitoRequest(t, h, "ListUsersInGroup", map[string]any{
+		"UserPoolId": poolID,
+		"GroupName":  "members",
+		"Limit":      2,
+		"NextToken":  page1.NextToken,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page2 struct {
+		NextToken string `json:"NextToken"`
+		Users     []struct {
+			Username string `json:"Username"`
+		} `json:"Users"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page2))
+	assert.Len(t, page2.Users, 2)
+	assert.Empty(t, page2.NextToken)
+}
+
+func TestBatch2_Group_Backend_Direct(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("group-backend-pool")
+	require.NoError(t, err)
+
+	roleArn := "arn:aws:iam::123:role/TestRole"
+	g, err := b.CreateGroupFull(pool.ID, "testers", "Test users", roleArn, 5)
+	require.NoError(t, err)
+	assert.Equal(t, roleArn, g.RoleArn)
+	assert.Equal(t, int32(5), g.Precedence)
+
+	// Duplicate should fail.
+	_, err = b.CreateGroupFull(pool.ID, "testers", "", "", 0)
+	require.Error(t, err)
+
+	// Update.
+	newRole := "arn:aws:iam::123:role/UpdatedRole"
+	updated, err := b.UpdateGroupFull(pool.ID, "testers", "Updated desc", newRole, 10)
+	require.NoError(t, err)
+	assert.Equal(t, newRole, updated.RoleArn)
+	assert.Equal(t, "Updated desc", updated.Description)
+}
+
+func TestBatch2_Group_ListGroupsPage_Backend(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("group-page-backend-pool")
+	require.NoError(t, err)
+
+	for i := range 6 {
+		_, err = b.CreateGroupFull(pool.ID, fmt.Sprintf("grp-%02d", i), "", "", int32(i))
+		require.NoError(t, err)
+	}
+
+	// First page.
+	page1, tok1, err := b.ListGroupsPage(pool.ID, 3, "")
+	require.NoError(t, err)
+	assert.Len(t, page1, 3)
+	assert.NotEmpty(t, tok1)
+
+	// Second page.
+	page2, tok2, err := b.ListGroupsPage(pool.ID, 3, tok1)
+	require.NoError(t, err)
+	assert.Len(t, page2, 3)
+	assert.Empty(t, tok2)
+
+	// All groups — no limit.
+	all, tok3, err := b.ListGroupsPage(pool.ID, 0, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 6)
+	assert.Empty(t, tok3)
+}
+
+// ---------------------------------------------------------------------------
+// AdminCreateUser — MessageAction
+// ---------------------------------------------------------------------------
+
+func TestBatch2_AdminCreateUser_Suppress(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "admin-create-suppress-pool")
+
+	rec := doCognitoRequest(t, h, "AdminCreateUser", map[string]any{
+		"UserPoolId":        poolID,
+		"Username":          "suppressed-user",
+		"TemporaryPassword": "Temp1234!",
+		"MessageAction":     "SUPPRESS",
+		"UserAttributes": []map[string]string{
+			{"Name": "email", "Value": "suppress@example.com"},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		User *struct {
+			Username   string `json:"Username"`
+			UserStatus string `json:"UserStatus"`
+		} `json:"User"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.User)
+	assert.Equal(t, "suppressed-user", out.User.Username)
+	assert.Equal(t, "FORCE_CHANGE_PASSWORD", out.User.UserStatus)
+}
+
+func TestBatch2_AdminCreateUser_Resend(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "admin-create-resend-pool")
+
+	// Create user.
+	rec := doCognitoRequest(t, h, "AdminCreateUser", map[string]any{
+		"UserPoolId":        poolID,
+		"Username":          "resend-user",
+		"TemporaryPassword": "Temp1234!",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Resend — should succeed and return same user.
+	rec = doCognitoRequest(t, h, "AdminCreateUser", map[string]any{
+		"UserPoolId":    poolID,
+		"Username":      "resend-user",
+		"MessageAction": "RESEND",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		User *struct {
+			Username   string `json:"Username"`
+			UserStatus string `json:"UserStatus"`
+		} `json:"User"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.User)
+	assert.Equal(t, "resend-user", out.User.Username)
+}
+
+func TestBatch2_AdminCreateUser_DeliveryMediums(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "admin-create-delivery-pool")
+
+	rec := doCognitoRequest(t, h, "AdminCreateUser", map[string]any{
+		"UserPoolId":             poolID,
+		"Username":               "delivery-user",
+		"TemporaryPassword":      "Temp1234!",
+		"DesiredDeliveryMediums": []string{"EMAIL"},
+		"UserAttributes": []map[string]string{
+			{"Name": "email", "Value": "delivery@example.com"},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		User *struct {
+			Username string `json:"Username"`
+		} `json:"User"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.User)
+	assert.Equal(t, "delivery-user", out.User.Username)
+}
+
+func TestBatch2_AdminCreateUser_Backend_Full(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("admin-create-backend-pool")
+	require.NoError(t, err)
+
+	// Create with SUPPRESS.
+	user, err := b.AdminCreateUserFull(
+		pool.ID, "backend-user", "Temp1234!",
+		map[string]string{"email": "backend@example.com"},
+		"SUPPRESS", nil, false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "FORCE_CHANGE_PASSWORD", user.Status)
+	// SUPPRESS: custom:temporaryPassword should NOT be set.
+	assert.Empty(t, user.Attributes["custom:temporaryPassword"])
+
+	// Duplicate should fail (not RESEND).
+	_, err = b.AdminCreateUserFull(pool.ID, "backend-user", "New1234!", nil, "", nil, false)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// AdminSetUserPassword — policy enforcement
+// ---------------------------------------------------------------------------
+
+func TestBatch2_AdminSetUserPassword_Permanent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "admin-pwd-perm-pool")
+
+	// Create user in FORCE_CHANGE_PASSWORD.
+	rec := doCognitoRequest(t, h, "AdminCreateUser", map[string]any{
+		"UserPoolId":        poolID,
+		"Username":          "pwd-user",
+		"TemporaryPassword": "Temp1234!",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Set permanent password.
+	rec = doCognitoRequest(t, h, "AdminSetUserPassword", map[string]any{
+		"UserPoolId": poolID,
+		"Username":   "pwd-user",
+		"Password":   "Perm5678!",
+		"Permanent":  true,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// User should now be CONFIRMED.
+	rec = doCognitoRequest(t, h, "AdminGetUser", map[string]any{
+		"UserPoolId": poolID,
+		"Username":   "pwd-user",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		UserStatus string `json:"UserStatus"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "CONFIRMED", out.UserStatus)
+}
+
+func TestBatch2_AdminSetUserPassword_Temporary(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	poolID, _ := setupHandlerPoolAndClient(t, h, "admin-pwd-temp-pool")
+
+	rec := doCognitoRequest(t, h, "AdminCreateUser", map[string]any{
+		"UserPoolId":        poolID,
+		"Username":          "temp-pwd-user",
+		"TemporaryPassword": "Temp1234!",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Set another temporary password.
+	rec = doCognitoRequest(t, h, "AdminSetUserPassword", map[string]any{
+		"UserPoolId": poolID,
+		"Username":   "temp-pwd-user",
+		"Password":   "NewTemp9999!",
+		"Permanent":  false,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// User should remain FORCE_CHANGE_PASSWORD.
+	rec = doCognitoRequest(t, h, "AdminGetUser", map[string]any{
+		"UserPoolId": poolID,
+		"Username":   "temp-pwd-user",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		UserStatus string `json:"UserStatus"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "FORCE_CHANGE_PASSWORD", out.UserStatus)
+}
+
+func TestBatch2_AdminSetUserPassword_PolicyEnforced(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPoolWithOpts("admin-pwd-policy-pool", cognitoidp.UserPoolOptions{
+		PasswordPolicy: &cognitoidp.PasswordPolicy{
+			MinimumLength:    10,
+			RequireUppercase: true,
+			RequireNumbers:   true,
+			RequireSymbols:   true,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = b.AdminCreateUser(pool.ID, "policy-user", "Temp1234!@#", nil)
+	require.NoError(t, err)
+
+	// Short password — policy violation.
+	err = b.AdminSetUserPasswordFull(pool.ID, "policy-user", "short", true)
+	require.Error(t, err)
+
+	// Valid password.
+	err = b.AdminSetUserPasswordFull(pool.ID, "policy-user", "LongPass1234!", true)
+	require.NoError(t, err)
+}
+
+func TestBatch2_AdminSetUserPassword_Backend_UserNotFound(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("admin-pwd-notfound-pool")
+	require.NoError(t, err)
+
+	err = b.AdminSetUserPasswordFull(pool.ID, "nonexistent", "Pass1234!", true)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// EvictExpiredAttrVerificationCodes
+// ---------------------------------------------------------------------------
+
+func TestBatch2_EvictExpiredAttrVerificationCodes(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("evict-attr-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "evict-client")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "evict-user", "Pass1234!", map[string]string{
+		"email": "evict@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "evict-user", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "evict-user", "Pass1234!")
+	require.NoError(t, err)
+
+	code, _, _, err := b.GetUserAttributeVerificationCode(result.Tokens.AccessToken, "email")
+	require.NoError(t, err)
+	assert.NotEmpty(t, code)
+
+	// Evict — code should still be there (not expired).
+	b.EvictExpiredAttrVerificationCodes()
+
+	// Code should still work since not expired.
+	storedCode := b.GetAttrVerificationCodeForTest(pool.ID, "evict-user", "email")
+	assert.NotEmpty(t, storedCode)
+}
+
+// ---------------------------------------------------------------------------
+// maskEmail and maskPhone helpers (via handler output)
+// ---------------------------------------------------------------------------
+
+func TestBatch2_GetUserAttributeVerifCode_MasksEmail(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackend()
+	pool, err := b.CreateUserPool("mask-email-pool")
+	require.NoError(t, err)
+	client, err := b.CreateUserPoolClient(pool.ID, "mask-client")
+	require.NoError(t, err)
+
+	user, err := b.SignUp(client.ClientID, "mask-user", "Pass1234!", map[string]string{
+		"email": "johndoe@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.ConfirmSignUp(client.ClientID, "mask-user", user.ConfirmCode))
+
+	result, err := b.InitiateAuth(client.ClientID, "USER_PASSWORD_AUTH", "mask-user", "Pass1234!")
+	require.NoError(t, err)
+
+	_, dest, medium, err := b.GetUserAttributeVerificationCode(result.Tokens.AccessToken, "email")
+	require.NoError(t, err)
+	assert.Equal(t, "EMAIL", medium)
+	// Should start with "jo***" and contain the domain.
+	assert.Contains(t, dest, "jo***")
+	assert.Contains(t, dest, "@example.com")
+}

--- a/services/cognitoidp/batch2_test.go
+++ b/services/cognitoidp/batch2_test.go
@@ -246,20 +246,20 @@ func TestBatch2_UICustomization_SetGet_WithImageUrl(t *testing.T) {
 
 	var setOut struct {
 		UICustomization *struct {
-			UserPoolId       string  `json:"UserPoolId"`
-			ClientId         string  `json:"ClientId"`
+			UserPoolID       string  `json:"UserPoolId"`
+			ClientID         string  `json:"ClientId"`
 			CSS              string  `json:"CSS"`
-			ImageUrl         string  `json:"ImageUrl"`
+			ImageURL         string  `json:"ImageUrl"`
 			CreationDate     float64 `json:"CreationDate"`
 			LastModifiedDate float64 `json:"LastModifiedDate"`
 		} `json:"UICustomization"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &setOut))
 	require.NotNil(t, setOut.UICustomization)
-	assert.Equal(t, poolID, setOut.UICustomization.UserPoolId)
-	assert.Equal(t, clientID, setOut.UICustomization.ClientId)
+	assert.Equal(t, poolID, setOut.UICustomization.UserPoolID)
+	assert.Equal(t, clientID, setOut.UICustomization.ClientID)
 	assert.Equal(t, ".banner { background: blue; }", setOut.UICustomization.CSS)
-	assert.Equal(t, "https://example.com/logo.png", setOut.UICustomization.ImageUrl)
+	assert.Equal(t, "https://example.com/logo.png", setOut.UICustomization.ImageURL)
 	assert.Greater(t, setOut.UICustomization.CreationDate, float64(0))
 	assert.Greater(t, setOut.UICustomization.LastModifiedDate, float64(0))
 
@@ -273,14 +273,14 @@ func TestBatch2_UICustomization_SetGet_WithImageUrl(t *testing.T) {
 	var getOut struct {
 		UICustomization *struct {
 			CSS              string  `json:"CSS"`
-			ImageUrl         string  `json:"ImageUrl"`
+			ImageURL         string  `json:"ImageUrl"`
 			LastModifiedDate float64 `json:"LastModifiedDate"`
 		} `json:"UICustomization"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &getOut))
 	require.NotNil(t, getOut.UICustomization)
 	assert.Equal(t, ".banner { background: blue; }", getOut.UICustomization.CSS)
-	assert.Equal(t, "https://example.com/logo.png", getOut.UICustomization.ImageUrl)
+	assert.Equal(t, "https://example.com/logo.png", getOut.UICustomization.ImageURL)
 	assert.Greater(t, getOut.UICustomization.LastModifiedDate, float64(0))
 }
 
@@ -297,7 +297,7 @@ func TestBatch2_UICustomization_Get_Empty(t *testing.T) {
 
 	var out struct {
 		UICustomization *struct {
-			UserPoolId string `json:"UserPoolId"`
+			UserPoolID string `json:"UserPoolId"`
 			CSS        string `json:"CSS"`
 		} `json:"UICustomization"`
 	}
@@ -340,14 +340,14 @@ func TestBatch2_UICustomization_Backend_Direct(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, ".body { color: red; }", ui.CSS)
-	assert.Equal(t, "https://img.example.com/logo.png", ui.ImageUrl)
+	assert.Equal(t, "https://img.example.com/logo.png", ui.ImageURL)
 	assert.False(t, ui.CreatedAt.IsZero())
 	assert.False(t, ui.LastModifiedAt.IsZero())
 
 	got, err := b.GetUICustomizationFull(pool.ID, client.ClientID)
 	require.NoError(t, err)
 	assert.Equal(t, ui.CSS, got.CSS)
-	assert.Equal(t, ui.ImageUrl, got.ImageUrl)
+	assert.Equal(t, ui.ImageURL, got.ImageURL)
 }
 
 // ---------------------------------------------------------------------------

--- a/services/cognitoidp/completeness_backend.go
+++ b/services/cognitoidp/completeness_backend.go
@@ -13,12 +13,14 @@ import (
 
 // IdentityProvider represents a federated identity provider attached to a user pool.
 type IdentityProvider struct {
-	ProviderDetails map[string]string
-	CreatedAt       time.Time
-	LastModifiedAt  time.Time
-	UserPoolID      string
-	ProviderName    string
-	ProviderType    string
+	ProviderDetails  map[string]string
+	AttributeMapping map[string]string
+	CreatedAt        time.Time
+	LastModifiedAt   time.Time
+	UserPoolID       string
+	ProviderName     string
+	ProviderType     string
+	IdpIdentifiers   []string
 }
 
 // UserPoolDomain holds the custom domain configuration for a user pool.
@@ -26,6 +28,7 @@ type UserPoolDomain struct {
 	Domain                 string
 	UserPoolID             string
 	CloudFrontDistribution string
+	CertificateArn         string
 	Status                 string
 }
 
@@ -42,9 +45,12 @@ type LogDeliveryConfig struct {
 
 // UICustomization stores hosted-UI CSS and logo settings for a pool or client.
 type UICustomization struct {
-	UserPoolID string
-	ClientID   string
-	CSS        string
+	CreatedAt      time.Time
+	LastModifiedAt time.Time
+	UserPoolID     string
+	ClientID       string
+	CSS            string
+	ImageUrl       string
 }
 
 // ManagedLoginBranding stores managed login branding for a pool client.

--- a/services/cognitoidp/completeness_backend.go
+++ b/services/cognitoidp/completeness_backend.go
@@ -3,6 +3,7 @@ package cognitoidp
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"time"
 )
@@ -50,7 +51,7 @@ type UICustomization struct {
 	UserPoolID     string
 	ClientID       string
 	CSS            string
-	ImageUrl       string
+	ImageURL       string
 }
 
 // ManagedLoginBranding stores managed login branding for a pool client.
@@ -157,13 +158,11 @@ func (b *InMemoryBackend) GetIdentityProviderByIdentifier(userPoolID, identifier
 			return &cp, nil
 		}
 
-		for _, idpID := range idp.IdpIdentifiers {
-			if idpID == identifier {
-				cp := *idp
-				cp.ProviderDetails = maps.Clone(idp.ProviderDetails)
+		if slices.Contains(idp.IdpIdentifiers, identifier) {
+			cp := *idp
+			cp.ProviderDetails = maps.Clone(idp.ProviderDetails)
 
-				return &cp, nil
-			}
+			return &cp, nil
 		}
 	}
 

--- a/services/cognitoidp/completeness_backend.go
+++ b/services/cognitoidp/completeness_backend.go
@@ -156,6 +156,15 @@ func (b *InMemoryBackend) GetIdentityProviderByIdentifier(userPoolID, identifier
 
 			return &cp, nil
 		}
+
+		for _, idpID := range idp.IdpIdentifiers {
+			if idpID == identifier {
+				cp := *idp
+				cp.ProviderDetails = maps.Clone(idp.ProviderDetails)
+
+				return &cp, nil
+			}
+		}
 	}
 
 	return nil, fmt.Errorf("%w: identity provider with identifier %q not found in pool %q",

--- a/services/cognitoidp/completeness_stubs_test.go
+++ b/services/cognitoidp/completeness_stubs_test.go
@@ -5,6 +5,7 @@ package cognitoidp_test
 // with an empty JSON response body. One request per stub is sufficient for coverage.
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -36,7 +37,6 @@ func TestCompleteness_StubOperations(t *testing.T) {
 		"ForgetDevice",
 		"GetCSVHeader",
 		"GetDevice",
-		"GetUserAttributeVerificationCode",
 		"GetUserAuthFactors",
 		"ListDevices",
 		"ListTagsForResource",
@@ -426,38 +426,66 @@ func TestHandler_DeleteUserAttributes(t *testing.T) {
 func TestHandler_VerifyUserAttribute(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
-		wantCode int
-	}{
-		{name: "success", wantCode: http.StatusOK},
-		{name: "bad_token", wantCode: http.StatusBadRequest},
-	}
+	t.Run("bad_token", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			h := newTestHandler(t)
-			_, clientID := setupHandlerPoolAndClient(t, h, "verify-attr-pool")
-
-			var accessToken string
-
-			if tt.name == "success" {
-				signUpAndConfirmViaHandler(t, h, clientID, "verify-attr-user")
-				accessToken = loginViaHandler(t, h, clientID, "verify-attr-user")
-			} else {
-				accessToken = "bad-token"
-			}
-
-			rec := doCognitoRequest(t, h, "VerifyUserAttribute", map[string]any{
-				"AccessToken":   accessToken,
-				"AttributeName": "email",
-				"Code":          "123456",
-			})
-			assert.Equal(t, tt.wantCode, rec.Code)
+		h := newTestHandler(t)
+		rec := doCognitoRequest(t, h, "VerifyUserAttribute", map[string]any{
+			"AccessToken":   "bad-token",
+			"AttributeName": "email",
+			"Code":          "123456",
 		})
-	}
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("success_with_real_code", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		poolID, clientID := setupHandlerPoolAndClient(t, h, "verify-attr-pool2")
+
+		// Sign up with email so GetUserAttributeVerificationCode works.
+		rec := doCognitoRequest(t, h, "SignUp", map[string]any{
+			"ClientId": clientID,
+			"Username": "verify-attr-user2",
+			"Password": "Pass1234!",
+			"UserAttributes": []map[string]string{
+				{"Name": "email", "Value": "verify@example.com"},
+			},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var signUpResp struct {
+			CodeDeliveryDetails map[string]string `json:"CodeDeliveryDetails"`
+			UserConfirmed       bool              `json:"UserConfirmed"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &signUpResp))
+
+		if !signUpResp.UserConfirmed {
+			confirmRec := doCognitoRequest(t, h, "ConfirmSignUp", map[string]any{
+				"ClientId":         clientID,
+				"Username":         "verify-attr-user2",
+				"ConfirmationCode": signUpResp.CodeDeliveryDetails["ConfirmationCode"],
+			})
+			require.Equal(t, http.StatusOK, confirmRec.Code)
+		}
+
+		accessToken := loginViaHandler(t, h, clientID, "verify-attr-user2")
+
+		// Generate and store a verification code.
+		_, _, _, err := h.Backend.GetUserAttributeVerificationCode(accessToken, "email")
+		require.NoError(t, err)
+
+		code := h.Backend.GetAttrVerificationCodeForTest(poolID, "verify-attr-user2", "email")
+		require.NotEmpty(t, code)
+
+		rec = doCognitoRequest(t, h, "VerifyUserAttribute", map[string]any{
+			"AccessToken":   accessToken,
+			"AttributeName": "email",
+			"Code":          code,
+		})
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
 }
 
 // TestBackend_ListUsers covers the backend ListUsers function.

--- a/services/cognitoidp/export_test.go
+++ b/services/cognitoidp/export_test.go
@@ -87,3 +87,16 @@ func (b *InMemoryBackend) UserPoolID(clientID string) string {
 
 	return ""
 }
+
+// GetAttrVerificationCodeForTest returns the pending verification code for a user attribute. For testing only.
+func (b *InMemoryBackend) GetAttrVerificationCodeForTest(poolID, username, attrName string) string {
+	b.mu.RLock("GetAttrVerificationCodeForTest")
+	defer b.mu.RUnlock()
+
+	key := poolID + ":" + username + ":" + attrName
+	if entry, ok := b.attrVerificationCodes[key]; ok {
+		return entry.Code
+	}
+
+	return ""
+}

--- a/services/cognitoidp/handler.go
+++ b/services/cognitoidp/handler.go
@@ -510,7 +510,7 @@ type userPoolData struct {
 
 func mfaConfigOrDefault(s string) string {
 	if s == "" {
-		return "OFF"
+		return mfaConfigOFF
 	}
 
 	return s
@@ -694,7 +694,7 @@ func (h *Handler) handleGetUserPoolMfaConfig(
 
 	mfa := pool.MfaConfiguration
 	if mfa == "" {
-		mfa = "OFF"
+		mfa = mfaConfigOFF
 	}
 
 	return &getUserPoolMfaConfigOutput{MfaConfiguration: mfa}, nil

--- a/services/cognitoidp/handler.go
+++ b/services/cognitoidp/handler.go
@@ -366,6 +366,7 @@ func (h *Handler) dispatchTable() map[string]service.JSONOpFunc {
 	}
 	maps.Copy(table, h.completenessDispatchTable())
 	maps.Copy(table, h.accuracyDispatchTable())
+	maps.Copy(table, h.batch2DispatchTable())
 
 	return table
 }


### PR DESCRIPTION
## Summary

- Full MFA sub-config (SMS/TOTP/Email) for `GetUserPoolMfaConfig`/`SetUserPoolMfaConfig`
- Stateful `GetUserAttributeVerificationCode` + `VerifyUserAttribute` with code storage and validation
- `IdentityProvider` CRUD with `AttributeMapping`, `IdpIdentifiers` (SAML/OIDC/social)
- `UserPoolDomain` with `CertificateArn` for custom domains and CloudFront distribution generation
- Typed `RiskConfiguration` (`CompromisedCredentials` + `AccountTakeover` with per-risk-level actions)
- `UICustomization` with `ImageURL`, `CreatedAt`, `LastModifiedAt` timestamps
- `Group` with `RoleArn`; `ListGroups`/`ListUsersInGroup` with `NextToken` pagination
- `AdminCreateUser` with `MessageAction` (SUPPRESS/RESEND), `DesiredDeliveryMediums`
- `AdminSetUserPassword` with password policy enforcement and proper status transitions
- 1765 lines of tests, 50+ test cases covering all new ops

Closes #1702

## Test plan
- [ ] `go test ./services/cognitoidp/...` — all tests pass
- [ ] `golangci-lint run ./services/cognitoidp/...` — 0 issues
- [ ] Batch-2 test cases cover backend-direct and handler-over-HTTP paths for all new ops

🤖 Generated with [Claude Code](https://claude.ai/claude-code)