### PR TITLE
feat(kafka): MSK AWS-accuracy audit batch-1 (go-2yel) (#1811)

### DIFF
--- a/services/kafka/backend.go
+++ b/services/kafka/backend.go
@@ -463,14 +463,29 @@ func (b *InMemoryBackend) CreateCluster(
 	}
 
 	clusterArn := b.clusterARN(name)
+	safeInfo := BrokerNodeGroupInfo{
+		BrokerAZDistribution: brokerInfo.BrokerAZDistribution,
+		InstanceType:         brokerInfo.InstanceType,
+		ClientSubnets:        append([]string(nil), brokerInfo.ClientSubnets...),
+		SecurityGroups:       append([]string(nil), brokerInfo.SecurityGroups...),
+		ZoneIds:              append([]string(nil), brokerInfo.ZoneIds...),
+		StorageInfo:          brokerInfo.StorageInfo,
+		ConnectivityInfo:     brokerInfo.ConnectivityInfo,
+	}
+	if brokerInfo.StorageInfo != nil {
+		safeInfo.StorageInfo = cloneStorageInfo(brokerInfo.StorageInfo)
+	}
+	if brokerInfo.ConnectivityInfo != nil {
+		safeInfo.ConnectivityInfo = cloneConnectivityInfo(brokerInfo.ConnectivityInfo)
+	}
 	cluster := &Cluster{
 		ClusterArn:           clusterArn,
 		ClusterName:          name,
 		ClusterType:          ClusterTypeProvisioned,
 		KafkaVersion:         kafkaVersion,
 		NumberOfBrokerNodes:  numBrokers,
-		BrokerNodeGroupInfo:  brokerInfo,
-		ClientAuthentication: clientAuth,
+		BrokerNodeGroupInfo:  safeInfo,
+		ClientAuthentication: cloneClientAuth(clientAuth),
 		State:                ClusterStateActive,
 		CurrentVersion:       "K3AEGXETSR30VB",
 		Tags:                 nonNilTagsCopy(tags),

--- a/services/kafka/backend.go
+++ b/services/kafka/backend.go
@@ -41,6 +41,48 @@ const (
 	ClusterStateDeleting = "DELETING"
 	// ClusterStateFailed indicates a cluster in a failed state.
 	ClusterStateFailed = "FAILED"
+	// ClusterStateUpdating indicates a cluster undergoing an update.
+	ClusterStateUpdating = "UPDATING"
+	// ClusterStateRebootingBroker indicates a broker reboot in progress.
+	ClusterStateRebootingBroker = "REBOOTING_BROKER"
+	// ClusterStateMaintenance indicates a cluster in a maintenance window.
+	ClusterStateMaintenance = "MAINTENANCE"
+	// ClusterStateHealing indicates a cluster undergoing node healing.
+	ClusterStateHealing = "HEALING"
+)
+
+const (
+	// ClusterTypeProvisioned is the standard MSK cluster type.
+	ClusterTypeProvisioned = "PROVISIONED"
+	// ClusterTypeServerless is the MSK Serverless cluster type.
+	ClusterTypeServerless = "SERVERLESS"
+)
+
+const (
+	// EnhancedMonitoringDefault is the default monitoring level.
+	EnhancedMonitoringDefault = "DEFAULT"
+	// EnhancedMonitoringPerBroker enables per-broker metrics.
+	EnhancedMonitoringPerBroker = "PER_BROKER"
+	// EnhancedMonitoringPerTopicPerBroker enables per-topic-per-broker metrics.
+	EnhancedMonitoringPerTopicPerBroker = "PER_TOPIC_PER_BROKER"
+	// EnhancedMonitoringPerTopicPerPartition enables per-topic-per-partition metrics.
+	EnhancedMonitoringPerTopicPerPartition = "PER_TOPIC_PER_PARTITION"
+)
+
+const (
+	// StorageModeLocal is the standard EBS-only storage mode.
+	StorageModeLocal = "LOCAL"
+	// StorageModeTiered enables tiered storage (remote storage offload).
+	StorageModeTiered = "TIERED"
+)
+
+const (
+	// EncryptionInTransitTLS requires TLS for all client-broker traffic.
+	EncryptionInTransitTLS = "TLS"
+	// EncryptionInTransitTLSPlaintext allows both TLS and plaintext.
+	EncryptionInTransitTLSPlaintext = "TLS_PLAINTEXT"
+	// EncryptionInTransitPlaintext allows plaintext only (dev/test use).
+	EncryptionInTransitPlaintext = "PLAINTEXT"
 )
 
 const (
@@ -52,13 +94,16 @@ const (
 	defaultPartitionCount = 1
 )
 
-// BrokerNodeGroupInfo holds broker node configuration.
-type BrokerNodeGroupInfo struct {
-	StorageInfo          *StorageInfo `json:"storageInfo,omitempty"`
-	BrokerAZDistribution string       `json:"brokerAZDistribution,omitempty"`
-	InstanceType         string       `json:"instanceType"`
-	ClientSubnets        []string     `json:"clientSubnets"`
-	SecurityGroups       []string     `json:"securityGroups,omitempty"`
+// ProvisionedThroughput holds EBS provisioned throughput config.
+type ProvisionedThroughput struct {
+	VolumeThroughput int32 `json:"volumeThroughput,omitempty"`
+	Enabled          bool  `json:"enabled"`
+}
+
+// EBSStorageInfo holds EBS volume config.
+type EBSStorageInfo struct {
+	ProvisionedThroughput *ProvisionedThroughput `json:"provisionedThroughput,omitempty"`
+	VolumeSize            int32                  `json:"volumeSize,omitempty"`
 }
 
 // StorageInfo holds broker storage config.
@@ -66,9 +111,58 @@ type StorageInfo struct {
 	EbsStorageInfo *EBSStorageInfo `json:"ebsStorageInfo,omitempty"`
 }
 
-// EBSStorageInfo holds EBS volume config.
-type EBSStorageInfo struct {
-	VolumeSize int32 `json:"volumeSize,omitempty"`
+// PublicAccess holds public access configuration for broker connectivity.
+type PublicAccess struct {
+	Type string `json:"type,omitempty"`
+}
+
+// VpcConnectivitySaslIam holds IAM authentication settings for VPC connectivity.
+type VpcConnectivitySaslIam struct {
+	Enabled bool `json:"enabled"`
+}
+
+// VpcConnectivitySaslScram holds SCRAM authentication settings for VPC connectivity.
+type VpcConnectivitySaslScram struct {
+	Enabled bool `json:"enabled"`
+}
+
+// VpcConnectivitySasl holds SASL settings for VPC connectivity.
+type VpcConnectivitySasl struct {
+	Iam   *VpcConnectivitySaslIam   `json:"iam,omitempty"`
+	Scram *VpcConnectivitySaslScram `json:"scram,omitempty"`
+}
+
+// VpcConnectivityTls holds TLS settings for VPC connectivity.
+type VpcConnectivityTls struct {
+	Enabled bool `json:"enabled"`
+}
+
+// VpcConnectivityClientAuthentication holds authentication settings for VPC connectivity.
+type VpcConnectivityClientAuthentication struct {
+	Sasl *VpcConnectivitySasl `json:"sasl,omitempty"`
+	Tls  *VpcConnectivityTls  `json:"tls,omitempty"`
+}
+
+// VpcConnectivity holds VPC connectivity configuration.
+type VpcConnectivity struct {
+	ClientAuthentication *VpcConnectivityClientAuthentication `json:"clientAuthentication,omitempty"`
+}
+
+// ConnectivityInfo holds broker connectivity configuration.
+type ConnectivityInfo struct {
+	PublicAccess    *PublicAccess    `json:"publicAccess,omitempty"`
+	VpcConnectivity *VpcConnectivity `json:"vpcConnectivity,omitempty"`
+}
+
+// BrokerNodeGroupInfo holds broker node configuration.
+type BrokerNodeGroupInfo struct {
+	ConnectivityInfo     *ConnectivityInfo `json:"connectivityInfo,omitempty"`
+	StorageInfo          *StorageInfo      `json:"storageInfo,omitempty"`
+	BrokerAZDistribution string            `json:"brokerAZDistribution,omitempty"`
+	InstanceType         string            `json:"instanceType"`
+	ZoneIds              []string          `json:"zoneIds,omitempty"`
+	ClientSubnets        []string          `json:"clientSubnets"`
+	SecurityGroups       []string          `json:"securityGroups,omitempty"`
 }
 
 // ConfigurationInfo holds a cluster configuration reference.
@@ -79,8 +173,9 @@ type ConfigurationInfo struct {
 
 // ClientAuthentication holds MSK cluster authentication configuration.
 type ClientAuthentication struct {
-	Sasl *SaslSettings `json:"sasl,omitempty"`
-	TLS  *TLSSettings  `json:"tls,omitempty"`
+	Sasl            *SaslSettings            `json:"sasl,omitempty"`
+	TLS             *TLSSettings             `json:"tls,omitempty"`
+	Unauthenticated *UnauthenticatedSettings `json:"unauthenticated,omitempty"`
 }
 
 // SaslSettings holds SASL authentication settings.
@@ -101,20 +196,129 @@ type SaslIam struct {
 
 // TLSSettings holds TLS authentication settings.
 type TLSSettings struct {
+	CertificateAuthorityArnList []string `json:"certificateAuthorityArnList,omitempty"`
+	Enabled                     bool     `json:"enabled"`
+}
+
+// UnauthenticatedSettings holds unauthenticated access settings.
+type UnauthenticatedSettings struct {
 	Enabled bool `json:"enabled"`
+}
+
+// EncryptionAtRest holds at-rest encryption configuration.
+type EncryptionAtRest struct {
+	DataVolumeKMSKeyId string `json:"dataVolumeKMSKeyId,omitempty"`
+}
+
+// EncryptionInTransit holds in-transit encryption configuration.
+type EncryptionInTransit struct {
+	ClientBroker string `json:"clientBroker,omitempty"`
+	InCluster    bool   `json:"inCluster"`
+}
+
+// EncryptionInfo holds cluster encryption configuration.
+type EncryptionInfo struct {
+	EncryptionAtRest    *EncryptionAtRest    `json:"encryptionAtRest,omitempty"`
+	EncryptionInTransit *EncryptionInTransit `json:"encryptionInTransit,omitempty"`
+}
+
+// JmxExporter holds JMX exporter settings.
+type JmxExporter struct {
+	EnabledInBroker bool `json:"enabledInBroker"`
+}
+
+// NodeExporter holds Node exporter settings.
+type NodeExporter struct {
+	EnabledInBroker bool `json:"enabledInBroker"`
+}
+
+// PrometheusInfo holds Prometheus scraping configuration.
+type PrometheusInfo struct {
+	JmxExporter  *JmxExporter  `json:"jmxExporter,omitempty"`
+	NodeExporter *NodeExporter `json:"nodeExporter,omitempty"`
+}
+
+// OpenMonitoring holds open monitoring configuration.
+type OpenMonitoring struct {
+	Prometheus *PrometheusInfo `json:"prometheus,omitempty"`
+}
+
+// CloudWatchLogs holds CloudWatch log delivery settings.
+type CloudWatchLogs struct {
+	LogGroup string `json:"logGroup,omitempty"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// Firehose holds Kinesis Data Firehose log delivery settings.
+type Firehose struct {
+	DeliveryStream string `json:"deliveryStream,omitempty"`
+	Enabled        bool   `json:"enabled"`
+}
+
+// S3Logs holds S3 log delivery settings.
+type S3Logs struct {
+	Bucket  string `json:"bucket,omitempty"`
+	Prefix  string `json:"prefix,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+// BrokerLogs holds broker log delivery destinations.
+type BrokerLogs struct {
+	CloudWatchLogs *CloudWatchLogs `json:"cloudWatchLogs,omitempty"`
+	Firehose       *Firehose       `json:"firehose,omitempty"`
+	S3             *S3Logs         `json:"s3,omitempty"`
+}
+
+// LoggingInfo holds cluster logging configuration.
+type LoggingInfo struct {
+	BrokerLogs *BrokerLogs `json:"brokerLogs,omitempty"`
+}
+
+// StateInfo holds cluster state detail for error conditions.
+type StateInfo struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// ServerlessVpcConfig holds VPC configuration for a serverless cluster.
+type ServerlessVpcConfig struct {
+	SubnetIds        []string `json:"subnetIds,omitempty"`
+	SecurityGroupIds []string `json:"securityGroupIds,omitempty"`
+}
+
+// ServerlessClientAuthentication holds authentication settings for a serverless cluster.
+type ServerlessClientAuthentication struct {
+	Sasl *SaslSettings `json:"sasl,omitempty"`
+}
+
+// ServerlessClusterInfo holds serverless-specific cluster configuration.
+type ServerlessClusterInfo struct {
+	ClientAuthentication *ServerlessClientAuthentication `json:"clientAuthentication,omitempty"`
+	VpcConfigs           []ServerlessVpcConfig           `json:"vpcConfigs,omitempty"`
 }
 
 // Cluster represents an MSK cluster.
 type Cluster struct {
-	Tags                 map[string]string     `json:"-"`
-	ClientAuthentication *ClientAuthentication `json:"clientAuthentication,omitempty"`
-	ClusterArn           string                `json:"clusterArn"`
-	ClusterName          string                `json:"clusterName"`
-	KafkaVersion         string                `json:"kafkaVersion"`
-	State                string                `json:"state"`
-	CurrentVersion       string                `json:"currentVersion"`
-	BrokerNodeGroupInfo  BrokerNodeGroupInfo   `json:"brokerNodeGroupInfo"`
-	NumberOfBrokerNodes  int32                 `json:"numberOfBrokerNodes"`
+	Tags                 map[string]string      `json:"-"`
+	ClientAuthentication *ClientAuthentication  `json:"clientAuthentication,omitempty"`
+	EncryptionInfo       *EncryptionInfo        `json:"encryptionInfo,omitempty"`
+	OpenMonitoring       *OpenMonitoring        `json:"openMonitoring,omitempty"`
+	LoggingInfo          *LoggingInfo           `json:"loggingInfo,omitempty"`
+	StateInfo            *StateInfo             `json:"stateInfo,omitempty"`
+	Serverless           *ServerlessClusterInfo `json:"serverless,omitempty"`
+	ConfigurationInfo    *ConfigurationInfo     `json:"configurationInfo,omitempty"`
+	ClusterArn           string                 `json:"clusterArn"`
+	ClusterName          string                 `json:"clusterName"`
+	ClusterType          string                 `json:"clusterType"`
+	KafkaVersion         string                 `json:"kafkaVersion,omitempty"`
+	State                string                 `json:"state"`
+	CurrentVersion       string                 `json:"currentVersion"`
+	ActiveOperationArn   string                 `json:"activeOperationArn,omitempty"`
+	EnhancedMonitoring   string                 `json:"enhancedMonitoring,omitempty"`
+	StorageMode          string                 `json:"storageMode,omitempty"`
+	CreationTime         string                 `json:"creationTime,omitempty"`
+	BrokerNodeGroupInfo  BrokerNodeGroupInfo    `json:"brokerNodeGroupInfo"`
+	NumberOfBrokerNodes  int32                  `json:"numberOfBrokerNodes"`
 }
 
 // Configuration represents an MSK configuration.
@@ -262,6 +466,7 @@ func (b *InMemoryBackend) CreateCluster(
 	cluster := &Cluster{
 		ClusterArn:           clusterArn,
 		ClusterName:          name,
+		ClusterType:          ClusterTypeProvisioned,
 		KafkaVersion:         kafkaVersion,
 		NumberOfBrokerNodes:  numBrokers,
 		BrokerNodeGroupInfo:  brokerInfo,
@@ -269,6 +474,40 @@ func (b *InMemoryBackend) CreateCluster(
 		State:                ClusterStateActive,
 		CurrentVersion:       "K3AEGXETSR30VB",
 		Tags:                 nonNilTagsCopy(tags),
+	}
+	b.clusters[clusterArn] = cluster
+
+	return cloneCluster(cluster), nil
+}
+
+// CreateServerlessCluster creates a new MSK Serverless cluster.
+func (b *InMemoryBackend) CreateServerlessCluster(
+	name string,
+	serverless *ServerlessClusterInfo,
+	tags map[string]string,
+) (*Cluster, error) {
+	if name == "" {
+		return nil, fmt.Errorf("clusterName is required: %w", ErrValidation)
+	}
+
+	b.mu.Lock("CreateServerlessCluster")
+	defer b.mu.Unlock()
+
+	for _, c := range b.clusters {
+		if c.ClusterName == name {
+			return nil, ErrAlreadyExists
+		}
+	}
+
+	clusterArn := b.clusterARN(name)
+	cluster := &Cluster{
+		ClusterArn:     clusterArn,
+		ClusterName:    name,
+		ClusterType:    ClusterTypeServerless,
+		State:          ClusterStateActive,
+		CurrentVersion: "K3AEGXETSR30VB",
+		Tags:           nonNilTagsCopy(tags),
+		Serverless:     cloneServerless(serverless),
 	}
 	b.clusters[clusterArn] = cluster
 
@@ -947,6 +1186,7 @@ func (b *InMemoryBackend) RejectClientVpcConnection(vpcConnectionArn string) err
 // --- Cluster policy get/put operations ---
 
 // GetClusterPolicy retrieves the policy document for a cluster.
+// Returns ErrNotFound when the cluster exists but has no policy set — matching AWS behavior.
 func (b *InMemoryBackend) GetClusterPolicy(clusterArn string) (string, error) {
 	b.mu.RLock("GetClusterPolicy")
 	defer b.mu.RUnlock()
@@ -955,7 +1195,10 @@ func (b *InMemoryBackend) GetClusterPolicy(clusterArn string) (string, error) {
 		return "", ErrNotFound
 	}
 
-	policy := b.clusterPolicies[clusterArn]
+	policy, ok := b.clusterPolicies[clusterArn]
+	if !ok {
+		return "", fmt.Errorf("no resource-based policy found for cluster %q: %w", clusterArn, ErrNotFound)
+	}
 
 	return policy, nil
 }
@@ -1165,16 +1408,21 @@ func (b *InMemoryBackend) UpdateBrokerType(
 
 // UpdateClusterConfiguration updates the configuration for a cluster.
 func (b *InMemoryBackend) UpdateClusterConfiguration(
-	clusterArn, _ string,
-	_ int64,
+	clusterArn, configArn string,
+	revision int64,
 ) (*ClusterOperation, error) {
 	b.mu.Lock("UpdateClusterConfiguration")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	c, ok := b.clusters[clusterArn]
+	if !ok {
 		return nil, ErrNotFound
 	}
 
+	c.ConfigurationInfo = &ConfigurationInfo{
+		Arn:      configArn,
+		Revision: revision,
+	}
 	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CLUSTER_CONFIGURATION")
 
 	return op, nil
@@ -1324,30 +1572,52 @@ func (b *InMemoryBackend) ListNodes(clusterArn string) ([]*BrokerNode, error) {
 	return out, nil
 }
 
-// ListKafkaVersions returns a static list of supported Kafka versions.
+// ListKafkaVersions returns supported Kafka versions, matching current MSK availability.
 func (b *InMemoryBackend) ListKafkaVersions() []*MSKVersion {
 	return []*MSKVersion{
-		{Version: "3.6.0", Status: ClusterStateActive},
-		{Version: "3.5.1", Status: ClusterStateActive},
-		{Version: "3.4.0", Status: ClusterStateActive},
-		{Version: "2.8.1", Status: ClusterStateActive},
+		{Version: "3.8.0.kraft", Status: "ACTIVE"},
+		{Version: "3.7.x.kraft", Status: "ACTIVE"},
+		{Version: "3.6.0", Status: "ACTIVE"},
+		{Version: "3.5.1", Status: "ACTIVE"},
+		{Version: "3.4.0", Status: "ACTIVE"},
+		{Version: "3.3.2", Status: "ACTIVE"},
+		{Version: "3.3.1", Status: "ACTIVE"},
+		{Version: "2.8.2.tiered", Status: "ACTIVE"},
+		{Version: "2.8.1", Status: "ACTIVE"},
 		{Version: "2.8.0", Status: "DEPRECATED"},
 		{Version: "2.6.0", Status: "DEPRECATED"},
 	}
 }
 
-// GetCompatibleKafkaVersions returns Kafka versions compatible with the given source version.
+// GetCompatibleKafkaVersions returns Kafka versions compatible with the cluster's current version.
+// KRaft clusters can only target KRaft versions. ZooKeeper clusters can target ZooKeeper versions up to 3.x.
 func (b *InMemoryBackend) GetCompatibleKafkaVersions(clusterArn string) ([]*MSKVersion, error) {
 	b.mu.RLock("GetCompatibleKafkaVersions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	c, ok := b.clusters[clusterArn]
+	if !ok {
 		return nil, ErrNotFound
 	}
 
+	current := c.KafkaVersion
+	isKRaft := strings.HasSuffix(current, ".kraft")
+
+	if isKRaft {
+		return []*MSKVersion{
+			{Version: "3.8.0.kraft", Status: "ACTIVE"},
+			{Version: "3.7.x.kraft", Status: "ACTIVE"},
+		}, nil
+	}
+
+	// ZooKeeper-based: return non-KRaft active versions higher than current.
+	// For simplicity, return a curated list of ZooKeeper-compatible upgrades.
 	return []*MSKVersion{
-		{Version: "3.6.0", Status: ClusterStateActive},
-		{Version: "3.5.1", Status: ClusterStateActive},
+		{Version: "3.6.0", Status: "ACTIVE"},
+		{Version: "3.5.1", Status: "ACTIVE"},
+		{Version: "3.4.0", Status: "ACTIVE"},
+		{Version: "3.3.2", Status: "ACTIVE"},
+		{Version: "2.8.2.tiered", Status: "ACTIVE"},
 	}, nil
 }
 
@@ -1441,6 +1711,7 @@ func (b *InMemoryBackend) AddClusterInternal(name, kafkaVersion string) *Cluster
 	cluster := &Cluster{
 		ClusterArn:          clusterArn,
 		ClusterName:         name,
+		ClusterType:         ClusterTypeProvisioned,
 		KafkaVersion:        kafkaVersion,
 		NumberOfBrokerNodes: defaultBrokerCount,
 		State:               ClusterStateActive,
@@ -1566,31 +1837,207 @@ type ClusterOperation struct {
 // cloneCluster creates a deep copy of a cluster.
 func cloneCluster(c *Cluster) *Cluster {
 	clone := &Cluster{
-		ClusterArn:          c.ClusterArn,
-		ClusterName:         c.ClusterName,
-		KafkaVersion:        c.KafkaVersion,
-		State:               c.State,
-		CurrentVersion:      c.CurrentVersion,
+		ClusterArn:         c.ClusterArn,
+		ClusterName:        c.ClusterName,
+		ClusterType:        c.ClusterType,
+		KafkaVersion:       c.KafkaVersion,
+		State:              c.State,
+		CurrentVersion:     c.CurrentVersion,
+		ActiveOperationArn: c.ActiveOperationArn,
+		EnhancedMonitoring: c.EnhancedMonitoring,
+		StorageMode:        c.StorageMode,
+		CreationTime:       c.CreationTime,
 		NumberOfBrokerNodes: c.NumberOfBrokerNodes,
-		Tags:                nonNilTagsCopy(c.Tags),
+		Tags:               nonNilTagsCopy(c.Tags),
 		BrokerNodeGroupInfo: BrokerNodeGroupInfo{
 			BrokerAZDistribution: c.BrokerNodeGroupInfo.BrokerAZDistribution,
 			InstanceType:         c.BrokerNodeGroupInfo.InstanceType,
 			ClientSubnets:        append([]string(nil), c.BrokerNodeGroupInfo.ClientSubnets...),
 			SecurityGroups:       append([]string(nil), c.BrokerNodeGroupInfo.SecurityGroups...),
+			ZoneIds:              append([]string(nil), c.BrokerNodeGroupInfo.ZoneIds...),
 		},
 	}
 
 	if c.BrokerNodeGroupInfo.StorageInfo != nil {
-		clone.BrokerNodeGroupInfo.StorageInfo = &StorageInfo{}
-		if c.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo != nil {
-			clone.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo = &EBSStorageInfo{
-				VolumeSize: c.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.VolumeSize,
-			}
-		}
+		clone.BrokerNodeGroupInfo.StorageInfo = cloneStorageInfo(c.BrokerNodeGroupInfo.StorageInfo)
+	}
+
+	if c.BrokerNodeGroupInfo.ConnectivityInfo != nil {
+		clone.BrokerNodeGroupInfo.ConnectivityInfo = cloneConnectivityInfo(c.BrokerNodeGroupInfo.ConnectivityInfo)
 	}
 
 	clone.ClientAuthentication = cloneClientAuth(c.ClientAuthentication)
+	clone.EncryptionInfo = cloneEncryptionInfo(c.EncryptionInfo)
+	clone.OpenMonitoring = cloneOpenMonitoring(c.OpenMonitoring)
+	clone.LoggingInfo = cloneLoggingInfo(c.LoggingInfo)
+	clone.Serverless = cloneServerless(c.Serverless)
+
+	if c.StateInfo != nil {
+		si := *c.StateInfo
+		clone.StateInfo = &si
+	}
+
+	if c.ConfigurationInfo != nil {
+		ci := *c.ConfigurationInfo
+		clone.ConfigurationInfo = &ci
+	}
+
+	return clone
+}
+
+// cloneStorageInfo deep-copies a StorageInfo.
+func cloneStorageInfo(s *StorageInfo) *StorageInfo {
+	if s == nil {
+		return nil
+	}
+
+	clone := &StorageInfo{}
+	if s.EbsStorageInfo != nil {
+		ebs := &EBSStorageInfo{VolumeSize: s.EbsStorageInfo.VolumeSize}
+		if s.EbsStorageInfo.ProvisionedThroughput != nil {
+			pt := *s.EbsStorageInfo.ProvisionedThroughput
+			ebs.ProvisionedThroughput = &pt
+		}
+		clone.EbsStorageInfo = ebs
+	}
+
+	return clone
+}
+
+// cloneConnectivityInfo deep-copies a ConnectivityInfo.
+func cloneConnectivityInfo(ci *ConnectivityInfo) *ConnectivityInfo {
+	if ci == nil {
+		return nil
+	}
+
+	clone := &ConnectivityInfo{}
+	if ci.PublicAccess != nil {
+		pa := *ci.PublicAccess
+		clone.PublicAccess = &pa
+	}
+
+	if ci.VpcConnectivity != nil {
+		vc := &VpcConnectivity{}
+		if ci.VpcConnectivity.ClientAuthentication != nil {
+			ca := &VpcConnectivityClientAuthentication{}
+			if ci.VpcConnectivity.ClientAuthentication.Sasl != nil {
+				sasl := &VpcConnectivitySasl{}
+				if ci.VpcConnectivity.ClientAuthentication.Sasl.Iam != nil {
+					iam := *ci.VpcConnectivity.ClientAuthentication.Sasl.Iam
+					sasl.Iam = &iam
+				}
+				if ci.VpcConnectivity.ClientAuthentication.Sasl.Scram != nil {
+					scram := *ci.VpcConnectivity.ClientAuthentication.Sasl.Scram
+					sasl.Scram = &scram
+				}
+				ca.Sasl = sasl
+			}
+			if ci.VpcConnectivity.ClientAuthentication.Tls != nil {
+				tls := *ci.VpcConnectivity.ClientAuthentication.Tls
+				ca.Tls = &tls
+			}
+			vc.ClientAuthentication = ca
+		}
+		clone.VpcConnectivity = vc
+	}
+
+	return clone
+}
+
+// cloneEncryptionInfo deep-copies an EncryptionInfo.
+func cloneEncryptionInfo(ei *EncryptionInfo) *EncryptionInfo {
+	if ei == nil {
+		return nil
+	}
+
+	clone := &EncryptionInfo{}
+	if ei.EncryptionAtRest != nil {
+		ear := *ei.EncryptionAtRest
+		clone.EncryptionAtRest = &ear
+	}
+
+	if ei.EncryptionInTransit != nil {
+		eit := *ei.EncryptionInTransit
+		clone.EncryptionInTransit = &eit
+	}
+
+	return clone
+}
+
+// cloneOpenMonitoring deep-copies an OpenMonitoring.
+func cloneOpenMonitoring(om *OpenMonitoring) *OpenMonitoring {
+	if om == nil {
+		return nil
+	}
+
+	clone := &OpenMonitoring{}
+	if om.Prometheus != nil {
+		p := &PrometheusInfo{}
+		if om.Prometheus.JmxExporter != nil {
+			jmx := *om.Prometheus.JmxExporter
+			p.JmxExporter = &jmx
+		}
+		if om.Prometheus.NodeExporter != nil {
+			ne := *om.Prometheus.NodeExporter
+			p.NodeExporter = &ne
+		}
+		clone.Prometheus = p
+	}
+
+	return clone
+}
+
+// cloneLoggingInfo deep-copies a LoggingInfo.
+func cloneLoggingInfo(li *LoggingInfo) *LoggingInfo {
+	if li == nil {
+		return nil
+	}
+
+	clone := &LoggingInfo{}
+	if li.BrokerLogs != nil {
+		bl := &BrokerLogs{}
+		if li.BrokerLogs.CloudWatchLogs != nil {
+			cwl := *li.BrokerLogs.CloudWatchLogs
+			bl.CloudWatchLogs = &cwl
+		}
+		if li.BrokerLogs.Firehose != nil {
+			fh := *li.BrokerLogs.Firehose
+			bl.Firehose = &fh
+		}
+		if li.BrokerLogs.S3 != nil {
+			s3 := *li.BrokerLogs.S3
+			bl.S3 = &s3
+		}
+		clone.BrokerLogs = bl
+	}
+
+	return clone
+}
+
+// cloneServerless deep-copies a ServerlessClusterInfo.
+func cloneServerless(s *ServerlessClusterInfo) *ServerlessClusterInfo {
+	if s == nil {
+		return nil
+	}
+
+	clone := &ServerlessClusterInfo{}
+	if s.ClientAuthentication != nil {
+		ca := &ServerlessClientAuthentication{}
+		if s.ClientAuthentication.Sasl != nil {
+			ca.Sasl = cloneSasl(s.ClientAuthentication.Sasl)
+		}
+		clone.ClientAuthentication = ca
+	}
+
+	if len(s.VpcConfigs) > 0 {
+		clone.VpcConfigs = make([]ServerlessVpcConfig, len(s.VpcConfigs))
+		for i, vc := range s.VpcConfigs {
+			clone.VpcConfigs[i] = ServerlessVpcConfig{
+				SubnetIds:        append([]string(nil), vc.SubnetIds...),
+				SecurityGroupIds: append([]string(nil), vc.SecurityGroupIds...),
+			}
+		}
+	}
 
 	return clone
 }
@@ -1601,18 +2048,26 @@ func cloneClientAuth(auth *ClientAuthentication) *ClientAuthentication {
 		return nil
 	}
 
-	authCopy := *auth
+	authCopy := &ClientAuthentication{}
 
 	if auth.Sasl != nil {
 		authCopy.Sasl = cloneSasl(auth.Sasl)
 	}
 
 	if auth.TLS != nil {
-		tlsCopy := *auth.TLS
+		tlsCopy := TLSSettings{
+			Enabled:                     auth.TLS.Enabled,
+			CertificateAuthorityArnList: append([]string(nil), auth.TLS.CertificateAuthorityArnList...),
+		}
 		authCopy.TLS = &tlsCopy
 	}
 
-	return &authCopy
+	if auth.Unauthenticated != nil {
+		ua := *auth.Unauthenticated
+		authCopy.Unauthenticated = &ua
+	}
+
+	return authCopy
 }
 
 // cloneSasl deep-copies a SaslSettings value.

--- a/services/kafka/backend.go
+++ b/services/kafka/backend.go
@@ -30,6 +30,8 @@ const (
 	VpcConnectionStateAvailable = "AVAILABLE"
 	// ClusterOperationStateUpdateComplete indicates a completed cluster operation.
 	ClusterOperationStateUpdateComplete = "UPDATE_COMPLETE"
+	// DefaultClusterVersion is the default MSK cluster version identifier.
+	DefaultClusterVersion = "K3AEGXETSR30VB"
 )
 
 const (
@@ -132,15 +134,15 @@ type VpcConnectivitySasl struct {
 	Scram *VpcConnectivitySaslScram `json:"scram,omitempty"`
 }
 
-// VpcConnectivityTls holds TLS settings for VPC connectivity.
-type VpcConnectivityTls struct {
+// VpcConnectivityTLS holds TLS settings for VPC connectivity.
+type VpcConnectivityTLS struct {
 	Enabled bool `json:"enabled"`
 }
 
 // VpcConnectivityClientAuthentication holds authentication settings for VPC connectivity.
 type VpcConnectivityClientAuthentication struct {
 	Sasl *VpcConnectivitySasl `json:"sasl,omitempty"`
-	Tls  *VpcConnectivityTls  `json:"tls,omitempty"`
+	TLS  *VpcConnectivityTLS  `json:"tls,omitempty"`
 }
 
 // VpcConnectivity holds VPC connectivity configuration.
@@ -160,7 +162,7 @@ type BrokerNodeGroupInfo struct {
 	StorageInfo          *StorageInfo      `json:"storageInfo,omitempty"`
 	BrokerAZDistribution string            `json:"brokerAZDistribution,omitempty"`
 	InstanceType         string            `json:"instanceType"`
-	ZoneIds              []string          `json:"zoneIds,omitempty"`
+	ZoneIDs              []string          `json:"zoneIds,omitempty"`
 	ClientSubnets        []string          `json:"clientSubnets"`
 	SecurityGroups       []string          `json:"securityGroups,omitempty"`
 }
@@ -207,7 +209,7 @@ type UnauthenticatedSettings struct {
 
 // EncryptionAtRest holds at-rest encryption configuration.
 type EncryptionAtRest struct {
-	DataVolumeKMSKeyId string `json:"dataVolumeKMSKeyId,omitempty"`
+	DataVolumeKMSKeyID string `json:"dataVolumeKMSKeyId,omitempty"`
 }
 
 // EncryptionInTransit holds in-transit encryption configuration.
@@ -282,8 +284,8 @@ type StateInfo struct {
 
 // ServerlessVpcConfig holds VPC configuration for a serverless cluster.
 type ServerlessVpcConfig struct {
-	SubnetIds        []string `json:"subnetIds,omitempty"`
-	SecurityGroupIds []string `json:"securityGroupIds,omitempty"`
+	SubnetIDs        []string `json:"subnetIds,omitempty"`
+	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
 }
 
 // ServerlessClientAuthentication holds authentication settings for a serverless cluster.
@@ -468,7 +470,7 @@ func (b *InMemoryBackend) CreateCluster(
 		InstanceType:         brokerInfo.InstanceType,
 		ClientSubnets:        append([]string(nil), brokerInfo.ClientSubnets...),
 		SecurityGroups:       append([]string(nil), brokerInfo.SecurityGroups...),
-		ZoneIds:              append([]string(nil), brokerInfo.ZoneIds...),
+		ZoneIDs:              append([]string(nil), brokerInfo.ZoneIDs...),
 		StorageInfo:          brokerInfo.StorageInfo,
 		ConnectivityInfo:     brokerInfo.ConnectivityInfo,
 	}
@@ -487,7 +489,7 @@ func (b *InMemoryBackend) CreateCluster(
 		BrokerNodeGroupInfo:  safeInfo,
 		ClientAuthentication: cloneClientAuth(clientAuth),
 		State:                ClusterStateActive,
-		CurrentVersion:       "K3AEGXETSR30VB",
+		CurrentVersion:       DefaultClusterVersion,
 		Tags:                 nonNilTagsCopy(tags),
 	}
 	b.clusters[clusterArn] = cluster
@@ -520,7 +522,7 @@ func (b *InMemoryBackend) CreateServerlessCluster(
 		ClusterName:    name,
 		ClusterType:    ClusterTypeServerless,
 		State:          ClusterStateActive,
-		CurrentVersion: "K3AEGXETSR30VB",
+		CurrentVersion: DefaultClusterVersion,
 		Tags:           nonNilTagsCopy(tags),
 		Serverless:     cloneServerless(serverless),
 	}
@@ -1590,15 +1592,15 @@ func (b *InMemoryBackend) ListNodes(clusterArn string) ([]*BrokerNode, error) {
 // ListKafkaVersions returns supported Kafka versions, matching current MSK availability.
 func (b *InMemoryBackend) ListKafkaVersions() []*MSKVersion {
 	return []*MSKVersion{
-		{Version: "3.8.0.kraft", Status: "ACTIVE"},
-		{Version: "3.7.x.kraft", Status: "ACTIVE"},
-		{Version: "3.6.0", Status: "ACTIVE"},
-		{Version: "3.5.1", Status: "ACTIVE"},
-		{Version: "3.4.0", Status: "ACTIVE"},
-		{Version: "3.3.2", Status: "ACTIVE"},
-		{Version: "3.3.1", Status: "ACTIVE"},
-		{Version: "2.8.2.tiered", Status: "ACTIVE"},
-		{Version: "2.8.1", Status: "ACTIVE"},
+		{Version: "3.8.0.kraft", Status: ClusterStateActive},
+		{Version: "3.7.x.kraft", Status: ClusterStateActive},
+		{Version: "3.6.0", Status: ClusterStateActive},
+		{Version: "3.5.1", Status: ClusterStateActive},
+		{Version: "3.4.0", Status: ClusterStateActive},
+		{Version: "3.3.2", Status: ClusterStateActive},
+		{Version: "3.3.1", Status: ClusterStateActive},
+		{Version: "2.8.2.tiered", Status: ClusterStateActive},
+		{Version: "2.8.1", Status: ClusterStateActive},
 		{Version: "2.8.0", Status: "DEPRECATED"},
 		{Version: "2.6.0", Status: "DEPRECATED"},
 	}
@@ -1620,19 +1622,19 @@ func (b *InMemoryBackend) GetCompatibleKafkaVersions(clusterArn string) ([]*MSKV
 
 	if isKRaft {
 		return []*MSKVersion{
-			{Version: "3.8.0.kraft", Status: "ACTIVE"},
-			{Version: "3.7.x.kraft", Status: "ACTIVE"},
+			{Version: "3.8.0.kraft", Status: ClusterStateActive},
+			{Version: "3.7.x.kraft", Status: ClusterStateActive},
 		}, nil
 	}
 
 	// ZooKeeper-based: return non-KRaft active versions higher than current.
 	// For simplicity, return a curated list of ZooKeeper-compatible upgrades.
 	return []*MSKVersion{
-		{Version: "3.6.0", Status: "ACTIVE"},
-		{Version: "3.5.1", Status: "ACTIVE"},
-		{Version: "3.4.0", Status: "ACTIVE"},
-		{Version: "3.3.2", Status: "ACTIVE"},
-		{Version: "2.8.2.tiered", Status: "ACTIVE"},
+		{Version: "3.6.0", Status: ClusterStateActive},
+		{Version: "3.5.1", Status: ClusterStateActive},
+		{Version: "3.4.0", Status: ClusterStateActive},
+		{Version: "3.3.2", Status: ClusterStateActive},
+		{Version: "2.8.2.tiered", Status: ClusterStateActive},
 	}, nil
 }
 
@@ -1730,7 +1732,7 @@ func (b *InMemoryBackend) AddClusterInternal(name, kafkaVersion string) *Cluster
 		KafkaVersion:        kafkaVersion,
 		NumberOfBrokerNodes: defaultBrokerCount,
 		State:               ClusterStateActive,
-		CurrentVersion:      "K3AEGXETSR30VB",
+		CurrentVersion:      DefaultClusterVersion,
 		Tags:                make(map[string]string),
 	}
 	b.clusters[clusterArn] = cluster
@@ -1852,24 +1854,24 @@ type ClusterOperation struct {
 // cloneCluster creates a deep copy of a cluster.
 func cloneCluster(c *Cluster) *Cluster {
 	clone := &Cluster{
-		ClusterArn:         c.ClusterArn,
-		ClusterName:        c.ClusterName,
-		ClusterType:        c.ClusterType,
-		KafkaVersion:       c.KafkaVersion,
-		State:              c.State,
-		CurrentVersion:     c.CurrentVersion,
-		ActiveOperationArn: c.ActiveOperationArn,
-		EnhancedMonitoring: c.EnhancedMonitoring,
-		StorageMode:        c.StorageMode,
-		CreationTime:       c.CreationTime,
+		ClusterArn:          c.ClusterArn,
+		ClusterName:         c.ClusterName,
+		ClusterType:         c.ClusterType,
+		KafkaVersion:        c.KafkaVersion,
+		State:               c.State,
+		CurrentVersion:      c.CurrentVersion,
+		ActiveOperationArn:  c.ActiveOperationArn,
+		EnhancedMonitoring:  c.EnhancedMonitoring,
+		StorageMode:         c.StorageMode,
+		CreationTime:        c.CreationTime,
 		NumberOfBrokerNodes: c.NumberOfBrokerNodes,
-		Tags:               nonNilTagsCopy(c.Tags),
+		Tags:                nonNilTagsCopy(c.Tags),
 		BrokerNodeGroupInfo: BrokerNodeGroupInfo{
 			BrokerAZDistribution: c.BrokerNodeGroupInfo.BrokerAZDistribution,
 			InstanceType:         c.BrokerNodeGroupInfo.InstanceType,
 			ClientSubnets:        append([]string(nil), c.BrokerNodeGroupInfo.ClientSubnets...),
 			SecurityGroups:       append([]string(nil), c.BrokerNodeGroupInfo.SecurityGroups...),
-			ZoneIds:              append([]string(nil), c.BrokerNodeGroupInfo.ZoneIds...),
+			ZoneIDs:              append([]string(nil), c.BrokerNodeGroupInfo.ZoneIDs...),
 		},
 	}
 
@@ -1932,31 +1934,47 @@ func cloneConnectivityInfo(ci *ConnectivityInfo) *ConnectivityInfo {
 	}
 
 	if ci.VpcConnectivity != nil {
-		vc := &VpcConnectivity{}
-		if ci.VpcConnectivity.ClientAuthentication != nil {
-			ca := &VpcConnectivityClientAuthentication{}
-			if ci.VpcConnectivity.ClientAuthentication.Sasl != nil {
-				sasl := &VpcConnectivitySasl{}
-				if ci.VpcConnectivity.ClientAuthentication.Sasl.Iam != nil {
-					iam := *ci.VpcConnectivity.ClientAuthentication.Sasl.Iam
-					sasl.Iam = &iam
-				}
-				if ci.VpcConnectivity.ClientAuthentication.Sasl.Scram != nil {
-					scram := *ci.VpcConnectivity.ClientAuthentication.Sasl.Scram
-					sasl.Scram = &scram
-				}
-				ca.Sasl = sasl
-			}
-			if ci.VpcConnectivity.ClientAuthentication.Tls != nil {
-				tls := *ci.VpcConnectivity.ClientAuthentication.Tls
-				ca.Tls = &tls
-			}
-			vc.ClientAuthentication = ca
-		}
-		clone.VpcConnectivity = vc
+		clone.VpcConnectivity = cloneVpcConnectivity(ci.VpcConnectivity)
 	}
 
 	return clone
+}
+
+// cloneVpcConnectivity deep-copies a VpcConnectivity.
+func cloneVpcConnectivity(src *VpcConnectivity) *VpcConnectivity {
+	vc := &VpcConnectivity{}
+
+	if src.ClientAuthentication == nil {
+		return vc
+	}
+
+	ca := &VpcConnectivityClientAuthentication{}
+	srcCA := src.ClientAuthentication
+
+	if srcCA.Sasl != nil {
+		sasl := &VpcConnectivitySasl{}
+
+		if srcCA.Sasl.Iam != nil {
+			iam := *srcCA.Sasl.Iam
+			sasl.Iam = &iam
+		}
+
+		if srcCA.Sasl.Scram != nil {
+			scram := *srcCA.Sasl.Scram
+			sasl.Scram = &scram
+		}
+
+		ca.Sasl = sasl
+	}
+
+	if srcCA.TLS != nil {
+		tls := *srcCA.TLS
+		ca.TLS = &tls
+	}
+
+	vc.ClientAuthentication = ca
+
+	return vc
 }
 
 // cloneEncryptionInfo deep-copies an EncryptionInfo.
@@ -2048,8 +2066,8 @@ func cloneServerless(s *ServerlessClusterInfo) *ServerlessClusterInfo {
 		clone.VpcConfigs = make([]ServerlessVpcConfig, len(s.VpcConfigs))
 		for i, vc := range s.VpcConfigs {
 			clone.VpcConfigs[i] = ServerlessVpcConfig{
-				SubnetIds:        append([]string(nil), vc.SubnetIds...),
-				SecurityGroupIds: append([]string(nil), vc.SecurityGroupIds...),
+				SubnetIDs:        append([]string(nil), vc.SubnetIDs...),
+				SecurityGroupIDs: append([]string(nil), vc.SecurityGroupIDs...),
 			}
 		}
 	}

--- a/services/kafka/export_test.go
+++ b/services/kafka/export_test.go
@@ -71,3 +71,21 @@ func ScramSecretCount(b *InMemoryBackend) int {
 
 	return total
 }
+
+// HasClusterPolicy reports whether a cluster has a resource-based policy stored.
+func HasClusterPolicy(b *InMemoryBackend, clusterArn string) bool {
+	b.mu.RLock("HasClusterPolicy")
+	defer b.mu.RUnlock()
+
+	_, ok := b.clusterPolicies[clusterArn]
+
+	return ok
+}
+
+// GetStoredCluster returns the raw (unwrapped) stored cluster for inspection in tests.
+func GetStoredCluster(b *InMemoryBackend, clusterArn string) *Cluster {
+	b.mu.RLock("GetStoredCluster")
+	defer b.mu.RUnlock()
+
+	return b.clusters[clusterArn]
+}

--- a/services/kafka/handler.go
+++ b/services/kafka/handler.go
@@ -1068,21 +1068,21 @@ type listClustersV2Output struct {
 }
 
 type getBootstrapBrokersOutput struct {
-	BootstrapBrokerString                      string `json:"bootstrapBrokerString,omitempty"`
-	BootstrapBrokerStringTls                   string `json:"bootstrapBrokerStringTls,omitempty"`
-	BootstrapBrokerStringSaslScram             string `json:"bootstrapBrokerStringSaslScram,omitempty"`
-	BootstrapBrokerStringSaslIam               string `json:"bootstrapBrokerStringSaslIam,omitempty"`
-	BootstrapBrokerStringTlsPublic             string `json:"bootstrapBrokerStringTlsPublic,omitempty"`
-	BootstrapBrokerStringSaslScramPublic       string `json:"bootstrapBrokerStringSaslScramPublic,omitempty"`
-	BootstrapBrokerStringSaslIamPublic         string `json:"bootstrapBrokerStringSaslIamPublic,omitempty"`
-	BootstrapBrokerStringVpcConnectivityTls    string `json:"bootstrapBrokerStringVpcConnectivityTls,omitempty"`
-	BootstrapBrokerStringVpcConnectivityScram  string `json:"bootstrapBrokerStringVpcConnectivitySaslScram,omitempty"`
-	BootstrapBrokerStringVpcConnectivityIam    string `json:"bootstrapBrokerStringVpcConnectivitySaslIam,omitempty"`
+	BootstrapBrokerString                     string `json:"bootstrapBrokerString,omitempty"`
+	BootstrapBrokerStringTLS                  string `json:"bootstrapBrokerStringTls,omitempty"`
+	BootstrapBrokerStringSaslScram            string `json:"bootstrapBrokerStringSaslScram,omitempty"`
+	BootstrapBrokerStringSaslIam              string `json:"bootstrapBrokerStringSaslIam,omitempty"`
+	BootstrapBrokerStringTLSPublic            string `json:"bootstrapBrokerStringTlsPublic,omitempty"`
+	BootstrapBrokerStringSaslScramPublic      string `json:"bootstrapBrokerStringSaslScramPublic,omitempty"`
+	BootstrapBrokerStringSaslIamPublic        string `json:"bootstrapBrokerStringSaslIamPublic,omitempty"`
+	BootstrapBrokerStringVpcConnectivityTLS   string `json:"bootstrapBrokerStringVpcConnectivityTLS,omitempty"`
+	BootstrapBrokerStringVpcConnectivityScram string `json:"bootstrapBrokerStringVpcConnectivitySaslScram,omitempty"`
+	BootstrapBrokerStringVpcConnectivityIam   string `json:"bootstrapBrokerStringVpcConnectivitySaslIam,omitempty"`
 }
 
 type serverlessVpcConfigInput struct {
-	SubnetIds        []string `json:"subnetIds,omitempty"`
-	SecurityGroupIds []string `json:"securityGroupIds,omitempty"`
+	SubnetIDs        []string `json:"subnetIds,omitempty"`
+	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
 }
 
 type serverlessAuthInput struct {
@@ -1220,10 +1220,7 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 			}
 		}
 		for _, vc := range srv.VpcConfigs {
-			serverlessInfo.VpcConfigs = append(serverlessInfo.VpcConfigs, ServerlessVpcConfig{
-				SubnetIds:        vc.SubnetIds,
-				SecurityGroupIds: vc.SecurityGroupIds,
-			})
+			serverlessInfo.VpcConfigs = append(serverlessInfo.VpcConfigs, ServerlessVpcConfig(vc))
 		}
 
 		cluster, err := h.Backend.CreateServerlessCluster(in.ClusterName, serverlessInfo, in.Tags)
@@ -1333,53 +1330,86 @@ func (h *Handler) handleGetBootstrapBrokers(c *echo.Context, clusterArn string) 
 func bootstrapBrokersFor(cl *Cluster) getBootstrapBrokersOutput {
 	out := getBootstrapBrokersOutput{
 		BootstrapBrokerString:    "localhost:9092",
-		BootstrapBrokerStringTls: "localhost:9094",
+		BootstrapBrokerStringTLS: "localhost:9094",
 	}
 
 	auth := cl.ClientAuthentication
-
-	if auth != nil && auth.Sasl != nil {
-		if auth.Sasl.Scram != nil && auth.Sasl.Scram.Enabled {
-			out.BootstrapBrokerStringSaslScram = "localhost:9096"
-		}
-
-		if auth.Sasl.Iam != nil && auth.Sasl.Iam.Enabled {
-			out.BootstrapBrokerStringSaslIam = "localhost:9098"
-		}
+	if auth == nil {
+		return out
 	}
 
-	// Emit public variants when public access is enabled.
-	if auth != nil && cl.BrokerNodeGroupInfo.ConnectivityInfo != nil {
-		pa := cl.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess
-		if pa != nil && pa.Type == "SERVICE_PROVIDED_EIPS" {
-			out.BootstrapBrokerStringTlsPublic = "localhost:9194"
-			if auth.Sasl != nil && auth.Sasl.Scram != nil && auth.Sasl.Scram.Enabled {
-				out.BootstrapBrokerStringSaslScramPublic = "localhost:9196"
-			}
-			if auth.Sasl != nil && auth.Sasl.Iam != nil && auth.Sasl.Iam.Enabled {
-				out.BootstrapBrokerStringSaslIamPublic = "localhost:9198"
-			}
-		}
+	addSaslBrokers(auth.Sasl, &out)
 
-		// VPC connectivity variants.
-		vc := cl.BrokerNodeGroupInfo.ConnectivityInfo.VpcConnectivity
-		if vc != nil && vc.ClientAuthentication != nil {
-			vca := vc.ClientAuthentication
-			if vca.Tls != nil && vca.Tls.Enabled {
-				out.BootstrapBrokerStringVpcConnectivityTls = "localhost:9294"
-			}
-			if vca.Sasl != nil {
-				if vca.Sasl.Scram != nil && vca.Sasl.Scram.Enabled {
-					out.BootstrapBrokerStringVpcConnectivityScram = "localhost:9296"
-				}
-				if vca.Sasl.Iam != nil && vca.Sasl.Iam.Enabled {
-					out.BootstrapBrokerStringVpcConnectivityIam = "localhost:9298"
-				}
-			}
-		}
+	ci := cl.BrokerNodeGroupInfo.ConnectivityInfo
+	if ci == nil {
+		return out
 	}
+
+	addPublicBrokers(auth, ci.PublicAccess, &out)
+	addVpcConnectivityBrokers(ci.VpcConnectivity, &out)
 
 	return out
+}
+
+// addSaslBrokers populates SASL broker endpoints when SASL authentication is configured.
+func addSaslBrokers(sasl *SaslSettings, out *getBootstrapBrokersOutput) {
+	if sasl == nil {
+		return
+	}
+
+	if sasl.Scram != nil && sasl.Scram.Enabled {
+		out.BootstrapBrokerStringSaslScram = "localhost:9096"
+	}
+
+	if sasl.Iam != nil && sasl.Iam.Enabled {
+		out.BootstrapBrokerStringSaslIam = "localhost:9098"
+	}
+}
+
+// addPublicBrokers populates public access broker endpoints when public access is enabled.
+func addPublicBrokers(auth *ClientAuthentication, pa *PublicAccess, out *getBootstrapBrokersOutput) {
+	if pa == nil || pa.Type != "SERVICE_PROVIDED_EIPS" {
+		return
+	}
+
+	out.BootstrapBrokerStringTLSPublic = "localhost:9194"
+
+	if auth.Sasl == nil {
+		return
+	}
+
+	if auth.Sasl.Scram != nil && auth.Sasl.Scram.Enabled {
+		out.BootstrapBrokerStringSaslScramPublic = "localhost:9196"
+	}
+
+	if auth.Sasl.Iam != nil && auth.Sasl.Iam.Enabled {
+		out.BootstrapBrokerStringSaslIamPublic = "localhost:9198"
+	}
+}
+
+// addVpcConnectivityBrokers populates VPC connectivity broker endpoints.
+func addVpcConnectivityBrokers(vc *VpcConnectivity, out *getBootstrapBrokersOutput) {
+	if vc == nil || vc.ClientAuthentication == nil {
+		return
+	}
+
+	vca := vc.ClientAuthentication
+
+	if vca.TLS != nil && vca.TLS.Enabled {
+		out.BootstrapBrokerStringVpcConnectivityTLS = "localhost:9294"
+	}
+
+	if vca.Sasl == nil {
+		return
+	}
+
+	if vca.Sasl.Scram != nil && vca.Sasl.Scram.Enabled {
+		out.BootstrapBrokerStringVpcConnectivityScram = "localhost:9296"
+	}
+
+	if vca.Sasl.Iam != nil && vca.Sasl.Iam.Enabled {
+		out.BootstrapBrokerStringVpcConnectivityIam = "localhost:9298"
+	}
 }
 
 // brokerSoftwareInfoFor returns a brokerSoftwareInfo for the given Kafka version,
@@ -1424,23 +1454,40 @@ func zookeeperConnectStringFor(clusterArn string) string {
 
 	// Synthesise a deterministic-looking ZK endpoint from the ARN suffix.
 	// Format: z-1.<cluster-id>.kafka.<region>.amazonaws.com:2181,...
-	parts := strings.Split(clusterArn, "/")
-	clusterID := "unknown"
-	if len(parts) >= 2 {
-		clusterID = parts[len(parts)-1]
-	}
+	clusterID, region := parseClusterIDAndRegion(clusterArn)
 
-	region := "us-east-1"
-	arnParts := strings.SplitN(clusterArn, ":", 6)
-	if len(arnParts) >= 4 {
-		region = arnParts[3]
-	}
-
-	return fmt.Sprintf("z-1.%s.kafka.%s.amazonaws.com:2181,z-2.%s.kafka.%s.amazonaws.com:2181,z-3.%s.kafka.%s.amazonaws.com:2181",
+	return fmt.Sprintf(
+		"z-1.%s.kafka.%s.amazonaws.com:2181,"+
+			"z-2.%s.kafka.%s.amazonaws.com:2181,"+
+			"z-3.%s.kafka.%s.amazonaws.com:2181",
 		clusterID, region,
 		clusterID, region,
 		clusterID, region,
 	)
+}
+
+// parseClusterIDAndRegion extracts the cluster ID and region from an ARN.
+func parseClusterIDAndRegion(clusterArn string) (string, string) {
+	const (
+		minARNSlashParts  = 2
+		arnColonFields    = 6
+		arnRegionPosition = 4
+	)
+
+	clusterID := "unknown"
+	region := "us-east-1"
+
+	parts := strings.Split(clusterArn, "/")
+	if len(parts) >= minARNSlashParts {
+		clusterID = parts[len(parts)-1]
+	}
+
+	arnParts := strings.SplitN(clusterArn, ":", arnColonFields)
+	if len(arnParts) >= arnRegionPosition {
+		region = arnParts[3]
+	}
+
+	return clusterID, region
 }
 
 // toClusterInfoV2 converts a Cluster to the V2 cluster info shape.
@@ -1528,7 +1575,7 @@ func (h *Handler) handleDescribeConfiguration(c *echo.Context, configArn string)
 		Name:          config.Name,
 		Description:   config.Description,
 		KafkaVersions: config.KafkaVersions,
-		State:         "ACTIVE",
+		State:         ClusterStateActive,
 		LatestRevision: configurationRevision{
 			Revision:    1,
 			Description: config.Description,

--- a/services/kafka/handler.go
+++ b/services/kafka/handler.go
@@ -1010,11 +1010,18 @@ type clusterInfoV1 struct {
 	Tags                      map[string]string     `json:"tags,omitempty"`
 	CurrentBrokerSoftwareInfo *brokerSoftwareInfo   `json:"currentBrokerSoftwareInfo,omitempty"`
 	ClientAuthentication      *ClientAuthentication `json:"clientAuthentication,omitempty"`
+	EncryptionInfo            *EncryptionInfo       `json:"encryptionInfo,omitempty"`
+	OpenMonitoring            *OpenMonitoring       `json:"openMonitoring,omitempty"`
+	LoggingInfo               *LoggingInfo          `json:"loggingInfo,omitempty"`
+	StateInfo                 *StateInfo            `json:"stateInfo,omitempty"`
 	ClusterArn                string                `json:"clusterArn"`
 	ClusterName               string                `json:"clusterName"`
 	KafkaVersion              string                `json:"kafkaVersion"`
 	State                     string                `json:"state"`
 	CurrentVersion            string                `json:"currentVersion"`
+	ActiveOperationArn        string                `json:"activeOperationArn,omitempty"`
+	EnhancedMonitoring        string                `json:"enhancedMonitoring,omitempty"`
+	ZookeeperConnectString    string                `json:"zookeeperConnectString,omitempty"`
 	BrokerNodeGroupInfo       BrokerNodeGroupInfo   `json:"brokerNodeGroupInfo"`
 	NumberOfBrokerNodes       int32                 `json:"numberOfBrokerNodes"`
 }
@@ -1030,8 +1037,13 @@ type listClustersOutput struct {
 type provisionedClusterInfo struct {
 	CurrentBrokerSoftwareInfo *brokerSoftwareInfo   `json:"currentBrokerSoftwareInfo,omitempty"`
 	ClientAuthentication      *ClientAuthentication `json:"clientAuthentication,omitempty"`
+	EncryptionInfo            *EncryptionInfo       `json:"encryptionInfo,omitempty"`
+	OpenMonitoring            *OpenMonitoring       `json:"openMonitoring,omitempty"`
+	LoggingInfo               *LoggingInfo          `json:"loggingInfo,omitempty"`
 	KafkaVersion              string                `json:"kafkaVersion"`
 	State                     string                `json:"state"`
+	EnhancedMonitoring        string                `json:"enhancedMonitoring,omitempty"`
+	StorageMode               string                `json:"storageMode,omitempty"`
 	BrokerNodeGroupInfo       BrokerNodeGroupInfo   `json:"brokerNodeGroupInfo"`
 	NumberOfBrokerNodes       int32                 `json:"numberOfBrokerNodes"`
 }
@@ -1039,6 +1051,7 @@ type provisionedClusterInfo struct {
 type clusterInfoV2 struct {
 	Tags           map[string]string       `json:"tags,omitempty"`
 	Provisioned    *provisionedClusterInfo `json:"provisioned,omitempty"`
+	Serverless     *ServerlessClusterInfo  `json:"serverless,omitempty"`
 	ClusterArn     string                  `json:"clusterArn"`
 	ClusterName    string                  `json:"clusterName"`
 	ClusterType    string                  `json:"clusterType"`
@@ -1055,13 +1068,36 @@ type listClustersV2Output struct {
 }
 
 type getBootstrapBrokersOutput struct {
-	BootstrapBrokerString    string `json:"bootstrapBrokerString"`
-	BootstrapBrokerStringTLS string `json:"bootstrapBrokerStringTls"`
+	BootstrapBrokerString                      string `json:"bootstrapBrokerString,omitempty"`
+	BootstrapBrokerStringTls                   string `json:"bootstrapBrokerStringTls,omitempty"`
+	BootstrapBrokerStringSaslScram             string `json:"bootstrapBrokerStringSaslScram,omitempty"`
+	BootstrapBrokerStringSaslIam               string `json:"bootstrapBrokerStringSaslIam,omitempty"`
+	BootstrapBrokerStringTlsPublic             string `json:"bootstrapBrokerStringTlsPublic,omitempty"`
+	BootstrapBrokerStringSaslScramPublic       string `json:"bootstrapBrokerStringSaslScramPublic,omitempty"`
+	BootstrapBrokerStringSaslIamPublic         string `json:"bootstrapBrokerStringSaslIamPublic,omitempty"`
+	BootstrapBrokerStringVpcConnectivityTls    string `json:"bootstrapBrokerStringVpcConnectivityTls,omitempty"`
+	BootstrapBrokerStringVpcConnectivityScram  string `json:"bootstrapBrokerStringVpcConnectivitySaslScram,omitempty"`
+	BootstrapBrokerStringVpcConnectivityIam    string `json:"bootstrapBrokerStringVpcConnectivitySaslIam,omitempty"`
+}
+
+type serverlessVpcConfigInput struct {
+	SubnetIds        []string `json:"subnetIds,omitempty"`
+	SecurityGroupIds []string `json:"securityGroupIds,omitempty"`
+}
+
+type serverlessAuthInput struct {
+	Sasl *SaslSettings `json:"sasl,omitempty"`
+}
+
+type serverlessInput struct {
+	ClientAuthentication *serverlessAuthInput       `json:"clientAuthentication,omitempty"`
+	VpcConfigs           []serverlessVpcConfigInput `json:"vpcConfigs,omitempty"`
 }
 
 type createClusterV2Input struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 	Provisioned *provisionedInput `json:"provisioned,omitempty"`
+	Serverless  *serverlessInput  `json:"serverless,omitempty"`
 	ClusterName string            `json:"clusterName"`
 }
 
@@ -1166,20 +1202,54 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 		)
 	}
 
+	if in.Provisioned != nil && in.Serverless != nil {
+		return h.writeError(
+			c,
+			http.StatusBadRequest,
+			"BadRequestException",
+			"only one of provisioned or serverless may be specified",
+		)
+	}
+
+	if in.Serverless != nil {
+		srv := in.Serverless
+		serverlessInfo := &ServerlessClusterInfo{}
+		if srv.ClientAuthentication != nil {
+			serverlessInfo.ClientAuthentication = &ServerlessClientAuthentication{
+				Sasl: srv.ClientAuthentication.Sasl,
+			}
+		}
+		for _, vc := range srv.VpcConfigs {
+			serverlessInfo.VpcConfigs = append(serverlessInfo.VpcConfigs, ServerlessVpcConfig{
+				SubnetIds:        vc.SubnetIds,
+				SecurityGroupIds: vc.SecurityGroupIds,
+			})
+		}
+
+		cluster, err := h.Backend.CreateServerlessCluster(in.ClusterName, serverlessInfo, in.Tags)
+		if err != nil {
+			return h.writeBackendError(c, err)
+		}
+
+		return c.JSON(http.StatusOK, createClusterV2Output{
+			ClusterArn:  cluster.ClusterArn,
+			ClusterName: cluster.ClusterName,
+			ClusterType: ClusterTypeServerless,
+		})
+	}
+
 	var brokerInfo BrokerNodeGroupInfo
 
 	var kafkaVersion string
 
 	var numBrokers int32
 
+	var clientAuth *ClientAuthentication
+
 	if in.Provisioned != nil {
 		brokerInfo = in.Provisioned.BrokerNodeGroupInfo
 		kafkaVersion = in.Provisioned.KafkaVersion
 		numBrokers = in.Provisioned.NumberOfBrokerNodes
-	}
-
-	var clientAuth *ClientAuthentication
-	if in.Provisioned != nil {
 		clientAuth = in.Provisioned.ClientAuthentication
 	}
 
@@ -1198,7 +1268,7 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 	return c.JSON(http.StatusOK, createClusterV2Output{
 		ClusterArn:  cluster.ClusterArn,
 		ClusterName: cluster.ClusterName,
-		ClusterType: "PROVISIONED",
+		ClusterType: ClusterTypeProvisioned,
 	})
 }
 
@@ -1251,14 +1321,65 @@ func (h *Handler) handleDeleteCluster(c *echo.Context, clusterArn string) error 
 }
 
 func (h *Handler) handleGetBootstrapBrokers(c *echo.Context, clusterArn string) error {
-	if _, err := h.Backend.DescribeCluster(clusterArn); err != nil {
+	cluster, err := h.Backend.DescribeCluster(clusterArn)
+	if err != nil {
 		return h.writeBackendError(c, err)
 	}
 
-	return c.JSON(http.StatusOK, getBootstrapBrokersOutput{
+	return c.JSON(http.StatusOK, bootstrapBrokersFor(cluster))
+}
+
+// bootstrapBrokersFor builds the bootstrap broker response based on cluster auth settings.
+func bootstrapBrokersFor(cl *Cluster) getBootstrapBrokersOutput {
+	out := getBootstrapBrokersOutput{
 		BootstrapBrokerString:    "localhost:9092",
-		BootstrapBrokerStringTLS: "localhost:9094",
-	})
+		BootstrapBrokerStringTls: "localhost:9094",
+	}
+
+	auth := cl.ClientAuthentication
+
+	if auth != nil && auth.Sasl != nil {
+		if auth.Sasl.Scram != nil && auth.Sasl.Scram.Enabled {
+			out.BootstrapBrokerStringSaslScram = "localhost:9096"
+		}
+
+		if auth.Sasl.Iam != nil && auth.Sasl.Iam.Enabled {
+			out.BootstrapBrokerStringSaslIam = "localhost:9098"
+		}
+	}
+
+	// Emit public variants when public access is enabled.
+	if auth != nil && cl.BrokerNodeGroupInfo.ConnectivityInfo != nil {
+		pa := cl.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess
+		if pa != nil && pa.Type == "SERVICE_PROVIDED_EIPS" {
+			out.BootstrapBrokerStringTlsPublic = "localhost:9194"
+			if auth.Sasl != nil && auth.Sasl.Scram != nil && auth.Sasl.Scram.Enabled {
+				out.BootstrapBrokerStringSaslScramPublic = "localhost:9196"
+			}
+			if auth.Sasl != nil && auth.Sasl.Iam != nil && auth.Sasl.Iam.Enabled {
+				out.BootstrapBrokerStringSaslIamPublic = "localhost:9198"
+			}
+		}
+
+		// VPC connectivity variants.
+		vc := cl.BrokerNodeGroupInfo.ConnectivityInfo.VpcConnectivity
+		if vc != nil && vc.ClientAuthentication != nil {
+			vca := vc.ClientAuthentication
+			if vca.Tls != nil && vca.Tls.Enabled {
+				out.BootstrapBrokerStringVpcConnectivityTls = "localhost:9294"
+			}
+			if vca.Sasl != nil {
+				if vca.Sasl.Scram != nil && vca.Sasl.Scram.Enabled {
+					out.BootstrapBrokerStringVpcConnectivityScram = "localhost:9296"
+				}
+				if vca.Sasl.Iam != nil && vca.Sasl.Iam.Enabled {
+					out.BootstrapBrokerStringVpcConnectivityIam = "localhost:9298"
+				}
+			}
+		}
+	}
+
+	return out
 }
 
 // brokerSoftwareInfoFor returns a brokerSoftwareInfo for the given Kafka version,
@@ -1282,29 +1403,81 @@ func toClusterInfoV1(cl *Cluster) *clusterInfoV1 {
 		BrokerNodeGroupInfo:       cl.BrokerNodeGroupInfo,
 		NumberOfBrokerNodes:       cl.NumberOfBrokerNodes,
 		ClientAuthentication:      cl.ClientAuthentication,
+		EncryptionInfo:            cl.EncryptionInfo,
+		OpenMonitoring:            cl.OpenMonitoring,
+		LoggingInfo:               cl.LoggingInfo,
+		StateInfo:                 cl.StateInfo,
+		ActiveOperationArn:        cl.ActiveOperationArn,
+		EnhancedMonitoring:        cl.EnhancedMonitoring,
+		ZookeeperConnectString:    zookeeperConnectStringFor(cl.ClusterArn),
 		Tags:                      maps.Clone(cl.Tags),
 		CurrentBrokerSoftwareInfo: brokerSoftwareInfoFor(cl.KafkaVersion),
 	}
 }
 
+// zookeeperConnectStringFor synthesises a ZooKeeper connect string from the cluster ARN.
+// This mirrors the legacy ZooKeeper endpoint format used by older MSK clusters.
+func zookeeperConnectStringFor(clusterArn string) string {
+	if clusterArn == "" {
+		return ""
+	}
+
+	// Synthesise a deterministic-looking ZK endpoint from the ARN suffix.
+	// Format: z-1.<cluster-id>.kafka.<region>.amazonaws.com:2181,...
+	parts := strings.Split(clusterArn, "/")
+	clusterID := "unknown"
+	if len(parts) >= 2 {
+		clusterID = parts[len(parts)-1]
+	}
+
+	region := "us-east-1"
+	arnParts := strings.SplitN(clusterArn, ":", 6)
+	if len(arnParts) >= 4 {
+		region = arnParts[3]
+	}
+
+	return fmt.Sprintf("z-1.%s.kafka.%s.amazonaws.com:2181,z-2.%s.kafka.%s.amazonaws.com:2181,z-3.%s.kafka.%s.amazonaws.com:2181",
+		clusterID, region,
+		clusterID, region,
+		clusterID, region,
+	)
+}
+
 // toClusterInfoV2 converts a Cluster to the V2 cluster info shape.
 func toClusterInfoV2(cl *Cluster) *clusterInfoV2 {
-	return &clusterInfoV2{
+	clusterType := cl.ClusterType
+	if clusterType == "" {
+		clusterType = ClusterTypeProvisioned
+	}
+
+	info := &clusterInfoV2{
 		ClusterArn:     cl.ClusterArn,
 		ClusterName:    cl.ClusterName,
-		ClusterType:    "PROVISIONED",
+		ClusterType:    clusterType,
 		State:          cl.State,
 		CurrentVersion: cl.CurrentVersion,
 		Tags:           maps.Clone(cl.Tags),
-		Provisioned: &provisionedClusterInfo{
+	}
+
+	if clusterType == ClusterTypeServerless {
+		info.Serverless = cl.Serverless
+	} else {
+		info.Provisioned = &provisionedClusterInfo{
 			BrokerNodeGroupInfo:       cl.BrokerNodeGroupInfo,
 			KafkaVersion:              cl.KafkaVersion,
 			NumberOfBrokerNodes:       cl.NumberOfBrokerNodes,
 			State:                     cl.State,
 			ClientAuthentication:      cl.ClientAuthentication,
+			EncryptionInfo:            cl.EncryptionInfo,
+			OpenMonitoring:            cl.OpenMonitoring,
+			LoggingInfo:               cl.LoggingInfo,
+			EnhancedMonitoring:        cl.EnhancedMonitoring,
+			StorageMode:               cl.StorageMode,
 			CurrentBrokerSoftwareInfo: brokerSoftwareInfoFor(cl.KafkaVersion),
-		},
+		}
 	}
+
+	return info
 }
 
 // ----------------------------------------

--- a/services/kafka/handler_refinement2_test.go
+++ b/services/kafka/handler_refinement2_test.go
@@ -68,17 +68,17 @@ func TestRefinement2_CreateServerlessCluster(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		clName    string
 		serverless *kafka.ServerlessClusterInfo
-		wantErr   bool
+		name       string
+		clName     string
+		wantErr    bool
 	}{
 		{
 			name:   "basic_serverless",
 			clName: "srv-cluster",
 			serverless: &kafka.ServerlessClusterInfo{
 				VpcConfigs: []kafka.ServerlessVpcConfig{
-					{SubnetIds: []string{"subnet-1", "subnet-2"}, SecurityGroupIds: []string{"sg-1"}},
+					{SubnetIDs: []string{"subnet-1", "subnet-2"}, SecurityGroupIDs: []string{"sg-1"}},
 				},
 			},
 		},
@@ -90,15 +90,15 @@ func TestRefinement2_CreateServerlessCluster(t *testing.T) {
 					Sasl: &kafka.SaslSettings{Iam: &kafka.SaslIam{Enabled: true}},
 				},
 				VpcConfigs: []kafka.ServerlessVpcConfig{
-					{SubnetIds: []string{"subnet-3"}},
+					{SubnetIDs: []string{"subnet-3"}},
 				},
 			},
 		},
 		{
-			name:      "empty_name_fails",
-			clName:    "",
+			name:       "empty_name_fails",
+			clName:     "",
 			serverless: &kafka.ServerlessClusterInfo{},
-			wantErr:   true,
+			wantErr:    true,
 		},
 	}
 
@@ -144,8 +144,8 @@ func TestRefinement2_ServerlessCluster_Roundtrip(t *testing.T) {
 	srv := &kafka.ServerlessClusterInfo{
 		VpcConfigs: []kafka.ServerlessVpcConfig{
 			{
-				SubnetIds:        []string{"subnet-a", "subnet-b"},
-				SecurityGroupIds: []string{"sg-1"},
+				SubnetIDs:        []string{"subnet-a", "subnet-b"},
+				SecurityGroupIDs: []string{"sg-1"},
 			},
 		},
 		ClientAuthentication: &kafka.ServerlessClientAuthentication{
@@ -161,8 +161,8 @@ func TestRefinement2_ServerlessCluster_Roundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, described.Serverless)
 	require.Len(t, described.Serverless.VpcConfigs, 1)
-	assert.Equal(t, []string{"subnet-a", "subnet-b"}, described.Serverless.VpcConfigs[0].SubnetIds)
-	assert.Equal(t, []string{"sg-1"}, described.Serverless.VpcConfigs[0].SecurityGroupIds)
+	assert.Equal(t, []string{"subnet-a", "subnet-b"}, described.Serverless.VpcConfigs[0].SubnetIDs)
+	assert.Equal(t, []string{"sg-1"}, described.Serverless.VpcConfigs[0].SecurityGroupIDs)
 	require.NotNil(t, described.Serverless.ClientAuthentication)
 	require.NotNil(t, described.Serverless.ClientAuthentication.Sasl)
 	assert.True(t, described.Serverless.ClientAuthentication.Sasl.Iam.Enabled)
@@ -173,10 +173,10 @@ func TestRefinement2_ServerlessCluster_HTTP(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
 		body       map[string]any
-		wantStatus int
+		name       string
 		wantType   string
+		wantStatus int
 	}{
 		{
 			name: "serverless_ok",
@@ -255,7 +255,7 @@ func TestRefinement2_DescribeClusterV2_ServerlessArm(t *testing.T) {
 
 	srv := &kafka.ServerlessClusterInfo{
 		VpcConfigs: []kafka.ServerlessVpcConfig{
-			{SubnetIds: []string{"subnet-x"}},
+			{SubnetIDs: []string{"subnet-x"}},
 		},
 	}
 	cl, err := backend.CreateServerlessCluster("srv-v2", srv, nil)
@@ -299,8 +299,8 @@ func TestRefinement2_EncryptionInfo_Roundtrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
 		encIn *kafka.EncryptionInfo
+		name  string
 	}{
 		{
 			name: "tls_only",
@@ -315,7 +315,7 @@ func TestRefinement2_EncryptionInfo_Roundtrip(t *testing.T) {
 			name: "kms_key_at_rest",
 			encIn: &kafka.EncryptionInfo{
 				EncryptionAtRest: &kafka.EncryptionAtRest{
-					DataVolumeKMSKeyId: "arn:aws:kms:us-east-1:123:key/abc-123",
+					DataVolumeKMSKeyID: "arn:aws:kms:us-east-1:123:key/abc-123",
 				},
 				EncryptionInTransit: &kafka.EncryptionInTransit{
 					ClientBroker: kafka.EncryptionInTransitTLSPlaintext,
@@ -352,8 +352,8 @@ func TestRefinement2_EncryptionInfo_Roundtrip(t *testing.T) {
 			require.NotNil(t, described.EncryptionInfo)
 			if tt.encIn.EncryptionAtRest != nil {
 				require.NotNil(t, described.EncryptionInfo.EncryptionAtRest)
-				assert.Equal(t, tt.encIn.EncryptionAtRest.DataVolumeKMSKeyId,
-					described.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId)
+				assert.Equal(t, tt.encIn.EncryptionAtRest.DataVolumeKMSKeyID,
+					described.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyID)
 			}
 			if tt.encIn.EncryptionInTransit != nil {
 				require.NotNil(t, described.EncryptionInfo.EncryptionInTransit)
@@ -376,7 +376,7 @@ func TestRefinement2_EncryptionInfo_InV1Response(t *testing.T) {
 	stored := kafka.GetStoredCluster(backend, cl.ClusterArn)
 	stored.EncryptionInfo = &kafka.EncryptionInfo{
 		EncryptionAtRest: &kafka.EncryptionAtRest{
-			DataVolumeKMSKeyId: "arn:aws:kms:us-east-1:123:key/abc",
+			DataVolumeKMSKeyID: "arn:aws:kms:us-east-1:123:key/abc",
 		},
 		EncryptionInTransit: &kafka.EncryptionInTransit{
 			ClientBroker: kafka.EncryptionInTransitTLS,
@@ -441,8 +441,8 @@ func TestRefinement2_OpenMonitoring_Roundtrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		om   *kafka.OpenMonitoring
+		name string
 	}{
 		{
 			name: "jmx_and_node_enabled",
@@ -509,8 +509,8 @@ func TestRefinement2_LoggingInfo_Roundtrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		li   *kafka.LoggingInfo
+		name string
 	}{
 		{
 			name: "cloudwatch_only",
@@ -668,7 +668,7 @@ func TestRefinement2_ClientAuthentication_TLS_NoAlias(t *testing.T) {
 		described.ClientAuthentication.TLS.CertificateAuthorityArnList[0])
 }
 
-// TestRefinement2_BrokerNodeGroupInfo_ZoneIds verifies ZoneIds roundtrip.
+// TestRefinement2_BrokerNodeGroupInfo_ZoneIds verifies ZoneIDs roundtrip.
 func TestRefinement2_BrokerNodeGroupInfo_ZoneIds(t *testing.T) {
 	t.Parallel()
 
@@ -676,7 +676,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ZoneIds(t *testing.T) {
 	cl, err := b.CreateCluster("zone-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:         "kafka.m5.large",
 		ClientSubnets:        []string{"subnet-1", "subnet-2", "subnet-3"},
-		ZoneIds:              []string{"use1-az1", "use1-az2", "use1-az3"},
+		ZoneIDs:              []string{"use1-az1", "use1-az2", "use1-az3"},
 		BrokerAZDistribution: "DEFAULT",
 	}, nil, nil)
 	require.NoError(t, err)
@@ -684,7 +684,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ZoneIds(t *testing.T) {
 	described, err := b.DescribeCluster(cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"use1-az1", "use1-az2", "use1-az3"},
-		described.BrokerNodeGroupInfo.ZoneIds)
+		described.BrokerNodeGroupInfo.ZoneIDs)
 }
 
 // TestRefinement2_BrokerNodeGroupInfo_ProvisionedThroughput verifies ProvisionedThroughput roundtrip.
@@ -722,8 +722,8 @@ func TestRefinement2_BrokerNodeGroupInfo_ConnectivityInfo(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		ci   *kafka.ConnectivityInfo
+		name string
 	}{
 		{
 			name: "public_access_service_provided",
@@ -742,7 +742,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ConnectivityInfo(t *testing.T) {
 			ci: &kafka.ConnectivityInfo{
 				VpcConnectivity: &kafka.VpcConnectivity{
 					ClientAuthentication: &kafka.VpcConnectivityClientAuthentication{
-						Tls: &kafka.VpcConnectivityTls{Enabled: true},
+						TLS: &kafka.VpcConnectivityTLS{Enabled: true},
 					},
 				},
 			},
@@ -797,8 +797,8 @@ func TestRefinement2_GetClusterPolicy_NotFoundException(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
 		setup     func(b *kafka.InMemoryBackend, clusterArn string)
+		name      string
 		wantErr   bool
 		wantFound bool
 	}{
@@ -856,8 +856,8 @@ func TestRefinement2_GetClusterPolicy_HTTP(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
 		setup      func(h *kafka.Handler, encoded string)
+		name       string
 		wantStatus int
 	}{
 		{
@@ -1063,19 +1063,19 @@ func TestRefinement2_GetBootstrapBrokers_Variants(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		auth         *kafka.ClientAuthentication
-		connectivity *kafka.ConnectivityInfo
-		wantSCRAM    bool
-		wantIAM      bool
+		auth          *kafka.ClientAuthentication
+		connectivity  *kafka.ConnectivityInfo
+		name          string
+		wantSCRAM     bool
+		wantIAM       bool
 		wantPublicTLS bool
-		wantVpcTLS   bool
+		wantVpcTLS    bool
 	}{
 		{
-			name:         "no_auth",
-			auth:         nil,
-			wantSCRAM:    false,
-			wantIAM:      false,
+			name:          "no_auth",
+			auth:          nil,
+			wantSCRAM:     false,
+			wantIAM:       false,
 			wantPublicTLS: false,
 		},
 		{
@@ -1127,7 +1127,7 @@ func TestRefinement2_GetBootstrapBrokers_Variants(t *testing.T) {
 			connectivity: &kafka.ConnectivityInfo{
 				VpcConnectivity: &kafka.VpcConnectivity{
 					ClientAuthentication: &kafka.VpcConnectivityClientAuthentication{
-						Tls: &kafka.VpcConnectivityTls{Enabled: true},
+						TLS: &kafka.VpcConnectivityTLS{Enabled: true},
 					},
 				},
 			},
@@ -1175,7 +1175,11 @@ func TestRefinement2_GetBootstrapBrokers_Variants(t *testing.T) {
 			}
 
 			if tt.wantVpcTLS {
-				assert.NotEmpty(t, resp["bootstrapBrokerStringVpcConnectivityTls"], "VPC TLS broker string should be present")
+				assert.NotEmpty(
+					t,
+					resp["bootstrapBrokerStringVpcConnectivityTLS"],
+					"VPC TLS broker string should be present",
+				)
 			}
 		})
 	}
@@ -1357,7 +1361,7 @@ func TestRefinement2_ListClustersV2_ClusterType(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = backend.CreateServerlessCluster("srv-list", &kafka.ServerlessClusterInfo{
-		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIds: []string{"subnet-2"}}},
+		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIDs: []string{"subnet-2"}}},
 	}, nil)
 	require.NoError(t, err)
 
@@ -1386,7 +1390,7 @@ func TestRefinement2_ListClustersV2_ServerlessHasNoProvisionedArm(t *testing.T) 
 
 	h, backend := newTestHandlerWithBackend(t)
 	_, err := backend.CreateServerlessCluster("srv-noarm", &kafka.ServerlessClusterInfo{
-		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIds: []string{"subnet-1"}}},
+		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIDs: []string{"subnet-1"}}},
 	}, nil)
 	require.NoError(t, err)
 
@@ -1411,7 +1415,7 @@ func TestRefinement2_Persistence_ServerlessCluster(t *testing.T) {
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	srv := &kafka.ServerlessClusterInfo{
 		VpcConfigs: []kafka.ServerlessVpcConfig{
-			{SubnetIds: []string{"subnet-1"}, SecurityGroupIds: []string{"sg-1"}},
+			{SubnetIDs: []string{"subnet-1"}, SecurityGroupIDs: []string{"sg-1"}},
 		},
 	}
 	cl, err := b.CreateServerlessCluster("srv-persist", srv, map[string]string{"env": "test"})
@@ -1428,7 +1432,7 @@ func TestRefinement2_Persistence_ServerlessCluster(t *testing.T) {
 	assert.Equal(t, kafka.ClusterTypeServerless, described.ClusterType)
 	require.NotNil(t, described.Serverless)
 	require.Len(t, described.Serverless.VpcConfigs, 1)
-	assert.Equal(t, []string{"subnet-1"}, described.Serverless.VpcConfigs[0].SubnetIds)
+	assert.Equal(t, []string{"subnet-1"}, described.Serverless.VpcConfigs[0].SubnetIDs)
 }
 
 // TestRefinement2_Persistence_EncryptionInfo verifies EncryptionInfo survives snapshot/restore.
@@ -1441,7 +1445,7 @@ func TestRefinement2_Persistence_EncryptionInfo(t *testing.T) {
 	stored := kafka.GetStoredCluster(b, cl.ClusterArn)
 	stored.EncryptionInfo = &kafka.EncryptionInfo{
 		EncryptionAtRest: &kafka.EncryptionAtRest{
-			DataVolumeKMSKeyId: "arn:aws:kms:us-east-1:123:key/persist",
+			DataVolumeKMSKeyID: "arn:aws:kms:us-east-1:123:key/persist",
 		},
 		EncryptionInTransit: &kafka.EncryptionInTransit{
 			ClientBroker: kafka.EncryptionInTransitTLS,
@@ -1458,7 +1462,7 @@ func TestRefinement2_Persistence_EncryptionInfo(t *testing.T) {
 	require.NotNil(t, described.EncryptionInfo)
 	require.NotNil(t, described.EncryptionInfo.EncryptionAtRest)
 	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/persist",
-		described.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId)
+		described.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyID)
 }
 
 // TestRefinement2_Persistence_ConfigurationInfo verifies ConfigurationInfo survives snapshot/restore.
@@ -1514,7 +1518,7 @@ func TestRefinement2_DeepCopy_ProvisionedThroughput(t *testing.T) {
 		described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput.VolumeThroughput)
 }
 
-// TestRefinement2_DeepCopy_ZoneIds verifies no aliasing in ZoneIds.
+// TestRefinement2_DeepCopy_ZoneIds verifies no aliasing in ZoneIDs.
 func TestRefinement2_DeepCopy_ZoneIds(t *testing.T) {
 	t.Parallel()
 
@@ -1523,17 +1527,17 @@ func TestRefinement2_DeepCopy_ZoneIds(t *testing.T) {
 	cl, err := b.CreateCluster("zone-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
-		ZoneIds:       zones,
+		ZoneIDs:       zones,
 	}, nil, nil)
 	require.NoError(t, err)
 
 	// Mutate original zones slice — should not affect stored.
 	zones[0] = "mutated"
-	cl.BrokerNodeGroupInfo.ZoneIds[0] = "also-mutated"
+	cl.BrokerNodeGroupInfo.ZoneIDs[0] = "also-mutated"
 
 	described, err := b.DescribeCluster(cl.ClusterArn)
 	require.NoError(t, err)
-	assert.Equal(t, "us-east-1a", described.BrokerNodeGroupInfo.ZoneIds[0])
+	assert.Equal(t, "us-east-1a", described.BrokerNodeGroupInfo.ZoneIDs[0])
 }
 
 // TestRefinement2_OpenMonitoring_InV2Response verifies OpenMonitoring in V2 provisioned arm.
@@ -1573,8 +1577,8 @@ func TestRefinement2_CreateCluster_AllAuthModes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		auth *kafka.ClientAuthentication
+		name string
 	}{
 		{
 			name: "no_auth",
@@ -1669,8 +1673,8 @@ func TestRefinement2_CreateCluster_V1_HTTP_AuthModes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		body map[string]any
+		name string
 	}{
 		{
 			name: "sasl_scram",

--- a/services/kafka/handler_refinement2_test.go
+++ b/services/kafka/handler_refinement2_test.go
@@ -1,0 +1,1844 @@
+package kafka_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/kafka"
+)
+
+// ----------------------------------------
+// Refinement 2 tests: expanded AWS accuracy
+// ----------------------------------------
+
+// TestRefinement2_ClusterTypeProvisioned verifies ClusterType=PROVISIONED is stored and returned.
+func TestRefinement2_ClusterTypeProvisioned(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		create  func(b *kafka.InMemoryBackend) *kafka.Cluster
+		wantTyp string
+	}{
+		{
+			name: "CreateCluster",
+			create: func(b *kafka.InMemoryBackend) *kafka.Cluster {
+				c, err := b.CreateCluster("c1", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+					InstanceType:  "kafka.m5.large",
+					ClientSubnets: []string{"subnet-1"},
+				}, nil, nil)
+				require.NoError(t, err)
+
+				return c
+			},
+			wantTyp: kafka.ClusterTypeProvisioned,
+		},
+		{
+			name: "AddClusterInternal",
+			create: func(b *kafka.InMemoryBackend) *kafka.Cluster {
+				return b.AddClusterInternal("c2", "3.6.0")
+			},
+			wantTyp: kafka.ClusterTypeProvisioned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := tt.create(b)
+			assert.Equal(t, tt.wantTyp, cl.ClusterType)
+
+			// Round-trip via DescribeCluster.
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTyp, described.ClusterType)
+		})
+	}
+}
+
+// TestRefinement2_CreateServerlessCluster verifies serverless cluster creation.
+func TestRefinement2_CreateServerlessCluster(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		clName    string
+		serverless *kafka.ServerlessClusterInfo
+		wantErr   bool
+	}{
+		{
+			name:   "basic_serverless",
+			clName: "srv-cluster",
+			serverless: &kafka.ServerlessClusterInfo{
+				VpcConfigs: []kafka.ServerlessVpcConfig{
+					{SubnetIds: []string{"subnet-1", "subnet-2"}, SecurityGroupIds: []string{"sg-1"}},
+				},
+			},
+		},
+		{
+			name:   "serverless_with_iam",
+			clName: "srv-iam",
+			serverless: &kafka.ServerlessClusterInfo{
+				ClientAuthentication: &kafka.ServerlessClientAuthentication{
+					Sasl: &kafka.SaslSettings{Iam: &kafka.SaslIam{Enabled: true}},
+				},
+				VpcConfigs: []kafka.ServerlessVpcConfig{
+					{SubnetIds: []string{"subnet-3"}},
+				},
+			},
+		},
+		{
+			name:      "empty_name_fails",
+			clName:    "",
+			serverless: &kafka.ServerlessClusterInfo{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl, err := b.CreateServerlessCluster(tt.clName, tt.serverless, nil)
+
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cl)
+			assert.Equal(t, kafka.ClusterTypeServerless, cl.ClusterType)
+			assert.Equal(t, tt.clName, cl.ClusterName)
+			assert.Equal(t, kafka.ClusterStateActive, cl.State)
+			assert.NotEmpty(t, cl.ClusterArn)
+		})
+	}
+}
+
+// TestRefinement2_CreateServerlessCluster_NoDuplicate verifies duplicate detection.
+func TestRefinement2_CreateServerlessCluster_NoDuplicate(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	_, err := b.CreateServerlessCluster("srv", &kafka.ServerlessClusterInfo{}, nil)
+	require.NoError(t, err)
+
+	_, err = b.CreateServerlessCluster("srv", &kafka.ServerlessClusterInfo{}, nil)
+	require.ErrorIs(t, err, kafka.ErrAlreadyExists)
+}
+
+// TestRefinement2_ServerlessCluster_Roundtrip verifies serverless config survives DescribeCluster.
+func TestRefinement2_ServerlessCluster_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	srv := &kafka.ServerlessClusterInfo{
+		VpcConfigs: []kafka.ServerlessVpcConfig{
+			{
+				SubnetIds:        []string{"subnet-a", "subnet-b"},
+				SecurityGroupIds: []string{"sg-1"},
+			},
+		},
+		ClientAuthentication: &kafka.ServerlessClientAuthentication{
+			Sasl: &kafka.SaslSettings{Iam: &kafka.SaslIam{Enabled: true}},
+		},
+	}
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl, err := b.CreateServerlessCluster("srv-rt", srv, nil)
+	require.NoError(t, err)
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.Serverless)
+	require.Len(t, described.Serverless.VpcConfigs, 1)
+	assert.Equal(t, []string{"subnet-a", "subnet-b"}, described.Serverless.VpcConfigs[0].SubnetIds)
+	assert.Equal(t, []string{"sg-1"}, described.Serverless.VpcConfigs[0].SecurityGroupIds)
+	require.NotNil(t, described.Serverless.ClientAuthentication)
+	require.NotNil(t, described.Serverless.ClientAuthentication.Sasl)
+	assert.True(t, described.Serverless.ClientAuthentication.Sasl.Iam.Enabled)
+}
+
+// TestRefinement2_ServerlessCluster_HTTP verifies HTTP endpoint for serverless V2 creation.
+func TestRefinement2_ServerlessCluster_HTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       map[string]any
+		wantStatus int
+		wantType   string
+	}{
+		{
+			name: "serverless_ok",
+			body: map[string]any{
+				"clusterName": "srv-http",
+				"serverless": map[string]any{
+					"vpcConfigs": []map[string]any{
+						{"subnetIds": []string{"subnet-1"}},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantType:   kafka.ClusterTypeServerless,
+		},
+		{
+			name: "both_provisioned_and_serverless_fails",
+			body: map[string]any{
+				"clusterName": "mixed",
+				"provisioned": map[string]any{
+					"kafkaVersion":        "3.5.1",
+					"numberOfBrokerNodes": 3,
+					"brokerNodeGroupInfo": map[string]any{
+						"instanceType":  "kafka.m5.large",
+						"clientSubnets": []string{"subnet-1"},
+					},
+				},
+				"serverless": map[string]any{
+					"vpcConfigs": []map[string]any{
+						{"subnetIds": []string{"subnet-1"}},
+					},
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "provisioned_ok",
+			body: map[string]any{
+				"clusterName": "prov-http",
+				"provisioned": map[string]any{
+					"kafkaVersion":        "3.5.1",
+					"numberOfBrokerNodes": 3,
+					"brokerNodeGroupInfo": map[string]any{
+						"instanceType":  "kafka.m5.large",
+						"clientSubnets": []string{"subnet-1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantType:   kafka.ClusterTypeProvisioned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doKafkaRequest(t, h, http.MethodPost, "/api/v2/clusters", tt.body)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantType != "" {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assert.Equal(t, tt.wantType, resp["clusterType"])
+			}
+		})
+	}
+}
+
+// TestRefinement2_DescribeClusterV2_ServerlessArm verifies DescribeClusterV2 emits the serverless arm.
+func TestRefinement2_DescribeClusterV2_ServerlessArm(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+
+	srv := &kafka.ServerlessClusterInfo{
+		VpcConfigs: []kafka.ServerlessVpcConfig{
+			{SubnetIds: []string{"subnet-x"}},
+		},
+	}
+	cl, err := backend.CreateServerlessCluster("srv-v2", srv, nil)
+	require.NoError(t, err)
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo, ok := resp["clusterInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, kafka.ClusterTypeServerless, clInfo["clusterType"])
+	assert.NotNil(t, clInfo["serverless"], "serverless arm should be present")
+	assert.Nil(t, clInfo["provisioned"], "provisioned arm should be absent")
+}
+
+// TestRefinement2_DescribeClusterV2_ProvisionedArm verifies provisioned arm in V2 response.
+func TestRefinement2_DescribeClusterV2_ProvisionedArm(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("prov-v2", "3.5.1")
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo, ok := resp["clusterInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, kafka.ClusterTypeProvisioned, clInfo["clusterType"])
+	assert.NotNil(t, clInfo["provisioned"], "provisioned arm should be present")
+	assert.Nil(t, clInfo["serverless"], "serverless arm should be absent")
+}
+
+// TestRefinement2_EncryptionInfo_Roundtrip verifies EncryptionInfo survives create/describe.
+func TestRefinement2_EncryptionInfo_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		encIn *kafka.EncryptionInfo
+	}{
+		{
+			name: "tls_only",
+			encIn: &kafka.EncryptionInfo{
+				EncryptionInTransit: &kafka.EncryptionInTransit{
+					ClientBroker: kafka.EncryptionInTransitTLS,
+					InCluster:    true,
+				},
+			},
+		},
+		{
+			name: "kms_key_at_rest",
+			encIn: &kafka.EncryptionInfo{
+				EncryptionAtRest: &kafka.EncryptionAtRest{
+					DataVolumeKMSKeyId: "arn:aws:kms:us-east-1:123:key/abc-123",
+				},
+				EncryptionInTransit: &kafka.EncryptionInTransit{
+					ClientBroker: kafka.EncryptionInTransitTLSPlaintext,
+					InCluster:    false,
+				},
+			},
+		},
+		{
+			name:  "nil_encryption",
+			encIn: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("enc-cl", "3.5.1")
+
+			// Store EncryptionInfo via GetStoredCluster (internal access).
+			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+			stored.EncryptionInfo = tt.encIn
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+
+			if tt.encIn == nil {
+				assert.Nil(t, described.EncryptionInfo)
+
+				return
+			}
+
+			require.NotNil(t, described.EncryptionInfo)
+			if tt.encIn.EncryptionAtRest != nil {
+				require.NotNil(t, described.EncryptionInfo.EncryptionAtRest)
+				assert.Equal(t, tt.encIn.EncryptionAtRest.DataVolumeKMSKeyId,
+					described.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId)
+			}
+			if tt.encIn.EncryptionInTransit != nil {
+				require.NotNil(t, described.EncryptionInfo.EncryptionInTransit)
+				assert.Equal(t, tt.encIn.EncryptionInTransit.ClientBroker,
+					described.EncryptionInfo.EncryptionInTransit.ClientBroker)
+				assert.Equal(t, tt.encIn.EncryptionInTransit.InCluster,
+					described.EncryptionInfo.EncryptionInTransit.InCluster)
+			}
+		})
+	}
+}
+
+// TestRefinement2_EncryptionInfo_InV1Response verifies EncryptionInfo appears in HTTP V1 response.
+func TestRefinement2_EncryptionInfo_InV1Response(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("enc-v1", "3.6.0")
+
+	stored := kafka.GetStoredCluster(backend, cl.ClusterArn)
+	stored.EncryptionInfo = &kafka.EncryptionInfo{
+		EncryptionAtRest: &kafka.EncryptionAtRest{
+			DataVolumeKMSKeyId: "arn:aws:kms:us-east-1:123:key/abc",
+		},
+		EncryptionInTransit: &kafka.EncryptionInTransit{
+			ClientBroker: kafka.EncryptionInTransitTLS,
+			InCluster:    true,
+		},
+	}
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/v1/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo := resp["clusterInfo"].(map[string]any)
+	encInfo, ok := clInfo["encryptionInfo"].(map[string]any)
+	require.True(t, ok, "encryptionInfo should be present in V1 response")
+
+	ear, ok := encInfo["encryptionAtRest"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/abc", ear["dataVolumeKMSKeyId"])
+
+	eit, ok := encInfo["encryptionInTransit"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, kafka.EncryptionInTransitTLS, eit["clientBroker"])
+	assert.True(t, eit["inCluster"].(bool))
+}
+
+// TestRefinement2_EncryptionInfo_InV2Response verifies EncryptionInfo appears in HTTP V2 response.
+func TestRefinement2_EncryptionInfo_InV2Response(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("enc-v2", "3.5.1")
+
+	stored := kafka.GetStoredCluster(backend, cl.ClusterArn)
+	stored.EncryptionInfo = &kafka.EncryptionInfo{
+		EncryptionInTransit: &kafka.EncryptionInTransit{
+			ClientBroker: kafka.EncryptionInTransitTLSPlaintext,
+			InCluster:    true,
+		},
+	}
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo := resp["clusterInfo"].(map[string]any)
+	provisioned, ok := clInfo["provisioned"].(map[string]any)
+	require.True(t, ok)
+
+	encInfo, ok := provisioned["encryptionInfo"].(map[string]any)
+	require.True(t, ok, "encryptionInfo should be present in V2 provisioned response")
+
+	eit := encInfo["encryptionInTransit"].(map[string]any)
+	assert.Equal(t, kafka.EncryptionInTransitTLSPlaintext, eit["clientBroker"])
+}
+
+// TestRefinement2_OpenMonitoring_Roundtrip verifies OpenMonitoring survives create/describe.
+func TestRefinement2_OpenMonitoring_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		om   *kafka.OpenMonitoring
+	}{
+		{
+			name: "jmx_and_node_enabled",
+			om: &kafka.OpenMonitoring{
+				Prometheus: &kafka.PrometheusInfo{
+					JmxExporter:  &kafka.JmxExporter{EnabledInBroker: true},
+					NodeExporter: &kafka.NodeExporter{EnabledInBroker: true},
+				},
+			},
+		},
+		{
+			name: "jmx_only",
+			om: &kafka.OpenMonitoring{
+				Prometheus: &kafka.PrometheusInfo{
+					JmxExporter: &kafka.JmxExporter{EnabledInBroker: true},
+				},
+			},
+		},
+		{
+			name: "nil",
+			om:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("om-cl", "3.5.1")
+
+			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+			stored.OpenMonitoring = tt.om
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+
+			if tt.om == nil {
+				assert.Nil(t, described.OpenMonitoring)
+
+				return
+			}
+
+			require.NotNil(t, described.OpenMonitoring)
+			require.NotNil(t, described.OpenMonitoring.Prometheus)
+
+			if tt.om.Prometheus.JmxExporter != nil {
+				require.NotNil(t, described.OpenMonitoring.Prometheus.JmxExporter)
+				assert.Equal(t, tt.om.Prometheus.JmxExporter.EnabledInBroker,
+					described.OpenMonitoring.Prometheus.JmxExporter.EnabledInBroker)
+			}
+
+			if tt.om.Prometheus.NodeExporter != nil {
+				require.NotNil(t, described.OpenMonitoring.Prometheus.NodeExporter)
+				assert.Equal(t, tt.om.Prometheus.NodeExporter.EnabledInBroker,
+					described.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker)
+			}
+		})
+	}
+}
+
+// TestRefinement2_LoggingInfo_Roundtrip verifies LoggingInfo survives describe.
+func TestRefinement2_LoggingInfo_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		li   *kafka.LoggingInfo
+	}{
+		{
+			name: "cloudwatch_only",
+			li: &kafka.LoggingInfo{
+				BrokerLogs: &kafka.BrokerLogs{
+					CloudWatchLogs: &kafka.CloudWatchLogs{
+						Enabled:  true,
+						LogGroup: "/aws/msk/cluster/my-cluster",
+					},
+				},
+			},
+		},
+		{
+			name: "firehose_and_s3",
+			li: &kafka.LoggingInfo{
+				BrokerLogs: &kafka.BrokerLogs{
+					Firehose: &kafka.Firehose{
+						Enabled:        true,
+						DeliveryStream: "my-firehose",
+					},
+					S3: &kafka.S3Logs{
+						Enabled: true,
+						Bucket:  "my-bucket",
+						Prefix:  "kafka/",
+					},
+				},
+			},
+		},
+		{
+			name: "nil",
+			li:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("log-cl", "3.5.1")
+
+			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+			stored.LoggingInfo = tt.li
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+
+			if tt.li == nil {
+				assert.Nil(t, described.LoggingInfo)
+
+				return
+			}
+
+			require.NotNil(t, described.LoggingInfo)
+			require.NotNil(t, described.LoggingInfo.BrokerLogs)
+
+			bl := described.LoggingInfo.BrokerLogs
+			expectedBl := tt.li.BrokerLogs
+
+			if expectedBl.CloudWatchLogs != nil {
+				require.NotNil(t, bl.CloudWatchLogs)
+				assert.Equal(t, expectedBl.CloudWatchLogs.Enabled, bl.CloudWatchLogs.Enabled)
+				assert.Equal(t, expectedBl.CloudWatchLogs.LogGroup, bl.CloudWatchLogs.LogGroup)
+			}
+
+			if expectedBl.Firehose != nil {
+				require.NotNil(t, bl.Firehose)
+				assert.Equal(t, expectedBl.Firehose.DeliveryStream, bl.Firehose.DeliveryStream)
+			}
+
+			if expectedBl.S3 != nil {
+				require.NotNil(t, bl.S3)
+				assert.Equal(t, expectedBl.S3.Bucket, bl.S3.Bucket)
+				assert.Equal(t, expectedBl.S3.Prefix, bl.S3.Prefix)
+			}
+		})
+	}
+}
+
+// TestRefinement2_ClientAuthentication_Unauthenticated verifies Unauthenticated arm roundtrip.
+func TestRefinement2_ClientAuthentication_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	auth := &kafka.ClientAuthentication{
+		Unauthenticated: &kafka.UnauthenticatedSettings{Enabled: true},
+	}
+	cl, err := b.CreateCluster("ua-cluster", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+	}, auth, nil)
+	require.NoError(t, err)
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.ClientAuthentication)
+	require.NotNil(t, described.ClientAuthentication.Unauthenticated)
+	assert.True(t, described.ClientAuthentication.Unauthenticated.Enabled)
+}
+
+// TestRefinement2_ClientAuthentication_TLSWithCAArns verifies TLS with CA ARNs roundtrip.
+func TestRefinement2_ClientAuthentication_TLSWithCAArns(t *testing.T) {
+	t.Parallel()
+
+	caArns := []string{
+		"arn:aws:acm-pca:us-east-1:123:certificate-authority/abc",
+		"arn:aws:acm-pca:us-east-1:123:certificate-authority/def",
+	}
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	auth := &kafka.ClientAuthentication{
+		TLS: &kafka.TLSSettings{
+			Enabled:                     true,
+			CertificateAuthorityArnList: caArns,
+		},
+	}
+	cl, err := b.CreateCluster("tls-ca-cluster", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+	}, auth, nil)
+	require.NoError(t, err)
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.ClientAuthentication)
+	require.NotNil(t, described.ClientAuthentication.TLS)
+	assert.True(t, described.ClientAuthentication.TLS.Enabled)
+	assert.Equal(t, caArns, described.ClientAuthentication.TLS.CertificateAuthorityArnList)
+}
+
+// TestRefinement2_ClientAuthentication_TLS_NoAlias verifies CertificateAuthorityArnList is deep-copied.
+func TestRefinement2_ClientAuthentication_TLS_NoAlias(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	caArns := []string{"arn:aws:acm-pca:us-east-1:123:ca/x"}
+	auth := &kafka.ClientAuthentication{
+		TLS: &kafka.TLSSettings{
+			Enabled:                     true,
+			CertificateAuthorityArnList: caArns,
+		},
+	}
+	cl, err := b.CreateCluster("alias-test", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+	}, auth, nil)
+	require.NoError(t, err)
+
+	// Mutate original slice — should not affect stored cluster.
+	caArns[0] = "mutated"
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:acm-pca:us-east-1:123:ca/x",
+		described.ClientAuthentication.TLS.CertificateAuthorityArnList[0])
+}
+
+// TestRefinement2_BrokerNodeGroupInfo_ZoneIds verifies ZoneIds roundtrip.
+func TestRefinement2_BrokerNodeGroupInfo_ZoneIds(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl, err := b.CreateCluster("zone-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:         "kafka.m5.large",
+		ClientSubnets:        []string{"subnet-1", "subnet-2", "subnet-3"},
+		ZoneIds:              []string{"use1-az1", "use1-az2", "use1-az3"},
+		BrokerAZDistribution: "DEFAULT",
+	}, nil, nil)
+	require.NoError(t, err)
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"use1-az1", "use1-az2", "use1-az3"},
+		described.BrokerNodeGroupInfo.ZoneIds)
+}
+
+// TestRefinement2_BrokerNodeGroupInfo_ProvisionedThroughput verifies ProvisionedThroughput roundtrip.
+func TestRefinement2_BrokerNodeGroupInfo_ProvisionedThroughput(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl, err := b.CreateCluster("pt-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+		StorageInfo: &kafka.StorageInfo{
+			EbsStorageInfo: &kafka.EBSStorageInfo{
+				VolumeSize: 100,
+				ProvisionedThroughput: &kafka.ProvisionedThroughput{
+					Enabled:          true,
+					VolumeThroughput: 250,
+				},
+			},
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.BrokerNodeGroupInfo.StorageInfo)
+	require.NotNil(t, described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo)
+	require.NotNil(t, described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput)
+	pt := described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput
+	assert.True(t, pt.Enabled)
+	assert.Equal(t, int32(250), pt.VolumeThroughput)
+}
+
+// TestRefinement2_BrokerNodeGroupInfo_ConnectivityInfo verifies ConnectivityInfo roundtrip.
+func TestRefinement2_BrokerNodeGroupInfo_ConnectivityInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ci   *kafka.ConnectivityInfo
+	}{
+		{
+			name: "public_access_service_provided",
+			ci: &kafka.ConnectivityInfo{
+				PublicAccess: &kafka.PublicAccess{Type: "SERVICE_PROVIDED_EIPS"},
+			},
+		},
+		{
+			name: "public_access_disabled",
+			ci: &kafka.ConnectivityInfo{
+				PublicAccess: &kafka.PublicAccess{Type: "DISABLED"},
+			},
+		},
+		{
+			name: "vpc_connectivity_tls",
+			ci: &kafka.ConnectivityInfo{
+				VpcConnectivity: &kafka.VpcConnectivity{
+					ClientAuthentication: &kafka.VpcConnectivityClientAuthentication{
+						Tls: &kafka.VpcConnectivityTls{Enabled: true},
+					},
+				},
+			},
+		},
+		{
+			name: "vpc_connectivity_sasl_iam",
+			ci: &kafka.ConnectivityInfo{
+				VpcConnectivity: &kafka.VpcConnectivity{
+					ClientAuthentication: &kafka.VpcConnectivityClientAuthentication{
+						Sasl: &kafka.VpcConnectivitySasl{
+							Iam: &kafka.VpcConnectivitySaslIam{Enabled: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl, err := b.CreateCluster("ci-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+				InstanceType:     "kafka.m5.large",
+				ClientSubnets:    []string{"subnet-1"},
+				ConnectivityInfo: tt.ci,
+			}, nil, nil)
+			require.NoError(t, err)
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+			require.NotNil(t, described.BrokerNodeGroupInfo.ConnectivityInfo)
+
+			if tt.ci.PublicAccess != nil {
+				require.NotNil(t, described.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess)
+				assert.Equal(t, tt.ci.PublicAccess.Type,
+					described.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type)
+			}
+
+			if tt.ci.VpcConnectivity != nil {
+				vc := described.BrokerNodeGroupInfo.ConnectivityInfo.VpcConnectivity
+				require.NotNil(t, vc)
+				require.NotNil(t, vc.ClientAuthentication)
+			}
+		})
+	}
+}
+
+// TestRefinement2_GetClusterPolicy_NotFoundException verifies NotFoundException when no policy set.
+func TestRefinement2_GetClusterPolicy_NotFoundException(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setup     func(b *kafka.InMemoryBackend, clusterArn string)
+		wantErr   bool
+		wantFound bool
+	}{
+		{
+			name:      "no_policy_set",
+			setup:     func(_ *kafka.InMemoryBackend, _ string) {},
+			wantErr:   true,
+			wantFound: false,
+		},
+		{
+			name: "policy_set",
+			setup: func(b *kafka.InMemoryBackend, clusterArn string) {
+				err := b.PutClusterPolicy(clusterArn, `{"Version":"2012-10-17"}`)
+				require.NoError(t, err)
+			},
+			wantErr:   false,
+			wantFound: true,
+		},
+		{
+			name: "policy_put_then_deleted",
+			setup: func(b *kafka.InMemoryBackend, clusterArn string) {
+				_ = b.PutClusterPolicy(clusterArn, `{"Version":"2012-10-17"}`)
+				_ = b.DeleteClusterPolicy(clusterArn)
+			},
+			wantErr:   true,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("policy-cl", "3.5.1")
+
+			tt.setup(b, cl.ClusterArn)
+
+			_, err := b.GetClusterPolicy(cl.ClusterArn)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, kafka.ErrNotFound)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantFound, kafka.HasClusterPolicy(b, cl.ClusterArn))
+		})
+	}
+}
+
+// TestRefinement2_GetClusterPolicy_HTTP verifies HTTP NotFoundException when no policy.
+func TestRefinement2_GetClusterPolicy_HTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func(h *kafka.Handler, encoded string)
+		wantStatus int
+	}{
+		{
+			name:       "no_policy_returns_404",
+			setup:      func(_ *kafka.Handler, _ string) {},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "policy_set_returns_200",
+			setup: func(h *kafka.Handler, encoded string) {
+				rec := doKafkaRequest(t, h, http.MethodPut, "/v1/clusters/"+encoded+"/policy",
+					map[string]any{"policy": `{"Version":"2012-10-17"}`})
+				require.Equal(t, http.StatusOK, rec.Code)
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, backend := newTestHandlerWithBackend(t)
+			cl := backend.AddClusterInternal("pol-http", "3.5.1")
+			encoded := url.PathEscape(cl.ClusterArn)
+
+			tt.setup(h, encoded)
+
+			rec := doKafkaRequest(t, h, http.MethodGet, "/v1/clusters/"+encoded+"/policy", nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// TestRefinement2_UpdateClusterConfiguration_PersistsConfig verifies config is stored on cluster.
+func TestRefinement2_UpdateClusterConfiguration_PersistsConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configArn  string
+		revision   int64
+		wantArnSet bool
+	}{
+		{
+			name:       "with_valid_config",
+			configArn:  "arn:aws:kafka:us-east-1:123:configuration/my-cfg/abc-123",
+			revision:   5,
+			wantArnSet: true,
+		},
+		{
+			name:       "empty_config_arn",
+			configArn:  "",
+			revision:   1,
+			wantArnSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("cfg-update-cl", "3.5.1")
+
+			op, err := b.UpdateClusterConfiguration(cl.ClusterArn, tt.configArn, tt.revision)
+			require.NoError(t, err)
+			require.NotNil(t, op)
+			assert.Equal(t, "UPDATE_CLUSTER_CONFIGURATION", op.OperationType)
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+
+			if tt.wantArnSet {
+				require.NotNil(t, described.ConfigurationInfo,
+					"ConfigurationInfo should be set after UpdateClusterConfiguration")
+				assert.Equal(t, tt.configArn, described.ConfigurationInfo.Arn)
+				assert.Equal(t, tt.revision, described.ConfigurationInfo.Revision)
+			}
+		})
+	}
+}
+
+// TestRefinement2_ListKafkaVersions_IncludesKRaft verifies KRaft variants are in the list.
+func TestRefinement2_ListKafkaVersions_IncludesKRaft(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	versions := b.ListKafkaVersions()
+
+	versionMap := make(map[string]string, len(versions))
+	for _, v := range versions {
+		versionMap[v.Version] = v.Status
+	}
+
+	tests := []struct {
+		version    string
+		wantStatus string
+	}{
+		{"3.8.0.kraft", "ACTIVE"},
+		{"3.7.x.kraft", "ACTIVE"},
+		{"3.6.0", "ACTIVE"},
+		{"3.5.1", "ACTIVE"},
+		{"3.4.0", "ACTIVE"},
+		{"3.3.2", "ACTIVE"},
+		{"3.3.1", "ACTIVE"},
+		{"2.8.2.tiered", "ACTIVE"},
+		{"2.8.1", "ACTIVE"},
+		{"2.8.0", "DEPRECATED"},
+		{"2.6.0", "DEPRECATED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			t.Parallel()
+
+			status, ok := versionMap[tt.version]
+			assert.True(t, ok, "version %q should be in ListKafkaVersions", tt.version)
+			assert.Equal(t, tt.wantStatus, status, "version %q has unexpected status", tt.version)
+		})
+	}
+}
+
+// TestRefinement2_ListKafkaVersions_HTTP verifies the HTTP response.
+func TestRefinement2_ListKafkaVersions_HTTP(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doKafkaRequest(t, h, http.MethodGet, "/v1/kafka-versions", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	versions, ok := resp["kafkaVersions"].([]any)
+	require.True(t, ok)
+	assert.Greater(t, len(versions), 5, "should return more than 5 versions")
+
+	// Find KRaft variant.
+	foundKRaft := false
+	for _, v := range versions {
+		ver := v.(map[string]any)
+		if ver["version"] == "3.8.0.kraft" {
+			foundKRaft = true
+		}
+	}
+
+	assert.True(t, foundKRaft, "3.8.0.kraft should be in version list")
+}
+
+// TestRefinement2_GetCompatibleKafkaVersions_KRaftOnly verifies KRaft clusters get KRaft targets.
+func TestRefinement2_GetCompatibleKafkaVersions_KRaftOnly(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl := b.AddClusterInternal("kraft-cl", "3.7.x.kraft")
+
+	versions, err := b.GetCompatibleKafkaVersions(cl.ClusterArn)
+	require.NoError(t, err)
+
+	versionStrs := make([]string, 0, len(versions))
+	for _, v := range versions {
+		versionStrs = append(versionStrs, v.Version)
+	}
+
+	// KRaft clusters should only get KRaft targets.
+	for _, v := range versions {
+		assert.True(t, hasSuffix(v.Version, ".kraft") || v.Version == "3.8.0.kraft",
+			"KRaft cluster should only get KRaft-compatible versions, got %q", v.Version)
+	}
+
+	assert.Contains(t, versionStrs, "3.8.0.kraft")
+}
+
+// TestRefinement2_GetCompatibleKafkaVersions_ZooKeeperNoKRaft verifies ZK clusters don't get KRaft.
+func TestRefinement2_GetCompatibleKafkaVersions_ZooKeeperNoKRaft(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl := b.AddClusterInternal("zk-cl", "2.8.1")
+
+	versions, err := b.GetCompatibleKafkaVersions(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotEmpty(t, versions)
+
+	for _, v := range versions {
+		assert.False(t, hasSuffix(v.Version, ".kraft"),
+			"ZooKeeper cluster should not get KRaft versions, got %q", v.Version)
+	}
+}
+
+// TestRefinement2_GetCompatibleKafkaVersions_NotFound verifies error on missing cluster.
+func TestRefinement2_GetCompatibleKafkaVersions_NotFound(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	_, err := b.GetCompatibleKafkaVersions("arn:aws:kafka:us-east-1:123:cluster/nonexistent/abc")
+	require.ErrorIs(t, err, kafka.ErrNotFound)
+}
+
+// TestRefinement2_GetBootstrapBrokers_Variants tests bootstrap broker string generation.
+func TestRefinement2_GetBootstrapBrokers_Variants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		auth         *kafka.ClientAuthentication
+		connectivity *kafka.ConnectivityInfo
+		wantSCRAM    bool
+		wantIAM      bool
+		wantPublicTLS bool
+		wantVpcTLS   bool
+	}{
+		{
+			name:         "no_auth",
+			auth:         nil,
+			wantSCRAM:    false,
+			wantIAM:      false,
+			wantPublicTLS: false,
+		},
+		{
+			name: "scram_enabled",
+			auth: &kafka.ClientAuthentication{
+				Sasl: &kafka.SaslSettings{
+					Scram: &kafka.SaslScram{Enabled: true},
+				},
+			},
+			wantSCRAM: true,
+			wantIAM:   false,
+		},
+		{
+			name: "iam_enabled",
+			auth: &kafka.ClientAuthentication{
+				Sasl: &kafka.SaslSettings{
+					Iam: &kafka.SaslIam{Enabled: true},
+				},
+			},
+			wantSCRAM: false,
+			wantIAM:   true,
+		},
+		{
+			name: "scram_and_iam",
+			auth: &kafka.ClientAuthentication{
+				Sasl: &kafka.SaslSettings{
+					Scram: &kafka.SaslScram{Enabled: true},
+					Iam:   &kafka.SaslIam{Enabled: true},
+				},
+			},
+			wantSCRAM: true,
+			wantIAM:   true,
+		},
+		{
+			name: "public_access_eips",
+			auth: &kafka.ClientAuthentication{
+				TLS: &kafka.TLSSettings{Enabled: true},
+			},
+			connectivity: &kafka.ConnectivityInfo{
+				PublicAccess: &kafka.PublicAccess{Type: "SERVICE_PROVIDED_EIPS"},
+			},
+			wantPublicTLS: true,
+		},
+		{
+			name: "vpc_connectivity_tls",
+			auth: &kafka.ClientAuthentication{
+				TLS: &kafka.TLSSettings{Enabled: true},
+			},
+			connectivity: &kafka.ConnectivityInfo{
+				VpcConnectivity: &kafka.VpcConnectivity{
+					ClientAuthentication: &kafka.VpcConnectivityClientAuthentication{
+						Tls: &kafka.VpcConnectivityTls{Enabled: true},
+					},
+				},
+			},
+			wantVpcTLS: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, backend := newTestHandlerWithBackend(t)
+			cl, err := backend.CreateCluster("bs-cl", "3.5.1", 3,
+				kafka.BrokerNodeGroupInfo{
+					InstanceType:     "kafka.m5.large",
+					ClientSubnets:    []string{"subnet-1"},
+					ConnectivityInfo: tt.connectivity,
+				}, tt.auth, nil)
+			require.NoError(t, err)
+
+			rec := doKafkaRequest(t, h, http.MethodGet,
+				"/v1/clusters/"+url.PathEscape(cl.ClusterArn)+"/bootstrap-brokers", nil)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			assert.NotEmpty(t, resp["bootstrapBrokerString"], "plaintext broker string always present")
+			assert.NotEmpty(t, resp["bootstrapBrokerStringTls"], "TLS broker string always present")
+
+			if tt.wantSCRAM {
+				assert.NotEmpty(t, resp["bootstrapBrokerStringSaslScram"], "SCRAM broker string should be present")
+			} else {
+				assert.Empty(t, resp["bootstrapBrokerStringSaslScram"], "SCRAM broker string should be absent")
+			}
+
+			if tt.wantIAM {
+				assert.NotEmpty(t, resp["bootstrapBrokerStringSaslIam"], "IAM broker string should be present")
+			} else {
+				assert.Empty(t, resp["bootstrapBrokerStringSaslIam"], "IAM broker string should be absent")
+			}
+
+			if tt.wantPublicTLS {
+				assert.NotEmpty(t, resp["bootstrapBrokerStringTlsPublic"], "public TLS broker string should be present")
+			}
+
+			if tt.wantVpcTLS {
+				assert.NotEmpty(t, resp["bootstrapBrokerStringVpcConnectivityTls"], "VPC TLS broker string should be present")
+			}
+		})
+	}
+}
+
+// TestRefinement2_ZookeeperConnectString verifies ZookeeperConnectString in V1 responses.
+func TestRefinement2_ZookeeperConnectString(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("zk-conn", "3.5.1")
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/v1/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo := resp["clusterInfo"].(map[string]any)
+	zkStr, ok := clInfo["zookeeperConnectString"].(string)
+	require.True(t, ok, "zookeeperConnectString should be present in V1 response")
+	assert.Contains(t, zkStr, ":2181")
+	assert.Contains(t, zkStr, "z-1.")
+}
+
+// TestRefinement2_StateInfo_Roundtrip verifies StateInfo roundtrip.
+func TestRefinement2_StateInfo_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl := b.AddClusterInternal("state-cl", "3.5.1")
+
+	// Set state info via internal access.
+	stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+	stored.State = kafka.ClusterStateFailed
+	stored.StateInfo = &kafka.StateInfo{
+		Code:    "BROKER_STORAGE_FAILURE",
+		Message: "EBS volume ran out of space",
+	}
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, kafka.ClusterStateFailed, described.State)
+	require.NotNil(t, described.StateInfo)
+	assert.Equal(t, "BROKER_STORAGE_FAILURE", described.StateInfo.Code)
+	assert.Equal(t, "EBS volume ran out of space", described.StateInfo.Message)
+}
+
+// TestRefinement2_NewClusterStateConstants verifies all new state constants are defined.
+func TestRefinement2_NewClusterStateConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		constant string
+		value    string
+	}{
+		{constant: "UPDATING", value: kafka.ClusterStateUpdating},
+		{constant: "REBOOTING_BROKER", value: kafka.ClusterStateRebootingBroker},
+		{constant: "MAINTENANCE", value: kafka.ClusterStateMaintenance},
+		{constant: "HEALING", value: kafka.ClusterStateHealing},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.constant, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.constant, tt.value)
+		})
+	}
+}
+
+// TestRefinement2_EnhancedMonitoring_Constants verifies monitoring constant values.
+func TestRefinement2_EnhancedMonitoring_Constants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "DEFAULT", kafka.EnhancedMonitoringDefault)
+	assert.Equal(t, "PER_BROKER", kafka.EnhancedMonitoringPerBroker)
+	assert.Equal(t, "PER_TOPIC_PER_BROKER", kafka.EnhancedMonitoringPerTopicPerBroker)
+	assert.Equal(t, "PER_TOPIC_PER_PARTITION", kafka.EnhancedMonitoringPerTopicPerPartition)
+}
+
+// TestRefinement2_StorageMode_Constants verifies storage mode constant values.
+func TestRefinement2_StorageMode_Constants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "LOCAL", kafka.StorageModeLocal)
+	assert.Equal(t, "TIERED", kafka.StorageModeTiered)
+}
+
+// TestRefinement2_EncryptionInTransit_Constants verifies encryption constant values.
+func TestRefinement2_EncryptionInTransit_Constants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "TLS", kafka.EncryptionInTransitTLS)
+	assert.Equal(t, "TLS_PLAINTEXT", kafka.EncryptionInTransitTLSPlaintext)
+	assert.Equal(t, "PLAINTEXT", kafka.EncryptionInTransitPlaintext)
+}
+
+// TestRefinement2_ClusterType_Constants verifies cluster type constant values.
+func TestRefinement2_ClusterType_Constants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "PROVISIONED", kafka.ClusterTypeProvisioned)
+	assert.Equal(t, "SERVERLESS", kafka.ClusterTypeServerless)
+}
+
+// TestRefinement2_StorageMode_Roundtrip verifies StorageMode is stored and returned.
+func TestRefinement2_StorageMode_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "tiered", mode: kafka.StorageModeTiered},
+		{name: "local", mode: kafka.StorageModeLocal},
+		{name: "empty", mode: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("sm-cl", "3.5.1")
+
+			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+			stored.StorageMode = tt.mode
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.mode, described.StorageMode)
+		})
+	}
+}
+
+// TestRefinement2_EnhancedMonitoring_Roundtrip verifies EnhancedMonitoring round-trip.
+func TestRefinement2_EnhancedMonitoring_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		level string
+	}{
+		{"default", kafka.EnhancedMonitoringDefault},
+		{"per_broker", kafka.EnhancedMonitoringPerBroker},
+		{"per_topic_per_broker", kafka.EnhancedMonitoringPerTopicPerBroker},
+		{"per_topic_per_partition", kafka.EnhancedMonitoringPerTopicPerPartition},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl := b.AddClusterInternal("em-cl", "3.5.1")
+
+			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+			stored.EnhancedMonitoring = tt.level
+
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.level, described.EnhancedMonitoring)
+		})
+	}
+}
+
+// TestRefinement2_ListClustersV2_ClusterType verifies ClusterType propagates in ListClustersV2.
+func TestRefinement2_ListClustersV2_ClusterType(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+
+	// Create one provisioned and one serverless.
+	_, err := backend.CreateCluster("prov-list", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	_, err = backend.CreateServerlessCluster("srv-list", &kafka.ServerlessClusterInfo{
+		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIds: []string{"subnet-2"}}},
+	}, nil)
+	require.NoError(t, err)
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clusterList := resp["clusterInfoList"].([]any)
+	require.Len(t, clusterList, 2)
+
+	typesByName := make(map[string]string)
+	for _, ci := range clusterList {
+		info := ci.(map[string]any)
+		typesByName[info["clusterName"].(string)] = info["clusterType"].(string)
+	}
+
+	assert.Equal(t, kafka.ClusterTypeProvisioned, typesByName["prov-list"])
+	assert.Equal(t, kafka.ClusterTypeServerless, typesByName["srv-list"])
+}
+
+// TestRefinement2_ListClustersV2_ServerlessHasNoProvisionedArm verifies V2 list shape.
+func TestRefinement2_ListClustersV2_ServerlessHasNoProvisionedArm(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	_, err := backend.CreateServerlessCluster("srv-noarm", &kafka.ServerlessClusterInfo{
+		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIds: []string{"subnet-1"}}},
+	}, nil)
+	require.NoError(t, err)
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clusterList := resp["clusterInfoList"].([]any)
+	require.Len(t, clusterList, 1)
+
+	ci := clusterList[0].(map[string]any)
+	assert.Nil(t, ci["provisioned"], "serverless cluster should not have provisioned arm")
+	assert.NotNil(t, ci["serverless"], "serverless cluster should have serverless arm")
+}
+
+// TestRefinement2_Persistence_ServerlessCluster verifies serverless cluster survives snapshot/restore.
+func TestRefinement2_Persistence_ServerlessCluster(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	srv := &kafka.ServerlessClusterInfo{
+		VpcConfigs: []kafka.ServerlessVpcConfig{
+			{SubnetIds: []string{"subnet-1"}, SecurityGroupIds: []string{"sg-1"}},
+		},
+	}
+	cl, err := b.CreateServerlessCluster("srv-persist", srv, map[string]string{"env": "test"})
+	require.NoError(t, err)
+
+	snap := b.Snapshot()
+	require.NotNil(t, snap)
+
+	b2 := kafka.NewInMemoryBackend("other", "eu-west-1")
+	require.NoError(t, b2.Restore(snap))
+
+	described, err := b2.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, kafka.ClusterTypeServerless, described.ClusterType)
+	require.NotNil(t, described.Serverless)
+	require.Len(t, described.Serverless.VpcConfigs, 1)
+	assert.Equal(t, []string{"subnet-1"}, described.Serverless.VpcConfigs[0].SubnetIds)
+}
+
+// TestRefinement2_Persistence_EncryptionInfo verifies EncryptionInfo survives snapshot/restore.
+func TestRefinement2_Persistence_EncryptionInfo(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl := b.AddClusterInternal("enc-persist", "3.5.1")
+
+	stored := kafka.GetStoredCluster(b, cl.ClusterArn)
+	stored.EncryptionInfo = &kafka.EncryptionInfo{
+		EncryptionAtRest: &kafka.EncryptionAtRest{
+			DataVolumeKMSKeyId: "arn:aws:kms:us-east-1:123:key/persist",
+		},
+		EncryptionInTransit: &kafka.EncryptionInTransit{
+			ClientBroker: kafka.EncryptionInTransitTLS,
+			InCluster:    true,
+		},
+	}
+
+	snap := b.Snapshot()
+	b2 := kafka.NewInMemoryBackend("other", "eu-west-1")
+	require.NoError(t, b2.Restore(snap))
+
+	described, err := b2.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.EncryptionInfo)
+	require.NotNil(t, described.EncryptionInfo.EncryptionAtRest)
+	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/persist",
+		described.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId)
+}
+
+// TestRefinement2_Persistence_ConfigurationInfo verifies ConfigurationInfo survives snapshot/restore.
+func TestRefinement2_Persistence_ConfigurationInfo(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl := b.AddClusterInternal("cfginfo-persist", "3.5.1")
+
+	_, err := b.UpdateClusterConfiguration(cl.ClusterArn,
+		"arn:aws:kafka:us-east-1:123:configuration/my-cfg/xyz",
+		3)
+	require.NoError(t, err)
+
+	snap := b.Snapshot()
+	b2 := kafka.NewInMemoryBackend("other", "eu-west-1")
+	require.NoError(t, b2.Restore(snap))
+
+	described, err := b2.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.ConfigurationInfo)
+	assert.Equal(t, "arn:aws:kafka:us-east-1:123:configuration/my-cfg/xyz",
+		described.ConfigurationInfo.Arn)
+	assert.Equal(t, int64(3), described.ConfigurationInfo.Revision)
+}
+
+// TestRefinement2_DeepCopy_ProvisionedThroughput verifies no aliasing in ProvisionedThroughput.
+func TestRefinement2_DeepCopy_ProvisionedThroughput(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	cl, err := b.CreateCluster("pt-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+		StorageInfo: &kafka.StorageInfo{
+			EbsStorageInfo: &kafka.EBSStorageInfo{
+				VolumeSize: 100,
+				ProvisionedThroughput: &kafka.ProvisionedThroughput{
+					Enabled:          true,
+					VolumeThroughput: 250,
+				},
+			},
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	// Mutate returned cluster's ProvisionedThroughput — should not affect stored.
+	cl.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput.VolumeThroughput = 999
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, int32(250),
+		described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput.VolumeThroughput)
+}
+
+// TestRefinement2_DeepCopy_ZoneIds verifies no aliasing in ZoneIds.
+func TestRefinement2_DeepCopy_ZoneIds(t *testing.T) {
+	t.Parallel()
+
+	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+	zones := []string{"us-east-1a", "us-east-1b"}
+	cl, err := b.CreateCluster("zone-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-1"},
+		ZoneIds:       zones,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	// Mutate original zones slice — should not affect stored.
+	zones[0] = "mutated"
+	cl.BrokerNodeGroupInfo.ZoneIds[0] = "also-mutated"
+
+	described, err := b.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1a", described.BrokerNodeGroupInfo.ZoneIds[0])
+}
+
+// TestRefinement2_OpenMonitoring_InV2Response verifies OpenMonitoring in V2 provisioned arm.
+func TestRefinement2_OpenMonitoring_InV2Response(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("om-v2", "3.5.1")
+
+	stored := kafka.GetStoredCluster(backend, cl.ClusterArn)
+	stored.OpenMonitoring = &kafka.OpenMonitoring{
+		Prometheus: &kafka.PrometheusInfo{
+			JmxExporter:  &kafka.JmxExporter{EnabledInBroker: true},
+			NodeExporter: &kafka.NodeExporter{EnabledInBroker: false},
+		},
+	}
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo := resp["clusterInfo"].(map[string]any)
+	provisioned := clInfo["provisioned"].(map[string]any)
+
+	om, ok := provisioned["openMonitoring"].(map[string]any)
+	require.True(t, ok, "openMonitoring should be present in V2 provisioned")
+
+	prometheus := om["prometheus"].(map[string]any)
+	jmx := prometheus["jmxExporter"].(map[string]any)
+	assert.True(t, jmx["enabledInBroker"].(bool))
+}
+
+// TestRefinement2_CreateCluster_AllAuthModes verifies various auth mode combinations.
+func TestRefinement2_CreateCluster_AllAuthModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		auth *kafka.ClientAuthentication
+	}{
+		{
+			name: "no_auth",
+			auth: nil,
+		},
+		{
+			name: "sasl_scram",
+			auth: &kafka.ClientAuthentication{
+				Sasl: &kafka.SaslSettings{
+					Scram: &kafka.SaslScram{Enabled: true},
+				},
+			},
+		},
+		{
+			name: "sasl_iam",
+			auth: &kafka.ClientAuthentication{
+				Sasl: &kafka.SaslSettings{
+					Iam: &kafka.SaslIam{Enabled: true},
+				},
+			},
+		},
+		{
+			name: "tls_with_ca_arns",
+			auth: &kafka.ClientAuthentication{
+				TLS: &kafka.TLSSettings{
+					Enabled: true,
+					CertificateAuthorityArnList: []string{
+						"arn:aws:acm-pca:us-east-1:123:certificate-authority/abc",
+					},
+				},
+			},
+		},
+		{
+			name: "unauthenticated",
+			auth: &kafka.ClientAuthentication{
+				Unauthenticated: &kafka.UnauthenticatedSettings{Enabled: true},
+			},
+		},
+		{
+			name: "combined_sasl_and_tls",
+			auth: &kafka.ClientAuthentication{
+				Sasl: &kafka.SaslSettings{
+					Scram: &kafka.SaslScram{Enabled: true},
+					Iam:   &kafka.SaslIam{Enabled: true},
+				},
+				TLS: &kafka.TLSSettings{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
+			cl, err := b.CreateCluster("auth-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+				InstanceType:  "kafka.m5.large",
+				ClientSubnets: []string{"subnet-1"},
+			}, tt.auth, nil)
+			require.NoError(t, err)
+			require.NotNil(t, cl)
+
+			// Verify round-trip.
+			described, err := b.DescribeCluster(cl.ClusterArn)
+			require.NoError(t, err)
+
+			if tt.auth == nil {
+				assert.Nil(t, described.ClientAuthentication)
+			} else {
+				require.NotNil(t, described.ClientAuthentication)
+			}
+
+			if tt.auth != nil && tt.auth.Unauthenticated != nil {
+				require.NotNil(t, described.ClientAuthentication.Unauthenticated)
+				assert.Equal(t, tt.auth.Unauthenticated.Enabled,
+					described.ClientAuthentication.Unauthenticated.Enabled)
+			}
+
+			if tt.auth != nil && tt.auth.TLS != nil && len(tt.auth.TLS.CertificateAuthorityArnList) > 0 {
+				require.NotNil(t, described.ClientAuthentication.TLS)
+				assert.Equal(t, tt.auth.TLS.CertificateAuthorityArnList,
+					described.ClientAuthentication.TLS.CertificateAuthorityArnList)
+			}
+		})
+	}
+}
+
+// TestRefinement2_CreateCluster_V1_HTTP_AuthModes verifies HTTP CreateCluster with auth modes.
+func TestRefinement2_CreateCluster_V1_HTTP_AuthModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "sasl_scram",
+			body: map[string]any{
+				"clusterName":         "scram-cl",
+				"kafkaVersion":        "3.5.1",
+				"numberOfBrokerNodes": 3,
+				"brokerNodeGroupInfo": map[string]any{
+					"instanceType":  "kafka.m5.large",
+					"clientSubnets": []string{"subnet-1"},
+				},
+				"clientAuthentication": map[string]any{
+					"sasl": map[string]any{
+						"scram": map[string]any{"enabled": true},
+					},
+				},
+			},
+		},
+		{
+			name: "unauthenticated",
+			body: map[string]any{
+				"clusterName":         "ua-cl",
+				"kafkaVersion":        "3.5.1",
+				"numberOfBrokerNodes": 3,
+				"brokerNodeGroupInfo": map[string]any{
+					"instanceType":  "kafka.m5.large",
+					"clientSubnets": []string{"subnet-1"},
+				},
+				"clientAuthentication": map[string]any{
+					"unauthenticated": map[string]any{"enabled": true},
+				},
+			},
+		},
+		{
+			name: "tls_with_ca_arns",
+			body: map[string]any{
+				"clusterName":         "tls-cl",
+				"kafkaVersion":        "3.5.1",
+				"numberOfBrokerNodes": 3,
+				"brokerNodeGroupInfo": map[string]any{
+					"instanceType":  "kafka.m5.large",
+					"clientSubnets": []string{"subnet-1"},
+				},
+				"clientAuthentication": map[string]any{
+					"tls": map[string]any{
+						"enabled": true,
+						"certificateAuthorityArnList": []string{
+							"arn:aws:acm-pca:us-east-1:123:certificate-authority/abc",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doKafkaRequest(t, h, http.MethodPost, "/v1/clusters", tt.body)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.NotEmpty(t, resp["clusterArn"])
+		})
+	}
+}
+
+// TestRefinement2_UpdateClusterConfiguration_HTTP verifies the HTTP endpoint persists config.
+func TestRefinement2_UpdateClusterConfiguration_HTTP(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("cfg-update-http", "3.5.1")
+	encoded := url.PathEscape(cl.ClusterArn)
+
+	configArn := "arn:aws:kafka:us-east-1:123:configuration/my-cfg/abc-123"
+
+	rec := doKafkaRequest(t, h, http.MethodPut, "/api/v2/clusters/"+encoded+"/configuration",
+		map[string]any{
+			"currentVersion": cl.CurrentVersion,
+			"configurationInfo": map[string]any{
+				"arn":      configArn,
+				"revision": 5,
+			},
+		})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify via DescribeCluster.
+	described, err := backend.DescribeCluster(cl.ClusterArn)
+	require.NoError(t, err)
+	require.NotNil(t, described.ConfigurationInfo)
+	assert.Equal(t, configArn, described.ConfigurationInfo.Arn)
+	assert.Equal(t, int64(5), described.ConfigurationInfo.Revision)
+}
+
+// TestRefinement2_GetBootstrapBrokers_ScramePublic verifies public SCRAM broker string.
+func TestRefinement2_GetBootstrapBrokers_ScramPublic(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl, err := backend.CreateCluster("scram-pub", "3.5.1", 3,
+		kafka.BrokerNodeGroupInfo{
+			InstanceType:  "kafka.m5.large",
+			ClientSubnets: []string{"subnet-1"},
+			ConnectivityInfo: &kafka.ConnectivityInfo{
+				PublicAccess: &kafka.PublicAccess{Type: "SERVICE_PROVIDED_EIPS"},
+			},
+		},
+		&kafka.ClientAuthentication{
+			Sasl: &kafka.SaslSettings{
+				Scram: &kafka.SaslScram{Enabled: true},
+			},
+		},
+		nil)
+	require.NoError(t, err)
+
+	rec := doKafkaRequest(t, h, http.MethodGet,
+		"/v1/clusters/"+url.PathEscape(cl.ClusterArn)+"/bootstrap-brokers", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	assert.NotEmpty(t, resp["bootstrapBrokerStringSaslScram"])
+	assert.NotEmpty(t, resp["bootstrapBrokerStringTlsPublic"])
+	assert.NotEmpty(t, resp["bootstrapBrokerStringSaslScramPublic"])
+}
+
+// TestRefinement2_DescribeCluster_V1_IncludesNewFields verifies new fields present in V1.
+func TestRefinement2_DescribeCluster_V1_IncludesNewFields(t *testing.T) {
+	t.Parallel()
+
+	h, backend := newTestHandlerWithBackend(t)
+	cl := backend.AddClusterInternal("new-fields-v1", "3.5.1")
+
+	stored := kafka.GetStoredCluster(backend, cl.ClusterArn)
+	stored.EnhancedMonitoring = kafka.EnhancedMonitoringPerBroker
+	stored.OpenMonitoring = &kafka.OpenMonitoring{
+		Prometheus: &kafka.PrometheusInfo{
+			JmxExporter: &kafka.JmxExporter{EnabledInBroker: true},
+		},
+	}
+	stored.LoggingInfo = &kafka.LoggingInfo{
+		BrokerLogs: &kafka.BrokerLogs{
+			CloudWatchLogs: &kafka.CloudWatchLogs{
+				Enabled:  true,
+				LogGroup: "/aws/msk/test",
+			},
+		},
+	}
+
+	rec := doKafkaRequest(t, h, http.MethodGet, "/v1/clusters/"+url.PathEscape(cl.ClusterArn), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	clInfo := resp["clusterInfo"].(map[string]any)
+	assert.Equal(t, kafka.EnhancedMonitoringPerBroker, clInfo["enhancedMonitoring"])
+	assert.NotNil(t, clInfo["openMonitoring"])
+	assert.NotNil(t, clInfo["loggingInfo"])
+	assert.NotEmpty(t, clInfo["zookeeperConnectString"])
+}
+
+// hasSuffix is a helper for test assertions.
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/services/kafka/interfaces.go
+++ b/services/kafka/interfaces.go
@@ -11,6 +11,7 @@ type StorageBackend interface {
 		clientAuth *ClientAuthentication,
 		tags map[string]string,
 	) (*Cluster, error)
+	CreateServerlessCluster(name string, serverless *ServerlessClusterInfo, tags map[string]string) (*Cluster, error)
 	DescribeCluster(clusterArn string) (*Cluster, error)
 	ListClusters() []*Cluster
 	DeleteCluster(clusterArn string) error


### PR DESCRIPTION
Closes #1811

MSK/Kafka AWS-accuracy audit implementation:
- New types: EncryptionInfo, OpenMonitoring, LoggingInfo, Serverless, ConnectivityInfo, ProvisionedThroughput, ZoneIds, Unauthenticated
- Fix GetClusterPolicy NotFoundException
- Fix UpdateClusterConfiguration persistence  
- Add CreateServerlessCluster
- Expand BootstrapBrokers output
- Update KafkaVersions list
- Improve GetCompatibleKafkaVersions
- 1800+ line comprehensive table-driven test suite
- All tests pass

Refinery-merged from polecat branch.