### PR TITLE
feat(support): implement AWS-accurate support workflows

### DIFF
--- a/services/support/accuracy.go
+++ b/services/support/accuracy.go
@@ -1,0 +1,505 @@
+package support
+
+import (
+	"encoding/base64"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+)
+
+const (
+	defaultAccountID         = "000000000000"
+	defaultCaseLanguage      = "en"
+	defaultIssueType         = "technical"
+	defaultSubmittedBy       = "customer"
+	maxCCEmailAddresses      = 10
+	maxCommunicationBodySize = 8000
+	maxAttachmentsPerSet     = 3
+	maxAttachmentSize        = 5 * 1024 * 1024
+	defaultPageSize          = 100
+	minPageSize              = 10
+	maxPageSize              = 100
+	recentCommunicationsSize = 5
+)
+
+var (
+	// ErrAttachmentSetNotFound indicates an unknown staged attachment set.
+	ErrAttachmentSetNotFound = awserr.New("AttachmentSetIdNotFound", awserr.ErrNotFound)
+	// ErrAttachmentSetExpired indicates a staged attachment set passed its one-hour lifetime.
+	ErrAttachmentSetExpired = awserr.New("AttachmentSetExpired", awserr.ErrInvalidParameter)
+)
+
+// CreateCaseOptions contains API-visible case creation data.
+type CreateCaseOptions struct {
+	Subject           string
+	ServiceCode       string
+	CategoryCode      string
+	SeverityCode      string
+	CommunicationBody string
+	AttachmentSetID   string
+	Language          string
+	IssueType         string
+	CCEmails          []string
+}
+
+// AddCommunicationOptions contains API-visible communication input data.
+type AddCommunicationOptions struct {
+	CaseID            string
+	CommunicationBody string
+	AttachmentSetID   string
+	CCEmails          []string
+}
+
+// DescribeCasesOptions contains supported case query and pagination filters.
+type DescribeCasesOptions struct {
+	AfterTime             *time.Time
+	BeforeTime            *time.Time
+	DisplayID             string
+	Language              string
+	NextToken             string
+	CaseIDs               []string
+	MaxResults            int
+	IncludeResolvedCases  bool
+	IncludeCommunications bool
+}
+
+// DescribeCommunicationsOptions contains communication filters and pagination data.
+type DescribeCommunicationsOptions struct {
+	AfterTime  *time.Time
+	BeforeTime *time.Time
+	CaseID     string
+	NextToken  string
+	MaxResults int
+}
+
+// CreateCaseWithOptions stores an AWS-shaped support case and its initial communication.
+func (b *InMemoryBackend) CreateCaseWithOptions(in CreateCaseOptions) (*Case, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	attachments, err := b.consumeAttachmentSetLocked(in.AttachmentSetID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	b.nextDisplayID++
+	cs := &Case{
+		CaseID: fmt.Sprintf(
+			"case-%s-%d-%s",
+			defaultAccountID,
+			now.Year(),
+			strings.ReplaceAll(uuid.NewString(), "-", "")[:16],
+		),
+		DisplayID:    fmt.Sprintf("%010d", b.nextDisplayID),
+		Subject:      in.Subject,
+		Status:       caseStatusOpened,
+		ServiceCode:  in.ServiceCode,
+		CategoryCode: in.CategoryCode,
+		SeverityCode: in.SeverityCode,
+		Language:     defaultIfEmpty(in.Language, defaultCaseLanguage),
+		IssueType:    defaultIfEmpty(in.IssueType, defaultIssueType),
+		SubmittedBy:  defaultSubmittedBy,
+		CCEmails:     append([]string(nil), in.CCEmails...),
+		Body:         in.CommunicationBody,
+		CreatedTime:  now,
+	}
+	b.cases[cs.CaseID] = cs
+	b.communications[cs.CaseID] = []Communication{
+		newCommunication(cs.CaseID, in.CommunicationBody, in.CCEmails, attachments, now),
+	}
+
+	out := *cs
+	out.CCEmails = append([]string(nil), cs.CCEmails...)
+
+	return &out, nil
+}
+
+// DescribeCasesWithOptions returns ordered and paginated cases matching API filters.
+func (b *InMemoryBackend) DescribeCasesWithOptions(in DescribeCasesOptions) ([]Case, string, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	cases := make([]Case, 0, len(b.cases))
+	for _, cs := range b.cases {
+		if matchCase(cs, in) {
+			cp := *cs
+			cp.CCEmails = append([]string(nil), cs.CCEmails...)
+			cases = append(cases, cp)
+		}
+	}
+	sort.Slice(cases, func(i, j int) bool { return cases[i].CreatedTime.After(cases[j].CreatedTime) })
+
+	start, err := pageOffset(in.NextToken)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return paginate(cases, start, pageLimit(in.MaxResults))
+}
+
+// RecentCommunications returns up to five newest communications for DescribeCases.
+func (b *InMemoryBackend) RecentCommunications(caseID string) ([]Communication, string) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	comms := cloneCommunications(b.communications[caseID])
+	sortCommunications(comms)
+	page, token, _ := paginate(comms, 0, recentCommunicationsSize)
+
+	return page, token
+}
+
+// AddCommunicationWithOptions stores a customer response and reopens a resolved case.
+func (b *InMemoryBackend) AddCommunicationWithOptions(in AddCommunicationOptions) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	cs, ok := b.cases[in.CaseID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrNotFound, in.CaseID)
+	}
+	attachments, err := b.consumeAttachmentSetLocked(in.AttachmentSetID)
+	if err != nil {
+		return err
+	}
+	if cs.Status == caseStatusResolved {
+		cs.Status = "reopened"
+		cs.ResolvedTime = nil
+	}
+	b.communications[in.CaseID] = append(
+		b.communications[in.CaseID],
+		newCommunication(in.CaseID, in.CommunicationBody, in.CCEmails, attachments, time.Now()),
+	)
+
+	return nil
+}
+
+// ResolveCaseWithStatus resolves a case and returns its real prior status.
+func (b *InMemoryBackend) ResolveCaseWithStatus(caseID string) (string, *Case, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	cs, ok := b.cases[caseID]
+	if !ok {
+		return "", nil, fmt.Errorf("%w: %s", ErrNotFound, caseID)
+	}
+	if cs.Status == caseStatusResolved {
+		return "", nil, fmt.Errorf("%w: %s", ErrAlreadyResolved, caseID)
+	}
+	initialStatus := cs.Status
+	now := time.Now()
+	cs.Status = caseStatusResolved
+	cs.ResolvedTime = &now
+	out := *cs
+
+	return initialStatus, &out, nil
+}
+
+// DescribeCommunicationsWithOptions returns ordered communications matching API filters.
+func (b *InMemoryBackend) DescribeCommunicationsWithOptions(
+	in DescribeCommunicationsOptions,
+) ([]Communication, string, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if _, ok := b.cases[in.CaseID]; !ok {
+		return nil, "", fmt.Errorf("%w: %s", ErrNotFound, in.CaseID)
+	}
+	comms := make([]Communication, 0, len(b.communications[in.CaseID]))
+	for _, comm := range b.communications[in.CaseID] {
+		if in.AfterTime != nil && !comm.TimeCreated.After(*in.AfterTime) {
+			continue
+		}
+		if in.BeforeTime != nil && !comm.TimeCreated.Before(*in.BeforeTime) {
+			continue
+		}
+		comms = append(comms, cloneCommunication(comm))
+	}
+	sortCommunications(comms)
+	start, err := pageOffset(in.NextToken)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return paginate(comms, start, pageLimit(in.MaxResults))
+}
+
+// AddAttachmentsToSetWithAttachments stages uploaded files for single-use consumption.
+func (b *InMemoryBackend) AddAttachmentsToSetWithAttachments(
+	attachmentSetID string,
+	attachments []Attachment,
+) (string, time.Time, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(attachments) == 0 {
+		return "", time.Time{}, fmt.Errorf("%w: attachments is required", ErrValidation)
+	}
+	if err := validateAttachments(attachments); err != nil {
+		return "", time.Time{}, err
+	}
+	set, setID, err := b.attachmentSetForAppendLocked(attachmentSetID)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	if len(set.AttachmentIDs)+len(attachments) > maxAttachmentsPerSet {
+		return "", time.Time{}, fmt.Errorf(
+			"%w: maximum of %d attachments exceeded",
+			ErrValidation,
+			maxAttachmentsPerSet,
+		)
+	}
+	for _, attachment := range attachments {
+		attachment.AttachmentID = "att-" + uuid.NewString()
+		cp := attachment
+		cp.Data = append([]byte(nil), attachment.Data...)
+		b.attachments[cp.AttachmentID] = &cp
+		set.AttachmentIDs = append(set.AttachmentIDs, cp.AttachmentID)
+	}
+	set.Expiry = time.Now().Add(time.Hour)
+
+	return setID, set.Expiry, nil
+}
+
+func validateAttachments(attachments []Attachment) error {
+	for _, attachment := range attachments {
+		if attachment.FileName == "" || len(attachment.Data) > maxAttachmentSize {
+			return fmt.Errorf("%w: invalid attachment", ErrValidation)
+		}
+	}
+
+	return nil
+}
+
+func (b *InMemoryBackend) attachmentSetForAppendLocked(id string) (*AttachmentSet, string, error) {
+	if id == "" {
+		id = uuid.NewString()
+		set := &AttachmentSet{}
+		b.attachmentSets[id] = set
+
+		return set, id, nil
+	}
+	set, ok := b.attachmentSets[id]
+	if !ok {
+		return nil, "", fmt.Errorf("%w: %s", ErrAttachmentSetNotFound, id)
+	}
+	if time.Now().After(set.Expiry) {
+		return nil, "", fmt.Errorf("%w: %s", ErrAttachmentSetExpired, id)
+	}
+
+	return set, id, nil
+}
+
+func (b *InMemoryBackend) consumeAttachmentSetLocked(id string) ([]AttachmentRef, error) {
+	if id == "" {
+		return nil, nil
+	}
+	set, ok := b.attachmentSets[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrAttachmentSetNotFound, id)
+	}
+	if time.Now().After(set.Expiry) {
+		return nil, fmt.Errorf("%w: %s", ErrAttachmentSetExpired, id)
+	}
+	refs := make([]AttachmentRef, 0, len(set.AttachmentIDs))
+	for _, attachmentID := range set.AttachmentIDs {
+		attachment := b.attachments[attachmentID]
+		refs = append(refs, AttachmentRef{AttachmentID: attachmentID, FileName: attachment.FileName})
+	}
+	delete(b.attachmentSets, id)
+
+	return refs, nil
+}
+
+func validateCreateCase(in CreateCaseOptions) error {
+	switch {
+	case in.Subject == "":
+		return fmt.Errorf("%w: subject is required", ErrValidation)
+	case in.CommunicationBody == "":
+		return fmt.Errorf("%w: communicationBody is required", ErrValidation)
+	case len(in.CommunicationBody) > maxCommunicationBodySize:
+		return fmt.Errorf("%w: communicationBody exceeds %d characters", ErrValidation, maxCommunicationBodySize)
+	case len(in.CCEmails) > maxCCEmailAddresses:
+		return fmt.Errorf("%w: too many ccEmailAddresses", ErrValidation)
+	case in.Language != "" && !validLanguage(in.Language):
+		return fmt.Errorf("%w: invalid language", ErrValidation)
+	case in.IssueType != "" && !validIssueType(in.IssueType):
+		return fmt.Errorf("%w: invalid issueType", ErrValidation)
+	case in.SeverityCode != "" && !validSeverity(in.SeverityCode):
+		return fmt.Errorf("%w: invalid severityCode", ErrValidation)
+	}
+
+	return nil
+}
+
+func validateCommunication(in AddCommunicationOptions) error {
+	switch {
+	case in.CaseID == "":
+		return fmt.Errorf("%w: caseId is required", ErrValidation)
+	case in.CommunicationBody == "":
+		return fmt.Errorf("%w: communicationBody is required", ErrValidation)
+	case len(in.CommunicationBody) > maxCommunicationBodySize:
+		return fmt.Errorf("%w: communicationBody exceeds %d characters", ErrValidation, maxCommunicationBodySize)
+	case len(in.CCEmails) > maxCCEmailAddresses:
+		return fmt.Errorf("%w: too many ccEmailAddresses", ErrValidation)
+	}
+
+	return nil
+}
+
+func validLanguage(value string) bool {
+	return value == "en" || value == "ja" || value == "zh" || value == "ko"
+}
+
+func validIssueType(value string) bool {
+	return value == "technical" || value == "customer-service" || value == "account-and-billing"
+}
+
+func validSeverity(value string) bool {
+	return value == severityLow || value == severityNormal || value == severityHigh ||
+		value == severityUrgent || value == severityCritical
+}
+
+func validCheckID(checkID string) bool {
+	for _, check := range trustedAdvisorChecks() {
+		if check.ID == checkID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validateCheckIDs(checkIDs []string) error {
+	if len(checkIDs) == 0 {
+		return fmt.Errorf("%w: checkIds is required", ErrValidation)
+	}
+	for _, checkID := range checkIDs {
+		if !validCheckID(checkID) {
+			return fmt.Errorf("%w: invalid checkId %s", ErrValidation, checkID)
+		}
+	}
+
+	return nil
+}
+
+func newCommunication(
+	caseID string,
+	body string,
+	ccEmails []string,
+	attachments []AttachmentRef,
+	now time.Time,
+) Communication {
+	return Communication{
+		CaseID:        caseID,
+		Body:          body,
+		SubmittedBy:   defaultSubmittedBy,
+		TimeCreated:   now,
+		CCEmails:      append([]string(nil), ccEmails...),
+		AttachmentSet: append([]AttachmentRef(nil), attachments...),
+	}
+}
+
+func matchCase(cs *Case, in DescribeCasesOptions) bool {
+	if !in.IncludeResolvedCases && cs.Status == caseStatusResolved {
+		return false
+	}
+	if in.DisplayID != "" && cs.DisplayID != in.DisplayID {
+		return false
+	}
+	if in.Language != "" && cs.Language != in.Language {
+		return false
+	}
+	if in.AfterTime != nil && !cs.CreatedTime.After(*in.AfterTime) {
+		return false
+	}
+	if in.BeforeTime != nil && !cs.CreatedTime.Before(*in.BeforeTime) {
+		return false
+	}
+	if len(in.CaseIDs) == 0 {
+		return true
+	}
+
+	return slices.Contains(in.CaseIDs, cs.CaseID)
+}
+
+func cloneCommunication(comm Communication) Communication {
+	comm.CCEmails = append([]string(nil), comm.CCEmails...)
+	comm.AttachmentSet = append([]AttachmentRef(nil), comm.AttachmentSet...)
+
+	return comm
+}
+
+func cloneCommunications(comms []Communication) []Communication {
+	out := make([]Communication, 0, len(comms))
+	for _, comm := range comms {
+		out = append(out, cloneCommunication(comm))
+	}
+
+	return out
+}
+
+func sortCommunications(comms []Communication) {
+	sort.Slice(comms, func(i, j int) bool { return comms[i].TimeCreated.After(comms[j].TimeCreated) })
+}
+
+func pageLimit(maxResults int) int {
+	if maxResults == 0 {
+		return defaultPageSize
+	}
+
+	return maxResults
+}
+
+func validatePageSize(maxResults int) error {
+	if maxResults != 0 && (maxResults < minPageSize || maxResults > maxPageSize) {
+		return fmt.Errorf("%w: maxResults must be between %d and %d", ErrValidation, minPageSize, maxPageSize)
+	}
+
+	return nil
+}
+
+func pageOffset(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid nextToken", ErrValidation)
+	}
+	offset, err := strconv.Atoi(string(decoded))
+	if err != nil || offset < 0 {
+		return 0, fmt.Errorf("%w: invalid nextToken", ErrValidation)
+	}
+
+	return offset, nil
+}
+
+func paginate[T any](values []T, start, limit int) ([]T, string, error) {
+	if start > len(values) {
+		return nil, "", fmt.Errorf("%w: invalid nextToken", ErrValidation)
+	}
+	end := min(start+limit, len(values))
+	nextToken := ""
+	if end < len(values) {
+		nextToken = base64.RawURLEncoding.EncodeToString([]byte(strconv.Itoa(end)))
+	}
+
+	return values[start:end], nextToken, nil
+}
+
+func defaultIfEmpty(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}

--- a/services/support/backend.go
+++ b/services/support/backend.go
@@ -3,12 +3,12 @@ package support
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
-	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
 
 const (
@@ -35,6 +35,13 @@ const (
 	checkRefreshStatusProcessing = "processing"
 	checkRefreshStatusSuccess    = "success"
 
+	severityLow             = "low"
+	severityNormal          = "normal"
+	severityHigh            = "high"
+	severityUrgent          = "urgent"
+	severityCritical        = "critical"
+	japaneseGeneralGuidance = "一般的なガイダンス"
+
 	// defaultResourcesProcessed is the default count of processed resources for static check results.
 	defaultResourcesProcessed = int64(10)
 	// refreshMillisDefault is the default milliseconds until next refreshable after a refresh is enqueued.
@@ -56,22 +63,35 @@ var (
 type Case struct {
 	CreatedTime  time.Time  `json:"createdTime"`
 	ResolvedTime *time.Time `json:"resolvedTime,omitempty"`
-	CaseID       string     `json:"caseID"`
+	ServiceCode  string     `json:"serviceCode"`
+	DisplayID    string     `json:"displayId"`
 	Subject      string     `json:"subject"`
 	Status       string     `json:"status"`
-	ServiceCode  string     `json:"serviceCode"`
+	CaseID       string     `json:"caseID"`
 	CategoryCode string     `json:"categoryCode"`
 	SeverityCode string     `json:"severityCode"`
+	Language     string     `json:"language"`
+	IssueType    string     `json:"issueType"`
+	SubmittedBy  string     `json:"submittedBy"`
 	Body         string     `json:"body"`
+	CCEmails     []string   `json:"ccEmailAddresses"`
+}
+
+// AttachmentRef identifies an attachment included in a communication.
+type AttachmentRef struct {
+	AttachmentID string `json:"attachmentId"`
+	FileName     string `json:"fileName"`
 }
 
 // Communication represents a message added to a support case.
 type Communication struct {
-	TimeCreated     time.Time `json:"timeCreated"`
-	SubmittedBy     string    `json:"submittedBy"`
-	Body            string    `json:"body"`
-	CaseID          string    `json:"caseId"`
-	AttachmentSetID string    `json:"attachmentSetId,omitempty"`
+	TimeCreated     time.Time       `json:"timeCreated"`
+	SubmittedBy     string          `json:"submittedBy"`
+	Body            string          `json:"body"`
+	CaseID          string          `json:"caseId"`
+	AttachmentSetID string          `json:"attachmentSetId,omitempty"`
+	AttachmentSet   []AttachmentRef `json:"attachmentSet,omitempty"`
+	CCEmails        []string        `json:"ccEmailAddresses,omitempty"`
 }
 
 // TrustedAdvisorCheck represents a Trusted Advisor check.
@@ -88,6 +108,12 @@ type Attachment struct {
 	AttachmentID string `json:"attachmentId"`
 	FileName     string `json:"fileName"`
 	Data         []byte `json:"data"`
+}
+
+// AttachmentSet holds staged attachments until a case communication consumes them.
+type AttachmentSet struct {
+	Expiry        time.Time `json:"expiry"`
+	AttachmentIDs []string  `json:"attachmentIds"`
 }
 
 // ServiceCategory represents a category within an AWS service.
@@ -118,9 +144,11 @@ type SupportedLanguage struct {
 
 // TrustedAdvisorCheckRefreshStatus represents the refresh status for a Trusted Advisor check.
 type TrustedAdvisorCheckRefreshStatus struct {
-	CheckID                    string `json:"checkId"`
-	Status                     string `json:"status"`
-	MillisUntilNextRefreshable int64  `json:"millisUntilNextRefreshable"`
+	RefreshTime                time.Time `json:"refreshTime,omitzero"`
+	CheckID                    string    `json:"checkId"`
+	Status                     string    `json:"status"`
+	MillisUntilNextRefreshable int64     `json:"millisUntilNextRefreshable"`
+	PollCount                  int       `json:"pollCount,omitempty"`
 }
 
 // TrustedAdvisorResourcesSummary holds counts of resources examined by a Trusted Advisor check.
@@ -142,20 +170,33 @@ type TrustedAdvisorResourceDetail struct {
 
 // TrustedAdvisorCheckResult represents the full result of a Trusted Advisor check.
 type TrustedAdvisorCheckResult struct {
-	CheckID          string                         `json:"checkId"`
-	Status           string                         `json:"status"`
-	Timestamp        string                         `json:"timestamp"`
-	FlaggedResources []TrustedAdvisorResourceDetail `json:"flaggedResources"`
-	ResourcesSummary TrustedAdvisorResourcesSummary `json:"resourcesSummary"`
+	CategorySpecificSummary *TrustedAdvisorCategorySpecificSummary `json:"categorySpecificSummary"`
+	CheckID                 string                                 `json:"checkId"`
+	Status                  string                                 `json:"status"`
+	Timestamp               string                                 `json:"timestamp"`
+	FlaggedResources        []TrustedAdvisorResourceDetail         `json:"flaggedResources"`
+	ResourcesSummary        TrustedAdvisorResourcesSummary         `json:"resourcesSummary"`
+}
+
+// TrustedAdvisorCategorySpecificSummary provides cost optimization estimates.
+type TrustedAdvisorCategorySpecificSummary struct {
+	CostOptimizing TrustedAdvisorCostOptimizingSummary `json:"costOptimizing"`
+}
+
+// TrustedAdvisorCostOptimizingSummary estimates possible monthly savings.
+type TrustedAdvisorCostOptimizingSummary struct {
+	EstimatedMonthlySavings        float64 `json:"estimatedMonthlySavings"`
+	EstimatedPercentMonthlySavings float64 `json:"estimatedPercentMonthlySavings"`
 }
 
 // TrustedAdvisorCheckSummary represents a summary of a Trusted Advisor check result.
 type TrustedAdvisorCheckSummary struct {
-	CheckID             string                         `json:"checkId"`
-	Status              string                         `json:"status"`
-	Timestamp           string                         `json:"timestamp"`
-	HasFlaggedResources bool                           `json:"hasFlaggedResources"`
-	ResourcesSummary    TrustedAdvisorResourcesSummary `json:"resourcesSummary"`
+	CategorySpecificSummary *TrustedAdvisorCategorySpecificSummary `json:"categorySpecificSummary"`
+	CheckID                 string                                 `json:"checkId"`
+	Status                  string                                 `json:"status"`
+	Timestamp               string                                 `json:"timestamp"`
+	ResourcesSummary        TrustedAdvisorResourcesSummary         `json:"resourcesSummary"`
+	HasFlaggedResources     bool                                   `json:"hasFlaggedResources"`
 }
 
 // SupportedHour represents a time range when support is available.
@@ -270,10 +311,11 @@ func trustedAdvisorChecks() []TrustedAdvisorCheck {
 type InMemoryBackend struct {
 	cases                map[string]*Case
 	communications       map[string][]Communication                   // caseID -> communications
-	attachmentSets       map[string]time.Time                         // attachmentSetID -> expiryTime
+	attachmentSets       map[string]*AttachmentSet                    // attachmentSetID -> staged attachments
 	attachments          map[string]*Attachment                       // attachmentID -> Attachment
 	checkRefreshStatuses map[string]*TrustedAdvisorCheckRefreshStatus // checkID -> status
-	mu                   *lockmetrics.RWMutex
+	nextDisplayID        uint64
+	mu                   sync.RWMutex
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
@@ -281,28 +323,28 @@ func NewInMemoryBackend() *InMemoryBackend {
 	return &InMemoryBackend{
 		cases:                make(map[string]*Case),
 		communications:       make(map[string][]Communication),
-		attachmentSets:       make(map[string]time.Time),
+		attachmentSets:       make(map[string]*AttachmentSet),
 		attachments:          make(map[string]*Attachment),
 		checkRefreshStatuses: make(map[string]*TrustedAdvisorCheckRefreshStatus),
-		mu:                   lockmetrics.New("support"),
 	}
 }
 
 // Reset clears all backend state.
 func (b *InMemoryBackend) Reset() {
-	b.mu.Lock("Reset")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	b.cases = make(map[string]*Case)
 	b.communications = make(map[string][]Communication)
-	b.attachmentSets = make(map[string]time.Time)
+	b.attachmentSets = make(map[string]*AttachmentSet)
 	b.attachments = make(map[string]*Attachment)
 	b.checkRefreshStatuses = make(map[string]*TrustedAdvisorCheckRefreshStatus)
+	b.nextDisplayID = 0
 }
 
 // CreateCase creates a new support case.
 func (b *InMemoryBackend) CreateCase(subject, serviceCode, categoryCode, severityCode, body string) (*Case, error) {
-	b.mu.Lock("CreateCase")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	caseID := "case-" + uuid.New().String()[:8]
@@ -329,7 +371,7 @@ func (b *InMemoryBackend) CreateCase(subject, serviceCode, categoryCode, severit
 // Fast path: when caseIDs are supplied, look them up directly in the
 // case-ID-keyed map instead of scanning every case in the backend.
 func (b *InMemoryBackend) DescribeCases(caseIDs []string, includeResolvedCases bool) []Case {
-	b.mu.RLock("DescribeCases")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	if len(caseIDs) > 0 {
@@ -366,7 +408,7 @@ func (b *InMemoryBackend) DescribeCases(caseIDs []string, includeResolvedCases b
 
 // ResolveCase resolves a support case by caseId.
 func (b *InMemoryBackend) ResolveCase(caseID string) (*Case, error) {
-	b.mu.Lock("ResolveCase")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	c, ok := b.cases[caseID]
@@ -389,7 +431,7 @@ func (b *InMemoryBackend) ResolveCase(caseID string) (*Case, error) {
 
 // AddCommunicationToCase adds a communication to an existing support case.
 func (b *InMemoryBackend) AddCommunicationToCase(caseID, body, attachmentSetID string) error {
-	b.mu.Lock("AddCommunicationToCase")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	if body == "" {
@@ -415,7 +457,7 @@ func (b *InMemoryBackend) AddCommunicationToCase(caseID, body, attachmentSetID s
 
 // DescribeCommunications returns communications for the given case.
 func (b *InMemoryBackend) DescribeCommunications(caseID string) ([]Communication, error) {
-	b.mu.RLock("DescribeCommunications")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	if _, ok := b.cases[caseID]; !ok {
@@ -436,7 +478,7 @@ func (b *InMemoryBackend) DescribeTrustedAdvisorChecks() []TrustedAdvisorCheck {
 
 // AddAttachmentsToSet creates a new attachment set and returns its ID.
 func (b *InMemoryBackend) AddAttachmentsToSet(attachmentSetID string) (string, time.Time, error) {
-	b.mu.Lock("AddAttachmentsToSet")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	if attachmentSetID == "" {
@@ -444,14 +486,14 @@ func (b *InMemoryBackend) AddAttachmentsToSet(attachmentSetID string) (string, t
 	}
 
 	expiry := time.Now().Add(time.Hour)
-	b.attachmentSets[attachmentSetID] = expiry
+	b.attachmentSets[attachmentSetID] = &AttachmentSet{Expiry: expiry}
 
 	return attachmentSetID, expiry, nil
 }
 
 // DescribeAttachment returns the attachment with the given ID.
 func (b *InMemoryBackend) DescribeAttachment(attachmentID string) (*Attachment, error) {
-	b.mu.RLock("DescribeAttachment")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	a, ok := b.attachments[attachmentID]
@@ -466,7 +508,7 @@ func (b *InMemoryBackend) DescribeAttachment(attachmentID string) (*Attachment, 
 
 // AddAttachmentInternal seeds an attachment directly into the backend (for testing).
 func (b *InMemoryBackend) AddAttachmentInternal(a *Attachment) {
-	b.mu.Lock("AddAttachmentInternal")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	cp := *a
@@ -480,7 +522,7 @@ func (b *InMemoryBackend) AddAttachmentInternal(a *Attachment) {
 
 // AddCaseInternal seeds a case directly into the backend (for testing).
 func (b *InMemoryBackend) AddCaseInternal(c *Case) {
-	b.mu.Lock("AddCaseInternal")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	cp := *c
@@ -511,8 +553,8 @@ func (b *InMemoryBackend) DescribeCreateCaseOptions(_, _, _, _ string) *Describe
 }
 
 // DescribeServices returns AWS services, optionally filtered by service codes.
-func (b *InMemoryBackend) DescribeServices(serviceCodeList []string) []Service {
-	all := staticServices()
+func (b *InMemoryBackend) DescribeServices(serviceCodeList []string, language string) []Service {
+	all := staticServices(language)
 	if len(serviceCodeList) == 0 {
 		return all
 	}
@@ -533,13 +575,23 @@ func (b *InMemoryBackend) DescribeServices(serviceCodeList []string) []Service {
 }
 
 // DescribeSeverityLevels returns the available severity levels.
-func (b *InMemoryBackend) DescribeSeverityLevels(_ string) []SeverityLevel {
+func (b *InMemoryBackend) DescribeSeverityLevels(language string) []SeverityLevel {
+	if language == "ja" {
+		return []SeverityLevel{
+			{Code: severityLow, Name: japaneseGeneralGuidance},
+			{Code: severityNormal, Name: "システム障害"},
+			{Code: severityHigh, Name: "本番システム障害"},
+			{Code: severityUrgent, Name: "本番システム停止"},
+			{Code: severityCritical, Name: "ビジネスクリティカルシステム停止"},
+		}
+	}
+
 	return []SeverityLevel{
-		{Code: "low", Name: "General guidance"},
-		{Code: "normal", Name: "System impaired"},
-		{Code: "high", Name: "Production system impaired"},
-		{Code: "urgent", Name: "Production system down"},
-		{Code: "critical", Name: "Business-critical system down"},
+		{Code: severityLow, Name: "General guidance"},
+		{Code: severityNormal, Name: "System impaired"},
+		{Code: severityHigh, Name: "Production system impaired"},
+		{Code: severityUrgent, Name: "Production system down"},
+		{Code: severityCritical, Name: "Business-critical system down"},
 	}
 }
 
@@ -557,12 +609,22 @@ func (b *InMemoryBackend) DescribeSupportedLanguages(_, _, _ string) []Supported
 func (b *InMemoryBackend) DescribeTrustedAdvisorCheckRefreshStatuses(
 	checkIDs []string,
 ) []TrustedAdvisorCheckRefreshStatus {
-	b.mu.RLock("DescribeTrustedAdvisorCheckRefreshStatuses")
-	defer b.mu.RUnlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	out := make([]TrustedAdvisorCheckRefreshStatus, 0, len(checkIDs))
 	for _, id := range checkIDs {
 		if s, ok := b.checkRefreshStatuses[id]; ok {
+			switch s.PollCount {
+			case 0:
+				s.PollCount++
+			case 1:
+				s.Status = checkRefreshStatusProcessing
+				s.PollCount++
+			default:
+				s.Status = checkRefreshStatusSuccess
+				s.MillisUntilNextRefreshable = 0
+			}
 			out = append(out, *s)
 		} else {
 			out = append(out, TrustedAdvisorCheckRefreshStatus{
@@ -578,6 +640,8 @@ func (b *InMemoryBackend) DescribeTrustedAdvisorCheckRefreshStatuses(
 
 // DescribeTrustedAdvisorCheckResult returns the result for the given Trusted Advisor check.
 func (b *InMemoryBackend) DescribeTrustedAdvisorCheckResult(checkID, _ string) *TrustedAdvisorCheckResult {
+	categorySummary := &TrustedAdvisorCategorySpecificSummary{}
+
 	return &TrustedAdvisorCheckResult{
 		CheckID:          checkID,
 		Status:           "ok",
@@ -589,6 +653,7 @@ func (b *InMemoryBackend) DescribeTrustedAdvisorCheckResult(checkID, _ string) *
 			ResourcesIgnored:    0,
 			ResourcesSuppressed: 0,
 		},
+		CategorySpecificSummary: categorySummary,
 	}
 }
 
@@ -609,6 +674,7 @@ func (b *InMemoryBackend) DescribeTrustedAdvisorCheckSummaries(checkIDs []string
 				ResourcesIgnored:    0,
 				ResourcesSuppressed: 0,
 			},
+			CategorySpecificSummary: &TrustedAdvisorCategorySpecificSummary{},
 		})
 	}
 
@@ -617,13 +683,19 @@ func (b *InMemoryBackend) DescribeTrustedAdvisorCheckSummaries(checkIDs []string
 
 // RefreshTrustedAdvisorCheck enqueues a refresh for the given Trusted Advisor check.
 func (b *InMemoryBackend) RefreshTrustedAdvisorCheck(checkID string) (*TrustedAdvisorCheckRefreshStatus, error) {
-	b.mu.Lock("RefreshTrustedAdvisorCheck")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	if existing, ok := b.checkRefreshStatuses[checkID]; ok && time.Since(existing.RefreshTime) < time.Hour {
+		cp := *existing
+
+		return &cp, nil
+	}
 	status := &TrustedAdvisorCheckRefreshStatus{
 		CheckID:                    checkID,
 		Status:                     checkRefreshStatusEnqueued,
 		MillisUntilNextRefreshable: refreshMillisDefault,
+		RefreshTime:                time.Now(),
 	}
 	b.checkRefreshStatuses[checkID] = status
 
@@ -633,8 +705,8 @@ func (b *InMemoryBackend) RefreshTrustedAdvisorCheck(checkID string) (*TrustedAd
 }
 
 // staticServices returns a small static list of common AWS services.
-func staticServices() []Service {
-	return []Service{
+func staticServices(language string) []Service {
+	all := []Service{
 		{
 			Code: "amazon-s3",
 			Name: "Amazon Simple Storage Service (Amazon S3)",
@@ -678,4 +750,11 @@ func staticServices() []Service {
 			},
 		},
 	}
+	if language == "ja" {
+		all[0].Name = "Amazon Simple Storage Service (Amazon S3)"
+		all[0].Categories[2].Name = japaneseGeneralGuidance
+		all[1].Categories[2].Name = japaneseGeneralGuidance
+	}
+
+	return all
 }

--- a/services/support/export_test.go
+++ b/services/support/export_test.go
@@ -2,7 +2,7 @@ package support
 
 // CaseCount returns the number of cases in the backend.
 func CaseCount(b *InMemoryBackend) int {
-	b.mu.RLock("CaseCount")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	return len(b.cases)
@@ -10,7 +10,7 @@ func CaseCount(b *InMemoryBackend) int {
 
 // AttachmentCount returns the number of attachments in the backend.
 func AttachmentCount(b *InMemoryBackend) int {
-	b.mu.RLock("AttachmentCount")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	return len(b.attachments)
@@ -18,7 +18,7 @@ func AttachmentCount(b *InMemoryBackend) int {
 
 // CheckRefreshStatusCount returns the number of tracked refresh statuses.
 func CheckRefreshStatusCount(b *InMemoryBackend) int {
-	b.mu.RLock("CheckRefreshStatusCount")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	return len(b.checkRefreshStatuses)
@@ -26,7 +26,7 @@ func CheckRefreshStatusCount(b *InMemoryBackend) int {
 
 // CommunicationCount returns the total number of communications across all cases.
 func CommunicationCount(b *InMemoryBackend) int {
-	b.mu.RLock("CommunicationCount")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	total := 0

--- a/services/support/handler.go
+++ b/services/support/handler.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/labstack/echo/v5"
 
-	"github.com/blackbirdworks/gopherstack/pkgs/config"
 	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
 	"github.com/blackbirdworks/gopherstack/pkgs/service"
@@ -113,7 +112,7 @@ func (h *Handler) ChaosServiceName() string { return "support" }
 func (h *Handler) ChaosOperations() []string { return h.GetSupportedOperations() }
 
 // ChaosRegions returns all regions this Support instance handles.
-func (h *Handler) ChaosRegions() []string { return []string{config.DefaultRegion} }
+func (h *Handler) ChaosRegions() []string { return []string{"us-east-1"} }
 
 // RouteMatcher returns a function that matches Support requests.
 func (h *Handler) RouteMatcher() service.Matcher {
@@ -137,8 +136,10 @@ func (h *Handler) ExtractOperation(c *echo.Context) string {
 }
 
 type extractSupportResourceInput struct {
-	CaseID  string `json:"caseId"`
-	Subject string `json:"subject"`
+	CaseID       string `json:"caseId"`
+	CheckID      string `json:"checkId"`
+	AttachmentID string `json:"attachmentId"`
+	Subject      string `json:"subject"`
 }
 
 // ExtractResource extracts the case ID from the request body.
@@ -153,6 +154,12 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 
 	if req.CaseID != "" {
 		return req.CaseID
+	}
+	if req.CheckID != "" {
+		return req.CheckID
+	}
+	if req.AttachmentID != "" {
+		return req.AttachmentID
 	}
 
 	return req.Subject
@@ -222,9 +229,9 @@ func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err 
 	var typeErr *json.UnmarshalTypeError
 
 	switch {
-	case errors.Is(err, ErrNotFound), errors.Is(err, ErrAttachmentNotFound):
+	case errors.Is(err, ErrNotFound), errors.Is(err, ErrAttachmentNotFound), errors.Is(err, ErrAttachmentSetNotFound):
 		return c.JSON(http.StatusNotFound, map[string]string{keyMessageField: err.Error()})
-	case errors.Is(err, ErrValidation), errors.Is(err, ErrAlreadyResolved),
+	case errors.Is(err, ErrValidation), errors.Is(err, ErrAttachmentSetExpired), errors.Is(err, ErrAlreadyResolved),
 		errors.Is(err, errUnknownAction),
 		errors.As(err, &syntaxErr), errors.As(err, &typeErr):
 		return c.JSON(http.StatusBadRequest, map[string]string{keyMessageField: err.Error()})
@@ -234,14 +241,18 @@ func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err 
 }
 
 type caseView struct {
-	CreatedTime  string  `json:"timeCreated"`
-	ResolvedTime *string `json:"timeResolved,omitempty"`
-	CaseID       string  `json:"caseId"`
-	Subject      string  `json:"subject"`
-	Status       string  `json:"status"`
-	ServiceCode  string  `json:"serviceCode"`
-	CategoryCode string  `json:"categoryCode"`
-	SeverityCode string  `json:"severityCode"`
+	RecentCommunications *recentCaseCommunicationsView `json:"recentCommunications,omitempty"`
+	CreatedTime          string                        `json:"timeCreated"`
+	CaseID               string                        `json:"caseId"`
+	DisplayID            string                        `json:"displayId"`
+	Subject              string                        `json:"subject"`
+	Status               string                        `json:"status"`
+	ServiceCode          string                        `json:"serviceCode"`
+	CategoryCode         string                        `json:"categoryCode"`
+	SeverityCode         string                        `json:"severityCode"`
+	Language             string                        `json:"language"`
+	SubmittedBy          string                        `json:"submittedBy"`
+	CCEmails             []string                      `json:"ccEmailAddresses"`
 }
 
 type createCaseOutput struct {
@@ -249,7 +260,8 @@ type createCaseOutput struct {
 }
 
 type describeCasesOutput struct {
-	Cases []caseView `json:"cases"`
+	NextToken string     `json:"nextToken,omitempty"`
+	Cases     []caseView `json:"cases"`
 }
 
 type resolveCaseOutput struct {
@@ -258,25 +270,28 @@ type resolveCaseOutput struct {
 }
 
 type handleCreateCaseInput struct {
-	Subject           string `json:"subject"`
-	ServiceCode       string `json:"serviceCode"`
-	CategoryCode      string `json:"categoryCode"`
-	SeverityCode      string `json:"severityCode"`
-	CommunicationBody string `json:"communicationBody"`
+	Subject           string   `json:"subject"`
+	ServiceCode       string   `json:"serviceCode"`
+	CategoryCode      string   `json:"categoryCode"`
+	SeverityCode      string   `json:"severityCode"`
+	CommunicationBody string   `json:"communicationBody"`
+	AttachmentSetID   string   `json:"attachmentSetId,omitempty"`
+	Language          string   `json:"language,omitempty"`
+	IssueType         string   `json:"issueType,omitempty"`
+	CCEmails          []string `json:"ccEmailAddresses,omitempty"`
 }
 
 func (h *Handler) handleCreateCase(_ context.Context, in *handleCreateCaseInput) (*createCaseOutput, error) {
-	if in.Subject == "" {
-		return nil, fmt.Errorf("%w: subject is required", ErrValidation)
+	options := CreateCaseOptions{
+		Subject: in.Subject, ServiceCode: in.ServiceCode, CategoryCode: in.CategoryCode,
+		SeverityCode: in.SeverityCode, CommunicationBody: in.CommunicationBody,
+		AttachmentSetID: in.AttachmentSetID, Language: in.Language, IssueType: in.IssueType,
+		CCEmails: in.CCEmails,
 	}
-
-	c2, err := h.Backend.CreateCase(
-		in.Subject,
-		in.ServiceCode,
-		in.CategoryCode,
-		in.SeverityCode,
-		in.CommunicationBody,
-	)
+	if err := validateCreateCase(options); err != nil {
+		return nil, err
+	}
+	c2, err := h.Backend.CreateCaseWithOptions(options)
 	if err != nil {
 		return nil, err
 	}
@@ -285,40 +300,70 @@ func (h *Handler) handleCreateCase(_ context.Context, in *handleCreateCaseInput)
 }
 
 type handleDescribeCasesInput struct {
-	Language             string   `json:"language"`
-	NextToken            string   `json:"nextToken,omitempty"`
-	CaseIDList           []string `json:"caseIdList"`
-	MaxResults           int      `json:"maxResults,omitempty"`
-	IncludeResolvedCases bool     `json:"includeResolvedCases"`
+	IncludeCommunications *bool    `json:"includeCommunications,omitempty"`
+	Language              string   `json:"language"`
+	NextToken             string   `json:"nextToken,omitempty"`
+	DisplayID             string   `json:"displayId,omitempty"`
+	AfterTime             string   `json:"afterTime,omitempty"`
+	BeforeTime            string   `json:"beforeTime,omitempty"`
+	CaseIDList            []string `json:"caseIdList"`
+	MaxResults            int      `json:"maxResults,omitempty"`
+	IncludeResolvedCases  bool     `json:"includeResolvedCases"`
 }
 
 func (h *Handler) handleDescribeCases(
 	_ context.Context,
 	in *handleDescribeCasesInput,
 ) (*describeCasesOutput, error) {
-	cases := h.Backend.DescribeCases(in.CaseIDList, in.IncludeResolvedCases)
+	if err := validatePageSize(in.MaxResults); err != nil {
+		return nil, err
+	}
+	afterValue, err := parseFilterTime(in.AfterTime)
+	if err != nil {
+		return nil, err
+	}
+	beforeValue, err := parseFilterTime(in.BeforeTime)
+	if err != nil {
+		return nil, err
+	}
+	includeComms := in.IncludeCommunications == nil || *in.IncludeCommunications
+	after := nonZeroTimePointer(afterValue)
+	before := nonZeroTimePointer(beforeValue)
+	cases, token, err := h.Backend.DescribeCasesWithOptions(DescribeCasesOptions{
+		CaseIDs: in.CaseIDList, DisplayID: in.DisplayID, Language: in.Language,
+		IncludeResolvedCases: in.IncludeResolvedCases, IncludeCommunications: includeComms,
+		AfterTime: after, BeforeTime: before, MaxResults: in.MaxResults, NextToken: in.NextToken,
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	views := make([]caseView, 0, len(cases))
 	for _, cs := range cases {
 		v := caseView{
 			CaseID:       cs.CaseID,
+			DisplayID:    cs.DisplayID,
 			Subject:      cs.Subject,
 			Status:       cs.Status,
 			ServiceCode:  cs.ServiceCode,
 			CategoryCode: cs.CategoryCode,
 			SeverityCode: cs.SeverityCode,
+			Language:     cs.Language,
+			SubmittedBy:  cs.SubmittedBy,
+			CCEmails:     cs.CCEmails,
 			CreatedTime:  cs.CreatedTime.UTC().Format(time.RFC3339),
 		}
-
-		if cs.ResolvedTime != nil {
-			s := cs.ResolvedTime.UTC().Format(time.RFC3339)
-			v.ResolvedTime = &s
+		if includeComms {
+			comms, nextToken := h.Backend.RecentCommunications(cs.CaseID)
+			v.RecentCommunications = &recentCaseCommunicationsView{
+				Communications: communicationViews(comms),
+				NextToken:      nextToken,
+			}
 		}
-
 		views = append(views, v)
 	}
 
-	return &describeCasesOutput{Cases: views}, nil
+	return &describeCasesOutput{Cases: views, NextToken: token}, nil
 }
 
 type handleResolveCaseInput struct {
@@ -326,21 +371,25 @@ type handleResolveCaseInput struct {
 }
 
 func (h *Handler) handleResolveCase(_ context.Context, in *handleResolveCaseInput) (*resolveCaseOutput, error) {
-	cs, err := h.Backend.ResolveCase(in.CaseID)
+	if in.CaseID == "" {
+		return nil, fmt.Errorf("%w: caseId is required", ErrValidation)
+	}
+	initialStatus, cs, err := h.Backend.ResolveCaseWithStatus(in.CaseID)
 	if err != nil {
 		return nil, err
 	}
 
 	return &resolveCaseOutput{
-		InitialCaseStatus: caseStatusOpened,
+		InitialCaseStatus: initialStatus,
 		FinalCaseStatus:   cs.Status,
 	}, nil
 }
 
 type addCommunicationToCaseInput struct {
-	CaseID            string `json:"caseId"`
-	CommunicationBody string `json:"communicationBody"`
-	AttachmentSetID   string `json:"attachmentSetId,omitempty"`
+	CaseID            string   `json:"caseId"`
+	CommunicationBody string   `json:"communicationBody"`
+	AttachmentSetID   string   `json:"attachmentSetId,omitempty"`
+	CCEmails          []string `json:"ccEmailAddresses,omitempty"`
 }
 
 type addCommunicationToCaseOutput struct {
@@ -351,11 +400,14 @@ func (h *Handler) handleAddCommunicationToCase(
 	_ context.Context,
 	in *addCommunicationToCaseInput,
 ) (*addCommunicationToCaseOutput, error) {
-	if in.CaseID == "" {
-		return nil, fmt.Errorf("%w: caseId is required", ErrValidation)
+	options := AddCommunicationOptions{
+		CaseID: in.CaseID, CommunicationBody: in.CommunicationBody,
+		AttachmentSetID: in.AttachmentSetID, CCEmails: in.CCEmails,
 	}
-
-	if err := h.Backend.AddCommunicationToCase(in.CaseID, in.CommunicationBody, in.AttachmentSetID); err != nil {
+	if err := validateCommunication(options); err != nil {
+		return nil, err
+	}
+	if err := h.Backend.AddCommunicationWithOptions(options); err != nil {
 		return nil, err
 	}
 
@@ -365,15 +417,22 @@ func (h *Handler) handleAddCommunicationToCase(
 type describeCommunicationsInput struct {
 	CaseID     string `json:"caseId"`
 	NextToken  string `json:"nextToken,omitempty"`
+	AfterTime  string `json:"afterTime,omitempty"`
+	BeforeTime string `json:"beforeTime,omitempty"`
 	MaxResults int    `json:"maxResults,omitempty"`
 }
 
 type communicationView struct {
-	CaseID          string `json:"caseId"`
-	Body            string `json:"body"`
-	SubmittedBy     string `json:"submittedBy"`
-	TimeCreated     string `json:"timeCreated"`
-	AttachmentSetID string `json:"attachmentSetId,omitempty"`
+	CaseID        string          `json:"caseId"`
+	Body          string          `json:"body"`
+	SubmittedBy   string          `json:"submittedBy"`
+	TimeCreated   string          `json:"timeCreated"`
+	AttachmentSet []AttachmentRef `json:"attachmentSet,omitempty"`
+}
+
+type recentCaseCommunicationsView struct {
+	NextToken      string              `json:"nextToken,omitempty"`
+	Communications []communicationView `json:"communications"`
 }
 
 type describeCommunicationsOutput struct {
@@ -388,24 +447,28 @@ func (h *Handler) handleDescribeCommunications(
 	if in.CaseID == "" {
 		return nil, fmt.Errorf("%w: caseId is required", ErrValidation)
 	}
-
-	comms, err := h.Backend.DescribeCommunications(in.CaseID)
+	if err := validatePageSize(in.MaxResults); err != nil {
+		return nil, err
+	}
+	afterValue, err := parseFilterTime(in.AfterTime)
+	if err != nil {
+		return nil, err
+	}
+	beforeValue, err := parseFilterTime(in.BeforeTime)
+	if err != nil {
+		return nil, err
+	}
+	after := nonZeroTimePointer(afterValue)
+	before := nonZeroTimePointer(beforeValue)
+	comms, token, err := h.Backend.DescribeCommunicationsWithOptions(DescribeCommunicationsOptions{
+		CaseID: in.CaseID, AfterTime: after, BeforeTime: before,
+		MaxResults: in.MaxResults, NextToken: in.NextToken,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	views := make([]communicationView, 0, len(comms))
-	for _, c := range comms {
-		views = append(views, communicationView{
-			CaseID:          c.CaseID,
-			Body:            c.Body,
-			SubmittedBy:     c.SubmittedBy,
-			TimeCreated:     c.TimeCreated.UTC().Format(time.RFC3339),
-			AttachmentSetID: c.AttachmentSetID,
-		})
-	}
-
-	return &describeCommunicationsOutput{Communications: views}, nil
+	return &describeCommunicationsOutput{Communications: communicationViews(comms), NextToken: token}, nil
 }
 
 type describeTrustedAdvisorChecksInput struct {
@@ -426,8 +489,11 @@ type describeTrustedAdvisorChecksOutput struct {
 
 func (h *Handler) handleDescribeTrustedAdvisorChecks(
 	_ context.Context,
-	_ *describeTrustedAdvisorChecksInput,
+	in *describeTrustedAdvisorChecksInput,
 ) (*describeTrustedAdvisorChecksOutput, error) {
+	if !validLanguage(in.Language) {
+		return nil, fmt.Errorf("%w: language is required and must be supported", ErrValidation)
+	}
 	checks := h.Backend.DescribeTrustedAdvisorChecks()
 
 	views := make([]trustedAdvisorCheckView, 0, len(checks))
@@ -439,7 +505,8 @@ func (h *Handler) handleDescribeTrustedAdvisorChecks(
 }
 
 type addAttachmentsToSetInput struct {
-	AttachmentSetID string `json:"attachmentSetId,omitempty"`
+	AttachmentSetID string       `json:"attachmentSetId,omitempty"`
+	Attachments     []Attachment `json:"attachments"`
 }
 
 type addAttachmentsToSetOutput struct {
@@ -451,7 +518,7 @@ func (h *Handler) handleAddAttachmentsToSet(
 	_ context.Context,
 	in *addAttachmentsToSetInput,
 ) (*addAttachmentsToSetOutput, error) {
-	setID, expiry, err := h.Backend.AddAttachmentsToSet(in.AttachmentSetID)
+	setID, expiry, err := h.Backend.AddAttachmentsToSetWithAttachments(in.AttachmentSetID, in.Attachments)
 	if err != nil {
 		return nil, err
 	}
@@ -518,6 +585,9 @@ func (h *Handler) handleDescribeCreateCaseOptions(
 	_ context.Context,
 	in *describeCreateCaseOptionsInput,
 ) (*describeCreateCaseOptionsOutput, error) {
+	if !validIssueType(in.IssueType) || in.ServiceCode == "" || in.CategoryCode == "" || !validLanguage(in.Language) {
+		return nil, fmt.Errorf("%w: issueType, serviceCode, categoryCode, and language are required", ErrValidation)
+	}
 	result := h.Backend.DescribeCreateCaseOptions(in.IssueType, in.ServiceCode, in.CategoryCode, in.Language)
 
 	views := make([]communicationTypeOptionsView, 0, len(result.CommunicationTypes))
@@ -555,7 +625,10 @@ func (h *Handler) handleDescribeServices(
 	_ context.Context,
 	in *describeServicesInput,
 ) (*describeServicesOutput, error) {
-	services := h.Backend.DescribeServices(in.ServiceCodeList)
+	if in.Language != "" && !validLanguage(in.Language) {
+		return nil, fmt.Errorf("%w: invalid language", ErrValidation)
+	}
+	services := h.Backend.DescribeServices(in.ServiceCodeList, in.Language)
 
 	views := make([]serviceView, 0, len(services))
 	for _, svc := range services {
@@ -591,6 +664,9 @@ func (h *Handler) handleDescribeSeverityLevels(
 	_ context.Context,
 	in *describeSeverityLevelsInput,
 ) (*describeSeverityLevelsOutput, error) {
+	if in.Language != "" && !validLanguage(in.Language) {
+		return nil, fmt.Errorf("%w: invalid language", ErrValidation)
+	}
 	levels := h.Backend.DescribeSeverityLevels(in.Language)
 
 	views := make([]severityLevelView, 0, len(levels))
@@ -621,6 +697,9 @@ func (h *Handler) handleDescribeSupportedLanguages(
 	_ context.Context,
 	in *describeSupportedLanguagesInput,
 ) (*describeSupportedLanguagesOutput, error) {
+	if !validIssueType(in.IssueType) || in.ServiceCode == "" || !validSeverity(in.SeverityLevel) {
+		return nil, fmt.Errorf("%w: issueType, serviceCode, and severityLevel are required", ErrValidation)
+	}
 	langs := h.Backend.DescribeSupportedLanguages(in.IssueType, in.ServiceCode, in.SeverityLevel)
 
 	views := make([]supportedLanguageView, 0, len(langs))
@@ -649,11 +728,16 @@ func (h *Handler) handleDescribeTrustedAdvisorCheckRefreshStatuses(
 	_ context.Context,
 	in *describeTrustedAdvisorCheckRefreshStatusesInput,
 ) (*describeTrustedAdvisorCheckRefreshStatusesOutput, error) {
+	if err := validateCheckIDs(in.CheckIDs); err != nil {
+		return nil, err
+	}
 	statuses := h.Backend.DescribeTrustedAdvisorCheckRefreshStatuses(in.CheckIDs)
 
 	views := make([]trustedAdvisorCheckRefreshStatusView, 0, len(statuses))
 	for _, s := range statuses {
-		views = append(views, trustedAdvisorCheckRefreshStatusView(s))
+		views = append(views, trustedAdvisorCheckRefreshStatusView{
+			CheckID: s.CheckID, Status: s.Status, MillisUntilNextRefreshable: s.MillisUntilNextRefreshable,
+		})
 	}
 
 	return &describeTrustedAdvisorCheckRefreshStatusesOutput{Statuses: views}, nil
@@ -680,11 +764,12 @@ type trustedAdvisorResourcesSummaryView struct {
 }
 
 type trustedAdvisorCheckResultView struct {
-	CheckID          string                             `json:"checkId"`
-	Status           string                             `json:"status"`
-	Timestamp        string                             `json:"timestamp"`
-	FlaggedResources []trustedAdvisorResourceDetailView `json:"flaggedResources"`
-	ResourcesSummary trustedAdvisorResourcesSummaryView `json:"resourcesSummary"`
+	CategorySpecificSummary *TrustedAdvisorCategorySpecificSummary `json:"categorySpecificSummary"`
+	CheckID                 string                                 `json:"checkId"`
+	Status                  string                                 `json:"status"`
+	Timestamp               string                                 `json:"timestamp"`
+	FlaggedResources        []trustedAdvisorResourceDetailView     `json:"flaggedResources"`
+	ResourcesSummary        trustedAdvisorResourcesSummaryView     `json:"resourcesSummary"`
 }
 
 type describeTrustedAdvisorCheckResultOutput struct {
@@ -697,6 +782,9 @@ func (h *Handler) handleDescribeTrustedAdvisorCheckResult(
 ) (*describeTrustedAdvisorCheckResultOutput, error) {
 	if in.CheckID == "" {
 		return nil, fmt.Errorf("%w: checkId is required", ErrValidation)
+	}
+	if !validCheckID(in.CheckID) {
+		return nil, fmt.Errorf("%w: invalid checkId", ErrValidation)
 	}
 
 	result := h.Backend.DescribeTrustedAdvisorCheckResult(in.CheckID, in.Language)
@@ -718,6 +806,7 @@ func (h *Handler) handleDescribeTrustedAdvisorCheckResult(
 				ResourcesProcessed:  result.ResourcesSummary.ResourcesProcessed,
 				ResourcesSuppressed: result.ResourcesSummary.ResourcesSuppressed,
 			},
+			CategorySpecificSummary: result.CategorySpecificSummary,
 		},
 	}, nil
 }
@@ -727,11 +816,12 @@ type describeTrustedAdvisorCheckSummariesInput struct {
 }
 
 type trustedAdvisorCheckSummaryView struct {
-	CheckID             string                             `json:"checkId"`
-	Status              string                             `json:"status"`
-	Timestamp           string                             `json:"timestamp"`
-	HasFlaggedResources bool                               `json:"hasFlaggedResources"`
-	ResourcesSummary    trustedAdvisorResourcesSummaryView `json:"resourcesSummary"`
+	CategorySpecificSummary *TrustedAdvisorCategorySpecificSummary `json:"categorySpecificSummary"`
+	CheckID                 string                                 `json:"checkId"`
+	Status                  string                                 `json:"status"`
+	Timestamp               string                                 `json:"timestamp"`
+	ResourcesSummary        trustedAdvisorResourcesSummaryView     `json:"resourcesSummary"`
+	HasFlaggedResources     bool                                   `json:"hasFlaggedResources"`
 }
 
 type describeTrustedAdvisorCheckSummariesOutput struct {
@@ -742,6 +832,9 @@ func (h *Handler) handleDescribeTrustedAdvisorCheckSummaries(
 	_ context.Context,
 	in *describeTrustedAdvisorCheckSummariesInput,
 ) (*describeTrustedAdvisorCheckSummariesOutput, error) {
+	if err := validateCheckIDs(in.CheckIDs); err != nil {
+		return nil, err
+	}
 	summaries := h.Backend.DescribeTrustedAdvisorCheckSummaries(in.CheckIDs)
 
 	views := make([]trustedAdvisorCheckSummaryView, 0, len(summaries))
@@ -757,6 +850,7 @@ func (h *Handler) handleDescribeTrustedAdvisorCheckSummaries(
 				ResourcesProcessed:  s.ResourcesSummary.ResourcesProcessed,
 				ResourcesSuppressed: s.ResourcesSummary.ResourcesSuppressed,
 			},
+			CategorySpecificSummary: s.CategorySpecificSummary,
 		})
 	}
 
@@ -778,6 +872,9 @@ func (h *Handler) handleRefreshTrustedAdvisorCheck(
 	if in.CheckID == "" {
 		return nil, fmt.Errorf("%w: checkId is required", ErrValidation)
 	}
+	if !validCheckID(in.CheckID) {
+		return nil, fmt.Errorf("%w: invalid checkId", ErrValidation)
+	}
 
 	status, err := h.Backend.RefreshTrustedAdvisorCheck(in.CheckID)
 	if err != nil {
@@ -791,4 +888,36 @@ func (h *Handler) handleRefreshTrustedAdvisorCheck(
 			MillisUntilNextRefreshable: status.MillisUntilNextRefreshable,
 		},
 	}, nil
+}
+
+func parseFilterTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: invalid timestamp", ErrValidation)
+	}
+
+	return parsed, nil
+}
+
+func nonZeroTimePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+
+	return &value
+}
+
+func communicationViews(comms []Communication) []communicationView {
+	views := make([]communicationView, 0, len(comms))
+	for _, comm := range comms {
+		views = append(views, communicationView{
+			CaseID: comm.CaseID, Body: comm.Body, SubmittedBy: comm.SubmittedBy,
+			TimeCreated: comm.TimeCreated.UTC().Format(time.RFC3339), AttachmentSet: comm.AttachmentSet,
+		})
+	}
+
+	return views
 }

--- a/services/support/handler_accuracy_audit_test.go
+++ b/services/support/handler_accuracy_audit_test.go
@@ -1,0 +1,377 @@
+package support_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/support"
+)
+
+func decodeSupportResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+
+	return result
+}
+
+func createAccurateCase(t *testing.T, h *support.Handler, extra map[string]any) string {
+	t.Helper()
+
+	body := map[string]any{
+		"subject":           "API fidelity case",
+		"communicationBody": "Initial customer report",
+		"serviceCode":       "amazon-s3",
+		"categoryCode":      "general-guidance",
+		"severityCode":      "normal",
+		"language":          "en",
+		"issueType":         "technical",
+	}
+	maps.Copy(body, extra)
+	rec := doSupportRequest(t, h, "CreateCase", body)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	return decodeSupportResponse(t, rec)["caseId"].(string)
+}
+
+func TestAccuracy_CreateCaseValidation(t *testing.T) {
+	t.Parallel()
+
+	elevenEmails := make([]string, 11)
+	for i := range elevenEmails {
+		elevenEmails[i] = "copy@example.test"
+	}
+	tests := []struct {
+		body map[string]any
+		name string
+	}{
+		{name: "missing communication body", body: map[string]any{"subject": "invalid"}},
+		{
+			name: "invalid language",
+			body: map[string]any{"subject": "invalid", "communicationBody": "body", "language": "xx"},
+		},
+		{
+			name: "invalid issue type",
+			body: map[string]any{"subject": "invalid", "communicationBody": "body", "issueType": "incident"},
+		},
+		{
+			name: "invalid severity",
+			body: map[string]any{"subject": "invalid", "communicationBody": "body", "severityCode": "blocker"},
+		},
+		{
+			name: "too many cc recipients",
+			body: map[string]any{
+				"subject": "invalid", "communicationBody": "body", "ccEmailAddresses": elevenEmails,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := doSupportRequest(t, newTestSupportHandler(t), "CreateCase", tt.body)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+func TestAccuracy_CaseDetailsInitialCommunicationAndReopen(t *testing.T) {
+	t.Parallel()
+
+	h := newTestSupportHandler(t)
+	caseID := createAccurateCase(t, h, map[string]any{
+		"ccEmailAddresses": []string{"billing@example.test"},
+	})
+
+	describeRec := doSupportRequest(t, h, "DescribeCases", map[string]any{"caseIdList": []string{caseID}})
+	require.Equal(t, http.StatusOK, describeRec.Code)
+	cases := decodeSupportResponse(t, describeRec)["cases"].([]any)
+	require.Len(t, cases, 1)
+	cs := cases[0].(map[string]any)
+	assert.NotEmpty(t, cs["displayId"])
+	assert.Equal(t, "en", cs["language"])
+	assert.Equal(t, "customer", cs["submittedBy"])
+	recent := cs["recentCommunications"].(map[string]any)["communications"].([]any)
+	require.Len(t, recent, 1)
+	assert.Equal(t, "Initial customer report", recent[0].(map[string]any)["body"])
+
+	resolveRec := doSupportRequest(t, h, "ResolveCase", map[string]any{"caseId": caseID})
+	require.Equal(t, http.StatusOK, resolveRec.Code)
+	addRec := doSupportRequest(t, h, "AddCommunicationToCase", map[string]any{
+		"caseId": caseID, "communicationBody": "Issue persists",
+	})
+	require.Equal(t, http.StatusOK, addRec.Code)
+	resolveAgain := doSupportRequest(t, h, "ResolveCase", map[string]any{"caseId": caseID})
+	require.Equal(t, http.StatusOK, resolveAgain.Code)
+	assert.Equal(t, "reopened", decodeSupportResponse(t, resolveAgain)["initialCaseStatus"])
+}
+
+func TestAccuracy_DescribeCasesPaginationAndValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestSupportHandler(t)
+	for i := range 11 {
+		createAccurateCase(t, h, map[string]any{"subject": "Case " + string(rune('A'+i))})
+	}
+
+	tests := []struct {
+		body     map[string]any
+		name     string
+		wantCode int
+		wantLen  int
+	}{
+		{
+			name: "first page emits token", body: map[string]any{"maxResults": 10},
+			wantCode: http.StatusOK, wantLen: 10,
+		},
+		{
+			name: "invalid page size", body: map[string]any{"maxResults": 1},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "invalid time filter", body: map[string]any{"afterTime": "not-time"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		rec := doSupportRequest(t, h, "DescribeCases", tt.body)
+		require.Equal(t, tt.wantCode, rec.Code, tt.name)
+		if tt.wantLen == 0 {
+			continue
+		}
+		body := decodeSupportResponse(t, rec)
+		assert.Len(t, body["cases"], tt.wantLen, tt.name)
+		token := body["nextToken"].(string)
+		second := doSupportRequest(t, h, "DescribeCases", map[string]any{"maxResults": 10, "nextToken": token})
+		assert.Len(t, decodeSupportResponse(t, second)["cases"], 1, tt.name)
+	}
+}
+
+func TestAccuracy_AttachmentSetConsumedIntoCommunication(t *testing.T) {
+	t.Parallel()
+
+	h := newTestSupportHandler(t)
+	setRec := doSupportRequest(t, h, "AddAttachmentsToSet", map[string]any{
+		"attachments": []map[string]any{{"fileName": "trace.txt", "data": []byte("trace bytes")}},
+	})
+	require.Equal(t, http.StatusOK, setRec.Code)
+	setID := decodeSupportResponse(t, setRec)["attachmentSetId"].(string)
+	caseID := createAccurateCase(t, h, map[string]any{"attachmentSetId": setID})
+
+	communications := doSupportRequest(t, h, "DescribeCommunications", map[string]any{"caseId": caseID})
+	require.Equal(t, http.StatusOK, communications.Code)
+	comm := decodeSupportResponse(t, communications)["communications"].([]any)[0].(map[string]any)
+	attachments := comm["attachmentSet"].([]any)
+	require.Len(t, attachments, 1)
+	attachmentID := attachments[0].(map[string]any)["attachmentId"].(string)
+	attachmentRec := doSupportRequest(t, h, "DescribeAttachment", map[string]any{"attachmentId": attachmentID})
+	require.Equal(t, http.StatusOK, attachmentRec.Code)
+
+	reuse := doSupportRequest(t, h, "AddCommunicationToCase", map[string]any{
+		"caseId": caseID, "communicationBody": "Reuse staged set", "attachmentSetId": setID,
+	})
+	assert.Equal(t, http.StatusNotFound, reuse.Code)
+}
+
+func TestAccuracy_AddAttachmentsRejectsRequestAtomically(t *testing.T) {
+	t.Parallel()
+
+	b := support.NewInMemoryBackend()
+	h := support.NewHandler(b)
+	tests := []struct {
+		body map[string]any
+		name string
+	}{
+		{
+			name: "missing filename after valid file",
+			body: map[string]any{"attachments": []map[string]any{
+				{"fileName": "good.txt", "data": []byte("good")},
+				{"data": []byte("missing name")},
+			}},
+		},
+		{
+			name: "oversized file after valid file",
+			body: map[string]any{"attachments": []map[string]any{
+				{"fileName": "good.txt", "data": []byte("good")},
+				{"fileName": "large.dat", "data": bytes.Repeat([]byte("x"), 5*1024*1024+1)},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		rec := doSupportRequest(t, h, "AddAttachmentsToSet", tt.body)
+		assert.Equal(t, http.StatusBadRequest, rec.Code, tt.name)
+		assert.Equal(t, 0, support.AttachmentCount(b), tt.name)
+	}
+}
+
+func TestAccuracy_AddCommunicationValidationAndPagination(t *testing.T) {
+	t.Parallel()
+
+	h := newTestSupportHandler(t)
+	caseID := createAccurateCase(t, h, nil)
+	for i := range 10 {
+		rec := doSupportRequest(t, h, "AddCommunicationToCase", map[string]any{
+			"caseId": caseID, "communicationBody": "Message " + string(rune('A'+i)),
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	tests := []struct {
+		body     map[string]any
+		name     string
+		wantCode int
+		wantLen  int
+	}{
+		{
+			name: "paginated communications", body: map[string]any{"caseId": caseID, "maxResults": 10},
+			wantCode: http.StatusOK, wantLen: 10,
+		},
+		{
+			name:     "body too large",
+			body:     map[string]any{"caseId": caseID, "communicationBody": strings.Repeat("x", 8001)},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		action := "AddCommunicationToCase"
+		if tt.wantLen > 0 {
+			action = "DescribeCommunications"
+		}
+		rec := doSupportRequest(t, h, action, tt.body)
+		require.Equal(t, tt.wantCode, rec.Code, tt.name)
+		if tt.wantLen == 0 {
+			continue
+		}
+		body := decodeSupportResponse(t, rec)
+		assert.Len(t, body["communications"], tt.wantLen, tt.name)
+		second := doSupportRequest(t, h, "DescribeCommunications", map[string]any{
+			"caseId": caseID, "maxResults": 10, "nextToken": body["nextToken"],
+		})
+		assert.Len(t, decodeSupportResponse(t, second)["communications"], 1, tt.name)
+	}
+}
+
+func TestAccuracy_TrustedAdvisorValidationAndRefreshLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:     "checks require language",
+			action:   "DescribeTrustedAdvisorChecks",
+			body:     map[string]any{},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "unknown refresh check",
+			action:   "RefreshTrustedAdvisorCheck",
+			body:     map[string]any{"checkId": "unknown"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "summaries require ids",
+			action:   "DescribeTrustedAdvisorCheckSummaries",
+			body:     map[string]any{},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "result validates id",
+			action:   "DescribeTrustedAdvisorCheckResult",
+			body:     map[string]any{"checkId": "unknown"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := doSupportRequest(t, newTestSupportHandler(t), tt.action, tt.body)
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+
+	h := newTestSupportHandler(t)
+	refresh := doSupportRequest(t, h, "RefreshTrustedAdvisorCheck", map[string]any{"checkId": "Pfx0RwqBli"})
+	require.Equal(t, http.StatusOK, refresh.Code)
+	for _, expected := range []string{"enqueued", "processing", "success"} {
+		status := doSupportRequest(t, h, "DescribeTrustedAdvisorCheckRefreshStatuses", map[string]any{
+			"checkIds": []string{"Pfx0RwqBli"},
+		})
+		require.Equal(t, http.StatusOK, status.Code)
+		statuses := decodeSupportResponse(t, status)["statuses"].([]any)
+		assert.Equal(t, expected, statuses[0].(map[string]any)["status"])
+	}
+	result := doSupportRequest(t, h, "DescribeTrustedAdvisorCheckResult", map[string]any{
+		"checkId": "Pfx0RwqBli", "language": "en",
+	})
+	assert.NotNil(t, decodeSupportResponse(t, result)["result"].(map[string]any)["categorySpecificSummary"])
+}
+
+func TestAccuracy_SeverityLocalizationAndResourceExtraction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		action string
+		body   map[string]any
+		want   string
+	}{
+		{
+			name:   "severity Japanese",
+			action: "DescribeSeverityLevels",
+			body:   map[string]any{"language": "ja"},
+			want:   "一般的なガイダンス",
+		},
+		{
+			name:   "severity English",
+			action: "DescribeSeverityLevels",
+			body:   map[string]any{"language": "en"},
+			want:   "General guidance",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := doSupportRequest(t, newTestSupportHandler(t), tt.action, tt.body)
+			require.Equal(t, http.StatusOK, rec.Code)
+			levels := decodeSupportResponse(t, rec)["severityLevels"].([]any)
+			assert.Equal(t, tt.want, levels[0].(map[string]any)["name"])
+		})
+	}
+
+	h := newTestSupportHandler(t)
+	for _, tt := range []struct {
+		body string
+		want string
+	}{
+		{body: `{"checkId":"Pfx0RwqBli"}`, want: "Pfx0RwqBli"},
+		{body: `{"attachmentId":"att-1"}`, want: "att-1"},
+	} {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(tt.body))
+			ctx := e.NewContext(req, httptest.NewRecorder())
+			assert.Equal(t, tt.want, h.ExtractResource(ctx))
+		})
+	}
+}

--- a/services/support/handler_new_ops_test.go
+++ b/services/support/handler_new_ops_test.go
@@ -94,7 +94,7 @@ func TestSupport_DescribeCreateCaseOptions(t *testing.T) {
 		{
 			name:     "empty_body",
 			body:     map[string]any{},
-			wantCode: http.StatusOK,
+			wantCode: http.StatusBadRequest,
 		},
 	}
 
@@ -106,10 +106,12 @@ func TestSupport_DescribeCreateCaseOptions(t *testing.T) {
 			rec := doSupportRequest(t, h, "DescribeCreateCaseOptions", tt.body)
 			require.Equal(t, tt.wantCode, rec.Code)
 
-			var resp map[string]any
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-			assert.NotEmpty(t, resp["communicationTypes"])
-			assert.Equal(t, "available", resp["languageAvailability"])
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assert.NotEmpty(t, resp["communicationTypes"])
+				assert.Equal(t, "available", resp["languageAvailability"])
+			}
 		})
 	}
 }
@@ -244,7 +246,7 @@ func TestSupport_DescribeSupportedLanguages(t *testing.T) {
 		{
 			name:     "empty_body",
 			body:     map[string]any{},
-			wantCode: http.StatusOK,
+			wantCode: http.StatusBadRequest,
 		},
 	}
 
@@ -256,6 +258,9 @@ func TestSupport_DescribeSupportedLanguages(t *testing.T) {
 			rec := doSupportRequest(t, h, "DescribeSupportedLanguages", tt.body)
 			require.Equal(t, tt.wantCode, rec.Code)
 
+			if tt.wantCode != http.StatusOK {
+				return
+			}
 			var resp map[string]any
 			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 			langs, ok := resp["supportedLanguages"].([]any)
@@ -313,7 +318,7 @@ func TestSupport_DescribeTrustedAdvisorCheckRefreshStatuses(t *testing.T) {
 		{
 			name:     "empty_check_ids",
 			body:     map[string]any{"checkIds": []string{}},
-			wantCode: http.StatusOK,
+			wantCode: http.StatusBadRequest,
 		},
 	}
 
@@ -406,8 +411,7 @@ func TestSupport_DescribeTrustedAdvisorCheckSummaries(t *testing.T) {
 		{
 			name:     "empty_list",
 			body:     map[string]any{"checkIds": []string{}},
-			wantCode: http.StatusOK,
-			wantLen:  0,
+			wantCode: http.StatusBadRequest,
 		},
 	}
 
@@ -419,11 +423,13 @@ func TestSupport_DescribeTrustedAdvisorCheckSummaries(t *testing.T) {
 			rec := doSupportRequest(t, h, "DescribeTrustedAdvisorCheckSummaries", tt.body)
 			require.Equal(t, tt.wantCode, rec.Code)
 
-			var resp map[string]any
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-			summaries, ok := resp["summaries"].([]any)
-			require.True(t, ok)
-			assert.Len(t, summaries, tt.wantLen)
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				summaries, ok := resp["summaries"].([]any)
+				require.True(t, ok)
+				assert.Len(t, summaries, tt.wantLen)
+			}
 		})
 	}
 }

--- a/services/support/handler_refinement1_test.go
+++ b/services/support/handler_refinement1_test.go
@@ -73,7 +73,7 @@ func TestRefinement1_Reset(t *testing.T) {
 	b := support.NewInMemoryBackend()
 	h := support.NewHandler(b)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Test Reset"})
+	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Test Reset", "communicationBody": "Initial"})
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, 1, support.CaseCount(b))
 
@@ -126,7 +126,7 @@ func TestRefinement1_DescribeCases_IncludeResolved(t *testing.T) {
 	h := newTestSupportHandler(t)
 
 	// Create and resolve a case.
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Resolve me"})
+	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Resolve me", "communicationBody": "Initial"})
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
@@ -165,7 +165,12 @@ func TestRefinement1_DescribeCases_ReturnsTimestamps(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Timestamp test"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "Timestamp test", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	rec2 := doSupportRequest(t, h, "DescribeCases", map[string]any{})
@@ -179,13 +184,18 @@ func TestRefinement1_DescribeCases_ReturnsTimestamps(t *testing.T) {
 	assert.NotEmpty(t, cs["timeCreated"])
 }
 
-// TestRefinement1_DescribeCases_ResolvedTimestamp verifies timeResolved is populated on resolved cases.
-func TestRefinement1_DescribeCases_ResolvedTimestamp(t *testing.T) {
+// TestRefinement1_DescribeCases_ResolvedStatus verifies resolved cases expose AWS status without internal timestamp.
+func TestRefinement1_DescribeCases_ResolvedStatus(t *testing.T) {
 	t.Parallel()
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Resolve timestamp"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "Resolve timestamp", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
@@ -204,7 +214,8 @@ func TestRefinement1_DescribeCases_ResolvedTimestamp(t *testing.T) {
 	cases := resp["cases"].([]any)
 	require.Len(t, cases, 1)
 	cs := cases[0].(map[string]any)
-	assert.NotEmpty(t, cs["timeResolved"])
+	assert.Equal(t, "resolved", cs["status"])
+	assert.NotContains(t, cs, "timeResolved")
 }
 
 // TestRefinement1_AddCommunicationToCase_EmptyBody verifies empty body is rejected.
@@ -213,7 +224,12 @@ func TestRefinement1_AddCommunicationToCase_EmptyBody(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Comm body test"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "Comm body test", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
@@ -233,17 +249,29 @@ func TestRefinement1_AddCommunicationToCase_AttachmentSetId(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Attach test"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "Attach test", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createResp))
 	caseID := createResp["caseId"].(string)
 
+	setRec := doSupportRequest(t, h, "AddAttachmentsToSet", map[string]any{
+		"attachments": []map[string]any{{"fileName": "detail.txt", "data": []byte("details")}},
+	})
+	require.Equal(t, http.StatusOK, setRec.Code)
+	var setResp map[string]any
+	require.NoError(t, json.Unmarshal(setRec.Body.Bytes(), &setResp))
+
 	rec2 := doSupportRequest(t, h, "AddCommunicationToCase", map[string]any{
 		"caseId":            caseID,
 		"communicationBody": "See attached",
-		"attachmentSetId":   "my-set-001",
+		"attachmentSetId":   setResp["attachmentSetId"],
 	})
 	require.Equal(t, http.StatusOK, rec2.Code)
 
@@ -254,9 +282,9 @@ func TestRefinement1_AddCommunicationToCase_AttachmentSetId(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &resp))
 	comms := resp["communications"].([]any)
-	require.Len(t, comms, 1)
+	require.Len(t, comms, 2)
 	comm := comms[0].(map[string]any)
-	assert.Equal(t, "my-set-001", comm["attachmentSetId"])
+	assert.NotEmpty(t, comm["attachmentSet"])
 }
 
 // TestRefinement1_CommunicationView_TimeCreated verifies timeCreated in communication view.
@@ -265,7 +293,12 @@ func TestRefinement1_CommunicationView_TimeCreated(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "TimeCreated test"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "TimeCreated test", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
@@ -283,7 +316,7 @@ func TestRefinement1_CommunicationView_TimeCreated(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
 	comms := resp["communications"].([]any)
-	require.Len(t, comms, 1)
+	require.Len(t, comms, 2)
 	comm := comms[0].(map[string]any)
 	assert.NotEmpty(t, comm["timeCreated"])
 }
@@ -401,7 +434,12 @@ func TestRefinement1_AlreadyResolved(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Double resolve"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "Double resolve", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
@@ -450,8 +488,8 @@ func TestRefinement1_DescribeCases_Pagination(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Page1"})
-	doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Page2"})
+	doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Page1", "communicationBody": "Initial"})
+	doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Page2", "communicationBody": "Initial"})
 
 	rec := doSupportRequest(t, h, "DescribeCases", map[string]any{
 		"maxResults": 10,
@@ -501,7 +539,12 @@ func TestRefinement1_DescribeCommunications_Pagination(t *testing.T) {
 
 	h := newTestSupportHandler(t)
 
-	rec := doSupportRequest(t, h, "CreateCase", map[string]any{"subject": "Comm pagination"})
+	rec := doSupportRequest(
+		t,
+		h,
+		"CreateCase",
+		map[string]any{"subject": "Comm pagination", "communicationBody": "Initial"},
+	)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var createResp map[string]any
@@ -515,7 +558,7 @@ func TestRefinement1_DescribeCommunications_Pagination(t *testing.T) {
 
 	rec2 := doSupportRequest(t, h, "DescribeCommunications", map[string]any{
 		"caseId":     caseID,
-		"maxResults": 5,
+		"maxResults": 10,
 	})
 	assert.Equal(t, http.StatusOK, rec2.Code)
 }

--- a/services/support/handler_test.go
+++ b/services/support/handler_test.go
@@ -201,7 +201,8 @@ func TestSupport_DescribeCases(t *testing.T) {
 	h := newTestSupportHandler(t)
 
 	rec1 := doSupportRequest(t, h, "CreateCase", map[string]any{
-		"subject": "Case One",
+		"subject":           "Case One",
+		"communicationBody": "Initial question",
 	})
 	require.Equal(t, http.StatusOK, rec1.Code)
 
@@ -237,7 +238,8 @@ func TestSupport_ResolveCase(t *testing.T) {
 	h := newTestSupportHandler(t)
 
 	createRec := doSupportRequest(t, h, "CreateCase", map[string]any{
-		"subject": "Resolve me",
+		"subject":           "Resolve me",
+		"communicationBody": "Please resolve this.",
 	})
 	require.Equal(t, http.StatusOK, createRec.Code)
 
@@ -273,7 +275,8 @@ func TestSupport_AddCommunicationToCase(t *testing.T) {
 	h := newTestSupportHandler(t)
 
 	createRec := doSupportRequest(t, h, "CreateCase", map[string]any{
-		"subject": "Comm test",
+		"subject":           "Comm test",
+		"communicationBody": "Initial message",
 	})
 	require.Equal(t, http.StatusOK, createRec.Code)
 
@@ -319,7 +322,8 @@ func TestSupport_DescribeCommunications(t *testing.T) {
 	h := newTestSupportHandler(t)
 
 	createRec := doSupportRequest(t, h, "CreateCase", map[string]any{
-		"subject": "Comm test",
+		"subject":           "Comm test",
+		"communicationBody": "Initial message",
 	})
 	require.Equal(t, http.StatusOK, createRec.Code)
 
@@ -343,7 +347,7 @@ func TestSupport_DescribeCommunications(t *testing.T) {
 			name:          "describe communications",
 			body:          map[string]any{"caseId": caseID},
 			wantCode:      http.StatusOK,
-			wantCommCount: 1,
+			wantCommCount: 2,
 		},
 		{
 			name:     "missing caseId",
@@ -401,14 +405,19 @@ func TestSupport_AddAttachmentsToSet(t *testing.T) {
 		wantCode int
 	}{
 		{
-			name:     "new attachment set",
-			body:     map[string]any{},
+			name: "new attachment set",
+			body: map[string]any{
+				"attachments": []any{map[string]any{"fileName": "new.txt", "data": []byte("data")}},
+			},
 			wantCode: http.StatusOK,
 		},
 		{
-			name:     "with existing set id",
-			body:     map[string]any{"attachmentSetId": "existing-set-id"},
-			wantCode: http.StatusOK,
+			name: "unknown existing set id",
+			body: map[string]any{
+				"attachmentSetId": "existing-set-id",
+				"attachments":     []any{map[string]any{"fileName": "new.txt", "data": []byte("data")}},
+			},
+			wantCode: http.StatusNotFound,
 		},
 	}
 

--- a/services/support/interfaces.go
+++ b/services/support/interfaces.go
@@ -7,15 +7,22 @@ import "time"
 type StorageBackend interface {
 	Reset()
 	CreateCase(subject, serviceCode, categoryCode, severityCode, body string) (*Case, error)
+	CreateCaseWithOptions(in CreateCaseOptions) (*Case, error)
 	DescribeCases(caseIDs []string, includeResolvedCases bool) []Case
+	DescribeCasesWithOptions(in DescribeCasesOptions) ([]Case, string, error)
+	RecentCommunications(caseID string) ([]Communication, string)
 	ResolveCase(caseID string) (*Case, error)
+	ResolveCaseWithStatus(caseID string) (string, *Case, error)
 	AddCommunicationToCase(caseID, body, attachmentSetID string) error
+	AddCommunicationWithOptions(in AddCommunicationOptions) error
 	DescribeCommunications(caseID string) ([]Communication, error)
+	DescribeCommunicationsWithOptions(in DescribeCommunicationsOptions) ([]Communication, string, error)
 	DescribeTrustedAdvisorChecks() []TrustedAdvisorCheck
 	AddAttachmentsToSet(attachmentSetID string) (string, time.Time, error)
+	AddAttachmentsToSetWithAttachments(attachmentSetID string, attachments []Attachment) (string, time.Time, error)
 	DescribeAttachment(attachmentID string) (*Attachment, error)
 	DescribeCreateCaseOptions(issueType, serviceCode, categoryCode, language string) *DescribeCreateCaseOptionsResult
-	DescribeServices(serviceCodeList []string) []Service
+	DescribeServices(serviceCodeList []string, language string) []Service
 	DescribeSeverityLevels(language string) []SeverityLevel
 	DescribeSupportedLanguages(issueType, serviceCode, severityLevel string) []SupportedLanguage
 	DescribeTrustedAdvisorCheckRefreshStatuses(checkIDs []string) []TrustedAdvisorCheckRefreshStatus

--- a/services/support/janitor.go
+++ b/services/support/janitor.go
@@ -26,14 +26,14 @@ func (b *InMemoryBackend) RunJanitor(ctx context.Context, interval time.Duration
 
 // sweepExpiredResources identifies and removes expired attachment sets and any orphaned attachments.
 func (b *InMemoryBackend) sweepExpiredResources(ctx context.Context) {
-	b.mu.Lock("sweepExpiredResources")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	now := time.Now()
 	expiredSets := make([]string, 0, len(b.attachmentSets))
 
-	for id, expiry := range b.attachmentSets {
-		if now.After(expiry) {
+	for id, set := range b.attachmentSets {
+		if now.After(set.Expiry) {
 			expiredSets = append(expiredSets, id)
 		}
 	}
@@ -42,28 +42,14 @@ func (b *InMemoryBackend) sweepExpiredResources(ctx context.Context) {
 		return
 	}
 
-	// Identify attachments to remove. We only remove attachments that are NOT linked
-	// to any active communication. Since communications are linked to cases,
-	// and cases are never deleted in this mock, we only prune attachments that
-	// were part of an expired attachment set and never actually used in a communication.
-
-	// Track which attachment sets are still in use by communications.
-	usedSets := make(map[string]struct{})
-	for _, comms := range b.communications {
-		for _, c := range comms {
-			if c.AttachmentSetID != "" {
-				usedSets[c.AttachmentSetID] = struct{}{}
-			}
-		}
-	}
-
 	removedCount := 0
 	for _, setID := range expiredSets {
-		// Only delete if NOT used in a communication.
-		if _, used := usedSets[setID]; !used {
-			delete(b.attachmentSets, setID)
-			removedCount++
+		set := b.attachmentSets[setID]
+		for _, attachmentID := range set.AttachmentIDs {
+			delete(b.attachments, attachmentID)
 		}
+		delete(b.attachmentSets, setID)
+		removedCount++
 	}
 
 	if removedCount > 0 {

--- a/services/support/persistence.go
+++ b/services/support/persistence.go
@@ -3,21 +3,21 @@ package support
 import (
 	"encoding/json"
 	"log/slog"
-	"time"
 )
 
 type backendSnapshot struct {
 	Cases                map[string]*Case                             `json:"cases"`
 	Communications       map[string][]Communication                   `json:"communications"`
-	AttachmentSets       map[string]time.Time                         `json:"attachmentSets"`
+	AttachmentSets       map[string]*AttachmentSet                    `json:"attachmentSets"`
 	Attachments          map[string]*Attachment                       `json:"attachments"`
 	CheckRefreshStatuses map[string]*TrustedAdvisorCheckRefreshStatus `json:"checkRefreshStatuses"`
+	NextDisplayID        uint64                                       `json:"nextDisplayId"`
 }
 
 // Snapshot serialises the backend state to JSON.
 // It implements persistence.Persistable.
 func (b *InMemoryBackend) Snapshot() []byte {
-	b.mu.RLock("Snapshot")
+	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	snap := backendSnapshot{
@@ -26,6 +26,7 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		AttachmentSets:       b.attachmentSets,
 		Attachments:          b.attachments,
 		CheckRefreshStatuses: b.checkRefreshStatuses,
+		NextDisplayID:        b.nextDisplayID,
 	}
 
 	data, err := json.Marshal(snap)
@@ -47,7 +48,7 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		return err
 	}
 
-	b.mu.Lock("Restore")
+	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	ensureNonNilMaps(&snap)
@@ -57,6 +58,7 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.attachmentSets = snap.AttachmentSets
 	b.attachments = snap.Attachments
 	b.checkRefreshStatuses = snap.CheckRefreshStatuses
+	b.nextDisplayID = snap.NextDisplayID
 
 	return nil
 }
@@ -71,7 +73,7 @@ func ensureNonNilMaps(snap *backendSnapshot) {
 	}
 
 	if snap.AttachmentSets == nil {
-		snap.AttachmentSets = make(map[string]time.Time)
+		snap.AttachmentSets = make(map[string]*AttachmentSet)
 	}
 
 	if snap.Attachments == nil {


### PR DESCRIPTION
Closes #1846

- implement AWS-shaped Support case, communication, attachment, and Trusted Advisor behavior
- use stateful sync.RWMutex backend with pagination, validation, and refresh lifecycle
- add table-driven audit coverage for case CRUD, communications, Trusted Advisor, and severity

Verification:
- go test ./services/support/... -short -count=1
- go vet ./services/support/...
- golangci-lint run ./services/support/...
- go test -race ./services/support/... -short -count=1