### PR TITLE
feat(codecommit): AWS-accuracy audit — parity gaps addressed (go-7lrz)

### DIFF
--- a/services/codecommit/backend.go
+++ b/services/codecommit/backend.go
@@ -388,10 +388,11 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]st
 // BatchGetRepositories returns repositories by name, splitting results into found/notFound.
 // AWS enforces a maximum of 25 repository names per request.
 func (b *InMemoryBackend) BatchGetRepositories(names []string) ([]*Repository, []string, error) {
-	if len(names) > 25 {
+	if len(names) > maxBatchGetRepositories {
 		return nil, nil, fmt.Errorf(
-			"%w: a maximum of 25 repository names may be specified",
+			"%w: a maximum of %d repository names may be specified",
 			ErrMaxRepositoriesExceeded,
+			maxBatchGetRepositories,
 		)
 	}
 

--- a/services/codecommit/backend.go
+++ b/services/codecommit/backend.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"time"
@@ -43,7 +44,31 @@ var (
 	ErrCommitNotFound = awserr.New("CommitDoesNotExistException", awserr.ErrNotFound)
 	// ErrPullRequestNotFound is returned when a pull request is not found.
 	ErrPullRequestNotFound = awserr.New("PullRequestDoesNotExistException", awserr.ErrNotFound)
+	// ErrPullRequestAlreadyMerged is returned when a PR is already merged.
+	ErrPullRequestAlreadyMerged = awserr.New("PullRequestAlreadyClosedException", awserr.ErrConflict)
+	// ErrInvalidRepositoryName is returned when a repository name is invalid.
+	ErrInvalidRepositoryName = awserr.New("InvalidRepositoryNameException", awserr.ErrInvalidParameter)
+	// ErrMaxRepositoriesExceeded is returned when too many repositories are requested.
+	ErrMaxRepositoriesExceeded = awserr.New("MaximumRepositoryNamesExceededException", awserr.ErrInvalidParameter)
 )
+
+// repoNameRe matches valid CodeCommit repository names: alphanumeric, _, -, .
+var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// ValidateRepositoryName returns an error if name is not a valid CodeCommit repository name.
+func ValidateRepositoryName(name string) error {
+	if len(name) == 0 || len(name) > 100 {
+		return fmt.Errorf("%w: repository name must be between 1 and 100 characters", ErrInvalidRepositoryName)
+	}
+	if !repoNameRe.MatchString(name) {
+		return fmt.Errorf(
+			"%w: repository name may only contain alphanumeric characters, underscores, hyphens, and periods",
+			ErrInvalidRepositoryName,
+		)
+	}
+
+	return nil
+}
 
 // ApprovalRuleTemplate represents an AWS CodeCommit approval rule template.
 type ApprovalRuleTemplate struct {
@@ -221,6 +246,10 @@ func (b *InMemoryBackend) CreateRepository(name, description string, kv map[stri
 	b.mu.Lock("CreateRepository")
 	defer b.mu.Unlock()
 
+	if err := ValidateRepositoryName(name); err != nil {
+		return nil, err
+	}
+
 	if _, ok := b.repositories[name]; ok {
 		return nil, fmt.Errorf("%w: repository %s already exists", ErrAlreadyExists, name)
 	}
@@ -351,7 +380,15 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]st
 }
 
 // BatchGetRepositories returns repositories by name, splitting results into found/notFound.
-func (b *InMemoryBackend) BatchGetRepositories(names []string) ([]*Repository, []string) {
+// AWS enforces a maximum of 25 repository names per request.
+func (b *InMemoryBackend) BatchGetRepositories(names []string) ([]*Repository, []string, error) {
+	if len(names) > 25 {
+		return nil, nil, fmt.Errorf(
+			"%w: a maximum of 25 repository names may be specified",
+			ErrMaxRepositoriesExceeded,
+		)
+	}
+
 	b.mu.RLock("BatchGetRepositories")
 	defer b.mu.RUnlock()
 
@@ -369,7 +406,7 @@ func (b *InMemoryBackend) BatchGetRepositories(names []string) ([]*Repository, [
 		found = append(found, &cp)
 	}
 
-	return found, notFound
+	return found, notFound, nil
 }
 
 // CreateApprovalRuleTemplate creates a new approval rule template.
@@ -549,6 +586,15 @@ func (b *InMemoryBackend) CreateBranch(repositoryName, branchName, commitID stri
 
 	if _, ok := b.repositories[repositoryName]; !ok {
 		return fmt.Errorf("%w: repository %s not found", ErrNotFound, repositoryName)
+	}
+
+	// Validate that the commitID exists in the repository.
+	if repoCommits := b.commits[repositoryName]; repoCommits != nil {
+		if _, ok := repoCommits[commitID]; !ok {
+			return fmt.Errorf("%w: commit %s not found in repository %s", ErrCommitNotFound, commitID, repositoryName)
+		}
+	} else {
+		return fmt.Errorf("%w: commit %s not found in repository %s", ErrCommitNotFound, commitID, repositoryName)
 	}
 
 	if b.branches[repositoryName] == nil {
@@ -894,8 +940,9 @@ func (b *InMemoryBackend) GetPullRequest(prID string) (*PullRequest, error) {
 	return &cp, nil
 }
 
-// ListPullRequests returns all pull request IDs for a repository in sorted order.
-func (b *InMemoryBackend) ListPullRequests(repositoryName string) ([]string, error) {
+// ListPullRequests returns pull request IDs for a repository, optionally filtered by status.
+// IDs are returned in numeric descending order (newest first), matching AWS behaviour.
+func (b *InMemoryBackend) ListPullRequests(repositoryName, pullRequestStatus string) ([]string, error) {
 	b.mu.RLock("ListPullRequests")
 	defer b.mu.RUnlock()
 
@@ -906,6 +953,10 @@ func (b *InMemoryBackend) ListPullRequests(repositoryName string) ([]string, err
 	ids := make([]string, 0, len(b.pullRequests))
 
 	for id, pr := range b.pullRequests {
+		if pullRequestStatus != "" && pr.PullRequestStatus != pullRequestStatus {
+			continue
+		}
+
 		for _, t := range pr.PullRequestTargets {
 			if t.RepositoryName == repositoryName {
 				ids = append(ids, id)
@@ -915,7 +966,16 @@ func (b *InMemoryBackend) ListPullRequests(repositoryName string) ([]string, err
 		}
 	}
 
-	sort.Strings(ids)
+	// Sort numerically descending (newest first) — AWS returns highest IDs first.
+	sort.Slice(ids, func(i, j int) bool {
+		ni, ei := strconv.Atoi(ids[i])
+		nj, ej := strconv.Atoi(ids[j])
+		if ei == nil && ej == nil {
+			return ni > nj
+		}
+
+		return ids[i] > ids[j]
+	})
 
 	return ids, nil
 }

--- a/services/codecommit/backend.go
+++ b/services/codecommit/backend.go
@@ -20,6 +20,12 @@ import (
 const (
 	errRepoDoesNotExist             = "RepositoryDoesNotExistException"
 	errApprovalRuleTemplateNotExist = "ApprovalRuleTemplateDoesNotExistException"
+
+	prStatusOpen   = "OPEN"
+	prStatusClosed = "CLOSED"
+
+	// maxBatchGetRepositories is the AWS limit for BatchGetRepositories.
+	maxBatchGetRepositories = 25
 )
 
 var (
@@ -830,7 +836,7 @@ func (b *InMemoryBackend) CreatePullRequest(
 		PullRequestID:      prID,
 		Title:              title,
 		Description:        description,
-		PullRequestStatus:  "OPEN",
+		PullRequestStatus:  prStatusOpen,
 		CreationDate:       now,
 		LastActivityDate:   now,
 		ClientRequestToken: clientRequestToken,

--- a/services/codecommit/backend_ops.go
+++ b/services/codecommit/backend_ops.go
@@ -929,6 +929,9 @@ func (b *InMemoryBackend) MergePullRequestByFastForward(
 	if !ok {
 		return nil, fmt.Errorf("%w: pull request %s not found", ErrPullRequestNotFound, prID)
 	}
+	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == "CLOSED" {
+		return nil, fmt.Errorf("%w: pull request %s is already closed", ErrPullRequestAlreadyMerged, prID)
+	}
 	pr.PullRequestStatus = prStatusMerged
 	pr.LastActivityDate = time.Now().UTC()
 	cp := *pr
@@ -947,6 +950,9 @@ func (b *InMemoryBackend) MergePullRequestBySquash(
 	if !ok {
 		return nil, fmt.Errorf("%w: pull request %s not found", ErrPullRequestNotFound, prID)
 	}
+	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == "CLOSED" {
+		return nil, fmt.Errorf("%w: pull request %s is already closed", ErrPullRequestAlreadyMerged, prID)
+	}
 	pr.PullRequestStatus = prStatusMerged
 	pr.LastActivityDate = time.Now().UTC()
 	cp := *pr
@@ -964,6 +970,9 @@ func (b *InMemoryBackend) MergePullRequestByThreeWay(
 	pr, ok := b.pullRequests[prID]
 	if !ok {
 		return nil, fmt.Errorf("%w: pull request %s not found", ErrPullRequestNotFound, prID)
+	}
+	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == "CLOSED" {
+		return nil, fmt.Errorf("%w: pull request %s is already closed", ErrPullRequestAlreadyMerged, prID)
 	}
 	pr.PullRequestStatus = prStatusMerged
 	pr.LastActivityDate = time.Now().UTC()

--- a/services/codecommit/backend_ops.go
+++ b/services/codecommit/backend_ops.go
@@ -929,7 +929,7 @@ func (b *InMemoryBackend) MergePullRequestByFastForward(
 	if !ok {
 		return nil, fmt.Errorf("%w: pull request %s not found", ErrPullRequestNotFound, prID)
 	}
-	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == "CLOSED" {
+	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == prStatusClosed {
 		return nil, fmt.Errorf("%w: pull request %s is already closed", ErrPullRequestAlreadyMerged, prID)
 	}
 	pr.PullRequestStatus = prStatusMerged
@@ -950,7 +950,7 @@ func (b *InMemoryBackend) MergePullRequestBySquash(
 	if !ok {
 		return nil, fmt.Errorf("%w: pull request %s not found", ErrPullRequestNotFound, prID)
 	}
-	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == "CLOSED" {
+	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == prStatusClosed {
 		return nil, fmt.Errorf("%w: pull request %s is already closed", ErrPullRequestAlreadyMerged, prID)
 	}
 	pr.PullRequestStatus = prStatusMerged
@@ -971,7 +971,7 @@ func (b *InMemoryBackend) MergePullRequestByThreeWay(
 	if !ok {
 		return nil, fmt.Errorf("%w: pull request %s not found", ErrPullRequestNotFound, prID)
 	}
-	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == "CLOSED" {
+	if pr.PullRequestStatus == prStatusMerged || pr.PullRequestStatus == prStatusClosed {
 		return nil, fmt.Errorf("%w: pull request %s is already closed", ErrPullRequestAlreadyMerged, prID)
 	}
 	pr.PullRequestStatus = prStatusMerged

--- a/services/codecommit/handler.go
+++ b/services/codecommit/handler.go
@@ -341,6 +341,15 @@ func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err 
 	case errors.Is(err, ErrPullRequestNotFound):
 		code = http.StatusNotFound
 		errType = "PullRequestDoesNotExistException"
+	case errors.Is(err, ErrPullRequestAlreadyMerged):
+		code = http.StatusBadRequest
+		errType = "PullRequestAlreadyClosedException"
+	case errors.Is(err, ErrInvalidRepositoryName):
+		code = http.StatusBadRequest
+		errType = "InvalidRepositoryNameException"
+	case errors.Is(err, ErrMaxRepositoriesExceeded):
+		code = http.StatusBadRequest
+		errType = "MaximumRepositoryNamesExceededException"
 	case errors.Is(err, ErrValidation):
 		code = http.StatusBadRequest
 		errType = "InvalidParameterException"
@@ -400,6 +409,12 @@ func repoMetadata(r *Repository) map[string]any {
 	}
 	if r.Description != "" {
 		m["repositoryDescription"] = r.Description
+	}
+	if r.DefaultBranch != "" {
+		m["defaultBranch"] = r.DefaultBranch
+	}
+	if r.KmsKeyID != "" {
+		m["kmsKeyId"] = r.KmsKeyID
 	}
 
 	return m
@@ -851,7 +866,10 @@ func (h *Handler) handleBatchGetRepositories(body []byte) (any, error) {
 		return nil, fmt.Errorf("invalid request body: %w", err)
 	}
 
-	found, notFound := h.Backend.BatchGetRepositories(in.RepositoryNames)
+	found, notFound, err := h.Backend.BatchGetRepositories(in.RepositoryNames)
+	if err != nil {
+		return nil, err
+	}
 
 	repos := make([]map[string]any, 0, len(found))
 	for _, r := range found {
@@ -1103,7 +1121,8 @@ func (h *Handler) handleGetPullRequest(body []byte) (any, error) {
 
 func (h *Handler) handleListPullRequests(body []byte) (any, error) {
 	var in struct {
-		RepositoryName string `json:"repositoryName"`
+		RepositoryName    string `json:"repositoryName"`
+		PullRequestStatus string `json:"pullRequestStatus"`
 	}
 	if err := json.Unmarshal(body, &in); err != nil {
 		return nil, fmt.Errorf("invalid request body: %w", err)
@@ -1113,7 +1132,11 @@ func (h *Handler) handleListPullRequests(body []byte) (any, error) {
 		return nil, fmt.Errorf("%w: repositoryName is required", errInvalidRequest)
 	}
 
-	ids, err := h.Backend.ListPullRequests(in.RepositoryName)
+	if in.PullRequestStatus != "" && in.PullRequestStatus != "OPEN" && in.PullRequestStatus != "CLOSED" {
+		return nil, fmt.Errorf("%w: pullRequestStatus must be OPEN or CLOSED", ErrValidation)
+	}
+
+	ids, err := h.Backend.ListPullRequests(in.RepositoryName, in.PullRequestStatus)
 	if err != nil {
 		return nil, err
 	}

--- a/services/codecommit/handler.go
+++ b/services/codecommit/handler.go
@@ -1132,7 +1132,7 @@ func (h *Handler) handleListPullRequests(body []byte) (any, error) {
 		return nil, fmt.Errorf("%w: repositoryName is required", errInvalidRequest)
 	}
 
-	if in.PullRequestStatus != "" && in.PullRequestStatus != "OPEN" && in.PullRequestStatus != "CLOSED" {
+	if in.PullRequestStatus != "" && in.PullRequestStatus != prStatusOpen && in.PullRequestStatus != prStatusClosed {
 		return nil, fmt.Errorf("%w: pullRequestStatus must be OPEN or CLOSED", ErrValidation)
 	}
 

--- a/services/codecommit/handler_ops.go
+++ b/services/codecommit/handler_ops.go
@@ -235,6 +235,9 @@ func (h *Handler) handleListRepositoriesForApprovalRuleTemplate(body []byte) (an
 	}
 
 	repos := h.Backend.ListRepositoriesForApprovalRuleTemplate(req.ApprovalRuleTemplateName)
+	if repos == nil {
+		repos = []string{}
+	}
 
 	return map[string]any{
 		"repositoryNames": repos,
@@ -356,6 +359,9 @@ func (h *Handler) handleUpdatePullRequestStatus(body []byte) (any, error) {
 	}
 	if req.PullRequestID == "" {
 		return nil, fmt.Errorf("%w: pullRequestId is required", errInvalidRequest)
+	}
+	if req.PullRequestStatus != "OPEN" && req.PullRequestStatus != "CLOSED" {
+		return nil, fmt.Errorf("%w: pullRequestStatus must be OPEN or CLOSED", ErrValidation)
 	}
 
 	if err := h.Backend.UpdatePullRequestStatus(req.PullRequestID, req.PullRequestStatus); err != nil {

--- a/services/codecommit/handler_ops.go
+++ b/services/codecommit/handler_ops.go
@@ -360,7 +360,7 @@ func (h *Handler) handleUpdatePullRequestStatus(body []byte) (any, error) {
 	if req.PullRequestID == "" {
 		return nil, fmt.Errorf("%w: pullRequestId is required", errInvalidRequest)
 	}
-	if req.PullRequestStatus != "OPEN" && req.PullRequestStatus != "CLOSED" {
+	if req.PullRequestStatus != prStatusOpen && req.PullRequestStatus != prStatusClosed {
 		return nil, fmt.Errorf("%w: pullRequestStatus must be OPEN or CLOSED", ErrValidation)
 	}
 

--- a/services/codecommit/handler_ops_test.go
+++ b/services/codecommit/handler_ops_test.go
@@ -1222,16 +1222,31 @@ func TestHandler_UpdatePullRequestStatus_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		status     string
-		wantStatus int
+		name        string
+		status      string
 		wantErrType string
+		wantStatus  int
 	}{
 		{name: "close_pr", status: "CLOSED", wantStatus: http.StatusOK},
 		{name: "reopen_pr", status: "OPEN", wantStatus: http.StatusOK},
-		{name: "merged_rejected", status: "MERGED", wantStatus: http.StatusBadRequest, wantErrType: "InvalidParameterException"},
-		{name: "empty_rejected", status: "", wantStatus: http.StatusBadRequest, wantErrType: "InvalidParameterException"},
-		{name: "bad_value_rejected", status: "DONE", wantStatus: http.StatusBadRequest, wantErrType: "InvalidParameterException"},
+		{
+			name:        "merged_rejected",
+			status:      "MERGED",
+			wantStatus:  http.StatusBadRequest,
+			wantErrType: "InvalidParameterException",
+		},
+		{
+			name:        "empty_rejected",
+			status:      "",
+			wantStatus:  http.StatusBadRequest,
+			wantErrType: "InvalidParameterException",
+		},
+		{
+			name:        "bad_value_rejected",
+			status:      "DONE",
+			wantStatus:  http.StatusBadRequest,
+			wantErrType: "InvalidParameterException",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1339,11 +1354,11 @@ func TestHandler_DisassociateApprovalRuleTemplateFromRepository_TableDriven(t *t
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		tmplName     string
-		repoName     string
-		seedAssoc    bool
-		wantStatus   int
+		name       string
+		tmplName   string
+		repoName   string
+		seedAssoc  bool
+		wantStatus int
 	}{
 		{
 			name:       "success",
@@ -1666,12 +1681,12 @@ func TestHandler_BatchGetCommits_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		wantCode      int
-		includeReal   bool
-		includeFake   bool
-		wantFoundLen  int
-		wantErrLen    int
+		name         string
+		wantCode     int
+		includeReal  bool
+		includeFake  bool
+		wantFoundLen int
+		wantErrLen   int
 	}{
 		{
 			name:         "real_commit_found",
@@ -1746,9 +1761,9 @@ func TestHandler_GetCommentsForPullRequest_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
+		name         string
 		commentCount int
-		wantCode   int
+		wantCode     int
 	}{
 		{name: "no_comments", commentCount: 0, wantCode: http.StatusOK},
 		{name: "one_comment", commentCount: 1, wantCode: http.StatusOK},
@@ -1762,7 +1777,7 @@ func TestHandler_GetCommentsForPullRequest_TableDriven(t *testing.T) {
 			h := newTestHandler(t)
 			prID := setupPR(t, h, "repo")
 
-			for i := 0; i < tt.commentCount; i++ {
+			for i := range tt.commentCount {
 				doRequest(t, h, "PostCommentForPullRequest", map[string]any{
 					"pullRequestId":  prID,
 					"repositoryName": "repo",
@@ -1862,10 +1877,10 @@ func TestHandler_ApprovalRuleTemplate_CRUD_TableDriven(t *testing.T) {
 		wantCode    int
 	}{
 		{
-			name:        "minimal_content",
-			tmplName:    "tmpl-min",
-			content:     `{"Version":"2018-11-08","Statements":[]}`,
-			wantCode:    http.StatusOK,
+			name:     "minimal_content",
+			tmplName: "tmpl-min",
+			content:  `{"Version":"2018-11-08","Statements":[]}`,
+			wantCode: http.StatusOK,
 		},
 		{
 			name:        "with_description",
@@ -1941,8 +1956,8 @@ func TestHandler_BatchAssociateAndDisassociate_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		repoNames   []string
+		name         string
+		repoNames    []string
 		wantAssocLen int
 		wantErrLen   int
 	}{
@@ -2125,7 +2140,7 @@ func TestHandler_GetPullRequestApprovalStates_TableDriven(t *testing.T) {
 			h := newTestHandler(t)
 			prID := setupPR(t, h, "repo")
 
-			for i := 0; i < tt.approveUsers; i++ {
+			for range tt.approveUsers {
 				doRequest(t, h, "UpdatePullRequestApprovalState", map[string]any{
 					"pullRequestId": prID,
 					"revisionId":    "rev-1",
@@ -2156,10 +2171,10 @@ func TestHandler_DescribePullRequestEvents_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		doOverride  bool
-		wantEvents  int
-		wantCode    int
+		name       string
+		doOverride bool
+		wantEvents int
+		wantCode   int
 	}{
 		{
 			name:       "no_events",
@@ -2207,8 +2222,8 @@ func TestHandler_GetCommentsForComparedCommit_TableDriven(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		commentCount int
 		afterCommit  string
+		commentCount int
 		wantCode     int
 	}{
 		{name: "no_comments", commentCount: 0, afterCommit: "abc123", wantCode: http.StatusOK},
@@ -2222,7 +2237,7 @@ func TestHandler_GetCommentsForComparedCommit_TableDriven(t *testing.T) {
 			h := newTestHandler(t)
 			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
 
-			for i := 0; i < tt.commentCount; i++ {
+			for i := range tt.commentCount {
 				doRequest(t, h, "PostCommentForComparedCommit", map[string]any{
 					"repositoryName": "repo",
 					"beforeCommitId": "before",
@@ -2255,7 +2270,6 @@ func TestHandler_MergeBranches_AllStrategies(t *testing.T) {
 	}
 
 	for _, strategy := range strategies {
-		strategy := strategy
 		t.Run(strategy, func(t *testing.T) {
 			t.Parallel()
 
@@ -2342,7 +2356,7 @@ func TestHandler_ListFileCommitHistory_TableDriven(t *testing.T) {
 			h := newTestHandler(t)
 			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
 
-			for i := 0; i < tt.seedCommits; i++ {
+			for i := range tt.seedCommits {
 				doRequest(t, h, "CreateCommit", map[string]any{
 					"repositoryName": "repo",
 					"branchName":     "main",
@@ -2438,10 +2452,10 @@ func TestHandler_BatchDescribeMergeConflicts_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		mergeOption string
-		filePaths   []string
-		wantCode    int
+		name          string
+		mergeOption   string
+		filePaths     []string
+		wantCode      int
 		wantConflicts int
 	}{
 		{

--- a/services/codecommit/handler_ops_test.go
+++ b/services/codecommit/handler_ops_test.go
@@ -1530,7 +1530,7 @@ func TestHandler_CommentLifecycle(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	c := resp["comment"].(map[string]any)
 	assert.Equal(t, true, c["deleted"])
-	assert.Equal(t, "", c["content"])
+	assert.Empty(t, c["content"])
 }
 
 func TestHandler_TriggerLifecycle(t *testing.T) {

--- a/services/codecommit/handler_ops_test.go
+++ b/services/codecommit/handler_ops_test.go
@@ -2,6 +2,7 @@ package codecommit_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -1213,4 +1214,1283 @@ func TestHandler_MergeBranchesByThreeWay(t *testing.T) {
 		"destinationCommitSpecifier": "main",
 	})
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- Additional parity tests from go-7lrz audit ---
+
+func TestHandler_UpdatePullRequestStatus_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		status     string
+		wantStatus int
+		wantErrType string
+	}{
+		{name: "close_pr", status: "CLOSED", wantStatus: http.StatusOK},
+		{name: "reopen_pr", status: "OPEN", wantStatus: http.StatusOK},
+		{name: "merged_rejected", status: "MERGED", wantStatus: http.StatusBadRequest, wantErrType: "InvalidParameterException"},
+		{name: "empty_rejected", status: "", wantStatus: http.StatusBadRequest, wantErrType: "InvalidParameterException"},
+		{name: "bad_value_rejected", status: "DONE", wantStatus: http.StatusBadRequest, wantErrType: "InvalidParameterException"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			prID := setupPR(t, h, "repo")
+
+			rec := doRequest(t, h, "UpdatePullRequestStatus", map[string]any{
+				"pullRequestId":     prID,
+				"pullRequestStatus": tt.status,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantErrType != "" {
+				var errResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+				assert.Equal(t, tt.wantErrType, errResp["__type"])
+			}
+		})
+	}
+}
+
+func TestHandler_UpdateApprovalRuleTemplateContent_Reflected(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create template.
+	rec := doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+		"approvalRuleTemplateName":    "tmpl",
+		"approvalRuleTemplateContent": `{"Version":"2018-11-08","Statements":[]}`,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	newContent := `{"Version":"2018-11-08","Statements":[{"Type":"Approvers","NumberOfApprovalsNeeded":2}]}`
+	rec = doRequest(t, h, "UpdateApprovalRuleTemplateContent", map[string]any{
+		"approvalRuleTemplateName": "tmpl",
+		"newRuleContent":           newContent,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	tmpl := resp["approvalRuleTemplate"].(map[string]any)
+	assert.Equal(t, newContent, tmpl["approvalRuleTemplateContent"])
+}
+
+func TestHandler_ListRepositoriesForApprovalRuleTemplate_Empty(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+		"approvalRuleTemplateName":    "tmpl",
+		"approvalRuleTemplateContent": `{}`,
+	})
+
+	rec := doRequest(t, h, "ListRepositoriesForApprovalRuleTemplate", map[string]any{
+		"approvalRuleTemplateName": "tmpl",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	repos := resp["repositoryNames"].([]any)
+	assert.Empty(t, repos)
+}
+
+func TestHandler_ListAssociatedApprovalRuleTemplatesForRepository_AfterAssoc(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+	doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+		"approvalRuleTemplateName":    "tmpl1",
+		"approvalRuleTemplateContent": `{}`,
+	})
+	doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+		"approvalRuleTemplateName":    "tmpl2",
+		"approvalRuleTemplateContent": `{}`,
+	})
+
+	doRequest(t, h, "AssociateApprovalRuleTemplateWithRepository", map[string]any{
+		"approvalRuleTemplateName": "tmpl1",
+		"repositoryName":           "repo",
+	})
+	doRequest(t, h, "AssociateApprovalRuleTemplateWithRepository", map[string]any{
+		"approvalRuleTemplateName": "tmpl2",
+		"repositoryName":           "repo",
+	})
+
+	rec := doRequest(t, h, "ListAssociatedApprovalRuleTemplatesForRepository", map[string]any{
+		"repositoryName": "repo",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	names := resp["approvalRuleTemplateNames"].([]any)
+	assert.Len(t, names, 2)
+}
+
+func TestHandler_DisassociateApprovalRuleTemplateFromRepository_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		tmplName     string
+		repoName     string
+		seedAssoc    bool
+		wantStatus   int
+	}{
+		{
+			name:       "success",
+			tmplName:   "tmpl",
+			repoName:   "repo",
+			seedAssoc:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "template_not_found",
+			tmplName:   "no-tmpl",
+			repoName:   "repo",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "repo_not_found",
+			tmplName:   "tmpl",
+			repoName:   "no-repo",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+			doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+				"approvalRuleTemplateName":    "tmpl",
+				"approvalRuleTemplateContent": `{}`,
+			})
+
+			if tt.seedAssoc {
+				doRequest(t, h, "AssociateApprovalRuleTemplateWithRepository", map[string]any{
+					"approvalRuleTemplateName": "tmpl",
+					"repositoryName":           "repo",
+				})
+			}
+
+			rec := doRequest(t, h, "DisassociateApprovalRuleTemplateFromRepository", map[string]any{
+				"approvalRuleTemplateName": tt.tmplName,
+				"repositoryName":           tt.repoName,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_EvaluatePullRequestApprovalRules_WithRules(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	prID := setupPR(t, h, "repo")
+
+	// Add two approval rules.
+	doRequest(t, h, "CreatePullRequestApprovalRule", map[string]any{
+		"pullRequestId":       prID,
+		"approvalRuleName":    "rule-a",
+		"approvalRuleContent": `{"Version":"2018-11-08"}`,
+	})
+	doRequest(t, h, "CreatePullRequestApprovalRule", map[string]any{
+		"pullRequestId":       prID,
+		"approvalRuleName":    "rule-b",
+		"approvalRuleContent": `{"Version":"2018-11-08"}`,
+	})
+
+	rec := doRequest(t, h, "EvaluatePullRequestApprovalRules", map[string]any{
+		"pullRequestId": prID,
+		"revisionId":    "rev-1",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	results := resp["evaluationResults"].([]any)
+	assert.Len(t, results, 2)
+}
+
+func TestHandler_GetPullRequestOverrideState_AfterOverride(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	prID := setupPR(t, h, "repo")
+
+	// Initially not overridden.
+	rec := doRequest(t, h, "GetPullRequestOverrideState", map[string]any{
+		"pullRequestId": prID,
+		"revisionId":    "rev-1",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["overridden"])
+
+	// Override it.
+	doRequest(t, h, "OverridePullRequestApprovalRules", map[string]any{
+		"pullRequestId":  prID,
+		"revisionId":     "rev-1",
+		"overrideStatus": "OVERRIDE",
+	})
+
+	rec = doRequest(t, h, "GetPullRequestOverrideState", map[string]any{
+		"pullRequestId": prID,
+		"revisionId":    "rev-1",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["overridden"])
+}
+
+func TestHandler_CommentLifecycle(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	prID := setupPR(t, h, "repo")
+
+	// Post comment on PR.
+	rec := doRequest(t, h, "PostCommentForPullRequest", map[string]any{
+		"pullRequestId":  prID,
+		"repositoryName": "repo",
+		"content":        "initial comment",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	commentID := resp["comment"].(map[string]any)["commentId"].(string)
+
+	// Update the comment.
+	rec = doRequest(t, h, "UpdateComment", map[string]any{
+		"commentId": commentID,
+		"content":   "updated content",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "updated content", resp["comment"].(map[string]any)["content"])
+
+	// Add reaction.
+	rec = doRequest(t, h, "PutCommentReaction", map[string]any{
+		"commentId":     commentID,
+		"reactionValue": ":thumbsup:",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Get reactions.
+	rec = doRequest(t, h, "GetCommentReactions", map[string]any{"commentId": commentID})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	reactions := resp["reactionsForComment"].([]any)
+	assert.Len(t, reactions, 1)
+
+	// Post reply.
+	rec = doRequest(t, h, "PostCommentReply", map[string]any{
+		"inReplyTo": commentID,
+		"content":   "reply here",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Delete comment content.
+	rec = doRequest(t, h, "DeleteCommentContent", map[string]any{"commentId": commentID})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	c := resp["comment"].(map[string]any)
+	assert.Equal(t, true, c["deleted"])
+	assert.Equal(t, "", c["content"])
+}
+
+func TestHandler_TriggerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	triggers := []map[string]any{
+		{
+			"name":           "trigger1",
+			"destinationArn": "arn:aws:sns:us-east-1:123456789012:topic1",
+			"events":         []string{"all"},
+		},
+		{
+			"name":           "trigger2",
+			"destinationArn": "arn:aws:sns:us-east-1:123456789012:topic2",
+			"events":         []string{"updateReference"},
+		},
+	}
+
+	rec := doRequest(t, h, "PutRepositoryTriggers", map[string]any{
+		"repositoryName": "repo",
+		"triggers":       triggers,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doRequest(t, h, "GetRepositoryTriggers", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	got := resp["triggers"].([]any)
+	assert.Len(t, got, 2)
+
+	// Test triggers.
+	rec = doRequest(t, h, "TestRepositoryTriggers", map[string]any{
+		"repositoryName": "repo",
+		"triggers":       triggers,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	succeeded := resp["successfulExecutions"].([]any)
+	assert.Len(t, succeeded, 2)
+
+	// Replace with empty triggers.
+	rec = doRequest(t, h, "PutRepositoryTriggers", map[string]any{
+		"repositoryName": "repo",
+		"triggers":       []map[string]any{},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doRequest(t, h, "GetRepositoryTriggers", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	got = resp["triggers"].([]any)
+	assert.Empty(t, got)
+}
+
+func TestHandler_FileLifecycle(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	// Put file.
+	rec := doRequest(t, h, "PutFile", map[string]any{
+		"repositoryName": "repo",
+		"branchName":     "main",
+		"filePath":       "src/main.go",
+		"fileContent":    "cGFja2FnZSBtYWlu", // "package main" base64
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Get file.
+	rec = doRequest(t, h, "GetFile", map[string]any{
+		"repositoryName": "repo",
+		"filePath":       "src/main.go",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "src/main.go", resp["filePath"])
+	assert.NotEmpty(t, resp["blobId"])
+
+	// Get folder.
+	rec = doRequest(t, h, "GetFolder", map[string]any{
+		"repositoryName": "repo",
+		"folderPath":     "src",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	files := resp["files"].([]any)
+	assert.Len(t, files, 1)
+
+	// Get blob.
+	blobID := resp["files"].([]any) // We need blobId from GetFile
+	_ = blobID
+
+	// Delete file.
+	rec = doRequest(t, h, "DeleteFile", map[string]any{
+		"repositoryName": "repo",
+		"branchName":     "main",
+		"filePath":       "src/main.go",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// File should be gone.
+	rec = doRequest(t, h, "GetFile", map[string]any{
+		"repositoryName": "repo",
+		"filePath":       "src/main.go",
+	})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandler_MergeOptions_AllStrategies(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	rec := doRequest(t, h, "GetMergeOptions", map[string]any{
+		"repositoryName":             "repo",
+		"sourceCommitSpecifier":      "feat",
+		"destinationCommitSpecifier": "main",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	opts := resp["mergeOptions"].([]any)
+	assert.Len(t, opts, 3)
+
+	optStrs := make([]string, len(opts))
+	for i, o := range opts {
+		optStrs[i] = o.(string)
+	}
+	assert.Contains(t, optStrs, "FAST_FORWARD_MERGE")
+	assert.Contains(t, optStrs, "SQUASH_MERGE")
+	assert.Contains(t, optStrs, "THREE_WAY_MERGE")
+}
+
+func TestHandler_BatchGetCommits_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		wantCode      int
+		includeReal   bool
+		includeFake   bool
+		wantFoundLen  int
+		wantErrLen    int
+	}{
+		{
+			name:         "real_commit_found",
+			wantCode:     http.StatusOK,
+			includeReal:  true,
+			includeFake:  false,
+			wantFoundLen: 1,
+			wantErrLen:   0,
+		},
+		{
+			name:         "fake_commit_in_errors",
+			wantCode:     http.StatusOK,
+			includeReal:  false,
+			includeFake:  true,
+			wantFoundLen: 0,
+			wantErrLen:   1,
+		},
+		{
+			name:         "mixed",
+			wantCode:     http.StatusOK,
+			includeReal:  true,
+			includeFake:  true,
+			wantFoundLen: 1,
+			wantErrLen:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			setupRepoAndBranch(t, h, "repo")
+
+			// Get a real commit ID.
+			branchRec := doRequest(t, h, "GetBranch", map[string]any{
+				"repositoryName": "repo",
+				"branchName":     "main",
+			})
+			require.Equal(t, http.StatusOK, branchRec.Code)
+
+			var brResp map[string]any
+			require.NoError(t, json.Unmarshal(branchRec.Body.Bytes(), &brResp))
+			realCommitID := brResp["branch"].(map[string]any)["commitId"].(string)
+
+			var ids []string
+			if tt.includeReal {
+				ids = append(ids, realCommitID)
+			}
+			if tt.includeFake {
+				ids = append(ids, "00000000-0000-0000-0000-000000000000")
+			}
+
+			rec := doRequest(t, h, "BatchGetCommits", map[string]any{
+				"repositoryName": "repo",
+				"commitIds":      ids,
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+			commits := resp["commits"].([]any)
+			errors := resp["errors"].([]any)
+			assert.Len(t, commits, tt.wantFoundLen)
+			assert.Len(t, errors, tt.wantErrLen)
+		})
+	}
+}
+
+func TestHandler_GetCommentsForPullRequest_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		commentCount int
+		wantCode   int
+	}{
+		{name: "no_comments", commentCount: 0, wantCode: http.StatusOK},
+		{name: "one_comment", commentCount: 1, wantCode: http.StatusOK},
+		{name: "three_comments", commentCount: 3, wantCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			prID := setupPR(t, h, "repo")
+
+			for i := 0; i < tt.commentCount; i++ {
+				doRequest(t, h, "PostCommentForPullRequest", map[string]any{
+					"pullRequestId":  prID,
+					"repositoryName": "repo",
+					"content":        fmt.Sprintf("comment %d", i),
+				})
+			}
+
+			rec := doRequest(t, h, "GetCommentsForPullRequest", map[string]any{
+				"pullRequestId": prID,
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			items := resp["commentsForPullRequestData"].([]any)
+			assert.Len(t, items, tt.commentCount)
+		})
+	}
+}
+
+func TestHandler_UpdateRepositoryName_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		oldName    string
+		newName    string
+		seed       bool
+		wantStatus int
+	}{
+		{
+			name:       "success",
+			oldName:    "old",
+			newName:    "new",
+			seed:       true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "old_not_found",
+			oldName:    "no-such",
+			newName:    "new",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "new_already_exists",
+			oldName:    "old",
+			newName:    "existing",
+			seed:       true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_old_name",
+			oldName:    "",
+			newName:    "new",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.seed {
+				doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "old"})
+			}
+			if tt.newName == "existing" {
+				doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "existing"})
+			}
+
+			rec := doRequest(t, h, "UpdateRepositoryName", map[string]any{
+				"oldName": tt.oldName,
+				"newName": tt.newName,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			// Verify rename is reflected.
+			if tt.wantStatus == http.StatusOK {
+				rec = doRequest(t, h, "GetRepository", map[string]any{"repositoryName": tt.newName})
+				assert.Equal(t, http.StatusOK, rec.Code)
+
+				rec = doRequest(t, h, "GetRepository", map[string]any{"repositoryName": tt.oldName})
+				assert.Equal(t, http.StatusNotFound, rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandler_ApprovalRuleTemplate_CRUD_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		tmplName    string
+		content     string
+		description string
+		wantCode    int
+	}{
+		{
+			name:        "minimal_content",
+			tmplName:    "tmpl-min",
+			content:     `{"Version":"2018-11-08","Statements":[]}`,
+			wantCode:    http.StatusOK,
+		},
+		{
+			name:        "with_description",
+			tmplName:    "tmpl-desc",
+			content:     `{"Version":"2018-11-08","Statements":[]}`,
+			description: "Requires 2 approvers",
+			wantCode:    http.StatusOK,
+		},
+		{
+			name:     "missing_name",
+			tmplName: "",
+			content:  `{}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "missing_content",
+			tmplName: "tmpl-no-content",
+			content:  "",
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+				"approvalRuleTemplateName":        tt.tmplName,
+				"approvalRuleTemplateContent":     tt.content,
+				"approvalRuleTemplateDescription": tt.description,
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				tmpl := resp["approvalRuleTemplate"].(map[string]any)
+				assert.Equal(t, tt.tmplName, tmpl["approvalRuleTemplateName"])
+				assert.Equal(t, tt.content, tmpl["approvalRuleTemplateContent"])
+				assert.NotEmpty(t, tmpl["approvalRuleTemplateId"])
+				assert.NotEmpty(t, tmpl["approvalRuleTemplateArn"])
+				assert.NotEmpty(t, tmpl["ruleContentSha256"])
+				assert.NotNil(t, tmpl["creationDate"])
+				assert.NotNil(t, tmpl["lastModifiedDate"])
+				if tt.description != "" {
+					assert.Equal(t, tt.description, tmpl["approvalRuleTemplateDescription"])
+				}
+
+				// Get it back.
+				rec = doRequest(t, h, "GetApprovalRuleTemplate", map[string]any{
+					"approvalRuleTemplateName": tt.tmplName,
+				})
+				assert.Equal(t, http.StatusOK, rec.Code)
+
+				// Delete it.
+				rec = doRequest(t, h, "DeleteApprovalRuleTemplate", map[string]any{
+					"approvalRuleTemplateName": tt.tmplName,
+				})
+				assert.Equal(t, http.StatusOK, rec.Code)
+
+				// Verify deleted.
+				rec = doRequest(t, h, "GetApprovalRuleTemplate", map[string]any{
+					"approvalRuleTemplateName": tt.tmplName,
+				})
+				assert.Equal(t, http.StatusNotFound, rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandler_BatchAssociateAndDisassociate_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		repoNames   []string
+		wantAssocLen int
+		wantErrLen   int
+	}{
+		{
+			name:         "all_exist",
+			repoNames:    []string{"repo1", "repo2", "repo3"},
+			wantAssocLen: 3,
+			wantErrLen:   0,
+		},
+		{
+			name:         "some_missing",
+			repoNames:    []string{"repo1", "no-such", "repo2"},
+			wantAssocLen: 2,
+			wantErrLen:   1,
+		},
+		{
+			name:         "all_missing",
+			repoNames:    []string{"no1", "no2"},
+			wantAssocLen: 0,
+			wantErrLen:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+
+			// Create only repo1 and repo2.
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo1"})
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo2"})
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo3"})
+			doRequest(t, h, "CreateApprovalRuleTemplate", map[string]any{
+				"approvalRuleTemplateName":    "tmpl",
+				"approvalRuleTemplateContent": `{}`,
+			})
+
+			rec := doRequest(t, h, "BatchAssociateApprovalRuleTemplateWithRepositories", map[string]any{
+				"approvalRuleTemplateName": "tmpl",
+				"repositoryNames":          tt.repoNames,
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assoc := resp["associatedRepositoryNames"].([]any)
+			errs := resp["errors"].([]any)
+			assert.Len(t, assoc, tt.wantAssocLen)
+			assert.Len(t, errs, tt.wantErrLen)
+
+			// Now disassociate.
+			if tt.wantAssocLen > 0 {
+				rec = doRequest(t, h, "BatchDisassociateApprovalRuleTemplateFromRepositories", map[string]any{
+					"approvalRuleTemplateName": "tmpl",
+					"repositoryNames":          tt.repoNames,
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				disassoc := resp["disassociatedRepositoryNames"].([]any)
+				assert.Len(t, disassoc, tt.wantAssocLen)
+			}
+		})
+	}
+}
+
+func TestHandler_PullRequestApprovalRule_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	prID := setupPR(t, h, "repo")
+
+	// Create approval rule.
+	rec := doRequest(t, h, "CreatePullRequestApprovalRule", map[string]any{
+		"pullRequestId":       prID,
+		"approvalRuleName":    "my-rule",
+		"approvalRuleContent": `{"Version":"2018-11-08","Statements":[]}`,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	rule := resp["approvalRule"].(map[string]any)
+	assert.Equal(t, "my-rule", rule["approvalRuleName"])
+	assert.NotEmpty(t, rule["approvalRuleId"])
+
+	// Update content.
+	rec = doRequest(t, h, "UpdatePullRequestApprovalRuleContent", map[string]any{
+		"pullRequestId":    prID,
+		"approvalRuleName": "my-rule",
+		"newRuleContent":   `{"Version":"2018-11-08","Statements":[{"Type":"Approvers","NumberOfApprovalsNeeded":1}]}`,
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Evaluate.
+	rec = doRequest(t, h, "EvaluatePullRequestApprovalRules", map[string]any{
+		"pullRequestId": prID,
+		"revisionId":    "rev-1",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	evals := resp["evaluationResults"].([]any)
+	assert.Len(t, evals, 1)
+
+	// Delete rule.
+	rec = doRequest(t, h, "DeletePullRequestApprovalRule", map[string]any{
+		"pullRequestId":    prID,
+		"approvalRuleName": "my-rule",
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Evaluate — should be empty now.
+	rec = doRequest(t, h, "EvaluatePullRequestApprovalRules", map[string]any{
+		"pullRequestId": prID,
+		"revisionId":    "rev-1",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	evals = resp["evaluationResults"].([]any)
+	assert.Empty(t, evals)
+}
+
+func TestHandler_UpdatePullRequestTitle_Reflected(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	prID := setupPR(t, h, "repo")
+
+	rec := doRequest(t, h, "UpdatePullRequestTitle", map[string]any{
+		"pullRequestId": prID,
+		"title":         "Updated Title",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	pr := resp["pullRequest"].(map[string]any)
+	assert.Equal(t, "Updated Title", pr["title"])
+	assert.Equal(t, prID, pr["pullRequestId"])
+}
+
+func TestHandler_UpdatePullRequestDescription_Reflected(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	prID := setupPR(t, h, "repo")
+
+	rec := doRequest(t, h, "UpdatePullRequestDescription", map[string]any{
+		"pullRequestId": prID,
+		"description":   "A much better description",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	pr := resp["pullRequest"].(map[string]any)
+	assert.Equal(t, "A much better description", pr["description"])
+}
+
+func TestHandler_GetPullRequestApprovalStates_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		approveUsers int
+		wantCode     int
+	}{
+		{name: "no_approvals", approveUsers: 0, wantCode: http.StatusOK},
+		{name: "one_approval", approveUsers: 1, wantCode: http.StatusOK},
+		{name: "three_approvals", approveUsers: 3, wantCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			prID := setupPR(t, h, "repo")
+
+			for i := 0; i < tt.approveUsers; i++ {
+				doRequest(t, h, "UpdatePullRequestApprovalState", map[string]any{
+					"pullRequestId": prID,
+					"revisionId":    "rev-1",
+					"approvalState": "APPROVE",
+				})
+			}
+
+			rec := doRequest(t, h, "GetPullRequestApprovalStates", map[string]any{
+				"pullRequestId": prID,
+				"revisionId":    "rev-1",
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			approvals := resp["approvals"].([]any)
+			// Each UpdatePullRequestApprovalState with the same (empty) userARN just overwrites, so max 1.
+			if tt.approveUsers > 0 {
+				assert.NotEmpty(t, approvals)
+			} else {
+				assert.Empty(t, approvals)
+			}
+		})
+	}
+}
+
+func TestHandler_DescribePullRequestEvents_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		doOverride  bool
+		wantEvents  int
+		wantCode    int
+	}{
+		{
+			name:       "no_events",
+			wantEvents: 0,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "with_override_event",
+			doOverride: true,
+			wantEvents: 1,
+			wantCode:   http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			prID := setupPR(t, h, "repo")
+
+			if tt.doOverride {
+				doRequest(t, h, "OverridePullRequestApprovalRules", map[string]any{
+					"pullRequestId":  prID,
+					"revisionId":     "rev-1",
+					"overrideStatus": "OVERRIDE",
+				})
+			}
+
+			rec := doRequest(t, h, "DescribePullRequestEvents", map[string]any{
+				"pullRequestId": prID,
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			events := resp["pullRequestEvents"].([]any)
+			assert.Len(t, events, tt.wantEvents)
+		})
+	}
+}
+
+func TestHandler_GetCommentsForComparedCommit_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		commentCount int
+		afterCommit  string
+		wantCode     int
+	}{
+		{name: "no_comments", commentCount: 0, afterCommit: "abc123", wantCode: http.StatusOK},
+		{name: "two_comments", commentCount: 2, afterCommit: "commit-1", wantCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			for i := 0; i < tt.commentCount; i++ {
+				doRequest(t, h, "PostCommentForComparedCommit", map[string]any{
+					"repositoryName": "repo",
+					"beforeCommitId": "before",
+					"afterCommitId":  tt.afterCommit,
+					"content":        fmt.Sprintf("comment %d", i),
+				})
+			}
+
+			rec := doRequest(t, h, "GetCommentsForComparedCommit", map[string]any{
+				"repositoryName": "repo",
+				"afterCommitId":  tt.afterCommit,
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			items := resp["commentsForComparedCommitData"].([]any)
+			assert.Len(t, items, tt.commentCount)
+		})
+	}
+}
+
+func TestHandler_MergeBranches_AllStrategies(t *testing.T) {
+	t.Parallel()
+
+	strategies := []string{
+		"MergeBranchesByFastForward",
+		"MergeBranchesBySquash",
+		"MergeBranchesByThreeWay",
+	}
+
+	for _, strategy := range strategies {
+		strategy := strategy
+		t.Run(strategy, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			rec := doRequest(t, h, strategy, map[string]any{
+				"repositoryName":             "repo",
+				"sourceCommitSpecifier":      "feature",
+				"destinationCommitSpecifier": "main",
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.NotEmpty(t, resp["commitId"])
+			assert.NotEmpty(t, resp["treeId"])
+		})
+	}
+}
+
+func TestHandler_GetMergeCommit_NotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	// Repo with no commits.
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "empty-repo"})
+
+	rec := doRequest(t, h, "GetMergeCommit", map[string]any{
+		"repositoryName":             "empty-repo",
+		"sourceCommitSpecifier":      "feat",
+		"destinationCommitSpecifier": "main",
+	})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandler_CreateUnreferencedMergeCommit_Success(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupRepoAndBranch(t, h, "repo")
+
+	branchRec := doRequest(t, h, "GetBranch", map[string]any{
+		"repositoryName": "repo",
+		"branchName":     "main",
+	})
+	require.Equal(t, http.StatusOK, branchRec.Code)
+
+	var brResp map[string]any
+	require.NoError(t, json.Unmarshal(branchRec.Body.Bytes(), &brResp))
+	commitID := brResp["branch"].(map[string]any)["commitId"].(string)
+
+	rec := doRequest(t, h, "CreateUnreferencedMergeCommit", map[string]any{
+		"repositoryName":             "repo",
+		"sourceCommitSpecifier":      commitID,
+		"destinationCommitSpecifier": commitID,
+		"mergeOption":                "FAST_FORWARD_MERGE",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["commitId"])
+	assert.NotEmpty(t, resp["treeId"])
+}
+
+func TestHandler_ListFileCommitHistory_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		seedCommits int
+		wantCode    int
+	}{
+		{name: "no_commits", seedCommits: 0, wantCode: http.StatusOK},
+		{name: "one_commit", seedCommits: 1, wantCode: http.StatusOK},
+		{name: "three_commits", seedCommits: 3, wantCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			for i := 0; i < tt.seedCommits; i++ {
+				doRequest(t, h, "CreateCommit", map[string]any{
+					"repositoryName": "repo",
+					"branchName":     "main",
+					"authorName":     "author",
+					"email":          "a@b.com",
+					"commitMessage":  fmt.Sprintf("commit %d", i),
+				})
+			}
+
+			rec := doRequest(t, h, "ListFileCommitHistory", map[string]any{
+				"repositoryName": "repo",
+				"filePath":       "main.go",
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			dag := resp["revisionDag"].([]any)
+			assert.Len(t, dag, tt.seedCommits)
+		})
+	}
+}
+
+func TestHandler_DeleteBranch_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		branchName string
+		seed       bool
+		wantCode   int
+	}{
+		{name: "success", branchName: "main", seed: true, wantCode: http.StatusOK},
+		{name: "not_found", branchName: "no-branch", seed: true, wantCode: http.StatusNotFound},
+		{name: "repo_not_found", branchName: "main", seed: false, wantCode: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.seed {
+				setupRepoAndBranch(t, h, "repo")
+			}
+
+			repoName := "repo"
+			if !tt.seed {
+				repoName = "no-repo"
+			}
+
+			rec := doRequest(t, h, "DeleteBranch", map[string]any{
+				"repositoryName": repoName,
+				"branchName":     tt.branchName,
+			})
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+func TestHandler_GetDifferences_RepoNotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doRequest(t, h, "GetDifferences", map[string]any{
+		"repositoryName":       "no-repo",
+		"afterCommitSpecifier": "abc",
+	})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandler_GetMergeConflicts_NoConflicts(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	rec := doRequest(t, h, "GetMergeConflicts", map[string]any{
+		"repositoryName":             "repo",
+		"sourceCommitSpecifier":      "feat",
+		"destinationCommitSpecifier": "main",
+		"mergeOption":                "FAST_FORWARD_MERGE",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// Always no conflicts in emulation.
+	assert.Equal(t, false, resp["mergeable"])
+}
+
+func TestHandler_BatchDescribeMergeConflicts_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mergeOption string
+		filePaths   []string
+		wantCode    int
+		wantConflicts int
+	}{
+		{
+			name:          "no_file_paths",
+			mergeOption:   "FAST_FORWARD_MERGE",
+			filePaths:     nil,
+			wantCode:      http.StatusOK,
+			wantConflicts: 0,
+		},
+		{
+			name:          "two_file_paths",
+			mergeOption:   "SQUASH_MERGE",
+			filePaths:     []string{"a.go", "b.go"},
+			wantCode:      http.StatusOK,
+			wantConflicts: 2,
+		},
+		{
+			name:        "invalid_merge_option",
+			mergeOption: "INVALID_MERGE",
+			wantCode:    http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			body := map[string]any{
+				"repositoryName":             "repo",
+				"destinationCommitSpecifier": "main",
+				"sourceCommitSpecifier":      "feat",
+				"mergeOption":                tt.mergeOption,
+			}
+			if tt.filePaths != nil {
+				body["filePaths"] = tt.filePaths
+			}
+
+			rec := doRequest(t, h, "BatchDescribeMergeConflicts", body)
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				conflicts := resp["conflicts"].([]any)
+				assert.Len(t, conflicts, tt.wantConflicts)
+			}
+		})
+	}
 }

--- a/services/codecommit/handler_test.go
+++ b/services/codecommit/handler_test.go
@@ -3,6 +3,7 @@ package codecommit_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -1072,66 +1073,117 @@ func TestHandler_BatchGetRepositories(t *testing.T) {
 func TestHandler_CreateBranch(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		repoName   string
-		branchName string
-		commitID   string
-		seedRepo   bool
-		wantStatus int
-	}{
-		{
-			name:       "success",
-			repoName:   "repo",
-			branchName: "feature",
-			commitID:   "abc123",
-			seedRepo:   true,
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "repo_not_found",
-			repoName:   "missing-repo",
-			branchName: "feature",
-			commitID:   "abc123",
-			wantStatus: http.StatusNotFound,
-		},
-		{
-			name:       "missing_branch_name",
-			repoName:   "repo",
-			branchName: "",
-			commitID:   "abc123",
-			seedRepo:   true,
-			wantStatus: http.StatusBadRequest,
-		},
-		{
-			name:       "missing_commit_id",
-			repoName:   "repo",
-			branchName: "feature",
-			commitID:   "",
-			seedRepo:   true,
-			wantStatus: http.StatusBadRequest,
-		},
-	}
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		h := newTestHandler(t)
+		doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
 
-			h := newTestHandler(t)
-
-			if tt.seedRepo {
-				rec := doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
-				require.Equal(t, http.StatusOK, rec.Code)
-			}
-
-			rec := doRequest(t, h, "CreateBranch", map[string]any{
-				"repositoryName": tt.repoName,
-				"branchName":     tt.branchName,
-				"commitId":       tt.commitID,
-			})
-			assert.Equal(t, tt.wantStatus, rec.Code)
+		// Seed a real commit via CreateCommit.
+		commitRec := doRequest(t, h, "CreateCommit", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "main",
+			"authorName":     "test",
+			"email":          "test@example.com",
+			"commitMessage":  "init",
 		})
-	}
+		require.Equal(t, http.StatusOK, commitRec.Code)
+
+		var commitResp map[string]any
+		require.NoError(t, json.Unmarshal(commitRec.Body.Bytes(), &commitResp))
+		commitID := commitResp["commitId"].(string)
+
+		rec := doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "feature",
+			"commitId":       commitID,
+		})
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("commit_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+		rec := doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "feature",
+			"commitId":       "does-not-exist",
+		})
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("repo_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "missing-repo",
+			"branchName":     "feature",
+			"commitId":       "abc123",
+		})
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("missing_branch_name", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+		rec := doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "",
+			"commitId":       "abc123",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("missing_commit_id", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+		rec := doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "feature",
+			"commitId":       "",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("duplicate_branch", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+		commitRec := doRequest(t, h, "CreateCommit", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "main",
+			"authorName":     "test",
+			"email":          "test@example.com",
+			"commitMessage":  "init",
+		})
+		require.Equal(t, http.StatusOK, commitRec.Code)
+
+		var commitResp map[string]any
+		require.NoError(t, json.Unmarshal(commitRec.Body.Bytes(), &commitResp))
+		commitID := commitResp["commitId"].(string)
+
+		doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "feature",
+			"commitId":       commitID,
+		})
+		rec := doRequest(t, h, "CreateBranch", map[string]any{
+			"repositoryName": "repo",
+			"branchName":     "feature",
+			"commitId":       commitID,
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
 }
 
 func TestHandler_CreateCommit(t *testing.T) {
@@ -2019,4 +2071,655 @@ func TestHandler_SeedHelpers(t *testing.T) {
 			{RepositoryName: "seed-repo", SourceReference: "refs/heads/feat"},
 		},
 	})
+}
+
+// --- Parity gap tests added in go-7lrz audit ---
+
+func TestHandler_CreateRepository_NameValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		repoName   string
+		wantStatus int
+	}{
+		{
+			name:       "valid_name",
+			repoName:   "my-repo",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "valid_with_dots",
+			repoName:   "my.repo.name",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "valid_with_underscores",
+			repoName:   "my_repo_name",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "empty_name",
+			repoName:   "",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "name_with_spaces",
+			repoName:   "my repo",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "name_with_slash",
+			repoName:   "my/repo",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "name_too_long",
+			repoName:   string(make([]byte, 101)),
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doRequest(t, h, "CreateRepository", map[string]any{
+				"repositoryName": tt.repoName,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_RepoMetadata_DefaultBranchAndKmsKey(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Initially no defaultBranch or kmsKeyId in metadata.
+	rec = doRequest(t, h, "GetRepository", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	meta := resp["repositoryMetadata"].(map[string]any)
+	_, hasDefault := meta["defaultBranch"]
+	_, hasKms := meta["kmsKeyId"]
+	assert.False(t, hasDefault, "defaultBranch should not appear when unset")
+	assert.False(t, hasKms, "kmsKeyId should not appear when unset")
+
+	// Set defaultBranch.
+	rec = doRequest(t, h, "UpdateDefaultBranch", map[string]any{
+		"repositoryName":    "repo",
+		"defaultBranchName": "main",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Set kmsKeyId.
+	rec = doRequest(t, h, "UpdateRepositoryEncryptionKey", map[string]any{
+		"repositoryName": "repo",
+		"kmsKeyId":       "arn:aws:kms:us-east-1:123456789012:key/my-key",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Now GetRepository should include both.
+	rec = doRequest(t, h, "GetRepository", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	meta = resp["repositoryMetadata"].(map[string]any)
+	assert.Equal(t, "main", meta["defaultBranch"])
+	assert.Equal(t, "arn:aws:kms:us-east-1:123456789012:key/my-key", meta["kmsKeyId"])
+}
+
+func TestHandler_BatchGetRepositories_MaxLimit(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Create 26 repos.
+	names := make([]string, 26)
+	for i := range names {
+		names[i] = fmt.Sprintf("repo-%02d", i)
+		doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": names[i]})
+	}
+
+	// Request 26 — should fail.
+	rec := doRequest(t, h, "BatchGetRepositories", map[string]any{
+		"repositoryNames": names,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "MaximumRepositoryNamesExceededException", errResp["__type"])
+
+	// Request 25 — should succeed.
+	rec = doRequest(t, h, "BatchGetRepositories", map[string]any{
+		"repositoryNames": names[:25],
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_ListPullRequests_StatusFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		filterStatus  string
+		wantCount     int
+		wantHTTPCode  int
+	}{
+		{
+			name:         "all_no_filter",
+			filterStatus: "",
+			wantCount:    3,
+			wantHTTPCode: http.StatusOK,
+		},
+		{
+			name:         "open_only",
+			filterStatus: "OPEN",
+			wantCount:    2,
+			wantHTTPCode: http.StatusOK,
+		},
+		{
+			name:         "closed_only",
+			filterStatus: "CLOSED",
+			wantCount:    1,
+			wantHTTPCode: http.StatusOK,
+		},
+		{
+			name:         "invalid_status",
+			filterStatus: "INVALID",
+			wantHTTPCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			// Seed 2 OPEN + 1 CLOSED PR.
+			createPR := func() string {
+				rec := doRequest(t, h, "CreatePullRequest", map[string]any{
+					"title": "PR",
+					"targets": []map[string]any{
+						{"repositoryName": "repo", "sourceReference": "refs/heads/feat"},
+					},
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				return resp["pullRequest"].(map[string]any)["pullRequestId"].(string)
+			}
+
+			createPR()
+			createPR()
+			closedID := createPR()
+
+			doRequest(t, h, "UpdatePullRequestStatus", map[string]any{
+				"pullRequestId":     closedID,
+				"pullRequestStatus": "CLOSED",
+			})
+
+			body := map[string]any{"repositoryName": "repo"}
+			if tt.filterStatus != "" {
+				body["pullRequestStatus"] = tt.filterStatus
+			}
+			rec := doRequest(t, h, "ListPullRequests", body)
+			assert.Equal(t, tt.wantHTTPCode, rec.Code)
+
+			if tt.wantHTTPCode == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				ids := resp["pullRequestIds"].([]any)
+				assert.Len(t, ids, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestHandler_ListPullRequests_NumericDescendingOrder(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	// Create 3 PRs — expect IDs 1, 2, 3.
+	for i := 0; i < 3; i++ {
+		doRequest(t, h, "CreatePullRequest", map[string]any{
+			"title": fmt.Sprintf("PR %d", i),
+			"targets": []map[string]any{
+				{"repositoryName": "repo", "sourceReference": "refs/heads/feat"},
+			},
+		})
+	}
+
+	rec := doRequest(t, h, "ListPullRequests", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ids := resp["pullRequestIds"].([]any)
+	require.Len(t, ids, 3)
+
+	// Should be descending: "3", "2", "1".
+	assert.Equal(t, "3", ids[0])
+	assert.Equal(t, "2", ids[1])
+	assert.Equal(t, "1", ids[2])
+}
+
+func TestHandler_MergePullRequest_AlreadyMerged(t *testing.T) {
+	t.Parallel()
+
+	strategies := []string{
+		"MergePullRequestByFastForward",
+		"MergePullRequestBySquash",
+		"MergePullRequestByThreeWay",
+	}
+
+	for _, strategy := range strategies {
+		strategy := strategy
+		t.Run(strategy, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			rec := doRequest(t, h, "CreatePullRequest", map[string]any{
+				"title": "PR",
+				"targets": []map[string]any{
+					{"repositoryName": "repo", "sourceReference": "refs/heads/feat"},
+				},
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			prID := resp["pullRequest"].(map[string]any)["pullRequestId"].(string)
+
+			// First merge — should succeed.
+			rec = doRequest(t, h, strategy, map[string]any{"pullRequestId": prID})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			// Second merge — should fail with PullRequestAlreadyClosedException.
+			rec = doRequest(t, h, strategy, map[string]any{"pullRequestId": prID})
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+			var errResp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+			assert.Equal(t, "PullRequestAlreadyClosedException", errResp["__type"])
+		})
+	}
+}
+
+func TestHandler_UpdatePullRequestStatus_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		status     string
+		wantStatus int
+	}{
+		{
+			name:       "open_valid",
+			status:     "OPEN",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "closed_valid",
+			status:     "CLOSED",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "merged_invalid",
+			status:     "MERGED",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty_invalid",
+			status:     "",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "arbitrary_invalid",
+			status:     "DONE",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			rec := doRequest(t, h, "CreatePullRequest", map[string]any{
+				"title": "PR",
+				"targets": []map[string]any{
+					{"repositoryName": "repo", "sourceReference": "refs/heads/feat"},
+				},
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			prID := resp["pullRequest"].(map[string]any)["pullRequestId"].(string)
+
+			rec = doRequest(t, h, "UpdatePullRequestStatus", map[string]any{
+				"pullRequestId":     prID,
+				"pullRequestStatus": tt.status,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_CreateBranch_CommitValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	// Create a real commit.
+	commitRec := doRequest(t, h, "CreateCommit", map[string]any{
+		"repositoryName": "repo",
+		"branchName":     "main",
+		"authorName":     "test",
+		"email":          "test@example.com",
+		"commitMessage":  "init",
+	})
+	require.Equal(t, http.StatusOK, commitRec.Code)
+
+	var commitResp map[string]any
+	require.NoError(t, json.Unmarshal(commitRec.Body.Bytes(), &commitResp))
+	realCommitID := commitResp["commitId"].(string)
+
+	tests := []struct {
+		name       string
+		commitID   string
+		wantStatus int
+	}{
+		{
+			name:       "valid_commit",
+			commitID:   realCommitID,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "nonexistent_commit",
+			commitID:   "00000000-0000-0000-0000-000000000000",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hh := newTestHandler(t)
+			doRequest(t, hh, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			// Seed the commit into this handler's backend if needed.
+			if tt.commitID == realCommitID {
+				// Create our own real commit for this subtest handler.
+				cr := doRequest(t, hh, "CreateCommit", map[string]any{
+					"repositoryName": "repo",
+					"branchName":     "main",
+					"authorName":     "test",
+					"email":          "test@example.com",
+					"commitMessage":  "init",
+				})
+				require.Equal(t, http.StatusOK, cr.Code)
+				var cr2 map[string]any
+				require.NoError(t, json.Unmarshal(cr.Body.Bytes(), &cr2))
+				tt.commitID = cr2["commitId"].(string)
+			}
+
+			rec := doRequest(t, hh, "CreateBranch", map[string]any{
+				"repositoryName": "repo",
+				"branchName":     "feature",
+				"commitId":       tt.commitID,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_GetRepository_FullMetadata(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	rec := doRequest(t, h, "CreateRepository", map[string]any{
+		"repositoryName":        "full-meta-repo",
+		"repositoryDescription": "desc here",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doRequest(t, h, "GetRepository", map[string]any{"repositoryName": "full-meta-repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	meta := resp["repositoryMetadata"].(map[string]any)
+
+	assert.NotEmpty(t, meta["repositoryId"])
+	assert.Equal(t, "full-meta-repo", meta["repositoryName"])
+	assert.NotEmpty(t, meta["Arn"])
+	assert.NotEmpty(t, meta["accountId"])
+	assert.NotEmpty(t, meta["cloneUrlHttp"])
+	assert.NotEmpty(t, meta["cloneUrlSsh"])
+	assert.NotNil(t, meta["creationDate"])
+	assert.NotNil(t, meta["lastModifiedDate"])
+	assert.Equal(t, "desc here", meta["repositoryDescription"])
+}
+
+func TestHandler_BatchGetRepositories_PartialFound(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "exists"})
+
+	rec := doRequest(t, h, "BatchGetRepositories", map[string]any{
+		"repositoryNames": []string{"exists", "missing1", "missing2"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	repos := resp["repositories"].([]any)
+	notFound := resp["repositoriesNotFound"].([]any)
+
+	assert.Len(t, repos, 1)
+	assert.Len(t, notFound, 2)
+}
+
+func TestHandler_ListPullRequests_RepoNotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doRequest(t, h, "ListPullRequests", map[string]any{"repositoryName": "no-such-repo"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandler_CreatePullRequest_RepoMetadataInResponse(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	rec := doRequest(t, h, "CreatePullRequest", map[string]any{
+		"title":       "My PR",
+		"description": "A test pull request",
+		"targets": []map[string]any{
+			{
+				"repositoryName":       "repo",
+				"sourceReference":      "refs/heads/feat",
+				"destinationReference": "refs/heads/main",
+			},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	pr := resp["pullRequest"].(map[string]any)
+
+	assert.NotEmpty(t, pr["pullRequestId"])
+	assert.Equal(t, "My PR", pr["title"])
+	assert.Equal(t, "A test pull request", pr["description"])
+	assert.Equal(t, "OPEN", pr["pullRequestStatus"])
+	assert.NotEmpty(t, pr["revisionId"])
+	assert.NotNil(t, pr["creationDate"])
+	assert.NotNil(t, pr["lastActivityDate"])
+
+	targets := pr["pullRequestTargets"].([]any)
+	require.Len(t, targets, 1)
+	target := targets[0].(map[string]any)
+	assert.Equal(t, "repo", target["repositoryName"])
+	assert.Equal(t, "refs/heads/feat", target["sourceReference"])
+	assert.Equal(t, "refs/heads/main", target["destinationReference"])
+}
+
+func TestHandler_MergePullRequest_StatusBecomesmerged(t *testing.T) {
+	t.Parallel()
+
+	strategies := []string{
+		"MergePullRequestByFastForward",
+		"MergePullRequestBySquash",
+		"MergePullRequestByThreeWay",
+	}
+
+	for _, strategy := range strategies {
+		strategy := strategy
+		t.Run(strategy, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+			rec := doRequest(t, h, "CreatePullRequest", map[string]any{
+				"title": "PR",
+				"targets": []map[string]any{
+					{"repositoryName": "repo", "sourceReference": "refs/heads/feat"},
+				},
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			prID := resp["pullRequest"].(map[string]any)["pullRequestId"].(string)
+
+			rec = doRequest(t, h, strategy, map[string]any{"pullRequestId": prID})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			mergedPR := resp["pullRequest"].(map[string]any)
+			assert.Equal(t, "MERGED", mergedPR["pullRequestStatus"])
+		})
+	}
+}
+
+func TestHandler_UpdateRepositoryDescription_Reflected(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
+
+	doRequest(t, h, "UpdateRepositoryDescription", map[string]any{
+		"repositoryName":        "repo",
+		"repositoryDescription": "new description",
+	})
+
+	rec := doRequest(t, h, "GetRepository", map[string]any{"repositoryName": "repo"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	meta := resp["repositoryMetadata"].(map[string]any)
+	assert.Equal(t, "new description", meta["repositoryDescription"])
+}
+
+func TestHandler_CreateRepository_InvalidName_ErrorType(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	rec := doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "bad name with spaces"})
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "InvalidRepositoryNameException", errResp["__type"])
+}
+
+func TestHandler_ErrorTypes_Comprehensive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		action    string
+		body      map[string]any
+		wantCode  int
+		wantType  string
+	}{
+		{
+			name:     "repo_not_found",
+			action:   "GetRepository",
+			body:     map[string]any{"repositoryName": "no-such"},
+			wantCode: http.StatusNotFound,
+			wantType: "RepositoryDoesNotExistException",
+		},
+		{
+			name:     "branch_not_found",
+			action:   "GetBranch",
+			body:     map[string]any{"repositoryName": "no-such", "branchName": "main"},
+			wantCode: http.StatusNotFound,
+			wantType: "RepositoryDoesNotExistException",
+		},
+		{
+			name:     "pr_not_found",
+			action:   "GetPullRequest",
+			body:     map[string]any{"pullRequestId": "9999"},
+			wantCode: http.StatusNotFound,
+			wantType: "PullRequestDoesNotExistException",
+		},
+		{
+			name:     "invalid_repo_name",
+			action:   "CreateRepository",
+			body:     map[string]any{"repositoryName": "bad/name"},
+			wantCode: http.StatusBadRequest,
+			wantType: "InvalidRepositoryNameException",
+		},
+		{
+			name:     "approval_template_not_found",
+			action:   "GetApprovalRuleTemplate",
+			body:     map[string]any{"approvalRuleTemplateName": "no-such-tmpl"},
+			wantCode: http.StatusNotFound,
+			wantType: "ApprovalRuleTemplateDoesNotExistException",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doRequest(t, h, tt.action, tt.body)
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var errResp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+			assert.Equal(t, tt.wantType, errResp["__type"])
+		})
+	}
 }

--- a/services/codecommit/handler_test.go
+++ b/services/codecommit/handler_test.go
@@ -2256,8 +2256,10 @@ func TestHandler_ListPullRequests_StatusFilter(t *testing.T) {
 					},
 				})
 				require.Equal(t, http.StatusOK, rec.Code)
+
 				var resp map[string]any
 				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
 				return resp["pullRequest"].(map[string]any)["pullRequestId"].(string)
 			}
 

--- a/services/codecommit/handler_test.go
+++ b/services/codecommit/handler_test.go
@@ -2210,10 +2210,10 @@ func TestHandler_ListPullRequests_StatusFilter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		filterStatus  string
-		wantCount     int
-		wantHTTPCode  int
+		name         string
+		filterStatus string
+		wantCount    int
+		wantHTTPCode int
 	}{
 		{
 			name:         "all_no_filter",
@@ -2294,7 +2294,7 @@ func TestHandler_ListPullRequests_NumericDescendingOrder(t *testing.T) {
 	doRequest(t, h, "CreateRepository", map[string]any{"repositoryName": "repo"})
 
 	// Create 3 PRs — expect IDs 1, 2, 3.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		doRequest(t, h, "CreatePullRequest", map[string]any{
 			"title": fmt.Sprintf("PR %d", i),
 			"targets": []map[string]any{
@@ -2327,7 +2327,6 @@ func TestHandler_MergePullRequest_AlreadyMerged(t *testing.T) {
 	}
 
 	for _, strategy := range strategies {
-		strategy := strategy
 		t.Run(strategy, func(t *testing.T) {
 			t.Parallel()
 
@@ -2601,7 +2600,6 @@ func TestHandler_MergePullRequest_StatusBecomesmerged(t *testing.T) {
 	}
 
 	for _, strategy := range strategies {
-		strategy := strategy
 		t.Run(strategy, func(t *testing.T) {
 			t.Parallel()
 
@@ -2666,11 +2664,11 @@ func TestHandler_ErrorTypes_Comprehensive(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		action    string
-		body      map[string]any
-		wantCode  int
-		wantType  string
+		body     map[string]any
+		name     string
+		action   string
+		wantType string
+		wantCode int
 	}{
 		{
 			name:     "repo_not_found",


### PR DESCRIPTION
## Summary

- Repository name validation (1–100 chars, alphanumeric/._/-)
- `repoMetadata` now includes `defaultBranch` and `kmsKeyId` when set — matches real AWS GetRepository response
- `ListPullRequests`: add `pullRequestStatus` filter (OPEN/CLOSED) and fix sort to numeric descending
- `CreateBranch`: validate `commitId` exists in repository (returns `CommitDoesNotExistException`)
- `BatchGetRepositories`: enforce AWS max-25 repo limit (`MaximumRepositoryNamesExceededException`)
- `MergePullRequestBy{FastForward,Squash,ThreeWay}`: reject already-closed/merged PRs with `PullRequestAlreadyClosedException`
- `UpdatePullRequestStatus`: validate value is `OPEN` or `CLOSED` only
- `handleListRepositoriesForApprovalRuleTemplate`: return `[]` not `null` when empty
- 2k+ lines of new table-driven tests covering all ops and parity gaps

## Test plan

- [ ] `go test ./services/codecommit/...` passes
- [ ] `go vet ./services/codecommit/...` clean
- [ ] `TestSDKCompleteness` passes

Resolves go-7lrz

🤖 Generated with [Claude Code](https://claude.com/claude-code)