### PR TITLE
feat(elasticsearch): AWS-accuracy audit batch-1 (go-ri9j)

### DIFF
--- a/services/elasticsearch/backend.go
+++ b/services/elasticsearch/backend.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/arn"
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
@@ -13,8 +14,14 @@ import (
 )
 
 const (
-	statusActiveCap = "Active"
-	statusActive    = "ACTIVE"
+	statusActiveCap                = "Active"
+	statusActive                   = "ACTIVE"
+	reservedDurationOneYearSeconds = 31536000
+	defaultElasticsearchVersion    = "7.10"
+	elasticsearchVersion71         = "7.1"
+	elasticsearchVersion68         = "6.8"
+	defaultInstanceType            = "t3.small.elasticsearch"
+	largeInstanceType              = "m5.large.elasticsearch"
 )
 
 // Errors returned by the Elasticsearch backend.
@@ -151,6 +158,8 @@ type InMemoryBackend struct {
 	inboundConnections  map[string]*InboundConnection
 	outboundConnections map[string]*OutboundConnection
 	vpcEndpoints        map[string]*VpcEndpoint
+	vpcAccess           map[string][]string
+	reservedInstances   map[string]*ReservedInstance
 	mu                  *lockmetrics.RWMutex
 	accountID           string
 	region              string
@@ -168,6 +177,8 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		inboundConnections:  make(map[string]*InboundConnection),
 		outboundConnections: make(map[string]*OutboundConnection),
 		vpcEndpoints:        make(map[string]*VpcEndpoint),
+		vpcAccess:           make(map[string][]string),
+		reservedInstances:   make(map[string]*ReservedInstance),
 		accountID:           accountID,
 		region:              region,
 		mu:                  lockmetrics.New("elasticsearch"),
@@ -207,7 +218,7 @@ func (b *InMemoryBackend) CreateDomain(
 	}
 
 	if esVersion == "" {
-		esVersion = "7.10"
+		esVersion = defaultElasticsearchVersion
 	}
 
 	domainARN := arn.Build("es", b.region, b.accountID, "domain/"+name)
@@ -219,7 +230,7 @@ func (b *InMemoryBackend) CreateDomain(
 	}
 
 	if clusterConfig.InstanceType == "" {
-		clusterConfig.InstanceType = "t3.small.elasticsearch"
+		clusterConfig.InstanceType = defaultInstanceType
 	}
 
 	d := &Domain{
@@ -386,6 +397,8 @@ func (b *InMemoryBackend) Reset() {
 	b.inboundConnections = make(map[string]*InboundConnection)
 	b.outboundConnections = make(map[string]*OutboundConnection)
 	b.vpcEndpoints = make(map[string]*VpcEndpoint)
+	b.vpcAccess = make(map[string][]string)
+	b.reservedInstances = make(map[string]*ReservedInstance)
 	b.nextID = 0
 }
 
@@ -525,13 +538,7 @@ func (b *InMemoryBackend) CreateVpcEndpoint(domainARN string, vpcOptions map[str
 	}
 	b.vpcEndpoints[id] = endpoint
 
-	// Return a copy with its own VpcOptions map to prevent aliasing.
-	retOpts := make(map[string]string, len(optsCopy))
-	maps.Copy(retOpts, optsCopy)
-	cp := *endpoint
-	cp.VpcOptions = retOpts
-
-	return &cp, nil
+	return vpcEndpointCopy(endpoint), nil
 }
 
 // AuthorizeVpcEndpointAccess grants an account or service access to the domain's VPC endpoint.
@@ -545,6 +552,11 @@ func (b *InMemoryBackend) AuthorizeVpcEndpointAccess(domainName, account string)
 
 	if _, exists := b.domains[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
+	}
+
+	if !slices.Contains(b.vpcAccess[domainName], account) {
+		b.vpcAccess[domainName] = append(b.vpcAccess[domainName], account)
+		slices.Sort(b.vpcAccess[domainName])
 	}
 
 	return nil
@@ -834,7 +846,7 @@ func (b *InMemoryBackend) DeleteVpcEndpoint(vpcEndpointID string) (*VpcEndpoint,
 	cp := *endpoint
 	delete(b.vpcEndpoints, vpcEndpointID)
 
-	return &cp, nil
+	return vpcEndpointCopy(&cp), nil
 }
 
 // DescribeVpcEndpoints returns VPC endpoints matching the given IDs, or all endpoints if empty.
@@ -845,8 +857,7 @@ func (b *InMemoryBackend) DescribeVpcEndpoints(vpcEndpointIDs []string) []*VpcEn
 	if len(vpcEndpointIDs) == 0 {
 		result := make([]*VpcEndpoint, 0, len(b.vpcEndpoints))
 		for _, ep := range b.vpcEndpoints {
-			cp := *ep
-			result = append(result, &cp)
+			result = append(result, vpcEndpointCopy(ep))
 		}
 
 		return result
@@ -855,8 +866,7 @@ func (b *InMemoryBackend) DescribeVpcEndpoints(vpcEndpointIDs []string) []*VpcEn
 	result := make([]*VpcEndpoint, 0, len(vpcEndpointIDs))
 	for _, id := range vpcEndpointIDs {
 		if ep, exists := b.vpcEndpoints[id]; exists {
-			cp := *ep
-			result = append(result, &cp)
+			result = append(result, vpcEndpointCopy(ep))
 		}
 	}
 
@@ -872,7 +882,7 @@ func (b *InMemoryBackend) ListVpcEndpointAccess(domainName string) ([]string, er
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	return []string{}, nil
+	return slices.Clone(b.vpcAccess[domainName]), nil
 }
 
 // ListVpcEndpoints returns all VPC endpoints.
@@ -882,8 +892,7 @@ func (b *InMemoryBackend) ListVpcEndpoints() []*VpcEndpoint {
 
 	result := make([]*VpcEndpoint, 0, len(b.vpcEndpoints))
 	for _, ep := range b.vpcEndpoints {
-		cp := *ep
-		result = append(result, &cp)
+		result = append(result, vpcEndpointCopy(ep))
 	}
 
 	return result
@@ -902,8 +911,7 @@ func (b *InMemoryBackend) ListVpcEndpointsForDomain(domainName string) []*VpcEnd
 	var result []*VpcEndpoint
 	for _, ep := range b.vpcEndpoints {
 		if ep.DomainARN == d.ARN {
-			cp := *ep
-			result = append(result, &cp)
+			result = append(result, vpcEndpointCopy(ep))
 		}
 	}
 
@@ -912,14 +920,25 @@ func (b *InMemoryBackend) ListVpcEndpointsForDomain(domainName string) []*VpcEnd
 
 // RevokeVpcEndpointAccess revokes an account's access to a domain's VPC endpoint.
 func (b *InMemoryBackend) RevokeVpcEndpointAccess(domainName, account string) error {
-	b.mu.RLock("RevokeVpcEndpointAccess")
-	defer b.mu.RUnlock()
+	if account == "" {
+		return fmt.Errorf("%w: account principal is required", ErrValidation)
+	}
+
+	b.mu.Lock("RevokeVpcEndpointAccess")
+	defer b.mu.Unlock()
 
 	if _, exists := b.domains[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	_ = account
+	accounts := b.vpcAccess[domainName]
+	for i, authorized := range accounts {
+		if authorized == account {
+			b.vpcAccess[domainName] = append(accounts[:i], accounts[i+1:]...)
+
+			break
+		}
+	}
 
 	return nil
 }
@@ -938,12 +957,15 @@ func (b *InMemoryBackend) UpdateVpcEndpoint(vpcEndpointID string, vpcOptions map
 	maps.Copy(newOpts, vpcOptions)
 	endpoint.VpcOptions = newOpts
 
-	retOpts := make(map[string]string, len(newOpts))
-	maps.Copy(retOpts, newOpts)
-	cp := *endpoint
-	cp.VpcOptions = retOpts
+	return vpcEndpointCopy(endpoint), nil
+}
 
-	return &cp, nil
+func vpcEndpointCopy(endpoint *VpcEndpoint) *VpcEndpoint {
+	cp := *endpoint
+	cp.VpcOptions = maps.Clone(endpoint.VpcOptions)
+	cp.AuthorizedAccts = slices.Clone(endpoint.AuthorizedAccts)
+
+	return &cp
 }
 
 // DescribeDomainAutoTunes validates a domain exists and returns (the in-memory backend has no auto-tune state).
@@ -1026,12 +1048,30 @@ func (b *InMemoryBackend) UpgradeElasticsearchDomain(domainName, targetVersion s
 
 // DescribeReservedElasticsearchInstanceOfferings returns available reserved instance offerings.
 func (b *InMemoryBackend) DescribeReservedElasticsearchInstanceOfferings() []ReservedInstanceOffering {
-	return []ReservedInstanceOffering{}
+	return []ReservedInstanceOffering{{
+		OfferingID:    "offer-t3-small-1y",
+		InstanceType:  defaultInstanceType,
+		PaymentOption: "NO_UPFRONT",
+		Currency:      "USD",
+		Duration:      reservedDurationOneYearSeconds,
+	}}
 }
 
 // DescribeReservedElasticsearchInstances returns purchased reserved instances.
 func (b *InMemoryBackend) DescribeReservedElasticsearchInstances() []ReservedInstance {
-	return []ReservedInstance{}
+	b.mu.RLock("DescribeReservedElasticsearchInstances")
+	defer b.mu.RUnlock()
+
+	instances := make([]ReservedInstance, 0, len(b.reservedInstances))
+	for _, instance := range b.reservedInstances {
+		instances = append(instances, *instance)
+	}
+
+	slices.SortFunc(instances, func(a, c ReservedInstance) int {
+		return strings.Compare(a.ReservationID, c.ReservationID)
+	})
+
+	return instances
 }
 
 // PurchaseReservedElasticsearchInstanceOffering purchases a reserved instance offering.
@@ -1045,13 +1085,31 @@ func (b *InMemoryBackend) PurchaseReservedElasticsearchInstanceOffering(
 	b.mu.Lock("PurchaseReservedElasticsearchInstanceOffering")
 	defer b.mu.Unlock()
 
-	id := fmt.Sprintf("ri-%010d", b.nextIDLocked())
+	if count == 0 {
+		count = 1
+	}
 
-	return &ReservedInstance{
+	id := fmt.Sprintf("ri-%010d", b.nextIDLocked())
+	instance := &ReservedInstance{
 		ReservationID:   id,
 		ReservationName: name,
 		OfferingID:      offeringID,
 		Count:           count,
-		State:           "payment-pending",
-	}, nil
+		State:           statusActive,
+	}
+	for _, offering := range b.DescribeReservedElasticsearchInstanceOfferings() {
+		if offering.OfferingID == offeringID {
+			instance.InstanceType = offering.InstanceType
+			instance.FixedPrice = offering.FixedPrice
+			instance.UsagePrice = offering.UsagePrice
+			instance.Duration = offering.Duration
+
+			break
+		}
+	}
+
+	b.reservedInstances[id] = instance
+	cp := *instance
+
+	return &cp, nil
 }

--- a/services/elasticsearch/handler.go
+++ b/services/elasticsearch/handler.go
@@ -22,6 +22,10 @@ const (
 	keyEBSEnabled    = "EBSEnabled"
 	keyVolumeSize    = "VolumeSize"
 	keyVolumeType    = "VolumeType"
+
+	keyCrossClusterSearchConnection = "CrossClusterSearchConnection"
+	minimumInstanceCount            = 1
+	maximumInstanceCount            = 20
 )
 
 const (
@@ -1305,12 +1309,15 @@ func toPackageJSON(p *Package) packageJSON {
 
 // associatePackageOutput is the response for AssociatePackage.
 type associatePackageOutput struct {
-	DomainPackageDetails struct {
-		PackageID   string `json:"PackageID"`
-		DomainName  string `json:"DomainName"`
-		PackageType string `json:"PackageType"`
-		State       string `json:"DomainPackageStatus"`
-	} `json:"DomainPackageDetails"`
+	DomainPackageDetails domainPackageJSON `json:"DomainPackageDetails"`
+}
+
+type domainPackageJSON struct {
+	PackageID           string `json:"PackageID"`
+	PackageName         string `json:"PackageName,omitempty"`
+	DomainName          string `json:"DomainName"`
+	PackageType         string `json:"PackageType,omitempty"`
+	DomainPackageStatus string `json:"DomainPackageStatus"`
 }
 
 // associatePackagePathParts is the expected number of path segments after /associate/.
@@ -1348,7 +1355,7 @@ func (h *Handler) handleAssociatePackage(w http.ResponseWriter, r *http.Request)
 	var out associatePackageOutput
 	out.DomainPackageDetails.PackageID = packageID
 	out.DomainPackageDetails.DomainName = domainName
-	out.DomainPackageDetails.State = "ACTIVE"
+	out.DomainPackageDetails.DomainPackageStatus = "ACTIVE"
 
 	h.writeJSON(r, w, &out)
 }
@@ -1712,129 +1719,505 @@ func (h *Handler) handleDeleteElasticsearchServiceRole(w http.ResponseWriter, _ 
 }
 
 func (h *Handler) handleStartElasticsearchServiceSoftwareUpdate(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"ServiceSoftwareOptions": map[string]any{"UpdateStatus": "PENDING_UPDATE"}})
+	var req cancelSoftwareUpdateRequest
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	if _, err := h.Backend.StartElasticsearchServiceSoftwareUpdate(req.DomainName); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"ServiceSoftwareOptions": map[string]any{
+		"UpdateStatus": "PENDING_UPDATE",
+		"Cancellable":  true,
+	}})
 }
 
 func (h *Handler) handleDescribeInboundCrossClusterSearchConnections(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"CrossClusterSearchConnections": []any{}})
+	connections := h.Backend.DescribeInboundCrossClusterSearchConnections()
+	result := make([]inboundConnectionJSON, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, toInboundConnectionJSON(connection))
+	}
+
+	h.writeJSON(r, w, map[string]any{"CrossClusterSearchConnections": result})
 }
 
 func (h *Handler) handleDescribeOutboundCrossClusterSearchConnections(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"CrossClusterSearchConnections": []any{}})
+	connections := h.Backend.DescribeOutboundCrossClusterSearchConnections()
+	result := make([]outboundConnectionJSON, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, toOutboundConnectionJSON(connection))
+	}
+
+	h.writeJSON(r, w, map[string]any{"CrossClusterSearchConnections": result})
 }
 
 func (h *Handler) handleDescribePackages(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"PackageDetailsList": []any{}})
+	var req struct {
+		PackageIDs []string `json:"PackageIDs"`
+	}
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	packages := h.Backend.DescribePackages(req.PackageIDs)
+	result := make([]packageJSON, 0, len(packages))
+	for _, pkg := range packages {
+		result = append(result, toPackageJSON(pkg))
+	}
+
+	h.writeJSON(r, w, map[string]any{"PackageDetailsList": result})
 }
 
 func (h *Handler) handleUpdatePackage(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"PackageDetails": map[string]any{}})
+	var req struct {
+		PackageID          string `json:"PackageID"`
+		PackageDescription string `json:"PackageDescription"`
+	}
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	pkg, err := h.Backend.UpdatePackage(req.PackageID, req.PackageDescription)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"PackageDetails": toPackageJSON(pkg)})
 }
 
 func (h *Handler) handleDescribeVpcEndpoints(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"VpcEndpoints": []any{}})
+	var req struct {
+		VpcEndpointIDs []string `json:"VpcEndpointIds"`
+	}
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{
+		"VpcEndpoints":      toVpcEndpointsJSON(h.Backend.DescribeVpcEndpoints(req.VpcEndpointIDs)),
+		"VpcEndpointErrors": []any{},
+	})
 }
 
 func (h *Handler) handleUpdateVpcEndpoint(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"VpcEndpoint": map[string]any{}})
+	var req struct {
+		VpcOptions    map[string]string `json:"VpcOptions"`
+		VpcEndpointID string            `json:"VpcEndpointId"`
+	}
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	endpoint, err := h.Backend.UpdateVpcEndpoint(req.VpcEndpointID, req.VpcOptions)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"VpcEndpoint": toVpcEndpointJSON(endpoint)})
 }
 
 func (h *Handler) handleListVpcEndpoints(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"VpcEndpointSummaryList": []any{}})
+	h.writeJSON(r, w, map[string]any{
+		"VpcEndpointSummaryList": toVpcEndpointsJSON(h.Backend.ListVpcEndpoints()),
+	})
 }
 
 func (h *Handler) handleGetCompatibleElasticsearchVersions(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"CompatibleElasticsearchVersions": []any{}})
+	h.writeJSON(r, w, map[string]any{"CompatibleElasticsearchVersions": []any{
+		map[string]any{
+			"SourceVersion": elasticsearchVersion68,
+			"TargetVersions": []string{
+				elasticsearchVersion71,
+				defaultElasticsearchVersion,
+			},
+		},
+		map[string]any{
+			"SourceVersion":  elasticsearchVersion71,
+			"TargetVersions": []string{defaultElasticsearchVersion},
+		},
+	}})
 }
 
 func (h *Handler) handleListElasticsearchVersions(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{"ElasticsearchVersions": []string{"7.10", "7.1", "6.8"}})
+	h.writeJSON(r, w, map[string]any{
+		"ElasticsearchVersions": []string{defaultElasticsearchVersion, elasticsearchVersion71, elasticsearchVersion68},
+	})
 }
 
 func (h *Handler) handleDeleteInboundCrossClusterSearchConnection(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := strings.TrimPrefix(r.URL.Path, elasticsearchCCSInbound+"/")
+	connection, err := h.Backend.DeleteInboundCrossClusterSearchConnection(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{keyCrossClusterSearchConnection: toInboundConnectionJSON(connection)})
 }
 
 func (h *Handler) handleDeleteOutboundCrossClusterSearchConnection(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := strings.TrimPrefix(r.URL.Path, elasticsearchCCSOutbound+"/")
+	connection, err := h.Backend.DeleteOutboundCrossClusterSearchConnection(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{keyCrossClusterSearchConnection: toOutboundConnectionJSON(connection)})
 }
 
 func (h *Handler) handleDeleteVpcEndpoint(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := strings.TrimPrefix(r.URL.Path, elasticsearchVpcEndpoints+"/")
+	endpoint, err := h.Backend.DeleteVpcEndpoint(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"VpcEndpointSummary": toVpcEndpointJSON(endpoint)})
 }
 
 func (h *Handler) handleDescribeReservedElasticsearchInstanceOfferings(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	offerings := h.Backend.DescribeReservedElasticsearchInstanceOfferings()
+	result := make([]map[string]any, 0, len(offerings))
+	for _, offering := range offerings {
+		result = append(result, map[string]any{
+			"ReservedElasticsearchInstanceOfferingId": offering.OfferingID,
+			"ElasticsearchInstanceType":               offering.InstanceType,
+			"PaymentOption":                           offering.PaymentOption,
+			"CurrencyCode":                            offering.Currency,
+			"FixedPrice":                              offering.FixedPrice,
+			"UsagePrice":                              offering.UsagePrice,
+			"Duration":                                offering.Duration,
+		})
+	}
+
+	h.writeJSON(r, w, map[string]any{
+		"ReservedElasticsearchInstanceOfferings": result,
+	})
 }
 
 func (h *Handler) handleDescribeReservedElasticsearchInstances(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	instances := h.Backend.DescribeReservedElasticsearchInstances()
+	result := make([]map[string]any, 0, len(instances))
+	for _, instance := range instances {
+		result = append(result, map[string]any{
+			"ReservedElasticsearchInstanceId":         instance.ReservationID,
+			"ReservationName":                         instance.ReservationName,
+			"ReservedElasticsearchInstanceOfferingId": instance.OfferingID,
+			"ElasticsearchInstanceType":               instance.InstanceType,
+			"State":                                   instance.State,
+			"ElasticsearchInstanceCount":              instance.Count,
+		})
+	}
+
+	h.writeJSON(r, w, map[string]any{
+		"ReservedElasticsearchInstances": result,
+	})
 }
 
 func (h *Handler) handleDissociatePackage(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	rest := strings.TrimPrefix(r.URL.Path, elasticsearchPackages+"/dissociate/")
+	parts := strings.SplitN(rest, "/", associatePackagePathParts)
+	if len(parts) != associatePackagePathParts {
+		h.writeError(r, w, http.StatusBadRequest, "ValidationException", "invalid package dissociation path")
+
+		return
+	}
+
+	if err := h.Backend.DissociatePackage(parts[0], parts[1]); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"DomainPackageDetails": map[string]any{
+		"PackageID":           parts[0],
+		"DomainName":          parts[1],
+		"DomainPackageStatus": "DISSOCIATED",
+	}})
 }
 
 func (h *Handler) handleGetPackageVersionHistory(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := pathID(r.URL.Path, elasticsearchPackages+"/", "/history")
+	packages, err := h.Backend.GetPackageVersionHistory(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	history := make([]packageJSON, 0, len(packages))
+	for _, pkg := range packages {
+		history = append(history, toPackageJSON(pkg))
+	}
+
+	h.writeJSON(r, w, map[string]any{"PackageVersionHistoryList": history})
 }
 
 func (h *Handler) handlePurchaseReservedElasticsearchInstanceOffering(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	var req struct {
+		OfferingID      string `json:"ReservedElasticsearchInstanceOfferingId"`
+		ReservationName string `json:"ReservationName"`
+		InstanceCount   int    `json:"InstanceCount"`
+	}
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	instance, err := h.Backend.PurchaseReservedElasticsearchInstanceOffering(
+		req.OfferingID,
+		req.ReservationName,
+		req.InstanceCount,
+	)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{
+		"ReservedElasticsearchInstanceId": instance.ReservationID,
+		"ReservationName":                 instance.ReservationName,
+	})
 }
 
 func (h *Handler) handleRejectInboundCrossClusterSearchConnection(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := pathID(r.URL.Path, elasticsearchCCSInbound+"/", "/reject")
+	connection, err := h.Backend.RejectInboundCrossClusterSearchConnection(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{keyCrossClusterSearchConnection: toInboundConnectionJSON(connection)})
 }
 
 func (h *Handler) handleUpgradeElasticsearchDomain(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	var req struct {
+		DomainName       string `json:"DomainName"`
+		TargetVersion    string `json:"TargetVersion"`
+		PerformCheckOnly bool   `json:"PerformCheckOnly"`
+	}
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	if !req.PerformCheckOnly {
+		if _, err := h.Backend.UpgradeElasticsearchDomain(req.DomainName, req.TargetVersion); err != nil {
+			h.writeOperationError(r, w, err)
+
+			return
+		}
+	} else if _, err := h.Backend.DescribeDomain(req.DomainName); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, req)
 }
 
 func (h *Handler) handleDeletePackage(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := strings.TrimPrefix(r.URL.Path, elasticsearchPackages+"/")
+	pkg, err := h.Backend.DeletePackage(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"PackageDetails": toPackageJSON(pkg)})
 }
 
-func (h *Handler) handleDescribeDomainAutoTunes(w http.ResponseWriter, r *http.Request, _ string) {
-	h.writeJSON(r, w, map[string]any{})
+func (h *Handler) handleDescribeDomainAutoTunes(w http.ResponseWriter, r *http.Request, domainName string) {
+	if err := h.Backend.DescribeDomainAutoTunes(domainName); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"AutoTunes": []any{}})
 }
 
-func (h *Handler) handleDescribeDomainChangeProgress(w http.ResponseWriter, r *http.Request, _ string) {
-	h.writeJSON(r, w, map[string]any{})
+func (h *Handler) handleDescribeDomainChangeProgress(w http.ResponseWriter, r *http.Request, domainName string) {
+	if err := h.Backend.DescribeDomainChangeProgress(domainName); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"ChangeProgressStatus": map[string]any{"Status": "COMPLETED"}})
 }
 
 func (h *Handler) handleDescribeElasticsearchInstanceTypeLimits(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	h.writeJSON(r, w, map[string]any{"LimitsByRole": map[string]any{
+		"data": map[string]any{"InstanceLimits": map[string]any{"InstanceCountLimits": map[string]any{
+			"MinimumInstanceCount": minimumInstanceCount,
+			"MaximumInstanceCount": maximumInstanceCount,
+		}}},
+	}})
 }
 
 func (h *Handler) handleGetUpgradeHistory(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	domainName := pathID(r.URL.Path, elasticsearchUpgradeDomain+"/", "/history")
+	if err := h.Backend.GetUpgradeHistory(domainName); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"UpgradeHistories": []any{}})
 }
 
 func (h *Handler) handleGetUpgradeStatus(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	domainName := pathID(r.URL.Path, elasticsearchUpgradeDomain+"/", "/status")
+	if err := h.Backend.GetUpgradeStatus(domainName); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	h.writeJSON(r, w, map[string]any{"UpgradeStep": "UPGRADE", "StepStatus": "SUCCEEDED"})
 }
 
 func (h *Handler) handleListDomainsForPackage(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	id := pathID(r.URL.Path, elasticsearchPackages+"/", "/domains")
+	domains, err := h.Backend.ListDomainsForPackage(id)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	result := make([]domainPackageJSON, 0, len(domains))
+	for _, domainName := range domains {
+		result = append(result, domainPackageJSON{
+			PackageID: id, DomainName: domainName, DomainPackageStatus: statusActive,
+		})
+	}
+
+	h.writeJSON(r, w, map[string]any{"DomainPackageDetailsList": result})
 }
 
 func (h *Handler) handleListElasticsearchInstanceTypes(w http.ResponseWriter, r *http.Request) {
-	h.writeJSON(r, w, map[string]any{})
+	h.writeJSON(r, w, map[string]any{"ElasticsearchInstanceTypes": []string{
+		defaultInstanceType,
+		largeInstanceType,
+	}})
 }
 
 func (h *Handler) handleListPackagesForDomain(w http.ResponseWriter, r *http.Request) {
+	domainName := pathID(r.URL.Path, elasticsearchDomainPackages+"/", "/packages")
+	packages := h.Backend.ListPackagesForDomain(domainName)
+	result := make([]domainPackageJSON, 0, len(packages))
+	for _, pkg := range packages {
+		result = append(result, domainPackageJSON{
+			PackageID:           pkg.ID,
+			PackageName:         pkg.Name,
+			PackageType:         pkg.PackageType,
+			DomainName:          domainName,
+			DomainPackageStatus: statusActive,
+		})
+	}
+
+	h.writeJSON(r, w, map[string]any{"DomainPackageDetailsList": result})
+}
+
+func (h *Handler) handleListVpcEndpointAccess(w http.ResponseWriter, r *http.Request, domainName string) {
+	accounts, err := h.Backend.ListVpcEndpointAccess(domainName)
+	if err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
+	principals := make([]authorizedPrincipalJSON, 0, len(accounts))
+	for _, account := range accounts {
+		principals = append(principals, authorizedPrincipalJSON{PrincipalType: "AWS_ACCOUNT", Principal: account})
+	}
+
+	h.writeJSON(r, w, map[string]any{"AuthorizedPrincipalList": principals})
+}
+
+func (h *Handler) handleListVpcEndpointsForDomain(w http.ResponseWriter, r *http.Request, domainName string) {
+	h.writeJSON(r, w, map[string]any{
+		"VpcEndpointSummaryList": toVpcEndpointsJSON(h.Backend.ListVpcEndpointsForDomain(domainName)),
+	})
+}
+
+func (h *Handler) handleRevokeVpcEndpointAccess(w http.ResponseWriter, r *http.Request, domainName string) {
+	var req authorizeVpcEndpointAccessRequest
+	if !h.decodeRequest(w, r, &req) {
+		return
+	}
+
+	if err := h.Backend.RevokeVpcEndpointAccess(domainName, req.Account); err != nil {
+		h.writeOperationError(r, w, err)
+
+		return
+	}
+
 	h.writeJSON(r, w, map[string]any{})
 }
 
-func (h *Handler) handleListVpcEndpointAccess(w http.ResponseWriter, r *http.Request, _ string) {
-	h.writeJSON(r, w, map[string]any{})
+func (h *Handler) decodeRequest(w http.ResponseWriter, r *http.Request, out any) bool {
+	body, err := httputils.ReadBody(r)
+	if err != nil {
+		h.writeError(r, w, http.StatusBadRequest, "ValidationException", "failed to read body")
+
+		return false
+	}
+
+	if len(body) == 0 {
+		return true
+	}
+
+	if err = json.Unmarshal(body, out); err != nil {
+		h.writeError(r, w, http.StatusBadRequest, "ValidationException", "invalid JSON body")
+
+		return false
+	}
+
+	return true
 }
 
-func (h *Handler) handleListVpcEndpointsForDomain(w http.ResponseWriter, r *http.Request, _ string) {
-	h.writeJSON(r, w, map[string]any{"VpcEndpoints": []any{}})
+func (h *Handler) writeOperationError(r *http.Request, w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrDomainNotFound) || errors.Is(err, ErrPackageNotFound) ||
+		errors.Is(err, ErrVpcEndpointNotFound) || errors.Is(err, ErrConnectionNotFound) {
+		h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+
+		return
+	}
+
+	h.writeError(r, w, http.StatusBadRequest, "ValidationException", err.Error())
 }
 
-func (h *Handler) handleRevokeVpcEndpointAccess(w http.ResponseWriter, r *http.Request, _ string) {
-	h.writeJSON(r, w, map[string]any{})
+func toVpcEndpointsJSON(endpoints []*VpcEndpoint) []vpcEndpointJSON {
+	result := make([]vpcEndpointJSON, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		result = append(result, toVpcEndpointJSON(endpoint))
+	}
+
+	return result
+}
+
+func pathID(path, prefix, suffix string) string {
+	id := strings.TrimPrefix(path, prefix)
+	id, _ = strings.CutSuffix(id, suffix)
+
+	return id
 }

--- a/services/elasticsearch/handler_stateful_ops_test.go
+++ b/services/elasticsearch/handler_stateful_ops_test.go
@@ -1,0 +1,215 @@
+package elasticsearch_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/elasticsearch"
+)
+
+func TestElasticsearchStatefulOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(*testing.T)
+		name string
+	}{
+		{name: "packages", run: testStatefulPackages},
+		{name: "vpc endpoints and access", run: testStatefulVpcEndpoints},
+		{name: "upgrades and software", run: testStatefulUpgrade},
+		{name: "reserved instances", run: testStatefulReservedInstances},
+		{name: "instance metadata", run: testMetadataOperations},
+		{name: "cross cluster connections", run: testStatefulConnections},
+		{name: "snapshot extended state", run: testStatefulSnapshot},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			test.run(t)
+		})
+	}
+}
+
+func testStatefulPackages(t *testing.T) {
+	t.Helper()
+
+	h := newTestHandler()
+	domain := createTestDomainName(t, h, "pkg-state-domain")
+	packageID := createTestPackage(t, h, "state-package")
+
+	resp := doRequest(t, h, http.MethodPost, "/2015-01-01/packages/associate/"+packageID+"/"+domain, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/packages/update", map[string]any{
+		"PackageID": packageID, "PackageDescription": "changed",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "changed", esCoverageReadBody(t, resp)["PackageDetails"].(map[string]any)["PackageDescription"])
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/packages/describe", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["PackageDetailsList"], 1)
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/packages/"+packageID+"/domains", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["DomainPackageDetailsList"], 1)
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/domain/"+domain+"/packages", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["DomainPackageDetailsList"], 1)
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/packages/dissociate/"+packageID+"/"+domain, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodDelete, "/2015-01-01/packages/"+packageID, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/packages/describe", nil)
+	assert.Empty(t, esCoverageReadBody(t, resp)["PackageDetailsList"])
+}
+
+func testStatefulVpcEndpoints(t *testing.T) {
+	t.Helper()
+
+	h := newTestHandler()
+	domain := "vpc-state-domain"
+	domainARN := createDomainAndGetARN(t, h, domain)
+
+	resp := doRequest(t, h, http.MethodPost,
+		"/2015-01-01/es/domain/"+domain+"/authorizeVpcEndpointAccess", map[string]any{"Account": "222222222222"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/domain/"+domain+"/listVpcEndpointAccess", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["AuthorizedPrincipalList"], 1)
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/es/vpcEndpoints", map[string]any{
+		"DomainArn": domainARN, "VpcOptions": map[string]string{"SubnetId": "subnet-a"},
+	})
+	endpointID := esCoverageReadBody(t, resp)["VpcEndpoint"].(map[string]any)["VpcEndpointId"].(string)
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/es/vpcEndpoints/update", map[string]any{
+		"VpcEndpointId": endpointID, "VpcOptions": map[string]string{"SubnetId": "subnet-b"},
+	})
+	assert.Equal(
+		t,
+		"subnet-b",
+		esCoverageReadBody(t, resp)["VpcEndpoint"].(map[string]any)["VpcOptions"].(map[string]any)["SubnetId"],
+	)
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/domain/"+domain+"/vpcEndpoints", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["VpcEndpointSummaryList"], 1)
+
+	resp = doRequest(t, h, http.MethodPost,
+		"/2015-01-01/es/domain/"+domain+"/revokeVpcEndpointAccess", map[string]any{"Account": "222222222222"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/domain/"+domain+"/listVpcEndpointAccess", nil)
+	assert.Empty(t, esCoverageReadBody(t, resp)["AuthorizedPrincipalList"])
+
+	resp = doRequest(t, h, http.MethodDelete, "/2015-01-01/es/vpcEndpoints/"+endpointID, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func testStatefulUpgrade(t *testing.T) {
+	t.Helper()
+
+	h := newTestHandler()
+	createTestDomainName(t, h, "upgrade-state-domain")
+
+	resp := doRequest(t, h, http.MethodPost, "/2015-01-01/es/upgradeDomain", map[string]any{
+		"DomainName": "upgrade-state-domain", "TargetVersion": "7.11",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/domain/upgrade-state-domain", nil)
+	assert.Equal(t, "7.11", esCoverageReadBody(t, resp)["DomainStatus"].(map[string]any)["ElasticsearchVersion"])
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/es/serviceSoftwareUpdate", map[string]any{
+		"DomainName": "missing-domain",
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func testStatefulReservedInstances(t *testing.T) {
+	t.Helper()
+
+	h := newTestHandler()
+
+	resp := doRequest(t, h, http.MethodGet, "/2015-01-01/es/reservedInstanceOfferings", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["ReservedElasticsearchInstanceOfferings"], 1)
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/es/purchaseReservedInstanceOffering", map[string]any{
+		"ReservedElasticsearchInstanceOfferingId": "offer-t3-small-1y",
+		"ReservationName":                         "reserved-state",
+	})
+	require.NotEmpty(t, esCoverageReadBody(t, resp)["ReservedElasticsearchInstanceId"])
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/reservedInstances", nil)
+	require.Len(t, esCoverageReadBody(t, resp)["ReservedElasticsearchInstances"], 1)
+}
+
+func testMetadataOperations(t *testing.T) {
+	t.Helper()
+
+	h := newTestHandler()
+	resp := doRequest(t, h, http.MethodGet, "/2015-01-01/es/compatibleVersions", nil)
+	assert.NotEmpty(t, esCoverageReadBody(t, resp)["CompatibleElasticsearchVersions"])
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/instanceTypes/7.10", nil)
+	assert.NotEmpty(t, esCoverageReadBody(t, resp)["ElasticsearchInstanceTypes"])
+
+	resp = doRequest(t, h, http.MethodGet, "/2015-01-01/es/instanceTypeLimits/t3.small.elasticsearch/7.10", nil)
+	assert.NotEmpty(t, esCoverageReadBody(t, resp)["LimitsByRole"])
+}
+
+func testStatefulConnections(t *testing.T) {
+	t.Helper()
+
+	backend := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
+	backend.AddInboundConnectionInternal(elasticsearch.InboundConnection{
+		ConnectionID: "connection-state", ConnectionStatus: "PENDING_ACCEPTANCE",
+	})
+	h := elasticsearch.NewHandler(backend)
+
+	resp := doRequest(t, h, http.MethodPut,
+		"/2015-01-01/es/ccs/inboundConnection/connection-state/reject", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := esCoverageReadBody(t, resp)
+	connection := body["CrossClusterSearchConnection"].(map[string]any)
+	assert.Equal(t, "REJECTED", connection["ConnectionStatus"].(map[string]any)["StatusCode"])
+
+	resp = doRequest(t, h, http.MethodDelete, "/2015-01-01/es/ccs/inboundConnection/connection-state", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = doRequest(t, h, http.MethodPost, "/2015-01-01/es/ccs/inboundConnection/search", nil)
+	assert.Empty(t, esCoverageReadBody(t, resp)["CrossClusterSearchConnections"])
+}
+
+func testStatefulSnapshot(t *testing.T) {
+	t.Helper()
+
+	backend := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
+	_, err := backend.CreateDomain("saved-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	require.NoError(t, err)
+	require.NoError(t, backend.AuthorizeVpcEndpointAccess("saved-domain", "222222222222"))
+	_, err = backend.PurchaseReservedElasticsearchInstanceOffering("offer-t3-small-1y", "saved-reservation", 1)
+	require.NoError(t, err)
+
+	restored := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
+	require.NoError(t, restored.Restore(backend.Snapshot()))
+
+	accounts, err := restored.ListVpcEndpointAccess("saved-domain")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"222222222222"}, accounts)
+	assert.Len(t, restored.DescribeReservedElasticsearchInstances(), 1)
+}

--- a/services/elasticsearch/persistence.go
+++ b/services/elasticsearch/persistence.go
@@ -14,6 +14,8 @@ type backendSnapshot struct {
 	InboundConnections  map[string]*InboundConnection  `json:"inboundConnections"`
 	OutboundConnections map[string]*OutboundConnection `json:"outboundConnections"`
 	VpcEndpoints        map[string]*VpcEndpoint        `json:"vpcEndpoints"`
+	VpcAccess           map[string][]string            `json:"vpcAccess"`
+	ReservedInstances   map[string]*ReservedInstance   `json:"reservedInstances"`
 	AccountID           string                         `json:"accountID"`
 	Region              string                         `json:"region"`
 	NextID              int                            `json:"nextID"`
@@ -71,6 +73,17 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		vpcEndpoints[k] = &cp
 	}
 
+	vpcAccess := make(map[string][]string, len(b.vpcAccess))
+	for domainName, accounts := range b.vpcAccess {
+		vpcAccess[domainName] = append([]string(nil), accounts...)
+	}
+
+	reservedInstances := make(map[string]*ReservedInstance, len(b.reservedInstances))
+	for id, instance := range b.reservedInstances {
+		cp := *instance
+		reservedInstances[id] = &cp
+	}
+
 	snap := backendSnapshot{
 		Domains:             domains,
 		Packages:            packages,
@@ -79,6 +92,8 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		InboundConnections:  inbound,
 		OutboundConnections: outbound,
 		VpcEndpoints:        vpcEndpoints,
+		VpcAccess:           vpcAccess,
+		ReservedInstances:   reservedInstances,
 		AccountID:           b.accountID,
 		Region:              b.region,
 		NextID:              b.nextID,
@@ -138,6 +153,14 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		snap.VpcEndpoints = make(map[string]*VpcEndpoint)
 	}
 
+	if snap.VpcAccess == nil {
+		snap.VpcAccess = make(map[string][]string)
+	}
+
+	if snap.ReservedInstances == nil {
+		snap.ReservedInstances = make(map[string]*ReservedInstance)
+	}
+
 	b.domains = snap.Domains
 	b.packages = snap.Packages
 	b.packagesByName = snap.PackagesByName
@@ -145,6 +168,8 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.inboundConnections = snap.InboundConnections
 	b.outboundConnections = snap.OutboundConnections
 	b.vpcEndpoints = snap.VpcEndpoints
+	b.vpcAccess = snap.VpcAccess
+	b.reservedInstances = snap.ReservedInstances
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 	b.nextID = snap.NextID


### PR DESCRIPTION
Elasticsearch Service audit. Closes #1784. 835 changes.