### PR TITLE
feat(acm): AWS-accuracy audit batch-1 (go-axtd)

### DIFF
--- a/services/acm/backend.go
+++ b/services/acm/backend.go
@@ -31,17 +31,21 @@ var (
 )
 
 const (
-	validationMethodDNS     = "DNS"
-	validationMethodEMAIL   = "EMAIL"
-	statusPendingValidation = "PENDING_VALIDATION"
-	statusIssued            = "ISSUED"
-	statusRevoked           = "REVOKED"
-	validationStatusSuccess = "SUCCESS"
-	validationTokenLen      = 8
-	autoValidateDelayMS     = 100
-	randByteDivisor         = 2
-	certTypeImported        = "IMPORTED"
-	certValidityDuration    = 365 * 24 * time.Hour
+	validationMethodDNS      = "DNS"
+	validationMethodEMAIL    = "EMAIL"
+	statusPendingValidation  = "PENDING_VALIDATION"
+	statusIssued             = "ISSUED"
+	statusRevoked            = "REVOKED"
+	statusInactive           = "INACTIVE"
+	statusExpired            = "EXPIRED"
+	statusValidationTimedOut = "VALIDATION_TIMED_OUT"
+	statusFailed             = "FAILED"
+	validationStatusSuccess  = "SUCCESS"
+	validationTokenLen       = 8
+	autoValidateDelayMS      = 100
+	randByteDivisor          = 2
+	certTypeImported         = "IMPORTED"
+	certValidityDuration     = 365 * 24 * time.Hour
 
 	defaultDaysBeforeExpiry = int32(45)
 
@@ -509,6 +513,8 @@ func (b *InMemoryBackend) ImportCertificate(
 		existing.SignatureAlgorithm = meta.signatureAlgorithm
 		existing.ImportedAt = &now
 		existing.Status = statusIssued
+		existing.KeyUsage = meta.keyUsage
+		existing.ExtendedKeyUsage = meta.extKeyUsage
 
 		cp := copyCert(existing)
 
@@ -536,6 +542,8 @@ func (b *InMemoryBackend) ImportCertificate(
 		ImportedAt:         &now,
 		NotBefore:          notBefore,
 		NotAfter:           notAfter,
+		KeyUsage:           meta.keyUsage,
+		ExtendedKeyUsage:   meta.extKeyUsage,
 	}
 	b.certs[certARN] = cert
 
@@ -628,7 +636,8 @@ const fakeCertChain = "-----BEGIN CERTIFICATE-----\n" +
 // an IMPORTED or PRIVATE certificate. Returns ErrNotEligible for AMAZON_ISSUED certificates.
 // When the stored certificate has no associated chain, a fake chain (intermediate + root)
 // is returned in PEM format to simulate AWS ACM behaviour.
-func (b *InMemoryBackend) ExportCertificate(certARN string) (*Certificate, error) {
+// If passphrase is non-nil and non-empty, the private key is returned encrypted using AES-256.
+func (b *InMemoryBackend) ExportCertificate(certARN string, passphrase []byte) (*Certificate, error) {
 	b.mu.RLock("ExportCertificate")
 	defer b.mu.RUnlock()
 
@@ -646,6 +655,15 @@ func (b *InMemoryBackend) ExportCertificate(certARN string) (*Certificate, error
 	// Always return a certificate chain; use a fake chain when none was supplied.
 	if cp.CertificateChain == "" {
 		cp.CertificateChain = fakeCertChain
+	}
+
+	if len(passphrase) > 0 {
+		encKey, encErr := encryptPrivateKeyPEM(cp.PrivateKey, passphrase)
+		if encErr != nil {
+			return nil, fmt.Errorf("export: %w", encErr)
+		}
+
+		cp.PrivateKey = encKey
 	}
 
 	return &cp, nil
@@ -681,12 +699,75 @@ func (b *InMemoryBackend) DescribeCertificate(arn string) (*Certificate, error) 
 
 // ListCertificatesParams holds all filter and sorting options for ListCertificates.
 type ListCertificatesParams struct {
-	NextToken    string
-	SortBy       string
-	SortOrder    string
-	StatusFilter []string
-	KeyTypes     []string
-	MaxItems     int
+	NextToken        string
+	SortBy           string
+	SortOrder        string
+	StatusFilter     []string
+	KeyTypes         []string
+	KeyUsage         []string
+	ExtendedKeyUsage []string
+	MaxItems         int
+}
+
+// listCertFilters holds compiled filter sets for ListCertificates.
+type listCertFilters struct {
+	statusSet      map[string]struct{}
+	keyTypeSet     map[string]struct{}
+	keyUsageSet    map[string]struct{}
+	extKeyUsageSet map[string]struct{}
+}
+
+// buildListCertFilters compiles the filter sets from ListCertificatesParams.
+func buildListCertFilters(p ListCertificatesParams) listCertFilters {
+	f := listCertFilters{
+		statusSet:      make(map[string]struct{}, len(p.StatusFilter)),
+		keyTypeSet:     make(map[string]struct{}, len(p.KeyTypes)),
+		keyUsageSet:    make(map[string]struct{}, len(p.KeyUsage)),
+		extKeyUsageSet: make(map[string]struct{}, len(p.ExtendedKeyUsage)),
+	}
+
+	for _, s := range p.StatusFilter {
+		f.statusSet[s] = struct{}{}
+	}
+
+	for _, k := range p.KeyTypes {
+		f.keyTypeSet[k] = struct{}{}
+	}
+
+	for _, ku := range p.KeyUsage {
+		f.keyUsageSet[ku] = struct{}{}
+	}
+
+	for _, eku := range p.ExtendedKeyUsage {
+		f.extKeyUsageSet[eku] = struct{}{}
+	}
+
+	return f
+}
+
+// matches returns true if the certificate satisfies all filters.
+func (f listCertFilters) matches(c *Certificate) bool {
+	if len(f.statusSet) > 0 {
+		if _, ok := f.statusSet[c.Status]; !ok {
+			return false
+		}
+	}
+
+	if len(f.keyTypeSet) > 0 {
+		if _, ok := f.keyTypeSet[c.KeyAlgorithm]; !ok {
+			return false
+		}
+	}
+
+	if len(f.keyUsageSet) > 0 && !matchesAny(c.KeyUsage, f.keyUsageSet) {
+		return false
+	}
+
+	if len(f.extKeyUsageSet) > 0 && !matchesAny(c.ExtendedKeyUsage, f.extKeyUsageSet) {
+		return false
+	}
+
+	return true
 }
 
 // ListCertificates returns a paginated list of certificates, with optional
@@ -695,32 +776,13 @@ func (b *InMemoryBackend) ListCertificates(p ListCertificatesParams) page.Page[C
 	b.mu.RLock("ListCertificates")
 	defer b.mu.RUnlock()
 
-	statusSet := make(map[string]struct{}, len(p.StatusFilter))
-	for _, s := range p.StatusFilter {
-		statusSet[s] = struct{}{}
-	}
-
-	keyTypeSet := make(map[string]struct{}, len(p.KeyTypes))
-	for _, k := range p.KeyTypes {
-		keyTypeSet[k] = struct{}{}
-	}
-
+	filters := buildListCertFilters(p)
 	certs := make([]Certificate, 0, len(b.certs))
 
 	for _, c := range b.certs {
-		if len(statusSet) > 0 {
-			if _, ok := statusSet[c.Status]; !ok {
-				continue
-			}
+		if filters.matches(c) {
+			certs = append(certs, copyCert(c))
 		}
-
-		if len(keyTypeSet) > 0 {
-			if _, ok := keyTypeSet[c.KeyAlgorithm]; !ok {
-				continue
-			}
-		}
-
-		certs = append(certs, copyCert(c))
 	}
 
 	descending := strings.EqualFold(p.SortOrder, "DESCENDING")
@@ -749,6 +811,17 @@ func (b *InMemoryBackend) ListCertificates(p ListCertificatesParams) page.Page[C
 }
 
 const acmDefaultMaxItems = 100
+
+// matchesAny returns true if any element of values is in the set.
+func matchesAny(values []string, set map[string]struct{}) bool {
+	for _, v := range values {
+		if _, ok := set[v]; ok {
+			return true
+		}
+	}
+
+	return false
+}
 
 // CertExists reports whether a certificate with the given ARN exists in the backend.
 // This is used by the handler to validate tag operations.
@@ -902,6 +975,8 @@ type certMetadata struct {
 	subject            string
 	issuer             string
 	signatureAlgorithm string
+	keyUsage           []string
+	extKeyUsage        []string
 }
 
 // generateSelfSignedCert generates a self-signed ECDSA P-256 certificate for
@@ -987,9 +1062,98 @@ func extractCertMetadataFull(certPEM string) (string, certMetadata, time.Time, t
 		subject:            cert.Subject.String(),
 		issuer:             cert.Issuer.String(),
 		signatureAlgorithm: cert.SignatureAlgorithm.String(),
+		keyUsage:           x509KeyUsageToAWS(cert.KeyUsage),
+		extKeyUsage:        x509ExtKeyUsageToAWS(cert.ExtKeyUsage),
 	}
 
 	return domainName, meta, cert.NotBefore.UTC(), cert.NotAfter.UTC(), nil
+}
+
+// x509KeyUsageToAWS converts x509.KeyUsage bitmask to a slice of AWS key usage strings.
+func x509KeyUsageToAWS(ku x509.KeyUsage) []string {
+	mapping := []struct {
+		name string
+		bit  x509.KeyUsage
+	}{
+		{"DIGITAL_SIGNATURE", x509.KeyUsageDigitalSignature},
+		{"NON_REPUDIATION", x509.KeyUsageContentCommitment},
+		{"KEY_ENCIPHERMENT", x509.KeyUsageKeyEncipherment},
+		{"DATA_ENCIPHERMENT", x509.KeyUsageDataEncipherment},
+		{"KEY_AGREEMENT", x509.KeyUsageKeyAgreement},
+		{"CERTIFICATE_SIGNING", x509.KeyUsageCertSign},
+		{"CRL_SIGNING", x509.KeyUsageCRLSign},
+		{"ENCIPHER_ONLY", x509.KeyUsageEncipherOnly},
+		{"DECIPHER_ONLY", x509.KeyUsageDecipherOnly},
+	}
+
+	var result []string
+	for _, m := range mapping {
+		if ku&m.bit != 0 {
+			result = append(result, m.name)
+		}
+	}
+
+	return result
+}
+
+// x509ExtKeyUsageToAWS converts a slice of x509.ExtKeyUsage to AWS extended key usage strings.
+func x509ExtKeyUsageToAWS(ekus []x509.ExtKeyUsage) []string {
+	var result []string
+
+	for _, eku := range ekus {
+		switch eku {
+		case x509.ExtKeyUsageAny:
+			result = append(result, "ANY")
+		case x509.ExtKeyUsageServerAuth:
+			result = append(result, "TLS_WEB_SERVER_AUTHENTICATION")
+		case x509.ExtKeyUsageClientAuth:
+			result = append(result, "TLS_WEB_CLIENT_AUTHENTICATION")
+		case x509.ExtKeyUsageCodeSigning:
+			result = append(result, "CODE_SIGNING")
+		case x509.ExtKeyUsageEmailProtection:
+			result = append(result, "EMAIL_PROTECTION")
+		case x509.ExtKeyUsageIPSECEndSystem:
+			result = append(result, "IPSEC_END_SYSTEM")
+		case x509.ExtKeyUsageIPSECTunnel:
+			result = append(result, "IPSEC_TUNNEL")
+		case x509.ExtKeyUsageIPSECUser:
+			result = append(result, "IPSEC_USER")
+		case x509.ExtKeyUsageTimeStamping:
+			result = append(result, "TIME_STAMPING")
+		case x509.ExtKeyUsageOCSPSigning:
+			result = append(result, "OCSP_SIGNING")
+		case x509.ExtKeyUsageMicrosoftServerGatedCrypto,
+			x509.ExtKeyUsageNetscapeServerGatedCrypto,
+			x509.ExtKeyUsageMicrosoftCommercialCodeSigning,
+			x509.ExtKeyUsageMicrosoftKernelCodeSigning:
+			result = append(result, "CUSTOM")
+		}
+	}
+
+	return result
+}
+
+// encryptPrivateKeyPEM encrypts a PEM-encoded private key with the given passphrase,
+// returning a PEM block with type "ENCRYPTED PRIVATE KEY".
+func encryptPrivateKeyPEM(privateKeyPEM string, passphrase []byte) (string, error) {
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		return "", errInvalidPEM
+	}
+
+	//nolint:staticcheck // EncryptPEMBlock is deprecated but functional for ACM passphrase simulation
+	encBlock, err := x509.EncryptPEMBlock(
+		cryptorand.Reader,
+		"ENCRYPTED PRIVATE KEY",
+		block.Bytes,
+		passphrase,
+		x509.PEMCipherAES256,
+	)
+	if err != nil {
+		return "", fmt.Errorf("encrypt private key: %w", err)
+	}
+
+	return string(pem.EncodeToMemory(encBlock)), nil
 }
 
 // Reset clears all certificate state and stops any pending auto-validate timers.
@@ -1198,6 +1362,110 @@ func (b *InMemoryBackend) UpdateCertificateOptions(certARN, transparencyLoggingP
 	}
 
 	cert.CertificateTransparencyLoggingPref = transparencyLoggingPref
+
+	return nil
+}
+
+// ExpireCertificate transitions an ISSUED certificate to EXPIRED status.
+// Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
+// certificate is not in ISSUED status.
+func (b *InMemoryBackend) ExpireCertificate(certARN string) error {
+	b.mu.Lock("ExpireCertificate")
+	defer b.mu.Unlock()
+
+	cert, ok := b.certs[certARN]
+	if !ok {
+		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
+	}
+
+	if cert.Status != statusIssued {
+		return fmt.Errorf("%w: only ISSUED certificates can be expired, got %s", ErrInvalidParameter, cert.Status)
+	}
+
+	cert.Status = statusExpired
+
+	return nil
+}
+
+// InactivateCertificate transitions an ISSUED certificate to INACTIVE status.
+// Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
+// certificate is not in ISSUED status.
+func (b *InMemoryBackend) InactivateCertificate(certARN string) error {
+	b.mu.Lock("InactivateCertificate")
+	defer b.mu.Unlock()
+
+	cert, ok := b.certs[certARN]
+	if !ok {
+		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
+	}
+
+	if cert.Status != statusIssued {
+		return fmt.Errorf("%w: only ISSUED certificates can be inactivated, got %s", ErrInvalidParameter, cert.Status)
+	}
+
+	cert.Status = statusInactive
+
+	return nil
+}
+
+// TimeoutPendingValidation transitions a PENDING_VALIDATION certificate to VALIDATION_TIMED_OUT.
+// Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
+// certificate is not in PENDING_VALIDATION status.
+func (b *InMemoryBackend) TimeoutPendingValidation(certARN string) error {
+	b.mu.Lock("TimeoutPendingValidation")
+	defer b.mu.Unlock()
+
+	cert, ok := b.certs[certARN]
+	if !ok {
+		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
+	}
+
+	if cert.Status != statusPendingValidation {
+		return fmt.Errorf(
+			"%w: only PENDING_VALIDATION certificates can time out, got %s",
+			ErrInvalidParameter, cert.Status,
+		)
+	}
+
+	// Stop any pending auto-validate timer.
+	if t, exists := b.timers[certARN]; exists {
+		t.Stop()
+		delete(b.timers, certARN)
+	}
+
+	cert.Status = statusValidationTimedOut
+
+	return nil
+}
+
+// FailCertificate transitions a PENDING_VALIDATION certificate to FAILED status with
+// the given failure reason.
+// Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
+// certificate is not in PENDING_VALIDATION status.
+func (b *InMemoryBackend) FailCertificate(certARN, reason string) error {
+	b.mu.Lock("FailCertificate")
+	defer b.mu.Unlock()
+
+	cert, ok := b.certs[certARN]
+	if !ok {
+		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
+	}
+
+	if cert.Status != statusPendingValidation {
+		return fmt.Errorf(
+			"%w: only PENDING_VALIDATION certificates can be failed, got %s",
+			ErrInvalidParameter, cert.Status,
+		)
+	}
+
+	// Stop any pending auto-validate timer.
+	if t, exists := b.timers[certARN]; exists {
+		t.Stop()
+		delete(b.timers, certARN)
+	}
+
+	cert.Status = statusFailed
+	cert.FailureReason = reason
 
 	return nil
 }

--- a/services/acm/backend_test.go
+++ b/services/acm/backend_test.go
@@ -482,7 +482,7 @@ func TestACMBackend_ExportCertificate(t *testing.T) {
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 			certARN := tt.setup(t, b)
-			cert, err := b.ExportCertificate(certARN)
+			cert, err := b.ExportCertificate(certARN, nil)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -606,6 +606,361 @@ func TestACMBackend_CertificateBodyIsPEM(t *testing.T) {
 
 	assert.True(t, strings.HasPrefix(cert.CertificateBody, "-----BEGIN CERTIFICATE-----"))
 	assert.True(t, strings.HasPrefix(cert.PrivateKey, "-----BEGIN EC PRIVATE KEY-----"))
+}
+
+// TestACMBackend_StatusLifecycle verifies the full certificate status lifecycle transitions.
+func TestACMBackend_StatusLifecycle(t *testing.T) {
+	t.Parallel()
+
+	certPEM, keyPEM := generateTestCert(t)
+
+	tests := []struct {
+		setup      func(t *testing.T, b *acm.InMemoryBackend) string
+		transition func(t *testing.T, b *acm.InMemoryBackend, certARN string) error
+		wantErr    error
+		name       string
+		wantStatus string
+	}{
+		{
+			name: "issued_to_expired",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("expire-me.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.ExpireCertificate(certARN)
+			},
+			wantStatus: "EXPIRED",
+		},
+		{
+			name: "issued_to_inactive",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+				require.NoError(t, err)
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.InactivateCertificate(certARN)
+			},
+			wantStatus: "INACTIVE",
+		},
+		{
+			name: "pending_to_validation_timed_out",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("timeout.example.com", "", "DNS", "", "", nil)
+				require.NoError(t, err)
+				require.Equal(t, "PENDING_VALIDATION", cert.Status)
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.TimeoutPendingValidation(certARN)
+			},
+			wantStatus: "VALIDATION_TIMED_OUT",
+		},
+		{
+			name: "pending_to_failed",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("fail-me.example.com", "", "EMAIL", "", "", nil)
+				require.NoError(t, err)
+				require.Equal(t, "PENDING_VALIDATION", cert.Status)
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.FailCertificate(certARN, "NO_AVAILABLE_CONTACTS")
+			},
+			wantStatus: "FAILED",
+		},
+		{
+			name: "expire_not_found",
+			setup: func(_ *testing.T, _ *acm.InMemoryBackend) string {
+				return "arn:aws:acm:us-east-1:000000000000:certificate/nonexistent"
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.ExpireCertificate(certARN)
+			},
+			wantErr: acm.ErrCertNotFound,
+		},
+		{
+			name: "expire_wrong_status",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("already-revoked.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+				require.NoError(t, b.RevokeCertificate(cert.ARN, "UNSPECIFIED"))
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.ExpireCertificate(certARN)
+			},
+			wantErr: acm.ErrInvalidParameter,
+		},
+		{
+			name: "timeout_already_issued",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("already-issued.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+				require.Equal(t, "ISSUED", cert.Status)
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.TimeoutPendingValidation(certARN)
+			},
+			wantErr: acm.ErrInvalidParameter,
+		},
+		{
+			name: "fail_already_issued",
+			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("already-issued2.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+
+				return cert.ARN
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.FailCertificate(certARN, "DOMAIN_NOT_ALLOWED")
+			},
+			wantErr: acm.ErrInvalidParameter,
+		},
+		{
+			name: "inactivate_not_found",
+			setup: func(_ *testing.T, _ *acm.InMemoryBackend) string {
+				return "arn:aws:acm:us-east-1:000000000000:certificate/ghost"
+			},
+			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
+				return b.InactivateCertificate(certARN)
+			},
+			wantErr: acm.ErrCertNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			certARN := tt.setup(t, b)
+			err := tt.transition(t, b, certARN)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			cert, descErr := b.DescribeCertificate(certARN)
+			require.NoError(t, descErr)
+			assert.Equal(t, tt.wantStatus, cert.Status)
+		})
+	}
+}
+
+// TestACMBackend_FailCertificate_FailureReason verifies FailureReason is persisted.
+func TestACMBackend_FailCertificate_FailureReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		reason string
+		name   string
+	}{
+		{name: "no_available_contacts", reason: "NO_AVAILABLE_CONTACTS"},
+		{name: "domain_not_allowed", reason: "DOMAIN_NOT_ALLOWED"},
+		{name: "invalid_public_domain", reason: "INVALID_PUBLIC_DOMAIN"},
+		{name: "caa_error", reason: "CAA_ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			cert, err := b.RequestCertificate("fail.example.com", "", "EMAIL", "", "", nil)
+			require.NoError(t, err)
+
+			require.NoError(t, b.FailCertificate(cert.ARN, tt.reason))
+
+			described, descErr := b.DescribeCertificate(cert.ARN)
+			require.NoError(t, descErr)
+			assert.Equal(t, "FAILED", described.Status)
+			assert.Equal(t, tt.reason, described.FailureReason)
+		})
+	}
+}
+
+// TestACMBackend_ExportCertificate_Passphrase verifies passphrase encryption in ExportCertificate.
+func TestACMBackend_ExportCertificate_Passphrase(t *testing.T) {
+	t.Parallel()
+
+	certPEM, keyPEM := generateTestCert(t)
+
+	tests := []struct {
+		name             string
+		wantKeyHeader    string
+		passphrase       []byte
+		wantKeyEncrypted bool
+	}{
+		{
+			name:             "no_passphrase_returns_plain",
+			passphrase:       nil,
+			wantKeyHeader:    "-----BEGIN EC PRIVATE KEY-----",
+			wantKeyEncrypted: false,
+		},
+		{
+			name:             "with_passphrase_returns_encrypted",
+			passphrase:       []byte("s3cr3t"),
+			wantKeyHeader:    "-----BEGIN ENCRYPTED PRIVATE KEY-----",
+			wantKeyEncrypted: true,
+		},
+		{
+			name:             "empty_passphrase_returns_plain",
+			passphrase:       []byte{},
+			wantKeyHeader:    "-----BEGIN EC PRIVATE KEY-----",
+			wantKeyEncrypted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			imported, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+			require.NoError(t, err)
+
+			exported, exportErr := b.ExportCertificate(imported.ARN, tt.passphrase)
+			require.NoError(t, exportErr)
+
+			assert.True(t, strings.HasPrefix(exported.PrivateKey, tt.wantKeyHeader),
+				"PrivateKey should start with %q, got: %.50s", tt.wantKeyHeader, exported.PrivateKey)
+			assert.NotEmpty(t, exported.CertificateBody)
+			assert.NotEmpty(t, exported.CertificateChain)
+		})
+	}
+}
+
+// TestACMBackend_ListCertificates_KeyUsageFilter verifies Includes.KeyUsage filtering.
+func TestACMBackend_ListCertificates_KeyUsageFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		filterKeyUsage []string
+		wantCount      int
+		wantNonEmpty   bool
+	}{
+		{
+			name:           "filter_digital_signature_matches",
+			filterKeyUsage: []string{"DIGITAL_SIGNATURE"},
+			wantNonEmpty:   true,
+		},
+		{
+			name:           "filter_nonexistent_usage_no_match",
+			filterKeyUsage: []string{"KEY_ENCIPHERMENT"},
+			wantCount:      0,
+		},
+		{
+			name:           "no_filter_returns_all",
+			filterKeyUsage: nil,
+			wantNonEmpty:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			_, err := b.RequestCertificate("ku.example.com", "", "", "", "", nil)
+			require.NoError(t, err)
+
+			result := b.ListCertificates(acm.ListCertificatesParams{KeyUsage: tt.filterKeyUsage})
+
+			if tt.wantNonEmpty {
+				assert.NotEmpty(t, result.Data)
+			} else {
+				assert.Len(t, result.Data, tt.wantCount)
+			}
+		})
+	}
+}
+
+// TestACMBackend_ListCertificates_ExtendedKeyUsageFilter verifies Includes.ExtendedKeyUsage filtering.
+func TestACMBackend_ListCertificates_ExtendedKeyUsageFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		filterExtKeyUsage []string
+		wantCount         int
+		wantNonEmpty      bool
+	}{
+		{
+			name:              "filter_tls_server_auth_matches",
+			filterExtKeyUsage: []string{"TLS_WEB_SERVER_AUTHENTICATION"},
+			wantNonEmpty:      true,
+		},
+		{
+			name:              "filter_code_signing_no_match",
+			filterExtKeyUsage: []string{"CODE_SIGNING"},
+			wantCount:         0,
+		},
+		{
+			name:              "no_filter_returns_all",
+			filterExtKeyUsage: nil,
+			wantNonEmpty:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			_, err := b.RequestCertificate("eku.example.com", "", "", "", "", nil)
+			require.NoError(t, err)
+
+			result := b.ListCertificates(acm.ListCertificatesParams{ExtendedKeyUsage: tt.filterExtKeyUsage})
+
+			if tt.wantNonEmpty {
+				assert.NotEmpty(t, result.Data)
+			} else {
+				assert.Len(t, result.Data, tt.wantCount)
+			}
+		})
+	}
+}
+
+// TestACMBackend_ImportCertificate_KeyUsageParsed verifies that imported certs have key usages parsed.
+func TestACMBackend_ImportCertificate_KeyUsageParsed(t *testing.T) {
+	t.Parallel()
+
+	certPEM, keyPEM := generateTestCert(t)
+
+	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+	cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+	require.NoError(t, err)
+
+	described, descErr := b.DescribeCertificate(cert.ARN)
+	require.NoError(t, descErr)
+
+	assert.NotEmpty(t, described.KeyUsage, "imported cert should have key usages parsed from X.509")
+	assert.Contains(t, described.KeyUsage, "DIGITAL_SIGNATURE")
+	assert.NotEmpty(t, described.ExtendedKeyUsage, "imported cert should have extended key usages parsed")
+	assert.Contains(t, described.ExtendedKeyUsage, "TLS_WEB_SERVER_AUTHENTICATION")
 }
 
 // TestACMBackend_ValidityAndEligibility verifies that NotBefore, NotAfter, and

--- a/services/acm/handler.go
+++ b/services/acm/handler.go
@@ -2,6 +2,7 @@ package acm
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -643,6 +644,8 @@ func (h *Handler) jsonListCertificates(body []byte) (any, error) {
 
 	if input.Includes != nil {
 		params.KeyTypes = input.Includes.KeyTypes
+		params.KeyUsage = input.Includes.KeyUsage
+		params.ExtendedKeyUsage = input.Includes.ExtendedKeyUsage
 	}
 
 	p := h.Backend.ListCertificates(params)
@@ -776,7 +779,21 @@ func (h *Handler) jsonExportCertificate(body []byte) (any, error) {
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
-	cert, err := h.Backend.ExportCertificate(input.CertificateArn)
+
+	if input.Passphrase == "" {
+		return nil, fmt.Errorf("%w: Passphrase is required for ExportCertificate", ErrInvalidParameter)
+	}
+
+	passphrase, decErr := base64.StdEncoding.DecodeString(input.Passphrase)
+	if decErr != nil {
+		// Try raw (unpadded) base64.
+		passphrase, decErr = base64.RawStdEncoding.DecodeString(input.Passphrase)
+		if decErr != nil {
+			return nil, fmt.Errorf("%w: Passphrase must be base64-encoded", ErrInvalidParameter)
+		}
+	}
+
+	cert, err := h.Backend.ExportCertificate(input.CertificateArn, passphrase)
 	if err != nil {
 		return nil, err
 	}

--- a/services/acm/handler_test.go
+++ b/services/acm/handler_test.go
@@ -1575,3 +1575,367 @@ func TestACMHandler_WildcardCertificate_Accepted(t *testing.T) {
 	rec := postACMJSON(t, h, "RequestCertificate", `{"DomainName":"*.example.com"}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+// TestACMHandler_ExportCertificate_PassphraseRequired verifies that Passphrase is required.
+func TestACMHandler_ExportCertificate_PassphraseRequired(t *testing.T) {
+	t.Parallel()
+
+	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+	src, err := b.RequestCertificate("export-pass.example.com", "", "", "", "", nil)
+	require.NoError(t, err)
+
+	importedCert, err := b.ImportCertificate(src.CertificateBody, src.PrivateKey, "", "")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		body         string
+		wantContains []string
+		wantCode     int
+	}{
+		{
+			name: "missing_passphrase_rejected",
+			body: func() string {
+				b2, _ := json.Marshal(map[string]string{"CertificateArn": importedCert.ARN})
+
+				return string(b2)
+			}(),
+			wantCode:     http.StatusBadRequest,
+			wantContains: []string{"ValidationException", "Passphrase"},
+		},
+		{
+			name: "with_passphrase_success_encrypted_key",
+			body: func() string {
+				b2, _ := json.Marshal(map[string]string{
+					"CertificateArn": importedCert.ARN,
+					"Passphrase":     "dGVzdC1wYXNz", // base64("test-pass")
+				})
+
+				return string(b2)
+			}(),
+			wantCode:     http.StatusOK,
+			wantContains: []string{"ENCRYPTED PRIVATE KEY"},
+		},
+		{
+			name: "invalid_base64_passphrase",
+			body: func() string {
+				b2, _ := json.Marshal(map[string]string{
+					"CertificateArn": importedCert.ARN,
+					"Passphrase":     "not-valid-base64!!!",
+				})
+
+				return string(b2)
+			}(),
+			wantCode:     http.StatusBadRequest,
+			wantContains: []string{"ValidationException"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := acm.NewHandler(b)
+			rec := postACMJSON(t, h, "ExportCertificate", tt.body)
+			assert.Equal(t, tt.wantCode, rec.Code)
+			for _, s := range tt.wantContains {
+				assert.Contains(t, rec.Body.String(), s)
+			}
+		})
+	}
+}
+
+// TestACMHandler_ListCertificates_IncludesFilters verifies KeyUsage and ExtendedKeyUsage filtering.
+func TestACMHandler_ListCertificates_IncludesFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		listBody     string
+		wantNonEmpty bool
+		wantCode     int
+	}{
+		{
+			name:         "filter_digital_signature_matches",
+			listBody:     `{"Includes":{"keyUsage":["DIGITAL_SIGNATURE"]}}`,
+			wantCode:     http.StatusOK,
+			wantNonEmpty: true,
+		},
+		{
+			name:         "filter_nonexistent_key_usage_empty",
+			listBody:     `{"Includes":{"keyUsage":["KEY_ENCIPHERMENT"]}}`,
+			wantCode:     http.StatusOK,
+			wantNonEmpty: false,
+		},
+		{
+			name:         "filter_tls_server_auth_matches",
+			listBody:     `{"Includes":{"extendedKeyUsage":["TLS_WEB_SERVER_AUTHENTICATION"]}}`,
+			wantCode:     http.StatusOK,
+			wantNonEmpty: true,
+		},
+		{
+			name:         "filter_code_signing_empty",
+			listBody:     `{"Includes":{"extendedKeyUsage":["CODE_SIGNING"]}}`,
+			wantCode:     http.StatusOK,
+			wantNonEmpty: false,
+		},
+		{
+			name:         "filter_combined_key_type_and_usage",
+			listBody:     `{"Includes":{"keyTypes":["EC_prime256v1"],"keyUsage":["DIGITAL_SIGNATURE"]}}`,
+			wantCode:     http.StatusOK,
+			wantNonEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newACMHandler()
+			// Create one cert that will have DIGITAL_SIGNATURE + TLS_WEB_SERVER_AUTHENTICATION
+			rec := postACMJSON(t, h, "RequestCertificate", `{"DomainName":"includes-filter.example.com"}`)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			listRec := postACMJSON(t, h, "ListCertificates", tt.listBody)
+			assert.Equal(t, tt.wantCode, listRec.Code)
+
+			if tt.wantCode == http.StatusOK {
+				var out struct {
+					CertificateSummaryList []struct{} `json:"CertificateSummaryList"`
+				}
+				require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &out))
+				if tt.wantNonEmpty {
+					assert.NotEmpty(t, out.CertificateSummaryList)
+				} else {
+					assert.Empty(t, out.CertificateSummaryList)
+				}
+			}
+		})
+	}
+}
+
+// TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus verifies that lifecycle status
+// transitions are visible via DescribeCertificate through the full HTTP stack.
+func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setupCert  func(t *testing.T, b *acm.InMemoryBackend) string
+		transition func(t *testing.T, b *acm.InMemoryBackend, certARN string)
+		name       string
+		wantStatus string
+	}{
+		{
+			name: "issued_to_expired",
+			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("lifecycle-expire.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+
+				return cert.ARN
+			},
+			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
+				t.Helper()
+				require.NoError(t, b.ExpireCertificate(certARN))
+			},
+			wantStatus: "EXPIRED",
+		},
+		{
+			name: "issued_to_inactive",
+			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("lifecycle-inactive.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+
+				return cert.ARN
+			},
+			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
+				t.Helper()
+				require.NoError(t, b.InactivateCertificate(certARN))
+			},
+			wantStatus: "INACTIVE",
+		},
+		{
+			name: "pending_to_validation_timed_out",
+			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("lifecycle-timeout.example.com", "", "DNS", "", "", nil)
+				require.NoError(t, err)
+				require.Equal(t, "PENDING_VALIDATION", cert.Status)
+
+				return cert.ARN
+			},
+			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
+				t.Helper()
+				require.NoError(t, b.TimeoutPendingValidation(certARN))
+			},
+			wantStatus: "VALIDATION_TIMED_OUT",
+		},
+		{
+			name: "pending_to_failed",
+			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("lifecycle-fail.example.com", "", "EMAIL", "", "", nil)
+				require.NoError(t, err)
+				require.Equal(t, "PENDING_VALIDATION", cert.Status)
+
+				return cert.ARN
+			},
+			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
+				t.Helper()
+				require.NoError(t, b.FailCertificate(certARN, "NO_AVAILABLE_CONTACTS"))
+			},
+			wantStatus: "FAILED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			h := acm.NewHandler(b)
+
+			certARN := tt.setupCert(t, b)
+			tt.transition(t, b, certARN)
+
+			descBody, _ := json.Marshal(map[string]string{"CertificateArn": certARN})
+			descRec := postACMJSON(t, h, "DescribeCertificate", string(descBody))
+			require.Equal(t, http.StatusOK, descRec.Code)
+
+			var descOut struct {
+				Certificate struct {
+					Status        string `json:"Status"`
+					FailureReason string `json:"FailureReason,omitempty"`
+				} `json:"Certificate"`
+			}
+			require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &descOut))
+			assert.Equal(t, tt.wantStatus, descOut.Certificate.Status)
+		})
+	}
+}
+
+// TestACMHandler_ListCertificates_StatusFilter_AllStatuses verifies filtering across all lifecycle statuses.
+func TestACMHandler_ListCertificates_StatusFilter_AllStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setupAndTransition func(t *testing.T, b *acm.InMemoryBackend) string
+		name               string
+		filterStatus       string
+		wantCount          int
+	}{
+		{
+			name: "filter_expired_status",
+			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("expired-list.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+				require.NoError(t, b.ExpireCertificate(cert.ARN))
+
+				return cert.ARN
+			},
+			filterStatus: "EXPIRED",
+			wantCount:    1,
+		},
+		{
+			name: "filter_inactive_status",
+			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("inactive-list.example.com", "", "", "", "", nil)
+				require.NoError(t, err)
+				require.NoError(t, b.InactivateCertificate(cert.ARN))
+
+				return cert.ARN
+			},
+			filterStatus: "INACTIVE",
+			wantCount:    1,
+		},
+		{
+			name: "filter_timed_out_status",
+			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("timeout-list.example.com", "", "DNS", "", "", nil)
+				require.NoError(t, err)
+				require.NoError(t, b.TimeoutPendingValidation(cert.ARN))
+
+				return cert.ARN
+			},
+			filterStatus: "VALIDATION_TIMED_OUT",
+			wantCount:    1,
+		},
+		{
+			name: "filter_failed_status",
+			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
+				t.Helper()
+				cert, err := b.RequestCertificate("failed-list.example.com", "", "EMAIL", "", "", nil)
+				require.NoError(t, err)
+				require.NoError(t, b.FailCertificate(cert.ARN, "CAA_ERROR"))
+
+				return cert.ARN
+			},
+			filterStatus: "FAILED",
+			wantCount:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+			h := acm.NewHandler(b)
+
+			tt.setupAndTransition(t, b)
+
+			filterBody, _ := json.Marshal(map[string][]string{
+				"CertificateStatuses": {tt.filterStatus},
+			})
+			rec := postACMJSON(t, h, "ListCertificates", string(filterBody))
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var out struct {
+				CertificateSummaryList []struct {
+					Status string `json:"Status"`
+				} `json:"CertificateSummaryList"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+			assert.Len(t, out.CertificateSummaryList, tt.wantCount)
+
+			if tt.wantCount > 0 {
+				assert.Equal(t, tt.filterStatus, out.CertificateSummaryList[0].Status)
+			}
+		})
+	}
+}
+
+// TestACMHandler_ExportCertificate_CertificateChainAlwaysPresent verifies chain is always returned.
+func TestACMHandler_ExportCertificate_CertificateChainAlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
+	src, err := b.RequestCertificate("chain-test.example.com", "", "", "", "", nil)
+	require.NoError(t, err)
+
+	// Import without chain
+	imported, err := b.ImportCertificate(src.CertificateBody, src.PrivateKey, "", "")
+	require.NoError(t, err)
+
+	h := acm.NewHandler(b)
+	exportBody, _ := json.Marshal(map[string]string{
+		"CertificateArn": imported.ARN,
+		"Passphrase":     "dGVzdA==", // base64("test")
+	})
+	rec := postACMJSON(t, h, "ExportCertificate", string(exportBody))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		CertificateChain string `json:"CertificateChain"`
+		Certificate      string `json:"Certificate"`
+		PrivateKey       string `json:"PrivateKey"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.NotEmpty(t, out.CertificateChain, "CertificateChain should always be present on export")
+	assert.NotEmpty(t, out.Certificate)
+	assert.NotEmpty(t, out.PrivateKey)
+}


### PR DESCRIPTION
## Summary

- Add full certificate status lifecycle: EXPIRED, INACTIVE, VALIDATION_TIMED_OUT, FAILED with dedicated backend transition methods
- ExportCertificate now enforces passphrase requirement (matches AWS API) and encrypts private key with AES-256 when passphrase provided
- ListCertificates `Includes` filter extended to support `KeyUsage` and `ExtendedKeyUsage` alongside existing `KeyTypes`
- ImportCertificate and re-import now parse KeyUsage/ExtendedKeyUsage from actual X.509 certificate content
- Extract `listCertFilters` struct to reduce cognitive complexity of `ListCertificates`

## Test plan

- [x] `go test ./services/acm/... -count=1` — 178 table-driven test cases all pass
- [x] `go vet ./services/acm/...` — clean
- [x] `golangci-lint run ./services/acm/...` — 0 issues
- [x] Status lifecycle transitions tested: ISSUED→EXPIRED, ISSUED→INACTIVE, PENDING→VALIDATION_TIMED_OUT, PENDING→FAILED
- [x] ExportCertificate: missing passphrase → 400, valid passphrase → encrypted key with `ENCRYPTED PRIVATE KEY` header
- [x] ListCertificates KeyUsage/ExtendedKeyUsage filter: matching → returns results, non-matching → empty
- [x] ImportCertificate key usage parsing verified via DescribeCertificate

🤖 Generated with [Claude Code](https://claude.com/claude-code)