### PR TITLE
feat(dms): AWS-accuracy audit parity (go-qlyu)

### DIFF
--- a/services/dms/backend.go
+++ b/services/dms/backend.go
@@ -684,6 +684,7 @@ func (b *InMemoryBackend) DeleteReplicationTask(arnOrID string) (*ReplicationTas
 		rt.Tags.Close()
 		delete(b.replicationTasksByARN, rt.ReplicationTaskArn)
 		delete(b.replicationTasks, id)
+
 		return &cp, nil
 	}
 

--- a/services/dms/backend.go
+++ b/services/dms/backend.go
@@ -14,10 +14,12 @@ import (
 )
 
 const (
-	statusActive  = "active"
-	statusReady   = "ready"
-	statusRunning = "running"
-	statusStopped = "stopped"
+	statusActive         = "active"
+	statusReady          = "ready"
+	statusRunning        = "running"
+	statusStopped        = "stopped"
+	statusAvailable      = "available"
+	defaultEngineVersion = "3.5.3"
 )
 
 var (
@@ -293,18 +295,21 @@ func (b *InMemoryBackend) AccountID() string { return b.accountID }
 // mustDescribeReplicationInstances returns all replication instances without error (for internal use).
 func (b *InMemoryBackend) mustDescribeReplicationInstances() []*ReplicationInstance {
 	list, _ := b.DescribeReplicationInstances("")
+
 	return list
 }
 
 // mustDescribeEndpoints returns all endpoints without error (for internal use).
 func (b *InMemoryBackend) mustDescribeEndpoints() []*Endpoint {
 	list, _ := b.DescribeEndpoints("")
+
 	return list
 }
 
 // mustDescribeReplicationTasks returns all replication tasks without error (for internal use).
 func (b *InMemoryBackend) mustDescribeReplicationTasks() []*ReplicationTask {
 	list, _ := b.DescribeReplicationTasks("")
+
 	return list
 }
 
@@ -336,7 +341,7 @@ func (b *InMemoryBackend) CreateReplicationInstance(
 	}
 
 	if engineVersion == "" {
-		engineVersion = "3.5.3"
+		engineVersion = defaultEngineVersion
 	}
 
 	if allocatedStorage == 0 {
@@ -353,7 +358,7 @@ func (b *InMemoryBackend) CreateReplicationInstance(
 		MultiAZ:                       multiAZ,
 		AutoMinorVersionUpgrade:       autoMinorVersionUpgrade,
 		PubliclyAccessible:            publiclyAccessible,
-		ReplicationInstanceStatus:     "available",
+		ReplicationInstanceStatus:     statusAvailable,
 		AccountID:                     b.accountID,
 		Region:                        b.region,
 		CreationTime:                  time.Now().UTC(),
@@ -421,6 +426,7 @@ func (b *InMemoryBackend) DeleteReplicationInstance(arnOrID string) error {
 		ri.Tags.Close()
 		delete(b.replicationInstancesByARN, ri.ReplicationInstanceArn)
 		delete(b.replicationInstances, id)
+
 		return nil
 	}
 
@@ -1135,8 +1141,8 @@ func (b *InMemoryBackend) AddReplicationInstanceInternal(identifier, class strin
 		ReplicationInstanceIdentifier: identifier,
 		ReplicationInstanceArn:        instanceARN,
 		ReplicationInstanceClass:      class,
-		EngineVersion:                 "3.5.3",
-		ReplicationInstanceStatus:     "available",
+		EngineVersion:                 defaultEngineVersion,
+		ReplicationInstanceStatus:     statusAvailable,
 		AllocatedStorage:              defaultAllocatedStorage,
 		AccountID:                     b.accountID,
 		Region:                        b.region,

--- a/services/dms/backend.go
+++ b/services/dms/backend.go
@@ -183,6 +183,7 @@ type Certificate struct {
 
 // ReplicationSubnetGroup represents a DMS replication subnet group.
 type ReplicationSubnetGroup struct {
+	Tags                              *tags.Tags `json:"-"`
 	ReplicationSubnetGroupIdentifier  string
 	ReplicationSubnetGroupArn         string
 	ReplicationSubnetGroupDescription string
@@ -193,6 +194,7 @@ type ReplicationSubnetGroup struct {
 
 // MigrationProject represents a DMS migration project.
 type MigrationProject struct {
+	Tags                       *tags.Tags `json:"-"`
 	MigrationProjectName       string
 	MigrationProjectArn        string
 	MigrationProjectIdentifier string
@@ -203,6 +205,7 @@ type MigrationProject struct {
 
 // ReplicationConfig represents a DMS replication config.
 type ReplicationConfig struct {
+	Tags                        *tags.Tags `json:"-"`
 	ReplicationConfigIdentifier string
 	ReplicationConfigArn        string
 	ReplicationType             string
@@ -212,58 +215,97 @@ type ReplicationConfig struct {
 	Region                      string
 }
 
+// Connection represents a DMS connection between a replication instance and an endpoint.
+type Connection struct {
+	ReplicationInstanceArn        string
+	ReplicationInstanceIdentifier string
+	EndpointArn                   string
+	EndpointIdentifier            string
+	Status                        string
+	LastFailureMessage            string
+}
+
 // InMemoryBackend is the in-memory store for AWS DMS resources.
 type InMemoryBackend struct {
-	replicationInstances      map[string]*ReplicationInstance
-	endpoints                 map[string]*Endpoint
-	replicationTasks          map[string]*ReplicationTask
-	dataMigrations            map[string]*DataMigration
-	dataProviders             map[string]*DataProvider
-	eventSubscriptions        map[string]*EventSubscription
-	fleetAdvisorCollectors    map[string]*FleetAdvisorCollector
-	instanceProfiles          map[string]*InstanceProfile
-	replicationInstancesByARN map[string]*ReplicationInstance
-	endpointsByARN            map[string]*Endpoint
-	replicationTasksByARN     map[string]*ReplicationTask
-	dataMigrationsByARN       map[string]*DataMigration
-	dataProvidersByARN        map[string]*DataProvider
-	instanceProfilesByARN     map[string]*InstanceProfile
-	certificates              map[string]*Certificate
-	replicationSubnetGroups   map[string]*ReplicationSubnetGroup
-	migrationProjects         map[string]*MigrationProject
-	replicationConfigs        map[string]*ReplicationConfig
-	mu                        *lockmetrics.RWMutex
-	accountID                 string
-	region                    string
-	paginationSecret          string
+	replicationInstances         map[string]*ReplicationInstance
+	endpoints                    map[string]*Endpoint
+	replicationTasks             map[string]*ReplicationTask
+	dataMigrations               map[string]*DataMigration
+	dataProviders                map[string]*DataProvider
+	eventSubscriptions           map[string]*EventSubscription
+	fleetAdvisorCollectors       map[string]*FleetAdvisorCollector
+	instanceProfiles             map[string]*InstanceProfile
+	replicationInstancesByARN    map[string]*ReplicationInstance
+	endpointsByARN               map[string]*Endpoint
+	replicationTasksByARN        map[string]*ReplicationTask
+	dataMigrationsByARN          map[string]*DataMigration
+	dataProvidersByARN           map[string]*DataProvider
+	instanceProfilesByARN        map[string]*InstanceProfile
+	certificates                 map[string]*Certificate
+	replicationSubnetGroups      map[string]*ReplicationSubnetGroup
+	replicationSubnetGroupsByARN map[string]*ReplicationSubnetGroup
+	migrationProjects            map[string]*MigrationProject
+	migrationProjectsByARN       map[string]*MigrationProject
+	replicationConfigs           map[string]*ReplicationConfig
+	replicationConfigsByARN      map[string]*ReplicationConfig
+	connections                  map[string]*Connection // key: "riArn:epArn"
+	mu                           *lockmetrics.RWMutex
+	accountID                    string
+	region                       string
+	paginationSecret             string
 }
 
 // NewInMemoryBackend creates a new in-memory DMS backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		replicationInstances:      make(map[string]*ReplicationInstance),
-		endpoints:                 make(map[string]*Endpoint),
-		replicationTasks:          make(map[string]*ReplicationTask),
-		dataMigrations:            make(map[string]*DataMigration),
-		dataProviders:             make(map[string]*DataProvider),
-		eventSubscriptions:        make(map[string]*EventSubscription),
-		fleetAdvisorCollectors:    make(map[string]*FleetAdvisorCollector),
-		instanceProfiles:          make(map[string]*InstanceProfile),
-		replicationInstancesByARN: make(map[string]*ReplicationInstance),
-		endpointsByARN:            make(map[string]*Endpoint),
-		replicationTasksByARN:     make(map[string]*ReplicationTask),
-		dataMigrationsByARN:       make(map[string]*DataMigration),
-		dataProvidersByARN:        make(map[string]*DataProvider),
-		instanceProfilesByARN:     make(map[string]*InstanceProfile),
-		certificates:              make(map[string]*Certificate),
-		replicationSubnetGroups:   make(map[string]*ReplicationSubnetGroup),
-		migrationProjects:         make(map[string]*MigrationProject),
-		replicationConfigs:        make(map[string]*ReplicationConfig),
-		accountID:                 accountID,
-		region:                    region,
-		paginationSecret:          uuid.NewString(),
-		mu:                        lockmetrics.New("dms"),
+		replicationInstances:         make(map[string]*ReplicationInstance),
+		endpoints:                    make(map[string]*Endpoint),
+		replicationTasks:             make(map[string]*ReplicationTask),
+		dataMigrations:               make(map[string]*DataMigration),
+		dataProviders:                make(map[string]*DataProvider),
+		eventSubscriptions:           make(map[string]*EventSubscription),
+		fleetAdvisorCollectors:       make(map[string]*FleetAdvisorCollector),
+		instanceProfiles:             make(map[string]*InstanceProfile),
+		replicationInstancesByARN:    make(map[string]*ReplicationInstance),
+		endpointsByARN:               make(map[string]*Endpoint),
+		replicationTasksByARN:        make(map[string]*ReplicationTask),
+		dataMigrationsByARN:          make(map[string]*DataMigration),
+		dataProvidersByARN:           make(map[string]*DataProvider),
+		instanceProfilesByARN:        make(map[string]*InstanceProfile),
+		certificates:                 make(map[string]*Certificate),
+		replicationSubnetGroups:      make(map[string]*ReplicationSubnetGroup),
+		replicationSubnetGroupsByARN: make(map[string]*ReplicationSubnetGroup),
+		migrationProjects:            make(map[string]*MigrationProject),
+		migrationProjectsByARN:       make(map[string]*MigrationProject),
+		replicationConfigs:           make(map[string]*ReplicationConfig),
+		replicationConfigsByARN:      make(map[string]*ReplicationConfig),
+		connections:                  make(map[string]*Connection),
+		accountID:                    accountID,
+		region:                       region,
+		paginationSecret:             uuid.NewString(),
+		mu:                           lockmetrics.New("dms"),
 	}
+}
+
+// AccountID returns the AWS account ID this backend is configured for.
+func (b *InMemoryBackend) AccountID() string { return b.accountID }
+
+// mustDescribeReplicationInstances returns all replication instances without error (for internal use).
+func (b *InMemoryBackend) mustDescribeReplicationInstances() []*ReplicationInstance {
+	list, _ := b.DescribeReplicationInstances("")
+	return list
+}
+
+// mustDescribeEndpoints returns all endpoints without error (for internal use).
+func (b *InMemoryBackend) mustDescribeEndpoints() []*Endpoint {
+	list, _ := b.DescribeEndpoints("")
+	return list
+}
+
+// mustDescribeReplicationTasks returns all replication tasks without error (for internal use).
+func (b *InMemoryBackend) mustDescribeReplicationTasks() []*ReplicationTask {
+	list, _ := b.DescribeReplicationTasks("")
+	return list
 }
 
 // Region returns the AWS region this backend is configured for.
@@ -360,26 +402,36 @@ func (b *InMemoryBackend) DescribeReplicationInstances(
 }
 
 // DeleteReplicationInstance deletes a replication instance by ARN or identifier.
+// AWS requires all replication tasks on the instance to be deleted first.
 func (b *InMemoryBackend) DeleteReplicationInstance(arnOrID string) error {
 	b.mu.Lock("DeleteReplicationInstance")
 	defer b.mu.Unlock()
 
-	// Try by identifier first.
-	if ri, ok := b.replicationInstances[arnOrID]; ok {
+	deleteInstance := func(ri *ReplicationInstance, id string) error {
+		// Check for tasks attached to this instance.
+		for _, rt := range b.replicationTasks {
+			if rt.ReplicationInstanceArn == ri.ReplicationInstanceArn {
+				return fmt.Errorf(
+					"%w: replication instance %s has tasks attached; delete all tasks first",
+					ErrInvalidState,
+					arnOrID,
+				)
+			}
+		}
 		ri.Tags.Close()
 		delete(b.replicationInstancesByARN, ri.ReplicationInstanceArn)
-		delete(b.replicationInstances, arnOrID)
-
+		delete(b.replicationInstances, id)
 		return nil
+	}
+
+	// Try by identifier first.
+	if ri, ok := b.replicationInstances[arnOrID]; ok {
+		return deleteInstance(ri, arnOrID)
 	}
 	// Try by ARN.
 	for id, ri := range b.replicationInstances {
 		if ri.ReplicationInstanceArn == arnOrID {
-			ri.Tags.Close()
-			delete(b.replicationInstancesByARN, arnOrID)
-			delete(b.replicationInstances, id)
-
-			return nil
+			return deleteInstance(ri, id)
 		}
 	}
 
@@ -609,28 +661,34 @@ func (b *InMemoryBackend) StopReplicationTask(arnOrID string) (*ReplicationTask,
 }
 
 // DeleteReplicationTask deletes a replication task by ARN or identifier.
+// AWS does not allow deleting a task while it is running.
 func (b *InMemoryBackend) DeleteReplicationTask(arnOrID string) (*ReplicationTask, error) {
 	b.mu.Lock("DeleteReplicationTask")
 	defer b.mu.Unlock()
 
-	// Try by identifier first.
-	if rt, ok := b.replicationTasks[arnOrID]; ok {
+	deleteTask := func(rt *ReplicationTask, id string) (*ReplicationTask, error) {
+		if rt.Status == statusRunning {
+			return nil, fmt.Errorf(
+				"%w: replication task %s cannot be deleted while running; stop it first",
+				ErrInvalidState,
+				arnOrID,
+			)
+		}
 		cp := *rt
 		rt.Tags.Close()
 		delete(b.replicationTasksByARN, rt.ReplicationTaskArn)
-		delete(b.replicationTasks, arnOrID)
-
+		delete(b.replicationTasks, id)
 		return &cp, nil
+	}
+
+	// Try by identifier first.
+	if rt, ok := b.replicationTasks[arnOrID]; ok {
+		return deleteTask(rt, arnOrID)
 	}
 	// Try by ARN.
 	for id, rt := range b.replicationTasks {
 		if rt.ReplicationTaskArn == arnOrID {
-			cp := *rt
-			rt.Tags.Close()
-			delete(b.replicationTasksByARN, arnOrID)
-			delete(b.replicationTasks, id)
-
-			return &cp, nil
+			return deleteTask(rt, id)
 		}
 	}
 
@@ -1037,6 +1095,16 @@ func (b *InMemoryBackend) Reset() {
 	b.replicationInstancesByARN = make(map[string]*ReplicationInstance)
 	b.endpoints = make(map[string]*Endpoint)
 	b.endpointsByARN = make(map[string]*Endpoint)
+	for _, mp := range b.migrationProjects {
+		mp.Tags.Close()
+	}
+	for _, sg := range b.replicationSubnetGroups {
+		sg.Tags.Close()
+	}
+	for _, rc := range b.replicationConfigs {
+		rc.Tags.Close()
+	}
+
 	b.replicationTasks = make(map[string]*ReplicationTask)
 	b.replicationTasksByARN = make(map[string]*ReplicationTask)
 	b.dataMigrations = make(map[string]*DataMigration)
@@ -1049,8 +1117,12 @@ func (b *InMemoryBackend) Reset() {
 	b.instanceProfilesByARN = make(map[string]*InstanceProfile)
 	b.certificates = make(map[string]*Certificate)
 	b.replicationSubnetGroups = make(map[string]*ReplicationSubnetGroup)
+	b.replicationSubnetGroupsByARN = make(map[string]*ReplicationSubnetGroup)
 	b.migrationProjects = make(map[string]*MigrationProject)
+	b.migrationProjectsByARN = make(map[string]*MigrationProject)
 	b.replicationConfigs = make(map[string]*ReplicationConfig)
+	b.replicationConfigsByARN = make(map[string]*ReplicationConfig)
+	b.connections = make(map[string]*Connection)
 }
 
 // AddReplicationInstanceInternal seeds a replication instance directly without HTTP.
@@ -1329,6 +1401,7 @@ func (b *InMemoryBackend) findReplicationInstance(arnOrID string) *ReplicationIn
 }
 
 // ModifyReplicationTask updates task settings.
+// AWS does not allow modifying a running task.
 func (b *InMemoryBackend) ModifyReplicationTask(
 	arnOrID, migrationType, tableMappings, replicationTaskSettings string,
 ) (*ReplicationTask, error) {
@@ -1338,6 +1411,14 @@ func (b *InMemoryBackend) ModifyReplicationTask(
 	rt := b.findTask(arnOrID)
 	if rt == nil {
 		return nil, fmt.Errorf("%w: replication task %s not found", ErrNotFound, arnOrID)
+	}
+
+	if rt.Status == statusRunning {
+		return nil, fmt.Errorf(
+			"%w: replication task %s cannot be modified while running; stop it first",
+			ErrInvalidState,
+			arnOrID,
+		)
 	}
 
 	if migrationType != "" {
@@ -1507,6 +1588,18 @@ func (b *InMemoryBackend) findResourceTags(resourceArn string) *tags.Tags {
 
 	if ip, ok := b.instanceProfilesByARN[resourceArn]; ok {
 		return ip.Tags
+	}
+
+	if mp, ok := b.migrationProjectsByARN[resourceArn]; ok {
+		return mp.Tags
+	}
+
+	if sg, ok := b.replicationSubnetGroupsByARN[resourceArn]; ok {
+		return sg.Tags
+	}
+
+	if rc, ok := b.replicationConfigsByARN[resourceArn]; ok {
+		return rc.Tags
 	}
 
 	return nil
@@ -1745,24 +1838,57 @@ func (b *InMemoryBackend) MoveReplicationTask(
 	return &cp, nil
 }
 
-// TestConnection tests a DMS connection (always succeeds in memory).
-func (b *InMemoryBackend) TestConnection(replicationInstanceArn, endpointArn string) error {
-	b.mu.RLock("TestConnection")
-	defer b.mu.RUnlock()
+// TestConnection tests a DMS connection and records the result.
+func (b *InMemoryBackend) TestConnection(replicationInstanceArn, endpointArn string) (*Connection, error) {
+	b.mu.Lock("TestConnection")
+	defer b.mu.Unlock()
 
-	if _, ok := b.replicationInstancesByARN[replicationInstanceArn]; !ok {
-		return fmt.Errorf(
+	ri, ok := b.replicationInstancesByARN[replicationInstanceArn]
+	if !ok {
+		return nil, fmt.Errorf(
 			"%w: replication instance %s not found",
 			ErrNotFound,
 			replicationInstanceArn,
 		)
 	}
 
-	if _, ok := b.endpointsByARN[endpointArn]; !ok {
-		return fmt.Errorf("%w: endpoint %s not found", ErrNotFound, endpointArn)
+	ep, ok := b.endpointsByARN[endpointArn]
+	if !ok {
+		return nil, fmt.Errorf("%w: endpoint %s not found", ErrNotFound, endpointArn)
 	}
 
-	return nil
+	key := replicationInstanceArn + ":" + endpointArn
+	conn := &Connection{
+		ReplicationInstanceArn:        replicationInstanceArn,
+		ReplicationInstanceIdentifier: ri.ReplicationInstanceIdentifier,
+		EndpointArn:                   endpointArn,
+		EndpointIdentifier:            ep.EndpointIdentifier,
+		Status:                        "successful",
+	}
+	b.connections[key] = conn
+	cp := *conn
+
+	return &cp, nil
+}
+
+// DescribeConnections returns stored connections, optionally filtered by replication instance ARN or endpoint ARN.
+func (b *InMemoryBackend) DescribeConnections(replicationInstanceArn, endpointArn string) ([]*Connection, error) {
+	b.mu.RLock("DescribeConnections")
+	defer b.mu.RUnlock()
+
+	list := make([]*Connection, 0, len(b.connections))
+	for _, conn := range b.connections {
+		if replicationInstanceArn != "" && conn.ReplicationInstanceArn != replicationInstanceArn {
+			continue
+		}
+		if endpointArn != "" && conn.EndpointArn != endpointArn {
+			continue
+		}
+		cp := *conn
+		list = append(list, &cp)
+	}
+
+	return list, nil
 }
 
 // ImportCertificate creates a certificate record.
@@ -1815,6 +1941,7 @@ func (b *InMemoryBackend) DeleteCertificate(identifierOrArn string) (*Certificat
 // CreateMigrationProject creates a migration project.
 func (b *InMemoryBackend) CreateMigrationProject(
 	name, description string,
+	kv map[string]string,
 ) (*MigrationProject, error) {
 	b.mu.Lock("CreateMigrationProject")
 	defer b.mu.Unlock()
@@ -1824,6 +1951,10 @@ func (b *InMemoryBackend) CreateMigrationProject(
 	}
 
 	projectARN := arn.Build("dms", b.region, b.accountID, "migration-project:"+uuid.NewString())
+	t := tags.New("dms.migration-project." + name + ".tags")
+	if len(kv) > 0 {
+		t.Merge(kv)
+	}
 	mp := &MigrationProject{
 		MigrationProjectName:       name,
 		MigrationProjectArn:        projectARN,
@@ -1831,8 +1962,10 @@ func (b *InMemoryBackend) CreateMigrationProject(
 		Description:                description,
 		AccountID:                  b.accountID,
 		Region:                     b.region,
+		Tags:                       t,
 	}
 	b.migrationProjects[name] = mp
+	b.migrationProjectsByARN[projectARN] = mp
 	cp := *mp
 
 	return &cp, nil
@@ -1843,7 +1976,9 @@ func (b *InMemoryBackend) DeleteMigrationProject(nameOrArn string) error {
 	b.mu.Lock("DeleteMigrationProject")
 	defer b.mu.Unlock()
 
-	if _, ok := b.migrationProjects[nameOrArn]; ok {
+	if mp, ok := b.migrationProjects[nameOrArn]; ok {
+		mp.Tags.Close()
+		delete(b.migrationProjectsByARN, mp.MigrationProjectArn)
 		delete(b.migrationProjects, nameOrArn)
 
 		return nil
@@ -1851,6 +1986,8 @@ func (b *InMemoryBackend) DeleteMigrationProject(nameOrArn string) error {
 
 	for name, mp := range b.migrationProjects {
 		if mp.MigrationProjectArn == nameOrArn {
+			mp.Tags.Close()
+			delete(b.migrationProjectsByARN, nameOrArn)
 			delete(b.migrationProjects, name)
 
 			return nil
@@ -1863,6 +2000,7 @@ func (b *InMemoryBackend) DeleteMigrationProject(nameOrArn string) error {
 // CreateReplicationSubnetGroup creates a subnet group.
 func (b *InMemoryBackend) CreateReplicationSubnetGroup(
 	identifier, description, vpcID string,
+	kv map[string]string,
 ) (*ReplicationSubnetGroup, error) {
 	b.mu.Lock("CreateReplicationSubnetGroup")
 	defer b.mu.Unlock()
@@ -1876,6 +2014,10 @@ func (b *InMemoryBackend) CreateReplicationSubnetGroup(
 	}
 
 	sgARN := arn.Build("dms", b.region, b.accountID, "subgrp:"+identifier)
+	t := tags.New("dms.replication-subnet-group." + identifier + ".tags")
+	if len(kv) > 0 {
+		t.Merge(kv)
+	}
 	sg := &ReplicationSubnetGroup{
 		ReplicationSubnetGroupIdentifier:  identifier,
 		ReplicationSubnetGroupArn:         sgARN,
@@ -1883,8 +2025,10 @@ func (b *InMemoryBackend) CreateReplicationSubnetGroup(
 		VpcID:                             vpcID,
 		AccountID:                         b.accountID,
 		Region:                            b.region,
+		Tags:                              t,
 	}
 	b.replicationSubnetGroups[identifier] = sg
+	b.replicationSubnetGroupsByARN[sgARN] = sg
 	cp := *sg
 
 	return &cp, nil
@@ -1895,7 +2039,9 @@ func (b *InMemoryBackend) DeleteReplicationSubnetGroup(identifierOrArn string) e
 	b.mu.Lock("DeleteReplicationSubnetGroup")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicationSubnetGroups[identifierOrArn]; ok {
+	if sg, ok := b.replicationSubnetGroups[identifierOrArn]; ok {
+		sg.Tags.Close()
+		delete(b.replicationSubnetGroupsByARN, sg.ReplicationSubnetGroupArn)
 		delete(b.replicationSubnetGroups, identifierOrArn)
 
 		return nil
@@ -1903,6 +2049,8 @@ func (b *InMemoryBackend) DeleteReplicationSubnetGroup(identifierOrArn string) e
 
 	for id, sg := range b.replicationSubnetGroups {
 		if sg.ReplicationSubnetGroupArn == identifierOrArn {
+			sg.Tags.Close()
+			delete(b.replicationSubnetGroupsByARN, identifierOrArn)
 			delete(b.replicationSubnetGroups, id)
 
 			return nil
@@ -1915,6 +2063,7 @@ func (b *InMemoryBackend) DeleteReplicationSubnetGroup(identifierOrArn string) e
 // CreateReplicationConfig creates a replication config.
 func (b *InMemoryBackend) CreateReplicationConfig(
 	identifier, replicationType, sourceEndpointArn, targetEndpointArn string,
+	kv map[string]string,
 ) (*ReplicationConfig, error) {
 	b.mu.Lock("CreateReplicationConfig")
 	defer b.mu.Unlock()
@@ -1928,6 +2077,10 @@ func (b *InMemoryBackend) CreateReplicationConfig(
 	}
 
 	configARN := arn.Build("dms", b.region, b.accountID, "replication-config:"+uuid.NewString())
+	t := tags.New("dms.replication-config." + identifier + ".tags")
+	if len(kv) > 0 {
+		t.Merge(kv)
+	}
 	rc := &ReplicationConfig{
 		ReplicationConfigIdentifier: identifier,
 		ReplicationConfigArn:        configARN,
@@ -1936,8 +2089,10 @@ func (b *InMemoryBackend) CreateReplicationConfig(
 		TargetEndpointArn:           targetEndpointArn,
 		AccountID:                   b.accountID,
 		Region:                      b.region,
+		Tags:                        t,
 	}
 	b.replicationConfigs[identifier] = rc
+	b.replicationConfigsByARN[configARN] = rc
 	cp := *rc
 
 	return &cp, nil
@@ -1948,7 +2103,9 @@ func (b *InMemoryBackend) DeleteReplicationConfig(identifierOrArn string) error 
 	b.mu.Lock("DeleteReplicationConfig")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicationConfigs[identifierOrArn]; ok {
+	if rc, ok := b.replicationConfigs[identifierOrArn]; ok {
+		rc.Tags.Close()
+		delete(b.replicationConfigsByARN, rc.ReplicationConfigArn)
 		delete(b.replicationConfigs, identifierOrArn)
 
 		return nil
@@ -1956,6 +2113,8 @@ func (b *InMemoryBackend) DeleteReplicationConfig(identifierOrArn string) error 
 
 	for id, rc := range b.replicationConfigs {
 		if rc.ReplicationConfigArn == identifierOrArn {
+			rc.Tags.Close()
+			delete(b.replicationConfigsByARN, identifierOrArn)
 			delete(b.replicationConfigs, id)
 
 			return nil

--- a/services/dms/export_test.go
+++ b/services/dms/export_test.go
@@ -63,3 +63,11 @@ func (b *InMemoryBackend) InstanceProfileCount() int {
 
 	return len(b.instanceProfiles)
 }
+
+// ConnectionCount returns the number of stored connections. Used only in tests.
+func (b *InMemoryBackend) ConnectionCount() int {
+	b.mu.RLock("ConnectionCount")
+	defer b.mu.RUnlock()
+
+	return len(b.connections)
+}

--- a/services/dms/handler.go
+++ b/services/dms/handler.go
@@ -1156,9 +1156,28 @@ type startReplicationTaskOutput struct {
 	ReplicationTask replicationTaskJSON `json:"ReplicationTask"`
 }
 
+var validStartReplicationTaskTypes = map[string]bool{
+	"start-replication": true,
+	"resume-processing": true,
+	"reload-target":     true,
+}
+
 func (h *Handler) handleStartReplicationTask(
 	_ context.Context, in *startReplicationTaskInput,
 ) (*startReplicationTaskOutput, error) {
+	taskType := ptrStr(in.StartReplicationTaskType)
+	if taskType == "" {
+		taskType = "start-replication"
+	}
+
+	if !validStartReplicationTaskTypes[taskType] {
+		return nil, fmt.Errorf(
+			"%w: invalid StartReplicationTaskType %q; valid: start-replication, resume-processing, reload-target",
+			ErrValidation,
+			taskType,
+		)
+	}
+
 	rt, err := h.Backend.StartReplicationTask(ptrStr(in.ReplicationTaskArn))
 	if err != nil {
 		return nil, err
@@ -1914,8 +1933,9 @@ func ipToJSON(ip *InstanceProfile) instanceProfileJSON {
 // --- CreateMigrationProject handler ---
 
 type createMigrationProjectInput struct {
-	MigrationProjectName *string `json:"MigrationProjectName"`
-	Description          *string `json:"Description"`
+	MigrationProjectName *string    `json:"MigrationProjectName"`
+	Description          *string    `json:"Description"`
+	Tags                 []tagEntry `json:"Tags"`
 }
 
 type migrationProjectJSON struct {
@@ -1946,7 +1966,8 @@ func (h *Handler) handleCreateMigrationProject(
 		return nil, fmt.Errorf("%w: MigrationProjectName is required", ErrValidation)
 	}
 
-	mp, err := h.Backend.CreateMigrationProject(name, ptrStr(in.Description))
+	kv := tagsToMap(in.Tags)
+	mp, err := h.Backend.CreateMigrationProject(name, ptrStr(in.Description), kv)
 	if err != nil {
 		return nil, err
 	}
@@ -1957,10 +1978,11 @@ func (h *Handler) handleCreateMigrationProject(
 // --- CreateReplicationConfig handler ---
 
 type createReplicationConfigInput struct {
-	ReplicationConfigIdentifier *string `json:"ReplicationConfigIdentifier"`
-	ReplicationType             *string `json:"ReplicationType"`
-	SourceEndpointArn           *string `json:"SourceEndpointArn"`
-	TargetEndpointArn           *string `json:"TargetEndpointArn"`
+	ReplicationConfigIdentifier *string    `json:"ReplicationConfigIdentifier"`
+	ReplicationType             *string    `json:"ReplicationType"`
+	SourceEndpointArn           *string    `json:"SourceEndpointArn"`
+	TargetEndpointArn           *string    `json:"TargetEndpointArn"`
+	Tags                        []tagEntry `json:"Tags"`
 }
 
 type replicationConfigJSON struct {
@@ -1993,11 +2015,13 @@ func (h *Handler) handleCreateReplicationConfig(
 		return nil, fmt.Errorf("%w: ReplicationConfigIdentifier is required", ErrValidation)
 	}
 
+	kv := tagsToMap(in.Tags)
 	rc, err := h.Backend.CreateReplicationConfig(
 		identifier,
 		ptrStr(in.ReplicationType),
 		ptrStr(in.SourceEndpointArn),
 		ptrStr(in.TargetEndpointArn),
+		kv,
 	)
 	if err != nil {
 		return nil, err
@@ -2009,9 +2033,10 @@ func (h *Handler) handleCreateReplicationConfig(
 // --- CreateReplicationSubnetGroup handler ---
 
 type createReplicationSubnetGroupInput struct {
-	ReplicationSubnetGroupIdentifier  *string  `json:"ReplicationSubnetGroupIdentifier"`
-	ReplicationSubnetGroupDescription *string  `json:"ReplicationSubnetGroupDescription"`
-	SubnetIDs                         []string `json:"SubnetIds"`
+	ReplicationSubnetGroupIdentifier  *string    `json:"ReplicationSubnetGroupIdentifier"`
+	ReplicationSubnetGroupDescription *string    `json:"ReplicationSubnetGroupDescription"`
+	SubnetIDs                         []string   `json:"SubnetIds"`
+	Tags                              []tagEntry `json:"Tags"`
 }
 
 type replicationSubnetGroupFullJSON struct {
@@ -2042,10 +2067,12 @@ func (h *Handler) handleCreateReplicationSubnetGroup(
 		return nil, fmt.Errorf("%w: ReplicationSubnetGroupIdentifier is required", ErrValidation)
 	}
 
+	kv := tagsToMap(in.Tags)
 	sg, err := h.Backend.CreateReplicationSubnetGroup(
 		identifier,
 		ptrStr(in.ReplicationSubnetGroupDescription),
 		"",
+		kv,
 	)
 	if err != nil {
 		return nil, err
@@ -2367,9 +2394,18 @@ type describeAccountAttributesOutput struct {
 func (h *Handler) handleDescribeAccountAttributes(
 	_ context.Context, _ *describeAccountAttributesInput,
 ) (*describeAccountAttributesOutput, error) {
+	riCount := int64(len(h.Backend.mustDescribeReplicationInstances()))
+	epCount := int64(len(h.Backend.mustDescribeEndpoints()))
+	taskCount := int64(len(h.Backend.mustDescribeReplicationTasks()))
+
 	return &describeAccountAttributesOutput{
-		UniqueAccountIdentifier: "000000000000",
-		AccountQuotas:           []accountQuotaJSON{},
+		UniqueAccountIdentifier: h.Backend.AccountID(),
+		AccountQuotas: []accountQuotaJSON{
+			{AccountQuotaName: "ReplicationInstances", Used: float64(riCount), Max: 60},
+			{AccountQuotaName: "AllocatedStorage", Used: float64(riCount * 50), Max: 6000},
+			{AccountQuotaName: "Endpoints", Used: float64(epCount), Max: 1000},
+			{AccountQuotaName: "ReplicationTasks", Used: float64(taskCount), Max: 200},
+		},
 	}, nil
 }
 
@@ -2437,13 +2473,30 @@ type describeConnectionsInput struct {
 
 type describeConnectionsOutput struct {
 	Marker      *string          `json:"Marker,omitempty"`
-	Connections []map[string]any `json:"Connections"`
+	Connections []connectionJSON `json:"Connections"`
 }
 
 func (h *Handler) handleDescribeConnections(
-	_ context.Context, _ *describeConnectionsInput,
+	_ context.Context, in *describeConnectionsInput,
 ) (*describeConnectionsOutput, error) {
-	return &describeConnectionsOutput{Connections: []map[string]any{}}, nil
+	riArn := extractFilterValue(in.Filters, "replication-instance-id")
+	epArn := extractFilterValue(in.Filters, "endpoint-id")
+
+	list, err := h.Backend.DescribeConnections(riArn, epArn)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].EndpointIdentifier < list[j].EndpointIdentifier
+	})
+
+	all := make([]connectionJSON, 0, len(list))
+	for _, conn := range list {
+		all = append(all, connToJSON(conn))
+	}
+
+	return &describeConnectionsOutput{Connections: all}, nil
 }
 
 // --- DescribeConversionConfiguration handler ---
@@ -2624,15 +2677,35 @@ type describeEngineVersionsInput struct {
 	MaxRecords *int32  `json:"MaxRecords"`
 }
 
+type engineVersionJSON struct {
+	Version           string `json:"Version"`
+	Lifecycle         string `json:"Lifecycle"`
+	ReleaseNotes      string `json:"ReleaseNotes,omitempty"`
+	LaunchDate        string `json:"LaunchDate,omitempty"`
+	AutoUpgradeDate   string `json:"AutoUpgradeDate,omitempty"`
+	DeprecationDate   string `json:"DeprecationDate,omitempty"`
+	ForceUpgradeDate  string `json:"ForceUpgradeDate,omitempty"`
+}
+
 type describeEngineVersionsOutput struct {
-	Marker         *string          `json:"Marker,omitempty"`
-	EngineVersions []map[string]any `json:"EngineVersions"`
+	Marker         *string             `json:"Marker,omitempty"`
+	EngineVersions []engineVersionJSON `json:"EngineVersions"`
+}
+
+var dmsEngineVersions = []engineVersionJSON{
+	{Version: "3.5.3", Lifecycle: "available", LaunchDate: "2023-11-01"},
+	{Version: "3.5.2", Lifecycle: "available", LaunchDate: "2023-07-01"},
+	{Version: "3.5.1", Lifecycle: "available", LaunchDate: "2023-03-01"},
+	{Version: "3.4.7", Lifecycle: "available", LaunchDate: "2022-11-01"},
+	{Version: "3.4.6", Lifecycle: "available", LaunchDate: "2022-07-01"},
+	{Version: "3.4.5", Lifecycle: "deprecated", LaunchDate: "2022-03-01", DeprecationDate: "2023-06-01"},
 }
 
 func (h *Handler) handleDescribeEngineVersions(
-	_ context.Context, _ *describeEngineVersionsInput,
+	_ context.Context, in *describeEngineVersionsInput,
 ) (*describeEngineVersionsOutput, error) {
-	return &describeEngineVersionsOutput{EngineVersions: []map[string]any{}}, nil
+	data, nextMarker := dmsPaginate(dmsEngineVersions, in.Marker, in.MaxRecords)
+	return &describeEngineVersionsOutput{EngineVersions: data, Marker: nextMarker}, nil
 }
 
 // --- DescribeEventCategories handler ---
@@ -2645,10 +2718,57 @@ type describeEventCategoriesOutput struct {
 	EventCategoryGroupList []map[string]any `json:"EventCategoryGroupList"`
 }
 
+type eventCategoryGroupJSON struct {
+	SourceType       string   `json:"SourceType"`
+	EventCategories  []string `json:"EventCategories"`
+}
+
+var dmsEventCategoryGroups = []eventCategoryGroupJSON{
+	{
+		SourceType: "replication-instance",
+		EventCategories: []string{
+			"low storage",
+			"configuration change",
+			"maintenance",
+			"deletion",
+			"creation",
+			"failover",
+			"failure",
+		},
+	},
+	{
+		SourceType: "replication-task",
+		EventCategories: []string{
+			"state change",
+			"configuration change",
+			"deletion",
+			"creation",
+			"failure",
+		},
+	},
+}
+
 func (h *Handler) handleDescribeEventCategories(
-	_ context.Context, _ *describeEventCategoriesInput,
+	_ context.Context, in *describeEventCategoriesInput,
 ) (*describeEventCategoriesOutput, error) {
-	return &describeEventCategoriesOutput{EventCategoryGroupList: []map[string]any{}}, nil
+	sourceType := ptrStr(in.SourceType)
+	result := make([]eventCategoryGroupJSON, 0, len(dmsEventCategoryGroups))
+
+	for _, group := range dmsEventCategoryGroups {
+		if sourceType == "" || group.SourceType == sourceType {
+			result = append(result, group)
+		}
+	}
+
+	out := make([]map[string]any, 0, len(result))
+	for _, g := range result {
+		out = append(out, map[string]any{
+			"SourceType":      g.SourceType,
+			"EventCategories": g.EventCategories,
+		})
+	}
+
+	return &describeEventCategoriesOutput{EventCategoryGroupList: out}, nil
 }
 
 // --- DescribeEventSubscriptions handler ---
@@ -3085,26 +3205,49 @@ type describeOrderableReplicationInstancesOutput struct {
 	OrderableReplicationInstances []orderableReplicationInstanceJSON `json:"OrderableReplicationInstances"`
 }
 
-func (h *Handler) handleDescribeOrderableReplicationInstances(
-	_ context.Context, _ *describeOrderableReplicationInstancesInput,
-) (*describeOrderableReplicationInstancesOutput, error) {
-	const (
-		defaultStorage = int32(50)
-		minStorage     = int32(5)
-		maxStorage     = int32(100)
-	)
+type orderableInstanceSpec struct {
+	class          string
+	defaultStorage int32
+	minStorage     int32
+	maxStorage     int32
+}
 
+var dmsOrderableInstances = []orderableInstanceSpec{
+	{class: "dms.t3.micro", defaultStorage: 50, minStorage: 5, maxStorage: 200},
+	{class: "dms.t3.small", defaultStorage: 50, minStorage: 5, maxStorage: 200},
+	{class: "dms.t3.medium", defaultStorage: 50, minStorage: 5, maxStorage: 200},
+	{class: "dms.t3.large", defaultStorage: 50, minStorage: 5, maxStorage: 200},
+	{class: "dms.c5.large", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.c5.xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.c5.2xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.c5.4xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.r5.large", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.r5.xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.r5.2xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.r5.4xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.r5.8xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+	{class: "dms.r5.16xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+}
+
+func (h *Handler) handleDescribeOrderableReplicationInstances(
+	_ context.Context, in *describeOrderableReplicationInstancesInput,
+) (*describeOrderableReplicationInstancesOutput, error) {
+	all := make([]orderableReplicationInstanceJSON, 0, len(dmsOrderableInstances))
+	for _, spec := range dmsOrderableInstances {
+		all = append(all, orderableReplicationInstanceJSON{
+			ReplicationInstanceClass: spec.class,
+			StorageType:              "gp2",
+			DefaultAllocatedStorage:  spec.defaultStorage,
+			MinAllocatedStorage:      spec.minStorage,
+			MaxAllocatedStorage:      spec.maxStorage,
+			ReleaseStatus:            "GA",
+		})
+	}
+
+	data, nextMarker := dmsPaginate(all, in.Marker, in.MaxRecords)
 	return &describeOrderableReplicationInstancesOutput{
-		OrderableReplicationInstances: []orderableReplicationInstanceJSON{
-			{
-				ReplicationInstanceClass: "dms.r5.large",
-				StorageType:              "gp2",
-				DefaultAllocatedStorage:  defaultStorage,
-				MinAllocatedStorage:      minStorage,
-				MaxAllocatedStorage:      maxStorage,
-				ReleaseStatus:            "GA",
-			},
-		},
+		OrderableReplicationInstances: data,
+		Marker:                        nextMarker,
 	}, nil
 }
 
@@ -4299,25 +4442,42 @@ type testConnectionInput struct {
 	EndpointArn            *string `json:"EndpointArn"`
 }
 
-type connectionStatusJSON struct {
-	Status string `json:"Status"`
+type connectionJSON struct {
+	ReplicationInstanceArn        string `json:"ReplicationInstanceArn,omitempty"`
+	ReplicationInstanceIdentifier string `json:"ReplicationInstanceIdentifier,omitempty"`
+	EndpointArn                   string `json:"EndpointArn,omitempty"`
+	EndpointIdentifier            string `json:"EndpointIdentifier,omitempty"`
+	Status                        string `json:"Status"`
+	LastFailureMessage            string `json:"LastFailureMessage,omitempty"`
 }
 
 type testConnectionOutput struct {
-	Connection connectionStatusJSON `json:"Connection"`
+	Connection connectionJSON `json:"Connection"`
+}
+
+func connToJSON(c *Connection) connectionJSON {
+	return connectionJSON{
+		ReplicationInstanceArn:        c.ReplicationInstanceArn,
+		ReplicationInstanceIdentifier: c.ReplicationInstanceIdentifier,
+		EndpointArn:                   c.EndpointArn,
+		EndpointIdentifier:            c.EndpointIdentifier,
+		Status:                        c.Status,
+		LastFailureMessage:            c.LastFailureMessage,
+	}
 }
 
 func (h *Handler) handleTestConnection(
 	_ context.Context, in *testConnectionInput,
 ) (*testConnectionOutput, error) {
-	if err := h.Backend.TestConnection(
+	conn, err := h.Backend.TestConnection(
 		ptrStr(in.ReplicationInstanceArn),
 		ptrStr(in.EndpointArn),
-	); err != nil {
+	)
+	if err != nil {
 		return nil, err
 	}
 
-	return &testConnectionOutput{Connection: connectionStatusJSON{Status: "successful"}}, nil
+	return &testConnectionOutput{Connection: connToJSON(conn)}, nil
 }
 
 // --- UpdateSubscriptionsToEventBridge handler ---

--- a/services/dms/handler.go
+++ b/services/dms/handler.go
@@ -1156,10 +1156,8 @@ type startReplicationTaskOutput struct {
 	ReplicationTask replicationTaskJSON `json:"ReplicationTask"`
 }
 
-var validStartReplicationTaskTypes = map[string]bool{
-	"start-replication": true,
-	"resume-processing": true,
-	"reload-target":     true,
+func isValidStartReplicationTaskType(s string) bool {
+	return s == "start-replication" || s == "resume-processing" || s == "reload-target"
 }
 
 func (h *Handler) handleStartReplicationTask(
@@ -1170,7 +1168,7 @@ func (h *Handler) handleStartReplicationTask(
 		taskType = "start-replication"
 	}
 
-	if !validStartReplicationTaskTypes[taskType] {
+	if !isValidStartReplicationTaskType(taskType) {
 		return nil, fmt.Errorf(
 			"%w: invalid StartReplicationTaskType %q; valid: start-replication, resume-processing, reload-target",
 			ErrValidation,
@@ -2391,6 +2389,14 @@ type describeAccountAttributesOutput struct {
 	AccountQuotas           []accountQuotaJSON `json:"AccountQuotas"`
 }
 
+const (
+	quotaMaxReplicationInstances = float64(60)
+	quotaMaxAllocatedStorage     = float64(6000)
+	quotaMaxEndpoints            = float64(1000)
+	quotaMaxReplicationTasks     = float64(200)
+	quotaStoragePerInstance      = int64(50)
+)
+
 func (h *Handler) handleDescribeAccountAttributes(
 	_ context.Context, _ *describeAccountAttributesInput,
 ) (*describeAccountAttributesOutput, error) {
@@ -2401,10 +2407,14 @@ func (h *Handler) handleDescribeAccountAttributes(
 	return &describeAccountAttributesOutput{
 		UniqueAccountIdentifier: h.Backend.AccountID(),
 		AccountQuotas: []accountQuotaJSON{
-			{AccountQuotaName: "ReplicationInstances", Used: float64(riCount), Max: 60},
-			{AccountQuotaName: "AllocatedStorage", Used: float64(riCount * 50), Max: 6000},
-			{AccountQuotaName: "Endpoints", Used: float64(epCount), Max: 1000},
-			{AccountQuotaName: "ReplicationTasks", Used: float64(taskCount), Max: 200},
+			{AccountQuotaName: "ReplicationInstances", Used: float64(riCount), Max: quotaMaxReplicationInstances},
+			{
+				AccountQuotaName: "AllocatedStorage",
+				Used:             float64(riCount * quotaStoragePerInstance),
+				Max:              quotaMaxAllocatedStorage,
+			},
+			{AccountQuotaName: "Endpoints", Used: float64(epCount), Max: quotaMaxEndpoints},
+			{AccountQuotaName: "ReplicationTasks", Used: float64(taskCount), Max: quotaMaxReplicationTasks},
 		},
 	}, nil
 }
@@ -2678,13 +2688,13 @@ type describeEngineVersionsInput struct {
 }
 
 type engineVersionJSON struct {
-	Version           string `json:"Version"`
-	Lifecycle         string `json:"Lifecycle"`
-	ReleaseNotes      string `json:"ReleaseNotes,omitempty"`
-	LaunchDate        string `json:"LaunchDate,omitempty"`
-	AutoUpgradeDate   string `json:"AutoUpgradeDate,omitempty"`
-	DeprecationDate   string `json:"DeprecationDate,omitempty"`
-	ForceUpgradeDate  string `json:"ForceUpgradeDate,omitempty"`
+	Version          string `json:"Version"`
+	Lifecycle        string `json:"Lifecycle"`
+	ReleaseNotes     string `json:"ReleaseNotes,omitempty"`
+	LaunchDate       string `json:"LaunchDate,omitempty"`
+	AutoUpgradeDate  string `json:"AutoUpgradeDate,omitempty"`
+	DeprecationDate  string `json:"DeprecationDate,omitempty"`
+	ForceUpgradeDate string `json:"ForceUpgradeDate,omitempty"`
 }
 
 type describeEngineVersionsOutput struct {
@@ -2692,19 +2702,22 @@ type describeEngineVersionsOutput struct {
 	EngineVersions []engineVersionJSON `json:"EngineVersions"`
 }
 
-var dmsEngineVersions = []engineVersionJSON{
-	{Version: "3.5.3", Lifecycle: "available", LaunchDate: "2023-11-01"},
-	{Version: "3.5.2", Lifecycle: "available", LaunchDate: "2023-07-01"},
-	{Version: "3.5.1", Lifecycle: "available", LaunchDate: "2023-03-01"},
-	{Version: "3.4.7", Lifecycle: "available", LaunchDate: "2022-11-01"},
-	{Version: "3.4.6", Lifecycle: "available", LaunchDate: "2022-07-01"},
-	{Version: "3.4.5", Lifecycle: "deprecated", LaunchDate: "2022-03-01", DeprecationDate: "2023-06-01"},
+func dmsEngineVersionList() []engineVersionJSON {
+	return []engineVersionJSON{
+		{Version: defaultEngineVersion, Lifecycle: statusAvailable, LaunchDate: "2023-11-01"},
+		{Version: "3.5.2", Lifecycle: "available", LaunchDate: "2023-07-01"},
+		{Version: "3.5.1", Lifecycle: "available", LaunchDate: "2023-03-01"},
+		{Version: "3.4.7", Lifecycle: "available", LaunchDate: "2022-11-01"},
+		{Version: "3.4.6", Lifecycle: "available", LaunchDate: "2022-07-01"},
+		{Version: "3.4.5", Lifecycle: "deprecated", LaunchDate: "2022-03-01", DeprecationDate: "2023-06-01"},
+	}
 }
 
 func (h *Handler) handleDescribeEngineVersions(
 	_ context.Context, in *describeEngineVersionsInput,
 ) (*describeEngineVersionsOutput, error) {
-	data, nextMarker := dmsPaginate(dmsEngineVersions, in.Marker, in.MaxRecords)
+	data, nextMarker := dmsPaginate(dmsEngineVersionList(), in.Marker, in.MaxRecords)
+
 	return &describeEngineVersionsOutput{EngineVersions: data, Marker: nextMarker}, nil
 }
 
@@ -2719,42 +2732,45 @@ type describeEventCategoriesOutput struct {
 }
 
 type eventCategoryGroupJSON struct {
-	SourceType       string   `json:"SourceType"`
-	EventCategories  []string `json:"EventCategories"`
+	SourceType      string   `json:"SourceType"`
+	EventCategories []string `json:"EventCategories"`
 }
 
-var dmsEventCategoryGroups = []eventCategoryGroupJSON{
-	{
-		SourceType: "replication-instance",
-		EventCategories: []string{
-			"low storage",
-			"configuration change",
-			"maintenance",
-			"deletion",
-			"creation",
-			"failover",
-			"failure",
+func dmsEventCategoryGroupList() []eventCategoryGroupJSON {
+	return []eventCategoryGroupJSON{
+		{
+			SourceType: "replication-instance",
+			EventCategories: []string{
+				"low storage",
+				"configuration change",
+				"maintenance",
+				"deletion",
+				"creation",
+				"failover",
+				"failure",
+			},
 		},
-	},
-	{
-		SourceType: "replication-task",
-		EventCategories: []string{
-			"state change",
-			"configuration change",
-			"deletion",
-			"creation",
-			"failure",
+		{
+			SourceType: "replication-task",
+			EventCategories: []string{
+				"state change",
+				"configuration change",
+				"deletion",
+				"creation",
+				"failure",
+			},
 		},
-	},
+	}
 }
 
 func (h *Handler) handleDescribeEventCategories(
 	_ context.Context, in *describeEventCategoriesInput,
 ) (*describeEventCategoriesOutput, error) {
 	sourceType := ptrStr(in.SourceType)
-	result := make([]eventCategoryGroupJSON, 0, len(dmsEventCategoryGroups))
+	groups := dmsEventCategoryGroupList()
+	result := make([]eventCategoryGroupJSON, 0, len(groups))
 
-	for _, group := range dmsEventCategoryGroups {
+	for _, group := range groups {
 		if sourceType == "" || group.SourceType == sourceType {
 			result = append(result, group)
 		}
@@ -3212,28 +3228,40 @@ type orderableInstanceSpec struct {
 	maxStorage     int32
 }
 
-var dmsOrderableInstances = []orderableInstanceSpec{
-	{class: "dms.t3.micro", defaultStorage: 50, minStorage: 5, maxStorage: 200},
-	{class: "dms.t3.small", defaultStorage: 50, minStorage: 5, maxStorage: 200},
-	{class: "dms.t3.medium", defaultStorage: 50, minStorage: 5, maxStorage: 200},
-	{class: "dms.t3.large", defaultStorage: 50, minStorage: 5, maxStorage: 200},
-	{class: "dms.c5.large", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.c5.xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.c5.2xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.c5.4xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.r5.large", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.r5.xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.r5.2xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.r5.4xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.r5.8xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
-	{class: "dms.r5.16xlarge", defaultStorage: 100, minStorage: 5, maxStorage: 1024},
+const (
+	t3DefaultStorage   int32 = 50
+	t3MaxStorage       int32 = 200
+	c5r5DefaultStorage int32 = 100
+	c5r5MaxStorage     int32 = 1024
+	minStorageAll      int32 = 5
+)
+
+func dmsOrderableInstanceList() []orderableInstanceSpec {
+	return []orderableInstanceSpec{
+		{class: "dms.t3.micro", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
+		{class: "dms.t3.small", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
+		{class: "dms.t3.medium", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
+		{class: "dms.t3.large", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
+		{class: "dms.c5.large", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.c5.xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.c5.2xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.c5.4xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.r5.large", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.r5.xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.r5.2xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.r5.4xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.r5.8xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{class: "dms.r5.16xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+	}
 }
 
 func (h *Handler) handleDescribeOrderableReplicationInstances(
 	_ context.Context, in *describeOrderableReplicationInstancesInput,
 ) (*describeOrderableReplicationInstancesOutput, error) {
-	all := make([]orderableReplicationInstanceJSON, 0, len(dmsOrderableInstances))
-	for _, spec := range dmsOrderableInstances {
+	specs := dmsOrderableInstanceList()
+	all := make([]orderableReplicationInstanceJSON, 0, len(specs))
+
+	for _, spec := range specs {
 		all = append(all, orderableReplicationInstanceJSON{
 			ReplicationInstanceClass: spec.class,
 			StorageType:              "gp2",
@@ -3245,6 +3273,7 @@ func (h *Handler) handleDescribeOrderableReplicationInstances(
 	}
 
 	data, nextMarker := dmsPaginate(all, in.Marker, in.MaxRecords)
+
 	return &describeOrderableReplicationInstancesOutput{
 		OrderableReplicationInstances: data,
 		Marker:                        nextMarker,

--- a/services/dms/handler.go
+++ b/services/dms/handler.go
@@ -2705,10 +2705,10 @@ type describeEngineVersionsOutput struct {
 func dmsEngineVersionList() []engineVersionJSON {
 	return []engineVersionJSON{
 		{Version: defaultEngineVersion, Lifecycle: statusAvailable, LaunchDate: "2023-11-01"},
-		{Version: "3.5.2", Lifecycle: "available", LaunchDate: "2023-07-01"},
-		{Version: "3.5.1", Lifecycle: "available", LaunchDate: "2023-03-01"},
-		{Version: "3.4.7", Lifecycle: "available", LaunchDate: "2022-11-01"},
-		{Version: "3.4.6", Lifecycle: "available", LaunchDate: "2022-07-01"},
+		{Version: "3.5.2", Lifecycle: statusAvailable, LaunchDate: "2023-07-01"},
+		{Version: "3.5.1", Lifecycle: statusAvailable, LaunchDate: "2023-03-01"},
+		{Version: "3.4.7", Lifecycle: statusAvailable, LaunchDate: "2022-11-01"},
+		{Version: "3.4.6", Lifecycle: statusAvailable, LaunchDate: "2022-07-01"},
 		{Version: "3.4.5", Lifecycle: "deprecated", LaunchDate: "2022-03-01", DeprecationDate: "2023-06-01"},
 	}
 }
@@ -3242,16 +3242,66 @@ func dmsOrderableInstanceList() []orderableInstanceSpec {
 		{class: "dms.t3.small", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
 		{class: "dms.t3.medium", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
 		{class: "dms.t3.large", defaultStorage: t3DefaultStorage, minStorage: minStorageAll, maxStorage: t3MaxStorage},
-		{class: "dms.c5.large", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.c5.xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.c5.2xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.c5.4xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.r5.large", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.r5.xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.r5.2xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.r5.4xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.r5.8xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
-		{class: "dms.r5.16xlarge", defaultStorage: c5r5DefaultStorage, minStorage: minStorageAll, maxStorage: c5r5MaxStorage},
+		{
+			class:          "dms.c5.large",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.c5.xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.c5.2xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.c5.4xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.r5.large",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.r5.xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.r5.2xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.r5.4xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.r5.8xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
+		{
+			class:          "dms.r5.16xlarge",
+			defaultStorage: c5r5DefaultStorage,
+			minStorage:     minStorageAll,
+			maxStorage:     c5r5MaxStorage,
+		},
 	}
 }
 

--- a/services/dms/handler_test.go
+++ b/services/dms/handler_test.go
@@ -2585,3 +2585,941 @@ func TestRefinement1_InstanceProfileSeedHelper(t *testing.T) {
 	h.Backend.AddInstanceProfileInternal("seed-profile")
 	assert.Equal(t, 1, h.Backend.InstanceProfileCount())
 }
+
+// ---- AWS-accuracy audit: state machine tests ----
+
+func TestHandler_DeleteRunningTaskFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "delete_running_task_rejected",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				h.Backend.AddReplicationInstanceInternal("sm-ri", "dms.t3.medium")
+				h.Backend.AddEndpointInternal("sm-src", "source", "mysql")
+				h.Backend.AddEndpointInternal("sm-tgt", "target", "s3")
+				h.Backend.AddReplicationTaskInternal("sm-task", "sm-src", "sm-tgt", "sm-ri", "full-load")
+
+				descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
+				require.Equal(t, http.StatusOK, descRec.Code)
+				taskArn := parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
+
+				startRec := doDMS(t, h, "StartReplicationTask", map[string]any{
+					"ReplicationTaskArn":       taskArn,
+					"StartReplicationTaskType": "start-replication",
+				})
+				require.Equal(t, http.StatusOK, startRec.Code)
+
+				delRec := doDMS(t, h, "DeleteReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+				})
+				assert.Equal(t, http.StatusBadRequest, delRec.Code)
+			},
+		},
+		{
+			name: "delete_stopped_task_succeeds",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				h.Backend.AddReplicationInstanceInternal("sm2-ri", "dms.t3.medium")
+				h.Backend.AddEndpointInternal("sm2-src", "source", "mysql")
+				h.Backend.AddEndpointInternal("sm2-tgt", "target", "s3")
+				h.Backend.AddReplicationTaskInternal("sm2-task", "sm2-src", "sm2-tgt", "sm2-ri", "full-load")
+
+				descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
+				require.Equal(t, http.StatusOK, descRec.Code)
+				taskArn := parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
+
+				startRec := doDMS(t, h, "StartReplicationTask", map[string]any{
+					"ReplicationTaskArn":       taskArn,
+					"StartReplicationTaskType": "start-replication",
+				})
+				require.Equal(t, http.StatusOK, startRec.Code)
+
+				stopRec := doDMS(t, h, "StopReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+				})
+				require.Equal(t, http.StatusOK, stopRec.Code)
+
+				delRec := doDMS(t, h, "DeleteReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+				})
+				assert.Equal(t, http.StatusOK, delRec.Code)
+			},
+		},
+		{
+			name: "delete_ready_task_succeeds",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				h.Backend.AddReplicationInstanceInternal("sm3-ri", "dms.t3.medium")
+				h.Backend.AddEndpointInternal("sm3-src", "source", "mysql")
+				h.Backend.AddEndpointInternal("sm3-tgt", "target", "s3")
+				h.Backend.AddReplicationTaskInternal("sm3-task", "sm3-src", "sm3-tgt", "sm3-ri", "full-load")
+
+				descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
+				require.Equal(t, http.StatusOK, descRec.Code)
+				taskArn := parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
+
+				delRec := doDMS(t, h, "DeleteReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+				})
+				assert.Equal(t, http.StatusOK, delRec.Code)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+func TestHandler_DeleteInstanceWithTasksFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "delete_instance_with_attached_task_rejected",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createInst := doDMS(t, h, "CreateReplicationInstance", map[string]any{
+					"ReplicationInstanceIdentifier": "inst-with-task",
+					"ReplicationInstanceClass":      "dms.t3.medium",
+				})
+				require.Equal(t, http.StatusOK, createInst.Code)
+				instArn := parseJSON(t, createInst)["ReplicationInstance"].(map[string]any)["ReplicationInstanceArn"].(string)
+
+				srcRec := doDMS(t, h, "CreateEndpoint", map[string]any{
+					"EndpointIdentifier": "iwt-src",
+					"EndpointType":       "SOURCE",
+					"EngineName":         "mysql",
+				})
+				require.Equal(t, http.StatusOK, srcRec.Code)
+				srcArn := parseJSON(t, srcRec)["Endpoint"].(map[string]any)["EndpointArn"].(string)
+
+				dstRec := doDMS(t, h, "CreateEndpoint", map[string]any{
+					"EndpointIdentifier": "iwt-dst",
+					"EndpointType":       "TARGET",
+					"EngineName":         "s3",
+				})
+				require.Equal(t, http.StatusOK, dstRec.Code)
+				dstArn := parseJSON(t, dstRec)["Endpoint"].(map[string]any)["EndpointArn"].(string)
+
+				doDMS(t, h, "CreateReplicationTask", map[string]any{
+					"ReplicationTaskIdentifier": "attached-task",
+					"SourceEndpointArn":         srcArn,
+					"TargetEndpointArn":         dstArn,
+					"ReplicationInstanceArn":    instArn,
+					"MigrationType":             "full-load",
+				})
+
+				delRec := doDMS(t, h, "DeleteReplicationInstance", map[string]any{
+					"ReplicationInstanceArn": instArn,
+				})
+				assert.Equal(t, http.StatusBadRequest, delRec.Code)
+			},
+		},
+		{
+			name: "delete_instance_after_task_deleted_succeeds",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createInst := doDMS(t, h, "CreateReplicationInstance", map[string]any{
+					"ReplicationInstanceIdentifier": "inst-after-task-del",
+					"ReplicationInstanceClass":      "dms.t3.medium",
+				})
+				require.Equal(t, http.StatusOK, createInst.Code)
+				instArn := parseJSON(t, createInst)["ReplicationInstance"].(map[string]any)["ReplicationInstanceArn"].(string)
+
+				srcRec := doDMS(t, h, "CreateEndpoint", map[string]any{
+					"EndpointIdentifier": "iatd-src",
+					"EndpointType":       "SOURCE",
+					"EngineName":         "mysql",
+				})
+				require.Equal(t, http.StatusOK, srcRec.Code)
+				srcArn := parseJSON(t, srcRec)["Endpoint"].(map[string]any)["EndpointArn"].(string)
+
+				dstRec := doDMS(t, h, "CreateEndpoint", map[string]any{
+					"EndpointIdentifier": "iatd-dst",
+					"EndpointType":       "TARGET",
+					"EngineName":         "s3",
+				})
+				require.Equal(t, http.StatusOK, dstRec.Code)
+				dstArn := parseJSON(t, dstRec)["Endpoint"].(map[string]any)["EndpointArn"].(string)
+
+				taskRec := doDMS(t, h, "CreateReplicationTask", map[string]any{
+					"ReplicationTaskIdentifier": "iatd-task",
+					"SourceEndpointArn":         srcArn,
+					"TargetEndpointArn":         dstArn,
+					"ReplicationInstanceArn":    instArn,
+					"MigrationType":             "full-load",
+				})
+				require.Equal(t, http.StatusOK, taskRec.Code)
+				taskArn := parseJSON(t, taskRec)["ReplicationTask"].(map[string]any)["ReplicationTaskArn"].(string)
+
+				delTask := doDMS(t, h, "DeleteReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+				})
+				require.Equal(t, http.StatusOK, delTask.Code)
+
+				delInst := doDMS(t, h, "DeleteReplicationInstance", map[string]any{
+					"ReplicationInstanceArn": instArn,
+				})
+				assert.Equal(t, http.StatusOK, delInst.Code)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+func TestHandler_ModifyRunningTaskFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "modify_running_task_rejected",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				h.Backend.AddReplicationInstanceInternal("mrt-ri", "dms.t3.medium")
+				h.Backend.AddEndpointInternal("mrt-src", "source", "mysql")
+				h.Backend.AddEndpointInternal("mrt-tgt", "target", "s3")
+				h.Backend.AddReplicationTaskInternal("mrt-task", "mrt-src", "mrt-tgt", "mrt-ri", "full-load")
+
+				descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
+				require.Equal(t, http.StatusOK, descRec.Code)
+				taskArn := parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
+
+				startRec := doDMS(t, h, "StartReplicationTask", map[string]any{
+					"ReplicationTaskArn":       taskArn,
+					"StartReplicationTaskType": "start-replication",
+				})
+				require.Equal(t, http.StatusOK, startRec.Code)
+
+				modRec := doDMS(t, h, "ModifyReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+					"MigrationType":      "cdc",
+				})
+				assert.Equal(t, http.StatusBadRequest, modRec.Code)
+			},
+		},
+		{
+			name: "modify_stopped_task_succeeds",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				h.Backend.AddReplicationInstanceInternal("mst-ri", "dms.t3.medium")
+				h.Backend.AddEndpointInternal("mst-src", "source", "mysql")
+				h.Backend.AddEndpointInternal("mst-tgt", "target", "s3")
+				h.Backend.AddReplicationTaskInternal("mst-task", "mst-src", "mst-tgt", "mst-ri", "full-load")
+
+				descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
+				require.Equal(t, http.StatusOK, descRec.Code)
+				taskArn := parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
+
+				startRec := doDMS(t, h, "StartReplicationTask", map[string]any{
+					"ReplicationTaskArn":       taskArn,
+					"StartReplicationTaskType": "start-replication",
+				})
+				require.Equal(t, http.StatusOK, startRec.Code)
+
+				stopRec := doDMS(t, h, "StopReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+				})
+				require.Equal(t, http.StatusOK, stopRec.Code)
+
+				modRec := doDMS(t, h, "ModifyReplicationTask", map[string]any{
+					"ReplicationTaskArn": taskArn,
+					"MigrationType":      "cdc",
+				})
+				assert.Equal(t, http.StatusOK, modRec.Code)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: StartReplicationTask type validation ----
+
+func TestHandler_StartReplicationTaskTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		startType  string
+		wantStatus int
+	}{
+		{
+			name:       "start_replication_valid",
+			startType:  "start-replication",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "resume_processing_valid",
+			startType:  "resume-processing",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "reload_target_valid",
+			startType:  "reload-target",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid_type_rejected",
+			startType:  "invalid-type",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty_type_defaults_to_start",
+			startType:  "",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	setupEnv := func(t *testing.T, h *dms.Handler) string {
+		t.Helper()
+		h.Backend.AddReplicationInstanceInternal("srtt-ri", "dms.t3.medium")
+		h.Backend.AddEndpointInternal("srtt-src", "source", "mysql")
+		h.Backend.AddEndpointInternal("srtt-tgt", "target", "s3")
+		h.Backend.AddReplicationTaskInternal("srtt-task", "srtt-src", "srtt-tgt", "srtt-ri", "full-load")
+		descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
+		require.Equal(t, http.StatusOK, descRec.Code)
+		return parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			taskArn := setupEnv(t, h)
+
+			body := map[string]any{"ReplicationTaskArn": taskArn}
+			if tt.startType != "" {
+				body["StartReplicationTaskType"] = tt.startType
+			}
+
+			rec := doDMS(t, h, "StartReplicationTask", body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: stateful TestConnection + DescribeConnections ----
+
+func TestHandler_TestConnectionAndDescribeConnections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "test_connection_records_result",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				riRec := doDMS(t, h, "CreateReplicationInstance", map[string]any{
+					"ReplicationInstanceIdentifier": "conn-ri",
+					"ReplicationInstanceClass":      "dms.t3.medium",
+				})
+				require.Equal(t, http.StatusOK, riRec.Code)
+				riArn := parseJSON(t, riRec)["ReplicationInstance"].(map[string]any)["ReplicationInstanceArn"].(string)
+
+				epRec := doDMS(t, h, "CreateEndpoint", map[string]any{
+					"EndpointIdentifier": "conn-ep",
+					"EndpointType":       "source",
+					"EngineName":         "mysql",
+				})
+				require.Equal(t, http.StatusOK, epRec.Code)
+				epArn := parseJSON(t, epRec)["Endpoint"].(map[string]any)["EndpointArn"].(string)
+
+				testRec := doDMS(t, h, "TestConnection", map[string]any{
+					"ReplicationInstanceArn": riArn,
+					"EndpointArn":            epArn,
+				})
+				assert.Equal(t, http.StatusOK, testRec.Code)
+				testResp := parseJSON(t, testRec)
+				conn, ok := testResp["Connection"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "successful", conn["Status"])
+				assert.Equal(t, "conn-ri", conn["ReplicationInstanceIdentifier"])
+				assert.Equal(t, "conn-ep", conn["EndpointIdentifier"])
+
+				descRec := doDMS(t, h, "DescribeConnections", map[string]any{})
+				assert.Equal(t, http.StatusOK, descRec.Code)
+				descResp := parseJSON(t, descRec)
+				conns, ok := descResp["Connections"].([]any)
+				require.True(t, ok)
+				assert.Len(t, conns, 1)
+				assert.Equal(t, "successful", conns[0].(map[string]any)["Status"])
+			},
+		},
+		{
+			name: "test_connection_missing_instance",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "TestConnection", map[string]any{
+					"ReplicationInstanceArn": "arn:nonexistent",
+					"EndpointArn":            "arn:ep",
+				})
+				assert.Equal(t, http.StatusNotFound, rec.Code)
+			},
+		},
+		{
+			name: "test_connection_missing_endpoint",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				riRec := doDMS(t, h, "CreateReplicationInstance", map[string]any{
+					"ReplicationInstanceIdentifier": "conn2-ri",
+					"ReplicationInstanceClass":      "dms.t3.medium",
+				})
+				require.Equal(t, http.StatusOK, riRec.Code)
+				riArn := parseJSON(t, riRec)["ReplicationInstance"].(map[string]any)["ReplicationInstanceArn"].(string)
+
+				rec := doDMS(t, h, "TestConnection", map[string]any{
+					"ReplicationInstanceArn": riArn,
+					"EndpointArn":            "arn:nonexistent-ep",
+				})
+				assert.Equal(t, http.StatusNotFound, rec.Code)
+			},
+		},
+		{
+			name: "describe_connections_empty_initially",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeConnections", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				conns := parseJSON(t, rec)["Connections"].([]any)
+				assert.Empty(t, conns)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: DescribeAccountAttributes ----
+
+func TestHandler_DescribeAccountAttributes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "returns_configured_account_id",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeAccountAttributes", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				assert.Equal(t, "123456789012", resp["UniqueAccountIdentifier"])
+			},
+		},
+		{
+			name: "returns_quota_list",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeAccountAttributes", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				quotas, ok := resp["AccountQuotas"].([]any)
+				require.True(t, ok)
+				assert.NotEmpty(t, quotas)
+				// Verify expected quota names are present.
+				quotaNames := make([]string, 0, len(quotas))
+				for _, q := range quotas {
+					quotaNames = append(quotaNames, q.(map[string]any)["AccountQuotaName"].(string))
+				}
+				assert.Contains(t, quotaNames, "ReplicationInstances")
+				assert.Contains(t, quotaNames, "Endpoints")
+			},
+		},
+		{
+			name: "quota_used_reflects_resources",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				doDMS(t, h, "CreateReplicationInstance", map[string]any{
+					"ReplicationInstanceIdentifier": "quota-inst",
+					"ReplicationInstanceClass":      "dms.t3.medium",
+				})
+
+				rec := doDMS(t, h, "DescribeAccountAttributes", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				quotas := resp["AccountQuotas"].([]any)
+
+				for _, q := range quotas {
+					qm := q.(map[string]any)
+					if qm["AccountQuotaName"] == "ReplicationInstances" {
+						assert.Equal(t, float64(1), qm["Used"])
+						return
+					}
+				}
+				t.Fatal("ReplicationInstances quota not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: DescribeEngineVersions ----
+
+func TestHandler_DescribeEngineVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "returns_non_empty_list",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEngineVersions", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				versions, ok := resp["EngineVersions"].([]any)
+				require.True(t, ok)
+				assert.NotEmpty(t, versions)
+			},
+		},
+		{
+			name: "versions_have_version_and_lifecycle",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEngineVersions", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				versions := resp["EngineVersions"].([]any)
+				require.NotEmpty(t, versions)
+				v0 := versions[0].(map[string]any)
+				assert.NotEmpty(t, v0["Version"])
+				assert.NotEmpty(t, v0["Lifecycle"])
+			},
+		},
+		{
+			name: "contains_current_default_engine_version",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEngineVersions", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				versions := resp["EngineVersions"].([]any)
+
+				found := false
+				for _, v := range versions {
+					if v.(map[string]any)["Version"] == "3.5.3" {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected version 3.5.3 in engine versions list")
+			},
+		},
+		{
+			name: "supports_pagination",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEngineVersions", map[string]any{"MaxRecords": 2})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				versions, ok := resp["EngineVersions"].([]any)
+				require.True(t, ok)
+				assert.Len(t, versions, 2)
+				_, hasMarker := resp["Marker"]
+				assert.True(t, hasMarker)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: DescribeOrderableReplicationInstances ----
+
+func TestHandler_DescribeOrderableReplicationInstances(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "returns_multiple_instance_types",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeOrderableReplicationInstances", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				instances, ok := resp["OrderableReplicationInstances"].([]any)
+				require.True(t, ok)
+				assert.Greater(t, len(instances), 1, "should have more than 1 instance type")
+			},
+		},
+		{
+			name: "includes_t3_and_r5_families",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeOrderableReplicationInstances", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				instances := resp["OrderableReplicationInstances"].([]any)
+
+				classes := make([]string, 0, len(instances))
+				for _, inst := range instances {
+					classes = append(classes, inst.(map[string]any)["ReplicationInstanceClass"].(string))
+				}
+				assert.Contains(t, classes, "dms.t3.medium")
+				assert.Contains(t, classes, "dms.r5.large")
+			},
+		},
+		{
+			name: "supports_pagination",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeOrderableReplicationInstances", map[string]any{"MaxRecords": 3})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				instances, ok := resp["OrderableReplicationInstances"].([]any)
+				require.True(t, ok)
+				assert.Len(t, instances, 3)
+				_, hasMarker := resp["Marker"]
+				assert.True(t, hasMarker)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: DescribeEventCategories ----
+
+func TestHandler_DescribeEventCategories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "returns_all_categories_no_filter",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEventCategories", map[string]any{})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				groups, ok := resp["EventCategoryGroupList"].([]any)
+				require.True(t, ok)
+				assert.NotEmpty(t, groups)
+			},
+		},
+		{
+			name: "filter_by_replication_instance_source_type",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEventCategories", map[string]any{
+					"SourceType": "replication-instance",
+				})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				groups := resp["EventCategoryGroupList"].([]any)
+				require.Len(t, groups, 1)
+				g := groups[0].(map[string]any)
+				assert.Equal(t, "replication-instance", g["SourceType"])
+				cats, ok := g["EventCategories"].([]any)
+				require.True(t, ok)
+				assert.NotEmpty(t, cats)
+			},
+		},
+		{
+			name: "filter_by_replication_task_source_type",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEventCategories", map[string]any{
+					"SourceType": "replication-task",
+				})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				groups := resp["EventCategoryGroupList"].([]any)
+				require.Len(t, groups, 1)
+				g := groups[0].(map[string]any)
+				assert.Equal(t, "replication-task", g["SourceType"])
+			},
+		},
+		{
+			name: "unknown_source_type_returns_empty",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				rec := doDMS(t, h, "DescribeEventCategories", map[string]any{
+					"SourceType": "unknown-type",
+				})
+				assert.Equal(t, http.StatusOK, rec.Code)
+				resp := parseJSON(t, rec)
+				groups := resp["EventCategoryGroupList"].([]any)
+				assert.Empty(t, groups)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit: tags on MigrationProject, ReplicationSubnetGroup, ReplicationConfig ----
+
+func TestHandler_TagsOnMigrationProject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "create_with_tags_and_list",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createRec := doDMS(t, h, "CreateMigrationProject", map[string]any{
+					"MigrationProjectName": "tagged-mp",
+					"Tags": []map[string]string{
+						{"Key": "env", "Value": "prod"},
+					},
+				})
+				require.Equal(t, http.StatusOK, createRec.Code)
+				mpArn := parseJSON(t, createRec)["MigrationProject"].(map[string]any)["MigrationProjectArn"].(string)
+
+				listRec := doDMS(t, h, "ListTagsForResource", map[string]any{
+					"ResourceArn": mpArn,
+				})
+				require.Equal(t, http.StatusOK, listRec.Code)
+				tagList := parseJSON(t, listRec)["TagList"].([]any)
+				require.Len(t, tagList, 1)
+				assert.Equal(t, "env", tagList[0].(map[string]any)["Key"])
+			},
+		},
+		{
+			name: "add_tags_after_create",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createRec := doDMS(t, h, "CreateMigrationProject", map[string]any{
+					"MigrationProjectName": "add-tag-mp",
+				})
+				require.Equal(t, http.StatusOK, createRec.Code)
+				mpArn := parseJSON(t, createRec)["MigrationProject"].(map[string]any)["MigrationProjectArn"].(string)
+
+				addRec := doDMS(t, h, "AddTagsToResource", map[string]any{
+					"ResourceArn": mpArn,
+					"Tags":        []map[string]string{{"Key": "owner", "Value": "team"}},
+				})
+				assert.Equal(t, http.StatusOK, addRec.Code)
+
+				listRec := doDMS(t, h, "ListTagsForResource", map[string]any{"ResourceArn": mpArn})
+				require.Equal(t, http.StatusOK, listRec.Code)
+				tagList := parseJSON(t, listRec)["TagList"].([]any)
+				assert.Len(t, tagList, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+func TestHandler_TagsOnReplicationSubnetGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "create_with_tags_and_list",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createRec := doDMS(t, h, "CreateReplicationSubnetGroup", map[string]any{
+					"ReplicationSubnetGroupIdentifier":  "tagged-sg",
+					"ReplicationSubnetGroupDescription": "test",
+					"Tags": []map[string]string{
+						{"Key": "env", "Value": "test"},
+					},
+				})
+				require.Equal(t, http.StatusOK, createRec.Code)
+				sgArn := parseJSON(t, createRec)["ReplicationSubnetGroup"].(map[string]any)["ReplicationSubnetGroupArn"].(string)
+
+				listRec := doDMS(t, h, "ListTagsForResource", map[string]any{
+					"ResourceArn": sgArn,
+				})
+				require.Equal(t, http.StatusOK, listRec.Code)
+				tagList := parseJSON(t, listRec)["TagList"].([]any)
+				require.Len(t, tagList, 1)
+				assert.Equal(t, "env", tagList[0].(map[string]any)["Key"])
+			},
+		},
+		{
+			name: "add_and_remove_tags",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createRec := doDMS(t, h, "CreateReplicationSubnetGroup", map[string]any{
+					"ReplicationSubnetGroupIdentifier":  "tag-rm-sg",
+					"ReplicationSubnetGroupDescription": "test",
+				})
+				require.Equal(t, http.StatusOK, createRec.Code)
+				sgArn := parseJSON(t, createRec)["ReplicationSubnetGroup"].(map[string]any)["ReplicationSubnetGroupArn"].(string)
+
+				doDMS(t, h, "AddTagsToResource", map[string]any{
+					"ResourceArn": sgArn,
+					"Tags": []map[string]string{
+						{"Key": "k1", "Value": "v1"},
+						{"Key": "k2", "Value": "v2"},
+					},
+				})
+
+				removeRec := doDMS(t, h, "RemoveTagsFromResource", map[string]any{
+					"ResourceArn": sgArn,
+					"TagKeys":     []string{"k1"},
+				})
+				assert.Equal(t, http.StatusOK, removeRec.Code)
+
+				listRec := doDMS(t, h, "ListTagsForResource", map[string]any{"ResourceArn": sgArn})
+				require.Equal(t, http.StatusOK, listRec.Code)
+				tagList := parseJSON(t, listRec)["TagList"].([]any)
+				assert.Len(t, tagList, 1)
+				assert.Equal(t, "k2", tagList[0].(map[string]any)["Key"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}
+
+func TestHandler_TagsOnReplicationConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		run  func(t *testing.T, h *dms.Handler)
+		name string
+	}{
+		{
+			name: "create_with_tags_and_list",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createRec := doDMS(t, h, "CreateReplicationConfig", map[string]any{
+					"ReplicationConfigIdentifier": "tagged-rc",
+					"ReplicationType":             "full-load",
+					"SourceEndpointArn":           "arn:src",
+					"TargetEndpointArn":           "arn:tgt",
+					"Tags": []map[string]string{
+						{"Key": "tier", "Value": "prod"},
+					},
+				})
+				require.Equal(t, http.StatusOK, createRec.Code)
+				rcArn := parseJSON(t, createRec)["ReplicationConfig"].(map[string]any)["ReplicationConfigArn"].(string)
+
+				listRec := doDMS(t, h, "ListTagsForResource", map[string]any{
+					"ResourceArn": rcArn,
+				})
+				require.Equal(t, http.StatusOK, listRec.Code)
+				tagList := parseJSON(t, listRec)["TagList"].([]any)
+				require.Len(t, tagList, 1)
+				assert.Equal(t, "tier", tagList[0].(map[string]any)["Key"])
+			},
+		},
+		{
+			name: "add_tags_to_existing_config",
+			run: func(t *testing.T, h *dms.Handler) {
+				t.Helper()
+				createRec := doDMS(t, h, "CreateReplicationConfig", map[string]any{
+					"ReplicationConfigIdentifier": "add-tag-rc",
+					"ReplicationType":             "cdc",
+					"SourceEndpointArn":           "arn:src",
+					"TargetEndpointArn":           "arn:tgt",
+				})
+				require.Equal(t, http.StatusOK, createRec.Code)
+				rcArn := parseJSON(t, createRec)["ReplicationConfig"].(map[string]any)["ReplicationConfigArn"].(string)
+
+				addRec := doDMS(t, h, "AddTagsToResource", map[string]any{
+					"ResourceArn": rcArn,
+					"Tags":        []map[string]string{{"Key": "owner", "Value": "dba"}},
+				})
+				assert.Equal(t, http.StatusOK, addRec.Code)
+
+				listRec := doDMS(t, h, "ListTagsForResource", map[string]any{"ResourceArn": rcArn})
+				require.Equal(t, http.StatusOK, listRec.Code)
+				tagList := parseJSON(t, listRec)["TagList"].([]any)
+				assert.Len(t, tagList, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestDMSHandler()
+			tt.run(t, h)
+		})
+	}
+}

--- a/services/dms/handler_test.go
+++ b/services/dms/handler_test.go
@@ -2907,6 +2907,7 @@ func TestHandler_StartReplicationTaskTypeValidation(t *testing.T) {
 		h.Backend.AddReplicationTaskInternal("srtt-task", "srtt-src", "srtt-tgt", "srtt-ri", "full-load")
 		descRec := doDMS(t, h, "DescribeReplicationTasks", map[string]any{})
 		require.Equal(t, http.StatusOK, descRec.Code)
+
 		return parseJSON(t, descRec)["ReplicationTasks"].([]any)[0].(map[string]any)["ReplicationTaskArn"].(string)
 	}
 
@@ -3081,7 +3082,8 @@ func TestHandler_DescribeAccountAttributes(t *testing.T) {
 				for _, q := range quotas {
 					qm := q.(map[string]any)
 					if qm["AccountQuotaName"] == "ReplicationInstances" {
-						assert.Equal(t, float64(1), qm["Used"])
+						assert.InEpsilon(t, float64(1), qm["Used"], 0.01)
+
 						return
 					}
 				}
@@ -3147,6 +3149,7 @@ func TestHandler_DescribeEngineVersions(t *testing.T) {
 				for _, v := range versions {
 					if v.(map[string]any)["Version"] == "3.5.3" {
 						found = true
+
 						break
 					}
 				}


### PR DESCRIPTION
## Summary
- State machine guards: delete/modify running task fails, delete instance with tasks fails
- Stateful `TestConnection` + `DescribeConnections` with `Connection` struct
- Tags on `MigrationProject`, `ReplicationSubnetGroup`, `ReplicationConfig`
- Real `DescribeEngineVersions`, `DescribeOrderableReplicationInstances`, `DescribeEventCategories`, `DescribeAccountAttributes`
- `StartReplicationTask` type validation (start-replication, resume-processing, reload-target)
- 938 lines of new table-driven tests

## Test plan
- [ ] `go test ./services/dms/...` passes (confirmed: ok)
- [ ] `go vet ./services/dms/...` passes (confirmed: clean)
- [ ] All services tests pass (confirmed: no FAIL)
- [ ] State machine: delete running task → 400, delete ready task → 200
- [ ] Delete instance with task → 400, delete instance after task deleted → 200
- [ ] Modify running task → 400, modify stopped task → 200
- [ ] TestConnection stores connection, DescribeConnections returns it
- [ ] Tags CRUD on MigrationProject/ReplicationSubnetGroup/ReplicationConfig
- [ ] DescribeEngineVersions returns 6 versions including 3.5.3
- [ ] DescribeOrderableReplicationInstances returns 14 instance types (t3, c5, r5)
- [ ] DescribeEventCategories filters by SourceType
- [ ] DescribeAccountAttributes returns configured account ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)