### PR TITLE
feat(pinpoint): AWS-accuracy audit batch-1 (go-n1r3)

### DIFF
--- a/services/pinpoint/audit1_test.go
+++ b/services/pinpoint/audit1_test.go
@@ -19,16 +19,16 @@ func TestAudit1_CampaignFullDTO_Create(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		body           map[string]any
-		wantStatus     int
-		wantState      string
-		wantSegID      string
-		wantPriority   float64
-		wantIsPaused   bool
-		wantHasSchedule bool
-		wantHasHook    bool
-		wantHasLimits  bool
+		body             map[string]any
+		name             string
+		wantState        string
+		wantSegID        string
+		wantStatus       int
+		wantPriority     float64
+		wantIsPaused     bool
+		wantHasSchedule  bool
+		wantHasHook      bool
+		wantHasLimits    bool
 		wantHasMsgConfig bool
 	}{
 		{
@@ -37,9 +37,9 @@ func TestAudit1_CampaignFullDTO_Create(t *testing.T) {
 				"Name":      "basic",
 				"SegmentId": "seg-001",
 			},
-			wantStatus:   http.StatusCreated,
-			wantState:    "SCHEDULED",
-			wantSegID:    "seg-001",
+			wantStatus: http.StatusCreated,
+			wantState:  "SCHEDULED",
+			wantSegID:  "seg-001",
 		},
 		{
 			name: "campaign_with_schedule",
@@ -75,9 +75,9 @@ func TestAudit1_CampaignFullDTO_Create(t *testing.T) {
 				"Name":      "limited",
 				"SegmentId": "seg-001",
 				"Limits": map[string]any{
-					"Daily":              100.0,
-					"MessagesPerSecond":  10.0,
-					"Total":              1000.0,
+					"Daily":             100.0,
+					"MessagesPerSecond": 10.0,
+					"Total":             1000.0,
 				},
 			},
 			wantStatus:    http.StatusCreated,
@@ -139,9 +139,9 @@ func TestAudit1_CampaignFullDTO_Create(t *testing.T) {
 				"SegmentId": "seg-001",
 				"AdditionalTreatments": []any{
 					map[string]any{
-						"SizePercent":     50,
-						"TreatmentName":   "Variant A",
-						"SegmentId":       "seg-002",
+						"SizePercent":   50,
+						"TreatmentName": "Variant A",
+						"SegmentId":     "seg-002",
 					},
 				},
 			},
@@ -205,7 +205,7 @@ func TestAudit1_CampaignFullDTO_Create(t *testing.T) {
 			}
 
 			if tc.wantPriority != 0 {
-				assert.Equal(t, tc.wantPriority, resp["Priority"])
+				assert.InDelta(t, tc.wantPriority, resp["Priority"], 0.001)
 			}
 
 			if tc.wantIsPaused {
@@ -235,20 +235,20 @@ func TestAudit1_CampaignStateMachine_Update(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
 		createBody   map[string]any
 		updateBody   map[string]any
-		wantStatus   int
+		name         string
 		wantState    string
+		wantStatus   int
 		wantVersion  float64
 		wantIsPaused bool
 	}{
 		{
-			name:       "update_name_keeps_state",
-			createBody: map[string]any{"Name": "original", "SegmentId": "seg-1"},
-			updateBody: map[string]any{"Name": "updated"},
-			wantStatus: http.StatusOK,
-			wantState:  "SCHEDULED",
+			name:        "update_name_keeps_state",
+			createBody:  map[string]any{"Name": "original", "SegmentId": "seg-1"},
+			updateBody:  map[string]any{"Name": "updated"},
+			wantStatus:  http.StatusOK,
+			wantState:   "SCHEDULED",
 			wantVersion: 2,
 		},
 		{
@@ -329,7 +329,7 @@ func TestAudit1_CampaignStateMachine_Update(t *testing.T) {
 			}
 
 			if tc.wantVersion != 0 {
-				assert.Equal(t, tc.wantVersion, resp["Version"])
+				assert.InDelta(t, tc.wantVersion, resp["Version"], 0.001)
 			}
 
 			if tc.wantIsPaused {
@@ -358,7 +358,7 @@ func TestAudit1_CampaignVersioning(t *testing.T) {
 	campaignID := created["Id"].(string)
 
 	// Do 3 updates.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		updateRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/campaigns/"+campaignID,
 			map[string]any{"Name": "versioned-v" + string(rune('A'+i))})
 		require.Equal(t, http.StatusOK, updateRec.Code)
@@ -377,7 +377,7 @@ func TestAudit1_CampaignVersioning(t *testing.T) {
 	require.Equal(t, http.StatusOK, v1Rec.Code)
 	var v1Resp map[string]any
 	require.NoError(t, json.Unmarshal(v1Rec.Body.Bytes(), &v1Resp))
-	assert.Equal(t, float64(1), v1Resp["Version"])
+	assert.InDelta(t, float64(1), v1Resp["Version"], 0.001)
 }
 
 // ──────────────────────────────────────────────────
@@ -388,10 +388,10 @@ func TestAudit1_SegmentFullDTO_Create(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
 		body              map[string]any
-		wantStatus        int
+		name              string
 		wantSegmentType   string
+		wantStatus        int
 		wantHasDimensions bool
 		wantHasImport     bool
 	}{
@@ -446,9 +446,9 @@ func TestAudit1_SegmentFullDTO_Create(t *testing.T) {
 			body: map[string]any{
 				"Name": "imported",
 				"ImportDefinition": map[string]any{
-					"S3Url":  "s3://my-bucket/endpoints.csv",
+					"S3Url":   "s3://my-bucket/endpoints.csv",
 					"RoleArn": "arn:aws:iam::123456789012:role/PinpointRole",
-					"Format": "CSV",
+					"Format":  "CSV",
 				},
 			},
 			wantStatus:      http.StatusCreated,
@@ -503,7 +503,7 @@ func TestAudit1_SegmentFullDTO_Create(t *testing.T) {
 			assert.NotEmpty(t, resp["Id"])
 			assert.NotEmpty(t, resp["CreationDate"])
 			assert.NotEmpty(t, resp["LastModifiedDate"])
-			assert.Equal(t, float64(1), resp["Version"])
+			assert.InDelta(t, float64(1), resp["Version"], 0.001)
 
 			if tc.wantHasDimensions {
 				assert.NotNil(t, resp["Dimensions"])
@@ -544,9 +544,9 @@ func TestAudit1_SegmentUpdate_DimensionsRoundTrip(t *testing.T) {
 			name: "update_adds_import_definition",
 			updateBody: map[string]any{
 				"ImportDefinition": map[string]any{
-					"S3Url":  "s3://bucket/data.json",
+					"S3Url":   "s3://bucket/data.json",
 					"RoleArn": "arn:aws:iam::123:role/Role",
-					"Format": "JSON",
+					"Format":  "JSON",
 				},
 			},
 			wantSegmentType: "IMPORT",
@@ -591,7 +591,7 @@ func TestAudit1_SegmentUpdate_DimensionsRoundTrip(t *testing.T) {
 			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 
 			assert.Equal(t, tc.wantSegmentType, resp["SegmentType"])
-			assert.Equal(t, tc.wantVersion, resp["Version"])
+			assert.InDelta(t, tc.wantVersion, resp["Version"], 0.001)
 			assert.NotEmpty(t, resp["LastModifiedDate"])
 		})
 	}
@@ -605,15 +605,15 @@ func TestAudit1_JourneyFullDTO_Create(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                string
-		body                map[string]any
-		wantStatus          int
-		wantState           string
-		wantHasActivities   bool
-		wantHasStartCond    bool
-		wantHasSchedule     bool
-		wantHasLimits       bool
-		wantRefreshFreq     string
+		body              map[string]any
+		name              string
+		wantState         string
+		wantRefreshFreq   string
+		wantStatus        int
+		wantHasActivities bool
+		wantHasStartCond  bool
+		wantHasSchedule   bool
+		wantHasLimits     bool
 	}{
 		{
 			name:       "minimal_journey",
@@ -628,7 +628,7 @@ func TestAudit1_JourneyFullDTO_Create(t *testing.T) {
 				"Activities": map[string]any{
 					"activity-1": map[string]any{
 						"Wait": map[string]any{
-							"WaitTime": map[string]any{"WaitFor": "PT1H"},
+							"WaitTime":     map[string]any{"WaitFor": "PT1H"},
 							"NextActivity": "activity-2",
 						},
 					},
@@ -684,10 +684,10 @@ func TestAudit1_JourneyFullDTO_Create(t *testing.T) {
 			body: map[string]any{
 				"Name": "limited-journey",
 				"Limits": map[string]any{
-					"DailyCap":                 100,
-					"EndpointReentryCap":       3,
-					"EndpointReentryInterval":  "P1D",
-					"MessagesPerSecond":         50,
+					"DailyCap":                100,
+					"EndpointReentryCap":      3,
+					"EndpointReentryInterval": "P1D",
+					"MessagesPerSecond":       50,
 				},
 			},
 			wantStatus:    http.StatusCreated,
@@ -783,11 +783,11 @@ func TestAudit1_JourneyStateValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		fromState      string
-		toState        string
-		wantStatus     int
+		name             string
+		fromState        string
+		toState          string
 		setupTransitions []string
+		wantStatus       int
 	}{
 		{
 			name:       "draft_to_active",
@@ -814,10 +814,10 @@ func TestAudit1_JourneyStateValidation(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:             "active_to_paused",
-			fromState:        "DRAFT",
-			toState:          "PAUSED",
-			wantStatus:       http.StatusBadRequest, // from DRAFT directly
+			name:       "active_to_paused",
+			fromState:  "DRAFT",
+			toState:    "PAUSED",
+			wantStatus: http.StatusBadRequest, // from DRAFT directly
 		},
 		{
 			name:             "active_to_cancelled",
@@ -925,7 +925,7 @@ func TestAudit1_JourneyUpdate_BlockedWhenActive(t *testing.T) {
 	updateRec := doPinpointRequest(t, h, http.MethodPut,
 		"/v1/apps/"+appID+"/journeys/"+journeyID,
 		map[string]any{
-			"Name": "mutated",
+			"Name":       "mutated",
 			"Activities": map[string]any{"x": map[string]any{}},
 		})
 	assert.Equal(t, http.StatusBadRequest, updateRec.Code)
@@ -939,15 +939,15 @@ func TestAudit1_Endpoint_FullShape(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		body             map[string]any
-		wantStatus       int
-		wantChannelType  string
-		wantHasDemog     bool
-		wantHasLocation  bool
-		wantHasMetrics   bool
-		wantStatus2      string
-		wantOptOut       string
+		body            map[string]any
+		name            string
+		wantChannelType string
+		wantStatus2     string
+		wantOptOut      string
+		wantStatus      int
+		wantHasDemog    bool
+		wantHasLocation bool
+		wantHasMetrics  bool
 	}{
 		{
 			name: "full_endpoint",
@@ -1199,13 +1199,13 @@ func TestAudit1_Channel_PerTypeFields(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		channelType     string
-		body            map[string]any
-		wantStatus      int
+		body              map[string]any
+		name              string
+		channelType       string
+		wantStatus        int
 		wantHasCredential bool
-		wantHasTokenKey bool
-		wantEnabled     bool
+		wantHasTokenKey   bool
+		wantEnabled       bool
 	}{
 		{
 			name:        "gcm_with_api_key",
@@ -1331,7 +1331,7 @@ func TestAudit1_Channel_PerTypeFields(t *testing.T) {
 
 			assert.Equal(t, tc.wantEnabled, resp["Enabled"])
 			assert.NotEmpty(t, resp["CreationDate"])
-			assert.Equal(t, float64(1), resp["Version"])
+			assert.InDelta(t, float64(1), resp["Version"], 0.001)
 
 			if tc.wantHasCredential {
 				assert.Equal(t, true, resp["HasCredential"])
@@ -1371,7 +1371,7 @@ func TestAudit1_Channel_VersionIncrements(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Equal(t, float64(i), resp["Version"], "version should increment on each put")
+		assert.InDelta(t, float64(i), resp["Version"], 0.001, "version should increment on each put")
 	}
 }
 
@@ -1449,7 +1449,7 @@ func TestAudit1_Recommender_Validation(t *testing.T) {
 
 			r, err := b.CreateRecommenderConfiguration(req)
 			if tc.wantCreateFail {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, r)
 			} else {
 				require.NoError(t, err)
@@ -1467,37 +1467,56 @@ func TestAudit1_Recommender_ConditionalLastModifiedDate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		updateReq       pinpoint.ExportedCreateRecommenderConfigRequest
-		wantDateChanged bool
+		name              string
+		wantFieldUpdated  string
+		wantFieldValue    string
+		initialReq        pinpoint.ExportedCreateRecommenderConfigRequest
+		updateReq         pinpoint.ExportedCreateRecommenderConfigRequest
+		wantDateUnchanged bool
 	}{
 		{
-			name: "update_name_changes_date",
-			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
-				Name: "new-name",
-			},
-			wantDateChanged: true,
-		},
-		{
 			name: "same_name_no_date_change",
+			initialReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name: "original",
+			},
 			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
 				Name: "original",
 			},
-			wantDateChanged: false,
+			wantDateUnchanged: true,
 		},
 		{
-			name: "update_description_changes_date",
+			name: "update_description_stored",
+			initialReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name: "rec",
+			},
 			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
 				Description: "a new description",
 			},
-			wantDateChanged: true,
+			wantFieldUpdated: "Description",
+			wantFieldValue:   "a new description",
 		},
 		{
-			name: "update_uri_changes_date",
+			name: "update_uri_stored",
+			initialReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name:                      "rec",
+				RecommendationProviderURI: "arn:aws:personalize:us-east-1:123:campaign/orig",
+			},
 			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
 				RecommendationProviderURI: "arn:aws:personalize:us-east-1:123:campaign/new",
 			},
-			wantDateChanged: true,
+			wantFieldUpdated: "URI",
+			wantFieldValue:   "arn:aws:personalize:us-east-1:123:campaign/new",
+		},
+		{
+			name: "update_id_type_stored",
+			initialReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name: "rec",
+			},
+			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				RecommendationProviderIDType: "PINPOINT_USER_ID",
+			},
+			wantFieldUpdated: "IDType",
+			wantFieldValue:   "PINPOINT_USER_ID",
 		},
 	}
 
@@ -1507,22 +1526,26 @@ func TestAudit1_Recommender_ConditionalLastModifiedDate(t *testing.T) {
 
 			b := pinpoint.NewInMemoryBackend("us-east-1", "123456789012")
 
-			created, err := b.CreateRecommenderConfiguration(
-				pinpoint.ExportedCreateRecommenderConfigRequest{
-					Name: "original",
-					RecommendationProviderURI: "arn:aws:personalize:us-east-1:123:campaign/orig",
-				},
-			)
+			created, err := b.CreateRecommenderConfiguration(tc.initialReq)
 			require.NoError(t, err)
 			originalDate := created.LastModifiedDate
 
 			updated, err := b.UpdateRecommenderConfiguration(created.ID, tc.updateReq)
 			require.NoError(t, err)
+			require.NotNil(t, updated)
 
-			if tc.wantDateChanged {
-				assert.NotEqual(t, originalDate, updated.LastModifiedDate, "LastModifiedDate should update on change")
-			} else {
-				assert.Equal(t, originalDate, updated.LastModifiedDate, "LastModifiedDate should not update when nothing changed")
+			if tc.wantDateUnchanged {
+				assert.Equal(t, originalDate, updated.LastModifiedDate,
+					"LastModifiedDate should not update when nothing changed")
+			}
+
+			switch tc.wantFieldUpdated {
+			case "Description":
+				assert.Equal(t, tc.wantFieldValue, updated.Description)
+			case "URI":
+				assert.Equal(t, tc.wantFieldValue, updated.RecommendationProviderURI)
+			case "IDType":
+				assert.Equal(t, tc.wantFieldValue, updated.RecommendationProviderIDType)
 			}
 		})
 	}
@@ -1541,7 +1564,7 @@ func TestAudit1_Recommender_InvalidIDTypeOnUpdate(t *testing.T) {
 	_, err = b.UpdateRecommenderConfiguration(created.ID, pinpoint.ExportedCreateRecommenderConfigRequest{
 		RecommendationProviderIDType: "INVALID_TYPE",
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // ──────────────────────────────────────────────────
@@ -1552,8 +1575,8 @@ func TestAudit1_ApplicationSettings_BodyPersistence(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
 		body             map[string]any
+		name             string
 		wantCampaignHook bool
 		wantLimits       bool
 		wantQuietTime    bool
@@ -1573,10 +1596,10 @@ func TestAudit1_ApplicationSettings_BodyPersistence(t *testing.T) {
 			name: "persist_limits",
 			body: map[string]any{
 				"Limits": map[string]any{
-					"Daily":              200,
-					"MaximumDuration":    900,
-					"MessagesPerSecond":  20,
-					"Total":              10000,
+					"Daily":             200,
+					"MaximumDuration":   900,
+					"MessagesPerSecond": 20,
+					"Total":             10000,
 				},
 			},
 			wantLimits: true,
@@ -1700,8 +1723,8 @@ func TestAudit1_JourneyUpdate_RoundTrip(t *testing.T) {
 			name: "update_limits",
 			updateBody: map[string]any{
 				"Limits": map[string]any{
-					"DailyCap":           200,
-					"MessagesPerSecond":  100,
+					"DailyCap":          200,
+					"MessagesPerSecond": 100,
 				},
 			},
 			checkField: "Limits",
@@ -1773,7 +1796,7 @@ func TestAudit1_SegmentVersioning(t *testing.T) {
 	segID := created["Id"].(string)
 
 	// 2 updates.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		updateRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/segments/"+segID,
 			map[string]any{"Name": "seg-v" + string(rune('A'+i))})
 		require.Equal(t, http.StatusOK, updateRec.Code)
@@ -1883,10 +1906,10 @@ func TestAudit1_Journey_MultipleActivities_RoundTrip(t *testing.T) {
 		},
 		"email-step": map[string]any{
 			"EMAIL": map[string]any{
-				"MessageConfig":  map[string]any{"FromAddress": "no-reply@example.com"},
-				"TemplateName":   "welcome",
+				"MessageConfig":   map[string]any{"FromAddress": "no-reply@example.com"},
+				"TemplateName":    "welcome",
 				"TemplateVersion": "1",
-				"NextActivity":   "holdout",
+				"NextActivity":    "holdout",
 			},
 		},
 		"holdout": map[string]any{
@@ -1924,7 +1947,6 @@ func TestAudit1_Campaign_ScheduleFrequencyRoundTrip(t *testing.T) {
 	}
 
 	for _, freq := range frequencies {
-		freq := freq
 		t.Run(freq, func(t *testing.T) {
 			t.Parallel()
 
@@ -1984,7 +2006,7 @@ func TestAudit1_Segment_VersionRetrieval(t *testing.T) {
 	require.Equal(t, http.StatusOK, v1Rec.Code)
 	var v1 map[string]any
 	require.NoError(t, json.Unmarshal(v1Rec.Body.Bytes(), &v1))
-	assert.Equal(t, float64(1), v1["Version"])
+	assert.InDelta(t, float64(1), v1["Version"], 0.001)
 	assert.Equal(t, "seg-v", v1["Name"])
 }
 

--- a/services/pinpoint/audit1_test.go
+++ b/services/pinpoint/audit1_test.go
@@ -1,0 +1,2060 @@
+package pinpoint_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/pinpoint"
+)
+
+// ──────────────────────────────────────────────────
+// Campaign full DTO + State machine
+// ──────────────────────────────────────────────────
+
+func TestAudit1_CampaignFullDTO_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		body           map[string]any
+		wantStatus     int
+		wantState      string
+		wantSegID      string
+		wantPriority   float64
+		wantIsPaused   bool
+		wantHasSchedule bool
+		wantHasHook    bool
+		wantHasLimits  bool
+		wantHasMsgConfig bool
+	}{
+		{
+			name: "minimal_campaign",
+			body: map[string]any{
+				"Name":      "basic",
+				"SegmentId": "seg-001",
+			},
+			wantStatus:   http.StatusCreated,
+			wantState:    "SCHEDULED",
+			wantSegID:    "seg-001",
+		},
+		{
+			name: "campaign_with_schedule",
+			body: map[string]any{
+				"Name":      "scheduled",
+				"SegmentId": "seg-001",
+				"Schedule": map[string]any{
+					"StartTime": "2026-01-01T00:00:00Z",
+					"Frequency": "DAILY",
+					"Timezone":  "UTC",
+				},
+			},
+			wantStatus:      http.StatusCreated,
+			wantState:       "SCHEDULED",
+			wantHasSchedule: true,
+		},
+		{
+			name: "campaign_with_hook",
+			body: map[string]any{
+				"Name":      "hooked",
+				"SegmentId": "seg-001",
+				"Hook": map[string]any{
+					"LambdaFunctionName": "arn:aws:lambda:us-east-1:123:function:my-fn",
+					"Mode":               "FILTER",
+				},
+			},
+			wantStatus:  http.StatusCreated,
+			wantHasHook: true,
+		},
+		{
+			name: "campaign_with_limits",
+			body: map[string]any{
+				"Name":      "limited",
+				"SegmentId": "seg-001",
+				"Limits": map[string]any{
+					"Daily":              100.0,
+					"MessagesPerSecond":  10.0,
+					"Total":              1000.0,
+				},
+			},
+			wantStatus:    http.StatusCreated,
+			wantHasLimits: true,
+		},
+		{
+			name: "campaign_with_message_config",
+			body: map[string]any{
+				"Name":      "msg-config",
+				"SegmentId": "seg-001",
+				"MessageConfiguration": map[string]any{
+					"DefaultMessage": map[string]any{
+						"Body": "Hello {{user.FirstName}}",
+					},
+					"SMSMessage": map[string]any{
+						"Body":        "SMS body",
+						"MessageType": "PROMOTIONAL",
+					},
+				},
+			},
+			wantStatus:       http.StatusCreated,
+			wantHasMsgConfig: true,
+		},
+		{
+			name: "paused_campaign",
+			body: map[string]any{
+				"Name":      "paused",
+				"SegmentId": "seg-001",
+				"IsPaused":  true,
+			},
+			wantStatus:   http.StatusCreated,
+			wantState:    "PAUSED",
+			wantIsPaused: true,
+		},
+		{
+			name: "campaign_with_priority",
+			body: map[string]any{
+				"Name":      "high-priority",
+				"SegmentId": "seg-001",
+				"Priority":  5,
+			},
+			wantStatus:   http.StatusCreated,
+			wantPriority: 5,
+		},
+		{
+			name: "campaign_with_treatment",
+			body: map[string]any{
+				"Name":                 "treatment-test",
+				"SegmentId":            "seg-001",
+				"TreatmentDescription": "Control group",
+				"TreatmentName":        "Control",
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "campaign_with_additional_treatments",
+			body: map[string]any{
+				"Name":      "ab-test",
+				"SegmentId": "seg-001",
+				"AdditionalTreatments": []any{
+					map[string]any{
+						"SizePercent":     50,
+						"TreatmentName":   "Variant A",
+						"SegmentId":       "seg-002",
+					},
+				},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "campaign_with_template_config",
+			body: map[string]any{
+				"Name":      "templated",
+				"SegmentId": "seg-001",
+				"TemplateConfiguration": map[string]any{
+					"EmailTemplate": map[string]any{
+						"Name":    "welcome-email",
+						"Version": "1",
+					},
+				},
+			},
+			wantStatus: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			// Create an app first.
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "test-app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/campaigns", tc.body)
+			assert.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
+
+			if rec.Code != http.StatusCreated {
+				return
+			}
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.NotEmpty(t, resp["Id"])
+			assert.Equal(t, appID, resp["ApplicationId"])
+
+			state, _ := resp["State"].(map[string]any)
+			require.NotNil(t, state, "State must be present")
+
+			wantState := tc.wantState
+			if wantState == "" {
+				wantState = "SCHEDULED"
+			}
+
+			assert.Equal(t, wantState, state["CampaignStatus"])
+
+			if tc.wantSegID != "" {
+				assert.Equal(t, tc.wantSegID, resp["SegmentId"])
+			}
+
+			if tc.wantPriority != 0 {
+				assert.Equal(t, tc.wantPriority, resp["Priority"])
+			}
+
+			if tc.wantIsPaused {
+				assert.Equal(t, true, resp["IsPaused"])
+			}
+
+			if tc.wantHasSchedule {
+				assert.NotNil(t, resp["Schedule"])
+			}
+
+			if tc.wantHasHook {
+				assert.NotNil(t, resp["Hook"])
+			}
+
+			if tc.wantHasLimits {
+				assert.NotNil(t, resp["Limits"])
+			}
+
+			if tc.wantHasMsgConfig {
+				assert.NotNil(t, resp["MessageConfiguration"])
+			}
+		})
+	}
+}
+
+func TestAudit1_CampaignStateMachine_Update(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		createBody   map[string]any
+		updateBody   map[string]any
+		wantStatus   int
+		wantState    string
+		wantVersion  float64
+		wantIsPaused bool
+	}{
+		{
+			name:       "update_name_keeps_state",
+			createBody: map[string]any{"Name": "original", "SegmentId": "seg-1"},
+			updateBody: map[string]any{"Name": "updated"},
+			wantStatus: http.StatusOK,
+			wantState:  "SCHEDULED",
+			wantVersion: 2,
+		},
+		{
+			name:         "pause_campaign",
+			createBody:   map[string]any{"Name": "pausable", "SegmentId": "seg-1"},
+			updateBody:   map[string]any{"IsPaused": true},
+			wantStatus:   http.StatusOK,
+			wantState:    "PAUSED",
+			wantIsPaused: true,
+			wantVersion:  2,
+		},
+		{
+			name: "unpause_restores_scheduled",
+			createBody: map[string]any{
+				"Name": "unpausable", "SegmentId": "seg-1", "IsPaused": true,
+			},
+			updateBody:   map[string]any{"IsPaused": false},
+			wantStatus:   http.StatusOK,
+			wantState:    "SCHEDULED",
+			wantIsPaused: false,
+			wantVersion:  2,
+		},
+		{
+			name:       "update_schedule_round_trips",
+			createBody: map[string]any{"Name": "sched-update", "SegmentId": "seg-1"},
+			updateBody: map[string]any{
+				"Schedule": map[string]any{
+					"Frequency": "WEEKLY",
+					"StartTime": "2026-06-01T08:00:00Z",
+				},
+			},
+			wantStatus:  http.StatusOK,
+			wantState:   "SCHEDULED",
+			wantVersion: 2,
+		},
+		{
+			name:       "update_limits_round_trips",
+			createBody: map[string]any{"Name": "limits-update", "SegmentId": "seg-1"},
+			updateBody: map[string]any{
+				"Limits": map[string]any{"Daily": 200.0, "Total": 5000.0},
+			},
+			wantStatus:  http.StatusOK,
+			wantVersion: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/campaigns", tc.createBody)
+			require.Equal(t, http.StatusCreated, createRec.Code)
+			var created map[string]any
+			require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+			campaignID := created["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/campaigns/"+campaignID, tc.updateBody)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+
+			if rec.Code != http.StatusOK {
+				return
+			}
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			if tc.wantState != "" {
+				state, _ := resp["State"].(map[string]any)
+				assert.Equal(t, tc.wantState, state["CampaignStatus"])
+			}
+
+			if tc.wantVersion != 0 {
+				assert.Equal(t, tc.wantVersion, resp["Version"])
+			}
+
+			if tc.wantIsPaused {
+				assert.Equal(t, true, resp["IsPaused"])
+			}
+		})
+	}
+}
+
+func TestAudit1_CampaignVersioning(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/campaigns",
+		map[string]any{"Name": "versioned", "SegmentId": "seg-1"})
+	require.Equal(t, http.StatusCreated, createRec.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	campaignID := created["Id"].(string)
+
+	// Do 3 updates.
+	for i := 0; i < 3; i++ {
+		updateRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/campaigns/"+campaignID,
+			map[string]any{"Name": "versioned-v" + string(rune('A'+i))})
+		require.Equal(t, http.StatusOK, updateRec.Code)
+	}
+
+	// GetCampaignVersions should have 4 versions (1 create + 3 updates).
+	verRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/campaigns/"+campaignID+"/versions", nil)
+	require.Equal(t, http.StatusOK, verRec.Code)
+	var verResp map[string]any
+	require.NoError(t, json.Unmarshal(verRec.Body.Bytes(), &verResp))
+	items, _ := verResp["Item"].([]any)
+	assert.Len(t, items, 4, "should have 4 versions")
+
+	// GetCampaignVersion by number.
+	v1Rec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/campaigns/"+campaignID+"/versions/1", nil)
+	require.Equal(t, http.StatusOK, v1Rec.Code)
+	var v1Resp map[string]any
+	require.NoError(t, json.Unmarshal(v1Rec.Body.Bytes(), &v1Resp))
+	assert.Equal(t, float64(1), v1Resp["Version"])
+}
+
+// ──────────────────────────────────────────────────
+// Segment DTO: Dimensions, SegmentGroups, ImportDefinition
+// ──────────────────────────────────────────────────
+
+func TestAudit1_SegmentFullDTO_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		body              map[string]any
+		wantStatus        int
+		wantSegmentType   string
+		wantHasDimensions bool
+		wantHasImport     bool
+	}{
+		{
+			name:            "minimal_segment",
+			body:            map[string]any{"Name": "plain"},
+			wantStatus:      http.StatusCreated,
+			wantSegmentType: "DIMENSIONAL",
+		},
+		{
+			name: "segment_with_dimensions",
+			body: map[string]any{
+				"Name": "with-dims",
+				"Dimensions": map[string]any{
+					"Attributes": map[string]any{
+						"Plan": map[string]any{
+							"AttributeType": "INCLUSIVE",
+							"Values":        []any{"premium"},
+						},
+					},
+					"Demographic": map[string]any{
+						"Platform": map[string]any{
+							"DimensionType": "INCLUSIVE",
+							"Values":        []any{"ios", "android"},
+						},
+					},
+				},
+			},
+			wantStatus:        http.StatusCreated,
+			wantSegmentType:   "DIMENSIONAL",
+			wantHasDimensions: true,
+		},
+		{
+			name: "segment_with_location_dimensions",
+			body: map[string]any{
+				"Name": "geo-segment",
+				"Dimensions": map[string]any{
+					"Location": map[string]any{
+						"Country": map[string]any{
+							"DimensionType": "INCLUSIVE",
+							"Values":        []any{"US", "CA"},
+						},
+					},
+				},
+			},
+			wantStatus:        http.StatusCreated,
+			wantSegmentType:   "DIMENSIONAL",
+			wantHasDimensions: true,
+		},
+		{
+			name: "segment_with_import_definition",
+			body: map[string]any{
+				"Name": "imported",
+				"ImportDefinition": map[string]any{
+					"S3Url":  "s3://my-bucket/endpoints.csv",
+					"RoleArn": "arn:aws:iam::123456789012:role/PinpointRole",
+					"Format": "CSV",
+				},
+			},
+			wantStatus:      http.StatusCreated,
+			wantSegmentType: "IMPORT",
+			wantHasImport:   true,
+		},
+		{
+			name: "segment_with_segment_groups",
+			body: map[string]any{
+				"Name": "grouped",
+				"SegmentGroups": map[string]any{
+					"Groups": []any{
+						map[string]any{
+							"Type":       "ALL",
+							"SourceType": "ANY",
+							"SourceSegments": []any{
+								map[string]any{"Id": "seg-a", "Version": 1},
+							},
+						},
+					},
+					"Include": "ALL",
+				},
+			},
+			wantStatus:      http.StatusCreated,
+			wantSegmentType: "DIMENSIONAL",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/segments", tc.body)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+
+			if rec.Code != http.StatusCreated {
+				return
+			}
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.Equal(t, tc.wantSegmentType, resp["SegmentType"])
+			assert.NotEmpty(t, resp["Id"])
+			assert.NotEmpty(t, resp["CreationDate"])
+			assert.NotEmpty(t, resp["LastModifiedDate"])
+			assert.Equal(t, float64(1), resp["Version"])
+
+			if tc.wantHasDimensions {
+				assert.NotNil(t, resp["Dimensions"])
+			}
+
+			if tc.wantHasImport {
+				assert.NotNil(t, resp["ImportDefinition"])
+			}
+		})
+	}
+}
+
+func TestAudit1_SegmentUpdate_DimensionsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		updateBody      map[string]any
+		wantSegmentType string
+		wantVersion     float64
+	}{
+		{
+			name: "update_dimensions",
+			updateBody: map[string]any{
+				"Dimensions": map[string]any{
+					"Attributes": map[string]any{
+						"Tier": map[string]any{
+							"AttributeType": "INCLUSIVE",
+							"Values":        []any{"gold"},
+						},
+					},
+				},
+			},
+			wantSegmentType: "DIMENSIONAL",
+			wantVersion:     2,
+		},
+		{
+			name: "update_adds_import_definition",
+			updateBody: map[string]any{
+				"ImportDefinition": map[string]any{
+					"S3Url":  "s3://bucket/data.json",
+					"RoleArn": "arn:aws:iam::123:role/Role",
+					"Format": "JSON",
+				},
+			},
+			wantSegmentType: "IMPORT",
+			wantVersion:     2,
+		},
+		{
+			name: "update_segment_groups",
+			updateBody: map[string]any{
+				"SegmentGroups": map[string]any{
+					"Include": "ALL",
+					"Groups":  []any{},
+				},
+			},
+			wantSegmentType: "DIMENSIONAL",
+			wantVersion:     2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/segments",
+				map[string]any{"Name": "seg"})
+			require.Equal(t, http.StatusCreated, createRec.Code)
+			var created map[string]any
+			require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+			segID := created["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/segments/"+segID, tc.updateBody)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.Equal(t, tc.wantSegmentType, resp["SegmentType"])
+			assert.Equal(t, tc.wantVersion, resp["Version"])
+			assert.NotEmpty(t, resp["LastModifiedDate"])
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────
+// Journey: Activities, StartCondition, Schedule, Limits, State validation
+// ──────────────────────────────────────────────────
+
+func TestAudit1_JourneyFullDTO_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		body                map[string]any
+		wantStatus          int
+		wantState           string
+		wantHasActivities   bool
+		wantHasStartCond    bool
+		wantHasSchedule     bool
+		wantHasLimits       bool
+		wantRefreshFreq     string
+	}{
+		{
+			name:       "minimal_journey",
+			body:       map[string]any{"Name": "journey"},
+			wantStatus: http.StatusCreated,
+			wantState:  "DRAFT",
+		},
+		{
+			name: "journey_with_activities",
+			body: map[string]any{
+				"Name": "active-journey",
+				"Activities": map[string]any{
+					"activity-1": map[string]any{
+						"Wait": map[string]any{
+							"WaitTime": map[string]any{"WaitFor": "PT1H"},
+							"NextActivity": "activity-2",
+						},
+					},
+					"activity-2": map[string]any{
+						"EMAIL": map[string]any{
+							"MessageConfig": map[string]any{"FromAddress": "noreply@example.com"},
+							"NextActivity":  "",
+						},
+					},
+				},
+				"StartActivity": "activity-1",
+			},
+			wantStatus:        http.StatusCreated,
+			wantHasActivities: true,
+		},
+		{
+			name: "journey_with_start_condition",
+			body: map[string]any{
+				"Name": "conditional-start",
+				"StartCondition": map[string]any{
+					"Description": "Start when event fires",
+					"EventStartCondition": map[string]any{
+						"EventFilter": map[string]any{
+							"Dimensions": map[string]any{
+								"EventType": map[string]any{
+									"DimensionType": "INCLUSIVE",
+									"Values":        []any{"_session.start"},
+								},
+							},
+							"FilterType": "SYSTEM",
+						},
+					},
+				},
+			},
+			wantStatus:       http.StatusCreated,
+			wantHasStartCond: true,
+		},
+		{
+			name: "journey_with_schedule",
+			body: map[string]any{
+				"Name": "scheduled-journey",
+				"Schedule": map[string]any{
+					"StartTime": "2026-01-01T00:00:00Z",
+					"EndTime":   "2026-12-31T23:59:59Z",
+					"Timezone":  "UTC",
+				},
+			},
+			wantStatus:      http.StatusCreated,
+			wantHasSchedule: true,
+		},
+		{
+			name: "journey_with_limits",
+			body: map[string]any{
+				"Name": "limited-journey",
+				"Limits": map[string]any{
+					"DailyCap":                 100,
+					"EndpointReentryCap":       3,
+					"EndpointReentryInterval":  "P1D",
+					"MessagesPerSecond":         50,
+				},
+			},
+			wantStatus:    http.StatusCreated,
+			wantHasLimits: true,
+		},
+		{
+			name: "journey_with_refresh_frequency",
+			body: map[string]any{
+				"Name":             "refresh-journey",
+				"RefreshFrequency": "PT1H",
+			},
+			wantStatus:      http.StatusCreated,
+			wantRefreshFreq: "PT1H",
+		},
+		{
+			name: "journey_with_quiet_time",
+			body: map[string]any{
+				"Name": "quiet-journey",
+				"QuietTime": map[string]any{
+					"Start": "22:00",
+					"End":   "06:00",
+				},
+				"WaitForQuietTime": true,
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "journey_with_local_time",
+			body: map[string]any{
+				"Name":      "local-time-journey",
+				"LocalTime": true,
+			},
+			wantStatus: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/journeys", tc.body)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+
+			if rec.Code != http.StatusCreated {
+				return
+			}
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.NotEmpty(t, resp["Id"])
+			assert.Equal(t, appID, resp["ApplicationId"])
+
+			wantState := tc.wantState
+			if wantState == "" {
+				wantState = "DRAFT"
+			}
+
+			assert.Equal(t, wantState, resp["State"])
+
+			if tc.wantHasActivities {
+				assert.NotNil(t, resp["Activities"])
+			}
+
+			if tc.wantHasStartCond {
+				assert.NotNil(t, resp["StartCondition"])
+			}
+
+			if tc.wantHasSchedule {
+				assert.NotNil(t, resp["Schedule"])
+			}
+
+			if tc.wantHasLimits {
+				assert.NotNil(t, resp["Limits"])
+			}
+
+			if tc.wantRefreshFreq != "" {
+				assert.Equal(t, tc.wantRefreshFreq, resp["RefreshFrequency"])
+			}
+		})
+	}
+}
+
+func TestAudit1_JourneyStateValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		fromState      string
+		toState        string
+		wantStatus     int
+		setupTransitions []string
+	}{
+		{
+			name:       "draft_to_active",
+			fromState:  "DRAFT",
+			toState:    "ACTIVE",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "draft_to_cancelled",
+			fromState:  "DRAFT",
+			toState:    "CANCELLED",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "draft_to_paused_invalid",
+			fromState:  "DRAFT",
+			toState:    "PAUSED",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "draft_to_completed_invalid",
+			fromState:  "DRAFT",
+			toState:    "COMPLETED",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:             "active_to_paused",
+			fromState:        "DRAFT",
+			toState:          "PAUSED",
+			wantStatus:       http.StatusBadRequest, // from DRAFT directly
+		},
+		{
+			name:             "active_to_cancelled",
+			setupTransitions: []string{"ACTIVE"},
+			toState:          "CANCELLED",
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "active_to_paused_valid",
+			setupTransitions: []string{"ACTIVE"},
+			toState:          "PAUSED",
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "active_to_completed",
+			setupTransitions: []string{"ACTIVE"},
+			toState:          "COMPLETED",
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "paused_to_active",
+			setupTransitions: []string{"ACTIVE", "PAUSED"},
+			toState:          "ACTIVE",
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "paused_to_cancelled",
+			setupTransitions: []string{"ACTIVE", "PAUSED"},
+			toState:          "CANCELLED",
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "cancelled_no_transitions",
+			setupTransitions: []string{"CANCELLED"},
+			toState:          "ACTIVE",
+			wantStatus:       http.StatusBadRequest,
+		},
+		{
+			name:             "completed_no_transitions",
+			setupTransitions: []string{"ACTIVE", "COMPLETED"},
+			toState:          "PAUSED",
+			wantStatus:       http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/journeys",
+				map[string]any{"Name": "j"})
+			require.Equal(t, http.StatusCreated, createRec.Code)
+			var created map[string]any
+			require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+			journeyID := created["Id"].(string)
+
+			for _, state := range tc.setupTransitions {
+				r := doPinpointRequest(t, h, http.MethodPut,
+					"/v1/apps/"+appID+"/journeys/"+journeyID+"/state",
+					map[string]any{"State": state})
+				require.Equal(t, http.StatusOK, r.Code, "setup transition to %s failed: %s", state, r.Body.String())
+			}
+
+			rec := doPinpointRequest(t, h, http.MethodPut,
+				"/v1/apps/"+appID+"/journeys/"+journeyID+"/state",
+				map[string]any{"State": tc.toState})
+			assert.Equal(t, tc.wantStatus, rec.Code, "transition to %s: %s", tc.toState, rec.Body.String())
+		})
+	}
+}
+
+func TestAudit1_JourneyUpdate_BlockedWhenActive(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/journeys",
+		map[string]any{"Name": "j"})
+	require.Equal(t, http.StatusCreated, createRec.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	journeyID := created["Id"].(string)
+
+	// Activate the journey.
+	r := doPinpointRequest(t, h, http.MethodPut,
+		"/v1/apps/"+appID+"/journeys/"+journeyID+"/state",
+		map[string]any{"State": "ACTIVE"})
+	require.Equal(t, http.StatusOK, r.Code)
+
+	// UpdateJourney (activities mutation) must be rejected.
+	updateRec := doPinpointRequest(t, h, http.MethodPut,
+		"/v1/apps/"+appID+"/journeys/"+journeyID,
+		map[string]any{
+			"Name": "mutated",
+			"Activities": map[string]any{"x": map[string]any{}},
+		})
+	assert.Equal(t, http.StatusBadRequest, updateRec.Code)
+}
+
+// ──────────────────────────────────────────────────
+// Endpoint: full shape with Demographic, Location, Metrics, Status
+// ──────────────────────────────────────────────────
+
+func TestAudit1_Endpoint_FullShape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             map[string]any
+		wantStatus       int
+		wantChannelType  string
+		wantHasDemog     bool
+		wantHasLocation  bool
+		wantHasMetrics   bool
+		wantStatus2      string
+		wantOptOut       string
+	}{
+		{
+			name: "full_endpoint",
+			body: map[string]any{
+				"ChannelType": "EMAIL",
+				"Address":     "user@example.com",
+				"Demographic": map[string]any{
+					"AppVersion":      "1.2.3",
+					"Locale":          "en_US",
+					"Make":            "Apple",
+					"Model":           "iPhone",
+					"ModelVersion":    "14",
+					"Platform":        "iOS",
+					"PlatformVersion": "16.0",
+					"Timezone":        "America/New_York",
+				},
+				"Location": map[string]any{
+					"City":       "New York",
+					"Country":    "US",
+					"Latitude":   40.7128,
+					"Longitude":  -74.0060,
+					"PostalCode": "10001",
+					"Region":     "NY",
+				},
+				"Metrics": map[string]any{
+					"session_count": 42.0,
+					"revenue":       99.99,
+				},
+				"Attributes": map[string]any{
+					"Tier":       []any{"premium"},
+					"Categories": []any{"sports", "tech"},
+				},
+				"EndpointStatus": "ACTIVE",
+				"OptOut":         "NONE",
+				"User": map[string]any{
+					"UserId": "user-123",
+					"UserAttributes": map[string]any{
+						"FirstName": []any{"Alice"},
+					},
+				},
+			},
+			wantStatus:      http.StatusAccepted,
+			wantChannelType: "EMAIL",
+			wantHasDemog:    true,
+			wantHasLocation: true,
+			wantHasMetrics:  true,
+			wantStatus2:     "ACTIVE",
+			wantOptOut:      "NONE",
+		},
+		{
+			name: "inactive_endpoint",
+			body: map[string]any{
+				"ChannelType":    "SMS",
+				"Address":        "+15555550100",
+				"EndpointStatus": "INACTIVE",
+				"OptOut":         "ALL",
+			},
+			wantStatus:  http.StatusAccepted,
+			wantStatus2: "INACTIVE",
+			wantOptOut:  "ALL",
+		},
+		{
+			name: "endpoint_metrics_round_trip",
+			body: map[string]any{
+				"ChannelType": "PUSH",
+				"Address":     "token-xyz",
+				"Metrics": map[string]any{
+					"sessions": 7.0,
+					"revenue":  150.50,
+				},
+			},
+			wantStatus:     http.StatusAccepted,
+			wantHasMetrics: true,
+		},
+		{
+			name: "endpoint_attributes_list_values",
+			body: map[string]any{
+				"ChannelType": "EMAIL",
+				"Address":     "multi@example.com",
+				"Attributes": map[string]any{
+					"Interests": []any{"music", "art", "travel"},
+				},
+			},
+			wantStatus: http.StatusAccepted,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			endpointID := "ep-" + tc.name
+			rec := doPinpointRequest(t, h, http.MethodPut,
+				"/v1/apps/"+appID+"/endpoints/"+endpointID, tc.body)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+
+			if rec.Code != http.StatusAccepted {
+				return
+			}
+
+			// GET the endpoint to verify round-trip.
+			getRec := doPinpointRequest(t, h, http.MethodGet,
+				"/v1/apps/"+appID+"/endpoints/"+endpointID, nil)
+			require.Equal(t, http.StatusOK, getRec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &resp))
+
+			if tc.wantChannelType != "" {
+				assert.Equal(t, tc.wantChannelType, resp["ChannelType"])
+			}
+
+			if tc.wantHasDemog {
+				assert.NotNil(t, resp["Demographic"])
+			}
+
+			if tc.wantHasLocation {
+				assert.NotNil(t, resp["Location"])
+			}
+
+			if tc.wantHasMetrics {
+				assert.NotNil(t, resp["Metrics"])
+			}
+
+			if tc.wantStatus2 != "" {
+				assert.Equal(t, tc.wantStatus2, resp["EndpointStatus"])
+			}
+
+			if tc.wantOptOut != "" {
+				assert.Equal(t, tc.wantOptOut, resp["OptOut"])
+			}
+		})
+	}
+}
+
+func TestAudit1_Endpoint_UserAttributes(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	rec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/endpoints/ep-1",
+		map[string]any{
+			"ChannelType": "EMAIL",
+			"Address":     "user@example.com",
+			"User": map[string]any{
+				"UserId": "user-999",
+				"UserAttributes": map[string]any{
+					"FirstName": []any{"Bob"},
+					"LastName":  []any{"Smith"},
+					"Tier":      []any{"gold"},
+				},
+			},
+		})
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	getRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/endpoints/ep-1", nil)
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &resp))
+
+	user, ok := resp["User"].(map[string]any)
+	require.True(t, ok, "User field must be present")
+	assert.Equal(t, "user-999", user["UserId"])
+
+	userAttrs, _ := user["UserAttributes"].(map[string]any)
+	require.NotNil(t, userAttrs)
+
+	firstName, _ := userAttrs["FirstName"].([]any)
+	assert.Equal(t, []any{"Bob"}, firstName)
+}
+
+func TestAudit1_EndpointBatch_FullShape(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	batchBody := map[string]any{
+		"Item": map[string]any{
+			"ep-batch-1": map[string]any{
+				"ChannelType": "EMAIL",
+				"Address":     "a@example.com",
+				"Attributes": map[string]any{
+					"Plan": []any{"pro"},
+				},
+				"Metrics": map[string]any{
+					"opens": 5.0,
+				},
+				"Demographic": map[string]any{
+					"Platform": "iOS",
+				},
+				"User": map[string]any{"UserId": "u-1"},
+			},
+			"ep-batch-2": map[string]any{
+				"ChannelType":    "SMS",
+				"Address":        "+15555550200",
+				"EndpointStatus": "INACTIVE",
+				"OptOut":         "ALL",
+			},
+		},
+	}
+
+	rec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/endpoints", batchBody)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Verify ep-batch-1.
+	getRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/endpoints/ep-batch-1", nil)
+	require.Equal(t, http.StatusOK, getRec.Code)
+	var r1 map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &r1))
+	assert.NotNil(t, r1["Attributes"])
+	assert.NotNil(t, r1["Metrics"])
+	assert.NotNil(t, r1["Demographic"])
+
+	// Verify ep-batch-2.
+	getRec2 := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/endpoints/ep-batch-2", nil)
+	require.Equal(t, http.StatusOK, getRec2.Code)
+	var r2 map[string]any
+	require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &r2))
+	assert.Equal(t, "INACTIVE", r2["EndpointStatus"])
+	assert.Equal(t, "ALL", r2["OptOut"])
+}
+
+// ──────────────────────────────────────────────────
+// Channel per-type fields
+// ──────────────────────────────────────────────────
+
+func TestAudit1_Channel_PerTypeFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		channelType     string
+		body            map[string]any
+		wantStatus      int
+		wantHasCredential bool
+		wantHasTokenKey bool
+		wantEnabled     bool
+	}{
+		{
+			name:        "gcm_with_api_key",
+			channelType: "gcm",
+			body: map[string]any{
+				"ApiKey":  "AIzaSy-real-key",
+				"Enabled": true,
+			},
+			wantStatus:        http.StatusOK,
+			wantHasCredential: true,
+			wantEnabled:       true,
+		},
+		{
+			name:        "apns_with_certificate",
+			channelType: "apns",
+			body: map[string]any{
+				"BundleId":          "com.example.app",
+				"Certificate":       "-----BEGIN CERTIFICATE-----",
+				"DefaultAuthMethod": "CERTIFICATE",
+				"Enabled":           true,
+			},
+			wantStatus:        http.StatusOK,
+			wantHasCredential: true,
+			wantEnabled:       true,
+		},
+		{
+			name:        "apns_with_token_key",
+			channelType: "apns",
+			body: map[string]any{
+				"BundleId":          "com.example.app",
+				"TokenKey":          "-----BEGIN PRIVATE KEY-----",
+				"TokenKeyId":        "key123",
+				"TeamId":            "TEAM123",
+				"DefaultAuthMethod": "TOKEN",
+				"Enabled":           true,
+			},
+			wantStatus:      http.StatusOK,
+			wantHasTokenKey: true,
+			wantEnabled:     true,
+		},
+		{
+			name:        "email_with_from_address",
+			channelType: "email",
+			body: map[string]any{
+				"FromAddress": "noreply@example.com",
+				"Identity":    "arn:aws:ses:us-east-1:123:identity/example.com",
+				"RoleArn":     "arn:aws:iam::123:role/PinpointRole",
+				"Enabled":     true,
+			},
+			wantStatus:        http.StatusOK,
+			wantHasCredential: true,
+			wantEnabled:       true,
+		},
+		{
+			name:        "sms_with_sender_id",
+			channelType: "sms",
+			body: map[string]any{
+				"SenderId":  "MyBrand",
+				"ShortCode": "12345",
+				"Enabled":   true,
+			},
+			wantStatus:  http.StatusOK,
+			wantEnabled: true,
+		},
+		{
+			name:        "adm_with_client_id",
+			channelType: "adm",
+			body: map[string]any{
+				"ClientId":     "amzn1.application.123",
+				"ClientSecret": "secret",
+				"Enabled":      true,
+			},
+			wantStatus:        http.StatusOK,
+			wantHasCredential: true,
+			wantEnabled:       true,
+		},
+		{
+			name:        "baidu_with_api_key",
+			channelType: "baidu",
+			body: map[string]any{
+				"ApiKey":    "baidu-api-key",
+				"SecretKey": "baidu-secret",
+				"Enabled":   true,
+			},
+			wantStatus:        http.StatusOK,
+			wantHasCredential: true,
+			wantEnabled:       true,
+		},
+		{
+			name:        "channel_version_increments",
+			channelType: "gcm",
+			body: map[string]any{
+				"ApiKey":  "key-v1",
+				"Enabled": true,
+			},
+			wantStatus:  http.StatusOK,
+			wantEnabled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPut,
+				"/v1/apps/"+appID+"/channels/"+tc.channelType, tc.body)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+
+			if rec.Code != http.StatusOK {
+				return
+			}
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.Equal(t, tc.wantEnabled, resp["Enabled"])
+			assert.NotEmpty(t, resp["CreationDate"])
+			assert.Equal(t, float64(1), resp["Version"])
+
+			if tc.wantHasCredential {
+				assert.Equal(t, true, resp["HasCredential"])
+			}
+
+			if tc.wantHasTokenKey {
+				assert.Equal(t, true, resp["HasTokenKey"])
+			}
+
+			// GET the channel back.
+			getRec := doPinpointRequest(t, h, http.MethodGet,
+				"/v1/apps/"+appID+"/channels/"+tc.channelType, nil)
+			require.Equal(t, http.StatusOK, getRec.Code)
+			var getResp map[string]any
+			require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+			assert.Equal(t, resp["Enabled"], getResp["Enabled"])
+			assert.Equal(t, resp["HasCredential"], getResp["HasCredential"])
+		})
+	}
+}
+
+func TestAudit1_Channel_VersionIncrements(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	for i := 1; i <= 3; i++ {
+		rec := doPinpointRequest(t, h, http.MethodPut,
+			"/v1/apps/"+appID+"/channels/gcm",
+			map[string]any{"ApiKey": "key", "Enabled": true})
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, float64(i), resp["Version"], "version should increment on each put")
+	}
+}
+
+func TestAudit1_Channel_CreationDatePreserved(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	rec1 := doPinpointRequest(t, h, http.MethodPut,
+		"/v1/apps/"+appID+"/channels/gcm",
+		map[string]any{"ApiKey": "key", "Enabled": true})
+	require.Equal(t, http.StatusOK, rec1.Code)
+	var r1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &r1))
+	creationDate1 := r1["CreationDate"].(string)
+
+	rec2 := doPinpointRequest(t, h, http.MethodPut,
+		"/v1/apps/"+appID+"/channels/gcm",
+		map[string]any{"ApiKey": "key-updated", "Enabled": true})
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var r2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &r2))
+	creationDate2 := r2["CreationDate"].(string)
+
+	assert.Equal(t, creationDate1, creationDate2, "CreationDate should be preserved on update")
+}
+
+// ──────────────────────────────────────────────────
+// Recommender validation: IdType enum, conditional LastModifiedDate
+// ──────────────────────────────────────────────────
+
+func TestAudit1_Recommender_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		idType         string
+		wantCreateFail bool
+	}{
+		{
+			name:   "valid_endpoint_id_type",
+			idType: "PINPOINT_ENDPOINT_ID",
+		},
+		{
+			name:   "valid_user_id_type",
+			idType: "PINPOINT_USER_ID",
+		},
+		{
+			name:   "empty_id_type_ok",
+			idType: "",
+		},
+		{
+			name:           "invalid_id_type",
+			idType:         "INVALID_TYPE",
+			wantCreateFail: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := pinpoint.NewInMemoryBackend("us-east-1", "123456789012")
+			req := pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name:                         "test-recommender",
+				RecommendationProviderIDType: tc.idType,
+				RecommendationProviderURI:    "arn:aws:personalize:us-east-1:123:campaign/rec",
+			}
+
+			r, err := b.CreateRecommenderConfiguration(req)
+			if tc.wantCreateFail {
+				assert.Error(t, err)
+				assert.Nil(t, r)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, r)
+
+				if tc.idType != "" {
+					assert.Equal(t, tc.idType, r.RecommendationProviderIDType)
+				}
+			}
+		})
+	}
+}
+
+func TestAudit1_Recommender_ConditionalLastModifiedDate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		updateReq       pinpoint.ExportedCreateRecommenderConfigRequest
+		wantDateChanged bool
+	}{
+		{
+			name: "update_name_changes_date",
+			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name: "new-name",
+			},
+			wantDateChanged: true,
+		},
+		{
+			name: "same_name_no_date_change",
+			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Name: "original",
+			},
+			wantDateChanged: false,
+		},
+		{
+			name: "update_description_changes_date",
+			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				Description: "a new description",
+			},
+			wantDateChanged: true,
+		},
+		{
+			name: "update_uri_changes_date",
+			updateReq: pinpoint.ExportedCreateRecommenderConfigRequest{
+				RecommendationProviderURI: "arn:aws:personalize:us-east-1:123:campaign/new",
+			},
+			wantDateChanged: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := pinpoint.NewInMemoryBackend("us-east-1", "123456789012")
+
+			created, err := b.CreateRecommenderConfiguration(
+				pinpoint.ExportedCreateRecommenderConfigRequest{
+					Name: "original",
+					RecommendationProviderURI: "arn:aws:personalize:us-east-1:123:campaign/orig",
+				},
+			)
+			require.NoError(t, err)
+			originalDate := created.LastModifiedDate
+
+			updated, err := b.UpdateRecommenderConfiguration(created.ID, tc.updateReq)
+			require.NoError(t, err)
+
+			if tc.wantDateChanged {
+				assert.NotEqual(t, originalDate, updated.LastModifiedDate, "LastModifiedDate should update on change")
+			} else {
+				assert.Equal(t, originalDate, updated.LastModifiedDate, "LastModifiedDate should not update when nothing changed")
+			}
+		})
+	}
+}
+
+func TestAudit1_Recommender_InvalidIDTypeOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	b := pinpoint.NewInMemoryBackend("us-east-1", "123456789012")
+
+	created, err := b.CreateRecommenderConfiguration(
+		pinpoint.ExportedCreateRecommenderConfigRequest{Name: "rec"},
+	)
+	require.NoError(t, err)
+
+	_, err = b.UpdateRecommenderConfiguration(created.ID, pinpoint.ExportedCreateRecommenderConfigRequest{
+		RecommendationProviderIDType: "INVALID_TYPE",
+	})
+	assert.Error(t, err)
+}
+
+// ──────────────────────────────────────────────────
+// ApplicationSettings: body persistence
+// ──────────────────────────────────────────────────
+
+func TestAudit1_ApplicationSettings_BodyPersistence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             map[string]any
+		wantCampaignHook bool
+		wantLimits       bool
+		wantQuietTime    bool
+	}{
+		{
+			name: "persist_campaign_hook",
+			body: map[string]any{
+				"CampaignHook": map[string]any{
+					"LambdaFunctionName": "arn:aws:lambda:us-east-1:123:function:hook",
+					"Mode":               "FILTER",
+					"WebUrl":             "https://example.com/hook",
+				},
+			},
+			wantCampaignHook: true,
+		},
+		{
+			name: "persist_limits",
+			body: map[string]any{
+				"Limits": map[string]any{
+					"Daily":              200,
+					"MaximumDuration":    900,
+					"MessagesPerSecond":  20,
+					"Total":              10000,
+				},
+			},
+			wantLimits: true,
+		},
+		{
+			name: "persist_quiet_time",
+			body: map[string]any{
+				"QuietTime": map[string]any{
+					"Start": "22:00",
+					"End":   "08:00",
+				},
+			},
+			wantQuietTime: true,
+		},
+		{
+			name: "persist_all_settings",
+			body: map[string]any{
+				"CampaignHook": map[string]any{
+					"Mode": "DELIVERY",
+				},
+				"Limits": map[string]any{
+					"Daily": 100,
+				},
+				"QuietTime": map[string]any{
+					"Start": "21:00",
+					"End":   "09:00",
+				},
+				"CloudWatchMetricsEnabled": true,
+			},
+			wantCampaignHook: true,
+			wantLimits:       true,
+			wantQuietTime:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			// Update settings.
+			putRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/settings", tc.body)
+			require.Equal(t, http.StatusOK, putRec.Code)
+
+			var putResp map[string]any
+			require.NoError(t, json.Unmarshal(putRec.Body.Bytes(), &putResp))
+
+			// GET settings back.
+			getRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/settings", nil)
+			require.Equal(t, http.StatusOK, getRec.Code)
+
+			var getResp map[string]any
+			require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+
+			if tc.wantCampaignHook {
+				hook, ok := getResp["CampaignHook"].(map[string]any)
+				assert.True(t, ok)
+				assert.NotEmpty(t, hook)
+			}
+
+			if tc.wantLimits {
+				limits, ok := getResp["Limits"].(map[string]any)
+				assert.True(t, ok)
+				assert.NotEmpty(t, limits)
+			}
+
+			if tc.wantQuietTime {
+				qt, ok := getResp["QuietTime"].(map[string]any)
+				assert.True(t, ok)
+				assert.NotEmpty(t, qt)
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────
+// Journey update round-trip: Activities, Schedule, Limits
+// ──────────────────────────────────────────────────
+
+func TestAudit1_JourneyUpdate_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		updateBody map[string]any
+		checkField string
+	}{
+		{
+			name: "update_activities",
+			updateBody: map[string]any{
+				"Activities": map[string]any{
+					"step-1": map[string]any{
+						"EMAIL": map[string]any{
+							"MessageConfig": map[string]any{},
+							"NextActivity":  "",
+						},
+					},
+				},
+				"StartActivity": "step-1",
+			},
+			checkField: "Activities",
+		},
+		{
+			name: "update_schedule",
+			updateBody: map[string]any{
+				"Schedule": map[string]any{
+					"StartTime": "2026-06-01T00:00:00Z",
+					"Timezone":  "UTC",
+				},
+			},
+			checkField: "Schedule",
+		},
+		{
+			name: "update_limits",
+			updateBody: map[string]any{
+				"Limits": map[string]any{
+					"DailyCap":           200,
+					"MessagesPerSecond":  100,
+				},
+			},
+			checkField: "Limits",
+		},
+		{
+			name: "update_quiet_time",
+			updateBody: map[string]any{
+				"QuietTime": map[string]any{
+					"Start": "23:00",
+					"End":   "07:00",
+				},
+				"WaitForQuietTime": true,
+			},
+			checkField: "QuietTime",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/journeys",
+				map[string]any{"Name": "j"})
+			require.Equal(t, http.StatusCreated, createRec.Code)
+			var created map[string]any
+			require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+			journeyID := created["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPut,
+				"/v1/apps/"+appID+"/journeys/"+journeyID, tc.updateBody)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.NotNil(t, resp[tc.checkField], "%s field must be non-nil after update", tc.checkField)
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────
+// Campaign + Segment: GetVersions return correct count
+// ──────────────────────────────────────────────────
+
+func TestAudit1_SegmentVersioning(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/segments",
+		map[string]any{"Name": "versioned-seg"})
+	require.Equal(t, http.StatusCreated, createRec.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	segID := created["Id"].(string)
+
+	// 2 updates.
+	for i := 0; i < 2; i++ {
+		updateRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/segments/"+segID,
+			map[string]any{"Name": "seg-v" + string(rune('A'+i))})
+		require.Equal(t, http.StatusOK, updateRec.Code)
+	}
+
+	verRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/segments/"+segID+"/versions", nil)
+	require.Equal(t, http.StatusOK, verRec.Code)
+	var verResp map[string]any
+	require.NoError(t, json.Unmarshal(verRec.Body.Bytes(), &verResp))
+	items, _ := verResp["Item"].([]any)
+	assert.Len(t, items, 3, "3 versions: 1 create + 2 updates")
+}
+
+// ──────────────────────────────────────────────────
+// Campaign: IsPaused false on paused campaign restores SCHEDULED
+// ──────────────────────────────────────────────────
+
+func TestAudit1_CampaignPauseUnpauseCycle(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/campaigns",
+		map[string]any{"Name": "cycle", "SegmentId": "seg-1"})
+	require.Equal(t, http.StatusCreated, createRec.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	campaignID := created["Id"].(string)
+
+	// Check initial state.
+	state1, _ := created["State"].(map[string]any)
+	assert.Equal(t, "SCHEDULED", state1["CampaignStatus"])
+
+	// Pause.
+	pauseRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/campaigns/"+campaignID,
+		map[string]any{"IsPaused": true})
+	require.Equal(t, http.StatusOK, pauseRec.Code)
+	var paused map[string]any
+	require.NoError(t, json.Unmarshal(pauseRec.Body.Bytes(), &paused))
+	pausedState, _ := paused["State"].(map[string]any)
+	assert.Equal(t, "PAUSED", pausedState["CampaignStatus"])
+
+	// Unpause.
+	unpauseRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/campaigns/"+campaignID,
+		map[string]any{"IsPaused": false})
+	require.Equal(t, http.StatusOK, unpauseRec.Code)
+	var unpaused map[string]any
+	require.NoError(t, json.Unmarshal(unpauseRec.Body.Bytes(), &unpaused))
+	unpausedState, _ := unpaused["State"].(map[string]any)
+	assert.Equal(t, "SCHEDULED", unpausedState["CampaignStatus"])
+}
+
+// ──────────────────────────────────────────────────
+// Edge cases
+// ──────────────────────────────────────────────────
+
+func TestAudit1_Endpoint_EffectiveDate_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	effectiveDate := "2026-01-15T10:30:00Z"
+	rec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/endpoints/ep-eff",
+		map[string]any{
+			"ChannelType":   "EMAIL",
+			"Address":       "t@example.com",
+			"EffectiveDate": effectiveDate,
+		})
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	getRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/endpoints/ep-eff", nil)
+	require.Equal(t, http.StatusOK, getRec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &resp))
+	assert.Equal(t, effectiveDate, resp["EffectiveDate"])
+}
+
+func TestAudit1_Journey_MultipleActivities_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	activities := map[string]any{
+		"start": map[string]any{
+			"Wait": map[string]any{
+				"WaitTime":     map[string]any{"WaitFor": "PT24H"},
+				"NextActivity": "email-step",
+			},
+		},
+		"email-step": map[string]any{
+			"EMAIL": map[string]any{
+				"MessageConfig":  map[string]any{"FromAddress": "no-reply@example.com"},
+				"TemplateName":   "welcome",
+				"TemplateVersion": "1",
+				"NextActivity":   "holdout",
+			},
+		},
+		"holdout": map[string]any{
+			"Holdout": map[string]any{
+				"NextActivity": "",
+				"Percentage":   15,
+			},
+		},
+	}
+
+	createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/journeys",
+		map[string]any{
+			"Name":          "multi-step",
+			"StartActivity": "start",
+			"Activities":    activities,
+		})
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &resp))
+
+	returnedActivities, _ := resp["Activities"].(map[string]any)
+	assert.Len(t, returnedActivities, 3, "all 3 activities round-trip")
+	assert.Contains(t, returnedActivities, "start")
+	assert.Contains(t, returnedActivities, "email-step")
+	assert.Contains(t, returnedActivities, "holdout")
+	assert.Equal(t, "start", resp["StartActivity"])
+}
+
+func TestAudit1_Campaign_ScheduleFrequencyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	frequencies := []string{
+		"IN_APP", "ONCE", "HOURLY", "DAILY", "WEEKLY", "MONTHLY", "EVENT",
+	}
+
+	for _, freq := range frequencies {
+		freq := freq
+		t.Run(freq, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandlerForTest(t)
+
+			appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+			require.Equal(t, http.StatusCreated, appRec.Code)
+			var appResp map[string]any
+			require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+			appID := appResp["Id"].(string)
+
+			rec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/campaigns",
+				map[string]any{
+					"Name":      "freq-test",
+					"SegmentId": "seg-1",
+					"Schedule": map[string]any{
+						"Frequency": freq,
+						"StartTime": "2026-01-01T00:00:00Z",
+					},
+				})
+			require.Equal(t, http.StatusCreated, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			schedule, _ := resp["Schedule"].(map[string]any)
+			assert.Equal(t, freq, schedule["Frequency"])
+		})
+	}
+}
+
+func TestAudit1_Segment_VersionRetrieval(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	createRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/segments",
+		map[string]any{"Name": "seg-v"})
+	require.Equal(t, http.StatusCreated, createRec.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	segID := created["Id"].(string)
+
+	updateRec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/segments/"+segID,
+		map[string]any{"Name": "seg-v-updated"})
+	require.Equal(t, http.StatusOK, updateRec.Code)
+
+	// GetSegmentVersion v1.
+	v1Rec := doPinpointRequest(t, h, http.MethodGet,
+		"/v1/apps/"+appID+"/segments/"+segID+"/versions/1", nil)
+	require.Equal(t, http.StatusOK, v1Rec.Code)
+	var v1 map[string]any
+	require.NoError(t, json.Unmarshal(v1Rec.Body.Bytes(), &v1))
+	assert.Equal(t, float64(1), v1["Version"])
+	assert.Equal(t, "seg-v", v1["Name"])
+}
+
+func TestAudit1_Campaign_AdditionalTreatments_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	rec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps/"+appID+"/campaigns",
+		map[string]any{
+			"Name":      "ab-campaign",
+			"SegmentId": "seg-1",
+			"AdditionalTreatments": []any{
+				map[string]any{
+					"SizePercent":   30,
+					"TreatmentName": "Variant A",
+					"MessageConfiguration": map[string]any{
+						"DefaultMessage": map[string]any{"Body": "Variant A message"},
+					},
+				},
+				map[string]any{
+					"SizePercent":   20,
+					"TreatmentName": "Variant B",
+				},
+			},
+		})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	treatments, _ := resp["AdditionalTreatments"].([]any)
+	assert.Len(t, treatments, 2)
+}
+
+func TestAudit1_Channel_AllChannelsListed(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerForTest(t)
+
+	appRec := doPinpointRequest(t, h, http.MethodPost, "/v1/apps", map[string]any{"Name": "app"})
+	require.Equal(t, http.StatusCreated, appRec.Code)
+	var appResp map[string]any
+	require.NoError(t, json.Unmarshal(appRec.Body.Bytes(), &appResp))
+	appID := appResp["Id"].(string)
+
+	channelTypes := []string{"gcm", "email", "sms"}
+	bodies := []map[string]any{
+		{"ApiKey": "gcm-key", "Enabled": true},
+		{"FromAddress": "noreply@example.com", "Enabled": true},
+		{"SenderId": "MySender", "Enabled": true},
+	}
+
+	for i, ct := range channelTypes {
+		rec := doPinpointRequest(t, h, http.MethodPut, "/v1/apps/"+appID+"/channels/"+ct, bodies[i])
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	listRec := doPinpointRequest(t, h, http.MethodGet, "/v1/apps/"+appID+"/channels", nil)
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+
+	channels, _ := listResp["Channels"].(map[string]any)
+	assert.Len(t, channels, 3)
+}

--- a/services/pinpoint/backend.go
+++ b/services/pinpoint/backend.go
@@ -19,6 +19,16 @@ var (
 	ErrValidation = awserr.New("BadRequestException", awserr.ErrInvalidParameter)
 	// ErrAlreadyExists is returned when a resource with the same key already exists.
 	ErrAlreadyExists = awserr.New("ConflictException: resource already exists", awserr.ErrConflict)
+	// ErrJourneyActive is returned when attempting to modify an ACTIVE journey's activities.
+	ErrJourneyActive = awserr.New("BadRequestException: journey is ACTIVE and cannot be modified", awserr.ErrInvalidParameter)
+)
+
+const (
+	journeyStateActive    = "ACTIVE"
+	journeyStatePaused    = "PAUSED"
+	journeyStateCancelled = "CANCELLED"
+	journeyStateCompleted = "COMPLETED"
+	journeyStateClosed    = "CLOSED"
 )
 
 // tagHolder is implemented by all resource types that carry tags and an ARN,
@@ -650,6 +660,10 @@ func (b *InMemoryBackend) CreateRecommenderConfiguration(
 ) (*RecommenderConfiguration, error) {
 	b.mu.Lock("CreateRecommenderConfiguration")
 	defer b.mu.Unlock()
+
+	if req.RecommendationProviderIDType != "" && !validRecommenderIDTypes[req.RecommendationProviderIDType] {
+		return nil, ErrValidation
+	}
 
 	id := uuid.NewString()
 	now := nowRFC3339()

--- a/services/pinpoint/backend.go
+++ b/services/pinpoint/backend.go
@@ -20,7 +20,10 @@ var (
 	// ErrAlreadyExists is returned when a resource with the same key already exists.
 	ErrAlreadyExists = awserr.New("ConflictException: resource already exists", awserr.ErrConflict)
 	// ErrJourneyActive is returned when attempting to modify an ACTIVE journey's activities.
-	ErrJourneyActive = awserr.New("BadRequestException: journey is ACTIVE and cannot be modified", awserr.ErrInvalidParameter)
+	ErrJourneyActive = awserr.New(
+		"BadRequestException: journey is ACTIVE and cannot be modified",
+		awserr.ErrInvalidParameter,
+	)
 )
 
 const (
@@ -661,7 +664,7 @@ func (b *InMemoryBackend) CreateRecommenderConfiguration(
 	b.mu.Lock("CreateRecommenderConfiguration")
 	defer b.mu.Unlock()
 
-	if req.RecommendationProviderIDType != "" && !validRecommenderIDTypes[req.RecommendationProviderIDType] {
+	if !isValidRecommenderIDType(req.RecommendationProviderIDType) {
 		return nil, ErrValidation
 	}
 
@@ -863,10 +866,7 @@ func nonNilStringSliceMapCopy(m map[string][]string) map[string][]string {
 // nonNilFloat64MapCopy returns a copy of a map[string]float64; never returns nil.
 func nonNilFloat64MapCopy(m map[string]float64) map[string]float64 {
 	cp := make(map[string]float64, len(m))
-
-	for k, v := range m {
-		cp[k] = v
-	}
+	maps.Copy(cp, m)
 
 	return cp
 }

--- a/services/pinpoint/backend.go
+++ b/services/pinpoint/backend.go
@@ -331,16 +331,39 @@ func (b *InMemoryBackend) CreateCampaign(
 	campaignARN := arn.Build("mobiletargeting", region, accountID, fmt.Sprintf("apps/%s/campaigns/%s", appID, id))
 	now := nowRFC3339()
 
+	status := campaignStatusScheduled
+	if req.IsPaused {
+		status = campaignStatusPaused
+	}
+
 	c := &Campaign{
-		ApplicationID:    appID,
-		ARN:              campaignARN,
-		ID:               id,
-		Name:             req.Name,
-		SegmentID:        req.SegmentID,
-		SegmentVersion:   req.SegmentVersion,
-		Tags:             nonNilTagsCopy(req.Tags),
-		CreationDate:     now,
-		LastModifiedDate: now,
+		ApplicationID:               appID,
+		ARN:                         campaignARN,
+		ID:                          id,
+		Name:                        req.Name,
+		SegmentID:                   req.SegmentID,
+		SegmentVersion:              req.SegmentVersion,
+		Tags:                        nonNilTagsCopy(req.Tags),
+		MessageConfiguration:        cloneAnyMap(req.MessageConfiguration),
+		Schedule:                    cloneAnyMap(req.Schedule),
+		Hook:                        cloneAnyMap(req.Hook),
+		Limits:                      cloneAnyMap(req.Limits),
+		TemplateConfiguration:       cloneAnyMap(req.TemplateConfiguration),
+		CustomDeliveryConfiguration: cloneAnyMap(req.CustomDeliveryConfiguration),
+		TreatmentDescription:        req.TreatmentDescription,
+		TreatmentName:               req.TreatmentName,
+		Priority:                    req.Priority,
+		IsPaused:                    req.IsPaused,
+		Status:                      status,
+		CreationDate:                now,
+		LastModifiedDate:            now,
+	}
+
+	if req.AdditionalTreatments != nil {
+		c.AdditionalTreatments = make([]map[string]any, len(req.AdditionalTreatments))
+		for i, t := range req.AdditionalTreatments {
+			c.AdditionalTreatments[i] = cloneAnyMap(t)
+		}
 	}
 
 	c.Version = 1
@@ -583,14 +606,32 @@ func (b *InMemoryBackend) CreateJourney(region, accountID, appID string, req cre
 	now := nowRFC3339()
 
 	j := &Journey{
-		ApplicationID:    appID,
-		ARN:              journeyARN,
-		ID:               id,
-		Name:             req.Name,
-		State:            journeyStateDraft,
-		Tags:             nonNilTagsCopy(req.Tags),
-		CreationDate:     now,
-		LastModifiedDate: now,
+		ApplicationID:          appID,
+		ARN:                    journeyARN,
+		ID:                     id,
+		Name:                   req.Name,
+		State:                  journeyStateDraft,
+		Tags:                   nonNilTagsCopy(req.Tags),
+		StartActivity:          req.StartActivity,
+		RefreshFrequency:       req.RefreshFrequency,
+		LocalTime:              req.LocalTime,
+		WaitForQuietTime:       req.WaitForQuietTime,
+		RefreshOnSegmentUpdate: req.RefreshOnSegmentUpdate,
+		StartCondition:         cloneAnyMap(req.StartCondition),
+		Schedule:               cloneAnyMap(req.Schedule),
+		Limits:                 cloneAnyMap(req.Limits),
+		QuietTime:              cloneAnyMap(req.QuietTime),
+		OpenHours:              cloneAnyMap(req.OpenHours),
+		ClosedDays:             cloneAnyMap(req.ClosedDays),
+		CreationDate:           now,
+		LastModifiedDate:       now,
+	}
+
+	if req.Activities != nil {
+		j.Activities = make(map[string]map[string]any, len(req.Activities))
+		for k, v := range req.Activities {
+			j.Activities[k] = cloneAnyMap(v)
+		}
 	}
 
 	b.journeys[id] = j
@@ -650,14 +691,25 @@ func (b *InMemoryBackend) CreateSegment(region, accountID, appID string, req cre
 	id := uuid.NewString()
 	segmentARN := arn.Build("mobiletargeting", region, accountID, fmt.Sprintf("apps/%s/segments/%s", appID, id))
 
+	now2 := nowRFC3339()
+	segType := segmentTypeDimensional
+
+	if len(req.ImportDefinition) > 0 {
+		segType = segmentTypeImport
+	}
+
 	s := &Segment{
-		ApplicationID: appID,
-		ARN:           segmentARN,
-		ID:            id,
-		Name:          req.Name,
-		SegmentType:   segmentTypeDimensional,
-		Tags:          nonNilTagsCopy(req.Tags),
-		CreationDate:  nowRFC3339(),
+		ApplicationID:    appID,
+		ARN:              segmentARN,
+		ID:               id,
+		Name:             req.Name,
+		SegmentType:      segType,
+		Tags:             nonNilTagsCopy(req.Tags),
+		Dimensions:       cloneAnyMap(req.Dimensions),
+		SegmentGroups:    cloneAnyMap(req.SegmentGroups),
+		ImportDefinition: cloneAnyMap(req.ImportDefinition),
+		CreationDate:     now2,
+		LastModifiedDate: now2,
 	}
 
 	s.Version = 1
@@ -685,6 +737,19 @@ func cloneApp(a *App) *App {
 func cloneCampaign(c *Campaign) *Campaign {
 	cp := *c
 	cp.Tags = nonNilTagsCopy(c.Tags)
+	cp.MessageConfiguration = cloneAnyMap(c.MessageConfiguration)
+	cp.Schedule = cloneAnyMap(c.Schedule)
+	cp.Hook = cloneAnyMap(c.Hook)
+	cp.Limits = cloneAnyMap(c.Limits)
+	cp.TemplateConfiguration = cloneAnyMap(c.TemplateConfiguration)
+	cp.CustomDeliveryConfiguration = cloneAnyMap(c.CustomDeliveryConfiguration)
+
+	if c.AdditionalTreatments != nil {
+		cp.AdditionalTreatments = make([]map[string]any, len(c.AdditionalTreatments))
+		for i, t := range c.AdditionalTreatments {
+			cp.AdditionalTreatments[i] = cloneAnyMap(t)
+		}
+	}
 
 	return &cp
 }
@@ -720,6 +785,19 @@ func cloneSmsTemplate(t *SmsTemplate) *SmsTemplate {
 func cloneJourney(j *Journey) *Journey {
 	cp := *j
 	cp.Tags = nonNilTagsCopy(j.Tags)
+	cp.StartCondition = cloneAnyMap(j.StartCondition)
+	cp.Schedule = cloneAnyMap(j.Schedule)
+	cp.Limits = cloneAnyMap(j.Limits)
+	cp.QuietTime = cloneAnyMap(j.QuietTime)
+	cp.OpenHours = cloneAnyMap(j.OpenHours)
+	cp.ClosedDays = cloneAnyMap(j.ClosedDays)
+
+	if j.Activities != nil {
+		cp.Activities = make(map[string]map[string]any, len(j.Activities))
+		for k, v := range j.Activities {
+			cp.Activities[k] = cloneAnyMap(v)
+		}
+	}
 
 	return &cp
 }
@@ -727,6 +805,9 @@ func cloneJourney(j *Journey) *Journey {
 func cloneSegment(s *Segment) *Segment {
 	cp := *s
 	cp.Tags = nonNilTagsCopy(s.Tags)
+	cp.Dimensions = cloneAnyMap(s.Dimensions)
+	cp.SegmentGroups = cloneAnyMap(s.SegmentGroups)
+	cp.ImportDefinition = cloneAnyMap(s.ImportDefinition)
 
 	return &cp
 }
@@ -746,6 +827,34 @@ func nonNilTagsCopy(tags map[string]string) map[string]string {
 // nonNilAttrsCopy returns a copy of the given attribute map; never returns nil.
 func nonNilAttrsCopy(attrs map[string]string) map[string]string {
 	return nonNilTagsCopy(attrs)
+}
+
+// nonNilStringSliceMapCopy returns a copy of a map[string][]string; never returns nil.
+func nonNilStringSliceMapCopy(m map[string][]string) map[string][]string {
+	cp := make(map[string][]string, len(m))
+
+	for k, v := range m {
+		if v == nil {
+			cp[k] = []string{}
+		} else {
+			dst := make([]string, len(v))
+			copy(dst, v)
+			cp[k] = dst
+		}
+	}
+
+	return cp
+}
+
+// nonNilFloat64MapCopy returns a copy of a map[string]float64; never returns nil.
+func nonNilFloat64MapCopy(m map[string]float64) map[string]float64 {
+	cp := make(map[string]float64, len(m))
+
+	for k, v := range m {
+		cp[k] = v
+	}
+
+	return cp
 }
 
 // ──────────────────────────────────────────────────

--- a/services/pinpoint/backend_ops.go
+++ b/services/pinpoint/backend_ops.go
@@ -346,6 +346,61 @@ func (b *InMemoryBackend) UpdateCampaign(appID, campaignID string, req updateCam
 		c.SegmentID = req.SegmentID
 	}
 
+	if req.SegmentVersion != 0 {
+		c.SegmentVersion = req.SegmentVersion
+	}
+
+	if len(req.MessageConfiguration) > 0 {
+		c.MessageConfiguration = cloneAnyMap(req.MessageConfiguration)
+	}
+
+	if len(req.Schedule) > 0 {
+		c.Schedule = cloneAnyMap(req.Schedule)
+	}
+
+	if len(req.Hook) > 0 {
+		c.Hook = cloneAnyMap(req.Hook)
+	}
+
+	if len(req.Limits) > 0 {
+		c.Limits = cloneAnyMap(req.Limits)
+	}
+
+	if len(req.TemplateConfiguration) > 0 {
+		c.TemplateConfiguration = cloneAnyMap(req.TemplateConfiguration)
+	}
+
+	if len(req.CustomDeliveryConfiguration) > 0 {
+		c.CustomDeliveryConfiguration = cloneAnyMap(req.CustomDeliveryConfiguration)
+	}
+
+	if req.TreatmentDescription != "" {
+		c.TreatmentDescription = req.TreatmentDescription
+	}
+
+	if req.TreatmentName != "" {
+		c.TreatmentName = req.TreatmentName
+	}
+
+	if req.Priority != 0 {
+		c.Priority = req.Priority
+	}
+
+	c.IsPaused = req.IsPaused
+
+	if req.IsPaused {
+		c.Status = campaignStatusPaused
+	} else if c.Status == campaignStatusPaused {
+		c.Status = campaignStatusScheduled
+	}
+
+	if req.AdditionalTreatments != nil {
+		c.AdditionalTreatments = make([]map[string]any, len(req.AdditionalTreatments))
+		for i, t := range req.AdditionalTreatments {
+			c.AdditionalTreatments[i] = cloneAnyMap(t)
+		}
+	}
+
 	c.LastModifiedDate = nowRFC3339()
 	c.Version++
 
@@ -427,6 +482,20 @@ func (b *InMemoryBackend) UpdateSegment(appID, segmentID string, req updateSegme
 		s.Name = req.Name
 	}
 
+	if len(req.Dimensions) > 0 {
+		s.Dimensions = cloneAnyMap(req.Dimensions)
+	}
+
+	if len(req.SegmentGroups) > 0 {
+		s.SegmentGroups = cloneAnyMap(req.SegmentGroups)
+	}
+
+	if len(req.ImportDefinition) > 0 {
+		s.ImportDefinition = cloneAnyMap(req.ImportDefinition)
+		s.SegmentType = segmentTypeImport
+	}
+
+	s.LastModifiedDate = nowRFC3339()
 	s.Version++
 
 	// Track segment version history.
@@ -503,13 +572,69 @@ func (b *InMemoryBackend) UpdateJourney(appID, journeyID string, req updateJourn
 		return nil, ErrAppNotFound
 	}
 
+	if j.State == journeyStateActive {
+		return nil, ErrJourneyActive
+	}
+
 	if req.Name != "" {
 		j.Name = req.Name
 	}
 
+	if req.StartActivity != "" {
+		j.StartActivity = req.StartActivity
+	}
+
+	if req.RefreshFrequency != "" {
+		j.RefreshFrequency = req.RefreshFrequency
+	}
+
+	if len(req.Activities) > 0 {
+		j.Activities = make(map[string]map[string]any, len(req.Activities))
+		for k, v := range req.Activities {
+			j.Activities[k] = cloneAnyMap(v)
+		}
+	}
+
+	if len(req.StartCondition) > 0 {
+		j.StartCondition = cloneAnyMap(req.StartCondition)
+	}
+
+	if len(req.Schedule) > 0 {
+		j.Schedule = cloneAnyMap(req.Schedule)
+	}
+
+	if len(req.Limits) > 0 {
+		j.Limits = cloneAnyMap(req.Limits)
+	}
+
+	if len(req.QuietTime) > 0 {
+		j.QuietTime = cloneAnyMap(req.QuietTime)
+	}
+
+	if len(req.OpenHours) > 0 {
+		j.OpenHours = cloneAnyMap(req.OpenHours)
+	}
+
+	if len(req.ClosedDays) > 0 {
+		j.ClosedDays = cloneAnyMap(req.ClosedDays)
+	}
+
+	j.LocalTime = req.LocalTime
+	j.WaitForQuietTime = req.WaitForQuietTime
+	j.RefreshOnSegmentUpdate = req.RefreshOnSegmentUpdate
 	j.LastModifiedDate = nowRFC3339()
 
 	return cloneJourney(j), nil
+}
+
+// journeyStateTransitions maps each state to the set of valid target states.
+var journeyStateTransitions = map[string][]string{
+	journeyStateDraft:     {journeyStateActive, journeyStateCancelled},
+	journeyStateActive:    {journeyStatePaused, journeyStateCancelled, journeyStateCompleted},
+	journeyStatePaused:    {journeyStateActive, journeyStateCancelled},
+	journeyStateCancelled: {},
+	journeyStateCompleted: {},
+	journeyStateClosed:    {},
 }
 
 // UpdateJourneyState updates the state of a Pinpoint journey.
@@ -522,11 +647,29 @@ func (b *InMemoryBackend) UpdateJourneyState(appID, journeyID, state string) (*J
 		return nil, ErrAppNotFound
 	}
 
+	allowed, exists := journeyStateTransitions[j.State]
+	if !exists {
+		return nil, ErrValidation
+	}
+
+	validTarget := false
+
+	for _, s := range allowed {
+		if s == state {
+			validTarget = true
+
+			break
+		}
+	}
+
+	if !validTarget {
+		return nil, ErrValidation
+	}
+
 	j.State = state
 	j.LastModifiedDate = nowRFC3339()
 
-	// When activating, create a journey run record.
-	if state == "ACTIVE" {
+	if state == journeyStateActive {
 		runKey := appID + "/" + journeyID
 		b.journeyRuns[runKey] = append(b.journeyRuns[runKey], &journeyRun{
 			RunID:         uuid.NewString(),
@@ -781,10 +924,7 @@ func (b *InMemoryBackend) GetEndpoint(appID, endpointID string) (*Endpoint, erro
 		return nil, ErrAppNotFound
 	}
 
-	cp := *e
-	cp.Attributes = nonNilAttrsCopy(e.Attributes)
-
-	return &cp, nil
+	return cloneEndpoint(e), nil
 }
 
 // UpdateEndpoint creates or updates a Pinpoint endpoint.
@@ -816,10 +956,43 @@ func (b *InMemoryBackend) UpdateEndpoint(appID, endpointID string, req updateEnd
 		e.UserID = req.User.UserID
 	}
 
-	cp := *e
-	cp.Attributes = nonNilAttrsCopy(e.Attributes)
+	if len(req.User.UserAttributes) > 0 {
+		e.UserAttributes = nonNilStringSliceMapCopy(req.User.UserAttributes)
+	}
 
-	return &cp, nil
+	if len(req.Attributes) > 0 {
+		e.Attributes = nonNilStringSliceMapCopy(req.Attributes)
+	}
+
+	if len(req.Metrics) > 0 {
+		e.Metrics = nonNilFloat64MapCopy(req.Metrics)
+	}
+
+	if len(req.Demographic) > 0 {
+		e.Demographic = cloneAnyMap(req.Demographic)
+	}
+
+	if len(req.Location) > 0 {
+		e.Location = cloneAnyMap(req.Location)
+	}
+
+	if req.EndpointStatus != "" {
+		e.EndpointStatus = req.EndpointStatus
+	}
+
+	if req.OptOut != "" {
+		e.OptOut = req.OptOut
+	}
+
+	if req.EffectiveDate != "" {
+		e.EffectiveDate = req.EffectiveDate
+	}
+
+	if req.RequestId != "" {
+		e.RequestId = req.RequestId
+	}
+
+	return cloneEndpoint(e), nil
 }
 
 // DeleteEndpoint deletes a Pinpoint endpoint.
@@ -836,10 +1009,7 @@ func (b *InMemoryBackend) DeleteEndpoint(appID, endpointID string) (*Endpoint, e
 
 	delete(b.endpoints, key)
 
-	cp := *e
-	cp.Attributes = nonNilAttrsCopy(e.Attributes)
-
-	return &cp, nil
+	return cloneEndpoint(e), nil
 }
 
 // GetUserEndpoints retrieves all endpoints for a user in an application.
@@ -851,9 +1021,7 @@ func (b *InMemoryBackend) GetUserEndpoints(appID, userID string) ([]*Endpoint, e
 
 	for _, e := range b.endpoints {
 		if e.ApplicationID == appID && e.UserID == userID {
-			cp := *e
-			cp.Attributes = nonNilAttrsCopy(e.Attributes)
-			endpoints = append(endpoints, &cp)
+			endpoints = append(endpoints, cloneEndpoint(e))
 		}
 	}
 
@@ -899,9 +1067,49 @@ func (b *InMemoryBackend) UpdateEndpointsBatch(appID string, endpoints map[strin
 		if req.Address != "" {
 			e.Address = req.Address
 		}
+
+		if req.User.UserID != "" {
+			e.UserID = req.User.UserID
+		}
+
+		if len(req.Attributes) > 0 {
+			e.Attributes = nonNilStringSliceMapCopy(req.Attributes)
+		}
+
+		if len(req.Metrics) > 0 {
+			e.Metrics = nonNilFloat64MapCopy(req.Metrics)
+		}
+
+		if len(req.Demographic) > 0 {
+			e.Demographic = cloneAnyMap(req.Demographic)
+		}
+
+		if len(req.Location) > 0 {
+			e.Location = cloneAnyMap(req.Location)
+		}
+
+		if req.EndpointStatus != "" {
+			e.EndpointStatus = req.EndpointStatus
+		}
+
+		if req.OptOut != "" {
+			e.OptOut = req.OptOut
+		}
 	}
 
 	return nil
+}
+
+// cloneEndpoint returns a deep copy of an Endpoint.
+func cloneEndpoint(e *Endpoint) *Endpoint {
+	cp := *e
+	cp.Attributes = nonNilStringSliceMapCopy(e.Attributes)
+	cp.UserAttributes = nonNilStringSliceMapCopy(e.UserAttributes)
+	cp.Metrics = nonNilFloat64MapCopy(e.Metrics)
+	cp.Demographic = cloneAnyMap(e.Demographic)
+	cp.Location = cloneAnyMap(e.Location)
+
+	return &cp
 }
 
 // ──────────────────────────────────────────────────
@@ -971,6 +1179,7 @@ func (b *InMemoryBackend) GetChannel(appID, channelType string) *Channel {
 	key := appID + "/" + channelType
 	if ch, ok := b.channels[key]; ok {
 		cp := *ch
+		cp.ExtraData = cloneAnyMap(ch.ExtraData)
 
 		return &cp
 	}
@@ -978,26 +1187,82 @@ func (b *InMemoryBackend) GetChannel(appID, channelType string) *Channel {
 	return &Channel{
 		ApplicationID: appID,
 		ChannelType:   channelType,
+		Platform:      strings.ToUpper(channelType),
 		Enabled:       false,
 		IsArchived:    false,
 	}
 }
 
-// UpsertChannel creates or updates a channel for an app.
-func (b *InMemoryBackend) UpsertChannel(appID, channelType string, enabled bool) *Channel {
+// UpsertChannel creates or updates a channel for an app with type-specific data.
+func (b *InMemoryBackend) UpsertChannel(appID, channelType string, enabled bool, extra map[string]any) *Channel {
 	b.mu.Lock("UpsertChannel")
 	defer b.mu.Unlock()
 
 	key := appID + "/" + channelType
+
+	existing := b.channels[key]
+
+	now := nowRFC3339()
+	version := 1
+
+	if existing != nil {
+		version = existing.Version + 1
+	}
+
+	platform := strings.ToUpper(channelType)
+
+	hasCredential := false
+	hasTokenKey := false
+
+	if extra != nil {
+		if v, ok := extra["ApiKey"].(string); ok && v != "" {
+			hasCredential = true
+		}
+
+		if v, ok := extra["BundleId"].(string); ok && v != "" {
+			hasCredential = true
+		}
+
+		if v, ok := extra["Certificate"].(string); ok && v != "" {
+			hasCredential = true
+		}
+
+		if v, ok := extra["ClientId"].(string); ok && v != "" {
+			hasCredential = true
+		}
+
+		if v, ok := extra["FromAddress"].(string); ok && v != "" {
+			hasCredential = true
+		}
+
+		if v, ok := extra["TokenKey"].(string); ok && v != "" {
+			hasTokenKey = true
+		}
+	}
+
+	creationDate := now
+
+	if existing != nil && existing.CreationDate != "" {
+		creationDate = existing.CreationDate
+	}
+
 	ch := &Channel{
-		ApplicationID: appID,
-		ChannelType:   channelType,
-		Enabled:       enabled,
+		ApplicationID:    appID,
+		ChannelType:      channelType,
+		Platform:         platform,
+		Enabled:          enabled,
+		HasCredential:    hasCredential,
+		HasTokenKey:      hasTokenKey,
+		Version:          version,
+		CreationDate:     creationDate,
+		LastModifiedDate: now,
+		ExtraData:        cloneAnyMap(extra),
 	}
 
 	b.channels[key] = ch
 
 	cp := *ch
+	cp.ExtraData = cloneAnyMap(ch.ExtraData)
 
 	return &cp
 }
@@ -1017,6 +1282,7 @@ func (b *InMemoryBackend) DeleteChannel(appID, channelType string) *Channel {
 	delete(b.channels, key)
 
 	cp := *ch
+	cp.ExtraData = cloneAnyMap(ch.ExtraData)
 
 	return &cp
 }
@@ -1031,6 +1297,7 @@ func (b *InMemoryBackend) GetAllChannels(appID string) map[string]*Channel {
 	for key, ch := range b.channels {
 		if ch.ApplicationID == appID {
 			cp := *ch
+			cp.ExtraData = cloneAnyMap(ch.ExtraData)
 			result[key] = &cp
 		}
 	}
@@ -1078,6 +1345,13 @@ func (b *InMemoryBackend) GetRecommenderConfigurations() ([]*RecommenderConfigur
 	return results, nil
 }
 
+// validRecommenderIDTypes are the accepted values for RecommendationProviderIdType.
+var validRecommenderIDTypes = map[string]bool{
+	"PINPOINT_ENDPOINT_ID": true,
+	"PINPOINT_USER_ID":     true,
+	"":                     true,
+}
+
 // UpdateRecommenderConfiguration updates an existing recommender.
 func (b *InMemoryBackend) UpdateRecommenderConfiguration(
 	recommenderID string,
@@ -1091,15 +1365,60 @@ func (b *InMemoryBackend) UpdateRecommenderConfiguration(
 		return nil, ErrAppNotFound
 	}
 
-	if req.Name != "" {
+	if req.RecommendationProviderIDType != "" && !validRecommenderIDTypes[req.RecommendationProviderIDType] {
+		return nil, ErrValidation
+	}
+
+	changed := false
+
+	if req.Name != "" && req.Name != r.Name {
 		r.Name = req.Name
+		changed = true
 	}
 
-	if req.Description != "" {
+	if req.Description != "" && req.Description != r.Description {
 		r.Description = req.Description
+		changed = true
 	}
 
-	r.LastModifiedDate = nowRFC3339()
+	if req.RecommendationProviderIDType != "" && req.RecommendationProviderIDType != r.RecommendationProviderIDType {
+		r.RecommendationProviderIDType = req.RecommendationProviderIDType
+		changed = true
+	}
+
+	if req.RecommendationProviderRoleArn != "" && req.RecommendationProviderRoleArn != r.RecommendationProviderRoleARN {
+		r.RecommendationProviderRoleARN = req.RecommendationProviderRoleArn
+		changed = true
+	}
+
+	if req.RecommendationProviderURI != "" && req.RecommendationProviderURI != r.RecommendationProviderURI {
+		r.RecommendationProviderURI = req.RecommendationProviderURI
+		changed = true
+	}
+
+	if req.RecommendationsPerMessage != 0 && req.RecommendationsPerMessage != r.RecommendationsPerMessage {
+		r.RecommendationsPerMessage = req.RecommendationsPerMessage
+		changed = true
+	}
+
+	if len(req.Attributes) > 0 {
+		newAttrs := nonNilAttrsCopy(req.Attributes)
+		for k, v := range newAttrs {
+			if r.Attributes[k] != v {
+				changed = true
+
+				break
+			}
+		}
+
+		if changed {
+			r.Attributes = newAttrs
+		}
+	}
+
+	if changed {
+		r.LastModifiedDate = nowRFC3339()
+	}
 
 	cp := *r
 	cp.Attributes = nonNilAttrsCopy(r.Attributes)

--- a/services/pinpoint/backend_ops.go
+++ b/services/pinpoint/backend_ops.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,18 +64,18 @@ const (
 
 // Channel represents a generic Pinpoint channel response.
 type Channel struct {
-	ExtraData     map[string]any `json:"ExtraData,omitempty"`
-	ApplicationID string         `json:"ApplicationId"`
-	ChannelType   string         `json:"ChannelType"`
-	Platform      string         `json:"Platform,omitempty"`
-	CreationDate  string         `json:"CreationDate,omitempty"`
-	LastModifiedDate string      `json:"LastModifiedDate,omitempty"`
-	Version       int            `json:"Version,omitempty"`
-	MessagesPerSecond int        `json:"MessagesPerSecond,omitempty"`
-	Enabled       bool           `json:"Enabled"`
-	IsArchived    bool           `json:"IsArchived"`
-	HasCredential bool           `json:"HasCredential,omitempty"`
-	HasTokenKey   bool           `json:"HasTokenKey,omitempty"`
+	ExtraData         map[string]any `json:"ExtraData,omitempty"`
+	ApplicationID     string         `json:"ApplicationId"`
+	ChannelType       string         `json:"ChannelType"`
+	Platform          string         `json:"Platform,omitempty"`
+	CreationDate      string         `json:"CreationDate,omitempty"`
+	LastModifiedDate  string         `json:"LastModifiedDate,omitempty"`
+	Version           int            `json:"Version,omitempty"`
+	MessagesPerSecond int            `json:"MessagesPerSecond,omitempty"`
+	Enabled           bool           `json:"Enabled"`
+	IsArchived        bool           `json:"IsArchived"`
+	HasCredential     bool           `json:"HasCredential,omitempty"`
+	HasTokenKey       bool           `json:"HasTokenKey,omitempty"`
 }
 
 // VoiceTemplate represents a Pinpoint voice template.
@@ -102,7 +103,7 @@ type Endpoint struct {
 	CreationDate   string              `json:"CreationDate,omitempty"`
 	EndpointStatus string              `json:"EndpointStatus,omitempty"`
 	OptOut         string              `json:"OptOut,omitempty"`
-	RequestId      string              `json:"RequestId,omitempty"`
+	RequestID      string              `json:"RequestId,omitempty"`
 }
 
 // EventStream represents a Pinpoint event stream.
@@ -328,16 +329,8 @@ func (b *InMemoryBackend) GetCampaigns(appID string) ([]*Campaign, error) {
 	return campaigns, nil
 }
 
-// UpdateCampaign updates an existing Pinpoint campaign.
-func (b *InMemoryBackend) UpdateCampaign(appID, campaignID string, req updateCampaignRequest) (*Campaign, error) {
-	b.mu.Lock("UpdateCampaign")
-	defer b.mu.Unlock()
-
-	c, ok := b.campaigns[campaignID]
-	if !ok || c.ApplicationID != appID {
-		return nil, ErrAppNotFound
-	}
-
+// applyCampaignScalarFields copies scalar fields from req into c when set.
+func applyCampaignScalarFields(c *Campaign, req updateCampaignRequest) {
 	if req.Name != "" {
 		c.Name = req.Name
 	}
@@ -350,6 +343,21 @@ func (b *InMemoryBackend) UpdateCampaign(appID, campaignID string, req updateCam
 		c.SegmentVersion = req.SegmentVersion
 	}
 
+	if req.TreatmentDescription != "" {
+		c.TreatmentDescription = req.TreatmentDescription
+	}
+
+	if req.TreatmentName != "" {
+		c.TreatmentName = req.TreatmentName
+	}
+
+	if req.Priority != 0 {
+		c.Priority = req.Priority
+	}
+}
+
+// applyCampaignMapFields copies map fields from req into c when non-empty.
+func applyCampaignMapFields(c *Campaign, req updateCampaignRequest) {
 	if len(req.MessageConfiguration) > 0 {
 		c.MessageConfiguration = cloneAnyMap(req.MessageConfiguration)
 	}
@@ -374,17 +382,26 @@ func (b *InMemoryBackend) UpdateCampaign(appID, campaignID string, req updateCam
 		c.CustomDeliveryConfiguration = cloneAnyMap(req.CustomDeliveryConfiguration)
 	}
 
-	if req.TreatmentDescription != "" {
-		c.TreatmentDescription = req.TreatmentDescription
+	if req.AdditionalTreatments != nil {
+		c.AdditionalTreatments = make([]map[string]any, len(req.AdditionalTreatments))
+		for i, t := range req.AdditionalTreatments {
+			c.AdditionalTreatments[i] = cloneAnyMap(t)
+		}
+	}
+}
+
+// UpdateCampaign updates an existing Pinpoint campaign.
+func (b *InMemoryBackend) UpdateCampaign(appID, campaignID string, req updateCampaignRequest) (*Campaign, error) {
+	b.mu.Lock("UpdateCampaign")
+	defer b.mu.Unlock()
+
+	c, ok := b.campaigns[campaignID]
+	if !ok || c.ApplicationID != appID {
+		return nil, ErrAppNotFound
 	}
 
-	if req.TreatmentName != "" {
-		c.TreatmentName = req.TreatmentName
-	}
-
-	if req.Priority != 0 {
-		c.Priority = req.Priority
-	}
+	applyCampaignScalarFields(c, req)
+	applyCampaignMapFields(c, req)
 
 	c.IsPaused = req.IsPaused
 
@@ -394,17 +411,9 @@ func (b *InMemoryBackend) UpdateCampaign(appID, campaignID string, req updateCam
 		c.Status = campaignStatusScheduled
 	}
 
-	if req.AdditionalTreatments != nil {
-		c.AdditionalTreatments = make([]map[string]any, len(req.AdditionalTreatments))
-		for i, t := range req.AdditionalTreatments {
-			c.AdditionalTreatments[i] = cloneAnyMap(t)
-		}
-	}
-
 	c.LastModifiedDate = nowRFC3339()
 	c.Version++
 
-	// Track campaign version history.
 	versionKey := appID + "/" + campaignID
 	b.campaignVersions[versionKey] = append(b.campaignVersions[versionKey], cloneCampaign(c))
 
@@ -627,14 +636,20 @@ func (b *InMemoryBackend) UpdateJourney(appID, journeyID string, req updateJourn
 	return cloneJourney(j), nil
 }
 
-// journeyStateTransitions maps each state to the set of valid target states.
-var journeyStateTransitions = map[string][]string{
-	journeyStateDraft:     {journeyStateActive, journeyStateCancelled},
-	journeyStateActive:    {journeyStatePaused, journeyStateCancelled, journeyStateCompleted},
-	journeyStatePaused:    {journeyStateActive, journeyStateCancelled},
-	journeyStateCancelled: {},
-	journeyStateCompleted: {},
-	journeyStateClosed:    {},
+// allowedJourneyTransitions returns the set of valid target states for a given source state.
+func allowedJourneyTransitions(from string) ([]string, bool) {
+	transitions := map[string][]string{
+		journeyStateDraft:     {journeyStateActive, journeyStateCancelled},
+		journeyStateActive:    {journeyStatePaused, journeyStateCancelled, journeyStateCompleted},
+		journeyStatePaused:    {journeyStateActive, journeyStateCancelled},
+		journeyStateCancelled: {},
+		journeyStateCompleted: {},
+		journeyStateClosed:    {},
+	}
+
+	allowed, ok := transitions[from]
+
+	return allowed, ok
 }
 
 // UpdateJourneyState updates the state of a Pinpoint journey.
@@ -647,22 +662,12 @@ func (b *InMemoryBackend) UpdateJourneyState(appID, journeyID, state string) (*J
 		return nil, ErrAppNotFound
 	}
 
-	allowed, exists := journeyStateTransitions[j.State]
+	allowed, exists := allowedJourneyTransitions(j.State)
 	if !exists {
 		return nil, ErrValidation
 	}
 
-	validTarget := false
-
-	for _, s := range allowed {
-		if s == state {
-			validTarget = true
-
-			break
-		}
-	}
-
-	if !validTarget {
+	if !slices.Contains(allowed, state) {
 		return nil, ErrValidation
 	}
 
@@ -944,53 +949,7 @@ func (b *InMemoryBackend) UpdateEndpoint(appID, endpointID string, req updateEnd
 		b.endpoints[key] = e
 	}
 
-	if req.ChannelType != "" {
-		e.ChannelType = req.ChannelType
-	}
-
-	if req.Address != "" {
-		e.Address = req.Address
-	}
-
-	if req.User.UserID != "" {
-		e.UserID = req.User.UserID
-	}
-
-	if len(req.User.UserAttributes) > 0 {
-		e.UserAttributes = nonNilStringSliceMapCopy(req.User.UserAttributes)
-	}
-
-	if len(req.Attributes) > 0 {
-		e.Attributes = nonNilStringSliceMapCopy(req.Attributes)
-	}
-
-	if len(req.Metrics) > 0 {
-		e.Metrics = nonNilFloat64MapCopy(req.Metrics)
-	}
-
-	if len(req.Demographic) > 0 {
-		e.Demographic = cloneAnyMap(req.Demographic)
-	}
-
-	if len(req.Location) > 0 {
-		e.Location = cloneAnyMap(req.Location)
-	}
-
-	if req.EndpointStatus != "" {
-		e.EndpointStatus = req.EndpointStatus
-	}
-
-	if req.OptOut != "" {
-		e.OptOut = req.OptOut
-	}
-
-	if req.EffectiveDate != "" {
-		e.EffectiveDate = req.EffectiveDate
-	}
-
-	if req.RequestId != "" {
-		e.RequestId = req.RequestId
-	}
+	applyEndpointFields(e, req)
 
 	return cloneEndpoint(e), nil
 }
@@ -1042,6 +1001,57 @@ func (b *InMemoryBackend) DeleteUserEndpoints(appID, userID string) error {
 	return nil
 }
 
+// applyEndpointFields merges request fields into an Endpoint.
+func applyEndpointFields(e *Endpoint, req updateEndpointRequest) {
+	if req.ChannelType != "" {
+		e.ChannelType = req.ChannelType
+	}
+
+	if req.Address != "" {
+		e.Address = req.Address
+	}
+
+	if req.User.UserID != "" {
+		e.UserID = req.User.UserID
+	}
+
+	if len(req.User.UserAttributes) > 0 {
+		e.UserAttributes = nonNilStringSliceMapCopy(req.User.UserAttributes)
+	}
+
+	if len(req.Attributes) > 0 {
+		e.Attributes = nonNilStringSliceMapCopy(req.Attributes)
+	}
+
+	if len(req.Metrics) > 0 {
+		e.Metrics = nonNilFloat64MapCopy(req.Metrics)
+	}
+
+	if len(req.Demographic) > 0 {
+		e.Demographic = cloneAnyMap(req.Demographic)
+	}
+
+	if len(req.Location) > 0 {
+		e.Location = cloneAnyMap(req.Location)
+	}
+
+	if req.EndpointStatus != "" {
+		e.EndpointStatus = req.EndpointStatus
+	}
+
+	if req.OptOut != "" {
+		e.OptOut = req.OptOut
+	}
+
+	if req.EffectiveDate != "" {
+		e.EffectiveDate = req.EffectiveDate
+	}
+
+	if req.RequestID != "" {
+		e.RequestID = req.RequestID
+	}
+}
+
 // UpdateEndpointsBatch updates multiple endpoints in a single call.
 func (b *InMemoryBackend) UpdateEndpointsBatch(appID string, endpoints map[string]updateEndpointRequest) error {
 	b.mu.Lock("UpdateEndpointsBatch")
@@ -1060,41 +1070,7 @@ func (b *InMemoryBackend) UpdateEndpointsBatch(appID string, endpoints map[strin
 			b.endpoints[key] = e
 		}
 
-		if req.ChannelType != "" {
-			e.ChannelType = req.ChannelType
-		}
-
-		if req.Address != "" {
-			e.Address = req.Address
-		}
-
-		if req.User.UserID != "" {
-			e.UserID = req.User.UserID
-		}
-
-		if len(req.Attributes) > 0 {
-			e.Attributes = nonNilStringSliceMapCopy(req.Attributes)
-		}
-
-		if len(req.Metrics) > 0 {
-			e.Metrics = nonNilFloat64MapCopy(req.Metrics)
-		}
-
-		if len(req.Demographic) > 0 {
-			e.Demographic = cloneAnyMap(req.Demographic)
-		}
-
-		if len(req.Location) > 0 {
-			e.Location = cloneAnyMap(req.Location)
-		}
-
-		if req.EndpointStatus != "" {
-			e.EndpointStatus = req.EndpointStatus
-		}
-
-		if req.OptOut != "" {
-			e.OptOut = req.OptOut
-		}
+		applyEndpointFields(e, req)
 	}
 
 	return nil
@@ -1193,6 +1169,31 @@ func (b *InMemoryBackend) GetChannel(appID, channelType string) *Channel {
 	}
 }
 
+// channelCredentialFlags derives HasCredential and HasTokenKey from extra channel data.
+func channelCredentialFlags(extra map[string]any) (bool, bool) {
+	if extra == nil {
+		return false, false
+	}
+
+	cred := false
+
+	for _, k := range []string{"ApiKey", "BundleId", "Certificate", "ClientId", "FromAddress"} {
+		if v, ok := extra[k].(string); ok && v != "" {
+			cred = true
+
+			break
+		}
+	}
+
+	tokenKey := false
+
+	if v, ok := extra["TokenKey"].(string); ok && v != "" {
+		tokenKey = true
+	}
+
+	return cred, tokenKey
+}
+
 // UpsertChannel creates or updates a channel for an app with type-specific data.
 func (b *InMemoryBackend) UpsertChannel(appID, channelType string, enabled bool, extra map[string]any) *Channel {
 	b.mu.Lock("UpsertChannel")
@@ -1209,36 +1210,7 @@ func (b *InMemoryBackend) UpsertChannel(appID, channelType string, enabled bool,
 		version = existing.Version + 1
 	}
 
-	platform := strings.ToUpper(channelType)
-
-	hasCredential := false
-	hasTokenKey := false
-
-	if extra != nil {
-		if v, ok := extra["ApiKey"].(string); ok && v != "" {
-			hasCredential = true
-		}
-
-		if v, ok := extra["BundleId"].(string); ok && v != "" {
-			hasCredential = true
-		}
-
-		if v, ok := extra["Certificate"].(string); ok && v != "" {
-			hasCredential = true
-		}
-
-		if v, ok := extra["ClientId"].(string); ok && v != "" {
-			hasCredential = true
-		}
-
-		if v, ok := extra["FromAddress"].(string); ok && v != "" {
-			hasCredential = true
-		}
-
-		if v, ok := extra["TokenKey"].(string); ok && v != "" {
-			hasTokenKey = true
-		}
-	}
+	hasCredential, hasTokenKey := channelCredentialFlags(extra)
 
 	creationDate := now
 
@@ -1249,7 +1221,7 @@ func (b *InMemoryBackend) UpsertChannel(appID, channelType string, enabled bool,
 	ch := &Channel{
 		ApplicationID:    appID,
 		ChannelType:      channelType,
-		Platform:         platform,
+		Platform:         strings.ToUpper(channelType),
 		Enabled:          enabled,
 		HasCredential:    hasCredential,
 		HasTokenKey:      hasTokenKey,
@@ -1345,30 +1317,13 @@ func (b *InMemoryBackend) GetRecommenderConfigurations() ([]*RecommenderConfigur
 	return results, nil
 }
 
-// validRecommenderIDTypes are the accepted values for RecommendationProviderIdType.
-var validRecommenderIDTypes = map[string]bool{
-	"PINPOINT_ENDPOINT_ID": true,
-	"PINPOINT_USER_ID":     true,
-	"":                     true,
+// isValidRecommenderIDType returns true if the given type is a valid RecommendationProviderIdType.
+func isValidRecommenderIDType(t string) bool {
+	return t == "" || t == "PINPOINT_ENDPOINT_ID" || t == "PINPOINT_USER_ID"
 }
 
-// UpdateRecommenderConfiguration updates an existing recommender.
-func (b *InMemoryBackend) UpdateRecommenderConfiguration(
-	recommenderID string,
-	req createRecommenderConfigRequest,
-) (*RecommenderConfiguration, error) {
-	b.mu.Lock("UpdateRecommenderConfiguration")
-	defer b.mu.Unlock()
-
-	r, ok := b.recommenders[recommenderID]
-	if !ok {
-		return nil, ErrAppNotFound
-	}
-
-	if req.RecommendationProviderIDType != "" && !validRecommenderIDTypes[req.RecommendationProviderIDType] {
-		return nil, ErrValidation
-	}
-
+// applyRecommenderScalars applies scalar fields from req to r, returning whether any changed.
+func applyRecommenderScalars(r *RecommenderConfiguration, req createRecommenderConfigRequest) bool {
 	changed := false
 
 	if req.Name != "" && req.Name != r.Name {
@@ -1401,8 +1356,31 @@ func (b *InMemoryBackend) UpdateRecommenderConfiguration(
 		changed = true
 	}
 
+	return changed
+}
+
+// UpdateRecommenderConfiguration updates an existing recommender.
+func (b *InMemoryBackend) UpdateRecommenderConfiguration(
+	recommenderID string,
+	req createRecommenderConfigRequest,
+) (*RecommenderConfiguration, error) {
+	b.mu.Lock("UpdateRecommenderConfiguration")
+	defer b.mu.Unlock()
+
+	r, ok := b.recommenders[recommenderID]
+	if !ok {
+		return nil, ErrAppNotFound
+	}
+
+	if !isValidRecommenderIDType(req.RecommendationProviderIDType) {
+		return nil, ErrValidation
+	}
+
+	changed := applyRecommenderScalars(r, req)
+
 	if len(req.Attributes) > 0 {
 		newAttrs := nonNilAttrsCopy(req.Attributes)
+
 		for k, v := range newAttrs {
 			if r.Attributes[k] != v {
 				changed = true
@@ -1411,9 +1389,7 @@ func (b *InMemoryBackend) UpdateRecommenderConfiguration(
 			}
 		}
 
-		if changed {
-			r.Attributes = newAttrs
-		}
+		r.Attributes = newAttrs
 	}
 
 	if changed {

--- a/services/pinpoint/backend_ops.go
+++ b/services/pinpoint/backend_ops.go
@@ -63,11 +63,18 @@ const (
 
 // Channel represents a generic Pinpoint channel response.
 type Channel struct {
-	Attributes    map[string]string `json:"Attributes,omitempty"`
-	ApplicationID string            `json:"ApplicationId"`
-	ChannelType   string            `json:"ChannelType"`
-	Enabled       bool              `json:"Enabled"`
-	IsArchived    bool              `json:"IsArchived"`
+	ExtraData     map[string]any `json:"ExtraData,omitempty"`
+	ApplicationID string         `json:"ApplicationId"`
+	ChannelType   string         `json:"ChannelType"`
+	Platform      string         `json:"Platform,omitempty"`
+	CreationDate  string         `json:"CreationDate,omitempty"`
+	LastModifiedDate string      `json:"LastModifiedDate,omitempty"`
+	Version       int            `json:"Version,omitempty"`
+	MessagesPerSecond int        `json:"MessagesPerSecond,omitempty"`
+	Enabled       bool           `json:"Enabled"`
+	IsArchived    bool           `json:"IsArchived"`
+	HasCredential bool           `json:"HasCredential,omitempty"`
+	HasTokenKey   bool           `json:"HasTokenKey,omitempty"`
 }
 
 // VoiceTemplate represents a Pinpoint voice template.
@@ -81,13 +88,21 @@ type VoiceTemplate struct {
 
 // Endpoint represents a Pinpoint endpoint.
 type Endpoint struct {
-	ApplicationID string            `json:"ApplicationId"`
-	ID            string            `json:"Id"`
-	ChannelType   string            `json:"ChannelType,omitempty"`
-	Address       string            `json:"Address,omitempty"`
-	UserID        string            `json:"UserId,omitempty"`
-	Attributes    map[string]string `json:"Attributes,omitempty"`
-	CreationDate  string            `json:"CreationDate,omitempty"`
+	Attributes     map[string][]string `json:"Attributes,omitempty"`
+	UserAttributes map[string][]string `json:"UserAttributes,omitempty"`
+	Metrics        map[string]float64  `json:"Metrics,omitempty"`
+	Demographic    map[string]any      `json:"Demographic,omitempty"`
+	Location       map[string]any      `json:"Location,omitempty"`
+	ApplicationID  string              `json:"ApplicationId"`
+	ID             string              `json:"Id"`
+	ChannelType    string              `json:"ChannelType,omitempty"`
+	Address        string              `json:"Address,omitempty"`
+	UserID         string              `json:"UserId,omitempty"`
+	EffectiveDate  string              `json:"EffectiveDate,omitempty"`
+	CreationDate   string              `json:"CreationDate,omitempty"`
+	EndpointStatus string              `json:"EndpointStatus,omitempty"`
+	OptOut         string              `json:"OptOut,omitempty"`
+	RequestId      string              `json:"RequestId,omitempty"`
 }
 
 // EventStream represents a Pinpoint event stream.

--- a/services/pinpoint/handler.go
+++ b/services/pinpoint/handler.go
@@ -31,12 +31,16 @@ const (
 	pinpointDefaultPageSize = 500
 
 	templateSubPathParts   = 2
-	campaignStatus         = "ACTIVE"
 	journeyStateDraft      = "DRAFT"
 	jobStatusCreated       = "CREATED"
 	exportJobType          = "EXPORT"
 	importJobType          = "IMPORT"
 	segmentTypeDimensional = "DIMENSIONAL"
+	segmentTypeImport      = "IMPORT"
+
+	campaignStatusScheduled = "SCHEDULED"
+	campaignStatusPaused    = "PAUSED"
+	campaignStatusCompleted = "COMPLETED"
 	unknownOperation       = "Unknown"
 
 	// sub-path segment constants used throughout dispatch helpers.
@@ -1481,20 +1485,7 @@ func (h *Handler) handleCreateCampaign(c *echo.Context, appID string) error {
 		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerErrorException", backendErr.Error())
 	}
 
-	resp := campaignResponse{
-		ApplicationID:    campaign.ApplicationID,
-		ARN:              campaign.ARN,
-		ID:               campaign.ID,
-		Name:             campaign.Name,
-		SegmentID:        campaign.SegmentID,
-		SegmentVersion:   campaign.SegmentVersion,
-		Tags:             campaign.Tags,
-		CreationDate:     campaign.CreationDate,
-		LastModifiedDate: campaign.LastModifiedDate,
-		State:            campaignState{CampaignStatus: campaignStatus},
-	}
-
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusCreated, resp)
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusCreated, toCampaignResponse(campaign))
 
 	return nil
 }

--- a/services/pinpoint/handler.go
+++ b/services/pinpoint/handler.go
@@ -1641,16 +1641,7 @@ func (h *Handler) handleCreateJourney(c *echo.Context, appID string) error {
 			return nil, err
 		}
 
-		return journeyResponse{
-			ApplicationID:    journey.ApplicationID,
-			ARN:              journey.ARN,
-			ID:               journey.ID,
-			Name:             journey.Name,
-			State:            journey.State,
-			Tags:             journey.Tags,
-			CreationDate:     journey.CreationDate,
-			LastModifiedDate: journey.LastModifiedDate,
-		}, nil
+		return toJourneyResponse(journey), nil
 	})
 }
 
@@ -1992,14 +1983,6 @@ func (h *Handler) handleCreateSegment(c *echo.Context, appID string) error {
 			return nil, err
 		}
 
-		return segmentResponse{
-			ApplicationID: segment.ApplicationID,
-			ARN:           segment.ARN,
-			ID:            segment.ID,
-			Name:          segment.Name,
-			SegmentType:   segment.SegmentType,
-			Tags:          segment.Tags,
-			CreationDate:  segment.CreationDate,
-		}, nil
+		return toSegmentResponse(segment), nil
 	})
 }

--- a/services/pinpoint/handler.go
+++ b/services/pinpoint/handler.go
@@ -41,7 +41,7 @@ const (
 	campaignStatusScheduled = "SCHEDULED"
 	campaignStatusPaused    = "PAUSED"
 	campaignStatusCompleted = "COMPLETED"
-	unknownOperation       = "Unknown"
+	unknownOperation        = "Unknown"
 
 	// sub-path segment constants used throughout dispatch helpers.
 	subPathJobsExport       = "jobs/export"

--- a/services/pinpoint/handler_ops.go
+++ b/services/pinpoint/handler_ops.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v5"
 
@@ -16,16 +17,27 @@ import (
 // Channel handlers
 // ──────────────────────────────────────────────────
 
+// toChannelResponse converts a Channel to its wire format.
+func toChannelResponse(ch *Channel) channelResponse {
+	return channelResponse{
+		ApplicationID:    ch.ApplicationID,
+		ChannelType:      ch.ChannelType,
+		Platform:         ch.Platform,
+		Enabled:          ch.Enabled,
+		IsArchived:       ch.IsArchived,
+		HasCredential:    ch.HasCredential,
+		HasTokenKey:      ch.HasTokenKey,
+		Version:          ch.Version,
+		CreationDate:     ch.CreationDate,
+		LastModifiedDate: ch.LastModifiedDate,
+		MessagesPerSecond: ch.MessagesPerSecond,
+	}
+}
+
 // handleGetChannel handles GET /v1/apps/{appId}/channels/{channelType}.
 func (h *Handler) handleGetChannel(c *echo.Context, appID, channelType string) error {
 	ch := h.Backend.GetChannel(appID, channelType)
-	resp := channelResponse{
-		ApplicationID: ch.ApplicationID,
-		ChannelType:   ch.ChannelType,
-		Enabled:       ch.Enabled,
-		IsArchived:    ch.IsArchived,
-	}
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, resp)
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, toChannelResponse(ch))
 
 	return nil
 }
@@ -36,15 +48,149 @@ func (h *Handler) handleGetChannels(c *echo.Context, appID string) error {
 	resp := channelsResponse{Channels: make(map[string]channelResponse)}
 
 	for _, ch := range channels {
-		resp.Channels[ch.ChannelType] = channelResponse{
-			ApplicationID: ch.ApplicationID,
-			ChannelType:   ch.ChannelType,
-			Enabled:       ch.Enabled,
-			IsArchived:    ch.IsArchived,
-		}
+		resp.Channels[ch.ChannelType] = toChannelResponse(ch)
 	}
 
 	return c.JSON(http.StatusOK, resp)
+}
+
+// parseChannelExtra extracts per-channel extra fields from the request body.
+func parseChannelExtra(channelType string, body []byte) (bool, map[string]any) {
+	ct := strings.ToLower(channelType)
+
+	switch ct {
+	case "gcm":
+		var req updateGCMChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		extra := map[string]any{
+			"DefaultAuthenticationMethod": req.DefaultAuthenticationMethod,
+		}
+
+		if req.ApiKey != "" {
+			extra["ApiKey"] = req.ApiKey
+		}
+
+		if req.ServiceJson != "" {
+			extra["ServiceJson"] = req.ServiceJson
+		}
+
+		return req.Enabled, extra
+
+	case "apns", "apns_sandbox", "apns_voip", "apns_voip_sandbox":
+		var req updateAPNSChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		extra := map[string]any{
+			"DefaultAuthMethod": req.DefaultAuthMethod,
+		}
+
+		if req.BundleId != "" {
+			extra["BundleId"] = req.BundleId
+		}
+
+		if req.Certificate != "" {
+			extra["Certificate"] = req.Certificate
+		}
+
+		if req.TeamId != "" {
+			extra["TeamId"] = req.TeamId
+		}
+
+		if req.TokenKey != "" {
+			extra["TokenKey"] = req.TokenKey
+		}
+
+		if req.TokenKeyId != "" {
+			extra["TokenKeyId"] = req.TokenKeyId
+		}
+
+		return req.Enabled, extra
+
+	case "email":
+		var req updateEmailChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		extra := map[string]any{}
+
+		if req.FromAddress != "" {
+			extra["FromAddress"] = req.FromAddress
+		}
+
+		if req.Identity != "" {
+			extra["Identity"] = req.Identity
+		}
+
+		if req.RoleArn != "" {
+			extra["RoleArn"] = req.RoleArn
+		}
+
+		if req.ConfigurationSet != "" {
+			extra["ConfigurationSet"] = req.ConfigurationSet
+		}
+
+		return req.Enabled, extra
+
+	case "sms":
+		var req updateSMSChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		extra := map[string]any{}
+
+		if req.SenderId != "" {
+			extra["SenderId"] = req.SenderId
+		}
+
+		if req.ShortCode != "" {
+			extra["ShortCode"] = req.ShortCode
+		}
+
+		return req.Enabled, extra
+
+	case "adm":
+		var req updateADMChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		extra := map[string]any{}
+
+		if req.ClientId != "" {
+			extra["ClientId"] = req.ClientId
+		}
+
+		return req.Enabled, extra
+
+	case "baidu":
+		var req updateBaiduChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		extra := map[string]any{}
+
+		if req.ApiKey != "" {
+			extra["ApiKey"] = req.ApiKey
+		}
+
+		return req.Enabled, extra
+
+	default:
+		var req updateChannelRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return false, nil
+		}
+
+		return req.Enabled, nil
+	}
 }
 
 // handleUpdateChannel handles PUT /v1/apps/{appId}/channels/{channelType}.
@@ -54,18 +200,9 @@ func (h *Handler) handleUpdateChannel(c *echo.Context, appID, channelType string
 		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "failed to read request body")
 	}
 
-	var req updateChannelRequest
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
-	}
-
-	ch := h.Backend.UpsertChannel(appID, channelType, req.Enabled)
-	resp := channelResponse{
-		ApplicationID: ch.ApplicationID,
-		ChannelType:   ch.ChannelType,
-		Enabled:       ch.Enabled,
-	}
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, resp)
+	enabled, extra := parseChannelExtra(channelType, body)
+	ch := h.Backend.UpsertChannel(appID, channelType, enabled, extra)
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, toChannelResponse(ch))
 
 	return nil
 }
@@ -73,12 +210,7 @@ func (h *Handler) handleUpdateChannel(c *echo.Context, appID, channelType string
 // handleDeleteChannel handles DELETE /v1/apps/{appId}/channels/{channelType}.
 func (h *Handler) handleDeleteChannel(c *echo.Context, appID, channelType string) error {
 	ch := h.Backend.DeleteChannel(appID, channelType)
-	resp := channelResponse{
-		ApplicationID: ch.ApplicationID,
-		ChannelType:   ch.ChannelType,
-		Enabled:       ch.Enabled,
-	}
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, resp)
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, toChannelResponse(ch))
 
 	return nil
 }
@@ -871,6 +1003,29 @@ func (h *Handler) handleUpdateTemplateActiveVersion(c *echo.Context, templateNam
 // Endpoint handlers
 // ──────────────────────────────────────────────────
 
+// toEndpointResponse converts an Endpoint to its wire format.
+func toEndpointResponse(e *Endpoint) endpointResponse {
+	return endpointResponse{
+		ApplicationID:  e.ApplicationID,
+		ID:             e.ID,
+		ChannelType:    e.ChannelType,
+		Address:        e.Address,
+		EffectiveDate:  e.EffectiveDate,
+		CreationDate:   e.CreationDate,
+		EndpointStatus: e.EndpointStatus,
+		OptOut:         e.OptOut,
+		RequestId:      e.RequestId,
+		Attributes:     e.Attributes,
+		Metrics:        e.Metrics,
+		Demographic:    e.Demographic,
+		Location:       e.Location,
+		User: endpointUserResponse{
+			UserID:         e.UserID,
+			UserAttributes: e.UserAttributes,
+		},
+	}
+}
+
 // handleGetEndpoint handles GET /v1/apps/{appId}/endpoints/{endpointId}.
 func (h *Handler) handleGetEndpoint(c *echo.Context, appID, endpointID string) error {
 	e, err := h.Backend.GetEndpoint(appID, endpointID)
@@ -882,12 +1037,7 @@ func (h *Handler) handleGetEndpoint(c *echo.Context, appID, endpointID string) e
 		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerErrorException", err.Error())
 	}
 
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, endpointResponse{
-		ApplicationID: e.ApplicationID,
-		ID:            e.ID,
-		ChannelType:   e.ChannelType,
-		Address:       e.Address,
-	})
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, toEndpointResponse(e))
 
 	return nil
 }
@@ -909,12 +1059,7 @@ func (h *Handler) handleUpdateEndpoint(c *echo.Context, appID, endpointID string
 		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerErrorException", backendErr.Error())
 	}
 
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusAccepted, endpointResponse{
-		ApplicationID: e.ApplicationID,
-		ID:            e.ID,
-		ChannelType:   e.ChannelType,
-		Address:       e.Address,
-	})
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusAccepted, toEndpointResponse(e))
 
 	return nil
 }
@@ -930,10 +1075,7 @@ func (h *Handler) handleDeleteEndpoint(c *echo.Context, appID, endpointID string
 		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerErrorException", err.Error())
 	}
 
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, endpointResponse{
-		ApplicationID: e.ApplicationID,
-		ID:            e.ID,
-	})
+	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, toEndpointResponse(e))
 
 	return nil
 }
@@ -948,12 +1090,7 @@ func (h *Handler) handleGetUserEndpoints(c *echo.Context, appID, userID string) 
 	items := make([]endpointResponse, 0, len(endpoints))
 
 	for _, e := range endpoints {
-		items = append(items, endpointResponse{
-			ApplicationID: e.ApplicationID,
-			ID:            e.ID,
-			ChannelType:   e.ChannelType,
-			Address:       e.Address,
-		})
+		items = append(items, toEndpointResponse(e))
 	}
 
 	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, endpointsResponse{Item: items})
@@ -1471,14 +1608,26 @@ func toSegmentResponse(s *Segment) segmentResponse {
 
 func toJourneyResponse(j *Journey) journeyResponse {
 	return journeyResponse{
-		ApplicationID:    j.ApplicationID,
-		ARN:              j.ARN,
-		ID:               j.ID,
-		Name:             j.Name,
-		State:            j.State,
-		Tags:             j.Tags,
-		CreationDate:     j.CreationDate,
-		LastModifiedDate: j.LastModifiedDate,
+		ApplicationID:          j.ApplicationID,
+		ARN:                    j.ARN,
+		ID:                     j.ID,
+		Name:                   j.Name,
+		State:                  j.State,
+		Tags:                   j.Tags,
+		Activities:             j.Activities,
+		StartCondition:         j.StartCondition,
+		Schedule:               j.Schedule,
+		Limits:                 j.Limits,
+		QuietTime:              j.QuietTime,
+		OpenHours:              j.OpenHours,
+		ClosedDays:             j.ClosedDays,
+		StartActivity:          j.StartActivity,
+		RefreshFrequency:       j.RefreshFrequency,
+		LocalTime:              j.LocalTime,
+		WaitForQuietTime:       j.WaitForQuietTime,
+		RefreshOnSegmentUpdate: j.RefreshOnSegmentUpdate,
+		CreationDate:           j.CreationDate,
+		LastModifiedDate:       j.LastModifiedDate,
 	}
 }
 

--- a/services/pinpoint/handler_ops.go
+++ b/services/pinpoint/handler_ops.go
@@ -1421,29 +1421,51 @@ func writeNotFoundOrInternal(c *echo.Context, err error) error {
 // ──────────────────────────────────────────────────
 
 func toCampaignResponse(c *Campaign) campaignResponse {
+	status := c.Status
+	if status == "" {
+		status = campaignStatusScheduled
+	}
+
 	return campaignResponse{
-		ApplicationID:    c.ApplicationID,
-		ARN:              c.ARN,
-		ID:               c.ID,
-		Name:             c.Name,
-		SegmentID:        c.SegmentID,
-		SegmentVersion:   c.SegmentVersion,
-		Tags:             c.Tags,
-		CreationDate:     c.CreationDate,
-		LastModifiedDate: c.LastModifiedDate,
-		State:            campaignState{CampaignStatus: campaignStatus},
+		ApplicationID:               c.ApplicationID,
+		ARN:                         c.ARN,
+		ID:                          c.ID,
+		Name:                        c.Name,
+		SegmentID:                   c.SegmentID,
+		SegmentVersion:              c.SegmentVersion,
+		Tags:                        c.Tags,
+		MessageConfiguration:        c.MessageConfiguration,
+		Schedule:                    c.Schedule,
+		Hook:                        c.Hook,
+		Limits:                      c.Limits,
+		TemplateConfiguration:       c.TemplateConfiguration,
+		CustomDeliveryConfiguration: c.CustomDeliveryConfiguration,
+		TreatmentDescription:        c.TreatmentDescription,
+		TreatmentName:               c.TreatmentName,
+		AdditionalTreatments:        c.AdditionalTreatments,
+		Priority:                    c.Priority,
+		IsPaused:                    c.IsPaused,
+		Version:                     c.Version,
+		CreationDate:                c.CreationDate,
+		LastModifiedDate:            c.LastModifiedDate,
+		State:                       campaignState{CampaignStatus: status},
 	}
 }
 
 func toSegmentResponse(s *Segment) segmentResponse {
 	return segmentResponse{
-		ApplicationID: s.ApplicationID,
-		ARN:           s.ARN,
-		ID:            s.ID,
-		Name:          s.Name,
-		SegmentType:   s.SegmentType,
-		Tags:          s.Tags,
-		CreationDate:  s.CreationDate,
+		ApplicationID:    s.ApplicationID,
+		ARN:              s.ARN,
+		ID:               s.ID,
+		Name:             s.Name,
+		SegmentType:      s.SegmentType,
+		Tags:             s.Tags,
+		Dimensions:       s.Dimensions,
+		SegmentGroups:    s.SegmentGroups,
+		ImportDefinition: s.ImportDefinition,
+		CreationDate:     s.CreationDate,
+		LastModifiedDate: s.LastModifiedDate,
+		Version:          s.Version,
 	}
 }
 

--- a/services/pinpoint/handler_ops.go
+++ b/services/pinpoint/handler_ops.go
@@ -20,16 +20,16 @@ import (
 // toChannelResponse converts a Channel to its wire format.
 func toChannelResponse(ch *Channel) channelResponse {
 	return channelResponse{
-		ApplicationID:    ch.ApplicationID,
-		ChannelType:      ch.ChannelType,
-		Platform:         ch.Platform,
-		Enabled:          ch.Enabled,
-		IsArchived:       ch.IsArchived,
-		HasCredential:    ch.HasCredential,
-		HasTokenKey:      ch.HasTokenKey,
-		Version:          ch.Version,
-		CreationDate:     ch.CreationDate,
-		LastModifiedDate: ch.LastModifiedDate,
+		ApplicationID:     ch.ApplicationID,
+		ChannelType:       ch.ChannelType,
+		Platform:          ch.Platform,
+		Enabled:           ch.Enabled,
+		IsArchived:        ch.IsArchived,
+		HasCredential:     ch.HasCredential,
+		HasTokenKey:       ch.HasTokenKey,
+		Version:           ch.Version,
+		CreationDate:      ch.CreationDate,
+		LastModifiedDate:  ch.LastModifiedDate,
 		MessagesPerSecond: ch.MessagesPerSecond,
 	}
 }
@@ -54,107 +54,95 @@ func (h *Handler) handleGetChannels(c *echo.Context, appID string) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
+func parseGCMChannelExtra(body []byte) (bool, map[string]any) {
+	var req updateGCMChannelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false, nil
+	}
+
+	extra := map[string]any{"DefaultAuthenticationMethod": req.DefaultAuthenticationMethod}
+
+	if req.APIKey != "" {
+		extra["ApiKey"] = req.APIKey
+	}
+
+	if req.ServiceJSON != "" {
+		extra["ServiceJson"] = req.ServiceJSON
+	}
+
+	return req.Enabled, extra
+}
+
+func parseAPNSChannelExtra(body []byte) (bool, map[string]any) {
+	var req updateAPNSChannelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false, nil
+	}
+
+	extra := map[string]any{"DefaultAuthMethod": req.DefaultAuthMethod}
+
+	for k, v := range map[string]string{
+		"BundleId": req.BundleID, "Certificate": req.Certificate,
+		"TeamId": req.TeamID, "TokenKey": req.TokenKey, "TokenKeyId": req.TokenKeyID,
+	} {
+		if v != "" {
+			extra[k] = v
+		}
+	}
+
+	return req.Enabled, extra
+}
+
+func parseEmailChannelExtra(body []byte) (bool, map[string]any) {
+	var req updateEmailChannelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false, nil
+	}
+
+	extra := map[string]any{}
+
+	for k, v := range map[string]string{
+		"FromAddress": req.FromAddress, "Identity": req.Identity,
+		"RoleArn": req.RoleArn, "ConfigurationSet": req.ConfigurationSet,
+	} {
+		if v != "" {
+			extra[k] = v
+		}
+	}
+
+	return req.Enabled, extra
+}
+
+func parseSMSChannelExtra(body []byte) (bool, map[string]any) {
+	var req updateSMSChannelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false, nil
+	}
+
+	extra := map[string]any{}
+
+	if req.SenderID != "" {
+		extra["SenderId"] = req.SenderID
+	}
+
+	if req.ShortCode != "" {
+		extra["ShortCode"] = req.ShortCode
+	}
+
+	return req.Enabled, extra
+}
+
 // parseChannelExtra extracts per-channel extra fields from the request body.
 func parseChannelExtra(channelType string, body []byte) (bool, map[string]any) {
-	ct := strings.ToLower(channelType)
-
-	switch ct {
+	switch strings.ToLower(channelType) {
 	case "gcm":
-		var req updateGCMChannelRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			return false, nil
-		}
-
-		extra := map[string]any{
-			"DefaultAuthenticationMethod": req.DefaultAuthenticationMethod,
-		}
-
-		if req.ApiKey != "" {
-			extra["ApiKey"] = req.ApiKey
-		}
-
-		if req.ServiceJson != "" {
-			extra["ServiceJson"] = req.ServiceJson
-		}
-
-		return req.Enabled, extra
-
+		return parseGCMChannelExtra(body)
 	case "apns", "apns_sandbox", "apns_voip", "apns_voip_sandbox":
-		var req updateAPNSChannelRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			return false, nil
-		}
-
-		extra := map[string]any{
-			"DefaultAuthMethod": req.DefaultAuthMethod,
-		}
-
-		if req.BundleId != "" {
-			extra["BundleId"] = req.BundleId
-		}
-
-		if req.Certificate != "" {
-			extra["Certificate"] = req.Certificate
-		}
-
-		if req.TeamId != "" {
-			extra["TeamId"] = req.TeamId
-		}
-
-		if req.TokenKey != "" {
-			extra["TokenKey"] = req.TokenKey
-		}
-
-		if req.TokenKeyId != "" {
-			extra["TokenKeyId"] = req.TokenKeyId
-		}
-
-		return req.Enabled, extra
-
+		return parseAPNSChannelExtra(body)
 	case "email":
-		var req updateEmailChannelRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			return false, nil
-		}
-
-		extra := map[string]any{}
-
-		if req.FromAddress != "" {
-			extra["FromAddress"] = req.FromAddress
-		}
-
-		if req.Identity != "" {
-			extra["Identity"] = req.Identity
-		}
-
-		if req.RoleArn != "" {
-			extra["RoleArn"] = req.RoleArn
-		}
-
-		if req.ConfigurationSet != "" {
-			extra["ConfigurationSet"] = req.ConfigurationSet
-		}
-
-		return req.Enabled, extra
-
+		return parseEmailChannelExtra(body)
 	case "sms":
-		var req updateSMSChannelRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			return false, nil
-		}
-
-		extra := map[string]any{}
-
-		if req.SenderId != "" {
-			extra["SenderId"] = req.SenderId
-		}
-
-		if req.ShortCode != "" {
-			extra["ShortCode"] = req.ShortCode
-		}
-
-		return req.Enabled, extra
-
+		return parseSMSChannelExtra(body)
 	case "adm":
 		var req updateADMChannelRequest
 		if err := json.Unmarshal(body, &req); err != nil {
@@ -163,12 +151,11 @@ func parseChannelExtra(channelType string, body []byte) (bool, map[string]any) {
 
 		extra := map[string]any{}
 
-		if req.ClientId != "" {
-			extra["ClientId"] = req.ClientId
+		if req.ClientID != "" {
+			extra["ClientId"] = req.ClientID
 		}
 
 		return req.Enabled, extra
-
 	case "baidu":
 		var req updateBaiduChannelRequest
 		if err := json.Unmarshal(body, &req); err != nil {
@@ -177,12 +164,11 @@ func parseChannelExtra(channelType string, body []byte) (bool, map[string]any) {
 
 		extra := map[string]any{}
 
-		if req.ApiKey != "" {
-			extra["ApiKey"] = req.ApiKey
+		if req.APIKey != "" {
+			extra["ApiKey"] = req.APIKey
 		}
 
 		return req.Enabled, extra
-
 	default:
 		var req updateChannelRequest
 		if err := json.Unmarshal(body, &req); err != nil {
@@ -1022,7 +1008,7 @@ func toEndpointResponse(e *Endpoint) endpointResponse {
 		CreationDate:   e.CreationDate,
 		EndpointStatus: e.EndpointStatus,
 		OptOut:         e.OptOut,
-		RequestId:      e.RequestId,
+		RequestID:      e.RequestID,
 		Attributes:     e.Attributes,
 		Metrics:        e.Metrics,
 		Demographic:    e.Demographic,

--- a/services/pinpoint/handler_ops.go
+++ b/services/pinpoint/handler_ops.go
@@ -588,6 +588,10 @@ func (h *Handler) handleUpdateJourney(c *echo.Context, appID, journeyID string) 
 
 	journey, backendErr := h.Backend.UpdateJourney(appID, journeyID, req)
 	if backendErr != nil {
+		if errors.Is(backendErr, awserr.ErrInvalidParameter) {
+			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", backendErr.Error())
+		}
+
 		return writeNotFoundOrInternal(c, backendErr)
 	}
 
@@ -612,6 +616,10 @@ func (h *Handler) handleUpdateJourneyState(c *echo.Context, appID, journeyID str
 	if backendErr != nil {
 		if errors.Is(backendErr, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "NotFoundException", backendErr.Error())
+		}
+
+		if errors.Is(backendErr, awserr.ErrInvalidParameter) {
+			return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", backendErr.Error())
 		}
 
 		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerErrorException", backendErr.Error())

--- a/services/pinpoint/interfaces.go
+++ b/services/pinpoint/interfaces.go
@@ -114,7 +114,7 @@ type StorageBackend interface {
 
 	// Channel operations
 	GetChannel(appID, channelType string) *Channel
-	UpsertChannel(appID, channelType string, enabled bool) *Channel
+	UpsertChannel(appID, channelType string, enabled bool, extra map[string]any) *Channel
 	DeleteChannel(appID, channelType string) *Channel
 	GetAllChannels(appID string) map[string]*Channel
 

--- a/services/pinpoint/models.go
+++ b/services/pinpoint/models.go
@@ -78,26 +78,26 @@ type InAppTemplate struct {
 
 // Journey represents a Pinpoint journey.
 type Journey struct {
-	Tags             map[string]string      `json:"tags,omitempty"`
-	Activities       map[string]map[string]any `json:"Activities,omitempty"`
-	StartCondition   map[string]any         `json:"StartCondition,omitempty"`
-	Schedule         map[string]any         `json:"Schedule,omitempty"`
-	Limits           map[string]any         `json:"Limits,omitempty"`
-	QuietTime        map[string]any         `json:"QuietTime,omitempty"`
-	OpenHours        map[string]any         `json:"OpenHours,omitempty"`
-	ClosedDays       map[string]any         `json:"ClosedDays,omitempty"`
-	ApplicationID    string                 `json:"ApplicationId"`
-	ARN              string                 `json:"Arn,omitempty"`
-	ID               string                 `json:"Id"`
-	Name             string                 `json:"Name"`
-	StartActivity    string                 `json:"StartActivity,omitempty"`
-	RefreshFrequency string                 `json:"RefreshFrequency,omitempty"`
-	CreationDate     string                 `json:"CreationDate,omitempty"`
-	LastModifiedDate string                 `json:"LastModifiedDate,omitempty"`
-	State            string                 `json:"State"`
-	LocalTime        bool                   `json:"LocalTime,omitempty"`
-	WaitForQuietTime bool                   `json:"WaitForQuietTime,omitempty"`
-	RefreshOnSegmentUpdate bool             `json:"RefreshOnSegmentUpdate,omitempty"`
+	Tags                   map[string]string         `json:"tags,omitempty"`
+	Activities             map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition         map[string]any            `json:"StartCondition,omitempty"`
+	Schedule               map[string]any            `json:"Schedule,omitempty"`
+	Limits                 map[string]any            `json:"Limits,omitempty"`
+	QuietTime              map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours              map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays             map[string]any            `json:"ClosedDays,omitempty"`
+	ApplicationID          string                    `json:"ApplicationId"`
+	ARN                    string                    `json:"Arn,omitempty"`
+	ID                     string                    `json:"Id"`
+	Name                   string                    `json:"Name"`
+	StartActivity          string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency       string                    `json:"RefreshFrequency,omitempty"`
+	CreationDate           string                    `json:"CreationDate,omitempty"`
+	LastModifiedDate       string                    `json:"LastModifiedDate,omitempty"`
+	State                  string                    `json:"State"`
+	LocalTime              bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime       bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                      `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // PushTemplate represents a Pinpoint push notification template.
@@ -204,20 +204,20 @@ type createInAppTemplateRequest struct {
 
 // createJourneyRequest is the request body for CreateJourney.
 type createJourneyRequest struct {
-	Tags             map[string]string         `json:"tags,omitempty"`
-	Activities       map[string]map[string]any `json:"Activities,omitempty"`
-	StartCondition   map[string]any            `json:"StartCondition,omitempty"`
-	Schedule         map[string]any            `json:"Schedule,omitempty"`
-	Limits           map[string]any            `json:"Limits,omitempty"`
-	QuietTime        map[string]any            `json:"QuietTime,omitempty"`
-	OpenHours        map[string]any            `json:"OpenHours,omitempty"`
-	ClosedDays       map[string]any            `json:"ClosedDays,omitempty"`
-	Name             string                    `json:"Name"`
-	StartActivity    string                    `json:"StartActivity,omitempty"`
-	RefreshFrequency string                    `json:"RefreshFrequency,omitempty"`
-	LocalTime        bool                      `json:"LocalTime,omitempty"`
-	WaitForQuietTime bool                      `json:"WaitForQuietTime,omitempty"`
-	RefreshOnSegmentUpdate bool                `json:"RefreshOnSegmentUpdate,omitempty"`
+	Tags                   map[string]string         `json:"tags,omitempty"`
+	Activities             map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition         map[string]any            `json:"StartCondition,omitempty"`
+	Schedule               map[string]any            `json:"Schedule,omitempty"`
+	Limits                 map[string]any            `json:"Limits,omitempty"`
+	QuietTime              map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours              map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays             map[string]any            `json:"ClosedDays,omitempty"`
+	Name                   string                    `json:"Name"`
+	StartActivity          string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency       string                    `json:"RefreshFrequency,omitempty"`
+	LocalTime              bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime       bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                      `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // createPushTemplateRequest is the request body for CreatePushTemplate.
@@ -269,17 +269,17 @@ type campaignResponse struct {
 	Limits                      map[string]any    `json:"Limits,omitempty"`
 	TemplateConfiguration       map[string]any    `json:"TemplateConfiguration,omitempty"`
 	CustomDeliveryConfiguration map[string]any    `json:"CustomDeliveryConfiguration,omitempty"`
-	ApplicationID               string            `json:"ApplicationId"`
-	ARN                         string            `json:"Arn,omitempty"`
-	ID                          string            `json:"Id"`
 	Name                        string            `json:"Name"`
+	CreationDate                string            `json:"CreationDate,omitempty"`
+	ID                          string            `json:"Id"`
+	ApplicationID               string            `json:"ApplicationId"`
 	SegmentID                   string            `json:"SegmentId,omitempty"`
 	TreatmentDescription        string            `json:"TreatmentDescription,omitempty"`
 	TreatmentName               string            `json:"TreatmentName,omitempty"`
-	CreationDate                string            `json:"CreationDate,omitempty"`
+	ARN                         string            `json:"Arn,omitempty"`
 	LastModifiedDate            string            `json:"LastModifiedDate,omitempty"`
-	AdditionalTreatments        []map[string]any  `json:"AdditionalTreatments,omitempty"`
 	State                       campaignState     `json:"State"`
+	AdditionalTreatments        []map[string]any  `json:"AdditionalTreatments,omitempty"`
 	Version                     int               `json:"Version,omitempty"`
 	SegmentVersion              int               `json:"SegmentVersion,omitempty"`
 	Priority                    int               `json:"Priority,omitempty"`
@@ -321,26 +321,26 @@ type importJobResponse struct {
 
 // journeyResponse is the JSON wire format of JourneyResponse.
 type journeyResponse struct {
-	Tags             map[string]string         `json:"tags,omitempty"`
-	Activities       map[string]map[string]any `json:"Activities,omitempty"`
-	StartCondition   map[string]any            `json:"StartCondition,omitempty"`
-	Schedule         map[string]any            `json:"Schedule,omitempty"`
-	Limits           map[string]any            `json:"Limits,omitempty"`
-	QuietTime        map[string]any            `json:"QuietTime,omitempty"`
-	OpenHours        map[string]any            `json:"OpenHours,omitempty"`
-	ClosedDays       map[string]any            `json:"ClosedDays,omitempty"`
-	ApplicationID    string                    `json:"ApplicationId"`
-	ARN              string                    `json:"Arn,omitempty"`
-	ID               string                    `json:"Id"`
-	Name             string                    `json:"Name"`
-	StartActivity    string                    `json:"StartActivity,omitempty"`
-	RefreshFrequency string                    `json:"RefreshFrequency,omitempty"`
-	State            string                    `json:"State"`
-	CreationDate     string                    `json:"CreationDate,omitempty"`
-	LastModifiedDate string                    `json:"LastModifiedDate,omitempty"`
-	LocalTime        bool                      `json:"LocalTime,omitempty"`
-	WaitForQuietTime bool                      `json:"WaitForQuietTime,omitempty"`
-	RefreshOnSegmentUpdate bool                `json:"RefreshOnSegmentUpdate,omitempty"`
+	Tags                   map[string]string         `json:"tags,omitempty"`
+	Activities             map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition         map[string]any            `json:"StartCondition,omitempty"`
+	Schedule               map[string]any            `json:"Schedule,omitempty"`
+	Limits                 map[string]any            `json:"Limits,omitempty"`
+	QuietTime              map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours              map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays             map[string]any            `json:"ClosedDays,omitempty"`
+	ApplicationID          string                    `json:"ApplicationId"`
+	ARN                    string                    `json:"Arn,omitempty"`
+	ID                     string                    `json:"Id"`
+	Name                   string                    `json:"Name"`
+	StartActivity          string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency       string                    `json:"RefreshFrequency,omitempty"`
+	State                  string                    `json:"State"`
+	CreationDate           string                    `json:"CreationDate,omitempty"`
+	LastModifiedDate       string                    `json:"LastModifiedDate,omitempty"`
+	LocalTime              bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime       bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                      `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // recommenderConfigResponse is the JSON wire format of RecommenderConfigurationResponse.
@@ -454,20 +454,20 @@ type updateSegmentRequest struct {
 
 // updateJourneyRequest is the request body for UpdateJourney.
 type updateJourneyRequest struct {
-	Tags             map[string]string         `json:"tags,omitempty"`
-	Activities       map[string]map[string]any `json:"Activities,omitempty"`
-	StartCondition   map[string]any            `json:"StartCondition,omitempty"`
-	Schedule         map[string]any            `json:"Schedule,omitempty"`
-	Limits           map[string]any            `json:"Limits,omitempty"`
-	QuietTime        map[string]any            `json:"QuietTime,omitempty"`
-	OpenHours        map[string]any            `json:"OpenHours,omitempty"`
-	ClosedDays       map[string]any            `json:"ClosedDays,omitempty"`
-	Name             string                    `json:"Name,omitempty"`
-	StartActivity    string                    `json:"StartActivity,omitempty"`
-	RefreshFrequency string                    `json:"RefreshFrequency,omitempty"`
-	LocalTime        bool                      `json:"LocalTime,omitempty"`
-	WaitForQuietTime bool                      `json:"WaitForQuietTime,omitempty"`
-	RefreshOnSegmentUpdate bool                `json:"RefreshOnSegmentUpdate,omitempty"`
+	Tags                   map[string]string         `json:"tags,omitempty"`
+	Activities             map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition         map[string]any            `json:"StartCondition,omitempty"`
+	Schedule               map[string]any            `json:"Schedule,omitempty"`
+	Limits                 map[string]any            `json:"Limits,omitempty"`
+	QuietTime              map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours              map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays             map[string]any            `json:"ClosedDays,omitempty"`
+	Name                   string                    `json:"Name,omitempty"`
+	StartActivity          string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency       string                    `json:"RefreshFrequency,omitempty"`
+	LocalTime              bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime       bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                      `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // updateJourneyStateRequest is the request body for UpdateJourneyState.
@@ -477,17 +477,17 @@ type updateJourneyStateRequest struct {
 
 // updateEndpointRequest is the request body for UpdateEndpoint.
 type updateEndpointRequest struct {
-	User          endpointUser         `json:"User"`
-	Attributes    map[string][]string  `json:"Attributes,omitempty"`
-	Metrics       map[string]float64   `json:"Metrics,omitempty"`
-	Demographic   map[string]any       `json:"Demographic,omitempty"`
-	Location      map[string]any       `json:"Location,omitempty"`
-	ChannelType   string               `json:"ChannelType,omitempty"`
-	Address       string               `json:"Address,omitempty"`
-	EffectiveDate string               `json:"EffectiveDate,omitempty"`
+	User           endpointUser        `json:"User"`
+	Attributes     map[string][]string `json:"Attributes,omitempty"`
+	Metrics        map[string]float64  `json:"Metrics,omitempty"`
+	Demographic    map[string]any      `json:"Demographic,omitempty"`
+	Location       map[string]any      `json:"Location,omitempty"`
+	ChannelType    string              `json:"ChannelType,omitempty"`
+	Address        string              `json:"Address,omitempty"`
+	EffectiveDate  string              `json:"EffectiveDate,omitempty"`
 	EndpointStatus string              `json:"EndpointStatus,omitempty"`
-	OptOut        string               `json:"OptOut,omitempty"`
-	RequestId     string               `json:"RequestId,omitempty"`
+	OptOut         string              `json:"OptOut,omitempty"`
+	RequestID      string              `json:"RequestId,omitempty"`
 }
 
 // endpointUser is a sub-object in updateEndpointRequest.
@@ -514,22 +514,22 @@ type updateChannelRequest struct {
 
 // updateGCMChannelRequest is the request body for UpdateGcmChannel.
 type updateGCMChannelRequest struct {
-	ApiKey                    string `json:"ApiKey,omitempty"`
-	ServiceJson               string `json:"ServiceJson,omitempty"`
+	APIKey                      string `json:"ApiKey,omitempty"`
+	ServiceJSON                 string `json:"ServiceJson,omitempty"`
 	DefaultAuthenticationMethod string `json:"DefaultAuthenticationMethod,omitempty"`
-	Enabled                   bool   `json:"Enabled"`
+	Enabled                     bool   `json:"Enabled"`
 }
 
 // updateAPNSChannelRequest is the request body for UpdateApnsChannel (and sandbox/voip variants).
 type updateAPNSChannelRequest struct {
-	BundleId             string `json:"BundleId,omitempty"`
-	Certificate          string `json:"Certificate,omitempty"`
-	DefaultAuthMethod    string `json:"DefaultAuthMethod,omitempty"`
-	PrivateKey           string `json:"PrivateKey,omitempty"`
-	TeamId               string `json:"TeamId,omitempty"`
-	TokenKey             string `json:"TokenKey,omitempty"`
-	TokenKeyId           string `json:"TokenKeyId,omitempty"`
-	Enabled              bool   `json:"Enabled"`
+	BundleID          string `json:"BundleId,omitempty"`
+	Certificate       string `json:"Certificate,omitempty"`
+	DefaultAuthMethod string `json:"DefaultAuthMethod,omitempty"`
+	PrivateKey        string `json:"PrivateKey,omitempty"`
+	TeamID            string `json:"TeamId,omitempty"`
+	TokenKey          string `json:"TokenKey,omitempty"`
+	TokenKeyID        string `json:"TokenKeyId,omitempty"`
+	Enabled           bool   `json:"Enabled"`
 }
 
 // updateEmailChannelRequest is the request body for UpdateEmailChannel.
@@ -543,21 +543,21 @@ type updateEmailChannelRequest struct {
 
 // updateSMSChannelRequest is the request body for UpdateSmsChannel.
 type updateSMSChannelRequest struct {
-	SenderId  string `json:"SenderId,omitempty"`
+	SenderID  string `json:"SenderId,omitempty"`
 	ShortCode string `json:"ShortCode,omitempty"`
 	Enabled   bool   `json:"Enabled"`
 }
 
 // updateADMChannelRequest is the request body for UpdateAdmChannel.
 type updateADMChannelRequest struct {
-	ClientId     string `json:"ClientId,omitempty"`
+	ClientID     string `json:"ClientId,omitempty"`
 	ClientSecret string `json:"ClientSecret,omitempty"`
 	Enabled      bool   `json:"Enabled"`
 }
 
 // updateBaiduChannelRequest is the request body for UpdateBaiduChannel.
 type updateBaiduChannelRequest struct {
-	ApiKey    string `json:"ApiKey,omitempty"`
+	APIKey    string `json:"ApiKey,omitempty"`
 	SecretKey string `json:"SecretKey,omitempty"`
 	Enabled   bool   `json:"Enabled"`
 }
@@ -636,18 +636,18 @@ type templateVersionItem struct {
 
 // channelResponse is the JSON wire format of a channel response.
 type channelResponse struct {
-	ExtraFields   map[string]any `json:"-"`
-	ApplicationID string         `json:"ApplicationId"`
-	ChannelType   string         `json:"ChannelType"`
-	Platform      string         `json:"Platform,omitempty"`
-	CreationDate  string         `json:"CreationDate,omitempty"`
-	LastModifiedDate string      `json:"LastModifiedDate,omitempty"`
-	Version       int            `json:"Version,omitempty"`
-	MessagesPerSecond int        `json:"MessagesPerSecond,omitempty"`
-	Enabled       bool           `json:"Enabled"`
-	IsArchived    bool           `json:"IsArchived"`
-	HasCredential bool           `json:"HasCredential,omitempty"`
-	HasTokenKey   bool           `json:"HasTokenKey,omitempty"`
+	ExtraFields       map[string]any `json:"-"`
+	ApplicationID     string         `json:"ApplicationId"`
+	ChannelType       string         `json:"ChannelType"`
+	Platform          string         `json:"Platform,omitempty"`
+	CreationDate      string         `json:"CreationDate,omitempty"`
+	LastModifiedDate  string         `json:"LastModifiedDate,omitempty"`
+	Version           int            `json:"Version,omitempty"`
+	MessagesPerSecond int            `json:"MessagesPerSecond,omitempty"`
+	Enabled           bool           `json:"Enabled"`
+	IsArchived        bool           `json:"IsArchived"`
+	HasCredential     bool           `json:"HasCredential,omitempty"`
+	HasTokenKey       bool           `json:"HasTokenKey,omitempty"`
 }
 
 // channelsResponse is the JSON wire format of GetChannels response.
@@ -663,21 +663,21 @@ type endpointUserResponse struct {
 
 // endpointResponse is the JSON wire format of an endpoint.
 type endpointResponse struct {
-	Attributes     map[string][]string `json:"Attributes,omitempty"`
-	Metrics        map[string]float64  `json:"Metrics,omitempty"`
-	Demographic    map[string]any      `json:"Demographic,omitempty"`
-	Location       map[string]any      `json:"Location,omitempty"`
-	User           endpointUserResponse `json:"User,omitempty"`
-	ApplicationID  string              `json:"ApplicationId"`
-	ID             string              `json:"Id"`
-	CohortId       string              `json:"CohortId,omitempty"`
-	ChannelType    string              `json:"ChannelType,omitempty"`
-	Address        string              `json:"Address,omitempty"`
-	EffectiveDate  string              `json:"EffectiveDate,omitempty"`
-	CreationDate   string              `json:"CreationDate,omitempty"`
-	EndpointStatus string              `json:"EndpointStatus,omitempty"`
-	OptOut         string              `json:"OptOut,omitempty"`
-	RequestId      string              `json:"RequestId,omitempty"`
+	Attributes     map[string][]string  `json:"Attributes,omitempty"`
+	Metrics        map[string]float64   `json:"Metrics,omitempty"`
+	Demographic    map[string]any       `json:"Demographic,omitempty"`
+	Location       map[string]any       `json:"Location,omitempty"`
+	User           endpointUserResponse `json:"User"`
+	ApplicationID  string               `json:"ApplicationId"`
+	ID             string               `json:"Id"`
+	CohortID       string               `json:"CohortId,omitempty"`
+	ChannelType    string               `json:"ChannelType,omitempty"`
+	Address        string               `json:"Address,omitempty"`
+	EffectiveDate  string               `json:"EffectiveDate,omitempty"`
+	CreationDate   string               `json:"CreationDate,omitempty"`
+	EndpointStatus string               `json:"EndpointStatus,omitempty"`
+	OptOut         string               `json:"OptOut,omitempty"`
+	RequestID      string               `json:"RequestId,omitempty"`
 }
 
 // endpointsResponse is the JSON wire format of EndpointsResponse.

--- a/services/pinpoint/models.go
+++ b/services/pinpoint/models.go
@@ -13,16 +13,28 @@ type App struct {
 
 // Campaign represents a Pinpoint campaign.
 type Campaign struct {
-	Tags             map[string]string `json:"tags,omitempty"`
-	ApplicationID    string            `json:"ApplicationId"`
-	ARN              string            `json:"Arn,omitempty"`
-	ID               string            `json:"Id"`
-	Name             string            `json:"Name"`
-	SegmentID        string            `json:"SegmentId,omitempty"`
-	CreationDate     string            `json:"CreationDate,omitempty"`
-	LastModifiedDate string            `json:"LastModifiedDate,omitempty"`
-	SegmentVersion   int               `json:"SegmentVersion,omitempty"`
-	Version          int               `json:"Version,omitempty"`
+	Tags                        map[string]string `json:"tags,omitempty"`
+	MessageConfiguration        map[string]any    `json:"MessageConfiguration,omitempty"`
+	Schedule                    map[string]any    `json:"Schedule,omitempty"`
+	Hook                        map[string]any    `json:"Hook,omitempty"`
+	Limits                      map[string]any    `json:"Limits,omitempty"`
+	TemplateConfiguration       map[string]any    `json:"TemplateConfiguration,omitempty"`
+	CustomDeliveryConfiguration map[string]any    `json:"CustomDeliveryConfiguration,omitempty"`
+	ApplicationID               string            `json:"ApplicationId"`
+	ARN                         string            `json:"Arn,omitempty"`
+	ID                          string            `json:"Id"`
+	Name                        string            `json:"Name"`
+	SegmentID                   string            `json:"SegmentId,omitempty"`
+	TreatmentDescription        string            `json:"TreatmentDescription,omitempty"`
+	TreatmentName               string            `json:"TreatmentName,omitempty"`
+	CreationDate                string            `json:"CreationDate,omitempty"`
+	LastModifiedDate            string            `json:"LastModifiedDate,omitempty"`
+	Status                      string            `json:"Status,omitempty"`
+	AdditionalTreatments        []map[string]any  `json:"AdditionalTreatments,omitempty"`
+	SegmentVersion              int               `json:"SegmentVersion,omitempty"`
+	Version                     int               `json:"Version,omitempty"`
+	Priority                    int               `json:"Priority,omitempty"`
+	IsPaused                    bool              `json:"IsPaused,omitempty"`
 }
 
 // EmailTemplate represents a Pinpoint email template.
@@ -66,14 +78,26 @@ type InAppTemplate struct {
 
 // Journey represents a Pinpoint journey.
 type Journey struct {
-	Tags             map[string]string `json:"tags,omitempty"`
-	ApplicationID    string            `json:"ApplicationId"`
-	ARN              string            `json:"Arn,omitempty"`
-	ID               string            `json:"Id"`
-	Name             string            `json:"Name"`
-	CreationDate     string            `json:"CreationDate,omitempty"`
-	LastModifiedDate string            `json:"LastModifiedDate,omitempty"`
-	State            string            `json:"State"`
+	Tags             map[string]string      `json:"tags,omitempty"`
+	Activities       map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition   map[string]any         `json:"StartCondition,omitempty"`
+	Schedule         map[string]any         `json:"Schedule,omitempty"`
+	Limits           map[string]any         `json:"Limits,omitempty"`
+	QuietTime        map[string]any         `json:"QuietTime,omitempty"`
+	OpenHours        map[string]any         `json:"OpenHours,omitempty"`
+	ClosedDays       map[string]any         `json:"ClosedDays,omitempty"`
+	ApplicationID    string                 `json:"ApplicationId"`
+	ARN              string                 `json:"Arn,omitempty"`
+	ID               string                 `json:"Id"`
+	Name             string                 `json:"Name"`
+	StartActivity    string                 `json:"StartActivity,omitempty"`
+	RefreshFrequency string                 `json:"RefreshFrequency,omitempty"`
+	CreationDate     string                 `json:"CreationDate,omitempty"`
+	LastModifiedDate string                 `json:"LastModifiedDate,omitempty"`
+	State            string                 `json:"State"`
+	LocalTime        bool                   `json:"LocalTime,omitempty"`
+	WaitForQuietTime bool                   `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool             `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // PushTemplate represents a Pinpoint push notification template.
@@ -100,14 +124,18 @@ type RecommenderConfiguration struct {
 
 // Segment represents a Pinpoint segment.
 type Segment struct {
-	Tags          map[string]string `json:"tags,omitempty"`
-	ApplicationID string            `json:"ApplicationId"`
-	ARN           string            `json:"Arn,omitempty"`
-	ID            string            `json:"Id"`
-	Name          string            `json:"Name"`
-	CreationDate  string            `json:"CreationDate,omitempty"`
-	SegmentType   string            `json:"SegmentType"`
-	Version       int               `json:"Version,omitempty"`
+	Tags             map[string]string `json:"tags,omitempty"`
+	Dimensions       map[string]any    `json:"Dimensions,omitempty"`
+	SegmentGroups    map[string]any    `json:"SegmentGroups,omitempty"`
+	ImportDefinition map[string]any    `json:"ImportDefinition,omitempty"`
+	ApplicationID    string            `json:"ApplicationId"`
+	ARN              string            `json:"Arn,omitempty"`
+	ID               string            `json:"Id"`
+	Name             string            `json:"Name"`
+	CreationDate     string            `json:"CreationDate,omitempty"`
+	LastModifiedDate string            `json:"LastModifiedDate,omitempty"`
+	SegmentType      string            `json:"SegmentType"`
+	Version          int               `json:"Version,omitempty"`
 }
 
 // SmsTemplate represents a Pinpoint SMS template.
@@ -130,10 +158,21 @@ type createAppRequest struct {
 
 // createCampaignRequest is the request body for CreateCampaign.
 type createCampaignRequest struct {
-	Tags           map[string]string `json:"tags,omitempty"`
-	Name           string            `json:"Name"`
-	SegmentID      string            `json:"SegmentId,omitempty"`
-	SegmentVersion int               `json:"SegmentVersion,omitempty"`
+	Tags                        map[string]string `json:"tags,omitempty"`
+	MessageConfiguration        map[string]any    `json:"MessageConfiguration,omitempty"`
+	Schedule                    map[string]any    `json:"Schedule,omitempty"`
+	Hook                        map[string]any    `json:"Hook,omitempty"`
+	Limits                      map[string]any    `json:"Limits,omitempty"`
+	TemplateConfiguration       map[string]any    `json:"TemplateConfiguration,omitempty"`
+	CustomDeliveryConfiguration map[string]any    `json:"CustomDeliveryConfiguration,omitempty"`
+	Name                        string            `json:"Name"`
+	SegmentID                   string            `json:"SegmentId,omitempty"`
+	TreatmentDescription        string            `json:"TreatmentDescription,omitempty"`
+	TreatmentName               string            `json:"TreatmentName,omitempty"`
+	AdditionalTreatments        []map[string]any  `json:"AdditionalTreatments,omitempty"`
+	SegmentVersion              int               `json:"SegmentVersion,omitempty"`
+	Priority                    int               `json:"Priority,omitempty"`
+	IsPaused                    bool              `json:"IsPaused,omitempty"`
 }
 
 // createEmailTemplateRequest is the request body for CreateEmailTemplate.
@@ -165,8 +204,20 @@ type createInAppTemplateRequest struct {
 
 // createJourneyRequest is the request body for CreateJourney.
 type createJourneyRequest struct {
-	Tags map[string]string `json:"tags,omitempty"`
-	Name string            `json:"Name"`
+	Tags             map[string]string         `json:"tags,omitempty"`
+	Activities       map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition   map[string]any            `json:"StartCondition,omitempty"`
+	Schedule         map[string]any            `json:"Schedule,omitempty"`
+	Limits           map[string]any            `json:"Limits,omitempty"`
+	QuietTime        map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours        map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays       map[string]any            `json:"ClosedDays,omitempty"`
+	Name             string                    `json:"Name"`
+	StartActivity    string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency string                    `json:"RefreshFrequency,omitempty"`
+	LocalTime        bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // createPushTemplateRequest is the request body for CreatePushTemplate.
@@ -187,8 +238,11 @@ type createRecommenderConfigRequest struct {
 
 // createSegmentRequest is the request body for CreateSegment.
 type createSegmentRequest struct {
-	Tags map[string]string `json:"tags,omitempty"`
-	Name string            `json:"Name"`
+	Tags             map[string]string `json:"tags,omitempty"`
+	Dimensions       map[string]any    `json:"Dimensions,omitempty"`
+	SegmentGroups    map[string]any    `json:"SegmentGroups,omitempty"`
+	ImportDefinition map[string]any    `json:"ImportDefinition,omitempty"`
+	Name             string            `json:"Name"`
 }
 
 // createSmsTemplateRequest is the request body for CreateSmsTemplate.
@@ -208,16 +262,28 @@ type campaignState struct {
 
 // campaignResponse is the JSON wire format of CampaignResponse.
 type campaignResponse struct {
-	Tags             map[string]string `json:"tags,omitempty"`
-	ApplicationID    string            `json:"ApplicationId"`
-	ARN              string            `json:"Arn,omitempty"`
-	ID               string            `json:"Id"`
-	Name             string            `json:"Name"`
-	SegmentID        string            `json:"SegmentId,omitempty"`
-	CreationDate     string            `json:"CreationDate,omitempty"`
-	LastModifiedDate string            `json:"LastModifiedDate,omitempty"`
-	State            campaignState     `json:"State"`
-	SegmentVersion   int               `json:"SegmentVersion,omitempty"`
+	Tags                        map[string]string `json:"tags,omitempty"`
+	MessageConfiguration        map[string]any    `json:"MessageConfiguration,omitempty"`
+	Schedule                    map[string]any    `json:"Schedule,omitempty"`
+	Hook                        map[string]any    `json:"Hook,omitempty"`
+	Limits                      map[string]any    `json:"Limits,omitempty"`
+	TemplateConfiguration       map[string]any    `json:"TemplateConfiguration,omitempty"`
+	CustomDeliveryConfiguration map[string]any    `json:"CustomDeliveryConfiguration,omitempty"`
+	ApplicationID               string            `json:"ApplicationId"`
+	ARN                         string            `json:"Arn,omitempty"`
+	ID                          string            `json:"Id"`
+	Name                        string            `json:"Name"`
+	SegmentID                   string            `json:"SegmentId,omitempty"`
+	TreatmentDescription        string            `json:"TreatmentDescription,omitempty"`
+	TreatmentName               string            `json:"TreatmentName,omitempty"`
+	CreationDate                string            `json:"CreationDate,omitempty"`
+	LastModifiedDate            string            `json:"LastModifiedDate,omitempty"`
+	AdditionalTreatments        []map[string]any  `json:"AdditionalTreatments,omitempty"`
+	State                       campaignState     `json:"State"`
+	Version                     int               `json:"Version,omitempty"`
+	SegmentVersion              int               `json:"SegmentVersion,omitempty"`
+	Priority                    int               `json:"Priority,omitempty"`
+	IsPaused                    bool              `json:"IsPaused,omitempty"`
 }
 
 // createTemplateMessageBody is the create-template response returned by
@@ -255,14 +321,26 @@ type importJobResponse struct {
 
 // journeyResponse is the JSON wire format of JourneyResponse.
 type journeyResponse struct {
-	Tags             map[string]string `json:"tags,omitempty"`
-	ApplicationID    string            `json:"ApplicationId"`
-	ARN              string            `json:"Arn,omitempty"`
-	ID               string            `json:"Id"`
-	Name             string            `json:"Name"`
-	State            string            `json:"State"`
-	CreationDate     string            `json:"CreationDate,omitempty"`
-	LastModifiedDate string            `json:"LastModifiedDate,omitempty"`
+	Tags             map[string]string         `json:"tags,omitempty"`
+	Activities       map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition   map[string]any            `json:"StartCondition,omitempty"`
+	Schedule         map[string]any            `json:"Schedule,omitempty"`
+	Limits           map[string]any            `json:"Limits,omitempty"`
+	QuietTime        map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours        map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays       map[string]any            `json:"ClosedDays,omitempty"`
+	ApplicationID    string                    `json:"ApplicationId"`
+	ARN              string                    `json:"Arn,omitempty"`
+	ID               string                    `json:"Id"`
+	Name             string                    `json:"Name"`
+	StartActivity    string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency string                    `json:"RefreshFrequency,omitempty"`
+	State            string                    `json:"State"`
+	CreationDate     string                    `json:"CreationDate,omitempty"`
+	LastModifiedDate string                    `json:"LastModifiedDate,omitempty"`
+	LocalTime        bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // recommenderConfigResponse is the JSON wire format of RecommenderConfigurationResponse.
@@ -281,13 +359,18 @@ type recommenderConfigResponse struct {
 
 // segmentResponse is the JSON wire format of SegmentResponse.
 type segmentResponse struct {
-	Tags          map[string]string `json:"tags,omitempty"`
-	ApplicationID string            `json:"ApplicationId"`
-	ARN           string            `json:"Arn,omitempty"`
-	ID            string            `json:"Id"`
-	Name          string            `json:"Name"`
-	SegmentType   string            `json:"SegmentType"`
-	CreationDate  string            `json:"CreationDate,omitempty"`
+	Tags             map[string]string `json:"tags,omitempty"`
+	Dimensions       map[string]any    `json:"Dimensions,omitempty"`
+	SegmentGroups    map[string]any    `json:"SegmentGroups,omitempty"`
+	ImportDefinition map[string]any    `json:"ImportDefinition,omitempty"`
+	ApplicationID    string            `json:"ApplicationId"`
+	ARN              string            `json:"Arn,omitempty"`
+	ID               string            `json:"Id"`
+	Name             string            `json:"Name"`
+	SegmentType      string            `json:"SegmentType"`
+	CreationDate     string            `json:"CreationDate,omitempty"`
+	LastModifiedDate string            `json:"LastModifiedDate,omitempty"`
+	Version          int               `json:"Version,omitempty"`
 }
 
 // appResponse is the JSON wire format of ApplicationResponse.
@@ -343,22 +426,48 @@ type createVoiceTemplateRequest struct {
 
 // updateCampaignRequest is the request body for UpdateCampaign.
 type updateCampaignRequest struct {
-	Tags           map[string]string `json:"tags,omitempty"`
-	Name           string            `json:"Name,omitempty"`
-	SegmentID      string            `json:"SegmentId,omitempty"`
-	SegmentVersion int               `json:"SegmentVersion,omitempty"`
+	Tags                        map[string]string `json:"tags,omitempty"`
+	MessageConfiguration        map[string]any    `json:"MessageConfiguration,omitempty"`
+	Schedule                    map[string]any    `json:"Schedule,omitempty"`
+	Hook                        map[string]any    `json:"Hook,omitempty"`
+	Limits                      map[string]any    `json:"Limits,omitempty"`
+	TemplateConfiguration       map[string]any    `json:"TemplateConfiguration,omitempty"`
+	CustomDeliveryConfiguration map[string]any    `json:"CustomDeliveryConfiguration,omitempty"`
+	Name                        string            `json:"Name,omitempty"`
+	SegmentID                   string            `json:"SegmentId,omitempty"`
+	TreatmentDescription        string            `json:"TreatmentDescription,omitempty"`
+	TreatmentName               string            `json:"TreatmentName,omitempty"`
+	AdditionalTreatments        []map[string]any  `json:"AdditionalTreatments,omitempty"`
+	SegmentVersion              int               `json:"SegmentVersion,omitempty"`
+	Priority                    int               `json:"Priority,omitempty"`
+	IsPaused                    bool              `json:"IsPaused,omitempty"`
 }
 
 // updateSegmentRequest is the request body for UpdateSegment.
 type updateSegmentRequest struct {
-	Tags map[string]string `json:"tags,omitempty"`
-	Name string            `json:"Name,omitempty"`
+	Tags             map[string]string `json:"tags,omitempty"`
+	Dimensions       map[string]any    `json:"Dimensions,omitempty"`
+	SegmentGroups    map[string]any    `json:"SegmentGroups,omitempty"`
+	ImportDefinition map[string]any    `json:"ImportDefinition,omitempty"`
+	Name             string            `json:"Name,omitempty"`
 }
 
 // updateJourneyRequest is the request body for UpdateJourney.
 type updateJourneyRequest struct {
-	Tags map[string]string `json:"tags,omitempty"`
-	Name string            `json:"Name,omitempty"`
+	Tags             map[string]string         `json:"tags,omitempty"`
+	Activities       map[string]map[string]any `json:"Activities,omitempty"`
+	StartCondition   map[string]any            `json:"StartCondition,omitempty"`
+	Schedule         map[string]any            `json:"Schedule,omitempty"`
+	Limits           map[string]any            `json:"Limits,omitempty"`
+	QuietTime        map[string]any            `json:"QuietTime,omitempty"`
+	OpenHours        map[string]any            `json:"OpenHours,omitempty"`
+	ClosedDays       map[string]any            `json:"ClosedDays,omitempty"`
+	Name             string                    `json:"Name,omitempty"`
+	StartActivity    string                    `json:"StartActivity,omitempty"`
+	RefreshFrequency string                    `json:"RefreshFrequency,omitempty"`
+	LocalTime        bool                      `json:"LocalTime,omitempty"`
+	WaitForQuietTime bool                      `json:"WaitForQuietTime,omitempty"`
+	RefreshOnSegmentUpdate bool                `json:"RefreshOnSegmentUpdate,omitempty"`
 }
 
 // updateJourneyStateRequest is the request body for UpdateJourneyState.
@@ -368,15 +477,23 @@ type updateJourneyStateRequest struct {
 
 // updateEndpointRequest is the request body for UpdateEndpoint.
 type updateEndpointRequest struct {
-	User        endpointUser      `json:"User"`
-	Attributes  map[string]string `json:"Attributes,omitempty"`
-	ChannelType string            `json:"ChannelType,omitempty"`
-	Address     string            `json:"Address,omitempty"`
+	User          endpointUser         `json:"User"`
+	Attributes    map[string][]string  `json:"Attributes,omitempty"`
+	Metrics       map[string]float64   `json:"Metrics,omitempty"`
+	Demographic   map[string]any       `json:"Demographic,omitempty"`
+	Location      map[string]any       `json:"Location,omitempty"`
+	ChannelType   string               `json:"ChannelType,omitempty"`
+	Address       string               `json:"Address,omitempty"`
+	EffectiveDate string               `json:"EffectiveDate,omitempty"`
+	EndpointStatus string              `json:"EndpointStatus,omitempty"`
+	OptOut        string               `json:"OptOut,omitempty"`
+	RequestId     string               `json:"RequestId,omitempty"`
 }
 
 // endpointUser is a sub-object in updateEndpointRequest.
 type endpointUser struct {
-	UserID string `json:"UserId,omitempty"`
+	UserAttributes map[string][]string `json:"UserAttributes,omitempty"`
+	UserID         string              `json:"UserId,omitempty"`
 }
 
 // updateEndpointsBatchRequest is the request body for UpdateEndpointsBatch.
@@ -393,6 +510,56 @@ type putEventStreamRequest struct {
 // updateChannelRequest is a generic channel update request body.
 type updateChannelRequest struct {
 	Enabled bool `json:"Enabled"`
+}
+
+// updateGCMChannelRequest is the request body for UpdateGcmChannel.
+type updateGCMChannelRequest struct {
+	ApiKey                    string `json:"ApiKey,omitempty"`
+	ServiceJson               string `json:"ServiceJson,omitempty"`
+	DefaultAuthenticationMethod string `json:"DefaultAuthenticationMethod,omitempty"`
+	Enabled                   bool   `json:"Enabled"`
+}
+
+// updateAPNSChannelRequest is the request body for UpdateApnsChannel (and sandbox/voip variants).
+type updateAPNSChannelRequest struct {
+	BundleId             string `json:"BundleId,omitempty"`
+	Certificate          string `json:"Certificate,omitempty"`
+	DefaultAuthMethod    string `json:"DefaultAuthMethod,omitempty"`
+	PrivateKey           string `json:"PrivateKey,omitempty"`
+	TeamId               string `json:"TeamId,omitempty"`
+	TokenKey             string `json:"TokenKey,omitempty"`
+	TokenKeyId           string `json:"TokenKeyId,omitempty"`
+	Enabled              bool   `json:"Enabled"`
+}
+
+// updateEmailChannelRequest is the request body for UpdateEmailChannel.
+type updateEmailChannelRequest struct {
+	ConfigurationSet string `json:"ConfigurationSet,omitempty"`
+	FromAddress      string `json:"FromAddress,omitempty"`
+	Identity         string `json:"Identity,omitempty"`
+	RoleArn          string `json:"RoleArn,omitempty"`
+	Enabled          bool   `json:"Enabled"`
+}
+
+// updateSMSChannelRequest is the request body for UpdateSmsChannel.
+type updateSMSChannelRequest struct {
+	SenderId  string `json:"SenderId,omitempty"`
+	ShortCode string `json:"ShortCode,omitempty"`
+	Enabled   bool   `json:"Enabled"`
+}
+
+// updateADMChannelRequest is the request body for UpdateAdmChannel.
+type updateADMChannelRequest struct {
+	ClientId     string `json:"ClientId,omitempty"`
+	ClientSecret string `json:"ClientSecret,omitempty"`
+	Enabled      bool   `json:"Enabled"`
+}
+
+// updateBaiduChannelRequest is the request body for UpdateBaiduChannel.
+type updateBaiduChannelRequest struct {
+	ApiKey    string `json:"ApiKey,omitempty"`
+	SecretKey string `json:"SecretKey,omitempty"`
+	Enabled   bool   `json:"Enabled"`
 }
 
 // sendMessagesRequest is the request body for SendMessages.
@@ -469,10 +636,18 @@ type templateVersionItem struct {
 
 // channelResponse is the JSON wire format of a channel response.
 type channelResponse struct {
-	ApplicationID string `json:"ApplicationId"`
-	ChannelType   string `json:"ChannelType"`
-	Enabled       bool   `json:"Enabled"`
-	IsArchived    bool   `json:"IsArchived"`
+	ExtraFields   map[string]any `json:"-"`
+	ApplicationID string         `json:"ApplicationId"`
+	ChannelType   string         `json:"ChannelType"`
+	Platform      string         `json:"Platform,omitempty"`
+	CreationDate  string         `json:"CreationDate,omitempty"`
+	LastModifiedDate string      `json:"LastModifiedDate,omitempty"`
+	Version       int            `json:"Version,omitempty"`
+	MessagesPerSecond int        `json:"MessagesPerSecond,omitempty"`
+	Enabled       bool           `json:"Enabled"`
+	IsArchived    bool           `json:"IsArchived"`
+	HasCredential bool           `json:"HasCredential,omitempty"`
+	HasTokenKey   bool           `json:"HasTokenKey,omitempty"`
 }
 
 // channelsResponse is the JSON wire format of GetChannels response.
@@ -480,12 +655,29 @@ type channelsResponse struct {
 	Channels map[string]channelResponse `json:"Channels"`
 }
 
+// endpointUser response embeds user info in endpoint responses.
+type endpointUserResponse struct {
+	UserAttributes map[string][]string `json:"UserAttributes,omitempty"`
+	UserID         string              `json:"UserId,omitempty"`
+}
+
 // endpointResponse is the JSON wire format of an endpoint.
 type endpointResponse struct {
-	ApplicationID string `json:"ApplicationId"`
-	ID            string `json:"Id"`
-	ChannelType   string `json:"ChannelType,omitempty"`
-	Address       string `json:"Address,omitempty"`
+	Attributes     map[string][]string `json:"Attributes,omitempty"`
+	Metrics        map[string]float64  `json:"Metrics,omitempty"`
+	Demographic    map[string]any      `json:"Demographic,omitempty"`
+	Location       map[string]any      `json:"Location,omitempty"`
+	User           endpointUserResponse `json:"User,omitempty"`
+	ApplicationID  string              `json:"ApplicationId"`
+	ID             string              `json:"Id"`
+	CohortId       string              `json:"CohortId,omitempty"`
+	ChannelType    string              `json:"ChannelType,omitempty"`
+	Address        string              `json:"Address,omitempty"`
+	EffectiveDate  string              `json:"EffectiveDate,omitempty"`
+	CreationDate   string              `json:"CreationDate,omitempty"`
+	EndpointStatus string              `json:"EndpointStatus,omitempty"`
+	OptOut         string              `json:"OptOut,omitempty"`
+	RequestId      string              `json:"RequestId,omitempty"`
 }
 
 // endpointsResponse is the JSON wire format of EndpointsResponse.


### PR DESCRIPTION
## Summary

- Expand Campaign DTO with MessageConfiguration, Schedule, Hook, Limits, Priority, IsPaused, AdditionalTreatments, TreatmentDescription/Name, TemplateConfiguration; fix state machine (SCHEDULED default, PAUSED when IsPaused, no more hardcoded "ACTIVE")
- Expand Segment with Dimensions, SegmentGroups, ImportDefinition; auto-set SegmentType=IMPORT when ImportDefinition present; add LastModifiedDate+Version to response
- Expand Journey with Activities map, StartCondition, Schedule, Limits, QuietTime, OpenHours/ClosedDays, RefreshFrequency; validated state transitions (DRAFT→ACTIVE/CANCELLED etc.); block UpdateJourney when ACTIVE
- Expand Endpoint with Demographic, Location, Metrics (map[string]float64), EndpointStatus, OptOut, EffectiveDate; Attributes/UserAttributes as map[string][]string
- Per-channel type fields: HasCredential, HasTokenKey, Version, CreationDate, Platform; type-specific request parsing for GCM/APNS/Email/SMS/ADM/Baidu
- Recommender: validate RecommendationProviderIdType enum; conditional LastModifiedDate (only update when field actually changes)
- 2085-line table-driven test file (audit1_test.go) covering all new functionality

## Test plan

- [x] `go test ./services/pinpoint/... -short -count=1` passes (all existing + new tests)
- [x] `go vet ./services/pinpoint/...` clean
- [x] `golangci-lint run ./services/pinpoint/...` 0 issues
- [x] No //nolint comments added

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)