### PR TITLE
feat(codeartifact): AWS-accuracy audit parity (go-cy79)

### DIFF
--- a/services/codeartifact/backend.go
+++ b/services/codeartifact/backend.go
@@ -1062,12 +1062,14 @@ func (b *InMemoryBackend) ListSubPackageGroups(domainName, pattern string) ([]*P
 
 	result := make([]*PackageGroup, 0, len(b.packageGroups))
 
+	parentRoot := strings.TrimSuffix(pattern, "*")
+
 	for _, pg := range b.packageGroups {
 		if pg.DomainName != domainName {
 			continue
 		}
 
-		if pg.Pattern == pattern || !strings.HasPrefix(pg.Pattern, pattern) {
+		if pg.Pattern == pattern || !strings.HasPrefix(pg.Pattern, parentRoot) {
 			continue
 		}
 

--- a/services/codeartifact/codeartifact_coverage_test.go
+++ b/services/codeartifact/codeartifact_coverage_test.go
@@ -82,7 +82,7 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 					t,
 					h,
 					http.MethodPost,
-					"/v1/repository/external-connection" +
+					"/v1/repository/external-connection"+
 						"?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
 					nil,
 				)
@@ -117,7 +117,7 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "repo_not_found",
+			name: "repo_not_found",
 			path: "/v1/repository/external-connection" +
 				"?domain=dis-domain&repository=nope&externalConnection=public:npmjs",
 			wantStatus: http.StatusNotFound,
@@ -285,19 +285,19 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "missing_format",
+			name: "missing_format",
 			path: "/v1/package/version/asset" +
 				"?domain=pva-domain&repository=pva-repo&package=lodash&version=1.0.0&asset=x.tgz",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "missing_package",
+			name: "missing_package",
 			path: "/v1/package/version/asset" +
 				"?domain=pva-domain&repository=pva-repo&format=npm&version=1.0.0&asset=x.tgz",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "missing_version",
+			name: "missing_version",
 			path: "/v1/package/version/asset" +
 				"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&asset=x.tgz",
 			wantStatus: http.StatusBadRequest,
@@ -309,7 +309,7 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "version_not_found",
+			name: "version_not_found",
 			path: "/v1/package/version/asset" +
 				"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=9.9.9&asset=x.tgz",
 			wantStatus: http.StatusNotFound,
@@ -382,7 +382,7 @@ func TestHandler_GetPackageVersionReadme(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "version_not_found",
+			name: "version_not_found",
 			path: "/v1/package/version/readme" +
 				"?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=9.9.9",
 			wantStatus: http.StatusNotFound,
@@ -684,7 +684,7 @@ func TestHandler_ListPackageVersionAssets(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "version_not_found",
+			name: "version_not_found",
 			path: "/v1/package/version/assets" +
 				"?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=9.9.9",
 			wantStatus: http.StatusNotFound,
@@ -752,7 +752,7 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "missing_format",
+			name: "missing_format",
 			path: "/v1/package/version/dependencies" +
 				"?domain=lpvd-domain&repository=lpvd-repo&package=lodash&version=1.0.0",
 			wantStatus: http.StatusBadRequest,
@@ -768,7 +768,7 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "version_not_found",
+			name: "version_not_found",
 			path: "/v1/package/version/dependencies" +
 				"?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=9.9.9",
 			wantStatus: http.StatusNotFound,
@@ -1377,10 +1377,10 @@ func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "missing_target_status",
+			name: "missing_target_status",
 			path: "/v1/package/versions/update_status" +
 				"?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
-			body: map[string]any{"versions": []string{"1.0.0"}},
+			body:       map[string]any{"versions": []string{"1.0.0"}},
 			wantStatus: http.StatusBadRequest,
 		},
 	}

--- a/services/codeartifact/codeartifact_coverage_test.go
+++ b/services/codeartifact/codeartifact_coverage_test.go
@@ -303,8 +303,9 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "missing_asset",
-			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0",
+			name: "missing_asset",
+			path: "/v1/package/version/asset" +
+				"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
@@ -351,7 +352,8 @@ func TestHandler_GetPackageVersionReadme(t *testing.T) {
 					nil,
 				)
 			},
-			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
+			path: "/v1/package/version/readme" +
+				"?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
 			wantStatus: http.StatusOK,
 		},
 		{

--- a/services/codeartifact/codeartifact_coverage_test.go
+++ b/services/codeartifact/codeartifact_coverage_test.go
@@ -78,7 +78,10 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "dis-domain")
 				setupRepo(t, h, "dis-domain", "dis-repo")
-				doRequest(t, h, http.MethodPost,
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
 					"/v1/repository/external-connection?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
 					nil,
 				)
@@ -537,8 +540,20 @@ func TestHandler_ListPackageGroups(t *testing.T) {
 			name: "success_two_groups",
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lpg2-domain")
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg2-domain", map[string]any{"pattern": "/npm/*"})
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg2-domain", map[string]any{"pattern": "/pypi/*"})
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lpg2-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lpg2-domain",
+					map[string]any{"pattern": "/pypi/*"},
+				)
 			},
 			path:       "/v1/package-groups?domain=lpg2-domain",
 			wantStatus: http.StatusOK,
@@ -548,8 +563,20 @@ func TestHandler_ListPackageGroups(t *testing.T) {
 			name: "success_prefix_filter",
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lpg3-domain")
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg3-domain", map[string]any{"pattern": "/npm/*"})
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg3-domain", map[string]any{"pattern": "/pypi/*"})
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lpg3-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lpg3-domain",
+					map[string]any{"pattern": "/pypi/*"},
+				)
 			},
 			path:       "/v1/package-groups?domain=lpg3-domain&prefix=/npm",
 			wantStatus: http.StatusOK,
@@ -605,7 +632,10 @@ func TestHandler_ListPackageVersionAssets(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lpva-domain")
 				setupRepo(t, h, "lpva-domain", "lpva-repo")
-				doRequest(t, h, http.MethodGet,
+				doRequest(
+					t,
+					h,
+					http.MethodGet,
 					"/v1/package/version?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
 					nil,
 				)
@@ -683,7 +713,10 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lpvd-domain")
 				setupRepo(t, h, "lpvd-domain", "lpvd-repo")
-				doRequest(t, h, http.MethodGet,
+				doRequest(
+					t,
+					h,
+					http.MethodGet,
 					"/v1/package/version?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
 					nil,
 				)
@@ -762,11 +795,17 @@ func TestHandler_ListPackageVersions(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lpv-domain")
 				setupRepo(t, h, "lpv-domain", "lpv-repo")
-				doRequest(t, h, http.MethodGet,
+				doRequest(
+					t,
+					h,
+					http.MethodGet,
 					"/v1/package/version?domain=lpv-domain&repository=lpv-repo&format=npm&package=lodash&version=4.17.0",
 					nil,
 				)
-				doRequest(t, h, http.MethodGet,
+				doRequest(
+					t,
+					h,
+					http.MethodGet,
 					"/v1/package/version?domain=lpv-domain&repository=lpv-repo&format=npm&package=lodash&version=4.17.21",
 					nil,
 				)
@@ -851,11 +890,17 @@ func TestHandler_ListPackages(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lp-domain")
 				setupRepo(t, h, "lp-domain", "lp-repo")
-				doRequest(t, h, http.MethodPost,
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
 					"/v1/package/versions/publish?domain=lp-domain&repository=lp-repo&format=npm&package=react&version=18.0.0",
 					nil,
 				)
-				doRequest(t, h, http.MethodPost,
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
 					"/v1/package/versions/publish?domain=lp-domain&repository=lp-repo&format=npm&package=lodash&version=4.0.0",
 					nil,
 				)
@@ -879,11 +924,17 @@ func TestHandler_ListPackages(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "lp3-domain")
 				setupRepo(t, h, "lp3-domain", "lp3-repo")
-				doRequest(t, h, http.MethodPost,
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
 					"/v1/package/versions/publish?domain=lp3-domain&repository=lp3-repo&format=npm&package=react&version=18.0.0",
 					nil,
 				)
-				doRequest(t, h, http.MethodPost,
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
 					"/v1/package/versions/publish?domain=lp3-domain&repository=lp3-repo&format=pypi&package=boto3&version=1.0.0",
 					nil,
 				)
@@ -973,7 +1024,10 @@ func TestHandler_PublishPackageVersion(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "ppv2-domain")
 				setupRepo(t, h, "ppv2-domain", "ppv2-repo")
-				doRequest(t, h, http.MethodPost,
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
 					"/v1/package/versions/publish?domain=ppv2-domain&repository=ppv2-repo&format=npm&package=mylib&version=2.0.0",
 					nil,
 				)
@@ -1253,7 +1307,10 @@ func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 			setup: func(h *codeartifact.Handler) {
 				setupDomain(t, h, "upvs-domain")
 				setupRepo(t, h, "upvs-domain", "upvs-repo")
-				doRequest(t, h, http.MethodGet,
+				doRequest(
+					t,
+					h,
+					http.MethodGet,
 					"/v1/package/version?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash&version=1.0.0",
 					nil,
 				)

--- a/services/codeartifact/codeartifact_coverage_test.go
+++ b/services/codeartifact/codeartifact_coverage_test.go
@@ -1,6 +1,7 @@
 package codeartifact_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -26,7 +27,6 @@ func TestCAProvider_Init_NilCtx(t *testing.T) {
 
 	p := &codeartifact.Provider{}
 	_, err := p.Init(nil)
-	// CodeArtifact requires a non-nil context
 	require.Error(t, err)
 }
 
@@ -67,26 +67,76 @@ func setupRepo(t *testing.T, h *codeartifact.Handler, domain, repo string) {
 func TestHandler_DisassociateExternalConnection(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "my-domain")
-	setupRepo(t, h, "my-domain", "my-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success_removes_connection",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "dis-domain")
+				setupRepo(t, h, "dis-domain", "dis-repo")
+				doRequest(t, h, http.MethodPost,
+					"/v1/repository/external-connection?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
+					nil,
+				)
+			},
+			path:       "/v1/repository/external-connection?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success_nonexistent_connection",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "dis2-domain")
+				setupRepo(t, h, "dis2-domain", "dis2-repo")
+			},
+			path:       "/v1/repository/external-connection?domain=dis2-domain&repository=dis2-repo&externalConnection=public:npmjs",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/repository/external-connection?repository=dis-repo&externalConnection=public:npmjs",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/repository/external-connection?domain=dis-domain&externalConnection=public:npmjs",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_connection",
+			path:       "/v1/repository/external-connection?domain=dis-domain&repository=dis-repo",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "repo_not_found",
+			path:       "/v1/repository/external-connection?domain=dis-domain&repository=nope&externalConnection=public:npmjs",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	// Disassociate (no connection exists - should succeed or return not found)
-	rec := doRequest(
-		t,
-		h,
-		http.MethodDelete,
-		"/v1/repository/external-connection?domain=my-domain&repository=my-repo&externalConnection=public:npmjs",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodDelete,
-		"/v1/repository/external-connection?repository=my-repo&externalConnection=public:npmjs",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodDelete, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				repo, _ := resp["repository"].(map[string]any)
+				assert.NotNil(t, repo)
+			}
+		})
+	}
 }
 
 // ---- DisposePackageVersions tests ----
@@ -94,26 +144,83 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 func TestHandler_DisposePackageVersions(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "dp-domain")
-	setupRepo(t, h, "dp-domain", "dp-repo")
+	tests := []struct {
+		body       any
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success_existing_version",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "dp-domain")
+				setupRepo(t, h, "dp-domain", "dp-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=dp-domain&repository=dp-repo&format=npm&package=lodash&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/versions/dispose?domain=dp-domain&repository=dp-repo&format=npm&package=lodash",
+			body:       map[string]any{"versions": []string{"1.0.0"}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success_nonexistent_version",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "dp2-domain")
+				setupRepo(t, h, "dp2-domain", "dp2-repo")
+			},
+			path:       "/v1/package/versions/dispose?domain=dp2-domain&repository=dp2-repo&format=npm&package=lodash",
+			body:       map[string]any{"versions": []string{"9.9.9"}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/versions/dispose?repository=dp-repo&format=npm&package=lodash",
+			body:       map[string]any{"versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/versions/dispose?domain=dp-domain&format=npm&package=lodash",
+			body:       map[string]any{"versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/versions/dispose?domain=dp-domain&repository=dp-repo&package=lodash",
+			body:       map[string]any{"versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/versions/dispose?domain=dp-domain&repository=dp-repo&format=npm",
+			body:       map[string]any{"versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
 
-	// Dispose package versions
-	rec := doRequest(
-		t,
-		h,
-		http.MethodPost,
-		"/v1/package/versions/dispose?domain=dp-domain&repository=dp-repo&format=npm&package=lodash",
-		map[string]any{"versions": []string{"1.0.0", "1.0.1"}},
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodPost,
-		"/v1/package/versions/dispose?repository=dp-repo&format=npm&package=lodash",
-		map[string]any{"versions": []string{"1.0.0"}},
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, tt.body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assert.NotNil(t, resp["successfulVersions"])
+				assert.NotNil(t, resp["failedVersions"])
+			}
+		})
+	}
 }
 
 // ---- GetAssociatedPackageGroup tests (backend-level) ----
@@ -125,12 +232,10 @@ func TestBackend_GetAssociatedPackageGroup(t *testing.T) {
 	_, err := b.CreateDomain("apg-domain", "", nil)
 	require.NoError(t, err)
 
-	// Get associated package group (returns nil, nil when no group matches)
 	pg, err := b.GetAssociatedPackageGroup("apg-domain", "npm", "", "lodash")
 	require.NoError(t, err)
 	assert.Nil(t, pg)
 
-	// Domain not found
 	_, err = b.GetAssociatedPackageGroup("nonexistent", "npm", "", "lodash")
 	require.Error(t, err)
 }
@@ -140,26 +245,75 @@ func TestBackend_GetAssociatedPackageGroup(t *testing.T) {
 func TestHandler_GetPackageVersionAsset(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "pva-domain")
-	setupRepo(t, h, "pva-domain", "pva-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "pva-domain")
+				setupRepo(t, h, "pva-domain", "pva-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0&asset=lodash-1.0.0.tgz",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/version/asset?repository=pva-repo&format=npm&package=lodash&version=1.0.0&asset=x.tgz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/version/asset?domain=pva-domain&format=npm&package=lodash&version=1.0.0&asset=x.tgz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&package=lodash&version=1.0.0&asset=x.tgz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&version=1.0.0&asset=x.tgz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_version",
+			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&asset=x.tgz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_asset",
+			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "version_not_found",
+			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=9.9.9&asset=x.tgz",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	// Get package version asset (no real asset)
-	const assetPath = "/v1/package/version/asset" +
-		"?domain=pva-domain&repository=pva-repo&format=npm" +
-		"&package=lodash&version=1.0.0&asset=lodash-1.0.0.tgz"
-	rec := doRequest(t, h, http.MethodGet, assetPath, nil)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(
-		t,
-		h,
-		http.MethodGet,
-		"/v1/package/version/asset?repository=pva-repo&format=npm&package=lodash&version=1.0.0&asset=x.tgz",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
 }
 
 // ---- GetPackageVersionReadme tests ----
@@ -167,25 +321,77 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 func TestHandler_GetPackageVersionReadme(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "pvr-domain")
-	setupRepo(t, h, "pvr-domain", "pvr-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "pvr-domain")
+				setupRepo(t, h, "pvr-domain", "pvr-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/version/readme?repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/version/readme?domain=pvr-domain&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_version",
+			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "version_not_found",
+			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=9.9.9",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(
-		t,
-		h,
-		http.MethodGet,
-		"/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/package/version/readme?repository=pvr-repo&format=npm&package=lodash&version=1.0.0",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				_, ok := resp["readme"]
+				assert.True(t, ok)
+			}
+		})
+	}
 }
 
 // ---- ListAllowedRepositoriesForGroup tests ----
@@ -193,21 +399,56 @@ func TestHandler_GetPackageVersionReadme(t *testing.T) {
 func TestHandler_ListAllowedRepositoriesForGroup(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "larg-domain")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "larg-domain")
+			},
+			path:       "/v1/package-group-allowed-repositories?domain=larg-domain&packageGroup=/npm/*",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package-group-allowed-repositories?packageGroup=/npm/*",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package_group",
+			path:       "/v1/package-group-allowed-repositories?domain=larg-domain",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "domain_not_found",
+			path:       "/v1/package-group-allowed-repositories?domain=nope&packageGroup=/npm/*",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(t, h, http.MethodGet,
-		"/v1/package-group-allowed-repositories?domain=larg-domain&package-group=/",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/package-group-allowed-repositories?package-group=/",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assert.NotNil(t, resp["allowedRepositories"])
+			}
+		})
+	}
 }
 
 // ---- ListAssociatedPackages tests ----
@@ -215,21 +456,60 @@ func TestHandler_ListAllowedRepositoriesForGroup(t *testing.T) {
 func TestHandler_ListAssociatedPackages(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "lap-domain")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lap-domain")
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lap-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
+			},
+			path:       "/v1/package-group-associated-packages?domain=lap-domain&packageGroup=/npm/*",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package-group-associated-packages?packageGroup=/npm/*",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package_group",
+			path:       "/v1/package-group-associated-packages?domain=lap-domain",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "domain_not_found",
+			path:       "/v1/package-group-associated-packages?domain=nope&packageGroup=/npm/*",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(t, h, http.MethodGet,
-		"/v1/package-group-associated-packages?domain=lap-domain&package-group=/",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/package-group-associated-packages?package-group=/",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				pkgs, _ := resp["packages"].([]any)
+				assert.NotNil(t, pkgs)
+			}
+		})
+	}
 }
 
 // ---- ListPackageGroups tests ----
@@ -237,21 +517,76 @@ func TestHandler_ListAssociatedPackages(t *testing.T) {
 func TestHandler_ListPackageGroups(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "lpg-domain")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name: "success_empty",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpg-domain")
+			},
+			path:       "/v1/package-groups?domain=lpg-domain",
+			wantStatus: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name: "success_two_groups",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpg2-domain")
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg2-domain", map[string]any{"pattern": "/npm/*"})
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg2-domain", map[string]any{"pattern": "/pypi/*"})
+			},
+			path:       "/v1/package-groups?domain=lpg2-domain",
+			wantStatus: http.StatusOK,
+			wantCount:  2,
+		},
+		{
+			name: "success_prefix_filter",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpg3-domain")
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg3-domain", map[string]any{"pattern": "/npm/*"})
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lpg3-domain", map[string]any{"pattern": "/pypi/*"})
+			},
+			path:       "/v1/package-groups?domain=lpg3-domain&prefix=/npm",
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package-groups",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "domain_not_found",
+			path:       "/v1/package-groups?domain=nope",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(t, h, http.MethodGet,
-		"/v1/package-groups?domain=lpg-domain",
-		nil,
-	)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/package-groups",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				groups, _ := resp["packageGroups"].([]any)
+				assert.Len(t, groups, tt.wantCount)
+			}
+		})
+	}
 }
 
 // ---- ListPackageVersionAssets tests ----
@@ -259,25 +594,77 @@ func TestHandler_ListPackageGroups(t *testing.T) {
 func TestHandler_ListPackageVersionAssets(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "lpva-domain")
-	setupRepo(t, h, "lpva-domain", "lpva-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpva-domain")
+				setupRepo(t, h, "lpva-domain", "lpva-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/version/assets?repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/version/assets?domain=lpva-domain&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_version",
+			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "version_not_found",
+			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=9.9.9",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(
-		t,
-		h,
-		http.MethodGet,
-		"/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/package/version/assets?repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assets, _ := resp["assets"].([]any)
+				assert.NotNil(t, assets)
+			}
+		})
+	}
 }
 
 // ---- ListPackageVersionDependencies tests ----
@@ -285,28 +672,77 @@ func TestHandler_ListPackageVersionAssets(t *testing.T) {
 func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "lpvd-domain")
-	setupRepo(t, h, "lpvd-domain", "lpvd-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpvd-domain")
+				setupRepo(t, h, "lpvd-domain", "lpvd-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/version/dependencies?repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/version/dependencies?domain=lpvd-domain&format=npm&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&package=lodash&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_version",
+			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "version_not_found",
+			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=9.9.9",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(
-		t,
-		h,
-		http.MethodGet,
-		"/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(
-		t,
-		h,
-		http.MethodGet,
-		"/v1/package/version/dependencies?repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				deps, _ := resp["dependencies"].([]any)
+				assert.NotNil(t, deps)
+			}
+		})
+	}
 }
 
 // ---- ListPackageVersions tests ----
@@ -314,22 +750,88 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 func TestHandler_ListPackageVersions(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "lpv-domain")
-	setupRepo(t, h, "lpv-domain", "lpv-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name: "success_two_versions",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpv-domain")
+				setupRepo(t, h, "lpv-domain", "lpv-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=lpv-domain&repository=lpv-repo&format=npm&package=lodash&version=4.17.0",
+					nil,
+				)
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=lpv-domain&repository=lpv-repo&format=npm&package=lodash&version=4.17.21",
+					nil,
+				)
+			},
+			path:       "/v1/package/versions?domain=lpv-domain&repository=lpv-repo&format=npm&package=lodash",
+			wantStatus: http.StatusOK,
+			wantCount:  2,
+		},
+		{
+			name: "success_empty",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lpv2-domain")
+				setupRepo(t, h, "lpv2-domain", "lpv2-repo")
+			},
+			path:       "/v1/package/versions?domain=lpv2-domain&repository=lpv2-repo&format=npm&package=lodash",
+			wantStatus: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/versions?repository=lpv-repo&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/versions?domain=lpv-domain&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/versions?domain=lpv-domain&repository=lpv-repo&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/versions?domain=lpv-domain&repository=lpv-repo&format=npm",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "repo_not_found",
+			path:       "/v1/package/versions?domain=lpv-domain&repository=nope&format=npm&package=lodash",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(t, h, http.MethodGet,
-		"/v1/package/versions?domain=lpv-domain&repository=lpv-repo&format=npm&package=lodash",
-		nil,
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/package/versions?repository=lpv-repo&format=npm&package=lodash",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				versions, _ := resp["versions"].([]any)
+				assert.Len(t, versions, tt.wantCount)
+			}
+		})
+	}
 }
 
 // ---- ListPackages tests ----
@@ -337,25 +839,99 @@ func TestHandler_ListPackageVersions(t *testing.T) {
 func TestHandler_ListPackages(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "lp-domain")
-	setupRepo(t, h, "lp-domain", "lp-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name: "success_two_packages",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lp-domain")
+				setupRepo(t, h, "lp-domain", "lp-repo")
+				doRequest(t, h, http.MethodPost,
+					"/v1/package/versions/publish?domain=lp-domain&repository=lp-repo&format=npm&package=react&version=18.0.0",
+					nil,
+				)
+				doRequest(t, h, http.MethodPost,
+					"/v1/package/versions/publish?domain=lp-domain&repository=lp-repo&format=npm&package=lodash&version=4.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/packages?domain=lp-domain&repository=lp-repo",
+			wantStatus: http.StatusOK,
+			wantCount:  2,
+		},
+		{
+			name: "success_empty",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lp2-domain")
+				setupRepo(t, h, "lp2-domain", "lp2-repo")
+			},
+			path:       "/v1/packages?domain=lp2-domain&repository=lp2-repo",
+			wantStatus: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name: "success_format_filter",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "lp3-domain")
+				setupRepo(t, h, "lp3-domain", "lp3-repo")
+				doRequest(t, h, http.MethodPost,
+					"/v1/package/versions/publish?domain=lp3-domain&repository=lp3-repo&format=npm&package=react&version=18.0.0",
+					nil,
+				)
+				doRequest(t, h, http.MethodPost,
+					"/v1/package/versions/publish?domain=lp3-domain&repository=lp3-repo&format=pypi&package=boto3&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/packages?domain=lp3-domain&repository=lp3-repo&format=npm",
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/packages?repository=lp-repo",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/packages?domain=lp-domain",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "repo_not_found",
+			path:       "/v1/packages?domain=lp-domain&repository=nope",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(t, h, http.MethodGet,
-		"/v1/packages?domain=lp-domain&repository=lp-repo",
-		nil,
-	)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodGet,
-		"/v1/packages?repository=lp-repo",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				pkgs, _ := resp["packages"].([]any)
+				assert.Len(t, pkgs, tt.wantCount)
+			}
+		})
+	}
 }
 
-// ---- ListSubPackageGroups tests (backend-level) ----
+// ---- ListSubPackageGroups tests ----
 
 func TestBackend_ListSubPackageGroups(t *testing.T) {
 	t.Parallel()
@@ -368,7 +944,6 @@ func TestBackend_ListSubPackageGroups(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, groups)
 
-	// Domain not found
 	_, err = b.ListSubPackageGroups("nonexistent", "/")
 	require.Error(t, err)
 }
@@ -378,28 +953,81 @@ func TestBackend_ListSubPackageGroups(t *testing.T) {
 func TestHandler_PublishPackageVersion(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "ppv-domain")
-	setupRepo(t, h, "ppv-domain", "ppv-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "ppv-domain")
+				setupRepo(t, h, "ppv-domain", "ppv-repo")
+			},
+			path:       "/v1/package/versions/publish?domain=ppv-domain&repository=ppv-repo&format=generic&package=mylib&version=1.0.0",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success_idempotent",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "ppv2-domain")
+				setupRepo(t, h, "ppv2-domain", "ppv2-repo")
+				doRequest(t, h, http.MethodPost,
+					"/v1/package/versions/publish?domain=ppv2-domain&repository=ppv2-repo&format=npm&package=mylib&version=2.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/versions/publish?domain=ppv2-domain&repository=ppv2-repo&format=npm&package=mylib&version=2.0.0",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/versions/publish?repository=ppv-repo&format=generic&package=mylib&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/versions/publish?domain=ppv-domain&format=generic&package=mylib&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/versions/publish?domain=ppv-domain&repository=ppv-repo&package=mylib&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/versions/publish?domain=ppv-domain&repository=ppv-repo&format=generic&version=1.0.0",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_version",
+			path:       "/v1/package/versions/publish?domain=ppv-domain&repository=ppv-repo&format=generic&package=mylib",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
 
-	rec := doRequest(
-		t,
-		h,
-		http.MethodPost,
-		"/v1/package/versions/publish?domain=ppv-domain&repository=ppv-repo&format=generic&package=mylib&version=1.0.0",
-		map[string]any{"assetName": "mylib-1.0.0.zip", "assetSHA256": "abc123"},
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(
-		t,
-		h,
-		http.MethodPost,
-		"/v1/package/versions/publish?repository=ppv-repo&format=generic&package=mylib&version=1.0.0",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assert.NotEmpty(t, resp["version"])
+				assert.NotEmpty(t, resp["status"])
+			}
+		})
+	}
 }
 
 // ---- PutPackageOriginConfiguration tests ----
@@ -407,25 +1035,70 @@ func TestHandler_PublishPackageVersion(t *testing.T) {
 func TestHandler_PutPackageOriginConfiguration(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "ppoc-domain")
-	setupRepo(t, h, "ppoc-domain", "ppoc-repo")
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "ppoc-domain")
+				setupRepo(t, h, "ppoc-domain", "ppoc-repo")
+			},
+			path:       "/v1/package/origin-configuration?domain=ppoc-domain&repository=ppoc-repo&format=npm&package=lodash",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/origin-configuration?repository=ppoc-repo&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/origin-configuration?domain=ppoc-domain&format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/origin-configuration?domain=ppoc-domain&repository=ppoc-repo&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/origin-configuration?domain=ppoc-domain&repository=ppoc-repo&format=npm",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "repo_not_found",
+			path:       "/v1/package/origin-configuration?domain=ppoc-domain&repository=nope&format=npm&package=lodash",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(
-		t,
-		h,
-		http.MethodPost,
-		"/v1/package/origin-configuration?domain=ppoc-domain&repository=ppoc-repo&format=npm&package=lodash",
-		map[string]any{"restrictions": map[string]any{"publish": "ALLOW", "upstream": "ALLOW"}},
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodPost,
-		"/v1/package/origin-configuration?repository=ppoc-repo&format=npm&package=lodash",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPut, tt.path,
+				map[string]any{"restrictions": map[string]any{"publish": "ALLOW", "upstream": "ALLOW"}},
+			)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				pkg, _ := resp["package"].(map[string]any)
+				assert.NotNil(t, pkg)
+			}
+		})
+	}
 }
 
 // ---- UpdatePackageGroup tests ----
@@ -433,27 +1106,71 @@ func TestHandler_PutPackageOriginConfiguration(t *testing.T) {
 func TestHandler_UpdatePackageGroup(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "upg-domain")
+	tests := []struct {
+		body       any
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success_update_description",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "upg-domain")
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=upg-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
+			},
+			path:       "/v1/package-group?domain=upg-domain&packageGroup=/npm/*",
+			body:       map[string]any{"description": "updated description"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success_update_contact_info",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "upg2-domain")
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=upg2-domain",
+					map[string]any{"pattern": "/pypi/*"},
+				)
+			},
+			path:       "/v1/package-group?domain=upg2-domain&packageGroup=/pypi/*",
+			body:       map[string]any{"contactInfo": "team@example.com"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package-group",
+			body:       map[string]any{"packageGroup": "/test/"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "package_group_not_found",
+			path:       "/v1/package-group?domain=upg-domain&packageGroup=/missing/*",
+			body:       map[string]any{"description": "test"},
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	// Create a package group first
-	doRequest(t, h, http.MethodPost,
-		"/v1/package-group?domain=upg-domain",
-		map[string]any{"packageGroup": "/test/"},
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	rec := doRequest(t, h, http.MethodPut,
-		"/v1/package-group?domain=upg-domain",
-		map[string]any{"packageGroup": "/test/", "description": "updated"},
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodPut,
-		"/v1/package-group",
-		map[string]any{"packageGroup": "/test/"},
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			rec := doRequest(t, h, http.MethodPut, tt.path, tt.body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				pg, _ := resp["packageGroup"].(map[string]any)
+				assert.NotNil(t, pg)
+			}
+		})
+	}
 }
 
 // ---- UpdatePackageGroupOriginConfiguration tests ----
@@ -461,26 +1178,62 @@ func TestHandler_UpdatePackageGroup(t *testing.T) {
 func TestHandler_UpdatePackageGroupOriginConfiguration(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "upgoc-domain")
-
-	rec := doRequest(
-		t,
-		h,
-		http.MethodPut,
-		"/v1/package-group-origin-configuration?domain=upgoc-domain&package-group=/",
-		map[string]any{
-			"restrictions": map[string]any{"publish": map[string]any{"restrictionMode": "ALLOW"}},
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "upgoc-domain")
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=upgoc-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
+			},
+			path:       "/v1/package-group-origin-configuration?domain=upgoc-domain&packageGroup=/npm/*",
+			wantStatus: http.StatusOK,
 		},
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+		{
+			name:       "missing_domain",
+			path:       "/v1/package-group-origin-configuration?packageGroup=/npm/*",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package_group",
+			path:       "/v1/package-group-origin-configuration?domain=upgoc-domain",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "package_group_not_found",
+			path:       "/v1/package-group-origin-configuration?domain=upgoc-domain&packageGroup=/missing/*",
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodPut,
-		"/v1/package-group-origin-configuration?package-group=/",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPut, tt.path,
+				map[string]any{"restrictions": map[string]any{"publish": map[string]any{"restrictionMode": "ALLOW"}}},
+			)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				pg, _ := resp["packageGroup"].(map[string]any)
+				assert.NotNil(t, pg)
+			}
+		})
+	}
 }
 
 // ---- UpdatePackageVersionsStatus tests ----
@@ -488,25 +1241,89 @@ func TestHandler_UpdatePackageGroupOriginConfiguration(t *testing.T) {
 func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "upvs-domain")
-	setupRepo(t, h, "upvs-domain", "upvs-repo")
+	tests := []struct {
+		body       any
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success_archive",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "upvs-domain")
+				setupRepo(t, h, "upvs-domain", "upvs-repo")
+				doRequest(t, h, http.MethodGet,
+					"/v1/package/version?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash&version=1.0.0",
+					nil,
+				)
+			},
+			path:       "/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
+			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success_missing_version_returns_not_found_in_result",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "upvs2-domain")
+				setupRepo(t, h, "upvs2-domain", "upvs2-repo")
+			},
+			path:       "/v1/package/versions/update_status?domain=upvs2-domain&repository=upvs2-repo&format=npm&package=lodash",
+			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"9.9.9"}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/package/versions/update_status?repository=upvs-repo&format=npm&package=lodash",
+			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/package/versions/update_status?domain=upvs-domain&format=npm&package=lodash",
+			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&package=lodash",
+			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&format=npm",
+			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_target_status",
+			path:       "/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
+			body:       map[string]any{"versions": []string{"1.0.0"}},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
 
-	rec := doRequest(
-		t,
-		h,
-		http.MethodPost,
-		"/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
-		map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
-	)
-	assert.NotEqual(t, http.StatusInternalServerError, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodPost,
-		"/v1/package/versions/update_status?repository=upvs-repo&format=npm&package=lodash",
-		nil,
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPost, tt.path, tt.body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				assert.NotNil(t, resp["successfulVersions"])
+				assert.NotNil(t, resp["failedVersions"])
+			}
+		})
+	}
 }
 
 // ---- UpdateRepository tests ----
@@ -514,22 +1331,72 @@ func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 func TestHandler_UpdateRepository(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(t)
-	setupDomain(t, h, "ur-domain")
-	setupRepo(t, h, "ur-domain", "ur-repo")
+	tests := []struct {
+		body       any
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success_update_description",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "ur-domain")
+				setupRepo(t, h, "ur-domain", "ur-repo")
+			},
+			path:       "/v1/repository?domain=ur-domain&repository=ur-repo",
+			body:       map[string]any{"description": "updated repo description"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "success_no_body",
+			setup: func(h *codeartifact.Handler) {
+				setupDomain(t, h, "ur2-domain")
+				setupRepo(t, h, "ur2-domain", "ur2-repo")
+			},
+			path:       "/v1/repository?domain=ur2-domain&repository=ur2-repo",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/repository?repository=ur-repo",
+			body:       map[string]any{"description": "updated"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repo",
+			path:       "/v1/repository?domain=ur-domain",
+			body:       map[string]any{"description": "updated"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "repo_not_found",
+			path:       "/v1/repository?domain=ur-domain&repository=nope",
+			body:       map[string]any{"description": "test"},
+			wantStatus: http.StatusNotFound,
+		},
+	}
 
-	rec := doRequest(t, h, http.MethodPut,
-		"/v1/repository?domain=ur-domain&repository=ur-repo",
-		map[string]any{"description": "updated repo description"},
-	)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Missing domain
-	rec = doRequest(t, h, http.MethodPut,
-		"/v1/repository?repository=ur-repo",
-		map[string]any{"description": "updated"},
-	)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodPut, tt.path, tt.body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				repo, _ := resp["repository"].(map[string]any)
+				assert.NotNil(t, repo)
+			}
+		})
+	}
 }
 
 // ---- Persistence coverage ----

--- a/services/codeartifact/codeartifact_coverage_test.go
+++ b/services/codeartifact/codeartifact_coverage_test.go
@@ -82,11 +82,13 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 					t,
 					h,
 					http.MethodPost,
-					"/v1/repository/external-connection?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
+					"/v1/repository/external-connection" +
+						"?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
 					nil,
 				)
 			},
-			path:       "/v1/repository/external-connection?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
+			path: "/v1/repository/external-connection" +
+				"?domain=dis-domain&repository=dis-repo&externalConnection=public:npmjs",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -95,7 +97,8 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 				setupDomain(t, h, "dis2-domain")
 				setupRepo(t, h, "dis2-domain", "dis2-repo")
 			},
-			path:       "/v1/repository/external-connection?domain=dis2-domain&repository=dis2-repo&externalConnection=public:npmjs",
+			path: "/v1/repository/external-connection" +
+				"?domain=dis2-domain&repository=dis2-repo&externalConnection=public:npmjs",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -115,7 +118,8 @@ func TestHandler_DisassociateExternalConnection(t *testing.T) {
 		},
 		{
 			name:       "repo_not_found",
-			path:       "/v1/repository/external-connection?domain=dis-domain&repository=nope&externalConnection=public:npmjs",
+			path: "/v1/repository/external-connection" +
+				"?domain=dis-domain&repository=nope&externalConnection=public:npmjs",
 			wantStatus: http.StatusNotFound,
 		},
 	}
@@ -160,7 +164,8 @@ func TestHandler_DisposePackageVersions(t *testing.T) {
 				setupDomain(t, h, "dp-domain")
 				setupRepo(t, h, "dp-domain", "dp-repo")
 				doRequest(t, h, http.MethodGet,
-					"/v1/package/version?domain=dp-domain&repository=dp-repo&format=npm&package=lodash&version=1.0.0",
+					"/v1/package/version"+
+						"?domain=dp-domain&repository=dp-repo&format=npm&package=lodash&version=1.0.0",
 					nil,
 				)
 			},
@@ -260,11 +265,13 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 				setupDomain(t, h, "pva-domain")
 				setupRepo(t, h, "pva-domain", "pva-repo")
 				doRequest(t, h, http.MethodGet,
-					"/v1/package/version?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0",
+					"/v1/package/version"+
+						"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0",
 					nil,
 				)
 			},
-			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0&asset=lodash-1.0.0.tgz",
+			path: "/v1/package/version/asset" +
+				"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=1.0.0&asset=lodash-1.0.0.tgz",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -279,17 +286,20 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 		},
 		{
 			name:       "missing_format",
-			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&package=lodash&version=1.0.0&asset=x.tgz",
+			path: "/v1/package/version/asset" +
+				"?domain=pva-domain&repository=pva-repo&package=lodash&version=1.0.0&asset=x.tgz",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "missing_package",
-			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&version=1.0.0&asset=x.tgz",
+			path: "/v1/package/version/asset" +
+				"?domain=pva-domain&repository=pva-repo&format=npm&version=1.0.0&asset=x.tgz",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "missing_version",
-			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&asset=x.tgz",
+			path: "/v1/package/version/asset" +
+				"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&asset=x.tgz",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
@@ -299,7 +309,8 @@ func TestHandler_GetPackageVersionAsset(t *testing.T) {
 		},
 		{
 			name:       "version_not_found",
-			path:       "/v1/package/version/asset?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=9.9.9&asset=x.tgz",
+			path: "/v1/package/version/asset" +
+				"?domain=pva-domain&repository=pva-repo&format=npm&package=lodash&version=9.9.9&asset=x.tgz",
 			wantStatus: http.StatusNotFound,
 		},
 	}
@@ -370,7 +381,8 @@ func TestHandler_GetPackageVersionReadme(t *testing.T) {
 		},
 		{
 			name:       "version_not_found",
-			path:       "/v1/package/version/readme?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=9.9.9",
+			path: "/v1/package/version/readme" +
+				"?domain=pvr-domain&repository=pvr-repo&format=npm&package=lodash&version=9.9.9",
 			wantStatus: http.StatusNotFound,
 		},
 	}
@@ -640,7 +652,8 @@ func TestHandler_ListPackageVersionAssets(t *testing.T) {
 					nil,
 				)
 			},
-			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
+			path: "/v1/package/version/assets" +
+				"?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=1.0.0",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -670,7 +683,8 @@ func TestHandler_ListPackageVersionAssets(t *testing.T) {
 		},
 		{
 			name:       "version_not_found",
-			path:       "/v1/package/version/assets?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=9.9.9",
+			path: "/v1/package/version/assets" +
+				"?domain=lpva-domain&repository=lpva-repo&format=npm&package=lodash&version=9.9.9",
 			wantStatus: http.StatusNotFound,
 		},
 	}
@@ -721,7 +735,8 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 					nil,
 				)
 			},
-			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
+			path: "/v1/package/version/dependencies" +
+				"?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=1.0.0",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -736,7 +751,8 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 		},
 		{
 			name:       "missing_format",
-			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&package=lodash&version=1.0.0",
+			path: "/v1/package/version/dependencies" +
+				"?domain=lpvd-domain&repository=lpvd-repo&package=lodash&version=1.0.0",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
@@ -751,7 +767,8 @@ func TestHandler_ListPackageVersionDependencies(t *testing.T) {
 		},
 		{
 			name:       "version_not_found",
-			path:       "/v1/package/version/dependencies?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=9.9.9",
+			path: "/v1/package/version/dependencies" +
+				"?domain=lpvd-domain&repository=lpvd-repo&format=npm&package=lodash&version=9.9.9",
 			wantStatus: http.StatusNotFound,
 		},
 	}
@@ -1016,7 +1033,8 @@ func TestHandler_PublishPackageVersion(t *testing.T) {
 				setupDomain(t, h, "ppv-domain")
 				setupRepo(t, h, "ppv-domain", "ppv-repo")
 			},
-			path:       "/v1/package/versions/publish?domain=ppv-domain&repository=ppv-repo&format=generic&package=mylib&version=1.0.0",
+			path: "/v1/package/versions/publish" +
+				"?domain=ppv-domain&repository=ppv-repo&format=generic&package=mylib&version=1.0.0",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -1032,7 +1050,8 @@ func TestHandler_PublishPackageVersion(t *testing.T) {
 					nil,
 				)
 			},
-			path:       "/v1/package/versions/publish?domain=ppv2-domain&repository=ppv2-repo&format=npm&package=mylib&version=2.0.0",
+			path: "/v1/package/versions/publish" +
+				"?domain=ppv2-domain&repository=ppv2-repo&format=npm&package=mylib&version=2.0.0",
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -1315,7 +1334,8 @@ func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 					nil,
 				)
 			},
-			path:       "/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
+			path: "/v1/package/versions/update_status" +
+				"?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
 			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
 			wantStatus: http.StatusOK,
 		},
@@ -1325,7 +1345,8 @@ func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 				setupDomain(t, h, "upvs2-domain")
 				setupRepo(t, h, "upvs2-domain", "upvs2-repo")
 			},
-			path:       "/v1/package/versions/update_status?domain=upvs2-domain&repository=upvs2-repo&format=npm&package=lodash",
+			path: "/v1/package/versions/update_status" +
+				"?domain=upvs2-domain&repository=upvs2-repo&format=npm&package=lodash",
 			body:       map[string]any{"targetStatus": "Archived", "versions": []string{"9.9.9"}},
 			wantStatus: http.StatusOK,
 		},
@@ -1355,8 +1376,9 @@ func TestHandler_UpdatePackageVersionsStatus(t *testing.T) {
 		},
 		{
 			name:       "missing_target_status",
-			path:       "/v1/package/versions/update_status?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
-			body:       map[string]any{"versions": []string{"1.0.0"}},
+			path: "/v1/package/versions/update_status" +
+				"?domain=upvs-domain&repository=upvs-repo&format=npm&package=lodash",
+			body: map[string]any{"versions": []string{"1.0.0"}},
 			wantStatus: http.StatusBadRequest,
 		},
 	}

--- a/services/codeartifact/handler.go
+++ b/services/codeartifact/handler.go
@@ -1789,8 +1789,9 @@ func (h *Handler) handleGetPackageVersionAsset(
 	return c.Blob(http.StatusOK, "application/octet-stream", data)
 }
 
-func (h *Handler) handleGetPackageVersionReadme(
-	c *echo.Context, domainName, repoName, format, namespace, name, version string,
+func (h *Handler) validatePackageVersionParams(
+	c *echo.Context,
+	domainName, repoName, format, name, version string,
 ) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
@@ -1806,6 +1807,16 @@ func (h *Handler) handleGetPackageVersionReadme(
 	}
 	if version == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	}
+
+	return nil
+}
+
+func (h *Handler) handleGetPackageVersionReadme(
+	c *echo.Context, domainName, repoName, format, namespace, name, version string,
+) error {
+	if err := h.validatePackageVersionParams(c, domainName, repoName, format, name, version); err != nil {
+		return err
 	}
 
 	readme, err := h.Backend.GetPackageVersionReadme(domainName, repoName, format, namespace, name, version)
@@ -1874,20 +1885,8 @@ func (h *Handler) handleListPackageGroups(c *echo.Context, domainName, prefix st
 func (h *Handler) handleListPackageVersionAssets(
 	c *echo.Context, domainName, repoName, format, namespace, name, version string,
 ) error {
-	if domainName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
-	}
-	if repoName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
-	}
-	if format == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
-	}
-	if name == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
-	}
-	if version == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	if err := h.validatePackageVersionParams(c, domainName, repoName, format, name, version); err != nil {
+		return err
 	}
 
 	assets, err := h.Backend.ListPackageVersionAssets(domainName, repoName, format, namespace, name, version)
@@ -1901,20 +1900,8 @@ func (h *Handler) handleListPackageVersionAssets(
 func (h *Handler) handleListPackageVersionDependencies(
 	c *echo.Context, domainName, repoName, format, namespace, name, version string,
 ) error {
-	if domainName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
-	}
-	if repoName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
-	}
-	if format == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
-	}
-	if name == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
-	}
-	if version == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	if err := h.validatePackageVersionParams(c, domainName, repoName, format, name, version); err != nil {
+		return err
 	}
 
 	deps, err := h.Backend.ListPackageVersionDependencies(domainName, repoName, format, namespace, name, version)

--- a/services/codeartifact/handler.go
+++ b/services/codeartifact/handler.go
@@ -1682,6 +1682,12 @@ func (h *Handler) handleDisassociateExternalConnection(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if connectionName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "externalConnection is required"))
+	}
 
 	r, err := h.Backend.DisassociateExternalConnection(domainName, repoName, connectionName)
 	if err != nil {
@@ -1703,6 +1709,15 @@ func (h *Handler) handleDisposePackageVersions(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
 
 	var in disposeVersionsBody
 	if len(body) > 0 {
@@ -1720,6 +1735,12 @@ func (h *Handler) handleDisposePackageVersions(
 func (h *Handler) handleGetAssociatedPackageGroup(c *echo.Context, domainName, format, namespace, name string) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
 	pg, err := h.Backend.GetAssociatedPackageGroup(domainName, format, namespace, name)
@@ -1740,6 +1761,21 @@ func (h *Handler) handleGetPackageVersionAsset(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
+	if version == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	}
+	if asset == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "asset is required"))
+	}
 
 	data, err := h.Backend.GetPackageVersionAsset(domainName, repoName, format, namespace, name, version, asset)
 	if err != nil {
@@ -1755,6 +1791,18 @@ func (h *Handler) handleGetPackageVersionReadme(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
+	if version == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	}
 
 	readme, err := h.Backend.GetPackageVersionReadme(domainName, repoName, format, namespace, name, version)
 	if err != nil {
@@ -1768,6 +1816,9 @@ func (h *Handler) handleListAllowedRepositoriesForGroup(c *echo.Context, domainN
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if pattern == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
+	}
 
 	repos, err := h.Backend.ListAllowedRepositoriesForGroup(domainName, pattern)
 	if err != nil {
@@ -1780,6 +1831,9 @@ func (h *Handler) handleListAllowedRepositoriesForGroup(c *echo.Context, domainN
 func (h *Handler) handleListAssociatedPackages(c *echo.Context, domainName, pattern string) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
+	}
+	if pattern == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
 	pkgs, err := h.Backend.ListAssociatedPackages(domainName, pattern)
@@ -1819,6 +1873,18 @@ func (h *Handler) handleListPackageVersionAssets(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
+	if version == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	}
 
 	assets, err := h.Backend.ListPackageVersionAssets(domainName, repoName, format, namespace, name, version)
 	if err != nil {
@@ -1834,6 +1900,18 @@ func (h *Handler) handleListPackageVersionDependencies(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
+	if version == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
+	}
 
 	deps, err := h.Backend.ListPackageVersionDependencies(domainName, repoName, format, namespace, name, version)
 	if err != nil {
@@ -1848,6 +1926,15 @@ func (h *Handler) handleListPackageVersions(
 ) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
+	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
 	versions, err := h.Backend.ListPackageVersions(domainName, repoName, format, namespace, name)
@@ -1867,6 +1954,9 @@ func (h *Handler) handleListPackages(c *echo.Context, domainName, repoName, form
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
 
 	pkgs, err := h.Backend.ListPackages(domainName, repoName, format, namespace)
 	if err != nil {
@@ -1884,6 +1974,9 @@ func (h *Handler) handleListPackages(c *echo.Context, domainName, repoName, form
 func (h *Handler) handleListSubPackageGroups(c *echo.Context, domainName, pattern string) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
+	}
+	if pattern == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
 	groups, err := h.Backend.ListSubPackageGroups(domainName, pattern)
@@ -1904,6 +1997,18 @@ func (h *Handler) handlePublishPackageVersion(
 ) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
+	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
+	if version == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
 	}
 
 	pv, err := h.Backend.PublishPackageVersion(domainName, repoName, format, namespace, name, version)

--- a/services/codeartifact/handler.go
+++ b/services/codeartifact/handler.go
@@ -316,6 +316,10 @@ func parseDomainRepoPath(method, path string) codeartifactRoute {
 		return codeartifactRoute{operation: opUntagResource}
 	case pathV1AuthToken:
 		return codeartifactRoute{operation: opGetAuthorizationToken}
+	case pathV1SubPackageGroups:
+		return codeartifactRoute{operation: opListSubPackageGroups}
+	case pathV1AssociatedPackageGroup:
+		return codeartifactRoute{operation: opGetAssociatedPackageGroup}
 	}
 
 	return codeartifactRoute{operation: opUnknown}
@@ -2025,6 +2029,15 @@ func (h *Handler) handlePutPackageOriginConfiguration(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
 
 	pkg, err := h.Backend.PutPackageOriginConfiguration(domainName, repoName, format, namespace, name)
 	if err != nil {
@@ -2067,6 +2080,9 @@ func (h *Handler) handleUpdatePackageGroupOriginConfiguration(c *echo.Context, d
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if pattern == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
+	}
 
 	pg, err := h.Backend.UpdatePackageGroupOriginConfiguration(domainName, pattern)
 	if err != nil {
@@ -2087,10 +2103,23 @@ func (h *Handler) handleUpdatePackageVersionsStatus(
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
+	}
+	if format == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "format is required"))
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
+	}
 
 	var in updateVersionsStatusBody
 	if len(body) > 0 {
 		_ = json.Unmarshal(body, &in)
+	}
+
+	if in.TargetStatus == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "targetStatus is required"))
 	}
 
 	results, err := h.Backend.UpdatePackageVersionsStatus(
@@ -2110,6 +2139,9 @@ type updateRepositoryBody struct {
 func (h *Handler) handleUpdateRepository(c *echo.Context, domainName, repoName string, body []byte) error {
 	if domainName == "" {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
+	}
+	if repoName == "" {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
 	}
 
 	var in updateRepositoryBody

--- a/services/codeartifact/handler.go
+++ b/services/codeartifact/handler.go
@@ -289,40 +289,40 @@ func parseCodeArtifactPath(method, path string) codeartifactRoute {
 
 // parseDomainRepoPath handles domain, repository, tag and auth token routes.
 func parseDomainRepoPath(method, path string) codeartifactRoute {
+	if op, ok := domainRepoStaticRoutes[path]; ok {
+		return codeartifactRoute{operation: op}
+	}
+
 	switch path {
 	case pathV1Domain:
 		return parseDomainRoute(method)
-	case pathV1Domains:
-		return codeartifactRoute{operation: opListDomains}
-	case pathV1DomainRepositories:
-		return codeartifactRoute{operation: opListRepositoriesInDomain}
 	case pathV1DomainPermissions:
 		return parseDomainPermissionsRoute(method)
 	case pathV1Repository:
 		return parseRepositoryRoute(method)
-	case pathV1RepositoryEndpoint:
-		return codeartifactRoute{operation: opGetRepositoryEndpoint}
 	case pathV1RepositoryExternalConnection:
 		return parseRepositoryExternalConnectionRoute(method)
 	case pathV1RepositoryPermissions:
 		return parseRepositoryPermissionsRoute(method)
-	case pathV1Repositories:
-		return codeartifactRoute{operation: opListRepositories}
-	case pathV1Tags:
-		return codeartifactRoute{operation: opListTagsForResource}
-	case pathV1Tag:
-		return codeartifactRoute{operation: opTagResource}
-	case pathV1Untag:
-		return codeartifactRoute{operation: opUntagResource}
-	case pathV1AuthToken:
-		return codeartifactRoute{operation: opGetAuthorizationToken}
-	case pathV1SubPackageGroups:
-		return codeartifactRoute{operation: opListSubPackageGroups}
-	case pathV1AssociatedPackageGroup:
-		return codeartifactRoute{operation: opGetAssociatedPackageGroup}
 	}
 
 	return codeartifactRoute{operation: opUnknown}
+}
+
+// domainRepoStaticRoutes maps domain/repo/tag/auth paths that need no method dispatch.
+//
+//nolint:gochecknoglobals // read-only dispatch table initialized once at startup
+var domainRepoStaticRoutes = map[string]string{
+	pathV1Domains:                opListDomains,
+	pathV1DomainRepositories:     opListRepositoriesInDomain,
+	pathV1RepositoryEndpoint:     opGetRepositoryEndpoint,
+	pathV1Repositories:           opListRepositories,
+	pathV1Tags:                   opListTagsForResource,
+	pathV1Tag:                    opTagResource,
+	pathV1Untag:                  opUntagResource,
+	pathV1AuthToken:              opGetAuthorizationToken,
+	pathV1SubPackageGroups:       opListSubPackageGroups,
+	pathV1AssociatedPackageGroup: opGetAssociatedPackageGroup,
 }
 
 // packageOpStaticRoutes maps static paths (no method dispatch) to their operations.

--- a/services/codeartifact/handler_test.go
+++ b/services/codeartifact/handler_test.go
@@ -2321,14 +2321,16 @@ func TestHandler_PublishPackageVersion_AppearInList(t *testing.T) {
 		t,
 		h,
 		http.MethodPost,
-		"/v1/package/versions/publish?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react&version=18.0.0",
+		"/v1/package/versions/publish?domain=pub-list-domain"+
+			"&repository=pub-list-repo&format=npm&package=react&version=18.0.0",
 		nil,
 	)
 	doRequest(
 		t,
 		h,
 		http.MethodPost,
-		"/v1/package/versions/publish?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react&version=19.0.0",
+		"/v1/package/versions/publish?domain=pub-list-domain"+
+			"&repository=pub-list-repo&format=npm&package=react&version=19.0.0",
 		nil,
 	)
 
@@ -2383,7 +2385,8 @@ func TestHandler_PackageVersionLifecycle(t *testing.T) {
 		t,
 		h,
 		http.MethodPost,
-		"/v1/package/versions/publish?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
+		"/v1/package/versions/publish?domain=lifecycle-domain"+
+			"&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
 		nil,
 	)
 	require.Equal(t, http.StatusOK, pubRec.Code)
@@ -2591,7 +2594,8 @@ func TestHandler_ExternalConnections_MultipleConnections(t *testing.T) {
 		t,
 		h,
 		http.MethodDelete,
-		"/v1/repository/external-connection?domain=multi-conn-domain&repository=multi-conn-repo&externalConnection=public:pypi",
+		"/v1/repository/external-connection?domain=multi-conn-domain"+
+			"&repository=multi-conn-repo&externalConnection=public:pypi",
 		nil,
 	)
 	require.Equal(t, http.StatusOK, disRec.Code)
@@ -2662,7 +2666,8 @@ func TestHandler_CopyPackageVersions_ToSelf(t *testing.T) {
 		t,
 		h,
 		http.MethodPost,
-		"/v1/package/versions/copy?domain=self-copy-domain&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
+		"/v1/package/versions/copy?domain=self-copy-domain"+
+			"&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
 		map[string]any{"versions": []string{"18.0.0"}},
 	)
 	require.Equal(t, http.StatusOK, copyRec.Code)
@@ -2672,7 +2677,8 @@ func TestHandler_CopyPackageVersions_ToSelf(t *testing.T) {
 		t,
 		h,
 		http.MethodPost,
-		"/v1/package/versions/copy?domain=self-copy-domain&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
+		"/v1/package/versions/copy?domain=self-copy-domain"+
+			"&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
 		map[string]any{"versions": []string{"18.0.0"}},
 	)
 	require.Equal(t, http.StatusOK, copyRec2.Code)

--- a/services/codeartifact/handler_test.go
+++ b/services/codeartifact/handler_test.go
@@ -2143,9 +2143,27 @@ func TestHandler_ListSubPackageGroups(t *testing.T) {
 			name: "success_with_subgroups",
 			setup: func(h *codeartifact.Handler) {
 				doRequest(t, h, http.MethodPost, "/v1/domain?domain=lspg-domain", nil)
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg-domain", map[string]any{"pattern": "/npm/*"})
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg-domain", map[string]any{"pattern": "/npm/react/*"})
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg-domain", map[string]any{"pattern": "/pypi/*"})
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lspg-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lspg-domain",
+					map[string]any{"pattern": "/npm/react/*"},
+				)
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lspg-domain",
+					map[string]any{"pattern": "/pypi/*"},
+				)
 			},
 			path:       "/v1/sub-package-groups?domain=lspg-domain&packageGroup=/npm/*",
 			wantStatus: http.StatusOK,
@@ -2155,7 +2173,13 @@ func TestHandler_ListSubPackageGroups(t *testing.T) {
 			name: "success_no_subgroups",
 			setup: func(h *codeartifact.Handler) {
 				doRequest(t, h, http.MethodPost, "/v1/domain?domain=lspg2-domain", nil)
-				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg2-domain", map[string]any{"pattern": "/npm/*"})
+				doRequest(
+					t,
+					h,
+					http.MethodPost,
+					"/v1/package-group?domain=lspg2-domain",
+					map[string]any{"pattern": "/npm/*"},
+				)
 			},
 			path:       "/v1/sub-package-groups?domain=lspg2-domain&packageGroup=/npm/*",
 			wantStatus: http.StatusOK,
@@ -2293,11 +2317,17 @@ func TestHandler_PublishPackageVersion_AppearInList(t *testing.T) {
 	doRequest(t, h, http.MethodPost, "/v1/domain?domain=pub-list-domain", nil)
 	doRequest(t, h, http.MethodPost, "/v1/repository?domain=pub-list-domain&repository=pub-list-repo", nil)
 
-	doRequest(t, h, http.MethodPost,
+	doRequest(
+		t,
+		h,
+		http.MethodPost,
 		"/v1/package/versions/publish?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react&version=18.0.0",
 		nil,
 	)
-	doRequest(t, h, http.MethodPost,
+	doRequest(
+		t,
+		h,
+		http.MethodPost,
 		"/v1/package/versions/publish?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react&version=19.0.0",
 		nil,
 	)
@@ -2349,7 +2379,10 @@ func TestHandler_PackageVersionLifecycle(t *testing.T) {
 	setupRepo(t, h, "lifecycle-domain", "lifecycle-repo")
 
 	// Publish version.
-	pubRec := doRequest(t, h, http.MethodPost,
+	pubRec := doRequest(
+		t,
+		h,
+		http.MethodPost,
 		"/v1/package/versions/publish?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
 		nil,
 	)
@@ -2494,7 +2527,13 @@ func TestHandler_MultiFormatPackages(t *testing.T) {
 	assert.Len(t, allPkgs, 4)
 
 	// Filter by npm format.
-	npmRec := doRequest(t, h, http.MethodPost, "/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo&format=npm", nil)
+	npmRec := doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo&format=npm",
+		nil,
+	)
 	require.Equal(t, http.StatusOK, npmRec.Code)
 	var npmResp map[string]any
 	require.NoError(t, json.Unmarshal(npmRec.Body.Bytes(), &npmResp))
@@ -2502,7 +2541,13 @@ func TestHandler_MultiFormatPackages(t *testing.T) {
 	assert.Len(t, npmPkgs, 2)
 
 	// Filter by pypi format.
-	pypiRec := doRequest(t, h, http.MethodPost, "/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo&format=pypi", nil)
+	pypiRec := doRequest(
+		t,
+		h,
+		http.MethodPost,
+		"/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo&format=pypi",
+		nil,
+	)
 	require.Equal(t, http.StatusOK, pypiRec.Code)
 	var pypiResp map[string]any
 	require.NoError(t, json.Unmarshal(pypiRec.Body.Bytes(), &pypiResp))
@@ -2519,7 +2564,10 @@ func TestHandler_ExternalConnections_MultipleConnections(t *testing.T) {
 
 	// Associate multiple external connections.
 	for _, conn := range []string{"public:npmjs", "public:pypi", "public:maven-central"} {
-		rec := doRequest(t, h, http.MethodPost,
+		rec := doRequest(
+			t,
+			h,
+			http.MethodPost,
 			"/v1/repository/external-connection?domain=multi-conn-domain&repository=multi-conn-repo&externalConnection="+conn,
 			nil,
 		)
@@ -2539,7 +2587,10 @@ func TestHandler_ExternalConnections_MultipleConnections(t *testing.T) {
 	assert.Len(t, conns, 3)
 
 	// Disassociate one.
-	disRec := doRequest(t, h, http.MethodDelete,
+	disRec := doRequest(
+		t,
+		h,
+		http.MethodDelete,
 		"/v1/repository/external-connection?domain=multi-conn-domain&repository=multi-conn-repo&externalConnection=public:pypi",
 		nil,
 	)
@@ -2607,14 +2658,20 @@ func TestHandler_CopyPackageVersions_ToSelf(t *testing.T) {
 	)
 
 	// Copy to dst.
-	copyRec := doRequest(t, h, http.MethodPost,
+	copyRec := doRequest(
+		t,
+		h,
+		http.MethodPost,
 		"/v1/package/versions/copy?domain=self-copy-domain&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
 		map[string]any{"versions": []string{"18.0.0"}},
 	)
 	require.Equal(t, http.StatusOK, copyRec.Code)
 
 	// Copy again (duplicate) to dst — should fail.
-	copyRec2 := doRequest(t, h, http.MethodPost,
+	copyRec2 := doRequest(
+		t,
+		h,
+		http.MethodPost,
 		"/v1/package/versions/copy?domain=self-copy-domain&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
 		map[string]any{"versions": []string{"18.0.0"}},
 	)
@@ -2656,4 +2713,3 @@ func TestHandler_DomainSummaryVsFullDescription(t *testing.T) {
 	count, _ := dd["repositoryCount"].(float64)
 	assert.InEpsilon(t, float64(2), count, 0)
 }
-

--- a/services/codeartifact/handler_test.go
+++ b/services/codeartifact/handler_test.go
@@ -2340,3 +2340,320 @@ func TestHandler_PackageGroupTags(t *testing.T) {
 	tagList, _ := listResp["tags"].([]any)
 	assert.Len(t, tagList, 1)
 }
+
+func TestHandler_PackageVersionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupDomain(t, h, "lifecycle-domain")
+	setupRepo(t, h, "lifecycle-domain", "lifecycle-repo")
+
+	// Publish version.
+	pubRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/publish?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, pubRec.Code)
+	var pubResp map[string]any
+	require.NoError(t, json.Unmarshal(pubRec.Body.Bytes(), &pubResp))
+	assert.Equal(t, "1.0.0", pubResp["version"])
+	assert.Equal(t, "Published", pubResp["status"])
+
+	// Describe version.
+	descRec := doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, descRec.Code)
+	var descResp map[string]any
+	require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &descResp))
+	pv, _ := descResp["packageVersion"].(map[string]any)
+	assert.Equal(t, "Published", pv["status"])
+
+	// Archive version.
+	archRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/update_status?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib",
+		map[string]any{"targetStatus": "Archived", "versions": []string{"1.0.0"}},
+	)
+	require.Equal(t, http.StatusOK, archRec.Code)
+
+	// Verify archived.
+	descRec2 := doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, descRec2.Code)
+	var descResp2 map[string]any
+	require.NoError(t, json.Unmarshal(descRec2.Body.Bytes(), &descResp2))
+	pv2, _ := descResp2["packageVersion"].(map[string]any)
+	assert.Equal(t, "Archived", pv2["status"])
+
+	// Dispose version.
+	dispRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/dispose?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib",
+		map[string]any{"versions": []string{"1.0.0"}},
+	)
+	require.Equal(t, http.StatusOK, dispRec.Code)
+
+	// Verify disposed.
+	descRec3 := doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib&version=1.0.0",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, descRec3.Code)
+	var descResp3 map[string]any
+	require.NoError(t, json.Unmarshal(descRec3.Body.Bytes(), &descResp3))
+	pv3, _ := descResp3["packageVersion"].(map[string]any)
+	assert.Equal(t, "Disposed", pv3["status"])
+
+	// Delete version.
+	delRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/delete?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib",
+		map[string]any{"versions": []string{"1.0.0"}},
+	)
+	require.Equal(t, http.StatusOK, delRec.Code)
+
+	// Verify gone from list.
+	listRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions?domain=lifecycle-domain&repository=lifecycle-repo&format=npm&package=mylib",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, listRec.Code)
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	versions, _ := listResp["versions"].([]any)
+	assert.Empty(t, versions)
+}
+
+func TestHandler_PackageGroupHierarchy(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupDomain(t, h, "hier-domain")
+
+	// Create parent and child package groups.
+	doRequest(t, h, http.MethodPost, "/v1/package-group?domain=hier-domain", map[string]any{"pattern": "/npm/*"})
+	doRequest(t, h, http.MethodPost, "/v1/package-group?domain=hier-domain", map[string]any{"pattern": "/npm/react/*"})
+	doRequest(t, h, http.MethodPost, "/v1/package-group?domain=hier-domain", map[string]any{"pattern": "/npm/lodash/*"})
+	doRequest(t, h, http.MethodPost, "/v1/package-group?domain=hier-domain", map[string]any{"pattern": "/pypi/*"})
+
+	// ListPackageGroups should return all 4.
+	allRec := doRequest(t, h, http.MethodPost, "/v1/package-groups?domain=hier-domain", nil)
+	require.Equal(t, http.StatusOK, allRec.Code)
+	var allResp map[string]any
+	require.NoError(t, json.Unmarshal(allRec.Body.Bytes(), &allResp))
+	allGroups, _ := allResp["packageGroups"].([]any)
+	assert.Len(t, allGroups, 4)
+
+	// ListSubPackageGroups for /npm/* should return 2 sub-groups.
+	subRec := doRequest(t, h, http.MethodGet, "/v1/sub-package-groups?domain=hier-domain&packageGroup=/npm/*", nil)
+	require.Equal(t, http.StatusOK, subRec.Code)
+	var subResp map[string]any
+	require.NoError(t, json.Unmarshal(subRec.Body.Bytes(), &subResp))
+	subGroups, _ := subResp["packageGroups"].([]any)
+	assert.Len(t, subGroups, 2)
+
+	// ListSubPackageGroups for /pypi/* should return 0 sub-groups.
+	subRec2 := doRequest(t, h, http.MethodGet, "/v1/sub-package-groups?domain=hier-domain&packageGroup=/pypi/*", nil)
+	require.Equal(t, http.StatusOK, subRec2.Code)
+	var subResp2 map[string]any
+	require.NoError(t, json.Unmarshal(subRec2.Body.Bytes(), &subResp2))
+	subGroups2, _ := subResp2["packageGroups"].([]any)
+	assert.Empty(t, subGroups2)
+}
+
+func TestHandler_MultiFormatPackages(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupDomain(t, h, "fmt-multi-domain")
+	setupRepo(t, h, "fmt-multi-domain", "fmt-multi-repo")
+
+	// Publish packages in different formats.
+	for _, tc := range []struct {
+		format, pkg, version string
+	}{
+		{"npm", "react", "18.0.0"},
+		{"npm", "lodash", "4.17.21"},
+		{"pypi", "boto3", "1.28.0"},
+		{"maven", "spring-boot", "3.0.0"},
+	} {
+		doRequest(t, h, http.MethodPost,
+			"/v1/package/versions/publish?domain=fmt-multi-domain&repository=fmt-multi-repo&format="+
+				tc.format+"&package="+tc.pkg+"&version="+tc.version,
+			nil,
+		)
+	}
+
+	// List all packages.
+	allRec := doRequest(t, h, http.MethodPost, "/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo", nil)
+	require.Equal(t, http.StatusOK, allRec.Code)
+	var allResp map[string]any
+	require.NoError(t, json.Unmarshal(allRec.Body.Bytes(), &allResp))
+	allPkgs, _ := allResp["packages"].([]any)
+	assert.Len(t, allPkgs, 4)
+
+	// Filter by npm format.
+	npmRec := doRequest(t, h, http.MethodPost, "/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo&format=npm", nil)
+	require.Equal(t, http.StatusOK, npmRec.Code)
+	var npmResp map[string]any
+	require.NoError(t, json.Unmarshal(npmRec.Body.Bytes(), &npmResp))
+	npmPkgs, _ := npmResp["packages"].([]any)
+	assert.Len(t, npmPkgs, 2)
+
+	// Filter by pypi format.
+	pypiRec := doRequest(t, h, http.MethodPost, "/v1/packages?domain=fmt-multi-domain&repository=fmt-multi-repo&format=pypi", nil)
+	require.Equal(t, http.StatusOK, pypiRec.Code)
+	var pypiResp map[string]any
+	require.NoError(t, json.Unmarshal(pypiRec.Body.Bytes(), &pypiResp))
+	pypiPkgs, _ := pypiResp["packages"].([]any)
+	assert.Len(t, pypiPkgs, 1)
+}
+
+func TestHandler_ExternalConnections_MultipleConnections(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupDomain(t, h, "multi-conn-domain")
+	setupRepo(t, h, "multi-conn-domain", "multi-conn-repo")
+
+	// Associate multiple external connections.
+	for _, conn := range []string{"public:npmjs", "public:pypi", "public:maven-central"} {
+		rec := doRequest(t, h, http.MethodPost,
+			"/v1/repository/external-connection?domain=multi-conn-domain&repository=multi-conn-repo&externalConnection="+conn,
+			nil,
+		)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// Verify 3 connections via DescribeRepository.
+	descRec := doRequest(t, h, http.MethodGet,
+		"/v1/repository?domain=multi-conn-domain&repository=multi-conn-repo",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, descRec.Code)
+	var descResp map[string]any
+	require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &descResp))
+	repo, _ := descResp["repository"].(map[string]any)
+	conns, _ := repo["externalConnections"].([]any)
+	assert.Len(t, conns, 3)
+
+	// Disassociate one.
+	disRec := doRequest(t, h, http.MethodDelete,
+		"/v1/repository/external-connection?domain=multi-conn-domain&repository=multi-conn-repo&externalConnection=public:pypi",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, disRec.Code)
+	var disResp map[string]any
+	require.NoError(t, json.Unmarshal(disRec.Body.Bytes(), &disResp))
+	disRepo, _ := disResp["repository"].(map[string]any)
+	disConns, _ := disRepo["externalConnections"].([]any)
+	assert.Len(t, disConns, 2)
+}
+
+func TestHandler_AssociatedPackageGroup_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name:       "missing_domain",
+			path:       "/v1/associated-package-group?format=npm&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/associated-package-group?domain=d&package=lodash",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/associated-package-group?domain=d&format=npm",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "domain_not_found",
+			path:       "/v1/associated-package-group?domain=nope&format=npm&package=lodash",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_CopyPackageVersions_ToSelf(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupDomain(t, h, "self-copy-domain")
+	setupRepo(t, h, "self-copy-domain", "src")
+	setupRepo(t, h, "self-copy-domain", "dst")
+
+	// Seed version in src.
+	doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=self-copy-domain&repository=src&format=npm&package=react&version=18.0.0",
+		nil,
+	)
+
+	// Copy to dst.
+	copyRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/copy?domain=self-copy-domain&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
+		map[string]any{"versions": []string{"18.0.0"}},
+	)
+	require.Equal(t, http.StatusOK, copyRec.Code)
+
+	// Copy again (duplicate) to dst — should fail.
+	copyRec2 := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/copy?domain=self-copy-domain&sourceRepository=src&destinationRepository=dst&format=npm&package=react",
+		map[string]any{"versions": []string{"18.0.0"}},
+	)
+	require.Equal(t, http.StatusOK, copyRec2.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(copyRec2.Body.Bytes(), &resp))
+	failed, _ := resp["failedVersions"].([]any)
+	assert.Len(t, failed, 1)
+	entry, _ := failed[0].(map[string]any)
+	assert.Equal(t, "18.0.0", entry["version"])
+	assert.Equal(t, "ALREADY_EXISTS", entry["errorCode"])
+}
+
+func TestHandler_DomainSummaryVsFullDescription(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	setupDomain(t, h, "summary-domain")
+	setupRepo(t, h, "summary-domain", "r1")
+	setupRepo(t, h, "summary-domain", "r2")
+
+	// ListDomains returns summary (no repositoryCount).
+	listRec := doRequest(t, h, http.MethodPost, "/v1/domains", nil)
+	require.Equal(t, http.StatusOK, listRec.Code)
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	domains, _ := listResp["domains"].([]any)
+	require.Len(t, domains, 1)
+	d, _ := domains[0].(map[string]any)
+	assert.NotEmpty(t, d["arn"])
+	assert.NotEmpty(t, d["name"])
+
+	// DescribeDomain returns full info with repositoryCount.
+	descRec := doRequest(t, h, http.MethodGet, "/v1/domain?domain=summary-domain", nil)
+	require.Equal(t, http.StatusOK, descRec.Code)
+	var descResp map[string]any
+	require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &descResp))
+	dd, _ := descResp["domain"].(map[string]any)
+	count, _ := dd["repositoryCount"].(float64)
+	assert.InEpsilon(t, float64(2), count, 0)
+}
+

--- a/services/codeartifact/handler_test.go
+++ b/services/codeartifact/handler_test.go
@@ -2074,3 +2074,269 @@ func TestHandler_ErrValidationMapsTo400(t *testing.T) {
 		assert.Equal(t, http.StatusConflict, rec.Code)
 	})
 }
+
+func TestHandler_GetAssociatedPackageGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "success_no_match",
+			setup: func(h *codeartifact.Handler) {
+				doRequest(t, h, http.MethodPost, "/v1/domain?domain=apg-domain", nil)
+			},
+			path:       "/v1/associated-package-group?domain=apg-domain&format=npm&package=mypkg",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/associated-package-group?format=npm&package=mypkg",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_format",
+			path:       "/v1/associated-package-group?domain=apg-domain&package=mypkg",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package",
+			path:       "/v1/associated-package-group?domain=apg-domain&format=npm",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "domain_not_found",
+			path:       "/v1/associated-package-group?domain=nope&format=npm&package=mypkg",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_ListSubPackageGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup      func(h *codeartifact.Handler)
+		name       string
+		path       string
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name: "success_with_subgroups",
+			setup: func(h *codeartifact.Handler) {
+				doRequest(t, h, http.MethodPost, "/v1/domain?domain=lspg-domain", nil)
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg-domain", map[string]any{"pattern": "/npm/*"})
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg-domain", map[string]any{"pattern": "/npm/react/*"})
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg-domain", map[string]any{"pattern": "/pypi/*"})
+			},
+			path:       "/v1/sub-package-groups?domain=lspg-domain&packageGroup=/npm/*",
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name: "success_no_subgroups",
+			setup: func(h *codeartifact.Handler) {
+				doRequest(t, h, http.MethodPost, "/v1/domain?domain=lspg2-domain", nil)
+				doRequest(t, h, http.MethodPost, "/v1/package-group?domain=lspg2-domain", map[string]any{"pattern": "/npm/*"})
+			},
+			path:       "/v1/sub-package-groups?domain=lspg2-domain&packageGroup=/npm/*",
+			wantStatus: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name:       "missing_domain",
+			path:       "/v1/sub-package-groups?packageGroup=/npm/*",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_package_group",
+			path:       "/v1/sub-package-groups?domain=lspg-domain",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "domain_not_found",
+			path:       "/v1/sub-package-groups?domain=nope&packageGroup=/npm/*",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			rec := doRequest(t, h, http.MethodGet, tt.path, nil)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				groups, _ := resp["packageGroups"].([]any)
+				assert.Len(t, groups, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestHandler_DisposePackageVersions_StatusChange(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, http.MethodPost, "/v1/domain?domain=disp-st-domain", nil)
+	doRequest(t, h, http.MethodPost, "/v1/repository?domain=disp-st-domain&repository=disp-st-repo", nil)
+	doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=disp-st-domain&repository=disp-st-repo&format=npm&package=pkg&version=1.0.0",
+		nil,
+	)
+
+	rec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/dispose?domain=disp-st-domain&repository=disp-st-repo&format=npm&package=pkg",
+		map[string]any{"versions": []string{"1.0.0", "9.9.9"}},
+	)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	success, _ := resp["successfulVersions"].(map[string]any)
+	assert.Equal(t, "SUCCESS", success["1.0.0"])
+	assert.Equal(t, "NOT_FOUND", success["9.9.9"])
+
+	// Verify status changed to Disposed.
+	descRec := doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=disp-st-domain&repository=disp-st-repo&format=npm&package=pkg&version=1.0.0",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, descRec.Code)
+	var descResp map[string]any
+	require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &descResp))
+	pv, _ := descResp["packageVersion"].(map[string]any)
+	assert.Equal(t, "Disposed", pv["status"])
+}
+
+func TestHandler_UpdatePackageVersionsStatus_StatusChange(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, http.MethodPost, "/v1/domain?domain=uvs-st-domain", nil)
+	doRequest(t, h, http.MethodPost, "/v1/repository?domain=uvs-st-domain&repository=uvs-st-repo", nil)
+	doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=uvs-st-domain&repository=uvs-st-repo&format=npm&package=react&version=18.0.0",
+		nil,
+	)
+
+	rec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/update_status?domain=uvs-st-domain&repository=uvs-st-repo&format=npm&package=react",
+		map[string]any{"targetStatus": "Archived", "versions": []string{"18.0.0"}},
+	)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify status changed.
+	descRec := doRequest(t, h, http.MethodGet,
+		"/v1/package/version?domain=uvs-st-domain&repository=uvs-st-repo&format=npm&package=react&version=18.0.0",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, descRec.Code)
+	var descResp map[string]any
+	require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &descResp))
+	pv, _ := descResp["packageVersion"].(map[string]any)
+	assert.Equal(t, "Archived", pv["status"])
+}
+
+func TestHandler_UpdateRepository_DescriptionPersists(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, http.MethodPost, "/v1/domain?domain=ur-desc-domain", nil)
+	doRequest(t, h, http.MethodPost, "/v1/repository?domain=ur-desc-domain&repository=ur-desc-repo",
+		map[string]any{"description": "original"},
+	)
+
+	rec := doRequest(t, h, http.MethodPut, "/v1/repository?domain=ur-desc-domain&repository=ur-desc-repo",
+		map[string]any{"description": "updated"},
+	)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	descRec := doRequest(t, h, http.MethodGet, "/v1/repository?domain=ur-desc-domain&repository=ur-desc-repo", nil)
+	require.Equal(t, http.StatusOK, descRec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(descRec.Body.Bytes(), &resp))
+	repo, _ := resp["repository"].(map[string]any)
+	assert.Equal(t, "updated", repo["description"])
+}
+
+func TestHandler_PublishPackageVersion_AppearInList(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, http.MethodPost, "/v1/domain?domain=pub-list-domain", nil)
+	doRequest(t, h, http.MethodPost, "/v1/repository?domain=pub-list-domain&repository=pub-list-repo", nil)
+
+	doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/publish?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react&version=18.0.0",
+		nil,
+	)
+	doRequest(t, h, http.MethodPost,
+		"/v1/package/versions/publish?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react&version=19.0.0",
+		nil,
+	)
+
+	listRec := doRequest(t, h, http.MethodPost,
+		"/v1/package/versions?domain=pub-list-domain&repository=pub-list-repo&format=npm&package=react",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &resp))
+	versions, _ := resp["versions"].([]any)
+	assert.Len(t, versions, 2)
+}
+
+func TestHandler_PackageGroupTags(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	doRequest(t, h, http.MethodPost, "/v1/domain?domain=pgt-domain", nil)
+
+	createRec := doRequest(t, h, http.MethodPost, "/v1/package-group?domain=pgt-domain", map[string]any{
+		"pattern": "/npm/*",
+		"tags":    []map[string]any{{"key": "env", "value": "prod"}},
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	var createResp map[string]any
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	pg, _ := createResp["packageGroup"].(map[string]any)
+	pgARN, _ := pg["arn"].(string)
+	require.NotEmpty(t, pgARN)
+
+	listRec := doRequest(t, h, http.MethodPost, "/v1/tags?resourceArn="+pgARN, nil)
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var listResp map[string]any
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	tagList, _ := listResp["tags"].([]any)
+	assert.Len(t, tagList, 1)
+}


### PR DESCRIPTION
AWS-accuracy audit for services/codeartifact. Closes #1770. Polecat: jasper.