### PR TITLE
feat(swf): AWS-accuracy audit batch-1 (go-ggz7)

### DIFF
--- a/services/swf/backend.go
+++ b/services/swf/backend.go
@@ -263,19 +263,64 @@ type activeActivityTaskRecord struct {
 	StartedEventID   int64
 }
 
+// activeDecisionTaskRecord tracks a decision task token dispatched to a poller.
+type activeDecisionTaskRecord struct {
+	Domain     string
+	WorkflowID string
+	RunID      string
+}
+
+// CompleteWorkflowExecutionDecisionAttrs holds attributes for CompleteWorkflowExecution.
+type CompleteWorkflowExecutionDecisionAttrs struct {
+	Result string
+}
+
+// FailWorkflowExecutionDecisionAttrs holds attributes for FailWorkflowExecution.
+type FailWorkflowExecutionDecisionAttrs struct {
+	Reason  string
+	Details string
+}
+
+// CancelWorkflowExecutionDecisionAttrs holds attributes for CancelWorkflowExecution.
+type CancelWorkflowExecutionDecisionAttrs struct {
+	Details string
+}
+
+// ScheduleActivityTaskDecisionAttrs holds attributes for ScheduleActivityTask.
+type ScheduleActivityTaskDecisionAttrs struct {
+	ActivityType           ActivityTaskActivityType
+	ActivityID             string
+	Input                  string
+	TaskList               string
+	ScheduleToCloseTimeout string
+	ScheduleToStartTimeout string
+	StartToCloseTimeout    string
+	HeartbeatTimeout       string
+}
+
+// Decision represents a single decision returned by a decider.
+type Decision struct {
+	DecisionType                   string
+	CompleteWorkflowExecutionAttrs *CompleteWorkflowExecutionDecisionAttrs
+	FailWorkflowExecutionAttrs     *FailWorkflowExecutionDecisionAttrs
+	CancelWorkflowExecutionAttrs   *CancelWorkflowExecutionDecisionAttrs
+	ScheduleActivityTaskAttrs      *ScheduleActivityTaskDecisionAttrs
+}
+
 // InMemoryBackend is the in-memory store for SWF resources.
 type InMemoryBackend struct {
-	domains             map[string]*Domain
-	workflows           map[string]*WorkflowType             // key: domain+":"+name+":"+version
-	activities          map[string]*ActivityType             // key: domain+":"+name+":"+version
-	executions          map[string]*WorkflowExecution        // key: domain+":"+workflowID
-	history             map[string][]HistoryEvent            // key: domain+":"+workflowID
-	activityQueues      map[string][]*ActivityTask           // key: domain+":"+taskList
-	decisionQueues      map[string][]*DecisionTask           // key: domain+":"+taskList
-	activeActivityTasks map[string]*activeActivityTaskRecord // key: taskToken
-	tags                map[string]map[string]string         // key: resourceARN
-	mu                  *lockmetrics.RWMutex
-	executionOrder      []string // FIFO order of execution keys for eviction
+	domains              map[string]*Domain
+	workflows            map[string]*WorkflowType              // key: domain+":"+name+":"+version
+	activities           map[string]*ActivityType              // key: domain+":"+name+":"+version
+	executions           map[string]*WorkflowExecution         // key: domain+":"+workflowID
+	history              map[string][]HistoryEvent             // key: domain+":"+workflowID
+	activityQueues       map[string][]*ActivityTask            // key: domain+":"+taskList
+	decisionQueues       map[string][]*DecisionTask            // key: domain+":"+taskList
+	activeActivityTasks  map[string]*activeActivityTaskRecord  // key: taskToken
+	activeDecisionTasks  map[string]*activeDecisionTaskRecord  // key: taskToken
+	tags                 map[string]map[string]string          // key: resourceARN
+	mu                   *lockmetrics.RWMutex
+	executionOrder       []string // FIFO order of execution keys for eviction
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
@@ -289,6 +334,7 @@ func NewInMemoryBackend() *InMemoryBackend {
 		activityQueues:      make(map[string][]*ActivityTask),
 		decisionQueues:      make(map[string][]*DecisionTask),
 		activeActivityTasks: make(map[string]*activeActivityTaskRecord),
+		activeDecisionTasks: make(map[string]*activeDecisionTaskRecord),
 		tags:                make(map[string]map[string]string),
 		mu:                  lockmetrics.New("swf"),
 	}
@@ -307,6 +353,7 @@ func (b *InMemoryBackend) Reset() {
 	b.activityQueues = make(map[string][]*ActivityTask)
 	b.decisionQueues = make(map[string][]*DecisionTask)
 	b.activeActivityTasks = make(map[string]*activeActivityTaskRecord)
+	b.activeDecisionTasks = make(map[string]*activeDecisionTaskRecord)
 	b.tags = make(map[string]map[string]string)
 	b.executionOrder = nil
 }
@@ -1425,6 +1472,12 @@ func (b *InMemoryBackend) PollForDecisionTask(
 	task := *queue[0]
 	b.decisionQueues[key] = queue[1:]
 	task.TaskToken = uuid.New().String()
+
+	b.activeDecisionTasks[task.TaskToken] = &activeDecisionTaskRecord{
+		Domain:     domain,
+		WorkflowID: task.WorkflowID,
+		RunID:      task.RunID,
+	}
 
 	histEvents := b.history[domain+":"+task.WorkflowID]
 	if len(histEvents) > 0 {

--- a/services/swf/backend.go
+++ b/services/swf/backend.go
@@ -60,6 +60,9 @@ const (
 
 	retentionNone     = "NONE"
 	attrDetails       = "details"
+	attrInput         = "input"
+	attrReason        = "reason"
+	attrName          = "name"
 	attrScheduledEvID = "scheduledEventId"
 	attrStartedEvID   = "startedEventId"
 )
@@ -300,27 +303,27 @@ type ScheduleActivityTaskDecisionAttrs struct {
 
 // Decision represents a single decision returned by a decider.
 type Decision struct {
-	DecisionType                   string
 	CompleteWorkflowExecutionAttrs *CompleteWorkflowExecutionDecisionAttrs
 	FailWorkflowExecutionAttrs     *FailWorkflowExecutionDecisionAttrs
 	CancelWorkflowExecutionAttrs   *CancelWorkflowExecutionDecisionAttrs
 	ScheduleActivityTaskAttrs      *ScheduleActivityTaskDecisionAttrs
+	DecisionType                   string
 }
 
 // InMemoryBackend is the in-memory store for SWF resources.
 type InMemoryBackend struct {
-	domains              map[string]*Domain
-	workflows            map[string]*WorkflowType              // key: domain+":"+name+":"+version
-	activities           map[string]*ActivityType              // key: domain+":"+name+":"+version
-	executions           map[string]*WorkflowExecution         // key: domain+":"+workflowID
-	history              map[string][]HistoryEvent             // key: domain+":"+workflowID
-	activityQueues       map[string][]*ActivityTask            // key: domain+":"+taskList
-	decisionQueues       map[string][]*DecisionTask            // key: domain+":"+taskList
-	activeActivityTasks  map[string]*activeActivityTaskRecord  // key: taskToken
-	activeDecisionTasks  map[string]*activeDecisionTaskRecord  // key: taskToken
-	tags                 map[string]map[string]string          // key: resourceARN
-	mu                   *lockmetrics.RWMutex
-	executionOrder       []string // FIFO order of execution keys for eviction
+	domains             map[string]*Domain
+	workflows           map[string]*WorkflowType             // key: domain+":"+name+":"+version
+	activities          map[string]*ActivityType             // key: domain+":"+name+":"+version
+	executions          map[string]*WorkflowExecution        // key: domain+":"+workflowID
+	history             map[string][]HistoryEvent            // key: domain+":"+workflowID
+	activityQueues      map[string][]*ActivityTask           // key: domain+":"+taskList
+	decisionQueues      map[string][]*DecisionTask           // key: domain+":"+taskList
+	activeActivityTasks map[string]*activeActivityTaskRecord // key: taskToken
+	activeDecisionTasks map[string]*activeDecisionTaskRecord // key: taskToken
+	tags                map[string]map[string]string         // key: resourceARN
+	mu                  *lockmetrics.RWMutex
+	executionOrder      []string // FIFO order of execution keys for eviction
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
@@ -1143,11 +1146,11 @@ func (b *InMemoryBackend) StartWorkflowExecution(
 	attrKey := eventAttrKey("WorkflowExecutionStarted")
 	attrs := map[string]any{
 		attrKey: map[string]any{
-			"input":       input.Input,
+			attrInput:     input.Input,
 			"childPolicy": childPolicy,
-			"taskList":    map[string]any{"name": taskList},
+			"taskList":    map[string]any{attrName: taskList},
 			"workflowType": map[string]any{
-				"name":    input.WorkflowTypeName,
+				attrName:  input.WorkflowTypeName,
 				"version": input.WorkflowTypeVersion,
 			},
 			"executionStartToCloseTimeout": execTimeout,
@@ -1195,7 +1198,7 @@ func (b *InMemoryBackend) TerminateWorkflowExecution(
 	attrKey := eventAttrKey("WorkflowExecutionTerminated")
 	attrs := map[string]any{
 		attrKey: map[string]any{
-			"reason":      reason,
+			attrReason:    reason,
 			attrDetails:   details,
 			"cause":       "OPERATOR_INITIATED",
 			"childPolicy": exec.ChildPolicy,
@@ -1626,8 +1629,8 @@ func (b *InMemoryBackend) RespondActivityTaskFailed(taskToken, reason, details s
 	attrKey := eventAttrKey("ActivityTaskFailed")
 	attrs := map[string]any{
 		attrKey: map[string]any{
-			"reason":          reason,
-			"details":         details,
+			attrReason:        reason,
+			attrDetails:       details,
 			attrScheduledEvID: rec.ScheduledEventID,
 			attrStartedEvID:   rec.StartedEventID,
 		},
@@ -1638,21 +1641,126 @@ func (b *InMemoryBackend) RespondActivityTaskFailed(taskToken, reason, details s
 	return nil
 }
 
-// RespondDecisionTaskCompleted processes a completed decision task.
-// executionContext is stored on the workflow execution.
-func (b *InMemoryBackend) RespondDecisionTaskCompleted(taskToken, executionContext string) error {
+// RespondDecisionTaskCompleted processes a completed decision task and applies decisions.
+func (b *InMemoryBackend) RespondDecisionTaskCompleted(
+	taskToken, executionContext string,
+	decisions []Decision,
+) error {
 	b.mu.Lock("RespondDecisionTaskCompleted")
 	defer b.mu.Unlock()
 
-	// Update the execution context if a workflow has this taskToken's workflow.
-	// (Full decision processing requires matching tokens to executions — tracked in future work.)
-	_ = taskToken
+	rec, ok := b.activeDecisionTasks[taskToken]
+	if !ok {
+		return fmt.Errorf("%w: decision task token %s not found", ErrNotFound, taskToken)
+	}
+	delete(b.activeDecisionTasks, taskToken)
 
-	// Store executionContext if we can find the execution. Without full token
-	// tracking we apply it best-effort — this will be wired properly with decision tracking.
-	_ = executionContext
+	key := rec.Domain + ":" + rec.WorkflowID
+	exec, ok := b.executions[key]
+	if !ok {
+		return nil
+	}
+
+	if executionContext != "" {
+		exec.LatestExecutionContext = executionContext
+	}
+
+	b.appendHistoryEventLocked(rec.Domain, rec.WorkflowID, "DecisionTaskCompleted", map[string]any{
+		eventAttrKey("DecisionTaskCompleted"): map[string]any{
+			"executionContext": executionContext,
+		},
+	})
+
+	for _, d := range decisions {
+		b.processDecisionLocked(rec.Domain, rec.WorkflowID, exec, d)
+	}
 
 	return nil
+}
+
+// processDecisionLocked applies a single decision to an execution.
+// Caller must hold the write lock.
+func (b *InMemoryBackend) processDecisionLocked(domain, workflowID string, exec *WorkflowExecution, d Decision) {
+	now := float64(time.Now().UnixMilli()) / milliDivisor
+
+	switch d.DecisionType {
+	case "CompleteWorkflowExecution":
+		result := ""
+		if d.CompleteWorkflowExecutionAttrs != nil {
+			result = d.CompleteWorkflowExecutionAttrs.Result
+		}
+		exec.Status = statusCompleted
+		exec.CloseStatus = statusCompleted
+		exec.CloseTimestamp = now
+		b.appendHistoryEventLocked(domain, workflowID, "WorkflowExecutionCompleted", map[string]any{
+			eventAttrKey("WorkflowExecutionCompleted"): map[string]any{"result": result},
+		})
+
+	case "FailWorkflowExecution":
+		reason, details := "", ""
+		if d.FailWorkflowExecutionAttrs != nil {
+			reason = d.FailWorkflowExecutionAttrs.Reason
+			details = d.FailWorkflowExecutionAttrs.Details
+		}
+		exec.Status = statusFailed
+		exec.CloseStatus = statusFailed
+		exec.CloseTimestamp = now
+		b.appendHistoryEventLocked(domain, workflowID, "WorkflowExecutionFailed", map[string]any{
+			eventAttrKey("WorkflowExecutionFailed"): map[string]any{
+				attrReason: reason, attrDetails: details,
+			},
+		})
+
+	case "CancelWorkflowExecution":
+		details := ""
+		if d.CancelWorkflowExecutionAttrs != nil {
+			details = d.CancelWorkflowExecutionAttrs.Details
+		}
+		exec.Status = statusCanceled
+		exec.CloseStatus = statusCanceled
+		exec.CloseTimestamp = now
+		b.appendHistoryEventLocked(domain, workflowID, "WorkflowExecutionCanceled", map[string]any{
+			eventAttrKey("WorkflowExecutionCanceled"): map[string]any{attrDetails: details},
+		})
+
+	case "ContinueAsNewWorkflowExecution":
+		exec.Status = statusContinuedAsNew
+		exec.CloseStatus = statusContinuedAsNew
+		exec.CloseTimestamp = now
+		b.appendHistoryEventLocked(domain, workflowID, "WorkflowExecutionContinuedAsNew", map[string]any{
+			eventAttrKey("WorkflowExecutionContinuedAsNew"): map[string]any{},
+		})
+
+	case "ScheduleActivityTask":
+		if d.ScheduleActivityTaskAttrs == nil {
+			return
+		}
+		attrs := d.ScheduleActivityTaskAttrs
+		taskList := attrs.TaskList
+		if taskList == "" {
+			taskList = exec.TaskList
+		}
+		scheduledEventID := b.appendHistoryEventLocked(domain, workflowID, "ActivityTaskScheduled", map[string]any{
+			eventAttrKey("ActivityTaskScheduled"): map[string]any{
+				"activityType": map[string]any{
+					attrName:  attrs.ActivityType.Name,
+					"version": attrs.ActivityType.Version,
+				},
+				"activityId": attrs.ActivityID,
+				attrInput:    attrs.Input,
+				"taskList":   map[string]any{attrName: taskList},
+			},
+		})
+		qkey := domain + ":" + taskList
+		b.activityQueues[qkey] = append(b.activityQueues[qkey], &ActivityTask{
+			ActivityID:       attrs.ActivityID,
+			ActivityType:     attrs.ActivityType,
+			Input:            attrs.Input,
+			WorkflowID:       workflowID,
+			RunID:            exec.RunID,
+			ScheduledEventID: scheduledEventID,
+		})
+	}
 }
 
 // enqueueDecisionTaskLocked adds a decision task for the execution's task list.

--- a/services/swf/decision_lifecycle_test.go
+++ b/services/swf/decision_lifecycle_test.go
@@ -1,0 +1,650 @@
+package swf_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/swf"
+)
+
+// pollDecisionTask polls for a decision task and returns the task token.
+//
+//nolint:unparam // domain is always "dom" in current tests but kept for clarity
+func pollDecisionTask(t *testing.T, b *swf.InMemoryBackend, domain, taskList string) string {
+	t.Helper()
+
+	task := b.PollForDecisionTask(domain, taskList, 0, "")
+	require.NotNil(t, task, "expected a decision task")
+
+	return task.TaskToken
+}
+
+func TestRespondDecisionTaskCompleted_CompleteWorkflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		result          string
+		wantCloseStatus string
+		wantEventType   string
+	}{
+		{
+			name:            "complete_with_result",
+			result:          `{"output":"done"}`,
+			wantCloseStatus: "COMPLETED",
+			wantEventType:   "WorkflowExecutionCompleted",
+		},
+		{
+			name:            "complete_empty_result",
+			result:          "",
+			wantCloseStatus: "COMPLETED",
+			wantEventType:   "WorkflowExecutionCompleted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+			_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+				Domain:     "dom",
+				WorkflowID: "wf-1",
+				TaskList:   "default",
+			})
+			require.NoError(t, err)
+
+			b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+			token := pollDecisionTask(t, b, "dom", "default")
+
+			decisions := []swf.Decision{{
+				DecisionType: "CompleteWorkflowExecution",
+				CompleteWorkflowExecutionAttrs: &swf.CompleteWorkflowExecutionDecisionAttrs{
+					Result: tt.result,
+				},
+			}}
+			require.NoError(t, b.RespondDecisionTaskCompleted(token, "", decisions))
+
+			exec, err := b.DescribeWorkflowExecution("dom", "wf-1")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCloseStatus, exec.Status)
+			assert.Equal(t, tt.wantCloseStatus, exec.CloseStatus)
+			assert.NotZero(t, exec.CloseTimestamp)
+
+			events, _ := b.GetWorkflowExecutionHistory("dom", "wf-1", 0, "", false)
+			var found bool
+			for _, ev := range events {
+				if ev.EventType == tt.wantEventType {
+					found = true
+				}
+			}
+			assert.True(t, found, "expected %s event in history", tt.wantEventType)
+		})
+	}
+}
+
+func TestRespondDecisionTaskCompleted_FailWorkflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		reason  string
+		details string
+	}{
+		{
+			name:    "fail_with_reason",
+			reason:  "timed out",
+			details: "after 300s",
+		},
+		{
+			name: "fail_no_reason",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+			_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+				Domain:     "dom",
+				WorkflowID: "wf-1",
+				TaskList:   "default",
+			})
+			require.NoError(t, err)
+
+			b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+			token := pollDecisionTask(t, b, "dom", "default")
+
+			decisions := []swf.Decision{{
+				DecisionType: "FailWorkflowExecution",
+				FailWorkflowExecutionAttrs: &swf.FailWorkflowExecutionDecisionAttrs{
+					Reason:  tt.reason,
+					Details: tt.details,
+				},
+			}}
+			require.NoError(t, b.RespondDecisionTaskCompleted(token, "", decisions))
+
+			exec, err := b.DescribeWorkflowExecution("dom", "wf-1")
+			require.NoError(t, err)
+			assert.Equal(t, "FAILED", exec.Status)
+			assert.Equal(t, "FAILED", exec.CloseStatus)
+			assert.NotZero(t, exec.CloseTimestamp)
+
+			events, _ := b.GetWorkflowExecutionHistory("dom", "wf-1", 0, "", false)
+			var failEvent *swf.HistoryEvent
+			for i := range events {
+				if events[i].EventType == "WorkflowExecutionFailed" {
+					failEvent = &events[i]
+				}
+			}
+			require.NotNil(t, failEvent)
+			if tt.reason != "" {
+				attrs := failEvent.Attributes["workflowExecutionFailedEventAttributes"].(map[string]any)
+				assert.Equal(t, tt.reason, attrs["reason"])
+			}
+		})
+	}
+}
+
+func TestRespondDecisionTaskCompleted_CancelWorkflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		details string
+	}{
+		{name: "cancel_with_details", details: "user cancelled"},
+		{name: "cancel_no_details"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+			_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+				Domain:     "dom",
+				WorkflowID: "wf-1",
+				TaskList:   "default",
+			})
+			require.NoError(t, err)
+
+			b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+			token := pollDecisionTask(t, b, "dom", "default")
+
+			decisions := []swf.Decision{{
+				DecisionType: "CancelWorkflowExecution",
+				CancelWorkflowExecutionAttrs: &swf.CancelWorkflowExecutionDecisionAttrs{
+					Details: tt.details,
+				},
+			}}
+			require.NoError(t, b.RespondDecisionTaskCompleted(token, "", decisions))
+
+			exec, err := b.DescribeWorkflowExecution("dom", "wf-1")
+			require.NoError(t, err)
+			assert.Equal(t, "CANCELED", exec.Status)
+			assert.Equal(t, "CANCELED", exec.CloseStatus)
+		})
+	}
+}
+
+func TestRespondDecisionTaskCompleted_ContinueAsNew(t *testing.T) {
+	t.Parallel()
+
+	b := swf.NewInMemoryBackend()
+	require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+	_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+		Domain:     "dom",
+		WorkflowID: "wf-1",
+		TaskList:   "default",
+	})
+	require.NoError(t, err)
+
+	b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+	token := pollDecisionTask(t, b, "dom", "default")
+
+	decisions := []swf.Decision{{
+		DecisionType: "ContinueAsNewWorkflowExecution",
+	}}
+	require.NoError(t, b.RespondDecisionTaskCompleted(token, "", decisions))
+
+	exec, err := b.DescribeWorkflowExecution("dom", "wf-1")
+	require.NoError(t, err)
+	assert.Equal(t, "CONTINUED_AS_NEW", exec.Status)
+	assert.Equal(t, "CONTINUED_AS_NEW", exec.CloseStatus)
+}
+
+func TestRespondDecisionTaskCompleted_ScheduleActivityTask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		taskList   string
+		activityID string
+		input      string
+	}{
+		{
+			name:       "schedule_with_explicit_tasklist",
+			taskList:   "activity-list",
+			activityID: "act-001",
+			input:      `{"key":"value"}`,
+		},
+		{
+			name:       "schedule_inherits_execution_tasklist",
+			taskList:   "",
+			activityID: "act-002",
+			input:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+			_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+				Domain:     "dom",
+				WorkflowID: "wf-1",
+				TaskList:   "default",
+			})
+			require.NoError(t, err)
+
+			b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+			token := pollDecisionTask(t, b, "dom", "default")
+
+			expectedTaskList := tt.taskList
+			if expectedTaskList == "" {
+				expectedTaskList = "default"
+			}
+
+			decisions := []swf.Decision{{
+				DecisionType: "ScheduleActivityTask",
+				ScheduleActivityTaskAttrs: &swf.ScheduleActivityTaskDecisionAttrs{
+					ActivityType: swf.ActivityTaskActivityType{Name: "my-act", Version: "1.0"},
+					ActivityID:   tt.activityID,
+					Input:        tt.input,
+					TaskList:     tt.taskList,
+				},
+			}}
+			require.NoError(t, b.RespondDecisionTaskCompleted(token, "", decisions))
+
+			assert.Equal(t, 1, b.CountPendingActivityTasks("dom", expectedTaskList))
+
+			task := b.PollForActivityTask("dom", expectedTaskList)
+			require.NotNil(t, task)
+			assert.Equal(t, tt.activityID, task.ActivityID)
+			assert.Equal(t, "my-act", task.ActivityType.Name)
+			assert.Equal(t, tt.input, task.Input)
+		})
+	}
+}
+
+func TestRespondDecisionTaskCompleted_ExecutionContext(t *testing.T) {
+	t.Parallel()
+
+	b := swf.NewInMemoryBackend()
+	require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+	_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+		Domain:     "dom",
+		WorkflowID: "wf-1",
+		TaskList:   "default",
+	})
+	require.NoError(t, err)
+
+	b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+	token := pollDecisionTask(t, b, "dom", "default")
+
+	require.NoError(t, b.RespondDecisionTaskCompleted(token, `{"state":"step2"}`, nil))
+
+	exec, err := b.DescribeWorkflowExecution("dom", "wf-1")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"state":"step2"}`, exec.LatestExecutionContext)
+}
+
+func TestRespondDecisionTaskCompleted_UnknownToken(t *testing.T) {
+	t.Parallel()
+
+	b := swf.NewInMemoryBackend()
+	err := b.RespondDecisionTaskCompleted("nonexistent-token", "", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, swf.ErrNotFound)
+}
+
+func TestRespondDecisionTaskCompleted_ClosedCountUpdates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		decision        swf.Decision
+		name            string
+		wantCloseStatus string
+	}{
+		{
+			name: "complete",
+			decision: swf.Decision{
+				DecisionType:                   "CompleteWorkflowExecution",
+				CompleteWorkflowExecutionAttrs: &swf.CompleteWorkflowExecutionDecisionAttrs{},
+			},
+			wantCloseStatus: "COMPLETED",
+		},
+		{
+			name: "fail",
+			decision: swf.Decision{
+				DecisionType:               "FailWorkflowExecution",
+				FailWorkflowExecutionAttrs: &swf.FailWorkflowExecutionDecisionAttrs{},
+			},
+			wantCloseStatus: "FAILED",
+		},
+		{
+			name: "cancel",
+			decision: swf.Decision{
+				DecisionType:                 "CancelWorkflowExecution",
+				CancelWorkflowExecutionAttrs: &swf.CancelWorkflowExecutionDecisionAttrs{},
+			},
+			wantCloseStatus: "CANCELED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+			_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+				Domain:     "dom",
+				WorkflowID: "wf-1",
+				TaskList:   "default",
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, 1, b.CountOpenWorkflowExecutions("dom", swf.ExecutionFilter{}))
+			assert.Equal(t, 0, b.CountClosedWorkflowExecutions("dom", swf.ExecutionFilter{}))
+
+			b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+			token := pollDecisionTask(t, b, "dom", "default")
+			require.NoError(t, b.RespondDecisionTaskCompleted(token, "", []swf.Decision{tt.decision}))
+
+			assert.Equal(t, 0, b.CountOpenWorkflowExecutions("dom", swf.ExecutionFilter{}))
+			assert.Equal(t, 1, b.CountClosedWorkflowExecutions("dom", swf.ExecutionFilter{}))
+
+			filter := swf.ExecutionFilter{CloseStatus: tt.wantCloseStatus}
+			assert.Equal(t, 1, b.CountClosedWorkflowExecutions("dom", filter))
+		})
+	}
+}
+
+func TestDecisionTask_HistoryIncluded(t *testing.T) {
+	t.Parallel()
+
+	b := swf.NewInMemoryBackend()
+	require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+	_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+		Domain:     "dom",
+		WorkflowID: "wf-1",
+		TaskList:   "default",
+	})
+	require.NoError(t, err)
+
+	b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+	task := b.PollForDecisionTask("dom", "default", 0, "")
+	require.NotNil(t, task)
+	assert.NotEmpty(t, task.Events, "decision task should include history events")
+	assert.NotEmpty(t, task.TaskToken)
+}
+
+// TestRespondDecisionTask_ViaHandler exercises RespondDecisionTaskCompleted through the HTTP handler.
+func TestRespondDecisionTask_ViaHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		wantExecStatus string
+		name           string
+		setupFn        func(*swf.InMemoryBackend) string
+		decisions      []map[string]any
+		wantCode       int
+	}{
+		{
+			name: "complete_via_handler",
+			setupFn: func(b *swf.InMemoryBackend) string {
+				require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+				_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+					Domain:     "dom",
+					WorkflowID: "wf-1",
+					TaskList:   "default",
+				})
+				require.NoError(t, err)
+				b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+				task := b.PollForDecisionTask("dom", "default", 0, "")
+				require.NotNil(t, task)
+
+				return task.TaskToken
+			},
+			decisions: []map[string]any{
+				{
+					"decisionType": "CompleteWorkflowExecution",
+					"completeWorkflowExecutionDecisionAttributes": map[string]any{
+						"result": "all-done",
+					},
+				},
+			},
+			wantCode:       http.StatusOK,
+			wantExecStatus: "COMPLETED",
+		},
+		{
+			name: "fail_via_handler",
+			setupFn: func(b *swf.InMemoryBackend) string {
+				require.NoError(t, b.RegisterDomain("dom2", "", "NONE"))
+				_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+					Domain:     "dom2",
+					WorkflowID: "wf-2",
+					TaskList:   "default",
+				})
+				require.NoError(t, err)
+				b.EnqueueDecisionTaskInternal("dom2", "default", "wf-2", "run-1")
+				task := b.PollForDecisionTask("dom2", "default", 0, "")
+				require.NotNil(t, task)
+
+				return task.TaskToken
+			},
+			decisions: []map[string]any{
+				{
+					"decisionType": "FailWorkflowExecution",
+					"failWorkflowExecutionDecisionAttributes": map[string]any{
+						"reason":  "business error",
+						"details": "step 3 failed",
+					},
+				},
+			},
+			wantCode:       http.StatusOK,
+			wantExecStatus: "FAILED",
+		},
+		{
+			name: "unknown_token_returns_404",
+			setupFn: func(_ *swf.InMemoryBackend) string {
+				return "bad-token"
+			},
+			decisions: nil,
+			wantCode:  http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			token := tt.setupFn(b)
+			h := swf.NewHandler(b)
+
+			body := map[string]any{
+				"taskToken": token,
+				"decisions": tt.decisions,
+			}
+			rec := doSWFRequest(t, h, "RespondDecisionTaskCompleted", body)
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			if tt.wantExecStatus != "" {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				// Verify via describe - pick the right domain/workflowID
+				var domainName, wfID string
+				if tt.wantExecStatus == "COMPLETED" {
+					domainName, wfID = "dom", "wf-1"
+				} else {
+					domainName, wfID = "dom2", "wf-2"
+				}
+				exec, err := b.DescribeWorkflowExecution(domainName, wfID)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantExecStatus, exec.Status)
+			}
+		})
+	}
+}
+
+func TestRespondDecisionTaskCompleted_MultipleDecisions(t *testing.T) {
+	t.Parallel()
+
+	b := swf.NewInMemoryBackend()
+	require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+	_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+		Domain:     "dom",
+		WorkflowID: "wf-1",
+		TaskList:   "default",
+	})
+	require.NoError(t, err)
+
+	b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+	token := pollDecisionTask(t, b, "dom", "default")
+
+	// Schedule two activity tasks, then complete the workflow.
+	decisions := []swf.Decision{
+		{
+			DecisionType: "ScheduleActivityTask",
+			ScheduleActivityTaskAttrs: &swf.ScheduleActivityTaskDecisionAttrs{
+				ActivityType: swf.ActivityTaskActivityType{Name: "act", Version: "1.0"},
+				ActivityID:   "a1",
+				TaskList:     "act-list",
+			},
+		},
+		{
+			DecisionType: "ScheduleActivityTask",
+			ScheduleActivityTaskAttrs: &swf.ScheduleActivityTaskDecisionAttrs{
+				ActivityType: swf.ActivityTaskActivityType{Name: "act", Version: "1.0"},
+				ActivityID:   "a2",
+				TaskList:     "act-list",
+			},
+		},
+		{
+			DecisionType:                   "CompleteWorkflowExecution",
+			CompleteWorkflowExecutionAttrs: &swf.CompleteWorkflowExecutionDecisionAttrs{Result: "done"},
+		},
+	}
+	require.NoError(t, b.RespondDecisionTaskCompleted(token, "", decisions))
+
+	assert.Equal(t, 2, b.CountPendingActivityTasks("dom", "act-list"))
+	exec, err := b.DescribeWorkflowExecution("dom", "wf-1")
+	require.NoError(t, err)
+	assert.Equal(t, "COMPLETED", exec.Status)
+}
+
+func TestDecisionTask_DecisionTaskCompletedEvent(t *testing.T) {
+	t.Parallel()
+
+	b := swf.NewInMemoryBackend()
+	require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+	_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+		Domain:     "dom",
+		WorkflowID: "wf-1",
+		TaskList:   "default",
+	})
+	require.NoError(t, err)
+
+	b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+	token := pollDecisionTask(t, b, "dom", "default")
+	require.NoError(t, b.RespondDecisionTaskCompleted(token, "ctx-value", nil))
+
+	events, _ := b.GetWorkflowExecutionHistory("dom", "wf-1", 0, "", false)
+	var found bool
+	for _, ev := range events {
+		if ev.EventType == "DecisionTaskCompleted" {
+			found = true
+		}
+	}
+	assert.True(t, found, "DecisionTaskCompleted event must appear in history")
+}
+
+func TestListClosedWorkflowExecutions_CloseStatusFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		decisionType    string
+		closeStatusFilt string
+		wantCount       int
+	}{
+		{
+			name:            "filter_completed",
+			decisionType:    "CompleteWorkflowExecution",
+			closeStatusFilt: "COMPLETED",
+			wantCount:       1,
+		},
+		{
+			name:            "filter_failed",
+			decisionType:    "FailWorkflowExecution",
+			closeStatusFilt: "FAILED",
+			wantCount:       1,
+		},
+		{
+			name:            "filter_completed_no_match",
+			decisionType:    "FailWorkflowExecution",
+			closeStatusFilt: "COMPLETED",
+			wantCount:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := swf.NewInMemoryBackend()
+			require.NoError(t, b.RegisterDomain("dom", "", "NONE"))
+			_, err := b.StartWorkflowExecution(swf.StartWorkflowExecutionInput{
+				Domain:     "dom",
+				WorkflowID: "wf-1",
+				TaskList:   "default",
+			})
+			require.NoError(t, err)
+
+			b.EnqueueDecisionTaskInternal("dom", "default", "wf-1", "run-1")
+			token := pollDecisionTask(t, b, "dom", "default")
+
+			var decision swf.Decision
+			switch tt.decisionType {
+			case "CompleteWorkflowExecution":
+				decision = swf.Decision{
+					DecisionType:                   "CompleteWorkflowExecution",
+					CompleteWorkflowExecutionAttrs: &swf.CompleteWorkflowExecutionDecisionAttrs{},
+				}
+			default:
+				decision = swf.Decision{
+					DecisionType:               "FailWorkflowExecution",
+					FailWorkflowExecutionAttrs: &swf.FailWorkflowExecutionDecisionAttrs{},
+				}
+			}
+			require.NoError(t, b.RespondDecisionTaskCompleted(token, "", []swf.Decision{decision}))
+
+			filter := swf.ExecutionFilter{CloseStatus: tt.closeStatusFilt}
+			execs := b.ListClosedWorkflowExecutions("dom", filter)
+			assert.Len(t, execs, tt.wantCount)
+		})
+	}
+}

--- a/services/swf/handler.go
+++ b/services/swf/handler.go
@@ -1527,9 +1527,43 @@ func (h *Handler) handleRespondActivityTaskFailed(
 
 // --- RespondDecisionTaskCompleted ---
 
+type completeWorkflowDecisionAttrs struct {
+	Result string `json:"result,omitempty"`
+}
+
+type failWorkflowDecisionAttrs struct {
+	Reason  string `json:"reason,omitempty"`
+	Details string `json:"details,omitempty"`
+}
+
+type cancelWorkflowDecisionAttrs struct {
+	Details string `json:"details,omitempty"`
+}
+
+type scheduleActivityDecisionAttrs struct {
+	ActivityType           activityTypeRef `json:"activityType"`
+	ActivityID             string          `json:"activityId"`
+	Input                  string          `json:"input,omitempty"`
+	TaskList               *taskListRef    `json:"taskList,omitempty"`
+	ScheduleToCloseTimeout string          `json:"scheduleToCloseTimeout,omitempty"`
+	ScheduleToStartTimeout string          `json:"scheduleToStartTimeout,omitempty"`
+	StartToCloseTimeout    string          `json:"startToCloseTimeout,omitempty"`
+	HeartbeatTimeout       string          `json:"heartbeatTimeout,omitempty"`
+}
+
+//nolint:lll // AWS API field names exceed 120 chars; cannot shorten JSON tags
+type decisionInput struct {
+	CompleteWorkflowExecutionDecisionAttributes *completeWorkflowDecisionAttrs `json:"completeWorkflowExecutionDecisionAttributes,omitempty"`
+	FailWorkflowExecutionDecisionAttributes     *failWorkflowDecisionAttrs     `json:"failWorkflowExecutionDecisionAttributes,omitempty"`
+	CancelWorkflowExecutionDecisionAttributes   *cancelWorkflowDecisionAttrs   `json:"cancelWorkflowExecutionDecisionAttributes,omitempty"`
+	ScheduleActivityTaskDecisionAttributes      *scheduleActivityDecisionAttrs `json:"scheduleActivityTaskDecisionAttributes,omitempty"`
+	DecisionType                                string                         `json:"decisionType"`
+}
+
 type handleRespondDecisionTaskCompletedInput struct {
-	TaskToken        string `json:"taskToken"`
-	ExecutionContext string `json:"executionContext,omitempty"`
+	TaskToken        string          `json:"taskToken"`
+	ExecutionContext string          `json:"executionContext,omitempty"`
+	Decisions        []decisionInput `json:"decisions,omitempty"`
 }
 
 type respondDecisionTaskCompletedOutput struct{}
@@ -1538,7 +1572,48 @@ func (h *Handler) handleRespondDecisionTaskCompleted(
 	_ context.Context,
 	in *handleRespondDecisionTaskCompletedInput,
 ) (*respondDecisionTaskCompletedOutput, error) {
-	if err := h.Backend.RespondDecisionTaskCompleted(in.TaskToken, in.ExecutionContext); err != nil {
+	decisions := make([]Decision, 0, len(in.Decisions))
+	for _, d := range in.Decisions {
+		dec := Decision{DecisionType: d.DecisionType}
+		if d.CompleteWorkflowExecutionDecisionAttributes != nil {
+			dec.CompleteWorkflowExecutionAttrs = &CompleteWorkflowExecutionDecisionAttrs{
+				Result: d.CompleteWorkflowExecutionDecisionAttributes.Result,
+			}
+		}
+		if d.FailWorkflowExecutionDecisionAttributes != nil {
+			dec.FailWorkflowExecutionAttrs = &FailWorkflowExecutionDecisionAttrs{
+				Reason:  d.FailWorkflowExecutionDecisionAttributes.Reason,
+				Details: d.FailWorkflowExecutionDecisionAttributes.Details,
+			}
+		}
+		if d.CancelWorkflowExecutionDecisionAttributes != nil {
+			dec.CancelWorkflowExecutionAttrs = &CancelWorkflowExecutionDecisionAttrs{
+				Details: d.CancelWorkflowExecutionDecisionAttributes.Details,
+			}
+		}
+		if d.ScheduleActivityTaskDecisionAttributes != nil {
+			sa := d.ScheduleActivityTaskDecisionAttributes
+			taskList := ""
+			if sa.TaskList != nil {
+				taskList = sa.TaskList.Name
+			}
+			dec.ScheduleActivityTaskAttrs = &ScheduleActivityTaskDecisionAttrs{
+				ActivityType: ActivityTaskActivityType{
+					Name:    sa.ActivityType.Name,
+					Version: sa.ActivityType.Version,
+				},
+				ActivityID:             sa.ActivityID,
+				Input:                  sa.Input,
+				TaskList:               taskList,
+				ScheduleToCloseTimeout: sa.ScheduleToCloseTimeout,
+				ScheduleToStartTimeout: sa.ScheduleToStartTimeout,
+				StartToCloseTimeout:    sa.StartToCloseTimeout,
+				HeartbeatTimeout:       sa.HeartbeatTimeout,
+			}
+		}
+		decisions = append(decisions, dec)
+	}
+	if err := h.Backend.RespondDecisionTaskCompleted(in.TaskToken, in.ExecutionContext, decisions); err != nil {
 		return nil, err
 	}
 

--- a/services/swf/interfaces.go
+++ b/services/swf/interfaces.go
@@ -54,7 +54,7 @@ type StorageBackend interface {
 	RespondActivityTaskCanceled(taskToken, details string) error
 	RespondActivityTaskCompleted(taskToken, result string) error
 	RespondActivityTaskFailed(taskToken, reason, details string) error
-	RespondDecisionTaskCompleted(taskToken, executionContext string) error
+	RespondDecisionTaskCompleted(taskToken, executionContext string, decisions []Decision) error
 
 	// Resource tagging
 	ListTagsForResource(resourceARN string) (map[string]string, error)


### PR DESCRIPTION
## Summary

- Implements real `RespondDecisionTaskCompleted` (was a stub): tracks decision task tokens and processes decisions to close workflows with correct status
- Adds `Decision` types: `CompleteWorkflowExecution`, `FailWorkflowExecution`, `CancelWorkflowExecution`, `ContinueAsNewWorkflowExecution`, `ScheduleActivityTask`
- Adds `activeDecisionTasks` map to backend; `PollForDecisionTask` now records token→execution mapping
- Workflow lifecycle now fully stateful: COMPLETED/FAILED/CANCELED/CONTINUED_AS_NEW via decisions, TERMINATED directly
- Adds 650-line `decision_lifecycle_test.go` with table-driven tests for all decision types, filter combinations, and handler path; 107 tests pass (was 95)
- Fixes goconst: adds `attrInput`/`attrReason`/`attrName` constants; passes golangci-lint clean

## Test plan

- [x] `go test ./services/swf/... -count=1` — 107/107 pass
- [x] `go vet ./services/swf/...` — clean
- [x] `golangci-lint run ./services/swf/` — 0 issues
- [x] Rebased onto `origin/main`

Closes #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)