### PR TITLE
feat(opensearch): AWS-accuracy audit batch-1 (go-b2ho)

### DIFF
--- a/services/cloudformation/resources_phase2.go
+++ b/services/cloudformation/resources_phase2.go
@@ -764,7 +764,11 @@ func (rc *ResourceCreator) createOpenSearchDomain(
 		}
 	}
 
-	domain, err := rc.backends.OpenSearch.Backend.CreateDomain(name, engineVersion, clusterConfig)
+	domain, err := rc.backends.OpenSearch.Backend.CreateDomain(opensearchbackend.CreateDomainInput{
+		Name:          name,
+		EngineVersion: engineVersion,
+		ClusterConfig: clusterConfig,
+	})
 	if err != nil {
 		return "", fmt.Errorf("create OpenSearch domain %s: %w", name, err)
 	}

--- a/services/opensearch/backend.go
+++ b/services/opensearch/backend.go
@@ -247,18 +247,18 @@ type DNSRegistrar interface {
 
 // ClusterConfig represents the cluster configuration for an OpenSearch domain.
 type ClusterConfig struct {
-	ZoneAwarenessConfig        *ZoneAwarenessConfig `json:"zoneAwarenessConfig,omitempty"`
-	InstanceType               string               `json:"instanceType"`
-	DedicatedMasterType        string               `json:"dedicatedMasterType,omitempty"`
-	WarmType                   string               `json:"warmType,omitempty"`
-	InstanceCount              int                  `json:"instanceCount"`
-	DedicatedMasterCount       int                  `json:"dedicatedMasterCount,omitempty"`
-	WarmCount                  int                  `json:"warmCount,omitempty"`
-	DedicatedMasterEnabled     bool                 `json:"dedicatedMasterEnabled,omitempty"`
-	ZoneAwarenessEnabled       bool                 `json:"zoneAwarenessEnabled,omitempty"`
-	WarmEnabled                bool                 `json:"warmEnabled,omitempty"`
-	ColdStorageEnabled         bool                 `json:"coldStorageEnabled,omitempty"`
-	MultiAZWithStandbyEnabled  bool                 `json:"multiAZWithStandbyEnabled,omitempty"`
+	ZoneAwarenessConfig       *ZoneAwarenessConfig `json:"zoneAwarenessConfig,omitempty"`
+	InstanceType              string               `json:"instanceType"`
+	DedicatedMasterType       string               `json:"dedicatedMasterType,omitempty"`
+	WarmType                  string               `json:"warmType,omitempty"`
+	InstanceCount             int                  `json:"instanceCount"`
+	DedicatedMasterCount      int                  `json:"dedicatedMasterCount,omitempty"`
+	WarmCount                 int                  `json:"warmCount,omitempty"`
+	DedicatedMasterEnabled    bool                 `json:"dedicatedMasterEnabled,omitempty"`
+	ZoneAwarenessEnabled      bool                 `json:"zoneAwarenessEnabled,omitempty"`
+	WarmEnabled               bool                 `json:"warmEnabled,omitempty"`
+	ColdStorageEnabled        bool                 `json:"coldStorageEnabled,omitempty"`
+	MultiAZWithStandbyEnabled bool                 `json:"multiAZWithStandbyEnabled,omitempty"`
 }
 
 // ZoneAwarenessConfig holds zone awareness settings.
@@ -303,12 +303,12 @@ type DomainEndpointOptions struct {
 
 // SAMLOptionsInput holds SAML configuration for AdvancedSecurityOptions.
 type SAMLOptionsInput struct {
-	IDPEntityID        string `json:"idpEntityId,omitempty"`
-	IDPMetadataContent string `json:"idpMetadataContent,omitempty"`
-	RolesKey           string `json:"rolesKey,omitempty"`
-	SubjectKey         string `json:"subjectKey,omitempty"`
-	SessionTimeoutMinutes int `json:"sessionTimeoutMinutes,omitempty"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	IDPEntityID           string `json:"idpEntityId,omitempty"`
+	IDPMetadataContent    string `json:"idpMetadataContent,omitempty"`
+	RolesKey              string `json:"rolesKey,omitempty"`
+	SubjectKey            string `json:"subjectKey,omitempty"`
+	SessionTimeoutMinutes int    `json:"sessionTimeoutMinutes,omitempty"`
+	Enabled               bool   `json:"enabled,omitempty"`
 }
 
 // AdvancedSecurityOptions holds fine-grained access control settings.
@@ -321,9 +321,9 @@ type AdvancedSecurityOptions struct {
 
 // VPCOptions holds VPC configuration for an OpenSearch domain.
 type VPCOptions struct {
+	VPCID            string   `json:"vpcId,omitempty"`
 	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
 	SubnetIDs        []string `json:"subnetIds,omitempty"`
-	VPCID            string   `json:"vpcId,omitempty"`
 }
 
 // CognitoOptions holds Cognito configuration for Kibana authentication.
@@ -342,24 +342,24 @@ type LogPublishingOption struct {
 
 // Domain represents an OpenSearch domain.
 type Domain struct {
-	EBSOptions                  *EBSOptions                  `json:"ebsOptions,omitempty"`
-	SnapshotOptions             *SnapshotOptions             `json:"snapshotOptions,omitempty"`
-	EncryptionAtRestOptions     *EncryptionAtRestOptions     `json:"encryptionAtRestOptions,omitempty"`
-	NodeToNodeEncryptionOptions *NodeToNodeEncryptionOptions `json:"nodeToNodeEncryptionOptions,omitempty"`
-	DomainEndpointOptions       *DomainEndpointOptions       `json:"domainEndpointOptions,omitempty"`
-	AdvancedSecurityOptions     *AdvancedSecurityOptions     `json:"advancedSecurityOptions,omitempty"`
-	VPCOptions                  *VPCOptions                  `json:"vpcOptions,omitempty"`
-	CognitoOptions              *CognitoOptions              `json:"cognitoOptions,omitempty"`
+	EBSOptions                  *EBSOptions                     `json:"ebsOptions,omitempty"`
+	SnapshotOptions             *SnapshotOptions                `json:"snapshotOptions,omitempty"`
+	EncryptionAtRestOptions     *EncryptionAtRestOptions        `json:"encryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions *NodeToNodeEncryptionOptions    `json:"nodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       *DomainEndpointOptions          `json:"domainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     *AdvancedSecurityOptions        `json:"advancedSecurityOptions,omitempty"`
+	VPCOptions                  *VPCOptions                     `json:"vpcOptions,omitempty"`
+	CognitoOptions              *CognitoOptions                 `json:"cognitoOptions,omitempty"`
 	LogPublishingOptions        map[string]*LogPublishingOption `json:"logPublishingOptions,omitempty"`
-	Tags                        *tags.Tags                   `json:"tags,omitempty"`
-	AccessPolicies              string                       `json:"accessPolicies,omitempty"`
-	Name                        string                       `json:"name"`
-	ARN                         string                       `json:"arn"`
-	EngineVersion               string                       `json:"engineVersion"`
-	Endpoint                    string                       `json:"endpoint"`
-	Status                      string                       `json:"status"`
-	LastChangeID                string                       `json:"lastChangeID,omitempty"`
-	ClusterConfig               ClusterConfig                `json:"clusterConfig"`
+	Tags                        *tags.Tags                      `json:"tags,omitempty"`
+	AccessPolicies              string                          `json:"accessPolicies,omitempty"`
+	Name                        string                          `json:"name"`
+	ARN                         string                          `json:"arn"`
+	EngineVersion               string                          `json:"engineVersion"`
+	Endpoint                    string                          `json:"endpoint"`
+	Status                      string                          `json:"status"`
+	LastChangeID                string                          `json:"lastChangeID,omitempty"`
+	ClusterConfig               ClusterConfig                   `json:"clusterConfig"`
 }
 
 // CreateDomainInput holds all options for creating a new OpenSearch domain.

--- a/services/opensearch/backend.go
+++ b/services/opensearch/backend.go
@@ -247,26 +247,153 @@ type DNSRegistrar interface {
 
 // ClusterConfig represents the cluster configuration for an OpenSearch domain.
 type ClusterConfig struct {
-	InstanceType  string `json:"instanceType"`
-	InstanceCount int    `json:"instanceCount"`
+	ZoneAwarenessConfig        *ZoneAwarenessConfig `json:"zoneAwarenessConfig,omitempty"`
+	InstanceType               string               `json:"instanceType"`
+	DedicatedMasterType        string               `json:"dedicatedMasterType,omitempty"`
+	WarmType                   string               `json:"warmType,omitempty"`
+	InstanceCount              int                  `json:"instanceCount"`
+	DedicatedMasterCount       int                  `json:"dedicatedMasterCount,omitempty"`
+	WarmCount                  int                  `json:"warmCount,omitempty"`
+	DedicatedMasterEnabled     bool                 `json:"dedicatedMasterEnabled,omitempty"`
+	ZoneAwarenessEnabled       bool                 `json:"zoneAwarenessEnabled,omitempty"`
+	WarmEnabled                bool                 `json:"warmEnabled,omitempty"`
+	ColdStorageEnabled         bool                 `json:"coldStorageEnabled,omitempty"`
+	MultiAZWithStandbyEnabled  bool                 `json:"multiAZWithStandbyEnabled,omitempty"`
+}
+
+// ZoneAwarenessConfig holds zone awareness settings.
+type ZoneAwarenessConfig struct {
+	AvailabilityZoneCount int `json:"availabilityZoneCount"`
+}
+
+// EBSOptions represents EBS volume settings for an OpenSearch domain.
+type EBSOptions struct {
+	VolumeType string `json:"volumeType,omitempty"`
+	KMSKeyID   string `json:"kmsKeyId,omitempty"`
+	VolumeSize int    `json:"volumeSize,omitempty"`
+	IOPS       int    `json:"iops,omitempty"`
+	Throughput int    `json:"throughput,omitempty"`
+	EBSEnabled bool   `json:"ebsEnabled"`
+}
+
+// SnapshotOptions holds automated snapshot settings.
+type SnapshotOptions struct {
+	AutomatedSnapshotStartHour int `json:"automatedSnapshotStartHour"`
+}
+
+// EncryptionAtRestOptions holds encryption at rest settings.
+type EncryptionAtRestOptions struct {
+	KMSKeyID string `json:"kmsKeyId,omitempty"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// NodeToNodeEncryptionOptions holds node-to-node encryption settings.
+type NodeToNodeEncryptionOptions struct {
+	Enabled bool `json:"enabled"`
+}
+
+// DomainEndpointOptions holds HTTPS and custom endpoint settings.
+type DomainEndpointOptions struct {
+	CustomEndpointCertificateArn string `json:"customEndpointCertificateArn,omitempty"`
+	CustomEndpoint               string `json:"customEndpoint,omitempty"`
+	TLSSecurityPolicy            string `json:"tlsSecurityPolicy,omitempty"`
+	EnforceHTTPS                 bool   `json:"enforceHTTPS,omitempty"`
+	CustomEndpointEnabled        bool   `json:"customEndpointEnabled,omitempty"`
+}
+
+// SAMLOptionsInput holds SAML configuration for AdvancedSecurityOptions.
+type SAMLOptionsInput struct {
+	IDPEntityID        string `json:"idpEntityId,omitempty"`
+	IDPMetadataContent string `json:"idpMetadataContent,omitempty"`
+	RolesKey           string `json:"rolesKey,omitempty"`
+	SubjectKey         string `json:"subjectKey,omitempty"`
+	SessionTimeoutMinutes int `json:"sessionTimeoutMinutes,omitempty"`
+	Enabled            bool   `json:"enabled,omitempty"`
+}
+
+// AdvancedSecurityOptions holds fine-grained access control settings.
+type AdvancedSecurityOptions struct {
+	SAMLOptions                 *SAMLOptionsInput `json:"samlOptions,omitempty"`
+	AnonymousAuthEnabled        bool              `json:"anonymousAuthEnabled,omitempty"`
+	Enabled                     bool              `json:"enabled"`
+	InternalUserDatabaseEnabled bool              `json:"internalUserDatabaseEnabled,omitempty"`
+}
+
+// VPCOptions holds VPC configuration for an OpenSearch domain.
+type VPCOptions struct {
+	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
+	SubnetIDs        []string `json:"subnetIds,omitempty"`
+	VPCID            string   `json:"vpcId,omitempty"`
+}
+
+// CognitoOptions holds Cognito configuration for Kibana authentication.
+type CognitoOptions struct {
+	IdentityPoolID string `json:"identityPoolId,omitempty"`
+	RoleARN        string `json:"roleArn,omitempty"`
+	UserPoolID     string `json:"userPoolId,omitempty"`
+	Enabled        bool   `json:"enabled"`
+}
+
+// LogPublishingOption holds a single log type publishing configuration.
+type LogPublishingOption struct {
+	CloudWatchLogsLogGroupARN string `json:"cloudWatchLogsLogGroupArn,omitempty"`
+	Enabled                   bool   `json:"enabled"`
 }
 
 // Domain represents an OpenSearch domain.
 type Domain struct {
-	Tags          *tags.Tags    `json:"tags,omitempty"`
-	Name          string        `json:"name"`
-	ARN           string        `json:"arn"`
-	EngineVersion string        `json:"engineVersion"`
-	Endpoint      string        `json:"endpoint"`
-	Status        string        `json:"status"`
-	LastChangeID  string        `json:"lastChangeID,omitempty"`
-	ClusterConfig ClusterConfig `json:"clusterConfig"`
+	EBSOptions                  *EBSOptions                  `json:"ebsOptions,omitempty"`
+	SnapshotOptions             *SnapshotOptions             `json:"snapshotOptions,omitempty"`
+	EncryptionAtRestOptions     *EncryptionAtRestOptions     `json:"encryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions *NodeToNodeEncryptionOptions `json:"nodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       *DomainEndpointOptions       `json:"domainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     *AdvancedSecurityOptions     `json:"advancedSecurityOptions,omitempty"`
+	VPCOptions                  *VPCOptions                  `json:"vpcOptions,omitempty"`
+	CognitoOptions              *CognitoOptions              `json:"cognitoOptions,omitempty"`
+	LogPublishingOptions        map[string]*LogPublishingOption `json:"logPublishingOptions,omitempty"`
+	Tags                        *tags.Tags                   `json:"tags,omitempty"`
+	AccessPolicies              string                       `json:"accessPolicies,omitempty"`
+	Name                        string                       `json:"name"`
+	ARN                         string                       `json:"arn"`
+	EngineVersion               string                       `json:"engineVersion"`
+	Endpoint                    string                       `json:"endpoint"`
+	Status                      string                       `json:"status"`
+	LastChangeID                string                       `json:"lastChangeID,omitempty"`
+	ClusterConfig               ClusterConfig                `json:"clusterConfig"`
+}
+
+// CreateDomainInput holds all options for creating a new OpenSearch domain.
+type CreateDomainInput struct {
+	EBSOptions                  *EBSOptions
+	SnapshotOptions             *SnapshotOptions
+	EncryptionAtRestOptions     *EncryptionAtRestOptions
+	NodeToNodeEncryptionOptions *NodeToNodeEncryptionOptions
+	DomainEndpointOptions       *DomainEndpointOptions
+	AdvancedSecurityOptions     *AdvancedSecurityOptions
+	VPCOptions                  *VPCOptions
+	CognitoOptions              *CognitoOptions
+	LogPublishingOptions        map[string]*LogPublishingOption
+	Tags                        map[string]string
+	Name                        string
+	EngineVersion               string
+	AccessPolicies              string
+	ClusterConfig               ClusterConfig
 }
 
 // UpdateDomainConfigInput holds mutable fields for UpdateDomainConfig.
 type UpdateDomainConfigInput struct {
-	ClusterConfig *ClusterConfig `json:"ClusterConfig"`
-	EngineVersion string         `json:"EngineVersion"`
+	EBSOptions                  *EBSOptions
+	SnapshotOptions             *SnapshotOptions
+	EncryptionAtRestOptions     *EncryptionAtRestOptions
+	NodeToNodeEncryptionOptions *NodeToNodeEncryptionOptions
+	DomainEndpointOptions       *DomainEndpointOptions
+	AdvancedSecurityOptions     *AdvancedSecurityOptions
+	VPCOptions                  *VPCOptions
+	CognitoOptions              *CognitoOptions
+	LogPublishingOptions        map[string]*LogPublishingOption
+	ClusterConfig               *ClusterConfig
+	AccessPolicies              string
+	EngineVersion               string
 }
 
 // AppSetting is a key-value pair for default application settings.
@@ -352,44 +479,59 @@ func (b *InMemoryBackend) SetDNSRegistrar(dns DNSRegistrar) {
 }
 
 // CreateDomain creates a new OpenSearch domain.
-func (b *InMemoryBackend) CreateDomain(name, engineVersion string, clusterConfig ClusterConfig) (*Domain, error) {
-	if name == "" {
+func (b *InMemoryBackend) CreateDomain(input CreateDomainInput) (*Domain, error) {
+	if input.Name == "" {
 		return nil, fmt.Errorf("%w: DomainName is required", ErrInvalidParameter)
 	}
 
 	b.mu.Lock("CreateDomain")
 	defer b.mu.Unlock()
 
-	if _, exists := b.domains[name]; exists {
-		return nil, fmt.Errorf("%w: domain %s already exists", ErrDomainAlreadyExists, name)
+	if _, exists := b.domains[input.Name]; exists {
+		return nil, fmt.Errorf("%w: domain %s already exists", ErrDomainAlreadyExists, input.Name)
 	}
 
-	if engineVersion == "" {
-		engineVersion = defaultEngineVersion
+	if input.EngineVersion == "" {
+		input.EngineVersion = defaultEngineVersion
 	}
 
-	domainARN := arn.Build("es", b.region, b.accountID, "domain/"+name)
-	endpoint := fmt.Sprintf("search-%s-%s.%s.es.amazonaws.com", name, b.accountID, b.region)
+	domainARN := arn.Build("es", b.region, b.accountID, "domain/"+input.Name)
+	endpoint := fmt.Sprintf("search-%s-%s.%s.es.amazonaws.com", input.Name, b.accountID, b.region)
 
-	if clusterConfig.InstanceCount == 0 {
-		clusterConfig.InstanceCount = 1
+	if input.ClusterConfig.InstanceCount == 0 {
+		input.ClusterConfig.InstanceCount = 1
 	}
 
-	if clusterConfig.InstanceType == "" {
-		clusterConfig.InstanceType = instanceTypeT3Small
+	if input.ClusterConfig.InstanceType == "" {
+		input.ClusterConfig.InstanceType = instanceTypeT3Small
 	}
 
 	d := &Domain{
-		Name:          name,
-		ARN:           domainARN,
-		EngineVersion: engineVersion,
-		Endpoint:      endpoint,
-		Status:        "Active",
-		ClusterConfig: clusterConfig,
-		Tags:          tags.New("opensearch." + name + ".tags"),
+		Name:                        input.Name,
+		ARN:                         domainARN,
+		EngineVersion:               input.EngineVersion,
+		Endpoint:                    endpoint,
+		Status:                      "Active",
+		ClusterConfig:               input.ClusterConfig,
+		Tags:                        tags.New("opensearch." + input.Name + ".tags"),
+		EBSOptions:                  input.EBSOptions,
+		SnapshotOptions:             input.SnapshotOptions,
+		EncryptionAtRestOptions:     input.EncryptionAtRestOptions,
+		NodeToNodeEncryptionOptions: input.NodeToNodeEncryptionOptions,
+		DomainEndpointOptions:       input.DomainEndpointOptions,
+		AdvancedSecurityOptions:     input.AdvancedSecurityOptions,
+		VPCOptions:                  input.VPCOptions,
+		CognitoOptions:              input.CognitoOptions,
+		LogPublishingOptions:        input.LogPublishingOptions,
+		AccessPolicies:              input.AccessPolicies,
 	}
-	b.domains[name] = d
-	b.arnIndex[domainARN] = name
+
+	if len(input.Tags) > 0 {
+		d.Tags.Merge(input.Tags)
+	}
+
+	b.domains[input.Name] = d
+	b.arnIndex[domainARN] = input.Name
 
 	if b.dnsRegistrar != nil {
 		b.dnsRegistrar.Register(endpoint)
@@ -1863,6 +2005,46 @@ func (b *InMemoryBackend) UpdateDomainConfig(name string, input UpdateDomainConf
 
 	if input.EngineVersion != "" {
 		d.EngineVersion = input.EngineVersion
+	}
+
+	if input.EBSOptions != nil {
+		d.EBSOptions = input.EBSOptions
+	}
+
+	if input.SnapshotOptions != nil {
+		d.SnapshotOptions = input.SnapshotOptions
+	}
+
+	if input.EncryptionAtRestOptions != nil {
+		d.EncryptionAtRestOptions = input.EncryptionAtRestOptions
+	}
+
+	if input.NodeToNodeEncryptionOptions != nil {
+		d.NodeToNodeEncryptionOptions = input.NodeToNodeEncryptionOptions
+	}
+
+	if input.DomainEndpointOptions != nil {
+		d.DomainEndpointOptions = input.DomainEndpointOptions
+	}
+
+	if input.AdvancedSecurityOptions != nil {
+		d.AdvancedSecurityOptions = input.AdvancedSecurityOptions
+	}
+
+	if input.VPCOptions != nil {
+		d.VPCOptions = input.VPCOptions
+	}
+
+	if input.CognitoOptions != nil {
+		d.CognitoOptions = input.CognitoOptions
+	}
+
+	if input.LogPublishingOptions != nil {
+		d.LogPublishingOptions = input.LogPublishingOptions
+	}
+
+	if input.AccessPolicies != "" {
+		d.AccessPolicies = input.AccessPolicies
 	}
 
 	changeID := fmt.Sprintf("change-%s-%d", name, time.Now().UnixNano())

--- a/services/opensearch/handler.go
+++ b/services/opensearch/handler.go
@@ -381,46 +381,44 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 
 // domainClusterConfig holds the cluster configuration request parameters for a domain.
 type domainClusterConfig struct {
-	InstanceType  string `json:"InstanceType"`
-	InstanceCount int    `json:"InstanceCount"`
+	ZoneAwarenessConfig       *zoneAwarenessConfigJSON `json:"ZoneAwarenessConfig,omitempty"`
+	InstanceType              string                   `json:"InstanceType"`
+	DedicatedMasterType       string                   `json:"DedicatedMasterType,omitempty"`
+	WarmType                  string                   `json:"WarmType,omitempty"`
+	InstanceCount             int                      `json:"InstanceCount"`
+	DedicatedMasterCount      int                      `json:"DedicatedMasterCount,omitempty"`
+	WarmCount                 int                      `json:"WarmCount,omitempty"`
+	DedicatedMasterEnabled    bool                     `json:"DedicatedMasterEnabled,omitempty"`
+	ZoneAwarenessEnabled      bool                     `json:"ZoneAwarenessEnabled,omitempty"`
+	WarmEnabled               bool                     `json:"WarmEnabled,omitempty"`
+	ColdStorageEnabled        bool                     `json:"ColdStorageEnabled,omitempty"`
+	MultiAZWithStandbyEnabled bool                     `json:"MultiAZWithStandbyEnabled,omitempty"`
 }
 
-// domainJSON is the JSON request body for CreateDomain.
-type domainJSON struct {
-	ClusterConfig *domainClusterConfig `json:"ClusterConfig"`
-	DomainName    string               `json:"DomainName"`
-	EngineVersion string               `json:"EngineVersion"`
-}
-
-// domainStatusJSON is the JSON response for domain operations.
-type domainStatusJSON struct {
-	DomainName                  string                      `json:"DomainName"`
-	ARN                         string                      `json:"ARN"`
-	EngineVersion               string                      `json:"EngineVersion"`
-	Endpoint                    string                      `json:"Endpoint"`
-	DomainProcessingStatus      string                      `json:"DomainProcessingStatus"`
-	ClusterConfig               clusterConfigJSON           `json:"ClusterConfig"`
-	EBSOptions                  ebsOptionsJSON              `json:"EBSOptions"`
-	CognitoOptions              cognitoOptionsJSON          `json:"CognitoOptions"`
-	EncryptionAtRestOptions     encryptAtRestOptionsJSON    `json:"EncryptionAtRestOptions"`
-	NodeToNodeEncryptionOptions nodeToNodeEncryptJSON       `json:"NodeToNodeEncryptionOptions"`
-	AdvancedSecurityOptions     advancedSecurityOptionsJSON `json:"AdvancedSecurityOptions"`
-	Processing                  bool                        `json:"Processing"`
+// zoneAwarenessConfigJSON holds zone awareness config in JSON.
+type zoneAwarenessConfigJSON struct {
+	AvailabilityZoneCount int `json:"AvailabilityZoneCount"`
 }
 
 // ebsOptionsJSON is the JSON representation of EBS options.
 type ebsOptionsJSON struct {
-	EBSEnabled bool `json:"EBSEnabled"`
+	VolumeType string `json:"VolumeType,omitempty"`
+	KMSKeyID   string `json:"KMSKeyId,omitempty"`
+	VolumeSize int    `json:"VolumeSize,omitempty"`
+	IOPS       int    `json:"Iops,omitempty"`
+	Throughput int    `json:"Throughput,omitempty"`
+	EBSEnabled bool   `json:"EBSEnabled"`
 }
 
-// cognitoOptionsJSON is the JSON representation of Cognito options.
-type cognitoOptionsJSON struct {
-	Enabled bool `json:"Enabled"`
+// snapshotOptionsJSON is the JSON representation of snapshot options.
+type snapshotOptionsJSON struct {
+	AutomatedSnapshotStartHour int `json:"AutomatedSnapshotStartHour"`
 }
 
 // encryptAtRestOptionsJSON is the JSON representation of encryption at rest options.
 type encryptAtRestOptionsJSON struct {
-	Enabled bool `json:"Enabled"`
+	KMSKeyID string `json:"KMSKeyId,omitempty"`
+	Enabled   bool   `json:"Enabled"`
 }
 
 // nodeToNodeEncryptJSON is the JSON representation of node-to-node encryption options.
@@ -428,16 +426,107 @@ type nodeToNodeEncryptJSON struct {
 	Enabled bool `json:"Enabled"`
 }
 
+// domainEndpointOptionsJSON is the JSON representation of domain endpoint options.
+type domainEndpointOptionsJSON struct {
+	CustomEndpointCertificateArn string `json:"CustomEndpointCertificateArn,omitempty"`
+	CustomEndpoint               string `json:"CustomEndpoint,omitempty"`
+	TLSSecurityPolicy            string `json:"TLSSecurityPolicy,omitempty"`
+	EnforceHTTPS                 bool   `json:"EnforceHTTPS"`
+	CustomEndpointEnabled        bool   `json:"CustomEndpointEnabled"`
+}
+
+// samlOptionsJSON is the JSON representation of SAML options.
+type samlOptionsJSON struct {
+	IDPEntityID           string `json:"Idp,omitempty"`
+	IDPMetadataContent    string `json:"MasterBackendRole,omitempty"`
+	RolesKey              string `json:"RolesKey,omitempty"`
+	SubjectKey            string `json:"SubjectKey,omitempty"`
+	SessionTimeoutMinutes int    `json:"SessionTimeoutMinutes,omitempty"`
+	Enabled               bool   `json:"Enabled"`
+}
+
 // advancedSecurityOptionsJSON is the JSON representation of advanced security options.
 type advancedSecurityOptionsJSON struct {
-	Enabled                     bool `json:"Enabled"`
-	InternalUserDatabaseEnabled bool `json:"InternalUserDatabaseEnabled"`
+	SAMLOptions                 *samlOptionsJSON `json:"SAMLOptions,omitempty"`
+	AnonymousAuthEnabled        bool             `json:"AnonymousAuthEnabled"`
+	Enabled                     bool             `json:"Enabled"`
+	InternalUserDatabaseEnabled bool             `json:"InternalUserDatabaseEnabled"`
+}
+
+// vpcOptionsJSON is the JSON representation of VPC options.
+type vpcOptionsJSON struct {
+	SecurityGroupIDs []string `json:"SecurityGroupIds,omitempty"`
+	SubnetIDs        []string `json:"SubnetIds,omitempty"`
+	VPCID            string   `json:"VPCId,omitempty"`
+}
+
+// cognitoOptionsJSON is the JSON representation of Cognito options.
+type cognitoOptionsJSON struct {
+	IdentityPoolID string `json:"IdentityPoolId,omitempty"`
+	RoleARN        string `json:"RoleArn,omitempty"`
+	UserPoolID     string `json:"UserPoolId,omitempty"`
+	Enabled        bool   `json:"Enabled"`
+}
+
+// logPublishingOptionJSON is the JSON representation of a log publishing option.
+type logPublishingOptionJSON struct {
+	CloudWatchLogsLogGroupARN string `json:"CloudWatchLogsLogGroupArn,omitempty"`
+	Enabled                   bool   `json:"Enabled"`
+}
+
+// domainJSON is the JSON request body for CreateDomain.
+type domainJSON struct {
+	ClusterConfig               *domainClusterConfig             `json:"ClusterConfig,omitempty"`
+	EBSOptions                  *ebsOptionsJSON                  `json:"EBSOptions,omitempty"`
+	SnapshotOptions             *snapshotOptionsJSON             `json:"SnapshotOptions,omitempty"`
+	EncryptionAtRestOptions     *encryptAtRestOptionsJSON        `json:"EncryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions *nodeToNodeEncryptJSON           `json:"NodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       *domainEndpointOptionsJSON       `json:"DomainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     *advancedSecurityOptionsJSON     `json:"AdvancedSecurityOptions,omitempty"`
+	VPCOptions                  *vpcOptionsJSON                  `json:"VPCOptions,omitempty"`
+	CognitoOptions              *cognitoOptionsJSON              `json:"CognitoOptions,omitempty"`
+	LogPublishingOptions        map[string]*logPublishingOptionJSON `json:"LogPublishingOptions,omitempty"`
+	Tags                        map[string]string                `json:"TagList,omitempty"`
+	DomainName                  string                           `json:"DomainName"`
+	EngineVersion               string                           `json:"EngineVersion"`
+	AccessPolicies              string                           `json:"AccessPolicies,omitempty"`
+}
+
+// domainStatusJSON is the JSON response for domain operations.
+type domainStatusJSON struct {
+	EBSOptions                  *ebsOptionsJSON              `json:"EBSOptions,omitempty"`
+	SnapshotOptions             *snapshotOptionsJSON         `json:"SnapshotOptions,omitempty"`
+	EncryptionAtRestOptions     *encryptAtRestOptionsJSON    `json:"EncryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions *nodeToNodeEncryptJSON       `json:"NodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       *domainEndpointOptionsJSON   `json:"DomainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     *advancedSecurityOptionsJSON `json:"AdvancedSecurityOptions,omitempty"`
+	VPCOptions                  *vpcOptionsJSON              `json:"VPCOptions,omitempty"`
+	CognitoOptions              *cognitoOptionsJSON          `json:"CognitoOptions,omitempty"`
+	LogPublishingOptions        map[string]*logPublishingOptionJSON `json:"LogPublishingOptions,omitempty"`
+	DomainName                  string                       `json:"DomainName"`
+	ARN                         string                       `json:"ARN"`
+	EngineVersion               string                       `json:"EngineVersion"`
+	Endpoint                    string                       `json:"Endpoint"`
+	DomainProcessingStatus      string                       `json:"DomainProcessingStatus"`
+	AccessPolicies              string                       `json:"AccessPolicies,omitempty"`
+	ClusterConfig               clusterConfigJSON            `json:"ClusterConfig"`
+	Processing                  bool                         `json:"Processing"`
 }
 
 // clusterConfigJSON is the JSON representation of cluster config.
 type clusterConfigJSON struct {
-	InstanceType  string `json:"InstanceType"`
-	InstanceCount int    `json:"InstanceCount"`
+	ZoneAwarenessConfig       *zoneAwarenessConfigJSON `json:"ZoneAwarenessConfig,omitempty"`
+	InstanceType              string                   `json:"InstanceType"`
+	DedicatedMasterType       string                   `json:"DedicatedMasterType,omitempty"`
+	WarmType                  string                   `json:"WarmType,omitempty"`
+	InstanceCount             int                      `json:"InstanceCount"`
+	DedicatedMasterCount      int                      `json:"DedicatedMasterCount,omitempty"`
+	WarmCount                 int                      `json:"WarmCount,omitempty"`
+	DedicatedMasterEnabled    bool                     `json:"DedicatedMasterEnabled"`
+	ZoneAwarenessEnabled      bool                     `json:"ZoneAwarenessEnabled"`
+	WarmEnabled               bool                     `json:"WarmEnabled"`
+	ColdStorageEnabled        bool                     `json:"ColdStorageEnabled"`
+	MultiAZWithStandbyEnabled bool                     `json:"MultiAZWithStandbyEnabled"`
 }
 
 // domainStatusWrapJSON wraps the domain status in a DomainStatus key.
@@ -613,9 +702,123 @@ func (h *Handler) dispatchDomainPutRoutes(w http.ResponseWriter, r *http.Request
 	}
 
 	body, _ := httputils.ReadBody(r)
-	var input UpdateDomainConfigInput
+	var req domainJSON
 	if len(body) > 0 {
-		_ = json.Unmarshal(body, &input)
+		_ = json.Unmarshal(body, &req)
+	}
+
+	input := UpdateDomainConfigInput{
+		EngineVersion:  req.EngineVersion,
+		AccessPolicies: req.AccessPolicies,
+	}
+
+	if req.ClusterConfig != nil {
+		cc := req.ClusterConfig
+		cfg := ClusterConfig{
+			InstanceType:              cc.InstanceType,
+			InstanceCount:             cc.InstanceCount,
+			DedicatedMasterEnabled:    cc.DedicatedMasterEnabled,
+			DedicatedMasterType:       cc.DedicatedMasterType,
+			DedicatedMasterCount:      cc.DedicatedMasterCount,
+			ZoneAwarenessEnabled:      cc.ZoneAwarenessEnabled,
+			WarmEnabled:               cc.WarmEnabled,
+			WarmType:                  cc.WarmType,
+			WarmCount:                 cc.WarmCount,
+			ColdStorageEnabled:        cc.ColdStorageEnabled,
+			MultiAZWithStandbyEnabled: cc.MultiAZWithStandbyEnabled,
+		}
+		if cc.ZoneAwarenessConfig != nil {
+			cfg.ZoneAwarenessConfig = &ZoneAwarenessConfig{
+				AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
+			}
+		}
+		input.ClusterConfig = &cfg
+	}
+
+	if req.EBSOptions != nil {
+		input.EBSOptions = &EBSOptions{
+			EBSEnabled: req.EBSOptions.EBSEnabled,
+			VolumeType: req.EBSOptions.VolumeType,
+			VolumeSize: req.EBSOptions.VolumeSize,
+			IOPS:       req.EBSOptions.IOPS,
+			Throughput: req.EBSOptions.Throughput,
+			KMSKeyID:   req.EBSOptions.KMSKeyID,
+		}
+	}
+
+	if req.SnapshotOptions != nil {
+		input.SnapshotOptions = &SnapshotOptions{
+			AutomatedSnapshotStartHour: req.SnapshotOptions.AutomatedSnapshotStartHour,
+		}
+	}
+
+	if req.EncryptionAtRestOptions != nil {
+		input.EncryptionAtRestOptions = &EncryptionAtRestOptions{
+			Enabled:  req.EncryptionAtRestOptions.Enabled,
+			KMSKeyID: req.EncryptionAtRestOptions.KMSKeyID,
+		}
+	}
+
+	if req.NodeToNodeEncryptionOptions != nil {
+		input.NodeToNodeEncryptionOptions = &NodeToNodeEncryptionOptions{
+			Enabled: req.NodeToNodeEncryptionOptions.Enabled,
+		}
+	}
+
+	if req.DomainEndpointOptions != nil {
+		input.DomainEndpointOptions = &DomainEndpointOptions{
+			EnforceHTTPS:                 req.DomainEndpointOptions.EnforceHTTPS,
+			TLSSecurityPolicy:            req.DomainEndpointOptions.TLSSecurityPolicy,
+			CustomEndpointEnabled:        req.DomainEndpointOptions.CustomEndpointEnabled,
+			CustomEndpoint:               req.DomainEndpointOptions.CustomEndpoint,
+			CustomEndpointCertificateArn: req.DomainEndpointOptions.CustomEndpointCertificateArn,
+		}
+	}
+
+	if req.AdvancedSecurityOptions != nil {
+		aso := &AdvancedSecurityOptions{
+			Enabled:                     req.AdvancedSecurityOptions.Enabled,
+			InternalUserDatabaseEnabled: req.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
+			AnonymousAuthEnabled:        req.AdvancedSecurityOptions.AnonymousAuthEnabled,
+		}
+		if req.AdvancedSecurityOptions.SAMLOptions != nil {
+			aso.SAMLOptions = &SAMLOptionsInput{
+				Enabled:               req.AdvancedSecurityOptions.SAMLOptions.Enabled,
+				IDPEntityID:           req.AdvancedSecurityOptions.SAMLOptions.IDPEntityID,
+				IDPMetadataContent:    req.AdvancedSecurityOptions.SAMLOptions.IDPMetadataContent,
+				RolesKey:              req.AdvancedSecurityOptions.SAMLOptions.RolesKey,
+				SubjectKey:            req.AdvancedSecurityOptions.SAMLOptions.SubjectKey,
+				SessionTimeoutMinutes: req.AdvancedSecurityOptions.SAMLOptions.SessionTimeoutMinutes,
+			}
+		}
+		input.AdvancedSecurityOptions = aso
+	}
+
+	if req.VPCOptions != nil {
+		input.VPCOptions = &VPCOptions{
+			VPCID:            req.VPCOptions.VPCID,
+			SubnetIDs:        req.VPCOptions.SubnetIDs,
+			SecurityGroupIDs: req.VPCOptions.SecurityGroupIDs,
+		}
+	}
+
+	if req.CognitoOptions != nil {
+		input.CognitoOptions = &CognitoOptions{
+			Enabled:        req.CognitoOptions.Enabled,
+			UserPoolID:     req.CognitoOptions.UserPoolID,
+			IdentityPoolID: req.CognitoOptions.IdentityPoolID,
+			RoleARN:        req.CognitoOptions.RoleARN,
+		}
+	}
+
+	if len(req.LogPublishingOptions) > 0 {
+		input.LogPublishingOptions = make(map[string]*LogPublishingOption, len(req.LogPublishingOptions))
+		for k, v := range req.LogPublishingOptions {
+			input.LogPublishingOptions[k] = &LogPublishingOption{
+				Enabled:                   v.Enabled,
+				CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
+			}
+		}
 	}
 
 	domain, err := h.Backend.UpdateDomainConfig(name, input)
@@ -629,11 +832,7 @@ func (h *Handler) dispatchDomainPutRoutes(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	cfg := map[string]any{
-		"Options":     domain.EngineVersion,
-		jsonKeyStatus: map[string]any{"State": domainStatusActive},
-	}
-	h.writeJSON(r, w, map[string]any{"DomainConfig": map[string]any{"EngineVersion": cfg}})
+	h.writeJSON(r, w, map[string]any{"DomainConfig": toDomainConfigJSON(domain)})
 }
 
 // dispatchDomainGetRoutes handles GET requests under a domain path.
@@ -716,13 +915,122 @@ func (h *Handler) handleCreateDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var cfg ClusterConfig
-	if req.ClusterConfig != nil {
-		cfg.InstanceType = req.ClusterConfig.InstanceType
-		cfg.InstanceCount = req.ClusterConfig.InstanceCount
+	input := CreateDomainInput{
+		Name:           req.DomainName,
+		EngineVersion:  req.EngineVersion,
+		AccessPolicies: req.AccessPolicies,
+		Tags:           req.Tags,
 	}
 
-	domain, err := h.Backend.CreateDomain(req.DomainName, req.EngineVersion, cfg)
+	if req.ClusterConfig != nil {
+		cc := req.ClusterConfig
+		input.ClusterConfig = ClusterConfig{
+			InstanceType:              cc.InstanceType,
+			InstanceCount:             cc.InstanceCount,
+			DedicatedMasterEnabled:    cc.DedicatedMasterEnabled,
+			DedicatedMasterType:       cc.DedicatedMasterType,
+			DedicatedMasterCount:      cc.DedicatedMasterCount,
+			ZoneAwarenessEnabled:      cc.ZoneAwarenessEnabled,
+			WarmEnabled:               cc.WarmEnabled,
+			WarmType:                  cc.WarmType,
+			WarmCount:                 cc.WarmCount,
+			ColdStorageEnabled:        cc.ColdStorageEnabled,
+			MultiAZWithStandbyEnabled: cc.MultiAZWithStandbyEnabled,
+		}
+		if cc.ZoneAwarenessConfig != nil {
+			input.ClusterConfig.ZoneAwarenessConfig = &ZoneAwarenessConfig{
+				AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
+			}
+		}
+	}
+
+	if req.EBSOptions != nil {
+		input.EBSOptions = &EBSOptions{
+			EBSEnabled: req.EBSOptions.EBSEnabled,
+			VolumeType: req.EBSOptions.VolumeType,
+			VolumeSize: req.EBSOptions.VolumeSize,
+			IOPS:       req.EBSOptions.IOPS,
+			Throughput: req.EBSOptions.Throughput,
+			KMSKeyID:   req.EBSOptions.KMSKeyID,
+		}
+	}
+
+	if req.SnapshotOptions != nil {
+		input.SnapshotOptions = &SnapshotOptions{
+			AutomatedSnapshotStartHour: req.SnapshotOptions.AutomatedSnapshotStartHour,
+		}
+	}
+
+	if req.EncryptionAtRestOptions != nil {
+		input.EncryptionAtRestOptions = &EncryptionAtRestOptions{
+			Enabled:  req.EncryptionAtRestOptions.Enabled,
+			KMSKeyID: req.EncryptionAtRestOptions.KMSKeyID,
+		}
+	}
+
+	if req.NodeToNodeEncryptionOptions != nil {
+		input.NodeToNodeEncryptionOptions = &NodeToNodeEncryptionOptions{
+			Enabled: req.NodeToNodeEncryptionOptions.Enabled,
+		}
+	}
+
+	if req.DomainEndpointOptions != nil {
+		input.DomainEndpointOptions = &DomainEndpointOptions{
+			EnforceHTTPS:                 req.DomainEndpointOptions.EnforceHTTPS,
+			TLSSecurityPolicy:            req.DomainEndpointOptions.TLSSecurityPolicy,
+			CustomEndpointEnabled:        req.DomainEndpointOptions.CustomEndpointEnabled,
+			CustomEndpoint:               req.DomainEndpointOptions.CustomEndpoint,
+			CustomEndpointCertificateArn: req.DomainEndpointOptions.CustomEndpointCertificateArn,
+		}
+	}
+
+	if req.AdvancedSecurityOptions != nil {
+		aso := &AdvancedSecurityOptions{
+			Enabled:                     req.AdvancedSecurityOptions.Enabled,
+			InternalUserDatabaseEnabled: req.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
+			AnonymousAuthEnabled:        req.AdvancedSecurityOptions.AnonymousAuthEnabled,
+		}
+		if req.AdvancedSecurityOptions.SAMLOptions != nil {
+			aso.SAMLOptions = &SAMLOptionsInput{
+				Enabled:               req.AdvancedSecurityOptions.SAMLOptions.Enabled,
+				IDPEntityID:           req.AdvancedSecurityOptions.SAMLOptions.IDPEntityID,
+				IDPMetadataContent:    req.AdvancedSecurityOptions.SAMLOptions.IDPMetadataContent,
+				RolesKey:              req.AdvancedSecurityOptions.SAMLOptions.RolesKey,
+				SubjectKey:            req.AdvancedSecurityOptions.SAMLOptions.SubjectKey,
+				SessionTimeoutMinutes: req.AdvancedSecurityOptions.SAMLOptions.SessionTimeoutMinutes,
+			}
+		}
+		input.AdvancedSecurityOptions = aso
+	}
+
+	if req.VPCOptions != nil {
+		input.VPCOptions = &VPCOptions{
+			VPCID:            req.VPCOptions.VPCID,
+			SubnetIDs:        req.VPCOptions.SubnetIDs,
+			SecurityGroupIDs: req.VPCOptions.SecurityGroupIDs,
+		}
+	}
+
+	if req.CognitoOptions != nil {
+		input.CognitoOptions = &CognitoOptions{
+			Enabled:        req.CognitoOptions.Enabled,
+			UserPoolID:     req.CognitoOptions.UserPoolID,
+			IdentityPoolID: req.CognitoOptions.IdentityPoolID,
+			RoleARN:        req.CognitoOptions.RoleARN,
+		}
+	}
+
+	if len(req.LogPublishingOptions) > 0 {
+		input.LogPublishingOptions = make(map[string]*LogPublishingOption, len(req.LogPublishingOptions))
+		for k, v := range req.LogPublishingOptions {
+			input.LogPublishingOptions[k] = &LogPublishingOption{
+				Enabled:                   v.Enabled,
+				CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
+			}
+		}
+	}
+
+	domain, err := h.Backend.CreateDomain(input)
 	if err != nil {
 		if errors.Is(err, ErrDomainAlreadyExists) {
 			h.writeError(r, w, http.StatusConflict, "ResourceAlreadyExistsException", err.Error())
@@ -893,27 +1201,178 @@ func (h *Handler) handleDissociatePackages(w http.ResponseWriter, r *http.Reques
 }
 
 func toDomainStatusJSON(d *Domain) domainStatusJSON {
-	return domainStatusJSON{
-		DomainName:                  d.Name,
-		ARN:                         d.ARN,
-		EngineVersion:               d.EngineVersion,
-		Endpoint:                    d.Endpoint,
-		Processing:                  false,
-		DomainProcessingStatus:      domainStatusActive,
-		EBSOptions:                  ebsOptionsJSON{EBSEnabled: false},
-		CognitoOptions:              cognitoOptionsJSON{Enabled: false},
-		EncryptionAtRestOptions:     encryptAtRestOptionsJSON{Enabled: false},
-		NodeToNodeEncryptionOptions: nodeToNodeEncryptJSON{Enabled: false},
-		AdvancedSecurityOptions:     advancedSecurityOptionsJSON{Enabled: false},
+	out := domainStatusJSON{
+		DomainName:             d.Name,
+		ARN:                    d.ARN,
+		EngineVersion:          d.EngineVersion,
+		Endpoint:               d.Endpoint,
+		Processing:             false,
+		DomainProcessingStatus: domainStatusActive,
+		AccessPolicies:         d.AccessPolicies,
 		ClusterConfig: clusterConfigJSON{
-			InstanceType:  d.ClusterConfig.InstanceType,
-			InstanceCount: d.ClusterConfig.InstanceCount,
+			InstanceType:              d.ClusterConfig.InstanceType,
+			InstanceCount:             d.ClusterConfig.InstanceCount,
+			DedicatedMasterEnabled:    d.ClusterConfig.DedicatedMasterEnabled,
+			DedicatedMasterType:       d.ClusterConfig.DedicatedMasterType,
+			DedicatedMasterCount:      d.ClusterConfig.DedicatedMasterCount,
+			ZoneAwarenessEnabled:      d.ClusterConfig.ZoneAwarenessEnabled,
+			WarmEnabled:               d.ClusterConfig.WarmEnabled,
+			WarmType:                  d.ClusterConfig.WarmType,
+			WarmCount:                 d.ClusterConfig.WarmCount,
+			ColdStorageEnabled:        d.ClusterConfig.ColdStorageEnabled,
+			MultiAZWithStandbyEnabled: d.ClusterConfig.MultiAZWithStandbyEnabled,
 		},
 	}
+
+	if d.ClusterConfig.ZoneAwarenessConfig != nil {
+		out.ClusterConfig.ZoneAwarenessConfig = &zoneAwarenessConfigJSON{
+			AvailabilityZoneCount: d.ClusterConfig.ZoneAwarenessConfig.AvailabilityZoneCount,
+		}
+	}
+
+	if d.EBSOptions != nil {
+		out.EBSOptions = &ebsOptionsJSON{
+			EBSEnabled: d.EBSOptions.EBSEnabled,
+			VolumeType: d.EBSOptions.VolumeType,
+			VolumeSize: d.EBSOptions.VolumeSize,
+			IOPS:       d.EBSOptions.IOPS,
+			Throughput: d.EBSOptions.Throughput,
+			KMSKeyID:   d.EBSOptions.KMSKeyID,
+		}
+	}
+
+	if d.SnapshotOptions != nil {
+		out.SnapshotOptions = &snapshotOptionsJSON{
+			AutomatedSnapshotStartHour: d.SnapshotOptions.AutomatedSnapshotStartHour,
+		}
+	}
+
+	if d.EncryptionAtRestOptions != nil {
+		out.EncryptionAtRestOptions = &encryptAtRestOptionsJSON{
+			Enabled:  d.EncryptionAtRestOptions.Enabled,
+			KMSKeyID: d.EncryptionAtRestOptions.KMSKeyID,
+		}
+	}
+
+	if d.NodeToNodeEncryptionOptions != nil {
+		out.NodeToNodeEncryptionOptions = &nodeToNodeEncryptJSON{
+			Enabled: d.NodeToNodeEncryptionOptions.Enabled,
+		}
+	}
+
+	if d.DomainEndpointOptions != nil {
+		out.DomainEndpointOptions = &domainEndpointOptionsJSON{
+			EnforceHTTPS:                 d.DomainEndpointOptions.EnforceHTTPS,
+			TLSSecurityPolicy:            d.DomainEndpointOptions.TLSSecurityPolicy,
+			CustomEndpointEnabled:        d.DomainEndpointOptions.CustomEndpointEnabled,
+			CustomEndpoint:               d.DomainEndpointOptions.CustomEndpoint,
+			CustomEndpointCertificateArn: d.DomainEndpointOptions.CustomEndpointCertificateArn,
+		}
+	}
+
+	if d.AdvancedSecurityOptions != nil {
+		aso := &advancedSecurityOptionsJSON{
+			Enabled:                     d.AdvancedSecurityOptions.Enabled,
+			InternalUserDatabaseEnabled: d.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
+			AnonymousAuthEnabled:        d.AdvancedSecurityOptions.AnonymousAuthEnabled,
+		}
+		if d.AdvancedSecurityOptions.SAMLOptions != nil {
+			aso.SAMLOptions = &samlOptionsJSON{
+				Enabled:               d.AdvancedSecurityOptions.SAMLOptions.Enabled,
+				IDPEntityID:           d.AdvancedSecurityOptions.SAMLOptions.IDPEntityID,
+				IDPMetadataContent:    d.AdvancedSecurityOptions.SAMLOptions.IDPMetadataContent,
+				RolesKey:              d.AdvancedSecurityOptions.SAMLOptions.RolesKey,
+				SubjectKey:            d.AdvancedSecurityOptions.SAMLOptions.SubjectKey,
+				SessionTimeoutMinutes: d.AdvancedSecurityOptions.SAMLOptions.SessionTimeoutMinutes,
+			}
+		}
+		out.AdvancedSecurityOptions = aso
+	}
+
+	if d.VPCOptions != nil {
+		out.VPCOptions = &vpcOptionsJSON{
+			VPCID:            d.VPCOptions.VPCID,
+			SubnetIDs:        d.VPCOptions.SubnetIDs,
+			SecurityGroupIDs: d.VPCOptions.SecurityGroupIDs,
+		}
+	}
+
+	if d.CognitoOptions != nil {
+		out.CognitoOptions = &cognitoOptionsJSON{
+			Enabled:        d.CognitoOptions.Enabled,
+			UserPoolID:     d.CognitoOptions.UserPoolID,
+			IdentityPoolID: d.CognitoOptions.IdentityPoolID,
+			RoleARN:        d.CognitoOptions.RoleARN,
+		}
+	}
+
+	if len(d.LogPublishingOptions) > 0 {
+		out.LogPublishingOptions = make(map[string]*logPublishingOptionJSON, len(d.LogPublishingOptions))
+		for k, v := range d.LogPublishingOptions {
+			out.LogPublishingOptions[k] = &logPublishingOptionJSON{
+				Enabled:                   v.Enabled,
+				CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
+			}
+		}
+	}
+
+	return out
 }
 
 type errorResponseJSON struct {
 	Message string `json:"message"`
+}
+
+// toDomainConfigJSON builds the DescribeDomainConfig / UpdateDomainConfig response body.
+func toDomainConfigJSON(d *Domain) domainConfigFields {
+	active := opensearchConfigStatus{State: domainStatusActive}
+	st := toDomainStatusJSON(d)
+
+	cfg := domainConfigFields{
+		EngineVersion: opensearchConfigValue{Options: d.EngineVersion, Status: active},
+		ClusterConfig: opensearchConfigValue{Options: st.ClusterConfig, Status: active},
+		EBSOptions:    opensearchConfigValue{Options: map[string]any{}, Status: active},
+		AccessPolicies: opensearchConfigValue{Options: d.AccessPolicies, Status: active},
+		AdvancedOptions: opensearchConfigValue{Options: map[string]any{}, Status: active},
+	}
+
+	if st.EBSOptions != nil {
+		cfg.EBSOptions = opensearchConfigValue{Options: st.EBSOptions, Status: active}
+	}
+
+	if st.SnapshotOptions != nil {
+		cfg.SnapshotOptions = opensearchConfigValue{Options: st.SnapshotOptions, Status: active}
+	}
+
+	if st.EncryptionAtRestOptions != nil {
+		cfg.EncryptionAtRestOptions = opensearchConfigValue{Options: st.EncryptionAtRestOptions, Status: active}
+	}
+
+	if st.NodeToNodeEncryptionOptions != nil {
+		cfg.NodeToNodeEncryptionOptions = opensearchConfigValue{Options: st.NodeToNodeEncryptionOptions, Status: active}
+	}
+
+	if st.DomainEndpointOptions != nil {
+		cfg.DomainEndpointOptions = opensearchConfigValue{Options: st.DomainEndpointOptions, Status: active}
+	}
+
+	if st.AdvancedSecurityOptions != nil {
+		cfg.AdvancedSecurityOptions = opensearchConfigValue{Options: st.AdvancedSecurityOptions, Status: active}
+	}
+
+	if st.VPCOptions != nil {
+		cfg.VPCOptions = opensearchConfigValue{Options: st.VPCOptions, Status: active}
+	}
+
+	if st.CognitoOptions != nil {
+		cfg.CognitoOptions = opensearchConfigValue{Options: st.CognitoOptions, Status: active}
+	}
+
+	if len(st.LogPublishingOptions) > 0 {
+		cfg.LogPublishingOptions = opensearchConfigValue{Options: st.LogPublishingOptions, Status: active}
+	}
+
+	return cfg
 }
 
 func (h *Handler) writeError(r *http.Request, w http.ResponseWriter, status int, code, message string) {
@@ -942,11 +1401,19 @@ type opensearchConfigValue struct {
 
 // domainConfigFields holds the per-feature configuration values for a domain.
 type domainConfigFields struct {
-	EngineVersion   opensearchConfigValue `json:"EngineVersion"`
-	ClusterConfig   opensearchConfigValue `json:"ClusterConfig"`
-	EBSOptions      opensearchConfigValue `json:"EBSOptions"`
-	AccessPolicies  opensearchConfigValue `json:"AccessPolicies"`
-	AdvancedOptions opensearchConfigValue `json:"AdvancedOptions"`
+	EngineVersion               opensearchConfigValue `json:"EngineVersion"`
+	ClusterConfig               opensearchConfigValue `json:"ClusterConfig"`
+	EBSOptions                  opensearchConfigValue `json:"EBSOptions"`
+	AccessPolicies              opensearchConfigValue `json:"AccessPolicies"`
+	AdvancedOptions             opensearchConfigValue `json:"AdvancedOptions"`
+	SnapshotOptions             opensearchConfigValue `json:"SnapshotOptions,omitempty"`
+	EncryptionAtRestOptions     opensearchConfigValue `json:"EncryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions opensearchConfigValue `json:"NodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       opensearchConfigValue `json:"DomainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     opensearchConfigValue `json:"AdvancedSecurityOptions,omitempty"`
+	VPCOptions                  opensearchConfigValue `json:"VPCOptions,omitempty"`
+	CognitoOptions              opensearchConfigValue `json:"CognitoOptions,omitempty"`
+	LogPublishingOptions        opensearchConfigValue `json:"LogPublishingOptions,omitempty"`
 }
 
 type describeDomainConfigOutput struct {
@@ -1055,20 +1522,7 @@ func (h *Handler) handleDescribeDomainConfig(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	activeStatus := opensearchConfigStatus{State: domainStatusActive}
-	out := describeDomainConfigOutput{}
-	out.DomainConfig.EngineVersion = opensearchConfigValue{Options: domain.EngineVersion, Status: activeStatus}
-	out.DomainConfig.ClusterConfig = opensearchConfigValue{
-		Options: map[string]any{
-			jsonKeyInstanceType: domain.ClusterConfig.InstanceType,
-			"InstanceCount":     domain.ClusterConfig.InstanceCount,
-		},
-		Status: activeStatus,
-	}
-	out.DomainConfig.EBSOptions = opensearchConfigValue{Options: map[string]any{}, Status: activeStatus}
-	out.DomainConfig.AccessPolicies = opensearchConfigValue{Options: "", Status: activeStatus}
-	out.DomainConfig.AdvancedOptions = opensearchConfigValue{Options: map[string]any{}, Status: activeStatus}
-	h.writeJSON(r, w, &out)
+	h.writeJSON(r, w, map[string]any{"DomainConfig": toDomainConfigJSON(domain)})
 }
 
 // handleDomainSubRoutes handles POST requests under /2021-01-01/opensearch/domain/{name}/...

--- a/services/opensearch/handler.go
+++ b/services/opensearch/handler.go
@@ -805,6 +805,7 @@ func parseClusterConfigFromReq(cc *domainClusterConfig) ClusterConfig {
 			AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
 		}
 	}
+
 	return cfg
 }
 
@@ -828,6 +829,7 @@ func parseAdvancedSecurityOptsFromReq(aso *advancedSecurityOptionsJSON) *Advance
 			SessionTimeoutMinutes: aso.SAMLOptions.SessionTimeoutMinutes,
 		}
 	}
+
 	return out
 }
 
@@ -843,6 +845,7 @@ func parseLogPublishingOptsFromReq(opts map[string]*logPublishingOptionJSON) map
 			CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
 		}
 	}
+
 	return out
 }
 
@@ -908,6 +911,7 @@ func applyReqToUpdateInput(req *domainJSON) UpdateDomainConfigInput {
 		}
 	}
 	input.LogPublishingOptions = parseLogPublishingOptsFromReq(req.LogPublishingOptions)
+
 	return input
 }
 
@@ -1139,6 +1143,7 @@ func toClusterConfigJSON(cc ClusterConfig) clusterConfigJSON {
 			AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
 		}
 	}
+
 	return out
 }
 
@@ -1161,6 +1166,7 @@ func toAdvancedSecurityOptionsJSON(aso *AdvancedSecurityOptions) *advancedSecuri
 			SessionTimeoutMinutes: aso.SAMLOptions.SessionTimeoutMinutes,
 		}
 	}
+
 	return out
 }
 
@@ -1175,6 +1181,7 @@ func toLogPublishingOptionsJSON(opts map[string]*LogPublishingOption) map[string
 			CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
 		}
 	}
+
 	return out
 }
 
@@ -1196,6 +1203,7 @@ func toDomainStatusJSON(d *Domain) domainStatusJSON {
 		AdvancedSecurityOptions:     toAdvancedSecurityOptionsJSON(nil),
 	}
 	applyDomainOptionalFields(d, &out)
+
 	return out
 }
 
@@ -1341,18 +1349,14 @@ type domainConfigFields struct {
 	EBSOptions                  opensearchConfigValue `json:"EBSOptions"`
 	AccessPolicies              opensearchConfigValue `json:"AccessPolicies"`
 	AdvancedOptions             opensearchConfigValue `json:"AdvancedOptions"`
-	SnapshotOptions             opensearchConfigValue `json:"SnapshotOptions,omitempty"`
-	EncryptionAtRestOptions     opensearchConfigValue `json:"EncryptionAtRestOptions,omitempty"`
-	NodeToNodeEncryptionOptions opensearchConfigValue `json:"NodeToNodeEncryptionOptions,omitempty"`
-	DomainEndpointOptions       opensearchConfigValue `json:"DomainEndpointOptions,omitempty"`
-	AdvancedSecurityOptions     opensearchConfigValue `json:"AdvancedSecurityOptions,omitempty"`
-	VPCOptions                  opensearchConfigValue `json:"VPCOptions,omitempty"`
-	CognitoOptions              opensearchConfigValue `json:"CognitoOptions,omitempty"`
-	LogPublishingOptions        opensearchConfigValue `json:"LogPublishingOptions,omitempty"`
-}
-
-type describeDomainConfigOutput struct {
-	DomainConfig domainConfigFields `json:"DomainConfig"`
+	SnapshotOptions             opensearchConfigValue `json:"SnapshotOptions"`
+	EncryptionAtRestOptions     opensearchConfigValue `json:"EncryptionAtRestOptions"`
+	NodeToNodeEncryptionOptions opensearchConfigValue `json:"NodeToNodeEncryptionOptions"`
+	DomainEndpointOptions       opensearchConfigValue `json:"DomainEndpointOptions"`
+	AdvancedSecurityOptions     opensearchConfigValue `json:"AdvancedSecurityOptions"`
+	VPCOptions                  opensearchConfigValue `json:"VPCOptions"`
+	CognitoOptions              opensearchConfigValue `json:"CognitoOptions"`
+	LogPublishingOptions        opensearchConfigValue `json:"LogPublishingOptions"`
 }
 
 func (h *Handler) handleListTags(w http.ResponseWriter, r *http.Request) {

--- a/services/opensearch/handler.go
+++ b/services/opensearch/handler.go
@@ -418,7 +418,7 @@ type snapshotOptionsJSON struct {
 // encryptAtRestOptionsJSON is the JSON representation of encryption at rest options.
 type encryptAtRestOptionsJSON struct {
 	KMSKeyID string `json:"KMSKeyId,omitempty"`
-	Enabled   bool   `json:"Enabled"`
+	Enabled  bool   `json:"Enabled"`
 }
 
 // nodeToNodeEncryptJSON is the JSON representation of node-to-node encryption options.
@@ -455,9 +455,9 @@ type advancedSecurityOptionsJSON struct {
 
 // vpcOptionsJSON is the JSON representation of VPC options.
 type vpcOptionsJSON struct {
+	VPCID            string   `json:"VPCId,omitempty"`
 	SecurityGroupIDs []string `json:"SecurityGroupIds,omitempty"`
 	SubnetIDs        []string `json:"SubnetIds,omitempty"`
-	VPCID            string   `json:"VPCId,omitempty"`
 }
 
 // cognitoOptionsJSON is the JSON representation of Cognito options.
@@ -476,41 +476,41 @@ type logPublishingOptionJSON struct {
 
 // domainJSON is the JSON request body for CreateDomain.
 type domainJSON struct {
-	ClusterConfig               *domainClusterConfig             `json:"ClusterConfig,omitempty"`
-	EBSOptions                  *ebsOptionsJSON                  `json:"EBSOptions,omitempty"`
-	SnapshotOptions             *snapshotOptionsJSON             `json:"SnapshotOptions,omitempty"`
-	EncryptionAtRestOptions     *encryptAtRestOptionsJSON        `json:"EncryptionAtRestOptions,omitempty"`
-	NodeToNodeEncryptionOptions *nodeToNodeEncryptJSON           `json:"NodeToNodeEncryptionOptions,omitempty"`
-	DomainEndpointOptions       *domainEndpointOptionsJSON       `json:"DomainEndpointOptions,omitempty"`
-	AdvancedSecurityOptions     *advancedSecurityOptionsJSON     `json:"AdvancedSecurityOptions,omitempty"`
-	VPCOptions                  *vpcOptionsJSON                  `json:"VPCOptions,omitempty"`
-	CognitoOptions              *cognitoOptionsJSON              `json:"CognitoOptions,omitempty"`
+	ClusterConfig               *domainClusterConfig                `json:"ClusterConfig,omitempty"`
+	EBSOptions                  *ebsOptionsJSON                     `json:"EBSOptions,omitempty"`
+	SnapshotOptions             *snapshotOptionsJSON                `json:"SnapshotOptions,omitempty"`
+	EncryptionAtRestOptions     *encryptAtRestOptionsJSON           `json:"EncryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions *nodeToNodeEncryptJSON              `json:"NodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       *domainEndpointOptionsJSON          `json:"DomainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     *advancedSecurityOptionsJSON        `json:"AdvancedSecurityOptions,omitempty"`
+	VPCOptions                  *vpcOptionsJSON                     `json:"VPCOptions,omitempty"`
+	CognitoOptions              *cognitoOptionsJSON                 `json:"CognitoOptions,omitempty"`
 	LogPublishingOptions        map[string]*logPublishingOptionJSON `json:"LogPublishingOptions,omitempty"`
-	Tags                        map[string]string                `json:"TagList,omitempty"`
-	DomainName                  string                           `json:"DomainName"`
-	EngineVersion               string                           `json:"EngineVersion"`
-	AccessPolicies              string                           `json:"AccessPolicies,omitempty"`
+	Tags                        map[string]string                   `json:"TagList,omitempty"`
+	DomainName                  string                              `json:"DomainName"`
+	EngineVersion               string                              `json:"EngineVersion"`
+	AccessPolicies              string                              `json:"AccessPolicies,omitempty"`
 }
 
 // domainStatusJSON is the JSON response for domain operations.
 type domainStatusJSON struct {
-	EBSOptions                  *ebsOptionsJSON              `json:"EBSOptions,omitempty"`
-	SnapshotOptions             *snapshotOptionsJSON         `json:"SnapshotOptions,omitempty"`
-	EncryptionAtRestOptions     *encryptAtRestOptionsJSON    `json:"EncryptionAtRestOptions,omitempty"`
-	NodeToNodeEncryptionOptions *nodeToNodeEncryptJSON       `json:"NodeToNodeEncryptionOptions,omitempty"`
-	DomainEndpointOptions       *domainEndpointOptionsJSON   `json:"DomainEndpointOptions,omitempty"`
-	AdvancedSecurityOptions     *advancedSecurityOptionsJSON `json:"AdvancedSecurityOptions,omitempty"`
-	VPCOptions                  *vpcOptionsJSON              `json:"VPCOptions,omitempty"`
-	CognitoOptions              *cognitoOptionsJSON          `json:"CognitoOptions,omitempty"`
+	EBSOptions                  *ebsOptionsJSON                     `json:"EBSOptions,omitempty"`
+	SnapshotOptions             *snapshotOptionsJSON                `json:"SnapshotOptions,omitempty"`
+	EncryptionAtRestOptions     *encryptAtRestOptionsJSON           `json:"EncryptionAtRestOptions,omitempty"`
+	NodeToNodeEncryptionOptions *nodeToNodeEncryptJSON              `json:"NodeToNodeEncryptionOptions,omitempty"`
+	DomainEndpointOptions       *domainEndpointOptionsJSON          `json:"DomainEndpointOptions,omitempty"`
+	AdvancedSecurityOptions     *advancedSecurityOptionsJSON        `json:"AdvancedSecurityOptions,omitempty"`
+	VPCOptions                  *vpcOptionsJSON                     `json:"VPCOptions,omitempty"`
+	CognitoOptions              *cognitoOptionsJSON                 `json:"CognitoOptions,omitempty"`
 	LogPublishingOptions        map[string]*logPublishingOptionJSON `json:"LogPublishingOptions,omitempty"`
-	DomainName                  string                       `json:"DomainName"`
-	ARN                         string                       `json:"ARN"`
-	EngineVersion               string                       `json:"EngineVersion"`
-	Endpoint                    string                       `json:"Endpoint"`
-	DomainProcessingStatus      string                       `json:"DomainProcessingStatus"`
-	AccessPolicies              string                       `json:"AccessPolicies,omitempty"`
-	ClusterConfig               clusterConfigJSON            `json:"ClusterConfig"`
-	Processing                  bool                         `json:"Processing"`
+	DomainName                  string                              `json:"DomainName"`
+	ARN                         string                              `json:"ARN"`
+	EngineVersion               string                              `json:"EngineVersion"`
+	Endpoint                    string                              `json:"Endpoint"`
+	DomainProcessingStatus      string                              `json:"DomainProcessingStatus"`
+	AccessPolicies              string                              `json:"AccessPolicies,omitempty"`
+	ClusterConfig               clusterConfigJSON                   `json:"ClusterConfig"`
+	Processing                  bool                                `json:"Processing"`
 }
 
 // clusterConfigJSON is the JSON representation of cluster config.
@@ -707,119 +707,7 @@ func (h *Handler) dispatchDomainPutRoutes(w http.ResponseWriter, r *http.Request
 		_ = json.Unmarshal(body, &req)
 	}
 
-	input := UpdateDomainConfigInput{
-		EngineVersion:  req.EngineVersion,
-		AccessPolicies: req.AccessPolicies,
-	}
-
-	if req.ClusterConfig != nil {
-		cc := req.ClusterConfig
-		cfg := ClusterConfig{
-			InstanceType:              cc.InstanceType,
-			InstanceCount:             cc.InstanceCount,
-			DedicatedMasterEnabled:    cc.DedicatedMasterEnabled,
-			DedicatedMasterType:       cc.DedicatedMasterType,
-			DedicatedMasterCount:      cc.DedicatedMasterCount,
-			ZoneAwarenessEnabled:      cc.ZoneAwarenessEnabled,
-			WarmEnabled:               cc.WarmEnabled,
-			WarmType:                  cc.WarmType,
-			WarmCount:                 cc.WarmCount,
-			ColdStorageEnabled:        cc.ColdStorageEnabled,
-			MultiAZWithStandbyEnabled: cc.MultiAZWithStandbyEnabled,
-		}
-		if cc.ZoneAwarenessConfig != nil {
-			cfg.ZoneAwarenessConfig = &ZoneAwarenessConfig{
-				AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
-			}
-		}
-		input.ClusterConfig = &cfg
-	}
-
-	if req.EBSOptions != nil {
-		input.EBSOptions = &EBSOptions{
-			EBSEnabled: req.EBSOptions.EBSEnabled,
-			VolumeType: req.EBSOptions.VolumeType,
-			VolumeSize: req.EBSOptions.VolumeSize,
-			IOPS:       req.EBSOptions.IOPS,
-			Throughput: req.EBSOptions.Throughput,
-			KMSKeyID:   req.EBSOptions.KMSKeyID,
-		}
-	}
-
-	if req.SnapshotOptions != nil {
-		input.SnapshotOptions = &SnapshotOptions{
-			AutomatedSnapshotStartHour: req.SnapshotOptions.AutomatedSnapshotStartHour,
-		}
-	}
-
-	if req.EncryptionAtRestOptions != nil {
-		input.EncryptionAtRestOptions = &EncryptionAtRestOptions{
-			Enabled:  req.EncryptionAtRestOptions.Enabled,
-			KMSKeyID: req.EncryptionAtRestOptions.KMSKeyID,
-		}
-	}
-
-	if req.NodeToNodeEncryptionOptions != nil {
-		input.NodeToNodeEncryptionOptions = &NodeToNodeEncryptionOptions{
-			Enabled: req.NodeToNodeEncryptionOptions.Enabled,
-		}
-	}
-
-	if req.DomainEndpointOptions != nil {
-		input.DomainEndpointOptions = &DomainEndpointOptions{
-			EnforceHTTPS:                 req.DomainEndpointOptions.EnforceHTTPS,
-			TLSSecurityPolicy:            req.DomainEndpointOptions.TLSSecurityPolicy,
-			CustomEndpointEnabled:        req.DomainEndpointOptions.CustomEndpointEnabled,
-			CustomEndpoint:               req.DomainEndpointOptions.CustomEndpoint,
-			CustomEndpointCertificateArn: req.DomainEndpointOptions.CustomEndpointCertificateArn,
-		}
-	}
-
-	if req.AdvancedSecurityOptions != nil {
-		aso := &AdvancedSecurityOptions{
-			Enabled:                     req.AdvancedSecurityOptions.Enabled,
-			InternalUserDatabaseEnabled: req.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
-			AnonymousAuthEnabled:        req.AdvancedSecurityOptions.AnonymousAuthEnabled,
-		}
-		if req.AdvancedSecurityOptions.SAMLOptions != nil {
-			aso.SAMLOptions = &SAMLOptionsInput{
-				Enabled:               req.AdvancedSecurityOptions.SAMLOptions.Enabled,
-				IDPEntityID:           req.AdvancedSecurityOptions.SAMLOptions.IDPEntityID,
-				IDPMetadataContent:    req.AdvancedSecurityOptions.SAMLOptions.IDPMetadataContent,
-				RolesKey:              req.AdvancedSecurityOptions.SAMLOptions.RolesKey,
-				SubjectKey:            req.AdvancedSecurityOptions.SAMLOptions.SubjectKey,
-				SessionTimeoutMinutes: req.AdvancedSecurityOptions.SAMLOptions.SessionTimeoutMinutes,
-			}
-		}
-		input.AdvancedSecurityOptions = aso
-	}
-
-	if req.VPCOptions != nil {
-		input.VPCOptions = &VPCOptions{
-			VPCID:            req.VPCOptions.VPCID,
-			SubnetIDs:        req.VPCOptions.SubnetIDs,
-			SecurityGroupIDs: req.VPCOptions.SecurityGroupIDs,
-		}
-	}
-
-	if req.CognitoOptions != nil {
-		input.CognitoOptions = &CognitoOptions{
-			Enabled:        req.CognitoOptions.Enabled,
-			UserPoolID:     req.CognitoOptions.UserPoolID,
-			IdentityPoolID: req.CognitoOptions.IdentityPoolID,
-			RoleARN:        req.CognitoOptions.RoleARN,
-		}
-	}
-
-	if len(req.LogPublishingOptions) > 0 {
-		input.LogPublishingOptions = make(map[string]*LogPublishingOption, len(req.LogPublishingOptions))
-		for k, v := range req.LogPublishingOptions {
-			input.LogPublishingOptions[k] = &LogPublishingOption{
-				Enabled:                   v.Enabled,
-				CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
-			}
-		}
-	}
+	input := applyReqToUpdateInput(&req)
 
 	domain, err := h.Backend.UpdateDomainConfig(name, input)
 	if err != nil {
@@ -894,6 +782,135 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	return h.Handle
 }
 
+// parseClusterConfigFromReq converts a JSON cluster config to backend ClusterConfig.
+func parseClusterConfigFromReq(cc *domainClusterConfig) ClusterConfig {
+	if cc == nil {
+		return ClusterConfig{}
+	}
+	cfg := ClusterConfig{
+		InstanceType:              cc.InstanceType,
+		InstanceCount:             cc.InstanceCount,
+		DedicatedMasterEnabled:    cc.DedicatedMasterEnabled,
+		DedicatedMasterType:       cc.DedicatedMasterType,
+		DedicatedMasterCount:      cc.DedicatedMasterCount,
+		ZoneAwarenessEnabled:      cc.ZoneAwarenessEnabled,
+		WarmEnabled:               cc.WarmEnabled,
+		WarmType:                  cc.WarmType,
+		WarmCount:                 cc.WarmCount,
+		ColdStorageEnabled:        cc.ColdStorageEnabled,
+		MultiAZWithStandbyEnabled: cc.MultiAZWithStandbyEnabled,
+	}
+	if cc.ZoneAwarenessConfig != nil {
+		cfg.ZoneAwarenessConfig = &ZoneAwarenessConfig{
+			AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
+		}
+	}
+	return cfg
+}
+
+// parseAdvancedSecurityOptsFromReq converts JSON advanced security options to backend type.
+func parseAdvancedSecurityOptsFromReq(aso *advancedSecurityOptionsJSON) *AdvancedSecurityOptions {
+	if aso == nil {
+		return nil
+	}
+	out := &AdvancedSecurityOptions{
+		Enabled:                     aso.Enabled,
+		InternalUserDatabaseEnabled: aso.InternalUserDatabaseEnabled,
+		AnonymousAuthEnabled:        aso.AnonymousAuthEnabled,
+	}
+	if aso.SAMLOptions != nil {
+		out.SAMLOptions = &SAMLOptionsInput{
+			Enabled:               aso.SAMLOptions.Enabled,
+			IDPEntityID:           aso.SAMLOptions.IDPEntityID,
+			IDPMetadataContent:    aso.SAMLOptions.IDPMetadataContent,
+			RolesKey:              aso.SAMLOptions.RolesKey,
+			SubjectKey:            aso.SAMLOptions.SubjectKey,
+			SessionTimeoutMinutes: aso.SAMLOptions.SessionTimeoutMinutes,
+		}
+	}
+	return out
+}
+
+// parseLogPublishingOptsFromReq converts JSON log publishing options to backend type.
+func parseLogPublishingOptsFromReq(opts map[string]*logPublishingOptionJSON) map[string]*LogPublishingOption {
+	if len(opts) == 0 {
+		return nil
+	}
+	out := make(map[string]*LogPublishingOption, len(opts))
+	for k, v := range opts {
+		out[k] = &LogPublishingOption{
+			Enabled:                   v.Enabled,
+			CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
+		}
+	}
+	return out
+}
+
+// applyReqToUpdateInput maps parsed domainJSON fields onto an UpdateDomainConfigInput.
+func applyReqToUpdateInput(req *domainJSON) UpdateDomainConfigInput {
+	input := UpdateDomainConfigInput{
+		EngineVersion:  req.EngineVersion,
+		AccessPolicies: req.AccessPolicies,
+	}
+	if req.ClusterConfig != nil {
+		cc := parseClusterConfigFromReq(req.ClusterConfig)
+		input.ClusterConfig = &cc
+	}
+	if req.EBSOptions != nil {
+		input.EBSOptions = &EBSOptions{
+			EBSEnabled: req.EBSOptions.EBSEnabled,
+			VolumeType: req.EBSOptions.VolumeType,
+			VolumeSize: req.EBSOptions.VolumeSize,
+			IOPS:       req.EBSOptions.IOPS,
+			Throughput: req.EBSOptions.Throughput,
+			KMSKeyID:   req.EBSOptions.KMSKeyID,
+		}
+	}
+	if req.SnapshotOptions != nil {
+		input.SnapshotOptions = &SnapshotOptions{
+			AutomatedSnapshotStartHour: req.SnapshotOptions.AutomatedSnapshotStartHour,
+		}
+	}
+	if req.EncryptionAtRestOptions != nil {
+		input.EncryptionAtRestOptions = &EncryptionAtRestOptions{
+			Enabled:  req.EncryptionAtRestOptions.Enabled,
+			KMSKeyID: req.EncryptionAtRestOptions.KMSKeyID,
+		}
+	}
+	if req.NodeToNodeEncryptionOptions != nil {
+		input.NodeToNodeEncryptionOptions = &NodeToNodeEncryptionOptions{
+			Enabled: req.NodeToNodeEncryptionOptions.Enabled,
+		}
+	}
+	if req.DomainEndpointOptions != nil {
+		input.DomainEndpointOptions = &DomainEndpointOptions{
+			EnforceHTTPS:                 req.DomainEndpointOptions.EnforceHTTPS,
+			TLSSecurityPolicy:            req.DomainEndpointOptions.TLSSecurityPolicy,
+			CustomEndpointEnabled:        req.DomainEndpointOptions.CustomEndpointEnabled,
+			CustomEndpoint:               req.DomainEndpointOptions.CustomEndpoint,
+			CustomEndpointCertificateArn: req.DomainEndpointOptions.CustomEndpointCertificateArn,
+		}
+	}
+	input.AdvancedSecurityOptions = parseAdvancedSecurityOptsFromReq(req.AdvancedSecurityOptions)
+	if req.VPCOptions != nil {
+		input.VPCOptions = &VPCOptions{
+			VPCID:            req.VPCOptions.VPCID,
+			SubnetIDs:        req.VPCOptions.SubnetIDs,
+			SecurityGroupIDs: req.VPCOptions.SecurityGroupIDs,
+		}
+	}
+	if req.CognitoOptions != nil {
+		input.CognitoOptions = &CognitoOptions{
+			Enabled:        req.CognitoOptions.Enabled,
+			UserPoolID:     req.CognitoOptions.UserPoolID,
+			IdentityPoolID: req.CognitoOptions.IdentityPoolID,
+			RoleARN:        req.CognitoOptions.RoleARN,
+		}
+	}
+	input.LogPublishingOptions = parseLogPublishingOptsFromReq(req.LogPublishingOptions)
+	return input
+}
+
 func (h *Handler) handleCreateDomain(w http.ResponseWriter, r *http.Request) {
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -915,119 +932,22 @@ func (h *Handler) handleCreateDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	upd := applyReqToUpdateInput(&req)
 	input := CreateDomainInput{
-		Name:           req.DomainName,
-		EngineVersion:  req.EngineVersion,
-		AccessPolicies: req.AccessPolicies,
-		Tags:           req.Tags,
-	}
-
-	if req.ClusterConfig != nil {
-		cc := req.ClusterConfig
-		input.ClusterConfig = ClusterConfig{
-			InstanceType:              cc.InstanceType,
-			InstanceCount:             cc.InstanceCount,
-			DedicatedMasterEnabled:    cc.DedicatedMasterEnabled,
-			DedicatedMasterType:       cc.DedicatedMasterType,
-			DedicatedMasterCount:      cc.DedicatedMasterCount,
-			ZoneAwarenessEnabled:      cc.ZoneAwarenessEnabled,
-			WarmEnabled:               cc.WarmEnabled,
-			WarmType:                  cc.WarmType,
-			WarmCount:                 cc.WarmCount,
-			ColdStorageEnabled:        cc.ColdStorageEnabled,
-			MultiAZWithStandbyEnabled: cc.MultiAZWithStandbyEnabled,
-		}
-		if cc.ZoneAwarenessConfig != nil {
-			input.ClusterConfig.ZoneAwarenessConfig = &ZoneAwarenessConfig{
-				AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
-			}
-		}
-	}
-
-	if req.EBSOptions != nil {
-		input.EBSOptions = &EBSOptions{
-			EBSEnabled: req.EBSOptions.EBSEnabled,
-			VolumeType: req.EBSOptions.VolumeType,
-			VolumeSize: req.EBSOptions.VolumeSize,
-			IOPS:       req.EBSOptions.IOPS,
-			Throughput: req.EBSOptions.Throughput,
-			KMSKeyID:   req.EBSOptions.KMSKeyID,
-		}
-	}
-
-	if req.SnapshotOptions != nil {
-		input.SnapshotOptions = &SnapshotOptions{
-			AutomatedSnapshotStartHour: req.SnapshotOptions.AutomatedSnapshotStartHour,
-		}
-	}
-
-	if req.EncryptionAtRestOptions != nil {
-		input.EncryptionAtRestOptions = &EncryptionAtRestOptions{
-			Enabled:  req.EncryptionAtRestOptions.Enabled,
-			KMSKeyID: req.EncryptionAtRestOptions.KMSKeyID,
-		}
-	}
-
-	if req.NodeToNodeEncryptionOptions != nil {
-		input.NodeToNodeEncryptionOptions = &NodeToNodeEncryptionOptions{
-			Enabled: req.NodeToNodeEncryptionOptions.Enabled,
-		}
-	}
-
-	if req.DomainEndpointOptions != nil {
-		input.DomainEndpointOptions = &DomainEndpointOptions{
-			EnforceHTTPS:                 req.DomainEndpointOptions.EnforceHTTPS,
-			TLSSecurityPolicy:            req.DomainEndpointOptions.TLSSecurityPolicy,
-			CustomEndpointEnabled:        req.DomainEndpointOptions.CustomEndpointEnabled,
-			CustomEndpoint:               req.DomainEndpointOptions.CustomEndpoint,
-			CustomEndpointCertificateArn: req.DomainEndpointOptions.CustomEndpointCertificateArn,
-		}
-	}
-
-	if req.AdvancedSecurityOptions != nil {
-		aso := &AdvancedSecurityOptions{
-			Enabled:                     req.AdvancedSecurityOptions.Enabled,
-			InternalUserDatabaseEnabled: req.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
-			AnonymousAuthEnabled:        req.AdvancedSecurityOptions.AnonymousAuthEnabled,
-		}
-		if req.AdvancedSecurityOptions.SAMLOptions != nil {
-			aso.SAMLOptions = &SAMLOptionsInput{
-				Enabled:               req.AdvancedSecurityOptions.SAMLOptions.Enabled,
-				IDPEntityID:           req.AdvancedSecurityOptions.SAMLOptions.IDPEntityID,
-				IDPMetadataContent:    req.AdvancedSecurityOptions.SAMLOptions.IDPMetadataContent,
-				RolesKey:              req.AdvancedSecurityOptions.SAMLOptions.RolesKey,
-				SubjectKey:            req.AdvancedSecurityOptions.SAMLOptions.SubjectKey,
-				SessionTimeoutMinutes: req.AdvancedSecurityOptions.SAMLOptions.SessionTimeoutMinutes,
-			}
-		}
-		input.AdvancedSecurityOptions = aso
-	}
-
-	if req.VPCOptions != nil {
-		input.VPCOptions = &VPCOptions{
-			VPCID:            req.VPCOptions.VPCID,
-			SubnetIDs:        req.VPCOptions.SubnetIDs,
-			SecurityGroupIDs: req.VPCOptions.SecurityGroupIDs,
-		}
-	}
-
-	if req.CognitoOptions != nil {
-		input.CognitoOptions = &CognitoOptions{
-			Enabled:        req.CognitoOptions.Enabled,
-			UserPoolID:     req.CognitoOptions.UserPoolID,
-			IdentityPoolID: req.CognitoOptions.IdentityPoolID,
-			RoleARN:        req.CognitoOptions.RoleARN,
-		}
-	}
-
-	if len(req.LogPublishingOptions) > 0 {
-		input.LogPublishingOptions = make(map[string]*LogPublishingOption, len(req.LogPublishingOptions))
-		for k, v := range req.LogPublishingOptions {
-			input.LogPublishingOptions[k] = &LogPublishingOption{
-				Enabled:                   v.Enabled,
-				CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
-			}
-		}
+		Name:                        req.DomainName,
+		EngineVersion:               upd.EngineVersion,
+		AccessPolicies:              upd.AccessPolicies,
+		Tags:                        req.Tags,
+		ClusterConfig:               parseClusterConfigFromReq(req.ClusterConfig),
+		EBSOptions:                  upd.EBSOptions,
+		SnapshotOptions:             upd.SnapshotOptions,
+		EncryptionAtRestOptions:     upd.EncryptionAtRestOptions,
+		NodeToNodeEncryptionOptions: upd.NodeToNodeEncryptionOptions,
+		DomainEndpointOptions:       upd.DomainEndpointOptions,
+		AdvancedSecurityOptions:     upd.AdvancedSecurityOptions,
+		VPCOptions:                  upd.VPCOptions,
+		CognitoOptions:              upd.CognitoOptions,
+		LogPublishingOptions:        upd.LogPublishingOptions,
 	}
 
 	domain, err := h.Backend.CreateDomain(input)
@@ -1200,6 +1120,64 @@ func (h *Handler) handleDissociatePackages(w http.ResponseWriter, r *http.Reques
 	h.writeJSON(r, w, map[string]any{"DomainPackageDetailsList": outList})
 }
 
+func toClusterConfigJSON(cc ClusterConfig) clusterConfigJSON {
+	out := clusterConfigJSON{
+		InstanceType:              cc.InstanceType,
+		InstanceCount:             cc.InstanceCount,
+		DedicatedMasterEnabled:    cc.DedicatedMasterEnabled,
+		DedicatedMasterType:       cc.DedicatedMasterType,
+		DedicatedMasterCount:      cc.DedicatedMasterCount,
+		ZoneAwarenessEnabled:      cc.ZoneAwarenessEnabled,
+		WarmEnabled:               cc.WarmEnabled,
+		WarmType:                  cc.WarmType,
+		WarmCount:                 cc.WarmCount,
+		ColdStorageEnabled:        cc.ColdStorageEnabled,
+		MultiAZWithStandbyEnabled: cc.MultiAZWithStandbyEnabled,
+	}
+	if cc.ZoneAwarenessConfig != nil {
+		out.ZoneAwarenessConfig = &zoneAwarenessConfigJSON{
+			AvailabilityZoneCount: cc.ZoneAwarenessConfig.AvailabilityZoneCount,
+		}
+	}
+	return out
+}
+
+func toAdvancedSecurityOptionsJSON(aso *AdvancedSecurityOptions) *advancedSecurityOptionsJSON {
+	if aso == nil {
+		return &advancedSecurityOptionsJSON{}
+	}
+	out := &advancedSecurityOptionsJSON{
+		Enabled:                     aso.Enabled,
+		InternalUserDatabaseEnabled: aso.InternalUserDatabaseEnabled,
+		AnonymousAuthEnabled:        aso.AnonymousAuthEnabled,
+	}
+	if aso.SAMLOptions != nil {
+		out.SAMLOptions = &samlOptionsJSON{
+			Enabled:               aso.SAMLOptions.Enabled,
+			IDPEntityID:           aso.SAMLOptions.IDPEntityID,
+			IDPMetadataContent:    aso.SAMLOptions.IDPMetadataContent,
+			RolesKey:              aso.SAMLOptions.RolesKey,
+			SubjectKey:            aso.SAMLOptions.SubjectKey,
+			SessionTimeoutMinutes: aso.SAMLOptions.SessionTimeoutMinutes,
+		}
+	}
+	return out
+}
+
+func toLogPublishingOptionsJSON(opts map[string]*LogPublishingOption) map[string]*logPublishingOptionJSON {
+	if len(opts) == 0 {
+		return nil
+	}
+	out := make(map[string]*logPublishingOptionJSON, len(opts))
+	for k, v := range opts {
+		out[k] = &logPublishingOptionJSON{
+			Enabled:                   v.Enabled,
+			CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
+		}
+	}
+	return out
+}
+
 func toDomainStatusJSON(d *Domain) domainStatusJSON {
 	out := domainStatusJSON{
 		DomainName:             d.Name,
@@ -1209,27 +1187,19 @@ func toDomainStatusJSON(d *Domain) domainStatusJSON {
 		Processing:             false,
 		DomainProcessingStatus: domainStatusActive,
 		AccessPolicies:         d.AccessPolicies,
-		ClusterConfig: clusterConfigJSON{
-			InstanceType:              d.ClusterConfig.InstanceType,
-			InstanceCount:             d.ClusterConfig.InstanceCount,
-			DedicatedMasterEnabled:    d.ClusterConfig.DedicatedMasterEnabled,
-			DedicatedMasterType:       d.ClusterConfig.DedicatedMasterType,
-			DedicatedMasterCount:      d.ClusterConfig.DedicatedMasterCount,
-			ZoneAwarenessEnabled:      d.ClusterConfig.ZoneAwarenessEnabled,
-			WarmEnabled:               d.ClusterConfig.WarmEnabled,
-			WarmType:                  d.ClusterConfig.WarmType,
-			WarmCount:                 d.ClusterConfig.WarmCount,
-			ColdStorageEnabled:        d.ClusterConfig.ColdStorageEnabled,
-			MultiAZWithStandbyEnabled: d.ClusterConfig.MultiAZWithStandbyEnabled,
-		},
+		ClusterConfig:          toClusterConfigJSON(d.ClusterConfig),
+		// Always emit these fields so providers see a consistent response shape.
+		EBSOptions:                  &ebsOptionsJSON{},
+		EncryptionAtRestOptions:     &encryptAtRestOptionsJSON{},
+		NodeToNodeEncryptionOptions: &nodeToNodeEncryptJSON{},
+		CognitoOptions:              &cognitoOptionsJSON{},
+		AdvancedSecurityOptions:     toAdvancedSecurityOptionsJSON(nil),
 	}
+	applyDomainOptionalFields(d, &out)
+	return out
+}
 
-	if d.ClusterConfig.ZoneAwarenessConfig != nil {
-		out.ClusterConfig.ZoneAwarenessConfig = &zoneAwarenessConfigJSON{
-			AvailabilityZoneCount: d.ClusterConfig.ZoneAwarenessConfig.AvailabilityZoneCount,
-		}
-	}
-
+func applyDomainOptionalFields(d *Domain, out *domainStatusJSON) {
 	if d.EBSOptions != nil {
 		out.EBSOptions = &ebsOptionsJSON{
 			EBSEnabled: d.EBSOptions.EBSEnabled,
@@ -1240,26 +1210,20 @@ func toDomainStatusJSON(d *Domain) domainStatusJSON {
 			KMSKeyID:   d.EBSOptions.KMSKeyID,
 		}
 	}
-
 	if d.SnapshotOptions != nil {
 		out.SnapshotOptions = &snapshotOptionsJSON{
 			AutomatedSnapshotStartHour: d.SnapshotOptions.AutomatedSnapshotStartHour,
 		}
 	}
-
 	if d.EncryptionAtRestOptions != nil {
 		out.EncryptionAtRestOptions = &encryptAtRestOptionsJSON{
 			Enabled:  d.EncryptionAtRestOptions.Enabled,
 			KMSKeyID: d.EncryptionAtRestOptions.KMSKeyID,
 		}
 	}
-
 	if d.NodeToNodeEncryptionOptions != nil {
-		out.NodeToNodeEncryptionOptions = &nodeToNodeEncryptJSON{
-			Enabled: d.NodeToNodeEncryptionOptions.Enabled,
-		}
+		out.NodeToNodeEncryptionOptions = &nodeToNodeEncryptJSON{Enabled: d.NodeToNodeEncryptionOptions.Enabled}
 	}
-
 	if d.DomainEndpointOptions != nil {
 		out.DomainEndpointOptions = &domainEndpointOptionsJSON{
 			EnforceHTTPS:                 d.DomainEndpointOptions.EnforceHTTPS,
@@ -1269,26 +1233,9 @@ func toDomainStatusJSON(d *Domain) domainStatusJSON {
 			CustomEndpointCertificateArn: d.DomainEndpointOptions.CustomEndpointCertificateArn,
 		}
 	}
-
 	if d.AdvancedSecurityOptions != nil {
-		aso := &advancedSecurityOptionsJSON{
-			Enabled:                     d.AdvancedSecurityOptions.Enabled,
-			InternalUserDatabaseEnabled: d.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
-			AnonymousAuthEnabled:        d.AdvancedSecurityOptions.AnonymousAuthEnabled,
-		}
-		if d.AdvancedSecurityOptions.SAMLOptions != nil {
-			aso.SAMLOptions = &samlOptionsJSON{
-				Enabled:               d.AdvancedSecurityOptions.SAMLOptions.Enabled,
-				IDPEntityID:           d.AdvancedSecurityOptions.SAMLOptions.IDPEntityID,
-				IDPMetadataContent:    d.AdvancedSecurityOptions.SAMLOptions.IDPMetadataContent,
-				RolesKey:              d.AdvancedSecurityOptions.SAMLOptions.RolesKey,
-				SubjectKey:            d.AdvancedSecurityOptions.SAMLOptions.SubjectKey,
-				SessionTimeoutMinutes: d.AdvancedSecurityOptions.SAMLOptions.SessionTimeoutMinutes,
-			}
-		}
-		out.AdvancedSecurityOptions = aso
+		out.AdvancedSecurityOptions = toAdvancedSecurityOptionsJSON(d.AdvancedSecurityOptions)
 	}
-
 	if d.VPCOptions != nil {
 		out.VPCOptions = &vpcOptionsJSON{
 			VPCID:            d.VPCOptions.VPCID,
@@ -1296,7 +1243,6 @@ func toDomainStatusJSON(d *Domain) domainStatusJSON {
 			SecurityGroupIDs: d.VPCOptions.SecurityGroupIDs,
 		}
 	}
-
 	if d.CognitoOptions != nil {
 		out.CognitoOptions = &cognitoOptionsJSON{
 			Enabled:        d.CognitoOptions.Enabled,
@@ -1305,18 +1251,7 @@ func toDomainStatusJSON(d *Domain) domainStatusJSON {
 			RoleARN:        d.CognitoOptions.RoleARN,
 		}
 	}
-
-	if len(d.LogPublishingOptions) > 0 {
-		out.LogPublishingOptions = make(map[string]*logPublishingOptionJSON, len(d.LogPublishingOptions))
-		for k, v := range d.LogPublishingOptions {
-			out.LogPublishingOptions[k] = &logPublishingOptionJSON{
-				Enabled:                   v.Enabled,
-				CloudWatchLogsLogGroupARN: v.CloudWatchLogsLogGroupARN,
-			}
-		}
-	}
-
-	return out
+	out.LogPublishingOptions = toLogPublishingOptionsJSON(d.LogPublishingOptions)
 }
 
 type errorResponseJSON struct {
@@ -1329,10 +1264,10 @@ func toDomainConfigJSON(d *Domain) domainConfigFields {
 	st := toDomainStatusJSON(d)
 
 	cfg := domainConfigFields{
-		EngineVersion: opensearchConfigValue{Options: d.EngineVersion, Status: active},
-		ClusterConfig: opensearchConfigValue{Options: st.ClusterConfig, Status: active},
-		EBSOptions:    opensearchConfigValue{Options: map[string]any{}, Status: active},
-		AccessPolicies: opensearchConfigValue{Options: d.AccessPolicies, Status: active},
+		EngineVersion:   opensearchConfigValue{Options: d.EngineVersion, Status: active},
+		ClusterConfig:   opensearchConfigValue{Options: st.ClusterConfig, Status: active},
+		EBSOptions:      opensearchConfigValue{Options: map[string]any{}, Status: active},
+		AccessPolicies:  opensearchConfigValue{Options: d.AccessPolicies, Status: active},
 		AdvancedOptions: opensearchConfigValue{Options: map[string]any{}, Status: active},
 	}
 

--- a/services/opensearch/handler_audit1_test.go
+++ b/services/opensearch/handler_audit1_test.go
@@ -570,6 +570,7 @@ func TestAudit1_CreateDomain_LogPublishingOptions(t *testing.T) {
 						"CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/opensearch/" + lt,
 					}
 				}
+
 				return opts
 			})(),
 			wantLogTypes: allLogTypes,
@@ -644,10 +645,17 @@ func TestAudit1_CreateDomain_SnapshotOptions(t *testing.T) {
 			require.True(t, ok)
 			snapOpts, ok := status["SnapshotOptions"].(map[string]any)
 			require.True(t, ok, "SnapshotOptions should be present")
-			assert.Equal(t, float64(tt.automatedSnapshotStartHour), snapOpts["AutomatedSnapshotStartHour"])
+			assert.InDelta(t, float64(tt.automatedSnapshotStartHour), snapOpts["AutomatedSnapshotStartHour"], 0)
 		})
 	}
 }
+
+// IAM policy strings used in access policy tests. Defined as const to stay within line-length limits.
+const (
+	policyAllowAll     = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:*","Resource":"*"}]}`                                                      //nolint:lll // raw JSON string literal cannot be split
+	policyIPBased      = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:ESHttp*","Condition":{"IpAddress":{"aws:SourceIp":["203.0.113.0/24"]}}}]}` //nolint:lll // raw JSON string literal cannot be split
+	policyRootAllowAll = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"es:*","Resource":"*"}]}`                         //nolint:lll // raw JSON string literal cannot be split
+)
 
 // TestAudit1_CreateDomain_AccessPolicies verifies the access policies JSON field.
 func TestAudit1_CreateDomain_AccessPolicies(t *testing.T) {
@@ -665,13 +673,13 @@ func TestAudit1_CreateDomain_AccessPolicies(t *testing.T) {
 		},
 		{
 			name:           "allow_all_policy",
-			accessPolicies: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:*","Resource":"*"}]}`,
-			wantPolicies:   `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:*","Resource":"*"}]}`,
+			accessPolicies: policyAllowAll,
+			wantPolicies:   policyAllowAll,
 		},
 		{
 			name:           "ip_based_policy",
-			accessPolicies: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:ESHttp*","Condition":{"IpAddress":{"aws:SourceIp":["203.0.113.0/24"]}}}]}`,
-			wantPolicies:   `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:ESHttp*","Condition":{"IpAddress":{"aws:SourceIp":["203.0.113.0/24"]}}}]}`,
+			accessPolicies: policyIPBased,
+			wantPolicies:   policyIPBased,
 		},
 	}
 
@@ -869,7 +877,7 @@ func TestAudit1_UpdateDomainConfig_AllOptions(t *testing.T) {
 		{
 			name: "update_access_policies",
 			updateBody: map[string]any{
-				"AccessPolicies": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"es:*","Resource":"*"}]}`,
+				"AccessPolicies": policyRootAllowAll,
 			},
 			verify: func(t *testing.T, status map[string]any) {
 				t.Helper()
@@ -901,7 +909,7 @@ func TestAudit1_UpdateDomainConfig_AllOptions(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, true, opts["DedicatedMasterEnabled"])
 				assert.Equal(t, "m6g.large.search", opts["DedicatedMasterType"])
-				assert.Equal(t, float64(3), opts["DedicatedMasterCount"])
+				assert.InDelta(t, float64(3), opts["DedicatedMasterCount"], 0)
 			},
 		},
 	}

--- a/services/opensearch/handler_audit1_test.go
+++ b/services/opensearch/handler_audit1_test.go
@@ -15,9 +15,9 @@ func TestAudit1_CreateDomain_FullClusterConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
 		clusterConfig map[string]any
 		wantCC        map[string]any
+		name          string
 	}{
 		{
 			name: "dedicated_master_enabled",
@@ -118,9 +118,9 @@ func TestAudit1_CreateDomain_EBSOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
 		ebsOptions map[string]any
 		wantEBS    map[string]any
+		name       string
 	}{
 		{
 			name: "ebs_enabled_gp3",
@@ -196,9 +196,9 @@ func TestAudit1_CreateDomain_EncryptionOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
 		body              map[string]any
 		wantEncryptFields map[string]any
+		name              string
 		wantN2NEnabled    bool
 	}{
 		{
@@ -254,16 +254,16 @@ func TestAudit1_CreateDomain_EncryptionOptions(t *testing.T) {
 			require.True(t, ok)
 
 			if len(tt.wantEncryptFields) > 0 {
-				enc, ok := status["EncryptionAtRestOptions"].(map[string]any)
-				require.True(t, ok, "EncryptionAtRestOptions should be present")
+				enc, encOk := status["EncryptionAtRestOptions"].(map[string]any)
+				require.True(t, encOk, "EncryptionAtRestOptions should be present")
 				for k, v := range tt.wantEncryptFields {
 					assert.Equal(t, v, enc[k], "EncryptionAtRestOptions.%s", k)
 				}
 			}
 
 			if tt.wantN2NEnabled {
-				n2n, ok := status["NodeToNodeEncryptionOptions"].(map[string]any)
-				require.True(t, ok, "NodeToNodeEncryptionOptions should be present")
+				n2n, n2nOk := status["NodeToNodeEncryptionOptions"].(map[string]any)
+				require.True(t, n2nOk, "NodeToNodeEncryptionOptions should be present")
 				assert.Equal(t, true, n2n["Enabled"])
 			}
 		})
@@ -275,9 +275,9 @@ func TestAudit1_CreateDomain_DomainEndpointOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		options  map[string]any
-		wantDEO  map[string]any
+		options map[string]any
+		wantDEO map[string]any
+		name    string
 	}{
 		{
 			name: "enforce_https",
@@ -337,9 +337,9 @@ func TestAudit1_CreateDomain_AdvancedSecurityOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
 		options map[string]any
 		wantASO map[string]any
+		name    string
 	}{
 		{
 			name: "internal_userdb_enabled",
@@ -419,9 +419,9 @@ func TestAudit1_CreateDomain_VPCOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
 		vpcOptions map[string]any
 		wantVPC    map[string]any
+		name       string
 	}{
 		{
 			name: "single_subnet_sg",
@@ -478,9 +478,9 @@ func TestAudit1_CreateDomain_CognitoOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		cognitoOpts   map[string]any
-		wantCognito   map[string]any
+		cognitoOpts map[string]any
+		wantCognito map[string]any
+		name        string
 	}{
 		{
 			name: "cognito_enabled",
@@ -546,8 +546,8 @@ func TestAudit1_CreateDomain_LogPublishingOptions(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
 		logPublishingOpts map[string]any
+		name              string
 		wantLogTypes      []string
 	}{
 		{
@@ -703,9 +703,9 @@ func TestAudit1_UpdateDomainConfig_AllOptions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
 		updateBody map[string]any
 		verify     func(t *testing.T, status map[string]any)
+		name       string
 	}{
 		{
 			name: "update_ebs_options",
@@ -933,9 +933,9 @@ func TestAudit1_DescribeDomainConfig_FullConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		createBody   map[string]any
-		wantKeys     []string
+		createBody map[string]any
+		name       string
+		wantKeys   []string
 	}{
 		{
 			name: "with_ebs_options",
@@ -952,11 +952,14 @@ func TestAudit1_DescribeDomainConfig_FullConfig(t *testing.T) {
 		{
 			name: "with_encryption",
 			createBody: map[string]any{
-				"DomainName": "cfg-enc",
-				"EncryptionAtRestOptions": map[string]any{"Enabled": true},
+				"DomainName":                  "cfg-enc",
+				"EncryptionAtRestOptions":     map[string]any{"Enabled": true},
 				"NodeToNodeEncryptionOptions": map[string]any{"Enabled": true},
 			},
-			wantKeys: []string{"EngineVersion", "ClusterConfig", "EncryptionAtRestOptions", "NodeToNodeEncryptionOptions"},
+			wantKeys: []string{
+				"EngineVersion", "ClusterConfig",
+				"EncryptionAtRestOptions", "NodeToNodeEncryptionOptions",
+			},
 		},
 		{
 			name: "with_advanced_security",

--- a/services/opensearch/handler_audit1_test.go
+++ b/services/opensearch/handler_audit1_test.go
@@ -1,0 +1,999 @@
+package opensearch_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAudit1_CreateDomain_FullClusterConfig verifies all ClusterConfig fields round-trip through
+// CreateDomain and are reflected in DescribeDomain.
+func TestAudit1_CreateDomain_FullClusterConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		clusterConfig map[string]any
+		wantCC        map[string]any
+	}{
+		{
+			name: "dedicated_master_enabled",
+			clusterConfig: map[string]any{
+				"InstanceType":           "m6g.large.search",
+				"InstanceCount":          3,
+				"DedicatedMasterEnabled": true,
+				"DedicatedMasterType":    "m6g.large.search",
+				"DedicatedMasterCount":   3,
+			},
+			wantCC: map[string]any{
+				"DedicatedMasterEnabled": true,
+				"DedicatedMasterType":    "m6g.large.search",
+				"DedicatedMasterCount":   float64(3),
+			},
+		},
+		{
+			name: "zone_awareness_enabled",
+			clusterConfig: map[string]any{
+				"InstanceType":         "r6g.large.search",
+				"InstanceCount":        6,
+				"ZoneAwarenessEnabled": true,
+				"ZoneAwarenessConfig":  map[string]any{"AvailabilityZoneCount": 3},
+			},
+			wantCC: map[string]any{
+				"ZoneAwarenessEnabled": true,
+			},
+		},
+		{
+			name: "warm_nodes_enabled",
+			clusterConfig: map[string]any{
+				"InstanceType": "r6g.large.search",
+				"WarmEnabled":  true,
+				"WarmType":     "ultrawarm1.medium.search",
+				"WarmCount":    2,
+			},
+			wantCC: map[string]any{
+				"WarmEnabled": true,
+				"WarmType":    "ultrawarm1.medium.search",
+				"WarmCount":   float64(2),
+			},
+		},
+		{
+			name: "cold_storage_enabled",
+			clusterConfig: map[string]any{
+				"InstanceType":       "r6g.large.search",
+				"WarmEnabled":        true,
+				"WarmType":           "ultrawarm1.medium.search",
+				"WarmCount":          2,
+				"ColdStorageEnabled": true,
+			},
+			wantCC: map[string]any{
+				"ColdStorageEnabled": true,
+			},
+		},
+		{
+			name: "multi_az_with_standby",
+			clusterConfig: map[string]any{
+				"InstanceType":              "m6g.large.search",
+				"InstanceCount":             3,
+				"MultiAZWithStandbyEnabled": true,
+			},
+			wantCC: map[string]any{
+				"MultiAZWithStandbyEnabled": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			body := map[string]any{
+				"DomainName":    "cc-domain-" + tt.name,
+				"ClusterConfig": tt.clusterConfig,
+			}
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", body)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			cc, ok := status["ClusterConfig"].(map[string]any)
+			require.True(t, ok)
+
+			for k, v := range tt.wantCC {
+				assert.Equal(t, v, cc[k], "ClusterConfig.%s", k)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_EBSOptions verifies EBSOptions are stored and returned.
+func TestAudit1_CreateDomain_EBSOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ebsOptions map[string]any
+		wantEBS    map[string]any
+	}{
+		{
+			name: "ebs_enabled_gp3",
+			ebsOptions: map[string]any{
+				"EBSEnabled": true,
+				"VolumeType": "gp3",
+				"VolumeSize": 100,
+				"Iops":       3000,
+				"Throughput": 125,
+			},
+			wantEBS: map[string]any{
+				"EBSEnabled": true,
+				"VolumeType": "gp3",
+				"VolumeSize": float64(100),
+				"Iops":       float64(3000),
+				"Throughput": float64(125),
+			},
+		},
+		{
+			name: "ebs_enabled_io1_with_kms",
+			ebsOptions: map[string]any{
+				"EBSEnabled": true,
+				"VolumeType": "io1",
+				"VolumeSize": 200,
+				"Iops":       10000,
+				"KMSKeyId":   "arn:aws:kms:us-east-1:123456789012:key/abc123",
+			},
+			wantEBS: map[string]any{
+				"EBSEnabled": true,
+				"VolumeType": "io1",
+				"KMSKeyId":   "arn:aws:kms:us-east-1:123456789012:key/abc123",
+			},
+		},
+		{
+			name: "ebs_disabled",
+			ebsOptions: map[string]any{
+				"EBSEnabled": false,
+			},
+			wantEBS: map[string]any{
+				"EBSEnabled": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName": "ebs-" + tt.name,
+				"EBSOptions": tt.ebsOptions,
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			ebs, ok := status["EBSOptions"].(map[string]any)
+			require.True(t, ok, "EBSOptions should be present in response")
+
+			for k, v := range tt.wantEBS {
+				assert.Equal(t, v, ebs[k], "EBSOptions.%s", k)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_EncryptionOptions verifies encryption at rest and node-to-node options.
+func TestAudit1_CreateDomain_EncryptionOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		body              map[string]any
+		wantEncryptFields map[string]any
+		wantN2NEnabled    bool
+	}{
+		{
+			name: "encrypt_at_rest_enabled",
+			body: map[string]any{
+				"DomainName": "enc-enabled",
+				"EncryptionAtRestOptions": map[string]any{
+					"Enabled":  true,
+					"KMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/test-key",
+				},
+			},
+			wantEncryptFields: map[string]any{
+				"Enabled":  true,
+				"KMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/test-key",
+			},
+		},
+		{
+			name: "encrypt_at_rest_disabled",
+			body: map[string]any{
+				"DomainName": "enc-disabled",
+				"EncryptionAtRestOptions": map[string]any{
+					"Enabled": false,
+				},
+			},
+			wantEncryptFields: map[string]any{
+				"Enabled": false,
+			},
+		},
+		{
+			name: "node_to_node_encryption",
+			body: map[string]any{
+				"DomainName": "n2n-enc",
+				"NodeToNodeEncryptionOptions": map[string]any{
+					"Enabled": true,
+				},
+			},
+			wantN2NEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", tt.body)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+
+			if len(tt.wantEncryptFields) > 0 {
+				enc, ok := status["EncryptionAtRestOptions"].(map[string]any)
+				require.True(t, ok, "EncryptionAtRestOptions should be present")
+				for k, v := range tt.wantEncryptFields {
+					assert.Equal(t, v, enc[k], "EncryptionAtRestOptions.%s", k)
+				}
+			}
+
+			if tt.wantN2NEnabled {
+				n2n, ok := status["NodeToNodeEncryptionOptions"].(map[string]any)
+				require.True(t, ok, "NodeToNodeEncryptionOptions should be present")
+				assert.Equal(t, true, n2n["Enabled"])
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_DomainEndpointOptions verifies HTTPS and custom endpoint options.
+func TestAudit1_CreateDomain_DomainEndpointOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  map[string]any
+		wantDEO  map[string]any
+	}{
+		{
+			name: "enforce_https",
+			options: map[string]any{
+				"EnforceHTTPS":      true,
+				"TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07",
+			},
+			wantDEO: map[string]any{
+				"EnforceHTTPS":      true,
+				"TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07",
+			},
+		},
+		{
+			name: "custom_endpoint_enabled",
+			options: map[string]any{
+				"EnforceHTTPS":                 true,
+				"CustomEndpointEnabled":        true,
+				"CustomEndpoint":               "search.example.com",
+				"CustomEndpointCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+			},
+			wantDEO: map[string]any{
+				"CustomEndpointEnabled":        true,
+				"CustomEndpoint":               "search.example.com",
+				"CustomEndpointCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName":            "deo-" + tt.name,
+				"DomainEndpointOptions": tt.options,
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			deo, ok := status["DomainEndpointOptions"].(map[string]any)
+			require.True(t, ok, "DomainEndpointOptions should be present")
+
+			for k, v := range tt.wantDEO {
+				assert.Equal(t, v, deo[k], "DomainEndpointOptions.%s", k)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_AdvancedSecurityOptions verifies FGAC settings including SAML.
+func TestAudit1_CreateDomain_AdvancedSecurityOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options map[string]any
+		wantASO map[string]any
+	}{
+		{
+			name: "internal_userdb_enabled",
+			options: map[string]any{
+				"Enabled":                     true,
+				"InternalUserDatabaseEnabled": true,
+			},
+			wantASO: map[string]any{
+				"Enabled":                     true,
+				"InternalUserDatabaseEnabled": true,
+			},
+		},
+		{
+			name: "saml_enabled",
+			options: map[string]any{
+				"Enabled":                     true,
+				"InternalUserDatabaseEnabled": false,
+				"SAMLOptions": map[string]any{
+					"Enabled":               true,
+					"SessionTimeoutMinutes": 60,
+				},
+			},
+			wantASO: map[string]any{
+				"Enabled": true,
+			},
+		},
+		{
+			name: "anonymous_auth_enabled",
+			options: map[string]any{
+				"Enabled":              true,
+				"AnonymousAuthEnabled": true,
+			},
+			wantASO: map[string]any{
+				"Enabled":              true,
+				"AnonymousAuthEnabled": true,
+			},
+		},
+		{
+			name: "disabled",
+			options: map[string]any{
+				"Enabled": false,
+			},
+			wantASO: map[string]any{
+				"Enabled": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName":              "aso-" + tt.name,
+				"AdvancedSecurityOptions": tt.options,
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			aso, ok := status["AdvancedSecurityOptions"].(map[string]any)
+			require.True(t, ok, "AdvancedSecurityOptions should be present")
+
+			for k, v := range tt.wantASO {
+				assert.Equal(t, v, aso[k], "AdvancedSecurityOptions.%s", k)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_VPCOptions verifies VPC configuration is stored and returned.
+func TestAudit1_CreateDomain_VPCOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		vpcOptions map[string]any
+		wantVPC    map[string]any
+	}{
+		{
+			name: "single_subnet_sg",
+			vpcOptions: map[string]any{
+				"SubnetIds":        []string{"subnet-abc123"},
+				"SecurityGroupIds": []string{"sg-abc123"},
+			},
+			wantVPC: map[string]any{
+				"SubnetIds":        []any{"subnet-abc123"},
+				"SecurityGroupIds": []any{"sg-abc123"},
+			},
+		},
+		{
+			name: "multi_subnet_multi_sg",
+			vpcOptions: map[string]any{
+				"SubnetIds":        []string{"subnet-aaa", "subnet-bbb", "subnet-ccc"},
+				"SecurityGroupIds": []string{"sg-one", "sg-two"},
+				"VPCId":            "vpc-12345",
+			},
+			wantVPC: map[string]any{
+				"VPCId": "vpc-12345",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName": "vpc-" + tt.name,
+				"VPCOptions": tt.vpcOptions,
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			vpc, ok := status["VPCOptions"].(map[string]any)
+			require.True(t, ok, "VPCOptions should be present")
+
+			for k, v := range tt.wantVPC {
+				assert.Equal(t, v, vpc[k], "VPCOptions.%s", k)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_CognitoOptions verifies Cognito / Kibana auth options.
+func TestAudit1_CreateDomain_CognitoOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cognitoOpts   map[string]any
+		wantCognito   map[string]any
+	}{
+		{
+			name: "cognito_enabled",
+			cognitoOpts: map[string]any{
+				"Enabled":        true,
+				"UserPoolId":     "us-east-1_abc123",
+				"IdentityPoolId": "us-east-1:abcd-1234",
+				"RoleArn":        "arn:aws:iam::123456789012:role/CognitoRole",
+			},
+			wantCognito: map[string]any{
+				"Enabled":        true,
+				"UserPoolId":     "us-east-1_abc123",
+				"IdentityPoolId": "us-east-1:abcd-1234",
+				"RoleArn":        "arn:aws:iam::123456789012:role/CognitoRole",
+			},
+		},
+		{
+			name: "cognito_disabled",
+			cognitoOpts: map[string]any{
+				"Enabled": false,
+			},
+			wantCognito: map[string]any{
+				"Enabled": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName":     "cognito-" + tt.name,
+				"CognitoOptions": tt.cognitoOpts,
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			cognito, ok := status["CognitoOptions"].(map[string]any)
+			require.True(t, ok, "CognitoOptions should be present")
+
+			for k, v := range tt.wantCognito {
+				assert.Equal(t, v, cognito[k], "CognitoOptions.%s", k)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_LogPublishingOptions verifies all 4 log type options.
+func TestAudit1_CreateDomain_LogPublishingOptions(t *testing.T) {
+	t.Parallel()
+
+	allLogTypes := []string{
+		"INDEX_SLOW_LOGS",
+		"SEARCH_SLOW_LOGS",
+		"ES_APPLICATION_LOGS",
+		"AUDIT_LOGS",
+	}
+
+	tests := []struct {
+		name              string
+		logPublishingOpts map[string]any
+		wantLogTypes      []string
+	}{
+		{
+			name: "single_log_type",
+			logPublishingOpts: map[string]any{
+				"INDEX_SLOW_LOGS": map[string]any{
+					"Enabled":                   true,
+					"CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/opensearch/index-slow",
+				},
+			},
+			wantLogTypes: []string{"INDEX_SLOW_LOGS"},
+		},
+		{
+			name: "all_four_log_types",
+			logPublishingOpts: (func() map[string]any {
+				opts := map[string]any{}
+				for _, lt := range allLogTypes {
+					opts[lt] = map[string]any{
+						"Enabled":                   true,
+						"CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/opensearch/" + lt,
+					}
+				}
+				return opts
+			})(),
+			wantLogTypes: allLogTypes,
+		},
+		{
+			name: "log_type_disabled",
+			logPublishingOpts: map[string]any{
+				"AUDIT_LOGS": map[string]any{
+					"Enabled": false,
+				},
+			},
+			wantLogTypes: []string{"AUDIT_LOGS"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName":           "logs-" + tt.name,
+				"LogPublishingOptions": tt.logPublishingOpts,
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			logs, ok := status["LogPublishingOptions"].(map[string]any)
+			require.True(t, ok, "LogPublishingOptions should be present")
+
+			for _, logType := range tt.wantLogTypes {
+				assert.Contains(t, logs, logType, "LogPublishingOptions should contain %s", logType)
+			}
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_SnapshotOptions verifies automated snapshot start hour.
+func TestAudit1_CreateDomain_SnapshotOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                       string
+		automatedSnapshotStartHour int
+	}{
+		{name: "hour_0", automatedSnapshotStartHour: 0},
+		{name: "hour_1", automatedSnapshotStartHour: 1},
+		{name: "hour_23", automatedSnapshotStartHour: 23},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", map[string]any{
+				"DomainName": "snap-" + tt.name,
+				"SnapshotOptions": map[string]any{
+					"AutomatedSnapshotStartHour": tt.automatedSnapshotStartHour,
+				},
+			})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			snapOpts, ok := status["SnapshotOptions"].(map[string]any)
+			require.True(t, ok, "SnapshotOptions should be present")
+			assert.Equal(t, float64(tt.automatedSnapshotStartHour), snapOpts["AutomatedSnapshotStartHour"])
+		})
+	}
+}
+
+// TestAudit1_CreateDomain_AccessPolicies verifies the access policies JSON field.
+func TestAudit1_CreateDomain_AccessPolicies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		accessPolicies string
+		wantPolicies   string
+	}{
+		{
+			name:           "empty_policy",
+			accessPolicies: "",
+			wantPolicies:   "",
+		},
+		{
+			name:           "allow_all_policy",
+			accessPolicies: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:*","Resource":"*"}]}`,
+			wantPolicies:   `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:*","Resource":"*"}]}`,
+		},
+		{
+			name:           "ip_based_policy",
+			accessPolicies: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:ESHttp*","Condition":{"IpAddress":{"aws:SourceIp":["203.0.113.0/24"]}}}]}`,
+			wantPolicies:   `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"es:ESHttp*","Condition":{"IpAddress":{"aws:SourceIp":["203.0.113.0/24"]}}}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			body := map[string]any{"DomainName": "ap-" + tt.name}
+			if tt.accessPolicies != "" {
+				body["AccessPolicies"] = tt.accessPolicies
+			}
+			resp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", body)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+			status, ok := out["DomainStatus"].(map[string]any)
+			require.True(t, ok)
+			gotPolicies, _ := status["AccessPolicies"].(string)
+			assert.Equal(t, tt.wantPolicies, gotPolicies)
+		})
+	}
+}
+
+// TestAudit1_UpdateDomainConfig_AllOptions verifies UpdateDomainConfig can set all new fields.
+func TestAudit1_UpdateDomainConfig_AllOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		updateBody map[string]any
+		verify     func(t *testing.T, status map[string]any)
+	}{
+		{
+			name: "update_ebs_options",
+			updateBody: map[string]any{
+				"EBSOptions": map[string]any{
+					"EBSEnabled": true,
+					"VolumeType": "gp3",
+					"VolumeSize": 200,
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				ebs, ok := dc["EBSOptions"].(map[string]any)
+				require.True(t, ok, "EBSOptions must be in DomainConfig")
+				opts, ok := ebs["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["EBSEnabled"])
+				assert.Equal(t, "gp3", opts["VolumeType"])
+			},
+		},
+		{
+			name: "update_encryption_at_rest",
+			updateBody: map[string]any{
+				"EncryptionAtRestOptions": map[string]any{
+					"Enabled":  true,
+					"KMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/new-key",
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				enc, ok := dc["EncryptionAtRestOptions"].(map[string]any)
+				require.True(t, ok, "EncryptionAtRestOptions must be in DomainConfig")
+				opts, ok := enc["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["Enabled"])
+			},
+		},
+		{
+			name: "update_node_to_node_encryption",
+			updateBody: map[string]any{
+				"NodeToNodeEncryptionOptions": map[string]any{
+					"Enabled": true,
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				n2n, ok := dc["NodeToNodeEncryptionOptions"].(map[string]any)
+				require.True(t, ok, "NodeToNodeEncryptionOptions must be in DomainConfig")
+				opts, ok := n2n["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["Enabled"])
+			},
+		},
+		{
+			name: "update_domain_endpoint_options",
+			updateBody: map[string]any{
+				"DomainEndpointOptions": map[string]any{
+					"EnforceHTTPS":      true,
+					"TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07",
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				deo, ok := dc["DomainEndpointOptions"].(map[string]any)
+				require.True(t, ok, "DomainEndpointOptions must be in DomainConfig")
+				opts, ok := deo["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["EnforceHTTPS"])
+			},
+		},
+		{
+			name: "update_advanced_security_options",
+			updateBody: map[string]any{
+				"AdvancedSecurityOptions": map[string]any{
+					"Enabled":                     true,
+					"InternalUserDatabaseEnabled": true,
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				aso, ok := dc["AdvancedSecurityOptions"].(map[string]any)
+				require.True(t, ok, "AdvancedSecurityOptions must be in DomainConfig")
+				opts, ok := aso["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["Enabled"])
+				assert.Equal(t, true, opts["InternalUserDatabaseEnabled"])
+			},
+		},
+		{
+			name: "update_vpc_options",
+			updateBody: map[string]any{
+				"VPCOptions": map[string]any{
+					"SubnetIds":        []string{"subnet-updated"},
+					"SecurityGroupIds": []string{"sg-updated"},
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				vpc, ok := dc["VPCOptions"].(map[string]any)
+				require.True(t, ok, "VPCOptions must be in DomainConfig")
+				opts, ok := vpc["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.NotNil(t, opts["SubnetIds"])
+			},
+		},
+		{
+			name: "update_cognito_options",
+			updateBody: map[string]any{
+				"CognitoOptions": map[string]any{
+					"Enabled":        true,
+					"UserPoolId":     "us-east-1_updated",
+					"IdentityPoolId": "us-east-1:updated-id",
+					"RoleArn":        "arn:aws:iam::123456789012:role/UpdatedRole",
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				cog, ok := dc["CognitoOptions"].(map[string]any)
+				require.True(t, ok, "CognitoOptions must be in DomainConfig")
+				opts, ok := cog["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["Enabled"])
+				assert.Equal(t, "us-east-1_updated", opts["UserPoolId"])
+			},
+		},
+		{
+			name: "update_log_publishing_options",
+			updateBody: map[string]any{
+				"LogPublishingOptions": map[string]any{
+					"SEARCH_SLOW_LOGS": map[string]any{
+						"Enabled":                   true,
+						"CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/updated",
+					},
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				logs, ok := dc["LogPublishingOptions"].(map[string]any)
+				require.True(t, ok, "LogPublishingOptions must be in DomainConfig")
+				opts, ok := logs["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Contains(t, opts, "SEARCH_SLOW_LOGS")
+			},
+		},
+		{
+			name: "update_access_policies",
+			updateBody: map[string]any{
+				"AccessPolicies": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"es:*","Resource":"*"}]}`,
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				ap, ok := dc["AccessPolicies"].(map[string]any)
+				require.True(t, ok, "AccessPolicies must be in DomainConfig")
+				assert.NotEmpty(t, ap["Options"])
+			},
+		},
+		{
+			name: "update_cluster_config_with_dedicated_master",
+			updateBody: map[string]any{
+				"ClusterConfig": map[string]any{
+					"InstanceType":           "r6g.large.search",
+					"InstanceCount":          3,
+					"DedicatedMasterEnabled": true,
+					"DedicatedMasterType":    "m6g.large.search",
+					"DedicatedMasterCount":   3,
+				},
+			},
+			verify: func(t *testing.T, status map[string]any) {
+				t.Helper()
+				dc, ok := status["DomainConfig"].(map[string]any)
+				require.True(t, ok)
+				cc, ok := dc["ClusterConfig"].(map[string]any)
+				require.True(t, ok, "ClusterConfig must be in DomainConfig")
+				opts, ok := cc["Options"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, true, opts["DedicatedMasterEnabled"])
+				assert.Equal(t, "m6g.large.search", opts["DedicatedMasterType"])
+				assert.Equal(t, float64(3), opts["DedicatedMasterCount"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			createResp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain",
+				map[string]any{"DomainName": "upd-" + tt.name})
+			createResp.Body.Close()
+			require.Equal(t, http.StatusOK, createResp.StatusCode)
+
+			upResp := doRequest(t, h, http.MethodPut, "/2021-01-01/opensearch/domain/upd-"+tt.name+"/config",
+				tt.updateBody)
+			defer upResp.Body.Close()
+			require.Equal(t, http.StatusOK, upResp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(upResp.Body).Decode(&out))
+			tt.verify(t, out)
+		})
+	}
+}
+
+// TestAudit1_DescribeDomainConfig_FullConfig verifies DescribeDomainConfig returns all new fields.
+func TestAudit1_DescribeDomainConfig_FullConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		createBody   map[string]any
+		wantKeys     []string
+	}{
+		{
+			name: "with_ebs_options",
+			createBody: map[string]any{
+				"DomainName": "cfg-ebs",
+				"EBSOptions": map[string]any{
+					"EBSEnabled": true,
+					"VolumeType": "gp3",
+					"VolumeSize": 100,
+				},
+			},
+			wantKeys: []string{"EngineVersion", "ClusterConfig", "EBSOptions"},
+		},
+		{
+			name: "with_encryption",
+			createBody: map[string]any{
+				"DomainName": "cfg-enc",
+				"EncryptionAtRestOptions": map[string]any{"Enabled": true},
+				"NodeToNodeEncryptionOptions": map[string]any{"Enabled": true},
+			},
+			wantKeys: []string{"EngineVersion", "ClusterConfig", "EncryptionAtRestOptions", "NodeToNodeEncryptionOptions"},
+		},
+		{
+			name: "with_advanced_security",
+			createBody: map[string]any{
+				"DomainName": "cfg-aso",
+				"AdvancedSecurityOptions": map[string]any{
+					"Enabled":                     true,
+					"InternalUserDatabaseEnabled": true,
+				},
+			},
+			wantKeys: []string{"EngineVersion", "ClusterConfig", "AdvancedSecurityOptions"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			createResp := doRequest(t, h, http.MethodPost, "/2021-01-01/opensearch/domain", tt.createBody)
+			createResp.Body.Close()
+			require.Equal(t, http.StatusOK, createResp.StatusCode)
+
+			domainName := tt.createBody["DomainName"].(string)
+			cfgResp := doRequest(t, h, http.MethodGet,
+				"/2021-01-01/opensearch/domain/"+domainName+"/config", nil)
+			defer cfgResp.Body.Close()
+			require.Equal(t, http.StatusOK, cfgResp.StatusCode)
+
+			var out map[string]any
+			require.NoError(t, json.NewDecoder(cfgResp.Body).Decode(&out))
+			dc, ok := out["DomainConfig"].(map[string]any)
+			require.True(t, ok)
+
+			for _, key := range tt.wantKeys {
+				assert.Contains(t, dc, key, "DomainConfig should contain %s", key)
+			}
+		})
+	}
+}

--- a/services/opensearch/handler_test.go
+++ b/services/opensearch/handler_test.go
@@ -673,7 +673,7 @@ func TestOpenSearchBackend_DNSRegistrar(t *testing.T) {
 			b := opensearch.NewInMemoryBackend("123456789012", "us-east-1")
 			b.SetDNSRegistrar(registrar)
 
-			domain, err := b.CreateDomain(tt.domainName, "", opensearch.ClusterConfig{})
+			domain, err := b.CreateDomain(opensearch.CreateDomainInput{Name: tt.domainName})
 			require.NoError(t, err)
 
 			if tt.deleteAfter {
@@ -1536,7 +1536,7 @@ func TestOpenSearchHandler_Persistence_NewOps(t *testing.T) {
 	b := opensearch.NewInMemoryBackend("123456789012", "us-east-1")
 
 	// Set up state with new ops
-	_, err := b.CreateDomain("snap-domain", "OpenSearch_2.11", opensearch.ClusterConfig{})
+	_, err := b.CreateDomain(opensearch.CreateDomainInput{Name: "snap-domain", EngineVersion: "OpenSearch_2.11"})
 	require.NoError(t, err)
 
 	_, err = b.AcceptInboundConnection("conn-abc")
@@ -1637,7 +1637,7 @@ func TestOpenSearchBackend_AddDataSource_MissingName(t *testing.T) {
 
 	b := opensearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreateDomain("my-domain", "", opensearch.ClusterConfig{})
+	_, err := b.CreateDomain(opensearch.CreateDomainInput{Name: "my-domain"})
 	require.NoError(t, err)
 
 	_, err = b.AddDataSource("my-domain", "", "desc", "S3GLUE")

--- a/services/opensearch/interfaces.go
+++ b/services/opensearch/interfaces.go
@@ -4,7 +4,7 @@ package opensearch
 // All mutating methods must be safe for concurrent use.
 type StorageBackend interface {
 	// Domain operations
-	CreateDomain(name, engineVersion string, clusterConfig ClusterConfig) (*Domain, error)
+	CreateDomain(input CreateDomainInput) (*Domain, error)
 	DeleteDomain(name string) (*Domain, error)
 	DescribeDomain(name string) (*Domain, error)
 	DescribeDomains(names []string) ([]*Domain, error)

--- a/services/opensearch/persistence_test.go
+++ b/services/opensearch/persistence_test.go
@@ -23,9 +23,13 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "round_trip_preserves_state",
 			setup: func(b *opensearch.InMemoryBackend) string {
-				domain, err := b.CreateDomain("test-domain", "OpenSearch_2.3", opensearch.ClusterConfig{
-					InstanceType:  "t3.small.search",
-					InstanceCount: 1,
+				domain, err := b.CreateDomain(opensearch.CreateDomainInput{
+					Name:          "test-domain",
+					EngineVersion: "OpenSearch_2.3",
+					ClusterConfig: opensearch.ClusterConfig{
+						InstanceType:  "t3.small.search",
+						InstanceCount: 1,
+					},
 				})
 				if err != nil {
 					return ""
@@ -87,7 +91,7 @@ func TestOpenSearchHandler_Persistence(t *testing.T) {
 	h := opensearch.NewHandler(backend)
 
 	// Create a domain in the backend
-	_, err := backend.CreateDomain("snap-domain", "OpenSearch_2.11", opensearch.ClusterConfig{})
+	_, err := backend.CreateDomain(opensearch.CreateDomainInput{Name: "snap-domain", EngineVersion: "OpenSearch_2.11"})
 	require.NoError(t, err)
 
 	snap := h.Snapshot()

--- a/test/e2e/opensearch_test.go
+++ b/test/e2e/opensearch_test.go
@@ -17,7 +17,10 @@ import (
 func TestOpenSearchDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	_, err := stack.OpenSearchHandler.Backend.CreateDomain("test-domain", "OpenSearch_2.11", opensearchbackend.ClusterConfig{})
+	_, err := stack.OpenSearchHandler.Backend.CreateDomain(opensearchbackend.CreateDomainInput{
+		Name:          "test-domain",
+		EngineVersion: "OpenSearch_2.11",
+	})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(stack.Echo)


### PR DESCRIPTION
## Summary

- Expand `ClusterConfig` with dedicated master, zone awareness, warm/cold storage, and multi-AZ fields
- Add full domain config option types to `Domain` struct: `EBSOptions`, `SnapshotOptions`, `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`, `DomainEndpointOptions`, `AdvancedSecurityOptions` (SAML + internal userdb), `VPCOptions`, `CognitoOptions`, `LogPublishingOptions`, `AccessPolicies`
- Change `CreateDomain` to use `CreateDomainInput` struct; `UpdateDomainConfig` handles all new fields
- Update handler JSON types and responses to reflect actual stored values (previously hardcoded `false` stubs)
- Add 997-line table-driven test file covering all new domain config options and update paths

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./services/opensearch/... ./services/cloudformation/...` — clean
- [x] `go test ./services/opensearch/... ./services/cloudformation/...` — all pass (97 opensearch tests)
- [x] All existing tests pass, including cloudformation which also calls `CreateDomain`

Closes #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)