### PR TITLE
feat(codeconnections): AWS-accuracy audit parity (go-av1w)

### DIFF
--- a/services/codeconnections/backend.go
+++ b/services/codeconnections/backend.go
@@ -57,6 +57,7 @@ type InMemoryBackend struct {
 	connections        map[string]*Connection        // keyed by ARN
 	connectionsByName  map[string]string             // name → ARN
 	hosts              map[string]*Host              // keyed by ARN
+	hostsByName        map[string]string             // name → ARN (uniqueness index)
 	repositoryLinks    map[string]*RepositoryLink    // keyed by RepositoryLinkID
 	syncConfigurations map[string]*SyncConfiguration // keyed by ResourceName+SyncType
 	mu                 *lockmetrics.RWMutex
@@ -70,6 +71,7 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		connections:        make(map[string]*Connection),
 		connectionsByName:  make(map[string]string),
 		hosts:              make(map[string]*Host),
+		hostsByName:        make(map[string]string),
 		repositoryLinks:    make(map[string]*RepositoryLink),
 		syncConfigurations: make(map[string]*SyncConfiguration),
 		accountID:          accountID,
@@ -86,6 +88,7 @@ func (b *InMemoryBackend) Reset() {
 	b.connections = make(map[string]*Connection)
 	b.connectionsByName = make(map[string]string)
 	b.hosts = make(map[string]*Host)
+	b.hostsByName = make(map[string]string)
 	b.repositoryLinks = make(map[string]*RepositoryLink)
 	b.syncConfigurations = make(map[string]*SyncConfiguration)
 }
@@ -94,7 +97,7 @@ func (b *InMemoryBackend) Reset() {
 func (b *InMemoryBackend) Region() string { return b.region }
 
 // CreateConnection creates a new connection.
-func (b *InMemoryBackend) CreateConnection(name, providerType string, tags map[string]string) (*Connection, error) {
+func (b *InMemoryBackend) CreateConnection(name, providerType, hostArn string, tags map[string]string) (*Connection, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: ConnectionName is required", ErrValidation)
 	}
@@ -122,6 +125,7 @@ func (b *InMemoryBackend) CreateConnection(name, providerType string, tags map[s
 		ConnectionName: name,
 		ConnectionArn:  connectionArn,
 		ProviderType:   providerType,
+		HostArn:        hostArn,
 		Status:         "AVAILABLE",
 		OwnerAccountID: b.accountID,
 		Tags:           tagsCopy,
@@ -301,6 +305,10 @@ func (b *InMemoryBackend) CreateHost(
 	b.mu.Lock("CreateHost")
 	defer b.mu.Unlock()
 
+	if _, exists := b.hostsByName[name]; exists {
+		return nil, fmt.Errorf("%w: host %q already exists", ErrAlreadyExists, name)
+	}
+
 	id := uuid.NewString()
 	hostArn := arn.Build("codeconnections", b.region, b.accountID, "host/"+id)
 
@@ -318,6 +326,7 @@ func (b *InMemoryBackend) CreateHost(
 	}
 
 	b.hosts[hostArn] = host
+	b.hostsByName[name] = hostArn
 
 	cp := *host
 	cp.Tags = make(map[string]string, len(host.Tags))
@@ -348,10 +357,12 @@ func (b *InMemoryBackend) DeleteHost(hostArn string) error {
 	b.mu.Lock("DeleteHost")
 	defer b.mu.Unlock()
 
-	if _, ok := b.hosts[hostArn]; !ok {
+	host, ok := b.hosts[hostArn]
+	if !ok {
 		return ErrNotFound
 	}
 
+	delete(b.hostsByName, host.Name)
 	delete(b.hosts, hostArn)
 
 	return nil
@@ -363,6 +374,7 @@ func (b *InMemoryBackend) AddHostInternal(host *Host) {
 	defer b.mu.Unlock()
 
 	b.hosts[host.HostArn] = host
+	b.hostsByName[host.Name] = host.HostArn
 }
 
 // RepositoryLink represents an AWS CodeConnections repository link.

--- a/services/codeconnections/backend.go
+++ b/services/codeconnections/backend.go
@@ -97,7 +97,10 @@ func (b *InMemoryBackend) Reset() {
 func (b *InMemoryBackend) Region() string { return b.region }
 
 // CreateConnection creates a new connection.
-func (b *InMemoryBackend) CreateConnection(name, providerType, hostArn string, tags map[string]string) (*Connection, error) {
+func (b *InMemoryBackend) CreateConnection(
+	name, providerType, hostArn string,
+	tags map[string]string,
+) (*Connection, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: ConnectionName is required", ErrValidation)
 	}

--- a/services/codeconnections/handler.go
+++ b/services/codeconnections/handler.go
@@ -827,8 +827,8 @@ type hostItem struct {
 }
 
 type listHostsOutput struct {
-	Hosts     []hostItem `json:"Hosts"`
 	NextToken *string    `json:"NextToken,omitempty"`
+	Hosts     []hostItem `json:"Hosts"`
 }
 
 func (h *Handler) handleListHosts(_ context.Context, in *listHostsInput) (*listHostsOutput, error) {
@@ -894,8 +894,8 @@ type listRepositoryLinksInput struct {
 }
 
 type listRepositoryLinksOutput struct {
-	RepositoryLinks []repositoryLinkItem `json:"RepositoryLinks"`
 	NextToken       *string              `json:"NextToken,omitempty"`
+	RepositoryLinks []repositoryLinkItem `json:"RepositoryLinks"`
 }
 
 func (h *Handler) handleListRepositoryLinks(
@@ -998,8 +998,8 @@ type listSyncConfigurationsInput struct {
 }
 
 type listSyncConfigurationsOutput struct {
-	SyncConfigurations []syncConfigurationItem `json:"SyncConfigurations"`
 	NextToken          *string                 `json:"NextToken,omitempty"`
+	SyncConfigurations []syncConfigurationItem `json:"SyncConfigurations"`
 }
 
 func (h *Handler) handleListSyncConfigurations(

--- a/services/codeconnections/handler.go
+++ b/services/codeconnections/handler.go
@@ -263,18 +263,22 @@ type createConnectionInput struct {
 
 type createConnectionOutput struct {
 	ConnectionArn string `json:"ConnectionArn"`
+	Tags          []tag  `json:"Tags,omitempty"`
 }
 
 func (h *Handler) handleCreateConnection(
 	_ context.Context,
 	in *createConnectionInput,
 ) (*createConnectionOutput, error) {
-	conn, err := h.Backend.CreateConnection(in.ConnectionName, in.ProviderType, tagsFromArray(in.Tags))
+	conn, err := h.Backend.CreateConnection(in.ConnectionName, in.ProviderType, in.HostArn, tagsFromArray(in.Tags))
 	if err != nil {
 		return nil, err
 	}
 
-	return &createConnectionOutput{ConnectionArn: conn.ConnectionArn}, nil
+	return &createConnectionOutput{
+		ConnectionArn: conn.ConnectionArn,
+		Tags:          tagsToSortedArray(conn.Tags),
+	}, nil
 }
 
 type getConnectionInput struct {
@@ -455,6 +459,7 @@ type getHostInput struct {
 
 type getHostOutput struct {
 	Name             string `json:"Name"`
+	HostArn          string `json:"HostArn,omitempty"`
 	ProviderEndpoint string `json:"ProviderEndpoint"`
 	ProviderType     string `json:"ProviderType"`
 	Status           string `json:"Status"`
@@ -474,6 +479,7 @@ func (h *Handler) handleGetHost(_ context.Context, in *getHostInput) (*getHostOu
 
 	return &getHostOutput{
 		Name:             host.Name,
+		HostArn:          host.HostArn,
 		ProviderEndpoint: host.ProviderEndpoint,
 		ProviderType:     host.ProviderType,
 		Status:           host.Status,
@@ -817,13 +823,15 @@ type hostItem struct {
 	ProviderType     string `json:"ProviderType"`
 	Status           string `json:"Status"`
 	StatusMessage    string `json:"StatusMessage,omitempty"`
+	Tags             []tag  `json:"Tags,omitempty"`
 }
 
 type listHostsOutput struct {
-	Hosts []hostItem `json:"Hosts"`
+	Hosts     []hostItem `json:"Hosts"`
+	NextToken *string    `json:"NextToken,omitempty"`
 }
 
-func (h *Handler) handleListHosts(_ context.Context, _ *listHostsInput) (*listHostsOutput, error) {
+func (h *Handler) handleListHosts(_ context.Context, in *listHostsInput) (*listHostsOutput, error) {
 	hosts := h.Backend.ListHosts()
 	items := make([]hostItem, len(hosts))
 
@@ -835,10 +843,28 @@ func (h *Handler) handleListHosts(_ context.Context, _ *listHostsInput) (*listHo
 			ProviderType:     host.ProviderType,
 			Status:           host.Status,
 			StatusMessage:    host.StatusMessage,
+			Tags:             tagsToSortedArray(host.Tags),
 		}
 	}
 
-	return &listHostsOutput{Hosts: items}, nil
+	var limit int
+	if in.MaxResults != nil && *in.MaxResults > 0 {
+		limit = int(*in.MaxResults)
+	}
+
+	token := ""
+	if in.NextToken != nil {
+		token = *in.NextToken
+	}
+
+	p := page.New(items, token, limit, ccDefaultPageSize)
+
+	var nextToken *string
+	if p.Next != "" {
+		nextToken = &p.Next
+	}
+
+	return &listHostsOutput{Hosts: p.Data, NextToken: nextToken}, nil
 }
 
 // --- UpdateHost ---
@@ -869,11 +895,12 @@ type listRepositoryLinksInput struct {
 
 type listRepositoryLinksOutput struct {
 	RepositoryLinks []repositoryLinkItem `json:"RepositoryLinks"`
+	NextToken       *string              `json:"NextToken,omitempty"`
 }
 
 func (h *Handler) handleListRepositoryLinks(
 	_ context.Context,
-	_ *listRepositoryLinksInput,
+	in *listRepositoryLinksInput,
 ) (*listRepositoryLinksOutput, error) {
 	links := h.Backend.ListRepositoryLinks()
 	items := make([]repositoryLinkItem, len(links))
@@ -882,7 +909,24 @@ func (h *Handler) handleListRepositoryLinks(
 		items[i] = repositoryLinkToItem(link)
 	}
 
-	return &listRepositoryLinksOutput{RepositoryLinks: items}, nil
+	var limit int
+	if in.MaxResults != nil && *in.MaxResults > 0 {
+		limit = int(*in.MaxResults)
+	}
+
+	token := ""
+	if in.NextToken != nil {
+		token = *in.NextToken
+	}
+
+	p := page.New(items, token, limit, ccDefaultPageSize)
+
+	var nextToken *string
+	if p.Next != "" {
+		nextToken = &p.Next
+	}
+
+	return &listRepositoryLinksOutput{RepositoryLinks: p.Data, NextToken: nextToken}, nil
 }
 
 // --- UpdateRepositoryLink ---
@@ -955,6 +999,7 @@ type listSyncConfigurationsInput struct {
 
 type listSyncConfigurationsOutput struct {
 	SyncConfigurations []syncConfigurationItem `json:"SyncConfigurations"`
+	NextToken          *string                 `json:"NextToken,omitempty"`
 }
 
 func (h *Handler) handleListSyncConfigurations(
@@ -972,7 +1017,24 @@ func (h *Handler) handleListSyncConfigurations(
 		items[i] = syncConfigToItem(cfg)
 	}
 
-	return &listSyncConfigurationsOutput{SyncConfigurations: items}, nil
+	var limit int
+	if in.MaxResults != nil && *in.MaxResults > 0 {
+		limit = int(*in.MaxResults)
+	}
+
+	token := ""
+	if in.NextToken != nil {
+		token = *in.NextToken
+	}
+
+	p := page.New(items, token, limit, ccDefaultPageSize)
+
+	var nextToken *string
+	if p.Next != "" {
+		nextToken = &p.Next
+	}
+
+	return &listSyncConfigurationsOutput{SyncConfigurations: p.Data, NextToken: nextToken}, nil
 }
 
 // --- UpdateSyncConfiguration ---

--- a/services/codeconnections/handler_parity_test.go
+++ b/services/codeconnections/handler_parity_test.go
@@ -1,0 +1,1314 @@
+package codeconnections_test
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/codeconnections"
+)
+
+// --- CreateConnection parity ---
+
+// TestParity_CreateConnection_HostArn verifies HostArn is accepted and round-tripped.
+func TestParity_CreateConnection_HostArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body       map[string]any
+		name       string
+		wantStatus int
+		wantArn    bool
+	}{
+		{
+			name: "with_host_arn",
+			body: map[string]any{
+				"ConnectionName": "ghe-conn",
+				"ProviderType":   "GitHubEnterpriseServer",
+				"HostArn":        "arn:aws:codeconnections:us-east-1:123456789012:host/abc",
+			},
+			wantStatus: http.StatusOK,
+			wantArn:    true,
+		},
+		{
+			name: "without_host_arn",
+			body: map[string]any{
+				"ConnectionName": "gh-conn",
+				"ProviderType":   "GitHub",
+			},
+			wantStatus: http.StatusOK,
+			wantArn:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			rec := doJSON(t, h, "CreateConnection", tt.body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantArn {
+				resp := parseResp(t, rec)
+				assert.NotEmpty(t, resp["ConnectionArn"])
+			}
+		})
+	}
+}
+
+// TestParity_CreateConnection_ReturnsTags verifies Tags are returned in CreateConnection response.
+func TestParity_CreateConnection_ReturnsTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inputTags []map[string]string
+		name      string
+		wantCount int
+	}{
+		{
+			name: "tags_returned",
+			inputTags: []map[string]string{
+				{"Key": "Env", "Value": "prod"},
+				{"Key": "Owner", "Value": "platform"},
+			},
+			wantCount: 2,
+		},
+		{
+			name:      "no_tags_omitted",
+			inputTags: nil,
+			wantCount: 0,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			body := map[string]any{
+				"ConnectionName": "tag-conn-" + strconv.Itoa(i),
+				"ProviderType":   "GitHub",
+			}
+
+			if tt.inputTags != nil {
+				body["Tags"] = tt.inputTags
+			}
+
+			rec := doJSON(t, h, "CreateConnection", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			if tt.wantCount > 0 {
+				tags, ok := resp["Tags"].([]any)
+				require.True(t, ok, "Tags field should be present")
+				assert.Len(t, tags, tt.wantCount)
+			} else {
+				// nil or missing Tags is acceptable for zero-tag case
+				if tags, ok := resp["Tags"].([]any); ok {
+					assert.Empty(t, tags)
+				}
+			}
+		})
+	}
+}
+
+// TestParity_CreateConnection_TagsSortedInResponse verifies tags are alphabetically sorted.
+func TestParity_CreateConnection_TagsSortedInResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inputTags []map[string]string
+		wantKeys  []string
+		name      string
+	}{
+		{
+			name: "sorted_alphabetically",
+			inputTags: []map[string]string{
+				{"Key": "Zebra", "Value": "z"},
+				{"Key": "Alpha", "Value": "a"},
+				{"Key": "Mango", "Value": "m"},
+			},
+			wantKeys: []string{"Alpha", "Mango", "Zebra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			rec := doJSON(t, h, "CreateConnection", map[string]any{
+				"ConnectionName": "sorted-conn",
+				"ProviderType":   "GitHub",
+				"Tags":           tt.inputTags,
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			tags, ok := resp["Tags"].([]any)
+			require.True(t, ok)
+			require.Len(t, tags, len(tt.wantKeys))
+
+			for i, wantKey := range tt.wantKeys {
+				tagMap, isMap := tags[i].(map[string]any)
+				require.True(t, isMap)
+				assert.Equal(t, wantKey, tagMap["Key"])
+			}
+		})
+	}
+}
+
+// --- GetConnection parity ---
+
+// TestParity_GetConnection_HostArnPreserved verifies HostArn is stored and returned.
+func TestParity_GetConnection_HostArnPreserved(t *testing.T) {
+	t.Parallel()
+
+	const hostArn = "arn:aws:codeconnections:us-east-1:123456789012:host/myhost"
+
+	tests := []struct {
+		name        string
+		wantHostArn string
+	}{
+		{name: "host_arn_preserved", wantHostArn: hostArn},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			rec := doJSON(t, h, "CreateConnection", map[string]any{
+				"ConnectionName": "ghe-conn",
+				"ProviderType":   "GitHubEnterpriseServer",
+				"HostArn":        hostArn,
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+			connArn := parseResp(t, rec)["ConnectionArn"].(string)
+
+			getRec := doJSON(t, h, "GetConnection", map[string]any{"ConnectionArn": connArn})
+			require.Equal(t, http.StatusOK, getRec.Code)
+
+			resp := parseResp(t, getRec)
+			conn, ok := resp["Connection"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantHostArn, conn["HostArn"])
+		})
+	}
+}
+
+// --- GetHost parity ---
+
+// TestParity_GetHost_IncludesHostArn verifies HostArn is returned in GetHost response.
+func TestParity_GetHost_IncludesHostArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		hostName      string
+		providerType  string
+		endpoint      string
+		wantFieldsSet bool
+	}{
+		{
+			name:          "host_arn_in_response",
+			hostName:      "my-ghe-host",
+			providerType:  "GitHubEnterpriseServer",
+			endpoint:      "https://ghe.example.com",
+			wantFieldsSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			hostArn := createHost(t, h, tt.hostName, tt.providerType, tt.endpoint)
+
+			rec := doJSON(t, h, "GetHost", map[string]any{"HostArn": hostArn})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			if tt.wantFieldsSet {
+				assert.Equal(t, hostArn, resp["HostArn"])
+				assert.Equal(t, tt.hostName, resp["Name"])
+				assert.Equal(t, tt.endpoint, resp["ProviderEndpoint"])
+				assert.Equal(t, tt.providerType, resp["ProviderType"])
+				assert.Equal(t, "AVAILABLE", resp["Status"])
+			}
+		})
+	}
+}
+
+// --- Host uniqueness parity ---
+
+// TestParity_CreateHost_NameUniqueness verifies duplicate host names are rejected.
+func TestParity_CreateHost_NameUniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		hostName      string
+		wantDuplicate bool
+		wantStatus    int
+	}{
+		{
+			name:       "unique_name_succeeds",
+			hostName:   "unique-host",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:          "duplicate_name_rejected",
+			hostName:      "dup-host",
+			wantDuplicate: true,
+			wantStatus:    http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			if tt.wantDuplicate {
+				createHost(t, h, tt.hostName, "GitHubEnterpriseServer", "https://a.example.com")
+			}
+
+			rec := doJSON(t, h, "CreateHost", map[string]any{
+				"Name":             tt.hostName,
+				"ProviderType":     "GitHubEnterpriseServer",
+				"ProviderEndpoint": "https://b.example.com",
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// TestParity_DeleteHost_CleansNameIndex verifies host name can be reused after delete.
+func TestParity_DeleteHost_CleansNameIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "can_recreate_after_delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			hostArn := createHost(t, h, "recycled-host", "GitHubEnterpriseServer", "https://a.example.com")
+
+			delRec := doJSON(t, h, "DeleteHost", map[string]any{"HostArn": hostArn})
+			require.Equal(t, http.StatusOK, delRec.Code)
+
+			rec := doJSON(t, h, "CreateHost", map[string]any{
+				"Name":             "recycled-host",
+				"ProviderType":     "GitHubEnterpriseServer",
+				"ProviderEndpoint": "https://b.example.com",
+			})
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+// --- ListHosts parity ---
+
+// TestParity_ListHosts_IncludesTags verifies Tags are included in ListHosts output items.
+func TestParity_ListHosts_IncludesTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tags     []map[string]string
+		name     string
+		wantTags int
+	}{
+		{
+			name: "tags_in_list_item",
+			tags: []map[string]string{
+				{"Key": "Env", "Value": "staging"},
+				{"Key": "Owner", "Value": "ops"},
+			},
+			wantTags: 2,
+		},
+		{
+			name:     "no_tags_list_item",
+			tags:     nil,
+			wantTags: 0,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			body := map[string]any{
+				"Name":             "tagged-host-" + strconv.Itoa(i),
+				"ProviderType":     "GitHubEnterpriseServer",
+				"ProviderEndpoint": "https://ghe.example.com",
+			}
+			if tt.tags != nil {
+				body["Tags"] = tt.tags
+			}
+
+			rec := doJSON(t, h, "CreateHost", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			listRec := doJSON(t, h, "ListHosts", nil)
+			require.Equal(t, http.StatusOK, listRec.Code)
+
+			resp := parseResp(t, listRec)
+			hosts, ok := resp["Hosts"].([]any)
+			require.True(t, ok)
+			require.Len(t, hosts, 1)
+
+			hostMap, isMap := hosts[0].(map[string]any)
+			require.True(t, isMap)
+
+			tags, _ := hostMap["Tags"].([]any)
+			assert.Len(t, tags, tt.wantTags)
+		})
+	}
+}
+
+// TestParity_ListHosts_Pagination verifies MaxResults and NextToken work for ListHosts.
+func TestParity_ListHosts_Pagination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		hostCount  int
+		maxResults int
+		wantCount  int
+		wantToken  bool
+	}{
+		{
+			name:       "first_page",
+			hostCount:  3,
+			maxResults: 2,
+			wantCount:  2,
+			wantToken:  true,
+		},
+		{
+			name:       "all_results",
+			hostCount:  2,
+			maxResults: 10,
+			wantCount:  2,
+			wantToken:  false,
+		},
+		{
+			name:       "zero_max_defaults",
+			hostCount:  2,
+			maxResults: 0,
+			wantCount:  2,
+			wantToken:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			for i := range tt.hostCount {
+				rec := doJSON(t, h, "CreateHost", map[string]any{
+					"Name":             "phost-" + strconv.Itoa(i),
+					"ProviderType":     "GitHubEnterpriseServer",
+					"ProviderEndpoint": "https://ghe" + strconv.Itoa(i) + ".example.com",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			body := map[string]any{}
+			if tt.maxResults > 0 {
+				body["MaxResults"] = tt.maxResults
+			}
+
+			rec := doJSON(t, h, "ListHosts", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			hosts, ok := resp["Hosts"].([]any)
+			require.True(t, ok)
+			assert.Len(t, hosts, tt.wantCount)
+
+			_, hasToken := resp["NextToken"]
+			assert.Equal(t, tt.wantToken, hasToken)
+		})
+	}
+}
+
+// TestParity_ListHosts_Continuation verifies two-page traversal for ListHosts.
+func TestParity_ListHosts_Continuation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler()
+	for i := range 3 {
+		rec := doJSON(t, h, "CreateHost", map[string]any{
+			"Name":             "cont-host-" + strconv.Itoa(i),
+			"ProviderType":     "GitHubEnterpriseServer",
+			"ProviderEndpoint": "https://ghe" + strconv.Itoa(i) + ".example.com",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	rec1 := doJSON(t, h, "ListHosts", map[string]any{"MaxResults": 2})
+	require.Equal(t, http.StatusOK, rec1.Code)
+	resp1 := parseResp(t, rec1)
+	page1, ok := resp1["Hosts"].([]any)
+	require.True(t, ok)
+	assert.Len(t, page1, 2)
+
+	nextToken, hasToken := resp1["NextToken"].(string)
+	require.True(t, hasToken)
+	require.NotEmpty(t, nextToken)
+
+	rec2 := doJSON(t, h, "ListHosts", map[string]any{
+		"MaxResults": 2,
+		"NextToken":  nextToken,
+	})
+	require.Equal(t, http.StatusOK, rec2.Code)
+	resp2 := parseResp(t, rec2)
+	page2, ok := resp2["Hosts"].([]any)
+	require.True(t, ok)
+	assert.Len(t, page2, 1)
+
+	_, stillHasToken := resp2["NextToken"]
+	assert.False(t, stillHasToken)
+
+	names := make([]string, 0, 3)
+	for _, item := range append(page1, page2...) {
+		hMap := item.(map[string]any)
+		names = append(names, hMap["Name"].(string))
+	}
+	assert.ElementsMatch(t, []string{"cont-host-0", "cont-host-1", "cont-host-2"}, names)
+}
+
+// --- ListRepositoryLinks parity ---
+
+// TestParity_ListRepositoryLinks_Pagination verifies MaxResults/NextToken for ListRepositoryLinks.
+func TestParity_ListRepositoryLinks_Pagination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		linkCount  int
+		maxResults int
+		wantCount  int
+		wantToken  bool
+	}{
+		{
+			name:       "first_page",
+			linkCount:  3,
+			maxResults: 2,
+			wantCount:  2,
+			wantToken:  true,
+		},
+		{
+			name:       "all_results",
+			linkCount:  2,
+			maxResults: 10,
+			wantCount:  2,
+			wantToken:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			connArn := createConn(t, h, "link-conn", "GitHub")
+
+			for i := range tt.linkCount {
+				rec := doJSON(t, h, "CreateRepositoryLink", map[string]any{
+					"ConnectionArn":  connArn,
+					"OwnerId":        "my-org",
+					"RepositoryName": "repo-" + strconv.Itoa(i),
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			body := map[string]any{}
+			if tt.maxResults > 0 {
+				body["MaxResults"] = tt.maxResults
+			}
+
+			rec := doJSON(t, h, "ListRepositoryLinks", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			links, ok := resp["RepositoryLinks"].([]any)
+			require.True(t, ok)
+			assert.Len(t, links, tt.wantCount)
+
+			_, hasToken := resp["NextToken"]
+			assert.Equal(t, tt.wantToken, hasToken)
+		})
+	}
+}
+
+// --- ListSyncConfigurations parity ---
+
+// TestParity_ListSyncConfigurations_Pagination verifies MaxResults/NextToken pagination.
+func TestParity_ListSyncConfigurations_Pagination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfgCount   int
+		maxResults int
+		wantCount  int
+		wantToken  bool
+	}{
+		{
+			name:       "first_page",
+			cfgCount:   3,
+			maxResults: 2,
+			wantCount:  2,
+			wantToken:  true,
+		},
+		{
+			name:       "all_results",
+			cfgCount:   2,
+			maxResults: 10,
+			wantCount:  2,
+			wantToken:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			connArn := createConn(t, h, "sync-conn", "GitHub")
+			linkID := createRepositoryLink(t, h, connArn, "my-org", "my-repo")
+
+			for i := range tt.cfgCount {
+				rec := doJSON(t, h, "CreateSyncConfiguration", map[string]any{
+					"Branch":           "main",
+					"ConfigFile":       "config.yaml",
+					"RepositoryLinkId": linkID,
+					"ResourceName":     "resource-" + strconv.Itoa(i),
+					"RoleArn":          "arn:aws:iam::123456789012:role/r",
+					"SyncType":         "CFN_STACK_SYNC",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			body := map[string]any{
+				"RepositoryLinkId": linkID,
+			}
+			if tt.maxResults > 0 {
+				body["MaxResults"] = tt.maxResults
+			}
+
+			rec := doJSON(t, h, "ListSyncConfigurations", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			cfgs, ok := resp["SyncConfigurations"].([]any)
+			require.True(t, ok)
+			assert.Len(t, cfgs, tt.wantCount)
+
+			_, hasToken := resp["NextToken"]
+			assert.Equal(t, tt.wantToken, hasToken)
+		})
+	}
+}
+
+// --- UpdateHost parity ---
+
+// TestParity_UpdateHost exercises UpdateHost happy path and error cases.
+func TestParity_UpdateHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setupHostArn func(t *testing.T, h *codeconnections.Handler) string
+		name         string
+		newEndpoint  string
+		wantStatus   int
+	}{
+		{
+			name: "success_updates_endpoint",
+			setupHostArn: func(t *testing.T, h *codeconnections.Handler) string {
+				t.Helper()
+
+				return createHost(t, h, "updateable-host", "GitHubEnterpriseServer", "https://old.example.com")
+			},
+			newEndpoint: "https://new.example.com",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name: "not_found",
+			setupHostArn: func(_ *testing.T, _ *codeconnections.Handler) string {
+				return "arn:aws:codeconnections:us-east-1:123:host/nonexistent"
+			},
+			newEndpoint: "https://new.example.com",
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name: "missing_arn",
+			setupHostArn: func(_ *testing.T, _ *codeconnections.Handler) string {
+				return ""
+			},
+			newEndpoint: "https://new.example.com",
+			wantStatus:  http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			hostArn := tt.setupHostArn(t, h)
+
+			rec := doJSON(t, h, "UpdateHost", map[string]any{
+				"HostArn":          hostArn,
+				"ProviderEndpoint": tt.newEndpoint,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				getRec := doJSON(t, h, "GetHost", map[string]any{"HostArn": hostArn})
+				require.Equal(t, http.StatusOK, getRec.Code)
+				resp := parseResp(t, getRec)
+				assert.Equal(t, tt.newEndpoint, resp["ProviderEndpoint"])
+			}
+		})
+	}
+}
+
+// --- UpdateRepositoryLink parity ---
+
+// TestParity_UpdateRepositoryLink exercises UpdateRepositoryLink operations.
+func TestParity_UpdateRepositoryLink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setupLinkID  func(t *testing.T, h *codeconnections.Handler) string
+		name         string
+		newConnArn   string
+		wantStatus   int
+		wantNewConn  bool
+	}{
+		{
+			name: "success_updates_connection",
+			setupLinkID: func(t *testing.T, h *codeconnections.Handler) string {
+				t.Helper()
+				connArn := createConn(t, h, "original-conn", "GitHub")
+
+				return createRepositoryLink(t, h, connArn, "my-org", "my-repo")
+			},
+			newConnArn:  "arn:aws:codeconnections:us-east-1:123:connection/new-conn",
+			wantStatus:  http.StatusOK,
+			wantNewConn: true,
+		},
+		{
+			name: "not_found",
+			setupLinkID: func(_ *testing.T, _ *codeconnections.Handler) string {
+				return "nonexistent-link-id"
+			},
+			newConnArn: "arn:aws:codeconnections:us-east-1:123:connection/new",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing_repository_link_id",
+			setupLinkID: func(_ *testing.T, _ *codeconnections.Handler) string {
+				return ""
+			},
+			newConnArn: "arn:aws:codeconnections:us-east-1:123:connection/new",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			linkID := tt.setupLinkID(t, h)
+
+			rec := doJSON(t, h, "UpdateRepositoryLink", map[string]any{
+				"RepositoryLinkId": linkID,
+				"ConnectionArn":    tt.newConnArn,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantNewConn {
+				resp := parseResp(t, rec)
+				info, ok := resp["RepositoryLinkInfo"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, tt.newConnArn, info["ConnectionArn"])
+			}
+		})
+	}
+}
+
+// --- GetSyncConfiguration parity ---
+
+// TestParity_GetSyncConfiguration exercises the GetSyncConfiguration handler.
+func TestParity_GetSyncConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		wantStatus   int
+		wantBranch   string
+		preCreate    bool
+	}{
+		{
+			name:       "success",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+			wantBranch: "feature-branch",
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+
+			if tt.preCreate {
+				connArn := createConn(t, h, "cfg-conn", "GitHub")
+				linkID := createRepositoryLink(t, h, connArn, "my-org", "my-repo")
+				rec := doJSON(t, h, "CreateSyncConfiguration", map[string]any{
+					"Branch":           "feature-branch",
+					"ConfigFile":       "sync.yaml",
+					"RepositoryLinkId": linkID,
+					"ResourceName":     "get-stack",
+					"RoleArn":          "arn:aws:iam::123456789012:role/r",
+					"SyncType":         "CFN_STACK_SYNC",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			rec := doJSON(t, h, "GetSyncConfiguration", map[string]any{
+				"ResourceName": "get-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				cfg, ok := resp["SyncConfiguration"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantBranch, cfg["Branch"])
+				assert.Equal(t, "my-org", cfg["OwnerId"])
+				assert.Equal(t, "my-repo", cfg["RepositoryName"])
+				assert.Equal(t, "GitHub", cfg["ProviderType"])
+			}
+		})
+	}
+}
+
+// --- UpdateSyncConfiguration parity ---
+
+// TestParity_UpdateSyncConfiguration exercises UpdateSyncConfiguration.
+func TestParity_UpdateSyncConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		newBranch  string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success_updates_branch",
+			preCreate:  true,
+			newBranch:  "release",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			newBranch:  "release",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+
+			if tt.preCreate {
+				connArn := createConn(t, h, "upd-conn", "GitHub")
+				linkID := createRepositoryLink(t, h, connArn, "my-org", "my-repo")
+				rec := doJSON(t, h, "CreateSyncConfiguration", map[string]any{
+					"Branch":           "main",
+					"ConfigFile":       "sync.yaml",
+					"RepositoryLinkId": linkID,
+					"ResourceName":     "upd-stack",
+					"RoleArn":          "arn:aws:iam::123456789012:role/r",
+					"SyncType":         "CFN_STACK_SYNC",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			rec := doJSON(t, h, "UpdateSyncConfiguration", map[string]any{
+				"ResourceName": "upd-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+				"Branch":       tt.newBranch,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				cfg, ok := resp["SyncConfiguration"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, tt.newBranch, cfg["Branch"])
+			}
+		})
+	}
+}
+
+// --- GetSyncBlockerSummary parity ---
+
+// TestParity_GetSyncBlockerSummary exercises the GetSyncBlockerSummary handler.
+func TestParity_GetSyncBlockerSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success_returns_summary",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_resource_name",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+
+			if tt.preCreate {
+				connArn := createConn(t, h, "blocker-conn", "GitHub")
+				linkID := createRepositoryLink(t, h, connArn, "my-org", "my-repo")
+				rec := doJSON(t, h, "CreateSyncConfiguration", map[string]any{
+					"Branch":           "main",
+					"ConfigFile":       "sync.yaml",
+					"RepositoryLinkId": linkID,
+					"ResourceName":     "blocker-stack",
+					"RoleArn":          "arn:aws:iam::123456789012:role/r",
+					"SyncType":         "CFN_STACK_SYNC",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			body := map[string]any{
+				"SyncType": "CFN_STACK_SYNC",
+			}
+			if tt.name != "missing_resource_name" {
+				body["ResourceName"] = "blocker-stack"
+			}
+
+			rec := doJSON(t, h, "GetSyncBlockerSummary", body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				summary, ok := resp["SyncBlockerSummary"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "blocker-stack", summary["ResourceName"])
+				_, hasBlockers := summary["LatestBlockers"]
+				assert.True(t, hasBlockers)
+			}
+		})
+	}
+}
+
+// --- UpdateSyncBlocker parity ---
+
+// TestParity_UpdateSyncBlocker verifies UpdateSyncBlocker validates Id is required.
+func TestParity_UpdateSyncBlocker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		id         string
+		wantStatus int
+	}{
+		{
+			name:       "success_with_id",
+			id:         "some-blocker-id",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_id",
+			id:         "",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			body := map[string]any{
+				"ResolvedReason": "issue fixed",
+				"ResourceName":   "my-stack",
+				"SyncType":       "CFN_STACK_SYNC",
+			}
+			if tt.id != "" {
+				body["Id"] = tt.id
+			}
+
+			rec := doJSON(t, h, "UpdateSyncBlocker", body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// --- ListRepositorySyncDefinitions parity ---
+
+// TestParity_ListRepositorySyncDefinitions exercises the handler.
+func TestParity_ListRepositorySyncDefinitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success_returns_empty",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing_repository_link_id",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			linkID := "nonexistent-link"
+
+			if tt.preCreate {
+				connArn := createConn(t, h, "def-conn", "GitHub")
+				linkID = createRepositoryLink(t, h, connArn, "my-org", "my-repo")
+			}
+
+			body := map[string]any{
+				"SyncType": "CFN_STACK_SYNC",
+			}
+			if tt.name != "missing_repository_link_id" {
+				body["RepositoryLinkId"] = linkID
+			}
+
+			rec := doJSON(t, h, "ListRepositorySyncDefinitions", body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				defs, ok := resp["RepositorySyncDefinitions"].([]any)
+				require.True(t, ok)
+				assert.NotNil(t, defs)
+			}
+		})
+	}
+}
+
+// --- Host name uniqueness after snapshot/restore ---
+
+// TestParity_SnapshotRestore_HostsByName verifies hostsByName index is preserved in snapshot.
+func TestParity_SnapshotRestore_HostsByName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "hosts_by_name_restored"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			createHost(t, h, "snap-host", "GitHubEnterpriseServer", "https://ghe.example.com")
+
+			snap := h.Backend.Snapshot()
+			require.NotNil(t, snap)
+
+			newBackend := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
+			require.NoError(t, newBackend.Restore(snap))
+
+			// Attempting to create a host with same name should fail (name index restored).
+			_, err := newBackend.CreateHost("snap-host", "GitHubEnterpriseServer", "https://new.example.com", nil)
+			require.Error(t, err, "duplicate host name should fail after restore")
+		})
+	}
+}
+
+// --- ListConnections with HostArn filter after CreateConnection with HostArn ---
+
+// TestParity_ListConnections_HostArnFilterAfterCreate verifies that connections created with
+// HostArn can be retrieved using the HostArnFilter.
+func TestParity_ListConnections_HostArnFilterAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	const hostArn = "arn:aws:codeconnections:us-east-1:123456789012:host/myhost"
+
+	tests := []struct {
+		name        string
+		applyFilter bool
+		wantCount   int
+	}{
+		{name: "no_filter_returns_both", applyFilter: false, wantCount: 2},
+		{name: "host_filter_returns_one", applyFilter: true, wantCount: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+
+			// conn1 with HostArn
+			rec1 := doJSON(t, h, "CreateConnection", map[string]any{
+				"ConnectionName": "ghe-conn",
+				"ProviderType":   "GitHubEnterpriseServer",
+				"HostArn":        hostArn,
+			})
+			require.Equal(t, http.StatusOK, rec1.Code)
+
+			// conn2 without HostArn
+			createConn(t, h, "gh-conn", "GitHub")
+
+			body := map[string]any{}
+			if tt.applyFilter {
+				body["HostArnFilter"] = hostArn
+			}
+
+			rec := doJSON(t, h, "ListConnections", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			conns, ok := resp["Connections"].([]any)
+			require.True(t, ok)
+			assert.Len(t, conns, tt.wantCount)
+		})
+	}
+}
+
+// --- Provider init parity (codeconnections allows nil ctx) ---
+
+// TestParity_ProviderInit_NilCtx verifies that codeconnections Provider.Init tolerates nil ctx.
+func TestParity_ProviderInit_NilCtx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "nil_ctx_no_panic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &codeconnections.Provider{}
+			reg, err := p.Init(nil)
+			require.NoError(t, err)
+			assert.NotNil(t, reg)
+		})
+	}
+}
+
+// --- Backend direct parity tests ---
+
+// TestParity_Backend_CreateConnection_HostArn verifies hostArn is stored in backend.
+func TestParity_Backend_CreateConnection_HostArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		hostArn     string
+		wantHostArn string
+	}{
+		{
+			name:        "with_host_arn",
+			hostArn:     "arn:aws:codeconnections:us-east-1:123:host/h1",
+			wantHostArn: "arn:aws:codeconnections:us-east-1:123:host/h1",
+		},
+		{
+			name:        "without_host_arn",
+			hostArn:     "",
+			wantHostArn: "",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
+			conn, err := b.CreateConnection("conn-"+strconv.Itoa(i), "GitHub", tt.hostArn, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHostArn, conn.HostArn)
+
+			got, err := b.GetConnection(conn.ConnectionArn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHostArn, got.HostArn)
+		})
+	}
+}
+
+// TestParity_Backend_CreateHost_NameUniqueness verifies duplicate host names fail.
+func TestParity_Backend_CreateHost_NameUniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantErrOn  string
+	}{
+		{name: "first_create_succeeds"},
+		{name: "second_create_fails", wantErrOn: "second"},
+	}
+
+	b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.wantErrOn == "" {
+				_, err := b.CreateHost("unique-host-x", "GitHubEnterpriseServer", "https://a.example.com", nil)
+				require.NoError(t, err)
+			} else {
+				_, err := b.CreateHost("unique-host-x", "GitHubEnterpriseServer", "https://b.example.com", nil)
+				require.Error(t, err, "duplicate host name must fail")
+			}
+		})
+	}
+}
+
+// TestParity_Backend_HostsByName_DeleteRestores verifies delete releases the name for reuse.
+func TestParity_Backend_HostsByName_DeleteRestores(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "name_reusable_after_delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
+			host, err := b.CreateHost("recycled-host", "GitHubEnterpriseServer", "https://a.example.com", nil)
+			require.NoError(t, err)
+
+			err = b.DeleteHost(host.HostArn)
+			require.NoError(t, err)
+
+			_, err = b.CreateHost("recycled-host", "GitHubEnterpriseServer", "https://b.example.com", nil)
+			require.NoError(t, err, "name should be reusable after delete")
+		})
+	}
+}
+
+// TestParity_Backend_AddHostInternal_UpdatesNameIndex verifies the name index is populated.
+func TestParity_Backend_AddHostInternal_UpdatesNameIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "internal_add_blocks_duplicate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
+			b.AddHostInternal(&codeconnections.Host{
+				Name:             "seeded-host",
+				HostArn:          "arn:aws:codeconnections:us-east-1:123:host/seeded",
+				ProviderType:     "GitHubEnterpriseServer",
+				ProviderEndpoint: "https://ghe.example.com",
+				Status:           "AVAILABLE",
+				Tags:             map[string]string{},
+			})
+
+			_, err := b.CreateHost("seeded-host", "GitHubEnterpriseServer", "https://other.example.com", nil)
+			require.Error(t, err, "AddHostInternal must populate name index")
+		})
+	}
+}
+
+// TestParity_Backend_ErrAlreadyExists_HostDuplicate verifies the correct error type.
+func TestParity_Backend_ErrAlreadyExists_HostDuplicate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "duplicate_host_returns_already_exists_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
+			_, err := b.CreateHost("dup-h", "GitHubEnterpriseServer", "https://a.example.com", nil)
+			require.NoError(t, err)
+
+			_, err = b.CreateHost("dup-h", "GitHubEnterpriseServer", "https://b.example.com", nil)
+			require.Error(t, err)
+			// The error should wrap ErrAlreadyExists.
+			assert.ErrorIs(t, err, codeconnections.ErrAlreadyExists)
+		})
+	}
+}

--- a/services/codeconnections/handler_parity_test.go
+++ b/services/codeconnections/handler_parity_test.go
@@ -1205,29 +1205,13 @@ func TestParity_Backend_CreateConnection_HostArn(t *testing.T) {
 func TestParity_Backend_CreateHost_NameUniqueness(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		wantErrOn string
-	}{
-		{name: "first_create_succeeds"},
-		{name: "second_create_fails", wantErrOn: "second"},
-	}
-
 	b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	_, err := b.CreateHost("unique-host-x", "GitHubEnterpriseServer", "https://a.example.com", nil)
+	require.NoError(t, err, "first create should succeed")
 
-			if tt.wantErrOn == "" {
-				_, err := b.CreateHost("unique-host-x", "GitHubEnterpriseServer", "https://a.example.com", nil)
-				require.NoError(t, err)
-			} else {
-				_, err := b.CreateHost("unique-host-x", "GitHubEnterpriseServer", "https://b.example.com", nil)
-				require.Error(t, err, "duplicate host name must fail")
-			}
-		})
-	}
+	_, err = b.CreateHost("unique-host-x", "GitHubEnterpriseServer", "https://b.example.com", nil)
+	require.Error(t, err, "duplicate host name must fail")
 }
 
 // TestParity_Backend_HostsByName_DeleteRestores verifies delete releases the name for reuse.

--- a/services/codeconnections/handler_parity_test.go
+++ b/services/codeconnections/handler_parity_test.go
@@ -65,8 +65,8 @@ func TestParity_CreateConnection_ReturnsTags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		inputTags []map[string]string
 		name      string
+		inputTags []map[string]string
 		wantCount int
 	}{
 		{
@@ -121,9 +121,9 @@ func TestParity_CreateConnection_TagsSortedInResponse(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name      string
 		inputTags []map[string]string
 		wantKeys  []string
-		name      string
 	}{
 		{
 			name: "sorted_alphabetically",
@@ -326,8 +326,8 @@ func TestParity_ListHosts_IncludesTags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		tags     []map[string]string
 		name     string
+		tags     []map[string]string
 		wantTags int
 	}{
 		{
@@ -696,11 +696,11 @@ func TestParity_UpdateRepositoryLink(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		setupLinkID  func(t *testing.T, h *codeconnections.Handler) string
-		name         string
-		newConnArn   string
-		wantStatus   int
-		wantNewConn  bool
+		setupLinkID func(t *testing.T, h *codeconnections.Handler) string
+		name        string
+		newConnArn  string
+		wantStatus  int
+		wantNewConn bool
 	}{
 		{
 			name: "success_updates_connection",
@@ -762,10 +762,10 @@ func TestParity_GetSyncConfiguration(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		wantStatus   int
-		wantBranch   string
-		preCreate    bool
+		name       string
+		wantBranch string
+		wantStatus int
+		preCreate  bool
 	}{
 		{
 			name:       "success",
@@ -1206,8 +1206,8 @@ func TestParity_Backend_CreateHost_NameUniqueness(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		wantErrOn  string
+		name      string
+		wantErrOn string
 	}{
 		{name: "first_create_succeeds"},
 		{name: "second_create_fails", wantErrOn: "second"},

--- a/services/codeconnections/handler_test.go
+++ b/services/codeconnections/handler_test.go
@@ -773,9 +773,9 @@ func TestBackendListConnections(t *testing.T) {
 			name: "no_filter_returns_all",
 			setup: func(t *testing.T, b *codeconnections.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateConnection("c1", "GitHub", nil)
+				_, err := b.CreateConnection("c1", "GitHub", "", nil)
 				require.NoError(t, err)
-				_, err = b.CreateConnection("c2", "GitLab", nil)
+				_, err = b.CreateConnection("c2", "GitLab", "", nil)
 				require.NoError(t, err)
 			},
 			filter:    "",
@@ -785,9 +785,9 @@ func TestBackendListConnections(t *testing.T) {
 			name: "filter_by_provider",
 			setup: func(t *testing.T, b *codeconnections.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateConnection("c1", "GitHub", nil)
+				_, err := b.CreateConnection("c1", "GitHub", "", nil)
 				require.NoError(t, err)
-				_, err = b.CreateConnection("c2", "GitLab", nil)
+				_, err = b.CreateConnection("c2", "GitLab", "", nil)
 				require.NoError(t, err)
 			},
 			filter:       "GitHub",
@@ -915,7 +915,7 @@ func TestBackendCreateAndGet(t *testing.T) {
 			t.Parallel()
 
 			b := codeconnections.NewInMemoryBackend("123456789012", "us-east-1")
-			conn, err := b.CreateConnection(tt.connName, tt.providerType, tt.inputTags)
+			conn, err := b.CreateConnection(tt.connName, tt.providerType, "", tt.inputTags)
 			require.NoError(t, err)
 			assert.NotEmpty(t, conn.ConnectionArn)
 			assert.Equal(t, tt.connName, conn.ConnectionName)

--- a/services/codeconnections/persistence.go
+++ b/services/codeconnections/persistence.go
@@ -6,6 +6,7 @@ type backendSnapshot struct {
 	Connections        map[string]*Connection        `json:"connections"`
 	ConnectionsByName  map[string]string             `json:"connectionsByName"`
 	Hosts              map[string]*Host              `json:"hosts"`
+	HostsByName        map[string]string             `json:"hostsByName"`
 	RepositoryLinks    map[string]*RepositoryLink    `json:"repositoryLinks"`
 	SyncConfigurations map[string]*SyncConfiguration `json:"syncConfigurations"`
 	AccountID          string                        `json:"accountID"`
@@ -22,6 +23,7 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		Connections:        b.connections,
 		ConnectionsByName:  b.connectionsByName,
 		Hosts:              b.hosts,
+		HostsByName:        b.hostsByName,
 		RepositoryLinks:    b.repositoryLinks,
 		SyncConfigurations: b.syncConfigurations,
 		AccountID:          b.accountID,
@@ -60,6 +62,10 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		snap.Hosts = make(map[string]*Host)
 	}
 
+	if snap.HostsByName == nil {
+		snap.HostsByName = make(map[string]string)
+	}
+
 	if snap.RepositoryLinks == nil {
 		snap.RepositoryLinks = make(map[string]*RepositoryLink)
 	}
@@ -71,6 +77,7 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.connections = snap.Connections
 	b.connectionsByName = snap.ConnectionsByName
 	b.hosts = snap.Hosts
+	b.hostsByName = snap.HostsByName
 	b.repositoryLinks = snap.RepositoryLinks
 	b.syncConfigurations = snap.SyncConfigurations
 	b.accountID = snap.AccountID

--- a/services/codestarconnections/handler.go
+++ b/services/codestarconnections/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
 	"github.com/blackbirdworks/gopherstack/pkgs/service"
 )
@@ -138,9 +139,37 @@ func (h *Handler) ExtractOperation(c *echo.Context) string {
 	return strings.TrimPrefix(target, codestarTargetPrefix)
 }
 
-// ExtractResource extracts the resource identifier from the request (not used for CodeStar Connections).
-func (h *Handler) ExtractResource(_ *echo.Context) string {
-	return ""
+// ExtractResource extracts the primary resource identifier from the JSON request body.
+func (h *Handler) ExtractResource(c *echo.Context) string {
+	body, err := httputils.ReadBody(c.Request())
+	if err != nil {
+		return ""
+	}
+
+	var req struct {
+		ConnectionArn    string `json:"ConnectionArn"`
+		ResourceArn      string `json:"ResourceArn"`
+		HostArn          string `json:"HostArn"`
+		RepositoryLinkID string `json:"RepositoryLinkId"`
+		ResourceName     string `json:"ResourceName"`
+	}
+
+	_ = json.Unmarshal(body, &req)
+
+	switch {
+	case req.ConnectionArn != "":
+		return req.ConnectionArn
+	case req.ResourceArn != "":
+		return req.ResourceArn
+	case req.HostArn != "":
+		return req.HostArn
+	case req.RepositoryLinkID != "":
+		return req.RepositoryLinkID
+	case req.ResourceName != "":
+		return req.ResourceName
+	default:
+		return ""
+	}
 }
 
 // Handler returns the Echo handler function for CodeStar Connections requests.

--- a/services/codestarconnections/handler_parity_test.go
+++ b/services/codestarconnections/handler_parity_test.go
@@ -1,0 +1,1000 @@
+package codestarconnections_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/codestarconnections"
+)
+
+// createCSCConn is a test helper that creates a connection and returns its ARN.
+func createCSCConn(t *testing.T, h *codestarconnections.Handler, name, providerType string) string {
+	t.Helper()
+
+	rec := doRequest(t, h, "CreateConnection", map[string]any{
+		"ConnectionName": name,
+		"ProviderType":   providerType,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+	arn, ok := resp["ConnectionArn"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, arn)
+
+	return arn
+}
+
+// createCSCHost is a test helper that creates a host and returns its ARN.
+func createCSCHost(t *testing.T, h *codestarconnections.Handler, name, providerType, endpoint string) string {
+	t.Helper()
+
+	rec := doRequest(t, h, "CreateHost", map[string]any{
+		"Name":             name,
+		"ProviderType":     providerType,
+		"ProviderEndpoint": endpoint,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+	arn, ok := resp["HostArn"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, arn)
+
+	return arn
+}
+
+// createCSCRepositoryLink is a test helper that creates a repository link and returns its ID.
+func createCSCRepositoryLink(t *testing.T, h *codestarconnections.Handler, connArn, repoName string) string {
+	t.Helper()
+
+	rec := doRequest(t, h, "CreateRepositoryLink", map[string]any{
+		"ConnectionArn":  connArn,
+		"OwnerId":        "my-org",
+		"RepositoryName": repoName,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+	info, ok := resp["RepositoryLinkInfo"].(map[string]any)
+	require.True(t, ok)
+
+	linkID, ok := info["RepositoryLinkId"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, linkID)
+
+	return linkID
+}
+
+// doCSCRequest sends a POST / request with X-Amz-Target set.
+func doCSCRequest(
+	t *testing.T,
+	h *codestarconnections.Handler,
+	action string,
+	body map[string]any,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		require.NoError(t, err)
+	} else {
+		bodyBytes = []byte("{}")
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "CodeStar_connections_20191201."+action)
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Handler()(c)
+	require.NoError(t, err)
+
+	return rec
+}
+
+// --- ExtractResource parity ---
+
+// TestParity_ExtractResource verifies ExtractResource correctly pulls ARNs from request body.
+func TestParity_ExtractResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body    map[string]any
+		name    string
+		wantRes string
+	}{
+		{
+			name:    "connection_arn",
+			body:    map[string]any{"ConnectionArn": "arn:aws:codestar-connections:us-east-1:123:connection/abc"},
+			wantRes: "arn:aws:codestar-connections:us-east-1:123:connection/abc",
+		},
+		{
+			name:    "resource_arn",
+			body:    map[string]any{"ResourceArn": "arn:aws:codestar-connections:us-east-1:123:connection/xyz"},
+			wantRes: "arn:aws:codestar-connections:us-east-1:123:connection/xyz",
+		},
+		{
+			name:    "host_arn",
+			body:    map[string]any{"HostArn": "arn:aws:codestar-connections:us-east-1:123:host/myhost"},
+			wantRes: "arn:aws:codestar-connections:us-east-1:123:host/myhost",
+		},
+		{
+			name:    "repository_link_id",
+			body:    map[string]any{"RepositoryLinkId": "repo-link-id-abc"},
+			wantRes: "repo-link-id-abc",
+		},
+		{
+			name:    "resource_name",
+			body:    map[string]any{"ResourceName": "my-stack"},
+			wantRes: "my-stack",
+		},
+		{
+			name:    "empty_body",
+			body:    map[string]any{},
+			wantRes: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			got := h.ExtractResource(c)
+			assert.Equal(t, tt.wantRes, got)
+		})
+	}
+}
+
+// --- Connection parity ---
+
+// TestParity_CreateConnection_WithHostArn verifies HostArn is accepted.
+func TestParity_CreateConnection_WithHostArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body    map[string]any
+		name    string
+		wantArn bool
+		wantOK  bool
+	}{
+		{
+			name: "with_host_arn",
+			body: map[string]any{
+				"ConnectionName": "ghe-conn",
+				"ProviderType":   "GitHubEnterpriseServer",
+				"HostArn":        "arn:aws:codestar-connections:us-east-1:123:host/ghe",
+			},
+			wantArn: true,
+			wantOK:  true,
+		},
+		{
+			name: "without_host_arn",
+			body: map[string]any{
+				"ConnectionName": "gh-conn",
+				"ProviderType":   "GitHub",
+			},
+			wantArn: true,
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doCSCRequest(t, h, "CreateConnection", tt.body)
+
+			if tt.wantOK {
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			if tt.wantArn {
+				resp := parseResp(t, rec)
+				assert.NotEmpty(t, resp["ConnectionArn"])
+			}
+		})
+	}
+}
+
+// TestParity_GetConnection_Fields verifies all expected fields are returned.
+func TestParity_GetConnection_Fields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		connName      string
+		providerType  string
+		wantStatus    string
+		wantOwnerAcct string
+	}{
+		{
+			name:          "github_connection_fields",
+			connName:      "my-gh-conn",
+			providerType:  "GitHub",
+			wantStatus:    "AVAILABLE",
+			wantOwnerAcct: "000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			connArn := createCSCConn(t, h, tt.connName, tt.providerType)
+
+			rec := doCSCRequest(t, h, "GetConnection", map[string]any{"ConnectionArn": connArn})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			conn, ok := resp["Connection"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.connName, conn["ConnectionName"])
+			assert.Equal(t, tt.providerType, conn["ProviderType"])
+			assert.Equal(t, tt.wantStatus, conn["ConnectionStatus"])
+			assert.Equal(t, tt.wantOwnerAcct, conn["OwnerAccountId"])
+			assert.Equal(t, connArn, conn["ConnectionArn"])
+		})
+	}
+}
+
+// TestParity_ListConnections_Sorted verifies connections are returned sorted by name.
+func TestParity_ListConnections_Sorted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		connNames []string
+		wantOrder []string
+	}{
+		{
+			name:      "sorted_alpha",
+			connNames: []string{"zebra-conn", "alpha-conn", "mango-conn"},
+			wantOrder: []string{"alpha-conn", "mango-conn", "zebra-conn"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			for _, n := range tt.connNames {
+				createCSCConn(t, h, n, "GitHub")
+			}
+
+			rec := doCSCRequest(t, h, "ListConnections", map[string]any{})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			conns, ok := resp["Connections"].([]any)
+			require.True(t, ok)
+			require.Len(t, conns, len(tt.wantOrder))
+
+			for i, wantName := range tt.wantOrder {
+				connMap, isMap := conns[i].(map[string]any)
+				require.True(t, isMap)
+				assert.Equal(t, wantName, connMap["ConnectionName"])
+			}
+		})
+	}
+}
+
+// TestParity_ListConnections_HostArnFilter verifies filtering by HostArn.
+func TestParity_ListConnections_HostArnFilter(t *testing.T) {
+	t.Parallel()
+
+	const hostArn = "arn:aws:codestar-connections:us-east-1:123:host/myghe"
+
+	tests := []struct {
+		name        string
+		applyFilter bool
+		wantCount   int
+	}{
+		{name: "no_filter_returns_all", applyFilter: false, wantCount: 2},
+		{name: "host_filter_returns_one", applyFilter: true, wantCount: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := codestarconnections.NewInMemoryBackend("000000000000", "us-east-1")
+			h := codestarconnections.NewHandler(b)
+
+			_, err := b.CreateConnection("ghe-conn", "GitHubEnterpriseServer", hostArn, nil)
+			require.NoError(t, err)
+
+			_, err = b.CreateConnection("gh-conn", "GitHub", "", nil)
+			require.NoError(t, err)
+
+			body := map[string]any{}
+			if tt.applyFilter {
+				body["HostArnFilter"] = hostArn
+			}
+
+			rec := doCSCRequest(t, h, "ListConnections", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			conns, ok := resp["Connections"].([]any)
+			require.True(t, ok)
+			assert.Len(t, conns, tt.wantCount)
+		})
+	}
+}
+
+// --- Host parity ---
+
+// TestParity_GetHost_IncludesHostArn verifies HostArn field in GetHost response.
+func TestParity_GetHost_IncludesHostArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		hostName     string
+		providerType string
+		endpoint     string
+	}{
+		{
+			name:         "host_arn_in_response",
+			hostName:     "my-ghe-host",
+			providerType: "GitHubEnterpriseServer",
+			endpoint:     "https://ghe.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			hostArn := createCSCHost(t, h, tt.hostName, tt.providerType, tt.endpoint)
+
+			rec := doCSCRequest(t, h, "GetHost", map[string]any{"HostArn": hostArn})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			assert.Equal(t, hostArn, resp["HostArn"])
+			assert.Equal(t, tt.hostName, resp["Name"])
+			assert.Equal(t, tt.endpoint, resp["ProviderEndpoint"])
+			assert.Equal(t, tt.providerType, resp["ProviderType"])
+		})
+	}
+}
+
+// TestParity_ListHosts_Sorted verifies hosts are returned sorted by name.
+func TestParity_ListHosts_Sorted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		hostNames []string
+		wantOrder []string
+	}{
+		{
+			name:      "sorted_alpha",
+			hostNames: []string{"zulu-host", "alpha-host", "mike-host"},
+			wantOrder: []string{"alpha-host", "mike-host", "zulu-host"},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			for j, n := range tt.hostNames {
+				createCSCHost(t, h, n, "GitHubEnterpriseServer",
+					"https://ghe"+strconv.Itoa(i)+strconv.Itoa(j)+".example.com")
+			}
+
+			rec := doCSCRequest(t, h, "ListHosts", map[string]any{})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			hosts, ok := resp["Hosts"].([]any)
+			require.True(t, ok)
+			require.Len(t, hosts, len(tt.wantOrder))
+
+			for k, wantName := range tt.wantOrder {
+				hostMap, isMap := hosts[k].(map[string]any)
+				require.True(t, isMap)
+				assert.Equal(t, wantName, hostMap["Name"])
+			}
+		})
+	}
+}
+
+// --- RepositoryLink parity ---
+
+// TestParity_RepositoryLink_ProviderTypeDerived verifies provider type comes from connection.
+func TestParity_RepositoryLink_ProviderTypeDerived(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		providerType string
+	}{
+		{name: "github_provider_derived", providerType: "GitHub"},
+		{name: "gitlab_provider_derived", providerType: "GitLab"},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			connArn := createCSCConn(t, h, "pt-conn-"+strconv.Itoa(i), tt.providerType)
+			linkID := createCSCRepositoryLink(t, h, connArn, "my-repo")
+
+			rec := doCSCRequest(t, h, "GetRepositoryLink", map[string]any{"RepositoryLinkId": linkID})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			info, ok := resp["RepositoryLinkInfo"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.providerType, info["ProviderType"])
+		})
+	}
+}
+
+// TestParity_ListRepositoryLinks_Sorted verifies links are returned sorted by RepositoryLinkId.
+func TestParity_ListRepositoryLinks_Sorted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		linkCount int
+	}{
+		{name: "multiple_links_sorted", linkCount: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			connArn := createCSCConn(t, h, "list-conn", "GitHub")
+
+			for i := range tt.linkCount {
+				createCSCRepositoryLink(t, h, connArn, "repo-"+strconv.Itoa(i))
+			}
+
+			rec := doCSCRequest(t, h, "ListRepositoryLinks", map[string]any{})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			links, ok := resp["RepositoryLinks"].([]any)
+			require.True(t, ok)
+			assert.Len(t, links, tt.linkCount)
+		})
+	}
+}
+
+// --- SyncConfiguration parity ---
+
+// TestParity_SyncConfiguration_RoundTrip exercises full create/get/update/delete cycle.
+func TestParity_SyncConfiguration_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "full_lifecycle"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			connArn := createCSCConn(t, h, "sync-conn", "GitHub")
+			linkID := createCSCRepositoryLink(t, h, connArn, "my-repo")
+
+			// Create
+			createRec := doCSCRequest(t, h, "CreateSyncConfiguration", map[string]any{
+				"Branch":           "main",
+				"ConfigFile":       "sync.yaml",
+				"RepositoryLinkId": linkID,
+				"ResourceName":     "rt-stack",
+				"RoleArn":          "arn:aws:iam::000000000000:role/r",
+				"SyncType":         "CFN_STACK_SYNC",
+			})
+			require.Equal(t, http.StatusOK, createRec.Code)
+
+			resp := parseResp(t, createRec)
+			cfg, ok := resp["SyncConfiguration"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "main", cfg["Branch"])
+			assert.Equal(t, "my-org", cfg["OwnerId"])
+			assert.Equal(t, "GitHub", cfg["ProviderType"])
+
+			// Get
+			getRec := doCSCRequest(t, h, "GetSyncConfiguration", map[string]any{
+				"ResourceName": "rt-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+			})
+			require.Equal(t, http.StatusOK, getRec.Code)
+
+			// Update
+			updRec := doCSCRequest(t, h, "UpdateSyncConfiguration", map[string]any{
+				"ResourceName": "rt-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+				"Branch":       "release",
+			})
+			require.Equal(t, http.StatusOK, updRec.Code)
+			updResp := parseResp(t, updRec)
+			updCfg, ok := updResp["SyncConfiguration"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "release", updCfg["Branch"])
+
+			// List
+			listRec := doCSCRequest(t, h, "ListSyncConfigurations", map[string]any{
+				"RepositoryLinkId": linkID,
+				"SyncType":         "CFN_STACK_SYNC",
+			})
+			require.Equal(t, http.StatusOK, listRec.Code)
+			listResp := parseResp(t, listRec)
+			cfgs, ok := listResp["SyncConfigurations"].([]any)
+			require.True(t, ok)
+			assert.Len(t, cfgs, 1)
+
+			// Delete
+			delRec := doCSCRequest(t, h, "DeleteSyncConfiguration", map[string]any{
+				"ResourceName": "rt-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+			})
+			require.Equal(t, http.StatusOK, delRec.Code)
+
+			// Get after delete should fail
+			afterDelRec := doCSCRequest(t, h, "GetSyncConfiguration", map[string]any{
+				"ResourceName": "rt-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+			})
+			assert.Equal(t, http.StatusBadRequest, afterDelRec.Code)
+		})
+	}
+}
+
+// TestParity_GetRepositorySyncStatus exercises the handler with valid and invalid inputs.
+func TestParity_GetRepositorySyncStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			linkID := "nonexistent-link"
+
+			if tt.preCreate {
+				connArn := createCSCConn(t, h, "sync-status-conn", "GitHub")
+				linkID = createCSCRepositoryLink(t, h, connArn, "my-repo")
+			}
+
+			rec := doCSCRequest(t, h, "GetRepositorySyncStatus", map[string]any{
+				"RepositoryLinkId": linkID,
+				"Branch":           "main",
+				"SyncType":         "CFN_STACK_SYNC",
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				latest, ok := resp["LatestSync"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "SUCCEEDED", latest["Status"])
+				assert.NotEmpty(t, latest["StartedAt"])
+			}
+		})
+	}
+}
+
+// TestParity_GetResourceSyncStatus exercises the handler.
+func TestParity_GetResourceSyncStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+
+			if tt.preCreate {
+				connArn := createCSCConn(t, h, "res-sync-conn", "GitHub")
+				linkID := createCSCRepositoryLink(t, h, connArn, "my-repo")
+				rec := doCSCRequest(t, h, "CreateSyncConfiguration", map[string]any{
+					"Branch":           "main",
+					"ConfigFile":       "sync.yaml",
+					"RepositoryLinkId": linkID,
+					"ResourceName":     "res-sync-stack",
+					"RoleArn":          "arn:aws:iam::000000000000:role/r",
+					"SyncType":         "CFN_STACK_SYNC",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			rec := doCSCRequest(t, h, "GetResourceSyncStatus", map[string]any{
+				"ResourceName": "res-sync-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				latest, ok := resp["LatestSync"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "SUCCEEDED", latest["Status"])
+			}
+		})
+	}
+}
+
+// TestParity_GetSyncBlockerSummary exercises the handler.
+func TestParity_GetSyncBlockerSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+
+			if tt.preCreate {
+				connArn := createCSCConn(t, h, "blocker-conn", "GitHub")
+				linkID := createCSCRepositoryLink(t, h, connArn, "my-repo")
+				rec := doCSCRequest(t, h, "CreateSyncConfiguration", map[string]any{
+					"Branch":           "main",
+					"ConfigFile":       "sync.yaml",
+					"RepositoryLinkId": linkID,
+					"ResourceName":     "blocker-stack",
+					"RoleArn":          "arn:aws:iam::000000000000:role/r",
+					"SyncType":         "CFN_STACK_SYNC",
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+
+			rec := doCSCRequest(t, h, "GetSyncBlockerSummary", map[string]any{
+				"ResourceName": "blocker-stack",
+				"SyncType":     "CFN_STACK_SYNC",
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				summary, ok := resp["SyncBlockerSummary"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "blocker-stack", summary["ResourceName"])
+			}
+		})
+	}
+}
+
+// TestParity_ListRepositorySyncDefinitions exercises the handler.
+func TestParity_ListRepositorySyncDefinitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success_empty",
+			preCreate:  true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			linkID := "nonexistent"
+
+			if tt.preCreate {
+				connArn := createCSCConn(t, h, "def-conn", "GitHub")
+				linkID = createCSCRepositoryLink(t, h, connArn, "my-repo")
+			}
+
+			rec := doCSCRequest(t, h, "ListRepositorySyncDefinitions", map[string]any{
+				"RepositoryLinkId": linkID,
+				"SyncType":         "CFN_STACK_SYNC",
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				defs, ok := resp["RepositorySyncDefinitions"].([]any)
+				require.True(t, ok)
+				assert.NotNil(t, defs)
+			}
+		})
+	}
+}
+
+// TestParity_UpdateSyncBlocker_RequiresId verifies Id is required.
+func TestParity_UpdateSyncBlocker_RequiresId(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		id         string
+		wantStatus int
+	}{
+		{
+			name:       "with_id",
+			id:         "blocker-abc",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing_id",
+			id:         "",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			body := map[string]any{
+				"ResolvedReason": "fixed",
+				"ResourceName":   "my-stack",
+				"SyncType":       "CFN_STACK_SYNC",
+			}
+			if tt.id != "" {
+				body["Id"] = tt.id
+			}
+
+			rec := doCSCRequest(t, h, "UpdateSyncBlocker", body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// --- Tagging parity ---
+
+// TestParity_Tags_NonNilOnList verifies Tags field is always non-nil (empty slice not null).
+func TestParity_Tags_NonNilOnList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "empty_tags_not_null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			connArn := createCSCConn(t, h, "tags-test-conn", "GitHub")
+
+			rec := doCSCRequest(t, h, "ListTagsForResource", map[string]any{"ResourceArn": connArn})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			tags, ok := resp["Tags"].([]any)
+			require.True(t, ok, "Tags must be an array, not null")
+			assert.Empty(t, tags)
+		})
+	}
+}
+
+// TestParity_TagResource_OnHost verifies tags can be managed on hosts.
+func TestParity_TagResource_OnHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "tag_untag_host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			hostArn := createCSCHost(t, h, "tag-host", "GitHubEnterpriseServer", "https://ghe.example.com")
+
+			tagRec := doCSCRequest(t, h, "TagResource", map[string]any{
+				"ResourceArn": hostArn,
+				"Tags":        []map[string]string{{"Key": "Env", "Value": "prod"}, {"Key": "Owner", "Value": "ops"}},
+			})
+			require.Equal(t, http.StatusOK, tagRec.Code)
+
+			listRec := doCSCRequest(t, h, "ListTagsForResource", map[string]any{"ResourceArn": hostArn})
+			require.Equal(t, http.StatusOK, listRec.Code)
+			resp := parseResp(t, listRec)
+			tags, ok := resp["Tags"].([]any)
+			require.True(t, ok)
+			assert.Len(t, tags, 2)
+
+			untagRec := doCSCRequest(t, h, "UntagResource", map[string]any{
+				"ResourceArn": hostArn,
+				"TagKeys":     []string{"Owner"},
+			})
+			require.Equal(t, http.StatusOK, untagRec.Code)
+
+			listRec2 := doCSCRequest(t, h, "ListTagsForResource", map[string]any{"ResourceArn": hostArn})
+			require.Equal(t, http.StatusOK, listRec2.Code)
+			resp2 := parseResp(t, listRec2)
+			tags2, ok := resp2["Tags"].([]any)
+			require.True(t, ok)
+			assert.Len(t, tags2, 1)
+		})
+	}
+}
+
+// --- UpdateRepositoryLink parity ---
+
+// TestParity_UpdateRepositoryLink exercises the handler.
+func TestParity_UpdateRepositoryLink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		newConnArn string
+		wantStatus int
+		preCreate  bool
+	}{
+		{
+			name:       "success",
+			preCreate:  true,
+			newConnArn: "arn:aws:codestar-connections:us-east-1:123:connection/new",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not_found",
+			preCreate:  false,
+			newConnArn: "arn:aws:codestar-connections:us-east-1:123:connection/new",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			linkID := "nonexistent"
+
+			if tt.preCreate {
+				connArn := createCSCConn(t, h, "upd-link-conn", "GitHub")
+				linkID = createCSCRepositoryLink(t, h, connArn, "my-repo")
+			}
+
+			rec := doCSCRequest(t, h, "UpdateRepositoryLink", map[string]any{
+				"RepositoryLinkId": linkID,
+				"ConnectionArn":    tt.newConnArn,
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				resp := parseResp(t, rec)
+				info, ok := resp["RepositoryLinkInfo"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, tt.newConnArn, info["ConnectionArn"])
+			}
+		})
+	}
+}
+
+// --- Provider parity ---
+
+// TestParity_Provider_NilCtx verifies codestarconnections Provider.Init requires non-nil ctx.
+func TestParity_Provider_NilCtx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "nil_ctx_returns_error", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &codestarconnections.Provider{}
+			reg, err := p.Init(nil)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, reg)
+				assert.ErrorIs(t, err, codestarconnections.ErrNilAppContext)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, reg)
+			}
+		})
+	}
+}

--- a/test/e2e/codeconnections_test.go
+++ b/test/e2e/codeconnections_test.go
@@ -16,7 +16,7 @@ import (
 func TestCodeConnectionsDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	_, err := stack.CodeConnectionsHandler.Backend.CreateConnection("e2e-test-conn", "GitHub", nil)
+	_, err := stack.CodeConnectionsHandler.Backend.CreateConnection("e2e-test-conn", "GitHub", "", nil)
 	require.NoError(t, err)
 
 	server := httptest.NewServer(stack.Echo)


### PR DESCRIPTION
AWS-accuracy audit for services/codeconnections + services/codestarconnections. Closes #1774. Polecat: obsidian.