### PR TITLE
feat(docdb): AWS-accuracy audit — 15+ parity gaps addressed (go-q7yo)

### DIFF
--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -797,6 +797,7 @@ func (rc *ResourceCreator) createDocDBCluster(
 		"",
 		nil,
 		nil,
+		nil,
 	)
 	if err != nil {
 		return "", fmt.Errorf("create DocDB cluster %s: %w", id, err)
@@ -812,7 +813,7 @@ func (rc *ResourceCreator) deleteDocDBCluster(arn string) error {
 
 	id := resourceNameFromARN(arn)
 
-	_, err := rc.backends.DocDB.Backend.DeleteDBCluster(id)
+	_, err := rc.backends.DocDB.Backend.DeleteDBCluster(id, nil)
 
 	return err
 }
@@ -835,7 +836,7 @@ func (rc *ResourceCreator) createDocDBInstance(
 	instanceClass := strProp(props, "DBInstanceClass", params, physicalIDs)
 	engine := strProp(props, "Engine", params, physicalIDs)
 
-	instance, err := rc.backends.DocDB.Backend.CreateDBInstance(id, clusterID, instanceClass, engine, 0, nil)
+	instance, err := rc.backends.DocDB.Backend.CreateDBInstance(id, clusterID, instanceClass, engine, 0, nil, nil)
 	if err != nil {
 		return "", fmt.Errorf("create DocDB instance %s: %w", id, err)
 	}

--- a/services/docdb/backend.go
+++ b/services/docdb/backend.go
@@ -569,11 +569,11 @@ func applyModifyDBClusterOpts(c *DBCluster, opts *ModifyDBClusterOptions) {
 
 // ModifyDBClusterOptions holds optional extra parameters for ModifyDBCluster.
 type ModifyDBClusterOptions struct {
-	VpcSecurityGroupIDs  []string
-	EnableLogsTypes      []string
-	DisableLogsTypes     []string
-	EngineVersion        string
-	Port                 int
+	EngineVersion       string
+	VpcSecurityGroupIDs []string
+	EnableLogsTypes     []string
+	DisableLogsTypes    []string
+	Port                int
 }
 
 func (b *InMemoryBackend) StopDBCluster(id string) (*DBCluster, error) {

--- a/services/docdb/backend.go
+++ b/services/docdb/backend.go
@@ -81,17 +81,17 @@ type DBCluster struct {
 	DBSubnetGroupName                string            `json:"dbSubnetGroupName"`
 	PreferredBackupWindow            string            `json:"preferredBackupWindow"`
 	ClusterCreateTime                string            `json:"clusterCreateTime"`
-	HostedZoneId                     string            `json:"hostedZoneId"`
-	KmsKeyId                         string            `json:"kmsKeyId"`
+	HostedZoneID                     string            `json:"hostedZoneId"`
+	KmsKeyID                         string            `json:"kmsKeyId"`
 	ReplicationSourceIdentifier      string            `json:"replicationSourceIdentifier"`
 	AvailabilityZones                []string          `json:"availabilityZones"`
-	VpcSecurityGroupIds              []string          `json:"vpcSecurityGroupIds"`
+	VpcSecurityGroupIDs              []string          `json:"vpcSecurityGroupIds"`
 	EnabledCloudwatchLogsExports     []string          `json:"enabledCloudwatchLogsExports"`
 	ReadReplicaIdentifiers           []string          `json:"readReplicaIdentifiers"`
 	Port                             int               `json:"port"`
 	BackupRetentionPeriod            int               `json:"backupRetentionPeriod"`
 	StorageEncrypted                 bool              `json:"storageEncrypted"`
-	MultiAZ                         bool              `json:"multiAZ"`
+	MultiAZ                          bool              `json:"multiAZ"`
 	DeletionProtection               bool              `json:"deletionProtection"`
 	IAMDatabaseAuthenticationEnabled bool              `json:"iamDatabaseAuthenticationEnabled"`
 }
@@ -350,17 +350,17 @@ func (b *InMemoryBackend) CreateDBCluster(
 	copy(azs, availabilityZones)
 
 	var (
-		kmsKeyId                         string
-		vpcSecurityGroupIds              []string
+		kmsKeyID                         string
+		vpcSecurityGroupIDs              []string
 		enabledCloudwatchLogsExports     []string
 		iamDatabaseAuthenticationEnabled bool
 	)
 	if opts != nil {
-		kmsKeyId = opts.KmsKeyId
+		kmsKeyID = opts.KmsKeyID
 		iamDatabaseAuthenticationEnabled = opts.IAMDatabaseAuthenticationEnabled
-		if len(opts.VpcSecurityGroupIds) > 0 {
-			vpcSecurityGroupIds = make([]string, len(opts.VpcSecurityGroupIds))
-			copy(vpcSecurityGroupIds, opts.VpcSecurityGroupIds)
+		if len(opts.VpcSecurityGroupIDs) > 0 {
+			vpcSecurityGroupIDs = make([]string, len(opts.VpcSecurityGroupIDs))
+			copy(vpcSecurityGroupIDs, opts.VpcSecurityGroupIDs)
 		}
 		if len(opts.EnabledCloudwatchLogsExports) > 0 {
 			enabledCloudwatchLogsExports = make([]string, len(opts.EnabledCloudwatchLogsExports))
@@ -389,8 +389,8 @@ func (b *InMemoryBackend) CreateDBCluster(
 		AvailabilityZones:                azs,
 		ClusterCreateTime:                time.Now().UTC().Format(time.RFC3339),
 		Tags:                             copyTags(tags),
-		KmsKeyId:                         kmsKeyId,
-		VpcSecurityGroupIds:              vpcSecurityGroupIds,
+		KmsKeyID:                         kmsKeyID,
+		VpcSecurityGroupIDs:              vpcSecurityGroupIDs,
 		EnabledCloudwatchLogsExports:     enabledCloudwatchLogsExports,
 		IAMDatabaseAuthenticationEnabled: iamDatabaseAuthenticationEnabled,
 	}
@@ -404,8 +404,8 @@ func (b *InMemoryBackend) CreateDBCluster(
 
 // CreateDBClusterOptions holds optional parameters for CreateDBCluster.
 type CreateDBClusterOptions struct {
-	KmsKeyId                         string
-	VpcSecurityGroupIds              []string
+	KmsKeyID                         string
+	VpcSecurityGroupIDs              []string
 	EnabledCloudwatchLogsExports     []string
 	IAMDatabaseAuthenticationEnabled bool
 }
@@ -432,7 +432,7 @@ func (b *InMemoryBackend) DescribeDBClusters(id string) ([]DBCluster, error) {
 	return result, nil
 }
 
-func (b *InMemoryBackend) DeleteDBCluster(id string) (*DBCluster, error) {
+func (b *InMemoryBackend) DeleteDBCluster(id string, opts *DeleteDBClusterOptions) (*DBCluster, error) {
 	if id == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
@@ -451,10 +451,42 @@ func (b *InMemoryBackend) DeleteDBCluster(id string) (*DBCluster, error) {
 		}
 	}
 	cp := copyCluster(c)
+
+	// Create a final snapshot if requested.
+	if opts != nil && !opts.SkipFinalSnapshot && opts.FinalDBClusterSnapshotIdentifier != "" {
+		snapID := opts.FinalDBClusterSnapshotIdentifier
+		if _, snapExists := b.clusterSnapshots[snapID]; snapExists {
+			return nil, fmt.Errorf(
+				"%w: cluster snapshot %s already exists",
+				ErrClusterSnapshotAlreadyExists,
+				snapID,
+			)
+		}
+		snap := &DBClusterSnapshot{
+			DBClusterSnapshotIdentifier: snapID,
+			DBClusterIdentifier:         id,
+			Engine:                      c.Engine,
+			Status:                      statusAvailable,
+			EngineVersion:               c.EngineVersion,
+			StorageEncrypted:            c.StorageEncrypted,
+			SnapshotType:                "manual",
+			PercentProgress:             snapshotPercentageComplete,
+			SnapshotCreateTime:          time.Now().UTC().Format(time.RFC3339),
+			DBClusterArn:                b.clusterARN(id),
+		}
+		b.clusterSnapshots[snapID] = snap
+	}
+
 	delete(b.clusters, id)
 	delete(b.tags, b.clusterARN(id))
 
 	return cp, nil
+}
+
+// DeleteDBClusterOptions holds optional parameters for DeleteDBCluster.
+type DeleteDBClusterOptions struct {
+	FinalDBClusterSnapshotIdentifier string
+	SkipFinalSnapshot                bool
 }
 
 func (b *InMemoryBackend) ModifyDBCluster(
@@ -462,6 +494,7 @@ func (b *InMemoryBackend) ModifyDBCluster(
 	deletionProtection *bool,
 	backupRetentionPeriod int,
 	preferredBackupWindow, preferredMaintenanceWindow string,
+	opts *ModifyDBClusterOptions,
 ) (*DBCluster, error) {
 	b.mu.Lock("ModifyDBCluster")
 	defer b.mu.Unlock()
@@ -487,8 +520,60 @@ func (b *InMemoryBackend) ModifyDBCluster(
 	if preferredMaintenanceWindow != "" {
 		c.PreferredMaintenanceWindow = preferredMaintenanceWindow
 	}
+	if opts != nil {
+		applyModifyDBClusterOpts(c, opts)
+	}
 
 	return copyCluster(c), nil
+}
+
+// applyModifyDBClusterOpts applies optional ModifyDBCluster parameters to an existing cluster.
+func applyModifyDBClusterOpts(c *DBCluster, opts *ModifyDBClusterOptions) {
+	if opts.EngineVersion != "" {
+		c.EngineVersion = opts.EngineVersion
+	}
+	if opts.Port > 0 {
+		c.Port = opts.Port
+	}
+	if len(opts.VpcSecurityGroupIDs) > 0 {
+		vpcSGs := make([]string, len(opts.VpcSecurityGroupIDs))
+		copy(vpcSGs, opts.VpcSecurityGroupIDs)
+		c.VpcSecurityGroupIDs = vpcSGs
+	}
+	if len(opts.EnableLogsTypes) > 0 {
+		existing := make(map[string]bool, len(c.EnabledCloudwatchLogsExports))
+		for _, t := range c.EnabledCloudwatchLogsExports {
+			existing[t] = true
+		}
+		for _, t := range opts.EnableLogsTypes {
+			if !existing[t] {
+				c.EnabledCloudwatchLogsExports = append(c.EnabledCloudwatchLogsExports, t)
+				existing[t] = true
+			}
+		}
+	}
+	if len(opts.DisableLogsTypes) > 0 {
+		disableSet := make(map[string]bool, len(opts.DisableLogsTypes))
+		for _, t := range opts.DisableLogsTypes {
+			disableSet[t] = true
+		}
+		kept := c.EnabledCloudwatchLogsExports[:0]
+		for _, t := range c.EnabledCloudwatchLogsExports {
+			if !disableSet[t] {
+				kept = append(kept, t)
+			}
+		}
+		c.EnabledCloudwatchLogsExports = kept
+	}
+}
+
+// ModifyDBClusterOptions holds optional extra parameters for ModifyDBCluster.
+type ModifyDBClusterOptions struct {
+	VpcSecurityGroupIDs  []string
+	EnableLogsTypes      []string
+	DisableLogsTypes     []string
+	EngineVersion        string
+	Port                 int
 }
 
 func (b *InMemoryBackend) StopDBCluster(id string) (*DBCluster, error) {
@@ -539,6 +624,7 @@ func (b *InMemoryBackend) CreateDBInstance(
 	id, clusterID, instanceClass, engine string,
 	promotionTier int,
 	tags map[string]string,
+	opts *CreateDBInstanceOptions,
 ) (*DBInstance, error) {
 	if id == "" {
 		return nil, fmt.Errorf("%w: DBInstanceIdentifier is required", ErrInvalidParameter)
@@ -571,21 +657,33 @@ func (b *InMemoryBackend) CreateDBInstance(
 	}
 	instanceArn := b.instanceARN(id)
 	endpoint := fmt.Sprintf("%s.docdb.%s.amazonaws.com", id, b.region)
+
+	var (
+		caCertID           string
+		copyTagsToSnapshot bool
+	)
+	if opts != nil {
+		caCertID = opts.CACertificateIdentifier
+		copyTagsToSnapshot = opts.CopyTagsToSnapshot
+	}
+
 	inst := &DBInstance{
-		DBInstanceIdentifier: id,
-		DBClusterIdentifier:  clusterID,
-		DBInstanceClass:      instanceClass,
-		Engine:               engine,
-		DBInstanceStatus:     statusAvailable,
-		Endpoint:             endpoint,
-		Port:                 defaultDocDBPort,
-		DBInstanceArn:        instanceArn,
-		EngineVersion:        valueOrDefault(clusterEngineVersion, defaultEngineVersion),
-		StorageEncrypted:     clusterStorageEncrypted,
-		AvailabilityZone:     clusterAZ,
-		DBSubnetGroupName:    clusterSubnetGroupName,
-		PromotionTier:        promotionTier,
-		Tags:                 copyTags(tags),
+		DBInstanceIdentifier:    id,
+		DBClusterIdentifier:     clusterID,
+		DBInstanceClass:         instanceClass,
+		Engine:                  engine,
+		DBInstanceStatus:        statusAvailable,
+		Endpoint:                endpoint,
+		Port:                    defaultDocDBPort,
+		DBInstanceArn:           instanceArn,
+		EngineVersion:           valueOrDefault(clusterEngineVersion, defaultEngineVersion),
+		StorageEncrypted:        clusterStorageEncrypted,
+		AvailabilityZone:        clusterAZ,
+		DBSubnetGroupName:       clusterSubnetGroupName,
+		PromotionTier:           promotionTier,
+		Tags:                    copyTags(tags),
+		CACertificateIdentifier: caCertID,
+		CopyTagsToSnapshot:      copyTagsToSnapshot,
 	}
 	b.instances[id] = inst
 	if len(tags) > 0 {
@@ -593,6 +691,12 @@ func (b *InMemoryBackend) CreateDBInstance(
 	}
 
 	return copyInstance(inst), nil
+}
+
+// CreateDBInstanceOptions holds optional parameters for CreateDBInstance.
+type CreateDBInstanceOptions struct {
+	CACertificateIdentifier string
+	CopyTagsToSnapshot      bool
 }
 
 func (b *InMemoryBackend) DescribeDBInstances(id, clusterID string) ([]DBInstance, error) {
@@ -641,6 +745,7 @@ func (b *InMemoryBackend) ModifyDBInstance(
 	id, instanceClass string,
 	autoMinorVersionUpgrade *bool,
 	preferredMaintenanceWindow string,
+	opts *ModifyDBInstanceOptions,
 ) (*DBInstance, error) {
 	b.mu.Lock("ModifyDBInstance")
 	defer b.mu.Unlock()
@@ -657,8 +762,26 @@ func (b *InMemoryBackend) ModifyDBInstance(
 	if preferredMaintenanceWindow != "" {
 		inst.PreferredMaintenanceWindow = preferredMaintenanceWindow
 	}
+	if opts != nil {
+		if opts.CACertificateIdentifier != "" {
+			inst.CACertificateIdentifier = opts.CACertificateIdentifier
+		}
+		if opts.CopyTagsToSnapshot != nil {
+			inst.CopyTagsToSnapshot = *opts.CopyTagsToSnapshot
+		}
+		if opts.PromotionTier != nil {
+			inst.PromotionTier = *opts.PromotionTier
+		}
+	}
 
 	return copyInstance(inst), nil
+}
+
+// ModifyDBInstanceOptions holds optional extra parameters for ModifyDBInstance.
+type ModifyDBInstanceOptions struct {
+	CopyTagsToSnapshot      *bool
+	PromotionTier           *int
+	CACertificateIdentifier string
 }
 
 func (b *InMemoryBackend) RebootDBInstance(id string) (*DBInstance, error) {
@@ -1888,6 +2011,18 @@ func copyCluster(c *DBCluster) *DBCluster {
 	if len(c.AvailabilityZones) > 0 {
 		cp.AvailabilityZones = make([]string, len(c.AvailabilityZones))
 		copy(cp.AvailabilityZones, c.AvailabilityZones)
+	}
+	if len(c.VpcSecurityGroupIDs) > 0 {
+		cp.VpcSecurityGroupIDs = make([]string, len(c.VpcSecurityGroupIDs))
+		copy(cp.VpcSecurityGroupIDs, c.VpcSecurityGroupIDs)
+	}
+	if len(c.EnabledCloudwatchLogsExports) > 0 {
+		cp.EnabledCloudwatchLogsExports = make([]string, len(c.EnabledCloudwatchLogsExports))
+		copy(cp.EnabledCloudwatchLogsExports, c.EnabledCloudwatchLogsExports)
+	}
+	if len(c.ReadReplicaIdentifiers) > 0 {
+		cp.ReadReplicaIdentifiers = make([]string, len(c.ReadReplicaIdentifiers))
+		copy(cp.ReadReplicaIdentifiers, c.ReadReplicaIdentifiers)
 	}
 
 	return &cp

--- a/services/docdb/backend.go
+++ b/services/docdb/backend.go
@@ -66,47 +66,57 @@ const (
 )
 
 type DBCluster struct {
-	Tags                        map[string]string `json:"tags"`
-	DBClusterArn                string            `json:"dbClusterArn"`
-	EngineVersion               string            `json:"engineVersion"`
-	Engine                      string            `json:"engine"`
-	PreferredMaintenanceWindow  string            `json:"preferredMaintenanceWindow"`
-	MasterUsername              string            `json:"masterUsername"`
-	DatabaseName                string            `json:"databaseName"`
-	DBClusterParameterGroupName string            `json:"dbClusterParameterGroupName"`
-	Endpoint                    string            `json:"endpoint"`
-	DBClusterIdentifier         string            `json:"dbClusterIdentifier"`
-	ReaderEndpoint              string            `json:"readerEndpoint"`
-	Status                      string            `json:"status"`
-	DBSubnetGroupName           string            `json:"dbSubnetGroupName"`
-	PreferredBackupWindow       string            `json:"preferredBackupWindow"`
-	ClusterCreateTime           string            `json:"clusterCreateTime"`
-	AvailabilityZones           []string          `json:"availabilityZones"`
-	Port                        int               `json:"port"`
-	BackupRetentionPeriod       int               `json:"backupRetentionPeriod"`
-	StorageEncrypted            bool              `json:"storageEncrypted"`
-	MultiAZ                     bool              `json:"multiAZ"`
-	DeletionProtection          bool              `json:"deletionProtection"`
+	Tags                             map[string]string `json:"tags"`
+	DBClusterArn                     string            `json:"dbClusterArn"`
+	EngineVersion                    string            `json:"engineVersion"`
+	Engine                           string            `json:"engine"`
+	PreferredMaintenanceWindow       string            `json:"preferredMaintenanceWindow"`
+	MasterUsername                   string            `json:"masterUsername"`
+	DatabaseName                     string            `json:"databaseName"`
+	DBClusterParameterGroupName      string            `json:"dbClusterParameterGroupName"`
+	Endpoint                         string            `json:"endpoint"`
+	DBClusterIdentifier              string            `json:"dbClusterIdentifier"`
+	ReaderEndpoint                   string            `json:"readerEndpoint"`
+	Status                           string            `json:"status"`
+	DBSubnetGroupName                string            `json:"dbSubnetGroupName"`
+	PreferredBackupWindow            string            `json:"preferredBackupWindow"`
+	ClusterCreateTime                string            `json:"clusterCreateTime"`
+	HostedZoneId                     string            `json:"hostedZoneId"`
+	KmsKeyId                         string            `json:"kmsKeyId"`
+	ReplicationSourceIdentifier      string            `json:"replicationSourceIdentifier"`
+	AvailabilityZones                []string          `json:"availabilityZones"`
+	VpcSecurityGroupIds              []string          `json:"vpcSecurityGroupIds"`
+	EnabledCloudwatchLogsExports     []string          `json:"enabledCloudwatchLogsExports"`
+	ReadReplicaIdentifiers           []string          `json:"readReplicaIdentifiers"`
+	Port                             int               `json:"port"`
+	BackupRetentionPeriod            int               `json:"backupRetentionPeriod"`
+	StorageEncrypted                 bool              `json:"storageEncrypted"`
+	MultiAZ                         bool              `json:"multiAZ"`
+	DeletionProtection               bool              `json:"deletionProtection"`
+	IAMDatabaseAuthenticationEnabled bool              `json:"iamDatabaseAuthenticationEnabled"`
 }
 
 type DBInstance struct {
-	Tags                       map[string]string `json:"tags"`
-	DBInstanceIdentifier       string            `json:"dbInstanceIdentifier"`
-	DBClusterIdentifier        string            `json:"dbClusterIdentifier"`
-	DBInstanceClass            string            `json:"dbInstanceClass"`
-	Engine                     string            `json:"engine"`
-	DBInstanceStatus           string            `json:"dbInstanceStatus"`
-	Endpoint                   string            `json:"endpoint"`
-	DBInstanceArn              string            `json:"dbInstanceArn"`
-	EngineVersion              string            `json:"engineVersion"`
-	AvailabilityZone           string            `json:"availabilityZone"`
-	DBSubnetGroupName          string            `json:"dbSubnetGroupName"`
-	PreferredMaintenanceWindow string            `json:"preferredMaintenanceWindow"`
-	Port                       int               `json:"port"`
-	PromotionTier              int               `json:"promotionTier"`
-	StorageEncrypted           bool              `json:"storageEncrypted"`
-	AutoMinorVersionUpgrade    bool              `json:"autoMinorVersionUpgrade"`
-	PubliclyAccessible         bool              `json:"publiclyAccessible"`
+	Tags                         map[string]string `json:"tags"`
+	DBInstanceIdentifier         string            `json:"dbInstanceIdentifier"`
+	DBClusterIdentifier          string            `json:"dbClusterIdentifier"`
+	DBInstanceClass              string            `json:"dbInstanceClass"`
+	Engine                       string            `json:"engine"`
+	DBInstanceStatus             string            `json:"dbInstanceStatus"`
+	Endpoint                     string            `json:"endpoint"`
+	DBInstanceArn                string            `json:"dbInstanceArn"`
+	EngineVersion                string            `json:"engineVersion"`
+	AvailabilityZone             string            `json:"availabilityZone"`
+	DBSubnetGroupName            string            `json:"dbSubnetGroupName"`
+	PreferredMaintenanceWindow   string            `json:"preferredMaintenanceWindow"`
+	CACertificateIdentifier      string            `json:"caCertificateIdentifier"`
+	EnabledCloudwatchLogsExports []string          `json:"enabledCloudwatchLogsExports"`
+	Port                         int               `json:"port"`
+	PromotionTier                int               `json:"promotionTier"`
+	StorageEncrypted             bool              `json:"storageEncrypted"`
+	AutoMinorVersionUpgrade      bool              `json:"autoMinorVersionUpgrade"`
+	PubliclyAccessible           bool              `json:"publiclyAccessible"`
+	CopyTagsToSnapshot           bool              `json:"copyTagsToSnapshot"`
 }
 
 type DBSubnetGroup struct {
@@ -302,6 +312,7 @@ func (b *InMemoryBackend) CreateDBCluster(
 	preferredBackupWindow, preferredMaintenanceWindow string,
 	availabilityZones []string,
 	tags map[string]string,
+	opts *CreateDBClusterOptions,
 ) (*DBCluster, error) {
 	if id == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
@@ -337,27 +348,51 @@ func (b *InMemoryBackend) CreateDBCluster(
 	readerEndpoint := fmt.Sprintf("%s.cluster-ro.docdb.%s.amazonaws.com", id, b.region)
 	azs := make([]string, len(availabilityZones))
 	copy(azs, availabilityZones)
+
+	var (
+		kmsKeyId                         string
+		vpcSecurityGroupIds              []string
+		enabledCloudwatchLogsExports     []string
+		iamDatabaseAuthenticationEnabled bool
+	)
+	if opts != nil {
+		kmsKeyId = opts.KmsKeyId
+		iamDatabaseAuthenticationEnabled = opts.IAMDatabaseAuthenticationEnabled
+		if len(opts.VpcSecurityGroupIds) > 0 {
+			vpcSecurityGroupIds = make([]string, len(opts.VpcSecurityGroupIds))
+			copy(vpcSecurityGroupIds, opts.VpcSecurityGroupIds)
+		}
+		if len(opts.EnabledCloudwatchLogsExports) > 0 {
+			enabledCloudwatchLogsExports = make([]string, len(opts.EnabledCloudwatchLogsExports))
+			copy(enabledCloudwatchLogsExports, opts.EnabledCloudwatchLogsExports)
+		}
+	}
+
 	cluster := &DBCluster{
-		DBClusterIdentifier:         id,
-		Engine:                      engine,
-		Status:                      statusAvailable,
-		MasterUsername:              masterUser,
-		DatabaseName:                dbName,
-		DBClusterParameterGroupName: paramGroupName,
-		DBSubnetGroupName:           subnetGroupName,
-		Endpoint:                    endpoint,
-		ReaderEndpoint:              readerEndpoint,
-		Port:                        port,
-		DBClusterArn:                clusterArn,
-		EngineVersion:               engineVersion,
-		StorageEncrypted:            storageEncrypted,
-		DeletionProtection:          deletionProtection,
-		BackupRetentionPeriod:       backupRetentionPeriod,
-		PreferredBackupWindow:       preferredBackupWindow,
-		PreferredMaintenanceWindow:  preferredMaintenanceWindow,
-		AvailabilityZones:           azs,
-		ClusterCreateTime:           time.Now().UTC().Format(time.RFC3339),
-		Tags:                        copyTags(tags),
+		DBClusterIdentifier:              id,
+		Engine:                           engine,
+		Status:                           statusAvailable,
+		MasterUsername:                   masterUser,
+		DatabaseName:                     dbName,
+		DBClusterParameterGroupName:      paramGroupName,
+		DBSubnetGroupName:                subnetGroupName,
+		Endpoint:                         endpoint,
+		ReaderEndpoint:                   readerEndpoint,
+		Port:                             port,
+		DBClusterArn:                     clusterArn,
+		EngineVersion:                    engineVersion,
+		StorageEncrypted:                 storageEncrypted,
+		DeletionProtection:               deletionProtection,
+		BackupRetentionPeriod:            backupRetentionPeriod,
+		PreferredBackupWindow:            preferredBackupWindow,
+		PreferredMaintenanceWindow:       preferredMaintenanceWindow,
+		AvailabilityZones:                azs,
+		ClusterCreateTime:                time.Now().UTC().Format(time.RFC3339),
+		Tags:                             copyTags(tags),
+		KmsKeyId:                         kmsKeyId,
+		VpcSecurityGroupIds:              vpcSecurityGroupIds,
+		EnabledCloudwatchLogsExports:     enabledCloudwatchLogsExports,
+		IAMDatabaseAuthenticationEnabled: iamDatabaseAuthenticationEnabled,
 	}
 	b.clusters[id] = cluster
 	if len(tags) > 0 {
@@ -365,6 +400,14 @@ func (b *InMemoryBackend) CreateDBCluster(
 	}
 
 	return copyCluster(cluster), nil
+}
+
+// CreateDBClusterOptions holds optional parameters for CreateDBCluster.
+type CreateDBClusterOptions struct {
+	KmsKeyId                         string
+	VpcSecurityGroupIds              []string
+	EnabledCloudwatchLogsExports     []string
+	IAMDatabaseAuthenticationEnabled bool
 }
 
 func (b *InMemoryBackend) DescribeDBClusters(id string) ([]DBCluster, error) {

--- a/services/docdb/handler.go
+++ b/services/docdb/handler.go
@@ -368,10 +368,16 @@ func (h *Handler) handleCreateDBCluster(vals url.Values) (any, error) {
 	preferredMaintenanceWindow := vals.Get("PreferredMaintenanceWindow")
 	availabilityZones := parseAvailabilityZones(vals)
 	tags := parseTags(vals)
+	opts := &CreateDBClusterOptions{
+		KmsKeyID:                         vals.Get("KmsKeyId"),
+		VpcSecurityGroupIDs:              parseVpcSecurityGroupIDs(vals),
+		EnabledCloudwatchLogsExports:     parseEnableLogTypes(vals),
+		IAMDatabaseAuthenticationEnabled: vals.Get("EnableIAMDatabaseAuthentication") == stringTrue,
+	}
 	cluster, err := h.Backend.CreateDBCluster(
 		id, engine, engineVersion, masterUser, dbName, paramGroupName, subnetGroupName,
 		port, storageEncrypted, deletionProtection, backupRetentionPeriod,
-		preferredBackupWindow, preferredMaintenanceWindow, availabilityZones, tags,
+		preferredBackupWindow, preferredMaintenanceWindow, availabilityZones, tags, opts,
 	)
 	if err != nil {
 		return nil, err
@@ -408,7 +414,11 @@ func (h *Handler) handleDescribeDBClusters(vals url.Values) (any, error) {
 
 func (h *Handler) handleDeleteDBCluster(vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.DeleteDBCluster(id)
+	opts := &DeleteDBClusterOptions{
+		SkipFinalSnapshot:                vals.Get("SkipFinalSnapshot") == stringTrue,
+		FinalDBClusterSnapshotIdentifier: vals.Get("FinalDBClusterSnapshotIdentifier"),
+	}
+	cluster, err := h.Backend.DeleteDBCluster(id, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -430,9 +440,24 @@ func (h *Handler) handleModifyDBCluster(vals url.Values) (any, error) {
 		backupRetentionPeriod, _ = strconv.Atoi(backupRetentionPeriodStr)
 	}
 	deletionProtection := parseBoolParam(vals, "DeletionProtection")
+
+	portStr := vals.Get("Port")
+	var port int
+	if portStr != "" {
+		port, _ = strconv.Atoi(portStr)
+	}
+
+	opts := &ModifyDBClusterOptions{
+		EngineVersion:       vals.Get("EngineVersion"),
+		VpcSecurityGroupIDs: parseVpcSecurityGroupIDs(vals),
+		EnableLogsTypes:     parseCloudwatchEnableLogTypes(vals),
+		DisableLogsTypes:    parseCloudwatchDisableLogTypes(vals),
+		Port:                port,
+	}
+
 	cluster, err := h.Backend.ModifyDBCluster(
 		id, paramGroupName, deletionProtection, backupRetentionPeriod,
-		preferredBackupWindow, preferredMaintenanceWindow,
+		preferredBackupWindow, preferredMaintenanceWindow, opts,
 	)
 	if err != nil {
 		return nil, err
@@ -493,7 +518,11 @@ func (h *Handler) handleCreateDBInstance(vals url.Values) (any, error) {
 		promotionTier, _ = strconv.Atoi(ptStr)
 	}
 	tags := parseTags(vals)
-	inst, err := h.Backend.CreateDBInstance(id, clusterID, instanceClass, engine, promotionTier, tags)
+	opts := &CreateDBInstanceOptions{
+		CACertificateIdentifier: vals.Get("CACertificateIdentifier"),
+		CopyTagsToSnapshot:      vals.Get("CopyTagsToSnapshot") == stringTrue,
+	}
+	inst, err := h.Backend.CreateDBInstance(id, clusterID, instanceClass, engine, promotionTier, tags, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -546,7 +575,19 @@ func (h *Handler) handleModifyDBInstance(vals url.Values) (any, error) {
 	instanceClass := vals.Get("DBInstanceClass")
 	autoMinorVersionUpgrade := parseBoolParam(vals, "AutoMinorVersionUpgrade")
 	preferredMaintenanceWindow := vals.Get("PreferredMaintenanceWindow")
-	inst, err := h.Backend.ModifyDBInstance(id, instanceClass, autoMinorVersionUpgrade, preferredMaintenanceWindow)
+
+	opts := &ModifyDBInstanceOptions{
+		CACertificateIdentifier: vals.Get("CACertificateIdentifier"),
+		CopyTagsToSnapshot:      parseBoolParam(vals, "CopyTagsToSnapshot"),
+	}
+	if ptStr := vals.Get("PromotionTier"); ptStr != "" {
+		pt, _ := strconv.Atoi(ptStr)
+		opts.PromotionTier = &pt
+	}
+
+	inst, err := h.Backend.ModifyDBInstance(
+		id, instanceClass, autoMinorVersionUpgrade, preferredMaintenanceWindow, opts,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1358,47 +1399,70 @@ func parseTagKeyMembers(vals url.Values) []string {
 }
 
 func toXMLCluster(c *DBCluster) xmlDBCluster {
+	vpcSGs := make([]xmlVpcSecurityGroupMembership, 0, len(c.VpcSecurityGroupIDs))
+	for _, sgID := range c.VpcSecurityGroupIDs {
+		vpcSGs = append(vpcSGs, xmlVpcSecurityGroupMembership{
+			VpcSecurityGroupID: sgID,
+			Status:             "active",
+		})
+	}
+	logTypes := make([]string, len(c.EnabledCloudwatchLogsExports))
+	copy(logTypes, c.EnabledCloudwatchLogsExports)
+
 	return xmlDBCluster{
-		DBClusterIdentifier:         c.DBClusterIdentifier,
-		Engine:                      c.Engine,
-		Status:                      c.Status,
-		MasterUsername:              c.MasterUsername,
-		DatabaseName:                c.DatabaseName,
-		DBClusterParameterGroupName: c.DBClusterParameterGroupName,
-		Endpoint:                    c.Endpoint,
-		ReaderEndpoint:              c.ReaderEndpoint,
-		DBSubnetGroupName:           c.DBSubnetGroupName,
-		PreferredBackupWindow:       c.PreferredBackupWindow,
-		PreferredMaintenanceWindow:  c.PreferredMaintenanceWindow,
-		Port:                        c.Port,
-		DBClusterArn:                c.DBClusterArn,
-		EngineVersion:               c.EngineVersion,
-		BackupRetentionPeriod:       c.BackupRetentionPeriod,
-		StorageEncrypted:            c.StorageEncrypted,
-		MultiAZ:                     c.MultiAZ,
-		DeletionProtection:          c.DeletionProtection,
-		ClusterCreateTime:           c.ClusterCreateTime,
+		DBClusterIdentifier:              c.DBClusterIdentifier,
+		Engine:                           c.Engine,
+		Status:                           c.Status,
+		MasterUsername:                   c.MasterUsername,
+		DatabaseName:                     c.DatabaseName,
+		DBClusterParameterGroupName:      c.DBClusterParameterGroupName,
+		Endpoint:                         c.Endpoint,
+		ReaderEndpoint:                   c.ReaderEndpoint,
+		DBSubnetGroupName:                c.DBSubnetGroupName,
+		PreferredBackupWindow:            c.PreferredBackupWindow,
+		PreferredMaintenanceWindow:       c.PreferredMaintenanceWindow,
+		Port:                             c.Port,
+		DBClusterArn:                     c.DBClusterArn,
+		EngineVersion:                    c.EngineVersion,
+		BackupRetentionPeriod:            c.BackupRetentionPeriod,
+		StorageEncrypted:                 c.StorageEncrypted,
+		MultiAZ:                          c.MultiAZ,
+		DeletionProtection:               c.DeletionProtection,
+		ClusterCreateTime:                c.ClusterCreateTime,
+		HostedZoneID:                     c.HostedZoneID,
+		KmsKeyID:                         c.KmsKeyID,
+		ReplicationSourceIdentifier:      c.ReplicationSourceIdentifier,
+		IAMDatabaseAuthenticationEnabled: c.IAMDatabaseAuthenticationEnabled,
+		VpcSecurityGroups:                xmlVpcSecurityGroupMembershipList{Members: vpcSGs},
+		EnabledCloudwatchLogsExports:     xmlLogTypeList{Members: logTypes},
+		DBClusterMembers:                 xmlDBClusterMemberList{},
 	}
 }
 
 func toXMLInstance(inst *DBInstance) xmlDBInstance {
+	logTypes := make([]string, len(inst.EnabledCloudwatchLogsExports))
+	copy(logTypes, inst.EnabledCloudwatchLogsExports)
+
 	return xmlDBInstance{
-		DBInstanceIdentifier:       inst.DBInstanceIdentifier,
-		DBClusterIdentifier:        inst.DBClusterIdentifier,
-		DBInstanceClass:            inst.DBInstanceClass,
-		Engine:                     inst.Engine,
-		DBInstanceStatus:           inst.DBInstanceStatus,
-		Endpoint:                   inst.Endpoint,
-		Port:                       inst.Port,
-		DBInstanceArn:              inst.DBInstanceArn,
-		EngineVersion:              inst.EngineVersion,
-		AvailabilityZone:           inst.AvailabilityZone,
-		DBSubnetGroupName:          inst.DBSubnetGroupName,
-		AutoMinorVersionUpgrade:    inst.AutoMinorVersionUpgrade,
-		PubliclyAccessible:         inst.PubliclyAccessible,
-		StorageEncrypted:           inst.StorageEncrypted,
-		PromotionTier:              inst.PromotionTier,
-		PreferredMaintenanceWindow: inst.PreferredMaintenanceWindow,
+		DBInstanceIdentifier:         inst.DBInstanceIdentifier,
+		DBClusterIdentifier:          inst.DBClusterIdentifier,
+		DBInstanceClass:              inst.DBInstanceClass,
+		Engine:                       inst.Engine,
+		DBInstanceStatus:             inst.DBInstanceStatus,
+		Endpoint:                     inst.Endpoint,
+		Port:                         inst.Port,
+		DBInstanceArn:                inst.DBInstanceArn,
+		EngineVersion:                inst.EngineVersion,
+		AvailabilityZone:             inst.AvailabilityZone,
+		DBSubnetGroupName:            inst.DBSubnetGroupName,
+		AutoMinorVersionUpgrade:      inst.AutoMinorVersionUpgrade,
+		PubliclyAccessible:           inst.PubliclyAccessible,
+		StorageEncrypted:             inst.StorageEncrypted,
+		PromotionTier:                inst.PromotionTier,
+		PreferredMaintenanceWindow:   inst.PreferredMaintenanceWindow,
+		CACertificateIdentifier:      inst.CACertificateIdentifier,
+		CopyTagsToSnapshot:           inst.CopyTagsToSnapshot,
+		EnabledCloudwatchLogsExports: xmlLogTypeList{Members: logTypes},
 	}
 }
 
@@ -1454,26 +1518,57 @@ type docdbErrorResponse struct {
 	Error   docdbError `xml:"Error"`
 }
 
+type xmlVpcSecurityGroupMembership struct {
+	VpcSecurityGroupID string `xml:"VpcSecurityGroupId"`
+	Status             string `xml:"Status"`
+}
+
+type xmlVpcSecurityGroupMembershipList struct {
+	Members []xmlVpcSecurityGroupMembership `xml:"VpcSecurityGroupMembership"`
+}
+
+type xmlLogTypeList struct {
+	Members []string `xml:"member"`
+}
+
+type xmlDBClusterMember struct {
+	DBInstanceIdentifier          string `xml:"DBInstanceIdentifier"`
+	DBClusterParameterGroupStatus string `xml:"DBClusterParameterGroupStatus"`
+	PromotionTier                 int    `xml:"PromotionTier"`
+	IsClusterWriter               bool   `xml:"IsClusterWriter"`
+}
+
+type xmlDBClusterMemberList struct {
+	Members []xmlDBClusterMember `xml:"DBClusterMember"`
+}
+
 type xmlDBCluster struct {
-	DBClusterIdentifier         string `xml:"DBClusterIdentifier"`
-	Engine                      string `xml:"Engine"`
-	Status                      string `xml:"Status"`
-	MasterUsername              string `xml:"MasterUsername,omitempty"`
-	DatabaseName                string `xml:"DatabaseName,omitempty"`
-	DBClusterParameterGroupName string `xml:"DBClusterParameterGroup,omitempty"`
-	Endpoint                    string `xml:"Endpoint,omitempty"`
-	ReaderEndpoint              string `xml:"ReaderEndpoint,omitempty"`
-	DBSubnetGroupName           string `xml:"DBSubnetGroup,omitempty"`
-	PreferredBackupWindow       string `xml:"PreferredBackupWindow,omitempty"`
-	PreferredMaintenanceWindow  string `xml:"PreferredMaintenanceWindow,omitempty"`
-	DBClusterArn                string `xml:"DBClusterArn,omitempty"`
-	EngineVersion               string `xml:"EngineVersion,omitempty"`
-	ClusterCreateTime           string `xml:"ClusterCreateTime,omitempty"`
-	Port                        int    `xml:"Port"`
-	BackupRetentionPeriod       int    `xml:"BackupRetentionPeriod,omitempty"`
-	StorageEncrypted            bool   `xml:"StorageEncrypted"`
-	MultiAZ                     bool   `xml:"MultiAZ"`
-	DeletionProtection          bool   `xml:"DeletionProtection"`
+	DBClusterIdentifier              string                            `xml:"DBClusterIdentifier"`
+	Engine                           string                            `xml:"Engine"`
+	Status                           string                            `xml:"Status"`
+	MasterUsername                   string                            `xml:"MasterUsername,omitempty"`
+	DatabaseName                     string                            `xml:"DatabaseName,omitempty"`
+	DBClusterParameterGroupName      string                            `xml:"DBClusterParameterGroup,omitempty"`
+	Endpoint                         string                            `xml:"Endpoint,omitempty"`
+	ReaderEndpoint                   string                            `xml:"ReaderEndpoint,omitempty"`
+	DBSubnetGroupName                string                            `xml:"DBSubnetGroup,omitempty"`
+	PreferredBackupWindow            string                            `xml:"PreferredBackupWindow,omitempty"`
+	PreferredMaintenanceWindow       string                            `xml:"PreferredMaintenanceWindow,omitempty"`
+	DBClusterArn                     string                            `xml:"DBClusterArn,omitempty"`
+	EngineVersion                    string                            `xml:"EngineVersion,omitempty"`
+	ClusterCreateTime                string                            `xml:"ClusterCreateTime,omitempty"`
+	HostedZoneID                     string                            `xml:"HostedZoneId,omitempty"`
+	KmsKeyID                         string                            `xml:"KmsKeyId,omitempty"`
+	ReplicationSourceIdentifier      string                            `xml:"ReplicationSourceIdentifier,omitempty"`
+	VpcSecurityGroups                xmlVpcSecurityGroupMembershipList `xml:"VpcSecurityGroups"`
+	EnabledCloudwatchLogsExports     xmlLogTypeList                    `xml:"EnabledCloudwatchLogsExports"`
+	DBClusterMembers                 xmlDBClusterMemberList            `xml:"DBClusterMembers"`
+	Port                             int                               `xml:"Port"`
+	BackupRetentionPeriod            int                               `xml:"BackupRetentionPeriod,omitempty"`
+	StorageEncrypted                 bool                              `xml:"StorageEncrypted"`
+	MultiAZ                          bool                              `xml:"MultiAZ"`
+	DeletionProtection               bool                              `xml:"DeletionProtection"`
+	IAMDatabaseAuthenticationEnabled bool                              `xml:"IAMDatabaseAuthenticationEnabled"`
 }
 
 type xmlDBClusterList struct {
@@ -1528,22 +1623,25 @@ type failoverDBClusterResponse struct {
 }
 
 type xmlDBInstance struct {
-	DBInstanceIdentifier       string `xml:"DBInstanceIdentifier"`
-	DBClusterIdentifier        string `xml:"DBClusterIdentifier,omitempty"`
-	DBInstanceClass            string `xml:"DBInstanceClass"`
-	Engine                     string `xml:"Engine"`
-	DBInstanceStatus           string `xml:"DBInstanceStatus"`
-	Endpoint                   string `xml:"Endpoint>Address,omitempty"`
-	DBInstanceArn              string `xml:"DBInstanceArn,omitempty"`
-	EngineVersion              string `xml:"EngineVersion,omitempty"`
-	AvailabilityZone           string `xml:"AvailabilityZone,omitempty"`
-	DBSubnetGroupName          string `xml:"DBSubnetGroup>DBSubnetGroupName,omitempty"`
-	PreferredMaintenanceWindow string `xml:"PreferredMaintenanceWindow,omitempty"`
-	StorageEncrypted           bool   `xml:"StorageEncrypted"`
-	AutoMinorVersionUpgrade    bool   `xml:"AutoMinorVersionUpgrade"`
-	PubliclyAccessible         bool   `xml:"PubliclyAccessible"`
-	Port                       int    `xml:"Endpoint>Port"`
-	PromotionTier              int    `xml:"PromotionTier,omitempty"`
+	DBInstanceIdentifier         string         `xml:"DBInstanceIdentifier"`
+	DBClusterIdentifier          string         `xml:"DBClusterIdentifier,omitempty"`
+	DBInstanceClass              string         `xml:"DBInstanceClass"`
+	Engine                       string         `xml:"Engine"`
+	DBInstanceStatus             string         `xml:"DBInstanceStatus"`
+	Endpoint                     string         `xml:"Endpoint>Address,omitempty"`
+	DBInstanceArn                string         `xml:"DBInstanceArn,omitempty"`
+	EngineVersion                string         `xml:"EngineVersion,omitempty"`
+	AvailabilityZone             string         `xml:"AvailabilityZone,omitempty"`
+	DBSubnetGroupName            string         `xml:"DBSubnetGroup>DBSubnetGroupName,omitempty"`
+	PreferredMaintenanceWindow   string         `xml:"PreferredMaintenanceWindow,omitempty"`
+	CACertificateIdentifier      string         `xml:"CACertificateIdentifier,omitempty"`
+	EnabledCloudwatchLogsExports xmlLogTypeList `xml:"EnabledCloudwatchLogsExports"`
+	StorageEncrypted             bool           `xml:"StorageEncrypted"`
+	AutoMinorVersionUpgrade      bool           `xml:"AutoMinorVersionUpgrade"`
+	PubliclyAccessible           bool           `xml:"PubliclyAccessible"`
+	CopyTagsToSnapshot           bool           `xml:"CopyTagsToSnapshot"`
+	Port                         int            `xml:"Endpoint>Port"`
+	PromotionTier                int            `xml:"PromotionTier,omitempty"`
 }
 
 type xmlDBInstanceList struct {
@@ -2232,5 +2330,49 @@ func parseAttributeValueMembers(vals url.Values, prefix string) []string {
 			return values
 		}
 		values = append(values, v)
+	}
+}
+
+func parseVpcSecurityGroupIDs(vals url.Values) []string {
+	var ids []string
+	for i := 1; ; i++ {
+		id := vals.Get(fmt.Sprintf("VpcSecurityGroupIds.member.%d", i))
+		if id == "" {
+			return ids
+		}
+		ids = append(ids, id)
+	}
+}
+
+func parseEnableLogTypes(vals url.Values) []string {
+	var types []string
+	for i := 1; ; i++ {
+		t := vals.Get(fmt.Sprintf("EnableCloudwatchLogsExports.member.%d", i))
+		if t == "" {
+			return types
+		}
+		types = append(types, t)
+	}
+}
+
+func parseCloudwatchEnableLogTypes(vals url.Values) []string {
+	var types []string
+	for i := 1; ; i++ {
+		t := vals.Get(fmt.Sprintf("CloudwatchLogsExportConfiguration.EnableLogTypes.member.%d", i))
+		if t == "" {
+			return types
+		}
+		types = append(types, t)
+	}
+}
+
+func parseCloudwatchDisableLogTypes(vals url.Values) []string {
+	var types []string
+	for i := 1; ; i++ {
+		t := vals.Get(fmt.Sprintf("CloudwatchLogsExportConfiguration.DisableLogTypes.member.%d", i))
+		if t == "" {
+			return types
+		}
+		types = append(types, t)
 	}
 }

--- a/services/docdb/handler_test.go
+++ b/services/docdb/handler_test.go
@@ -3861,9 +3861,9 @@ func TestAudit_CreateCluster_VpcSecurityGroups(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		vpcSGIDs     []string
 		name         string
 		wantContains string
+		vpcSGIDs     []string
 		wantStatus   int
 	}{
 		{
@@ -3995,8 +3995,8 @@ func TestAudit_CreateCluster_CloudwatchLogsExports(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		logTypes     []string
 		wantContains string
+		logTypes     []string
 		wantStatus   int
 	}{
 		{
@@ -4065,11 +4065,11 @@ func TestAudit_DeleteCluster_FinalSnapshot(t *testing.T) {
 		{
 			name: "create_final_snapshot",
 			vals: url.Values{
-				"Action":                             {"DeleteDBCluster"},
-				"Version":                            {"2014-10-31"},
-				"DBClusterIdentifier":                {"del-cluster"},
-				"SkipFinalSnapshot":                  {"false"},
-				"FinalDBClusterSnapshotIdentifier":   {"final-snap"},
+				"Action":                           {"DeleteDBCluster"},
+				"Version":                          {"2014-10-31"},
+				"DBClusterIdentifier":              {"del-cluster"},
+				"SkipFinalSnapshot":                {"false"},
+				"FinalDBClusterSnapshotIdentifier": {"final-snap"},
 			},
 			wantStatus:         200,
 			wantContains:       "DeleteDBClusterResponse",
@@ -4087,11 +4087,11 @@ func TestAudit_DeleteCluster_FinalSnapshot(t *testing.T) {
 				})
 			},
 			vals: url.Values{
-				"Action":                             {"DeleteDBCluster"},
-				"Version":                            {"2014-10-31"},
-				"DBClusterIdentifier":                {"del-cluster"},
-				"SkipFinalSnapshot":                  {"false"},
-				"FinalDBClusterSnapshotIdentifier":   {"final-snap"},
+				"Action":                           {"DeleteDBCluster"},
+				"Version":                          {"2014-10-31"},
+				"DBClusterIdentifier":              {"del-cluster"},
+				"SkipFinalSnapshot":                {"false"},
+				"FinalDBClusterSnapshotIdentifier": {"final-snap"},
 			},
 			wantStatus:   400,
 			wantContains: "DBClusterSnapshotAlreadyExistsFault",
@@ -4177,9 +4177,9 @@ func TestAudit_ModifyCluster_CloudwatchLogs(t *testing.T) {
 
 	tests := []struct {
 		name         string
+		wantContains string
 		enableLogs   []string
 		disableLogs  []string
-		wantContains string
 		wantStatus   int
 	}{
 		{
@@ -4475,9 +4475,9 @@ func TestAudit_DeleteCluster_DeletionProtection(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		deletionProtection bool
-		wantStatus         int
 		wantContains       string
+		wantStatus         int
+		deletionProtection bool
 	}{
 		{
 			name:               "deletion_protection_blocks_delete",
@@ -4521,9 +4521,9 @@ func TestAudit_DeleteCluster_WithInstances(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		addInstance  bool
-		wantStatus   int
 		wantContains string
+		wantStatus   int
+		addInstance  bool
 	}{
 		{
 			name:         "fails_with_instances",
@@ -4571,10 +4571,10 @@ func TestAudit_ClusterVpcSGPersistedToBackend(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		sgIDs       []string
-		wantLen     int
-		wantFirst   string
+		name      string
+		wantFirst string
+		sgIDs     []string
+		wantLen   int
 	}{
 		{
 			name:      "two_sgs_stored",
@@ -4815,8 +4815,8 @@ func TestAudit_StopCluster_AlreadyStopped(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		wantStatus   int
 		wantContains string
+		wantStatus   int
 	}{
 		{
 			name:         "stop_already_stopped_cluster_fails",
@@ -4851,8 +4851,8 @@ func TestAudit_StartCluster_AlreadyAvailable(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		wantStatus   int
 		wantContains string
+		wantStatus   int
 	}{
 		{
 			name:         "start_already_available_cluster_fails",
@@ -4887,8 +4887,8 @@ func TestAudit_FailoverCluster_StoppedFails(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		wantStatus   int
 		wantContains string
+		wantStatus   int
 	}{
 		{
 			name:         "failover_stopped_cluster_fails",
@@ -4959,10 +4959,10 @@ func TestAudit_InstanceInheritsClusterProperties(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		clusterID       string
-		wantEngineVer   string
-		wantStorageEnc  bool
+		name           string
+		clusterID      string
+		wantEngineVer  string
+		wantStorageEnc bool
 	}{
 		{
 			name:           "instance_inherits_from_cluster",
@@ -5048,11 +5048,11 @@ func TestAudit_RestoreCluster_FromSnapshot(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		snapshotExists   bool
-		targetExists     bool
-		wantStatus       int
-		wantContains     string
+		name           string
+		wantContains   string
+		wantStatus     int
+		snapshotExists bool
+		targetExists   bool
 	}{
 		{
 			name:           "restore_from_valid_snapshot",
@@ -5119,11 +5119,11 @@ func TestAudit_RestoreCluster_ToPointInTime(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		sourceExists    bool
-		targetExists    bool
-		wantStatus      int
-		wantContains    string
+		name         string
+		wantContains string
+		wantStatus   int
+		sourceExists bool
+		targetExists bool
 	}{
 		{
 			name:         "restore_from_source",
@@ -5168,10 +5168,10 @@ func TestAudit_RestoreCluster_ToPointInTime(t *testing.T) {
 				})
 			}
 			rr := doRequest(t, h, url.Values{
-				"Action":                       {"RestoreDBClusterToPointInTime"},
-				"Version":                      {"2014-10-31"},
-				"SourceDBClusterIdentifier":    {"pitr-source"},
-				"DBClusterIdentifier":          {"pitr-target"},
+				"Action":                    {"RestoreDBClusterToPointInTime"},
+				"Version":                   {"2014-10-31"},
+				"SourceDBClusterIdentifier": {"pitr-source"},
+				"DBClusterIdentifier":       {"pitr-target"},
 			})
 			assert.Equal(t, tt.wantStatus, rr.Code)
 			assert.Contains(t, rr.Body.String(), tt.wantContains)
@@ -5185,8 +5185,8 @@ func TestAudit_GlobalCluster_FailoverSwitchover(t *testing.T) {
 	tests := []struct {
 		name         string
 		action       string
-		wantStatus   int
 		wantContains string
+		wantStatus   int
 	}{
 		{
 			name:         "failover_sets_failing_over_status",
@@ -5213,9 +5213,9 @@ func TestAudit_GlobalCluster_FailoverSwitchover(t *testing.T) {
 				"GlobalClusterIdentifier": {"fo-gc"},
 			})
 			rr := doRequest(t, h, url.Values{
-				"Action":                  {tt.action},
-				"Version":                 {"2014-10-31"},
-				"GlobalClusterIdentifier": {"fo-gc"},
+				"Action":                    {tt.action},
+				"Version":                   {"2014-10-31"},
+				"GlobalClusterIdentifier":   {"fo-gc"},
 				"TargetDbClusterIdentifier": {"some-cluster"},
 			})
 			assert.Equal(t, tt.wantStatus, rr.Code)
@@ -5334,9 +5334,9 @@ func TestAudit_SnapshotAttributes_AddRemove(t *testing.T) {
 		name         string
 		operation    string
 		attrName     string
+		wantContains string
 		valuesToAdd  []string
 		valuesToRm   []string
-		wantContains string
 		wantStatus   int
 	}{
 		{
@@ -5446,10 +5446,10 @@ func TestAudit_EventSubscription_FullLifecycle(t *testing.T) {
 			setup: func(t *testing.T, h *docdb.Handler) {
 				t.Helper()
 				doRequest(t, h, url.Values{
-					"Action":                         {"CreateEventSubscription"},
-					"Version":                        {"2014-10-31"},
-					"SubscriptionName":               {"src-id-sub"},
-					"SourceIds.SourceId.1":            {"my-cluster"},
+					"Action":               {"CreateEventSubscription"},
+					"Version":              {"2014-10-31"},
+					"SubscriptionName":     {"src-id-sub"},
+					"SourceIds.SourceId.1": {"my-cluster"},
 				})
 			},
 			vals: url.Values{
@@ -5554,11 +5554,11 @@ func TestAudit_Pagination_Clusters(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		maxRecords   string
-		marker       string
-		wantCount    int
-		wantHasMore  bool
+		name        string
+		maxRecords  string
+		marker      string
+		wantCount   int
+		wantHasMore bool
 	}{
 		{
 			name:        "no_limit_returns_all",
@@ -5618,9 +5618,9 @@ func TestAudit_SubnetGroup_DeleteInUseFails(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		useInCluster bool
-		wantStatus   int
 		wantContains string
+		wantStatus   int
+		useInCluster bool
 	}{
 		{
 			name:         "in_use_by_cluster_fails",

--- a/services/docdb/handler_test.go
+++ b/services/docdb/handler_test.go
@@ -2,6 +2,7 @@ package docdb_test
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -2177,7 +2178,7 @@ func TestRefinement1_DeleteCluster_RequiresId(t *testing.T) {
 			t.Parallel()
 
 			b := docdb.NewInMemoryBackend("000000000000", "us-east-1")
-			_, err := b.DeleteDBCluster(tt.id)
+			_, err := b.DeleteDBCluster(tt.id, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -3847,6 +3848,1816 @@ func TestRefinement2_DeleteSubnetGroupInUse(t *testing.T) {
 				"Action":            {"DeleteDBSubnetGroup"},
 				"Version":           {"2014-10-31"},
 				"DBSubnetGroupName": {"my-sg"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+// ---- AWS-accuracy audit tests ----
+
+func TestAudit_CreateCluster_VpcSecurityGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		vpcSGIDs     []string
+		name         string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "single_vpc_sg",
+			vpcSGIDs:     []string{"sg-aaaa1111"},
+			wantContains: "sg-aaaa1111",
+			wantStatus:   200,
+		},
+		{
+			name:         "multiple_vpc_sgs",
+			vpcSGIDs:     []string{"sg-aaaa1111", "sg-bbbb2222"},
+			wantContains: "sg-aaaa1111",
+			wantStatus:   200,
+		},
+		{
+			name:         "no_vpc_sgs",
+			vpcSGIDs:     nil,
+			wantContains: "CreateDBClusterResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			vals := url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"vpc-test-cluster"},
+			}
+			for i, sgID := range tt.vpcSGIDs {
+				vals.Set(fmt.Sprintf("VpcSecurityGroupIds.member.%d", i+1), sgID)
+			}
+
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_CreateCluster_IAMDatabaseAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		paramVal     string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "iam_auth_enabled",
+			paramVal:     "true",
+			wantContains: "IAMDatabaseAuthenticationEnabled",
+			wantStatus:   200,
+		},
+		{
+			name:         "iam_auth_disabled",
+			paramVal:     "false",
+			wantContains: "CreateDBClusterResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rr := doRequest(t, h, url.Values{
+				"Action":                          {"CreateDBCluster"},
+				"Version":                         {"2014-10-31"},
+				"DBClusterIdentifier":             {"iam-auth-cluster"},
+				"EnableIAMDatabaseAuthentication": {tt.paramVal},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_CreateCluster_KmsKeyId(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		kmsKeyID     string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "kms_key_set",
+			kmsKeyID:     "arn:aws:kms:us-east-1:000000000000:key/test-key-id",
+			wantContains: "test-key-id",
+			wantStatus:   200,
+		},
+		{
+			name:         "no_kms_key",
+			kmsKeyID:     "",
+			wantContains: "CreateDBClusterResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			vals := url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"kms-cluster"},
+			}
+			if tt.kmsKeyID != "" {
+				vals.Set("KmsKeyId", tt.kmsKeyID)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_CreateCluster_CloudwatchLogsExports(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		logTypes     []string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "profiler_log_enabled",
+			logTypes:     []string{"profiler"},
+			wantContains: "profiler",
+			wantStatus:   200,
+		},
+		{
+			name:         "multiple_logs",
+			logTypes:     []string{"profiler", "audit"},
+			wantContains: "profiler",
+			wantStatus:   200,
+		},
+		{
+			name:         "no_logs",
+			logTypes:     nil,
+			wantContains: "CreateDBClusterResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			vals := url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"logs-cluster"},
+			}
+			for i, lt := range tt.logTypes {
+				vals.Set(fmt.Sprintf("EnableCloudwatchLogsExports.member.%d", i+1), lt)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_DeleteCluster_FinalSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup              func(*testing.T, *docdb.Handler)
+		vals               url.Values
+		name               string
+		wantContains       string
+		wantStatus         int
+		wantSnapshotExists bool
+	}{
+		{
+			name: "skip_final_snapshot",
+			vals: url.Values{
+				"Action":              {"DeleteDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"del-cluster"},
+				"SkipFinalSnapshot":   {"true"},
+			},
+			wantStatus:         200,
+			wantContains:       "DeleteDBClusterResponse",
+			wantSnapshotExists: false,
+		},
+		{
+			name: "create_final_snapshot",
+			vals: url.Values{
+				"Action":                             {"DeleteDBCluster"},
+				"Version":                            {"2014-10-31"},
+				"DBClusterIdentifier":                {"del-cluster"},
+				"SkipFinalSnapshot":                  {"false"},
+				"FinalDBClusterSnapshotIdentifier":   {"final-snap"},
+			},
+			wantStatus:         200,
+			wantContains:       "DeleteDBClusterResponse",
+			wantSnapshotExists: true,
+		},
+		{
+			name: "final_snapshot_already_exists_fails",
+			setup: func(t *testing.T, h *docdb.Handler) {
+				t.Helper()
+				doRequest(t, h, url.Values{
+					"Action":                      {"CreateDBClusterSnapshot"},
+					"Version":                     {"2014-10-31"},
+					"DBClusterSnapshotIdentifier": {"final-snap"},
+					"DBClusterIdentifier":         {"del-cluster"},
+				})
+			},
+			vals: url.Values{
+				"Action":                             {"DeleteDBCluster"},
+				"Version":                            {"2014-10-31"},
+				"DBClusterIdentifier":                {"del-cluster"},
+				"SkipFinalSnapshot":                  {"false"},
+				"FinalDBClusterSnapshotIdentifier":   {"final-snap"},
+			},
+			wantStatus:   400,
+			wantContains: "DBClusterSnapshotAlreadyExistsFault",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"del-cluster"},
+			})
+			if tt.setup != nil {
+				tt.setup(t, h)
+			}
+			rr := doRequest(t, h, tt.vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+
+			if tt.wantSnapshotExists {
+				snaps, err := h.Backend.DescribeDBClusterSnapshots("final-snap", "", "")
+				require.NoError(t, err)
+				assert.Len(t, snaps, 1)
+			}
+		})
+	}
+}
+
+func TestAudit_ModifyCluster_EngineVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		engineVersion string
+		wantContains  string
+		wantStatus    int
+	}{
+		{
+			name:          "upgrade_to_5_0",
+			engineVersion: "5.0.0",
+			wantContains:  "5.0.0",
+			wantStatus:    200,
+		},
+		{
+			name:          "no_version_change",
+			engineVersion: "",
+			wantContains:  "ModifyDBClusterResponse",
+			wantStatus:    200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-ev-cluster"},
+			})
+			vals := url.Values{
+				"Action":              {"ModifyDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-ev-cluster"},
+			}
+			if tt.engineVersion != "" {
+				vals.Set("EngineVersion", tt.engineVersion)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_ModifyCluster_CloudwatchLogs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		enableLogs   []string
+		disableLogs  []string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "enable_profiler_log",
+			enableLogs:   []string{"profiler"},
+			wantContains: "profiler",
+			wantStatus:   200,
+		},
+		{
+			name:         "enable_then_disable",
+			enableLogs:   []string{"profiler"},
+			disableLogs:  []string{"profiler"},
+			wantContains: "ModifyDBClusterResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-logs-cluster"},
+			})
+			vals := url.Values{
+				"Action":              {"ModifyDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-logs-cluster"},
+			}
+			for i, lt := range tt.enableLogs {
+				vals.Set(fmt.Sprintf("CloudwatchLogsExportConfiguration.EnableLogTypes.member.%d", i+1), lt)
+			}
+			for i, lt := range tt.disableLogs {
+				vals.Set(fmt.Sprintf("CloudwatchLogsExportConfiguration.DisableLogTypes.member.%d", i+1), lt)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_ModifyCluster_Port(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		port         string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "change_port",
+			port:         "27018",
+			wantContains: "ModifyDBClusterResponse",
+			wantStatus:   200,
+		},
+		{
+			name:         "no_port_change",
+			port:         "",
+			wantContains: "ModifyDBClusterResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-port-cluster"},
+			})
+			vals := url.Values{
+				"Action":              {"ModifyDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-port-cluster"},
+			}
+			if tt.port != "" {
+				vals.Set("Port", tt.port)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_CreateInstance_CACertificate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		caCertID     string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "ca_cert_set",
+			caCertID:     "rds-ca-rsa2048-g1",
+			wantContains: "rds-ca-rsa2048-g1",
+			wantStatus:   200,
+		},
+		{
+			name:         "no_ca_cert",
+			caCertID:     "",
+			wantContains: "CreateDBInstanceResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			vals := url.Values{
+				"Action":               {"CreateDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"ca-cert-inst"},
+				"Engine":               {"docdb"},
+			}
+			if tt.caCertID != "" {
+				vals.Set("CACertificateIdentifier", tt.caCertID)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_CreateInstance_CopyTagsToSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		copyTagsToSnapshot string
+		wantCopyTags       bool
+		wantStatus         int
+	}{
+		{
+			name:               "copy_tags_enabled",
+			copyTagsToSnapshot: "true",
+			wantCopyTags:       true,
+			wantStatus:         200,
+		},
+		{
+			name:               "copy_tags_disabled",
+			copyTagsToSnapshot: "false",
+			wantCopyTags:       false,
+			wantStatus:         200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rr := doRequest(t, h, url.Values{
+				"Action":               {"CreateDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"copy-tags-inst"},
+				"CopyTagsToSnapshot":   {tt.copyTagsToSnapshot},
+				"Engine":               {"docdb"},
+			})
+			require.Equal(t, tt.wantStatus, rr.Code)
+
+			instances, err := h.Backend.DescribeDBInstances("copy-tags-inst", "")
+			require.NoError(t, err)
+			require.Len(t, instances, 1)
+			assert.Equal(t, tt.wantCopyTags, instances[0].CopyTagsToSnapshot)
+		})
+	}
+}
+
+func TestAudit_ModifyInstance_CACertificate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		caCertID     string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "update_ca_cert",
+			caCertID:     "rds-ca-rsa2048-g1",
+			wantContains: "rds-ca-rsa2048-g1",
+			wantStatus:   200,
+		},
+		{
+			name:         "no_ca_cert_change",
+			caCertID:     "",
+			wantContains: "ModifyDBInstanceResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":               {"CreateDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"modify-ca-inst"},
+				"Engine":               {"docdb"},
+			})
+			vals := url.Values{
+				"Action":               {"ModifyDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"modify-ca-inst"},
+			}
+			if tt.caCertID != "" {
+				vals.Set("CACertificateIdentifier", tt.caCertID)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_ModifyInstance_PromotionTier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		promotionTier string
+		wantTier      int
+		wantStatus    int
+	}{
+		{
+			name:          "set_tier_0",
+			promotionTier: "0",
+			wantTier:      0,
+			wantStatus:    200,
+		},
+		{
+			name:          "set_tier_15",
+			promotionTier: "15",
+			wantTier:      15,
+			wantStatus:    200,
+		},
+		{
+			name:          "no_tier_change",
+			promotionTier: "",
+			wantTier:      1,
+			wantStatus:    200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":               {"CreateDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"tier-inst"},
+				"Engine":               {"docdb"},
+			})
+			vals := url.Values{
+				"Action":               {"ModifyDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"tier-inst"},
+			}
+			if tt.promotionTier != "" {
+				vals.Set("PromotionTier", tt.promotionTier)
+			}
+			rr := doRequest(t, h, vals)
+			require.Equal(t, tt.wantStatus, rr.Code)
+
+			instances, err := h.Backend.DescribeDBInstances("tier-inst", "")
+			require.NoError(t, err)
+			require.Len(t, instances, 1)
+			assert.Equal(t, tt.wantTier, instances[0].PromotionTier)
+		})
+	}
+}
+
+func TestAudit_DeleteCluster_DeletionProtection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		deletionProtection bool
+		wantStatus         int
+		wantContains       string
+	}{
+		{
+			name:               "deletion_protection_blocks_delete",
+			deletionProtection: true,
+			wantStatus:         400,
+			wantContains:       "InvalidDBClusterStateFault",
+		},
+		{
+			name:               "no_deletion_protection_allows_delete",
+			deletionProtection: false,
+			wantStatus:         200,
+			wantContains:       "DeleteDBClusterResponse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			b := h.Backend
+			b.AddDBClusterInternal(&docdb.DBCluster{
+				DBClusterIdentifier: "prot-cluster",
+				Status:              "available",
+				DeletionProtection:  tt.deletionProtection,
+			})
+			rr := doRequest(t, h, url.Values{
+				"Action":              {"DeleteDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"prot-cluster"},
+				"SkipFinalSnapshot":   {"true"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_DeleteCluster_WithInstances(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		addInstance  bool
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "fails_with_instances",
+			addInstance:  true,
+			wantStatus:   400,
+			wantContains: "InvalidDBClusterStateFault",
+		},
+		{
+			name:         "succeeds_without_instances",
+			addInstance:  false,
+			wantStatus:   200,
+			wantContains: "DeleteDBClusterResponse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			b := h.Backend
+			b.AddDBClusterInternal(&docdb.DBCluster{
+				DBClusterIdentifier: "inst-cluster",
+				Status:              "available",
+			})
+			if tt.addInstance {
+				b.AddDBInstanceInternal(&docdb.DBInstance{
+					DBInstanceIdentifier: "inst-to-block",
+					DBClusterIdentifier:  "inst-cluster",
+				})
+			}
+			rr := doRequest(t, h, url.Values{
+				"Action":              {"DeleteDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"inst-cluster"},
+				"SkipFinalSnapshot":   {"true"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_ClusterVpcSGPersistedToBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		sgIDs       []string
+		wantLen     int
+		wantFirst   string
+	}{
+		{
+			name:      "two_sgs_stored",
+			sgIDs:     []string{"sg-aaa", "sg-bbb"},
+			wantLen:   2,
+			wantFirst: "sg-aaa",
+		},
+		{
+			name:    "no_sgs",
+			sgIDs:   nil,
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			vals := url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"sg-test-cluster"},
+			}
+			for i, sgID := range tt.sgIDs {
+				vals.Set(fmt.Sprintf("VpcSecurityGroupIds.member.%d", i+1), sgID)
+			}
+			doRequest(t, h, vals)
+
+			clusters, err := h.Backend.DescribeDBClusters("sg-test-cluster")
+			require.NoError(t, err)
+			require.Len(t, clusters, 1)
+			assert.Len(t, clusters[0].VpcSecurityGroupIDs, tt.wantLen)
+			if tt.wantFirst != "" {
+				assert.Equal(t, tt.wantFirst, clusters[0].VpcSecurityGroupIDs[0])
+			}
+		})
+	}
+}
+
+func TestAudit_ModifyCluster_VpcSecurityGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		newSGIDs []string
+		wantLen  int
+	}{
+		{
+			name:     "replace_with_two_sgs",
+			newSGIDs: []string{"sg-new1", "sg-new2"},
+			wantLen:  2,
+		},
+		{
+			name:     "no_sg_update",
+			newSGIDs: nil,
+			wantLen:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-sg-cluster"},
+			})
+			vals := url.Values{
+				"Action":              {"ModifyDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"modify-sg-cluster"},
+			}
+			for i, sgID := range tt.newSGIDs {
+				vals.Set(fmt.Sprintf("VpcSecurityGroupIds.member.%d", i+1), sgID)
+			}
+			doRequest(t, h, vals)
+
+			clusters, err := h.Backend.DescribeDBClusters("modify-sg-cluster")
+			require.NoError(t, err)
+			require.Len(t, clusters, 1)
+			assert.Len(t, clusters[0].VpcSecurityGroupIDs, tt.wantLen)
+		})
+	}
+}
+
+func TestAudit_ModifyCluster_CloudwatchEnableDisable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		enableLogs   []string
+		disableLogs  []string
+		wantLogCount int
+	}{
+		{
+			name:         "enable_two_log_types",
+			enableLogs:   []string{"profiler", "audit"},
+			wantLogCount: 2,
+		},
+		{
+			name:         "enable_then_disable_one",
+			enableLogs:   []string{"profiler", "audit"},
+			disableLogs:  []string{"profiler"},
+			wantLogCount: 1,
+		},
+		{
+			name:         "disable_non_enabled_is_noop",
+			disableLogs:  []string{"profiler"},
+			wantLogCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"cw-cluster"},
+			})
+			vals := url.Values{
+				"Action":              {"ModifyDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"cw-cluster"},
+			}
+			for i, lt := range tt.enableLogs {
+				vals.Set(fmt.Sprintf("CloudwatchLogsExportConfiguration.EnableLogTypes.member.%d", i+1), lt)
+			}
+			for i, lt := range tt.disableLogs {
+				vals.Set(fmt.Sprintf("CloudwatchLogsExportConfiguration.DisableLogTypes.member.%d", i+1), lt)
+			}
+			doRequest(t, h, vals)
+
+			clusters, err := h.Backend.DescribeDBClusters("cw-cluster")
+			require.NoError(t, err)
+			require.Len(t, clusters, 1)
+			assert.Len(t, clusters[0].EnabledCloudwatchLogsExports, tt.wantLogCount)
+		})
+	}
+}
+
+func TestAudit_ClusterResponseFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantContains []string
+	}{
+		{
+			name: "all_expected_fields_present",
+			wantContains: []string{
+				"DBClusterArn",
+				"DBClusterIdentifier",
+				"Engine",
+				"Status",
+				"Endpoint",
+				"ReaderEndpoint",
+				"Port",
+				"EngineVersion",
+				"VpcSecurityGroups",
+				"DBClusterMembers",
+				"EnabledCloudwatchLogsExports",
+				"IAMDatabaseAuthenticationEnabled",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rr := doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"field-check-cluster"},
+				"Engine":              {"docdb"},
+				"MasterUsername":      {"admin"},
+			})
+			require.Equal(t, 200, rr.Code)
+			body := rr.Body.String()
+			for _, field := range tt.wantContains {
+				assert.Contains(t, body, field, "field %q missing from response", field)
+			}
+		})
+	}
+}
+
+func TestAudit_InstanceResponseFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantContains []string
+	}{
+		{
+			name: "all_expected_fields_present",
+			wantContains: []string{
+				"DBInstanceArn",
+				"DBInstanceIdentifier",
+				"Engine",
+				"DBInstanceStatus",
+				"DBInstanceClass",
+				"EngineVersion",
+				"EnabledCloudwatchLogsExports",
+				"CopyTagsToSnapshot",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rr := doRequest(t, h, url.Values{
+				"Action":               {"CreateDBInstance"},
+				"Version":              {"2014-10-31"},
+				"DBInstanceIdentifier": {"field-check-inst"},
+				"Engine":               {"docdb"},
+			})
+			require.Equal(t, 200, rr.Code)
+			body := rr.Body.String()
+			for _, field := range tt.wantContains {
+				assert.Contains(t, body, field, "field %q missing from response", field)
+			}
+		})
+	}
+}
+
+func TestAudit_StopCluster_AlreadyStopped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "stop_already_stopped_cluster_fails",
+			wantStatus:   400,
+			wantContains: "InvalidDBClusterStateFault",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			b := h.Backend
+			b.AddDBClusterInternal(&docdb.DBCluster{
+				DBClusterIdentifier: "stopped-cluster",
+				Status:              "stopped",
+			})
+			rr := doRequest(t, h, url.Values{
+				"Action":              {"StopDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"stopped-cluster"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_StartCluster_AlreadyAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "start_already_available_cluster_fails",
+			wantStatus:   400,
+			wantContains: "InvalidDBClusterStateFault",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"avail-cluster"},
+			})
+			rr := doRequest(t, h, url.Values{
+				"Action":              {"StartDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"avail-cluster"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_FailoverCluster_StoppedFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "failover_stopped_cluster_fails",
+			wantStatus:   400,
+			wantContains: "InvalidDBClusterStateFault",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			b := h.Backend
+			b.AddDBClusterInternal(&docdb.DBCluster{
+				DBClusterIdentifier: "stopped-fo-cluster",
+				Status:              "stopped",
+			})
+			rr := doRequest(t, h, url.Values{
+				"Action":              {"FailoverDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"stopped-fo-cluster"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_ClusterInheritedDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		wantEngine          string
+		wantEngineVersion   string
+		wantPort            int
+		wantBackupRetention int
+	}{
+		{
+			name:                "defaults_applied",
+			wantEngine:          "docdb",
+			wantEngineVersion:   "4.0.0",
+			wantPort:            27017,
+			wantBackupRetention: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := docdb.NewInMemoryBackend("000000000000", "us-east-1")
+			cluster, err := b.CreateDBCluster(
+				"defaults-cluster", "", "", "admin", "", "", "",
+				0, false, false, 0, "", "", nil, nil, nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEngine, cluster.Engine)
+			assert.Equal(t, tt.wantEngineVersion, cluster.EngineVersion)
+			assert.Equal(t, tt.wantPort, cluster.Port)
+			assert.Equal(t, tt.wantBackupRetention, cluster.BackupRetentionPeriod)
+		})
+	}
+}
+
+func TestAudit_InstanceInheritsClusterProperties(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		clusterID       string
+		wantEngineVer   string
+		wantStorageEnc  bool
+	}{
+		{
+			name:           "instance_inherits_from_cluster",
+			clusterID:      "parent-cluster",
+			wantEngineVer:  "5.0.0",
+			wantStorageEnc: true,
+		},
+		{
+			name:           "instance_no_cluster_uses_defaults",
+			clusterID:      "",
+			wantEngineVer:  "4.0.0",
+			wantStorageEnc: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := docdb.NewInMemoryBackend("000000000000", "us-east-1")
+			if tt.clusterID != "" {
+				b.AddDBClusterInternal(&docdb.DBCluster{
+					DBClusterIdentifier: tt.clusterID,
+					EngineVersion:       "5.0.0",
+					StorageEncrypted:    true,
+				})
+			}
+			inst, err := b.CreateDBInstance(
+				"inherit-inst", tt.clusterID, "", "docdb", 1, nil, nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEngineVer, inst.EngineVersion)
+			assert.Equal(t, tt.wantStorageEnc, inst.StorageEncrypted)
+		})
+	}
+}
+
+func TestAudit_CopyCluster_SnapshotRetainsMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "copy_snapshot_retains_engine_version",
+			wantContains: "4.0.0",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"snap-src-cluster"},
+				"EngineVersion":       {"4.0.0"},
+			})
+			doRequest(t, h, url.Values{
+				"Action":                      {"CreateDBClusterSnapshot"},
+				"Version":                     {"2014-10-31"},
+				"DBClusterSnapshotIdentifier": {"src-snap"},
+				"DBClusterIdentifier":         {"snap-src-cluster"},
+			})
+			rr := doRequest(t, h, url.Values{
+				"Action":                            {"CopyDBClusterSnapshot"},
+				"Version":                           {"2014-10-31"},
+				"SourceDBClusterSnapshotIdentifier": {"src-snap"},
+				"TargetDBClusterSnapshotIdentifier": {"dst-snap"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_RestoreCluster_FromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		snapshotExists   bool
+		targetExists     bool
+		wantStatus       int
+		wantContains     string
+	}{
+		{
+			name:           "restore_from_valid_snapshot",
+			snapshotExists: true,
+			targetExists:   false,
+			wantStatus:     200,
+			wantContains:   "RestoreDBClusterFromSnapshotResponse",
+		},
+		{
+			name:           "restore_with_nonexistent_snapshot_fails",
+			snapshotExists: false,
+			targetExists:   false,
+			wantStatus:     400,
+			wantContains:   "DBClusterSnapshotNotFoundFault",
+		},
+		{
+			name:           "restore_when_target_exists_fails",
+			snapshotExists: true,
+			targetExists:   true,
+			wantStatus:     400,
+			wantContains:   "DBClusterAlreadyExistsFault",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.snapshotExists {
+				doRequest(t, h, url.Values{
+					"Action":              {"CreateDBCluster"},
+					"Version":             {"2014-10-31"},
+					"DBClusterIdentifier": {"orig-cluster"},
+				})
+				doRequest(t, h, url.Values{
+					"Action":                      {"CreateDBClusterSnapshot"},
+					"Version":                     {"2014-10-31"},
+					"DBClusterSnapshotIdentifier": {"restore-snap"},
+					"DBClusterIdentifier":         {"orig-cluster"},
+				})
+			}
+			if tt.targetExists {
+				doRequest(t, h, url.Values{
+					"Action":              {"CreateDBCluster"},
+					"Version":             {"2014-10-31"},
+					"DBClusterIdentifier": {"restored-cluster"},
+				})
+			}
+			rr := doRequest(t, h, url.Values{
+				"Action":                      {"RestoreDBClusterFromSnapshot"},
+				"Version":                     {"2014-10-31"},
+				"DBClusterSnapshotIdentifier": {"restore-snap"},
+				"DBClusterIdentifier":         {"restored-cluster"},
+				"Engine":                      {"docdb"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_RestoreCluster_ToPointInTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		sourceExists    bool
+		targetExists    bool
+		wantStatus      int
+		wantContains    string
+	}{
+		{
+			name:         "restore_from_source",
+			sourceExists: true,
+			targetExists: false,
+			wantStatus:   200,
+			wantContains: "RestoreDBClusterToPointInTimeResponse",
+		},
+		{
+			name:         "source_not_found_fails",
+			sourceExists: false,
+			targetExists: false,
+			wantStatus:   400,
+			wantContains: "DBClusterNotFoundFault",
+		},
+		{
+			name:         "target_already_exists_fails",
+			sourceExists: true,
+			targetExists: true,
+			wantStatus:   400,
+			wantContains: "DBClusterAlreadyExistsFault",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.sourceExists {
+				doRequest(t, h, url.Values{
+					"Action":              {"CreateDBCluster"},
+					"Version":             {"2014-10-31"},
+					"DBClusterIdentifier": {"pitr-source"},
+				})
+			}
+			if tt.targetExists {
+				doRequest(t, h, url.Values{
+					"Action":              {"CreateDBCluster"},
+					"Version":             {"2014-10-31"},
+					"DBClusterIdentifier": {"pitr-target"},
+				})
+			}
+			rr := doRequest(t, h, url.Values{
+				"Action":                       {"RestoreDBClusterToPointInTime"},
+				"Version":                      {"2014-10-31"},
+				"SourceDBClusterIdentifier":    {"pitr-source"},
+				"DBClusterIdentifier":          {"pitr-target"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_GlobalCluster_FailoverSwitchover(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		action       string
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "failover_sets_failing_over_status",
+			action:       "FailoverGlobalCluster",
+			wantStatus:   200,
+			wantContains: "failing-over",
+		},
+		{
+			name:         "switchover_sets_switching_over_status",
+			action:       "SwitchoverGlobalCluster",
+			wantStatus:   200,
+			wantContains: "switching-over",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":                  {"CreateGlobalCluster"},
+				"Version":                 {"2014-10-31"},
+				"GlobalClusterIdentifier": {"fo-gc"},
+			})
+			rr := doRequest(t, h, url.Values{
+				"Action":                  {tt.action},
+				"Version":                 {"2014-10-31"},
+				"GlobalClusterIdentifier": {"fo-gc"},
+				"TargetDbClusterIdentifier": {"some-cluster"},
+			})
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_GlobalCluster_ModifyRenameAndDeletionProtection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		newID              string
+		deletionProtection string
+		wantContains       string
+		wantStatus         int
+	}{
+		{
+			name:         "rename_global_cluster",
+			newID:        "renamed-gc",
+			wantContains: "renamed-gc",
+			wantStatus:   200,
+		},
+		{
+			name:               "set_deletion_protection",
+			newID:              "",
+			deletionProtection: "true",
+			wantContains:       "ModifyGlobalClusterResponse",
+			wantStatus:         200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":                  {"CreateGlobalCluster"},
+				"Version":                 {"2014-10-31"},
+				"GlobalClusterIdentifier": {"mod-gc"},
+			})
+			vals := url.Values{
+				"Action":                  {"ModifyGlobalCluster"},
+				"Version":                 {"2014-10-31"},
+				"GlobalClusterIdentifier": {"mod-gc"},
+			}
+			if tt.newID != "" {
+				vals.Set("NewGlobalClusterIdentifier", tt.newID)
+			}
+			if tt.deletionProtection != "" {
+				vals.Set("DeletionProtection", tt.deletionProtection)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_SubnetGroup_ModifyDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		newDescription string
+		wantContains   string
+		wantStatus     int
+	}{
+		{
+			name:           "update_description",
+			newDescription: "updated description",
+			wantContains:   "ModifyDBSubnetGroupResponse",
+			wantStatus:     200,
+		},
+		{
+			name:           "no_description_change",
+			newDescription: "",
+			wantContains:   "ModifyDBSubnetGroupResponse",
+			wantStatus:     200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":                   {"CreateDBSubnetGroup"},
+				"Version":                  {"2014-10-31"},
+				"DBSubnetGroupName":        {"mod-sg"},
+				"DBSubnetGroupDescription": {"original"},
+				"SubnetIds.member.1":       {"subnet-111"},
+			})
+			vals := url.Values{
+				"Action":            {"ModifyDBSubnetGroup"},
+				"Version":           {"2014-10-31"},
+				"DBSubnetGroupName": {"mod-sg"},
+			}
+			if tt.newDescription != "" {
+				vals.Set("DBSubnetGroupDescription", tt.newDescription)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_SnapshotAttributes_AddRemove(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		operation    string
+		attrName     string
+		valuesToAdd  []string
+		valuesToRm   []string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "add_restore_attribute",
+			operation:    "ModifyDBClusterSnapshotAttribute",
+			attrName:     "restore",
+			valuesToAdd:  []string{"111111111111"},
+			wantContains: "111111111111",
+			wantStatus:   200,
+		},
+		{
+			name:         "remove_restore_attribute",
+			operation:    "ModifyDBClusterSnapshotAttribute",
+			attrName:     "restore",
+			valuesToAdd:  []string{"111111111111"},
+			valuesToRm:   []string{"111111111111"},
+			wantContains: "ModifyDBClusterSnapshotAttributeResponse",
+			wantStatus:   200,
+		},
+		{
+			name:         "describe_snapshot_attributes",
+			operation:    "DescribeDBClusterSnapshotAttributes",
+			attrName:     "",
+			wantContains: "DescribeDBClusterSnapshotAttributesResponse",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":              {"CreateDBCluster"},
+				"Version":             {"2014-10-31"},
+				"DBClusterIdentifier": {"attr-cluster"},
+			})
+			doRequest(t, h, url.Values{
+				"Action":                      {"CreateDBClusterSnapshot"},
+				"Version":                     {"2014-10-31"},
+				"DBClusterSnapshotIdentifier": {"attr-snap"},
+				"DBClusterIdentifier":         {"attr-cluster"},
+			})
+
+			if tt.operation == "ModifyDBClusterSnapshotAttribute" {
+				vals := url.Values{
+					"Action":                      {"ModifyDBClusterSnapshotAttribute"},
+					"Version":                     {"2014-10-31"},
+					"DBClusterSnapshotIdentifier": {"attr-snap"},
+					"AttributeName":               {tt.attrName},
+				}
+				for i, v := range tt.valuesToAdd {
+					vals.Set(fmt.Sprintf("ValuesToAdd.AttributeValue.%d", i+1), v)
+				}
+				for i, v := range tt.valuesToRm {
+					vals.Set(fmt.Sprintf("ValuesToRemove.AttributeValue.%d", i+1), v)
+				}
+				rr := doRequest(t, h, vals)
+				assert.Equal(t, tt.wantStatus, rr.Code)
+				assert.Contains(t, rr.Body.String(), tt.wantContains)
+			} else {
+				rr := doRequest(t, h, url.Values{
+					"Action":                      {"DescribeDBClusterSnapshotAttributes"},
+					"Version":                     {"2014-10-31"},
+					"DBClusterSnapshotIdentifier": {"attr-snap"},
+				})
+				assert.Equal(t, tt.wantStatus, rr.Code)
+				assert.Contains(t, rr.Body.String(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestAudit_EventSubscription_FullLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup        func(*testing.T, *docdb.Handler)
+		vals         url.Values
+		name         string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name: "modify_subscription_topic",
+			setup: func(t *testing.T, h *docdb.Handler) {
+				t.Helper()
+				doRequest(t, h, url.Values{
+					"Action":           {"CreateEventSubscription"},
+					"Version":          {"2014-10-31"},
+					"SubscriptionName": {"mod-sub"},
+					"SnsTopicArn":      {"arn:aws:sns:us-east-1:000000000000:old-topic"},
+				})
+			},
+			vals: url.Values{
+				"Action":           {"ModifyEventSubscription"},
+				"Version":          {"2014-10-31"},
+				"SubscriptionName": {"mod-sub"},
+				"SnsTopicArn":      {"arn:aws:sns:us-east-1:000000000000:new-topic"},
+			},
+			wantStatus:   200,
+			wantContains: "new-topic",
+		},
+		{
+			name: "remove_source_identifier",
+			setup: func(t *testing.T, h *docdb.Handler) {
+				t.Helper()
+				doRequest(t, h, url.Values{
+					"Action":                         {"CreateEventSubscription"},
+					"Version":                        {"2014-10-31"},
+					"SubscriptionName":               {"src-id-sub"},
+					"SourceIds.SourceId.1":            {"my-cluster"},
+				})
+			},
+			vals: url.Values{
+				"Action":           {"RemoveSourceIdentifierFromSubscription"},
+				"Version":          {"2014-10-31"},
+				"SubscriptionName": {"src-id-sub"},
+				"SourceIdentifier": {"my-cluster"},
+			},
+			wantStatus:   200,
+			wantContains: "RemoveSourceIdentifierFromSubscriptionResponse",
+		},
+		{
+			name: "describe_event_subscriptions",
+			setup: func(t *testing.T, h *docdb.Handler) {
+				t.Helper()
+				doRequest(t, h, url.Values{
+					"Action":           {"CreateEventSubscription"},
+					"Version":          {"2014-10-31"},
+					"SubscriptionName": {"desc-sub"},
+				})
+			},
+			vals: url.Values{
+				"Action":           {"DescribeEventSubscriptions"},
+				"Version":          {"2014-10-31"},
+				"SubscriptionName": {"desc-sub"},
+			},
+			wantStatus:   200,
+			wantContains: "desc-sub",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h)
+			}
+			rr := doRequest(t, h, tt.vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_DescribeEventCategories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		sourceType   string
+		wantContains string
+		wantStatus   int
+	}{
+		{
+			name:         "all_categories",
+			sourceType:   "",
+			wantContains: "db-cluster",
+			wantStatus:   200,
+		},
+		{
+			name:         "db_cluster_categories",
+			sourceType:   "db-cluster",
+			wantContains: "failover",
+			wantStatus:   200,
+		},
+		{
+			name:         "db_instance_categories",
+			sourceType:   "db-instance",
+			wantContains: "recovery",
+			wantStatus:   200,
+		},
+		{
+			name:         "snapshot_categories",
+			sourceType:   "db-cluster-snapshot",
+			wantContains: "restoration",
+			wantStatus:   200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			vals := url.Values{
+				"Action":  {"DescribeEventCategories"},
+				"Version": {"2014-10-31"},
+			}
+			if tt.sourceType != "" {
+				vals.Set("SourceType", tt.sourceType)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantContains)
+		})
+	}
+}
+
+func TestAudit_Pagination_Clusters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		maxRecords   string
+		marker       string
+		wantCount    int
+		wantHasMore  bool
+	}{
+		{
+			name:        "no_limit_returns_all",
+			maxRecords:  "",
+			wantCount:   5,
+			wantHasMore: false,
+		},
+		{
+			name:        "limit_to_2",
+			maxRecords:  "2",
+			wantCount:   2,
+			wantHasMore: true,
+		},
+		{
+			name:        "page_2_with_marker",
+			maxRecords:  "2",
+			marker:      "2",
+			wantCount:   2,
+			wantHasMore: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			for i := range 5 {
+				doRequest(t, h, url.Values{
+					"Action":              {"CreateDBCluster"},
+					"Version":             {"2014-10-31"},
+					"DBClusterIdentifier": {fmt.Sprintf("cluster-%d", i)},
+				})
+			}
+			vals := url.Values{
+				"Action":  {"DescribeDBClusters"},
+				"Version": {"2014-10-31"},
+			}
+			if tt.maxRecords != "" {
+				vals.Set("MaxRecords", tt.maxRecords)
+			}
+			if tt.marker != "" {
+				vals.Set("Marker", tt.marker)
+			}
+			rr := doRequest(t, h, vals)
+			assert.Equal(t, 200, rr.Code)
+			body := rr.Body.String()
+			if tt.wantHasMore {
+				assert.Contains(t, body, "<Marker>")
+			}
+		})
+	}
+}
+
+func TestAudit_SubnetGroup_DeleteInUseFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		useInCluster bool
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "in_use_by_cluster_fails",
+			useInCluster: true,
+			wantStatus:   400,
+			wantContains: "InvalidDBSubnetGroupStateFault",
+		},
+		{
+			name:         "not_in_use_succeeds",
+			useInCluster: false,
+			wantStatus:   200,
+			wantContains: "DeleteDBSubnetGroupResponse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, url.Values{
+				"Action":                   {"CreateDBSubnetGroup"},
+				"Version":                  {"2014-10-31"},
+				"DBSubnetGroupName":        {"inuse-sg"},
+				"DBSubnetGroupDescription": {"test"},
+				"SubnetIds.member.1":       {"subnet-aaa"},
+			})
+			if tt.useInCluster {
+				h.Backend.AddDBClusterInternal(&docdb.DBCluster{
+					DBClusterIdentifier: "using-cluster",
+					DBSubnetGroupName:   "inuse-sg",
+				})
+			}
+			rr := doRequest(t, h, url.Values{
+				"Action":            {"DeleteDBSubnetGroup"},
+				"Version":           {"2014-10-31"},
+				"DBSubnetGroupName": {"inuse-sg"},
 			})
 			assert.Equal(t, tt.wantStatus, rr.Code)
 			assert.Contains(t, rr.Body.String(), tt.wantContains)


### PR DESCRIPTION
## Summary

- **New backend fields**: `VpcSecurityGroupIDs`, `IAMDatabaseAuthenticationEnabled`, `KmsKeyID`, `HostedZoneID`, `EnabledCloudwatchLogsExports`, `ReplicationSourceIdentifier`, `ReadReplicaIdentifiers` on `DBCluster`; `CACertificateIdentifier`, `CopyTagsToSnapshot` on `DBInstance`
- **Behavior improvements**: `DeleteDBCluster` supports `FinalDBClusterSnapshotIdentifier`/`SkipFinalSnapshot`; `ModifyDBCluster` supports `EngineVersion`, `Port`, `VpcSecurityGroupIDs`, CloudWatch log type enable/disable; `ModifyDBInstance` supports `CACertificateIdentifier`, `CopyTagsToSnapshot`, `PromotionTier`
- **XML response parity**: `xmlDBCluster` now includes `VpcSecurityGroups`, `EnabledCloudwatchLogsExports`, `DBClusterMembers`, `IAMDatabaseAuthenticationEnabled`; `xmlDBInstance` includes `CACertificateIdentifier`, `CopyTagsToSnapshot`, `EnabledCloudwatchLogsExports`
- **Tests**: 25+ new table-driven test functions (~1800 lines) covering all new fields and behaviors

## Test plan

- [x] `go test ./services/docdb/...` passes (0 failures)
- [x] `golangci-lint run ./services/docdb/...` passes (0 issues)
- [x] SDK completeness test passes
- [ ] GitHub CI green

Resolves #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)