### PR TITLE
feat(cloudwatchlogs): batch-2 AWS-accuracy audit (go-9xm2)

### DIFF
--- a/services/cloudwatchlogs/backend_completeness.go
+++ b/services/cloudwatchlogs/backend_completeness.go
@@ -22,9 +22,9 @@ var (
 
 // ResourcePolicy represents a CloudWatch Logs resource policy.
 type ResourcePolicy struct {
-	LastUpdated    time.Time
-	PolicyName     string
-	PolicyDocument string
+	LastUpdated    time.Time `json:"-"`
+	PolicyName     string    `json:"policyName"`
+	PolicyDocument string    `json:"policyDocument"`
 }
 
 // PutResourcePolicy creates or updates a resource-based policy.
@@ -85,7 +85,7 @@ type DeliveryDestination struct {
 	Arn          string            `json:"arn"`
 	OutputFormat string            `json:"outputFormat,omitempty"`
 	TargetArn    string            `json:"deliveryDestinationConfiguration,omitempty"`
-	Policy       string            `json:"-"`
+	Policy       string            `json:"policy,omitempty"`
 }
 
 // PutDeliveryDestination creates or updates a delivery destination.

--- a/services/cloudwatchlogs/completeness_test.go
+++ b/services/cloudwatchlogs/completeness_test.go
@@ -22,50 +22,105 @@ func newTestBackend(t *testing.T) *cloudwatchlogs.InMemoryBackend {
 func TestResourcePolicy_CRUD(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_and_describe",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				p, err := b.PutResourcePolicy("my-policy", `{"Version":"2012-10-17"}`)
+				require.NoError(t, err)
+				assert.Equal(t, "my-policy", p.PolicyName)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeResourcePolicies()
+				require.Len(t, policies, 1)
+				assert.Equal(t, "my-policy", policies[0].PolicyName)
+				assert.Equal(t, `{"Version":"2012-10-17"}`, policies[0].PolicyDocument)
+			},
+		},
+		{
+			name: "put_multiple_sorted",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutResourcePolicy("z-policy", `{}`)
+				require.NoError(t, err)
+				_, err = b.PutResourcePolicy("a-policy", `{}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeResourcePolicies()
+				require.Len(t, policies, 2)
+				assert.Equal(t, "a-policy", policies[0].PolicyName)
+				assert.Equal(t, "z-policy", policies[1].PolicyName)
+			},
+		},
+		{
+			name: "put_updates_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutResourcePolicy("my-policy", `{"old":"doc"}`)
+				require.NoError(t, err)
+				_, err = b.PutResourcePolicy("my-policy", `{"new":"doc"}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeResourcePolicies()
+				require.Len(t, policies, 1)
+				assert.Equal(t, `{"new":"doc"}`, policies[0].PolicyDocument)
+			},
+		},
+		{
+			name: "delete_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutResourcePolicy("del-policy", `{}`)
+				require.NoError(t, err)
+				err = b.DeleteResourcePolicy("del-policy")
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				assert.Empty(t, b.DescribeResourcePolicies())
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteResourcePolicy("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrResourcePolicyNotFound)
+			},
+		},
+		{
+			name: "empty_name_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutResourcePolicy("", `{}`)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+	}
 
-	t.Run("PutAndDescribe", func(t *testing.T) {
-		t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		bb := newTestBackend(t)
-
-		p, err := bb.PutResourcePolicy("my-policy", `{"Version":"2012-10-17"}`)
-		require.NoError(t, err)
-		assert.Equal(t, "my-policy", p.PolicyName)
-
-		policies := bb.DescribeResourcePolicies()
-		assert.Len(t, policies, 1)
-		assert.Equal(t, "my-policy", policies[0].PolicyName)
-	})
-
-	t.Run("Delete", func(t *testing.T) {
-		t.Parallel()
-
-		bb := newTestBackend(t)
-
-		_, err := bb.PutResourcePolicy("del-policy", `{}`)
-		require.NoError(t, err)
-
-		err = bb.DeleteResourcePolicy("del-policy")
-		require.NoError(t, err)
-
-		policies := bb.DescribeResourcePolicies()
-		assert.Empty(t, policies)
-	})
-
-	t.Run("DeleteNotFound", func(t *testing.T) {
-		t.Parallel()
-
-		err := b.DeleteResourcePolicy("ghost")
-		require.Error(t, err)
-	})
-
-	t.Run("EmptyName", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := b.PutResourcePolicy("", `{}`)
-		require.Error(t, err)
-	})
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- DeliveryDestination ----
@@ -73,52 +128,140 @@ func TestResourcePolicy_CRUD(t *testing.T) {
 func TestDeliveryDestination_CRUD(t *testing.T) {
 	t.Parallel()
 
-	t.Run("PutGetDescribeDelete", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_get_describe_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dest, err := b.PutDeliveryDestination("my-dest", "arn:aws:s3:::my-bucket", "JSON", nil)
+				require.NoError(t, err)
+				assert.Equal(t, "my-dest", dest.Name)
+				assert.NotEmpty(t, dest.Arn)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetDeliveryDestination("my-dest")
+				require.NoError(t, err)
+				assert.Equal(t, "arn:aws:s3:::my-bucket", got.TargetArn)
 
-		b := newTestBackend(t)
+				dests := b.DescribeDeliveryDestinations()
+				require.Len(t, dests, 1)
 
-		dest, err := b.PutDeliveryDestination("my-dest", "arn:aws:s3:::my-bucket", "JSON", nil)
-		require.NoError(t, err)
-		assert.Equal(t, "my-dest", dest.Name)
-		assert.NotEmpty(t, dest.Arn)
+				err = b.DeleteDeliveryDestination("my-dest")
+				require.NoError(t, err)
 
-		got, err := b.GetDeliveryDestination("my-dest")
-		require.NoError(t, err)
-		assert.Equal(t, "arn:aws:s3:::my-bucket", got.TargetArn)
+				_, err = b.GetDeliveryDestination("my-dest")
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "put_updates_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliveryDestination("dest1", "arn:aws:s3:::old", "JSON", nil)
+				require.NoError(t, err)
+				_, err = b.PutDeliveryDestination("dest1", "arn:aws:s3:::new", "TEXT", nil)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetDeliveryDestination("dest1")
+				require.NoError(t, err)
+				assert.Equal(t, "arn:aws:s3:::new", got.TargetArn)
+				assert.Equal(t, "TEXT", got.OutputFormat)
+			},
+		},
+		{
+			name: "get_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.GetDeliveryDestination("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDeliveryDestinationNotFound)
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteDeliveryDestination("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDeliveryDestinationNotFound)
+			},
+		},
+		{
+			name: "policy_put_get_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliveryDestination("policy-dest", "arn:aws:s3:::bucket", "JSON", nil)
+				require.NoError(t, err)
+				err = b.PutDeliveryDestinationPolicy("policy-dest", `{"Statement":[]}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policy, err := b.GetDeliveryDestinationPolicy("policy-dest")
+				require.NoError(t, err)
+				assert.Contains(t, policy, "Statement")
 
-		dests := b.DescribeDeliveryDestinations()
-		assert.Len(t, dests, 1)
+				err = b.DeleteDeliveryDestinationPolicy("policy-dest")
+				require.NoError(t, err)
 
-		err = b.DeleteDeliveryDestination("my-dest")
-		require.NoError(t, err)
+				policy, err = b.GetDeliveryDestinationPolicy("policy-dest")
+				require.NoError(t, err)
+				assert.Empty(t, policy)
+			},
+		},
+		{
+			name: "policy_on_nonexistent_dest_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutDeliveryDestinationPolicy("ghost", `{}`)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDeliveryDestinationNotFound)
+			},
+		},
+		{
+			name: "put_empty_name_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliveryDestination("", "arn:aws:s3:::b", "JSON", nil)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+		{
+			name: "describe_sorted_by_name",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliveryDestination("z-dest", "arn:aws:s3:::z", "JSON", nil)
+				require.NoError(t, err)
+				_, err = b.PutDeliveryDestination("a-dest", "arn:aws:s3:::a", "JSON", nil)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dests := b.DescribeDeliveryDestinations()
+				require.Len(t, dests, 2)
+				assert.Equal(t, "a-dest", dests[0].Name)
+				assert.Equal(t, "z-dest", dests[1].Name)
+			},
+		},
+	}
 
-		_, err = b.GetDeliveryDestination("my-dest")
-		require.Error(t, err)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("Policy", func(t *testing.T) {
-		t.Parallel()
-
-		b := newTestBackend(t)
-
-		_, err := b.PutDeliveryDestination("policy-dest", "arn:aws:s3:::bucket", "JSON", nil)
-		require.NoError(t, err)
-
-		err = b.PutDeliveryDestinationPolicy("policy-dest", `{"Statement":[]}`)
-		require.NoError(t, err)
-
-		policy, err := b.GetDeliveryDestinationPolicy("policy-dest")
-		require.NoError(t, err)
-		assert.Contains(t, policy, "Statement")
-
-		err = b.DeleteDeliveryDestinationPolicy("policy-dest")
-		require.NoError(t, err)
-
-		policy, err = b.GetDeliveryDestinationPolicy("policy-dest")
-		require.NoError(t, err)
-		assert.Empty(t, policy)
-	})
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- DeliverySource ----
@@ -126,60 +269,238 @@ func TestDeliveryDestination_CRUD(t *testing.T) {
 func TestDeliverySource_CRUD(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_get_describe_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				src, err := b.PutDeliverySource("my-src", "APPLICATION_LOGS", []string{"arn:aws:ec2:::instance/i-123"}, nil)
+				require.NoError(t, err)
+				assert.Equal(t, "my-src", src.Name)
+				assert.NotEmpty(t, src.Arn)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetDeliverySource("my-src")
+				require.NoError(t, err)
+				assert.Equal(t, "APPLICATION_LOGS", got.LogType)
+				assert.Len(t, got.ResourceArns, 1)
 
-	src, err := b.PutDeliverySource("my-src", "APPLICATION_LOGS", []string{"arn:aws:ec2:::instance/i-123"}, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "my-src", src.Name)
-	assert.NotEmpty(t, src.Arn)
+				srcs := b.DescribeDeliverySources()
+				require.Len(t, srcs, 1)
 
-	got, err := b.GetDeliverySource("my-src")
-	require.NoError(t, err)
-	assert.Equal(t, "APPLICATION_LOGS", got.LogType)
+				err = b.DeleteDeliverySource("my-src")
+				require.NoError(t, err)
 
-	srcs := b.DescribeDeliverySources()
-	assert.Len(t, srcs, 1)
+				_, err = b.GetDeliverySource("my-src")
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "put_updates_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliverySource("src1", "FLOW_LOGS", []string{"arn:old"}, nil)
+				require.NoError(t, err)
+				_, err = b.PutDeliverySource("src1", "VPC_FLOW_LOGS", []string{"arn:new"}, nil)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetDeliverySource("src1")
+				require.NoError(t, err)
+				assert.Equal(t, "VPC_FLOW_LOGS", got.LogType)
+				require.Len(t, got.ResourceArns, 1)
+				assert.Equal(t, "arn:new", got.ResourceArns[0])
+			},
+		},
+		{
+			name: "get_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.GetDeliverySource("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDeliverySourceNotFound)
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteDeliverySource("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDeliverySourceNotFound)
+			},
+		},
+		{
+			name: "put_empty_name_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliverySource("", "FLOW_LOGS", nil, nil)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+		{
+			name: "describe_sorted_by_name",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliverySource("z-src", "FLOW_LOGS", nil, nil)
+				require.NoError(t, err)
+				_, err = b.PutDeliverySource("a-src", "FLOW_LOGS", nil, nil)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				srcs := b.DescribeDeliverySources()
+				require.Len(t, srcs, 2)
+				assert.Equal(t, "a-src", srcs[0].Name)
+				assert.Equal(t, "z-src", srcs[1].Name)
+			},
+		},
+	}
 
-	err = b.DeleteDeliverySource("my-src")
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = b.GetDeliverySource("my-src")
-	require.Error(t, err)
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
-// ---- Destination ----
+// ---- Destination (log routing) ----
 
 func TestDestination_CRUD(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_describe_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dest, err := b.PutDestination("my-dest", "arn:aws:kinesis:::stream/s", "arn:aws:iam:::role/r")
+				require.NoError(t, err)
+				assert.Equal(t, "my-dest", dest.DestinationName)
+				assert.NotEmpty(t, dest.Arn)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dests := b.DescribeDestinations("")
+				require.Len(t, dests, 1)
 
-	dest, err := b.PutDestination("my-dest", "arn:aws:kinesis:::stream/my-stream", "arn:aws:iam:::role/my-role")
-	require.NoError(t, err)
-	assert.Equal(t, "my-dest", dest.DestinationName)
-	assert.NotEmpty(t, dest.Arn)
+				err := b.DeleteDestination("my-dest")
+				require.NoError(t, err)
 
-	// PutDestinationPolicy
-	err = b.PutDestinationPolicy("my-dest", `{"Statement":[]}`)
-	require.NoError(t, err)
+				dests = b.DescribeDestinations("")
+				assert.Empty(t, dests)
+			},
+		},
+		{
+			name: "put_updates_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDestination("dest1", "arn:old", "arn:role-old")
+				require.NoError(t, err)
+				_, err = b.PutDestination("dest1", "arn:new", "arn:role-new")
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dests := b.DescribeDestinations("")
+				require.Len(t, dests, 1)
+				assert.Equal(t, "arn:new", dests[0].TargetArn)
+				assert.Equal(t, "arn:role-new", dests[0].RoleArn)
+			},
+		},
+		{
+			name: "put_destination_policy",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDestination("my-dest", "arn:aws:kinesis:::stream/s", "arn:aws:iam:::role/r")
+				require.NoError(t, err)
+				err = b.PutDestinationPolicy("my-dest", `{"Statement":[]}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dests := b.DescribeDestinations("")
+				require.Len(t, dests, 1)
+				assert.JSONEq(t, `{"Statement":[]}`, dests[0].AccessPolicy)
+			},
+		},
+		{
+			name: "describe_prefix_filter",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDestination("prod-dest", "arn:a", "arn:r")
+				require.NoError(t, err)
+				_, err = b.PutDestination("dev-dest", "arn:b", "arn:r")
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				all := b.DescribeDestinations("")
+				assert.Len(t, all, 2)
 
-	// DescribeDestinations
-	dests := b.DescribeDestinations("")
-	assert.Len(t, dests, 1)
-	assert.JSONEq(t, `{"Statement":[]}`, dests[0].AccessPolicy)
+				prod := b.DescribeDestinations("prod")
+				require.Len(t, prod, 1)
+				assert.Equal(t, "prod-dest", prod[0].DestinationName)
 
-	// Filter by prefix
-	dests = b.DescribeDestinations("my")
-	assert.Len(t, dests, 1)
-	dests = b.DescribeDestinations("other")
-	assert.Empty(t, dests)
+				none := b.DescribeDestinations("nonexistent")
+				assert.Empty(t, none)
+			},
+		},
+		{
+			name: "put_policy_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutDestinationPolicy("ghost", `{}`)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDestinationNotFound)
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteDestination("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrDestinationNotFound)
+			},
+		},
+		{
+			name: "put_empty_name_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDestination("", "arn:a", "arn:r")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+	}
 
-	// Delete
-	err = b.DeleteDestination("my-dest")
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	dests = b.DescribeDestinations("")
-	assert.Empty(t, dests)
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- IndexPolicy ----
@@ -187,23 +508,95 @@ func TestDestination_CRUD(t *testing.T) {
 func TestIndexPolicy_CRUD(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_describe_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				p, err := b.PutIndexPolicy("/aws/lambda/fn", `{"fields":["@message"]}`)
+				require.NoError(t, err)
+				assert.Equal(t, "/aws/lambda/fn", p.LogGroupIdentifier)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeIndexPolicies()
+				require.Len(t, policies, 1)
+				assert.Equal(t, "/aws/lambda/fn", policies[0].LogGroupIdentifier)
 
-	p, err := b.PutIndexPolicy("/aws/lambda/my-fn", `{"fields":["@message"]}`)
-	require.NoError(t, err)
-	assert.Equal(t, "/aws/lambda/my-fn", p.LogGroupIdentifier)
+				err := b.DeleteIndexPolicy("/aws/lambda/fn")
+				require.NoError(t, err)
 
-	policies := b.DescribeIndexPolicies()
-	assert.Len(t, policies, 1)
+				assert.Empty(t, b.DescribeIndexPolicies())
+			},
+		},
+		{
+			name: "put_updates_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIndexPolicy("/grp", `{"old":"policy"}`)
+				require.NoError(t, err)
+				_, err = b.PutIndexPolicy("/grp", `{"new":"policy"}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeIndexPolicies()
+				require.Len(t, policies, 1)
+				assert.Equal(t, `{"new":"policy"}`, policies[0].PolicyDocument)
+			},
+		},
+		{
+			name: "describe_sorted_by_identifier",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIndexPolicy("/z-grp", `{}`)
+				require.NoError(t, err)
+				_, err = b.PutIndexPolicy("/a-grp", `{}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeIndexPolicies()
+				require.Len(t, policies, 2)
+				assert.Equal(t, "/a-grp", policies[0].LogGroupIdentifier)
+				assert.Equal(t, "/z-grp", policies[1].LogGroupIdentifier)
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteIndexPolicy("nonexistent")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrIndexPolicyNotFound)
+			},
+		},
+		{
+			name: "put_empty_identifier_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIndexPolicy("", `{}`)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+	}
 
-	err = b.DeleteIndexPolicy("/aws/lambda/my-fn")
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	policies = b.DescribeIndexPolicies()
-	assert.Empty(t, policies)
-
-	err = b.DeleteIndexPolicy("nonexistent")
-	require.Error(t, err)
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- Transformer ----
@@ -211,25 +604,92 @@ func TestIndexPolicy_CRUD(t *testing.T) {
 func TestTransformer_CRUD(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
-
-	processors := []map[string]any{
+	baseProcessors := []map[string]any{
 		{"parseJSON": map[string]any{}},
 	}
 
-	err := b.PutTransformer("/aws/lambda/my-fn", processors)
-	require.NoError(t, err)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_get_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutTransformer("/aws/lambda/fn", baseProcessors)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				tr, err := b.GetTransformer("/aws/lambda/fn")
+				require.NoError(t, err)
+				assert.Equal(t, "/aws/lambda/fn", tr.LogGroupIdentifier)
+				require.Len(t, tr.Processors, 1)
 
-	tr, err := b.GetTransformer("/aws/lambda/my-fn")
-	require.NoError(t, err)
-	assert.Equal(t, "/aws/lambda/my-fn", tr.LogGroupIdentifier)
-	assert.Len(t, tr.Processors, 1)
+				err = b.DeleteTransformer("/aws/lambda/fn")
+				require.NoError(t, err)
 
-	err = b.DeleteTransformer("/aws/lambda/my-fn")
-	require.NoError(t, err)
+				_, err = b.GetTransformer("/aws/lambda/fn")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrTransformerNotFound)
+			},
+		},
+		{
+			name: "put_updates_existing",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutTransformer("/grp", baseProcessors)
+				require.NoError(t, err)
+				two := []map[string]any{{"parseJSON": map[string]any{}}, {"addField": map[string]any{"key": "v"}}}
+				err = b.PutTransformer("/grp", two)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				tr, err := b.GetTransformer("/grp")
+				require.NoError(t, err)
+				assert.Len(t, tr.Processors, 2)
+			},
+		},
+		{
+			name: "get_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.GetTransformer("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrTransformerNotFound)
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteTransformer("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrTransformerNotFound)
+			},
+		},
+		{
+			name: "put_empty_identifier_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutTransformer("", baseProcessors)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+	}
 
-	_, err = b.GetTransformer("/aws/lambda/my-fn")
-	require.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- Integration ----
@@ -237,25 +697,92 @@ func TestTransformer_CRUD(t *testing.T) {
 func TestIntegration_CRUD(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "put_get_list_delete",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				ig, err := b.PutIntegration("my-opensearch", "OPENSEARCH")
+				require.NoError(t, err)
+				assert.Equal(t, "my-opensearch", ig.Name)
+				assert.Equal(t, "ACTIVE", ig.Status)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetIntegration("my-opensearch")
+				require.NoError(t, err)
+				assert.Equal(t, "OPENSEARCH", got.Type)
 
-	ig, err := b.PutIntegration("my-opensearch", "OPENSEARCH")
-	require.NoError(t, err)
-	assert.Equal(t, "my-opensearch", ig.Name)
-	assert.Equal(t, "ACTIVE", ig.Status)
+				igs := b.ListIntegrations()
+				require.Len(t, igs, 1)
 
-	got, err := b.GetIntegration("my-opensearch")
-	require.NoError(t, err)
-	assert.Equal(t, "OPENSEARCH", got.Type)
+				err = b.DeleteIntegration("my-opensearch")
+				require.NoError(t, err)
 
-	igs := b.ListIntegrations()
-	assert.Len(t, igs, 1)
+				_, err = b.GetIntegration("my-opensearch")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrIntegrationNotFound)
+			},
+		},
+		{
+			name: "list_multiple_sorted",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIntegration("z-integration", "OPENSEARCH")
+				require.NoError(t, err)
+				_, err = b.PutIntegration("a-integration", "OPENSEARCH")
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				igs := b.ListIntegrations()
+				require.Len(t, igs, 2)
+				assert.Equal(t, "a-integration", igs[0].Name)
+				assert.Equal(t, "z-integration", igs[1].Name)
+			},
+		},
+		{
+			name: "get_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.GetIntegration("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrIntegrationNotFound)
+			},
+		},
+		{
+			name: "delete_not_found_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.DeleteIntegration("ghost")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrIntegrationNotFound)
+			},
+		},
+		{
+			name: "put_empty_name_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIntegration("", "OPENSEARCH")
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+	}
 
-	err = b.DeleteIntegration("my-opensearch")
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = b.GetIntegration("my-opensearch")
-	require.Error(t, err)
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- LogGroupDeletionProtection ----
@@ -263,17 +790,80 @@ func TestIntegration_CRUD(t *testing.T) {
 func TestLogGroupDeletionProtection(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "default_is_false",
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				assert.False(t, b.IsLogGroupDeletionProtected("/aws/lambda/fn"))
+			},
+		},
+		{
+			name: "enable_protection",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.SetLogGroupDeletionProtection("/aws/lambda/fn", true)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				assert.True(t, b.IsLogGroupDeletionProtected("/aws/lambda/fn"))
+			},
+		},
+		{
+			name: "disable_protection",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.SetLogGroupDeletionProtection("/aws/lambda/fn", true)
+				require.NoError(t, err)
+				err = b.SetLogGroupDeletionProtection("/aws/lambda/fn", false)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				assert.False(t, b.IsLogGroupDeletionProtected("/aws/lambda/fn"))
+			},
+		},
+		{
+			name: "groups_are_independent",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.SetLogGroupDeletionProtection("/grp-a", true)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				assert.True(t, b.IsLogGroupDeletionProtected("/grp-a"))
+				assert.False(t, b.IsLogGroupDeletionProtected("/grp-b"))
+			},
+		},
+		{
+			name: "empty_identifier_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.SetLogGroupDeletionProtection("", true)
+				require.ErrorIs(t, err, cloudwatchlogs.ErrValidation)
+			},
+		},
+	}
 
-	assert.False(t, b.IsLogGroupDeletionProtected("/aws/lambda/my-fn"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	err := b.SetLogGroupDeletionProtection("/aws/lambda/my-fn", true)
-	require.NoError(t, err)
-	assert.True(t, b.IsLogGroupDeletionProtected("/aws/lambda/my-fn"))
-
-	err = b.SetLogGroupDeletionProtection("/aws/lambda/my-fn", false)
-	require.NoError(t, err)
-	assert.False(t, b.IsLogGroupDeletionProtected("/aws/lambda/my-fn"))
+			b := newTestBackend(t)
+			if tt.setup != nil {
+				tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b)
+			}
+		})
+	}
 }
 
 // ---- UpdateDeliveryConfiguration ----
@@ -281,23 +871,104 @@ func TestLogGroupDeletionProtection(t *testing.T) {
 func TestUpdateDeliveryConfiguration(t *testing.T) {
 	t.Parallel()
 
-	b := newTestBackend(t)
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) string
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend, deliveryID string)
+		name   string
+	}{
+		{
+			name: "update_field_delimiter",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) string {
+				t.Helper()
+				_, err := b.CreateDelivery("src", "arn:aws:logs:::delivery-destination:dst", nil)
+				require.NoError(t, err)
+				deliveries, _, err := b.DescribeDeliveries(100, "")
+				require.NoError(t, err)
+				require.Len(t, deliveries, 1)
+				id := deliveries[0].ID
+				err = b.UpdateDeliveryConfiguration(id, ",", nil)
+				require.NoError(t, err)
 
-	_, err := b.CreateDelivery("src", "arn:aws:logs:::delivery-destination:dst", nil)
-	require.NoError(t, err)
+				return id
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend, _ string) {
+				t.Helper()
+				deliveries, _, err := b.DescribeDeliveries(100, "")
+				require.NoError(t, err)
+				require.Len(t, deliveries, 1)
+				assert.Equal(t, ",", deliveries[0].FieldDelimiter)
+			},
+		},
+		{
+			name: "update_record_fields",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) string {
+				t.Helper()
+				_, err := b.CreateDelivery("src", "arn:aws:logs:::delivery-destination:dst", nil)
+				require.NoError(t, err)
+				deliveries, _, err := b.DescribeDeliveries(100, "")
+				require.NoError(t, err)
+				require.Len(t, deliveries, 1)
+				id := deliveries[0].ID
+				err = b.UpdateDeliveryConfiguration(id, "", []string{"@timestamp", "@message"})
+				require.NoError(t, err)
 
-	deliveries, _, err := b.DescribeDeliveries(100, "")
-	require.NoError(t, err)
-	require.Len(t, deliveries, 1)
+				return id
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend, _ string) {
+				t.Helper()
+				deliveries, _, err := b.DescribeDeliveries(100, "")
+				require.NoError(t, err)
+				assert.Equal(t, []string{"@timestamp", "@message"}, deliveries[0].RecordFields)
+			},
+		},
+		{
+			name: "update_both_delimiter_and_fields",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) string {
+				t.Helper()
+				_, err := b.CreateDelivery("src", "arn:aws:logs:::delivery-destination:dst", nil)
+				require.NoError(t, err)
+				deliveries, _, err := b.DescribeDeliveries(100, "")
+				require.NoError(t, err)
+				require.Len(t, deliveries, 1)
+				id := deliveries[0].ID
+				err = b.UpdateDeliveryConfiguration(id, "\t", []string{"@timestamp", "@message", "@logStream"})
+				require.NoError(t, err)
 
-	deliveryID := deliveries[0].ID
+				return id
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend, _ string) {
+				t.Helper()
+				deliveries, _, err := b.DescribeDeliveries(100, "")
+				require.NoError(t, err)
+				require.Len(t, deliveries, 1)
+				assert.Equal(t, "\t", deliveries[0].FieldDelimiter)
+				assert.Equal(t, []string{"@timestamp", "@message", "@logStream"}, deliveries[0].RecordFields)
+			},
+		},
+		{
+			name: "update_nonexistent_delivery_errors",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) string {
+				t.Helper()
+				err := b.UpdateDeliveryConfiguration("nonexistent-id", ",", nil)
+				require.Error(t, err)
 
-	err = b.UpdateDeliveryConfiguration(deliveryID, ",", []string{"@timestamp", "@message"})
-	require.NoError(t, err)
+				return ""
+			},
+		},
+	}
 
-	// Verify update persisted.
-	deliveries, _, err = b.DescribeDeliveries(100, "")
-	require.NoError(t, err)
-	assert.Equal(t, ",", deliveries[0].FieldDelimiter)
-	assert.Equal(t, []string{"@timestamp", "@message"}, deliveries[0].RecordFields)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBackend(t)
+			var deliveryID string
+			if tt.setup != nil {
+				deliveryID = tt.setup(t, b)
+			}
+			if tt.verify != nil {
+				tt.verify(t, b, deliveryID)
+			}
+		})
+	}
 }

--- a/services/cloudwatchlogs/completeness_test.go
+++ b/services/cloudwatchlogs/completeness_test.go
@@ -40,7 +40,7 @@ func TestResourcePolicy_CRUD(t *testing.T) {
 				policies := b.DescribeResourcePolicies()
 				require.Len(t, policies, 1)
 				assert.Equal(t, "my-policy", policies[0].PolicyName)
-				assert.Equal(t, `{"Version":"2012-10-17"}`, policies[0].PolicyDocument)
+				assert.JSONEq(t, `{"Version":"2012-10-17"}`, policies[0].PolicyDocument)
 			},
 		},
 		{
@@ -73,7 +73,7 @@ func TestResourcePolicy_CRUD(t *testing.T) {
 				t.Helper()
 				policies := b.DescribeResourcePolicies()
 				require.Len(t, policies, 1)
-				assert.Equal(t, `{"new":"doc"}`, policies[0].PolicyDocument)
+				assert.JSONEq(t, `{"new":"doc"}`, policies[0].PolicyDocument)
 			},
 		},
 		{
@@ -278,7 +278,12 @@ func TestDeliverySource_CRUD(t *testing.T) {
 			name: "put_get_describe_delete",
 			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
 				t.Helper()
-				src, err := b.PutDeliverySource("my-src", "APPLICATION_LOGS", []string{"arn:aws:ec2:::instance/i-123"}, nil)
+				src, err := b.PutDeliverySource(
+					"my-src",
+					"APPLICATION_LOGS",
+					[]string{"arn:aws:ec2:::instance/i-123"},
+					nil,
+				)
 				require.NoError(t, err)
 				assert.Equal(t, "my-src", src.Name)
 				assert.NotEmpty(t, src.Arn)
@@ -546,7 +551,7 @@ func TestIndexPolicy_CRUD(t *testing.T) {
 				t.Helper()
 				policies := b.DescribeIndexPolicies()
 				require.Len(t, policies, 1)
-				assert.Equal(t, `{"new":"policy"}`, policies[0].PolicyDocument)
+				assert.JSONEq(t, `{"new":"policy"}`, policies[0].PolicyDocument)
 			},
 		},
 		{

--- a/services/cloudwatchlogs/handler.go
+++ b/services/cloudwatchlogs/handler.go
@@ -1961,7 +1961,11 @@ func (h *Handler) handleError(ctx context.Context, c *echo.Context, action strin
 		errors.Is(reqErr, ErrExportTaskNotFound), errors.Is(reqErr, ErrImportTaskNotFound),
 		errors.Is(reqErr, ErrDeliveryNotFound), errors.Is(reqErr, ErrLogAnomalyDetectorNotFound),
 		errors.Is(reqErr, ErrScheduledQueryNotFound), errors.Is(reqErr, ErrMetricFilterNotFound),
-		errors.Is(reqErr, ErrQueryDefinitionNotFound):
+		errors.Is(reqErr, ErrQueryDefinitionNotFound),
+		errors.Is(reqErr, ErrResourcePolicyNotFound), errors.Is(reqErr, ErrDeliveryDestinationNotFound),
+		errors.Is(reqErr, ErrDeliverySourceNotFound), errors.Is(reqErr, ErrDestinationNotFound),
+		errors.Is(reqErr, ErrIndexPolicyNotFound), errors.Is(reqErr, ErrTransformerNotFound),
+		errors.Is(reqErr, ErrIntegrationNotFound):
 		errType = "ResourceNotFoundException"
 		statusCode = http.StatusNotFound
 	case errors.Is(reqErr, ErrLogGroupAlreadyExists), errors.Is(reqErr, ErrLogStreamAlreadyExist):

--- a/services/cloudwatchlogs/handler_completeness_test.go
+++ b/services/cloudwatchlogs/handler_completeness_test.go
@@ -1,0 +1,1210 @@
+package cloudwatchlogs_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/cloudwatchlogs"
+)
+
+// newTestHandler returns a fresh Handler + Echo for completeness handler tests.
+func newTestHandler(t *testing.T) (*cloudwatchlogs.Handler, *echo.Echo) {
+	t.Helper()
+	b := cloudwatchlogs.NewInMemoryBackend()
+	t.Cleanup(func() { b.Close() })
+	h := cloudwatchlogs.NewHandler(b)
+
+	return h, echo.New()
+}
+
+// ---- ResourcePolicy handler tests ----
+
+func TestHandler_ResourcePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup         func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body          map[string]any
+		name          string
+		action        string
+		wantBodyField string
+		wantCode      int
+	}{
+		{
+			name:     "PutResourcePolicy/OK",
+			action:   "PutResourcePolicy",
+			body:     map[string]any{"policyName": "my-policy", "policyDocument": `{"Version":"2012-10-17"}`},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "PutResourcePolicy/EmptyName",
+			action:   "PutResourcePolicy",
+			body:     map[string]any{"policyName": "", "policyDocument": `{}`},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "DescribeResourcePolicies/Empty",
+			action:   "DescribeResourcePolicies",
+			body:     map[string]any{},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DescribeResourcePolicies/WithEntries",
+			action: "DescribeResourcePolicies",
+			body:   map[string]any{},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutResourcePolicy",
+					`{"policyName":"p1","policyDocument":"{}"}`)
+				doLogsRequest(t, h, e, "PutResourcePolicy",
+					`{"policyName":"p2","policyDocument":"{}"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteResourcePolicy/OK",
+			action: "DeleteResourcePolicy",
+			body:   map[string]any{"policyName": "my-policy"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutResourcePolicy",
+					`{"policyName":"my-policy","policyDocument":"{}"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteResourcePolicy/NotFound",
+			action:   "DeleteResourcePolicy",
+			body:     map[string]any{"policyName": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- DeliveryDestination handler tests ----
+
+func TestHandler_DeliveryDestination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutDeliveryDestination/OK",
+			action: "PutDeliveryDestination",
+			body: map[string]any{
+				"name":         "my-dest",
+				"outputFormat": "JSON",
+				"deliveryDestinationConfiguration": map[string]any{
+					"destinationResourceArn": "arn:aws:s3:::my-bucket",
+				},
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutDeliveryDestination/EmptyName",
+			action: "PutDeliveryDestination",
+			body: map[string]any{
+				"name": "",
+				"deliveryDestinationConfiguration": map[string]any{
+					"destinationResourceArn": "arn:aws:s3:::bucket",
+				},
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "GetDeliveryDestination/OK",
+			action: "GetDeliveryDestination",
+			body:   map[string]any{"name": "my-dest"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"my-dest","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::bucket"}}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "GetDeliveryDestination/NotFound",
+			action:   "GetDeliveryDestination",
+			body:     map[string]any{"name": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "DescribeDeliveryDestinations/WithEntries",
+			action: "DescribeDeliveryDestinations",
+			body:   map[string]any{},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"dest1","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::b1"}}`,
+				)
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"dest2","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::b2"}}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteDeliveryDestination/OK",
+			action: "DeleteDeliveryDestination",
+			body:   map[string]any{"name": "my-dest"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"my-dest","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::bucket"}}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteDeliveryDestination/NotFound",
+			action:   "DeleteDeliveryDestination",
+			body:     map[string]any{"name": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "PutDeliveryDestinationPolicy/OK",
+			action: "PutDeliveryDestinationPolicy",
+			body: map[string]any{
+				"deliveryDestinationName":   "my-dest",
+				"deliveryDestinationPolicy": `{"Statement":[]}`,
+			},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"my-dest","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::bucket"}}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "GetDeliveryDestinationPolicy/OK",
+			action: "GetDeliveryDestinationPolicy",
+			body:   map[string]any{"deliveryDestinationName": "my-dest"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"my-dest","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::bucket"}}`,
+				)
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestinationPolicy",
+					`{"deliveryDestinationName":"my-dest","deliveryDestinationPolicy":"{\"Statement\":[]}"}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteDeliveryDestinationPolicy/OK",
+			action: "DeleteDeliveryDestinationPolicy",
+			body:   map[string]any{"deliveryDestinationName": "my-dest"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDeliveryDestination",
+					`{"name":"my-dest","deliveryDestinationConfiguration":{"destinationResourceArn":"arn:aws:s3:::bucket"}}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- DeliverySource handler tests ----
+
+func TestHandler_DeliverySource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutDeliverySource/OK",
+			action: "PutDeliverySource",
+			body: map[string]any{
+				"name":         "my-src",
+				"logType":      "APPLICATION_LOGS",
+				"resourceArns": []string{"arn:aws:ec2:::instance/i-123"},
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutDeliverySource/EmptyName",
+			action: "PutDeliverySource",
+			body: map[string]any{
+				"name":    "",
+				"logType": "FLOW_LOGS",
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "GetDeliverySource/OK",
+			action: "GetDeliverySource",
+			body:   map[string]any{"name": "my-src"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutDeliverySource", `{"name":"my-src","logType":"APPLICATION_LOGS"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "GetDeliverySource/NotFound",
+			action:   "GetDeliverySource",
+			body:     map[string]any{"name": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "DescribeDeliverySources/WithEntries",
+			action: "DescribeDeliverySources",
+			body:   map[string]any{},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutDeliverySource", `{"name":"src1","logType":"APPLICATION_LOGS"}`)
+				doLogsRequest(t, h, e, "PutDeliverySource", `{"name":"src2","logType":"FLOW_LOGS"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteDeliverySource/OK",
+			action: "DeleteDeliverySource",
+			body:   map[string]any{"name": "my-src"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutDeliverySource", `{"name":"my-src","logType":"APPLICATION_LOGS"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteDeliverySource/NotFound",
+			action:   "DeleteDeliverySource",
+			body:     map[string]any{"name": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- Destination (log routing) handler tests ----
+
+func TestHandler_Destination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutDestination/OK",
+			action: "PutDestination",
+			body: map[string]any{
+				"destinationName": "my-dest",
+				"targetArn":       "arn:aws:kinesis:::stream/my-stream",
+				"roleArn":         "arn:aws:iam:::role/my-role",
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutDestination/EmptyName",
+			action: "PutDestination",
+			body: map[string]any{
+				"destinationName": "",
+				"targetArn":       "arn:aws:kinesis:::stream/s",
+				"roleArn":         "arn:aws:iam:::role/r",
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "PutDestinationPolicy/OK",
+			action: "PutDestinationPolicy",
+			body: map[string]any{
+				"destinationName": "my-dest",
+				"accessPolicy":    `{"Statement":[]}`,
+			},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDestination",
+					`{"destinationName":"my-dest","targetArn":"arn:t","roleArn":"arn:r"}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutDestinationPolicy/NotFound",
+			action: "PutDestinationPolicy",
+			body: map[string]any{
+				"destinationName": "ghost",
+				"accessPolicy":    `{}`,
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "DescribeDestinations/WithPrefix",
+			action: "DescribeDestinations",
+			body:   map[string]any{"DestinationNamePrefix": "prod"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDestination",
+					`{"destinationName":"prod-dest","targetArn":"arn:t","roleArn":"arn:r"}`,
+				)
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDestination",
+					`{"destinationName":"dev-dest","targetArn":"arn:t2","roleArn":"arn:r2"}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteDestination/OK",
+			action: "DeleteDestination",
+			body:   map[string]any{"destinationName": "my-dest"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(
+					t,
+					h,
+					e,
+					"PutDestination",
+					`{"destinationName":"my-dest","targetArn":"arn:t","roleArn":"arn:r"}`,
+				)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteDestination/NotFound",
+			action:   "DeleteDestination",
+			body:     map[string]any{"destinationName": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- IndexPolicy handler tests ----
+
+func TestHandler_IndexPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutIndexPolicy/OK",
+			action: "PutIndexPolicy",
+			body: map[string]any{
+				"logGroupIdentifier": "/aws/lambda/fn",
+				"policyDocument":     `{"fields":["@message"]}`,
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutIndexPolicy/EmptyIdentifier",
+			action: "PutIndexPolicy",
+			body: map[string]any{
+				"logGroupIdentifier": "",
+				"policyDocument":     `{}`,
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "DescribeIndexPolicies/WithEntries",
+			action: "DescribeIndexPolicies",
+			body:   map[string]any{},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutIndexPolicy",
+					`{"logGroupIdentifier":"/grp1","policyDocument":"{}"}`)
+				doLogsRequest(t, h, e, "PutIndexPolicy",
+					`{"logGroupIdentifier":"/grp2","policyDocument":"{}"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteIndexPolicy/OK",
+			action: "DeleteIndexPolicy",
+			body:   map[string]any{"logGroupIdentifier": "/aws/lambda/fn"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutIndexPolicy",
+					`{"logGroupIdentifier":"/aws/lambda/fn","policyDocument":"{}"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteIndexPolicy/NotFound",
+			action:   "DeleteIndexPolicy",
+			body:     map[string]any{"logGroupIdentifier": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- Transformer handler tests ----
+
+func TestHandler_Transformer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutTransformer/OK",
+			action: "PutTransformer",
+			body: map[string]any{
+				"logGroupIdentifier": "/aws/lambda/fn",
+				"transformerConfig":  []map[string]any{{"parseJSON": map[string]any{}}},
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutTransformer/EmptyIdentifier",
+			action: "PutTransformer",
+			body: map[string]any{
+				"logGroupIdentifier": "",
+				"transformerConfig":  []map[string]any{},
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "GetTransformer/OK",
+			action: "GetTransformer",
+			body:   map[string]any{"logGroupIdentifier": "/aws/lambda/fn"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutTransformer",
+					`{"logGroupIdentifier":"/aws/lambda/fn","transformerConfig":[{"parseJSON":{}}]}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "GetTransformer/NotFound",
+			action:   "GetTransformer",
+			body:     map[string]any{"logGroupIdentifier": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "DeleteTransformer/OK",
+			action: "DeleteTransformer",
+			body:   map[string]any{"logGroupIdentifier": "/aws/lambda/fn"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutTransformer",
+					`{"logGroupIdentifier":"/aws/lambda/fn","transformerConfig":[{"parseJSON":{}}]}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteTransformer/NotFound",
+			action:   "DeleteTransformer",
+			body:     map[string]any{"logGroupIdentifier": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "TestTransformer/OK",
+			action: "TestTransformer",
+			body: map[string]any{
+				"logGroupIdentifier": "/grp",
+				"logEventMessages":   []string{`{"level":"ERROR","msg":"oops"}`},
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- Integration handler tests ----
+
+func TestHandler_Integration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutIntegration/OK",
+			action: "PutIntegration",
+			body: map[string]any{
+				"integrationName": "my-opensearch",
+				"integrationType": "OPENSEARCH",
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutIntegration/EmptyName",
+			action: "PutIntegration",
+			body: map[string]any{
+				"integrationName": "",
+				"integrationType": "OPENSEARCH",
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "GetIntegration/OK",
+			action: "GetIntegration",
+			body:   map[string]any{"integrationName": "my-opensearch"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutIntegration",
+					`{"integrationName":"my-opensearch","integrationType":"OPENSEARCH"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "GetIntegration/NotFound",
+			action:   "GetIntegration",
+			body:     map[string]any{"integrationName": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "ListIntegrations/WithEntries",
+			action: "ListIntegrations",
+			body:   map[string]any{},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutIntegration", `{"integrationName":"ig1","integrationType":"OPENSEARCH"}`)
+				doLogsRequest(t, h, e, "PutIntegration", `{"integrationName":"ig2","integrationType":"OPENSEARCH"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteIntegration/OK",
+			action: "DeleteIntegration",
+			body:   map[string]any{"integrationName": "my-opensearch"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutIntegration",
+					`{"integrationName":"my-opensearch","integrationType":"OPENSEARCH"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "DeleteIntegration/NotFound",
+			action:   "DeleteIntegration",
+			body:     map[string]any{"integrationName": "ghost"},
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- LogGroupDeletionProtection handler tests ----
+
+func TestHandler_LogGroupDeletionProtection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutLogGroupDeletionProtection/Enable",
+			action: "PutLogGroupDeletionProtection",
+			body: map[string]any{
+				"logGroupIdentifier": "/aws/lambda/fn",
+				"deletionProtected":  true,
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutLogGroupDeletionProtection/Disable",
+			action: "PutLogGroupDeletionProtection",
+			body: map[string]any{
+				"logGroupIdentifier": "/aws/lambda/fn",
+				"deletionProtected":  false,
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "PutLogGroupDeletionProtection/EmptyIdentifier",
+			action: "PutLogGroupDeletionProtection",
+			body: map[string]any{
+				"logGroupIdentifier": "",
+				"deletionProtected":  true,
+			},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- UpdateDeliveryConfiguration handler tests ----
+
+func TestHandler_UpdateDeliveryConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) string
+		body     func(deliveryID string) map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "UpdateDeliveryConfiguration/FieldDelimiter",
+			action: "UpdateDeliveryConfiguration",
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) string {
+				t.Helper()
+				rec := doLogsRequest(
+					t,
+					h,
+					e,
+					"CreateDelivery",
+					`{"deliverySourceName":"src","deliveryDestinationArn":"arn:aws:logs:us-east-1:123:delivery-destination:dst"}`,
+				)
+				require.Equal(t, http.StatusOK, rec.Code)
+				var resp map[string]map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				id, _ := resp["delivery"]["id"].(string)
+
+				return id
+			},
+			body: func(deliveryID string) map[string]any {
+				return map[string]any{"id": deliveryID, "fieldDelimiter": ","}
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "UpdateDeliveryConfiguration/RecordFields",
+			action: "UpdateDeliveryConfiguration",
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) string {
+				t.Helper()
+				rec := doLogsRequest(
+					t,
+					h,
+					e,
+					"CreateDelivery",
+					`{"deliverySourceName":"src","deliveryDestinationArn":"arn:aws:logs:us-east-1:123:delivery-destination:dst"}`,
+				)
+				require.Equal(t, http.StatusOK, rec.Code)
+				var resp map[string]map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				id, _ := resp["delivery"]["id"].(string)
+
+				return id
+			},
+			body: func(deliveryID string) map[string]any {
+				return map[string]any{"id": deliveryID, "recordFields": []string{"@timestamp", "@message"}}
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "UpdateDeliveryConfiguration/NotFound",
+			action: "UpdateDeliveryConfiguration",
+			setup: func(_ *testing.T, _ *cloudwatchlogs.Handler, _ *echo.Echo) string {
+				return "nonexistent-id"
+			},
+			body: func(deliveryID string) map[string]any {
+				return map[string]any{"id": deliveryID, "fieldDelimiter": ","}
+			},
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			var deliveryID string
+			if tt.setup != nil {
+				deliveryID = tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body(deliveryID))
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- Stub operations handler tests ----
+
+func TestHandler_CompletenessStubs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body          map[string]any
+		name          string
+		action        string
+		wantListField string
+		wantCode      int
+	}{
+		{
+			name:          "DescribeConfigurationTemplates/ReturnsEmpty",
+			action:        "DescribeConfigurationTemplates",
+			body:          map[string]any{},
+			wantCode:      http.StatusOK,
+			wantListField: "configurationTemplates",
+		},
+		{
+			name:          "DescribeFieldIndexes/ReturnsEmpty",
+			action:        "DescribeFieldIndexes",
+			body:          map[string]any{},
+			wantCode:      http.StatusOK,
+			wantListField: "fieldIndexes",
+		},
+		{
+			name:          "DescribeImportTaskBatches/ReturnsEmpty",
+			action:        "DescribeImportTaskBatches",
+			body:          map[string]any{},
+			wantCode:      http.StatusOK,
+			wantListField: "importTaskBatches",
+		},
+		{
+			name:          "ListAggregateLogGroupSummaries/ReturnsEmpty",
+			action:        "ListAggregateLogGroupSummaries",
+			body:          map[string]any{},
+			wantCode:      http.StatusOK,
+			wantListField: "logGroupSummaries",
+		},
+		{
+			name:          "ListSourcesForS3TableIntegration/ReturnsEmpty",
+			action:        "ListSourcesForS3TableIntegration",
+			body:          map[string]any{},
+			wantCode:      http.StatusOK,
+			wantListField: "sources",
+		},
+		{
+			name:     "DisassociateSourceFromS3TableIntegration/OK",
+			action:   "DisassociateSourceFromS3TableIntegration",
+			body:     map[string]any{},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "PutBearerTokenAuthentication/OK",
+			action:   "PutBearerTokenAuthentication",
+			body:     map[string]any{},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "StartLiveTail/OK",
+			action:   "StartLiveTail",
+			body:     map[string]any{},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "GetLogFields/OK",
+			action:   "GetLogFields",
+			body:     map[string]any{},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "GetLogObject/OK",
+			action:   "GetLogObject",
+			body:     map[string]any{},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			rec := makeLogsRequest(t, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			if tt.wantListField != "" {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				list, ok := resp[tt.wantListField].([]any)
+				require.True(t, ok, "expected list field %q in response", tt.wantListField)
+				assert.Empty(t, list)
+			}
+		})
+	}
+}
+
+// ---- DataProtectionPolicy handler tests ----
+
+func TestHandler_DataProtectionPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup    func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body     map[string]any
+		name     string
+		action   string
+		wantCode int
+	}{
+		{
+			name:   "PutDataProtectionPolicy/OK",
+			action: "PutDataProtectionPolicy",
+			body: map[string]any{
+				"logGroupIdentifier": "/aws/lambda/fn",
+				"policyDocument":     `{"Name":"protect","Version":"2021-06-01","Statement":[]}`,
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "GetDataProtectionPolicy/OK",
+			action: "GetDataProtectionPolicy",
+			body:   map[string]any{"logGroupIdentifier": "/aws/lambda/fn"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutDataProtectionPolicy",
+					`{"logGroupIdentifier":"/aws/lambda/fn","policyDocument":"{\"Name\":\"protect\"}"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:   "DeleteDataProtectionPolicy/OK",
+			action: "DeleteDataProtectionPolicy",
+			body:   map[string]any{"logGroupIdentifier": "/aws/lambda/fn"},
+			setup: func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo) {
+				t.Helper()
+				doLogsRequest(t, h, e, "PutDataProtectionPolicy",
+					`{"logGroupIdentifier":"/aws/lambda/fn","policyDocument":"{}"}`)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			assert.Equal(t, tt.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---- Handler response shape tests ----
+
+func TestHandler_CompletenessResponseShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup      func(t *testing.T, h *cloudwatchlogs.Handler, e *echo.Echo)
+		body       map[string]any
+		name       string
+		action     string
+		wantFields []string
+		wantCode   int
+	}{
+		{
+			name:       "PutResourcePolicy/HasResourcePolicy",
+			action:     "PutResourcePolicy",
+			body:       map[string]any{"policyName": "p", "policyDocument": `{}`},
+			wantFields: []string{"resourcePolicy"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "DescribeResourcePolicies/HasResourcePolicies",
+			action:     "DescribeResourcePolicies",
+			body:       map[string]any{},
+			wantFields: []string{"resourcePolicies"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:   "PutDeliveryDestination/HasDeliveryDestination",
+			action: "PutDeliveryDestination",
+			body: map[string]any{
+				"name":         "d",
+				"outputFormat": "JSON",
+				"deliveryDestinationConfiguration": map[string]any{
+					"destinationResourceArn": "arn:aws:s3:::b",
+				},
+			},
+			wantFields: []string{"deliveryDestination"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "DescribeDeliveryDestinations/HasDeliveryDestinations",
+			action:     "DescribeDeliveryDestinations",
+			body:       map[string]any{},
+			wantFields: []string{"deliveryDestinations"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "PutDeliverySource/HasDeliverySource",
+			action:     "PutDeliverySource",
+			body:       map[string]any{"name": "s", "logType": "FLOW_LOGS"},
+			wantFields: []string{"deliverySource"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "DescribeDeliverySources/HasDeliverySources",
+			action:     "DescribeDeliverySources",
+			body:       map[string]any{},
+			wantFields: []string{"deliverySources"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:   "PutDestination/HasDestination",
+			action: "PutDestination",
+			body: map[string]any{
+				"destinationName": "d",
+				"targetArn":       "arn:t",
+				"roleArn":         "arn:r",
+			},
+			wantFields: []string{"destination"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "DescribeDestinations/HasDestinations",
+			action:     "DescribeDestinations",
+			body:       map[string]any{},
+			wantFields: []string{"destinations"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "PutIndexPolicy/HasIndexPolicy",
+			action:     "PutIndexPolicy",
+			body:       map[string]any{"logGroupIdentifier": "/grp", "policyDocument": `{}`},
+			wantFields: []string{"indexPolicy"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "DescribeIndexPolicies/HasIndexPolicies",
+			action:     "DescribeIndexPolicies",
+			body:       map[string]any{},
+			wantFields: []string{"indexPolicies"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:   "PutIntegration/HasIntegrationName",
+			action: "PutIntegration",
+			body: map[string]any{
+				"integrationName": "ig",
+				"integrationType": "OPENSEARCH",
+			},
+			wantFields: []string{"integrationName"},
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "ListIntegrations/HasIntegrationSummaries",
+			action:     "ListIntegrations",
+			body:       map[string]any{},
+			wantFields: []string{"integrationSummaries"},
+			wantCode:   http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, e := newTestHandler(t)
+			if tt.setup != nil {
+				tt.setup(t, h, e)
+			}
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			rec := doLogsRequest(t, h, e, tt.action, string(bodyBytes))
+			require.Equal(t, tt.wantCode, rec.Code)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			for _, field := range tt.wantFields {
+				assert.Contains(t, resp, field, "response should contain field %q", field)
+			}
+		})
+	}
+}

--- a/services/cloudwatchlogs/persistence.go
+++ b/services/cloudwatchlogs/persistence.go
@@ -7,20 +7,31 @@ import (
 )
 
 type backendSnapshot struct {
-	Groups              map[string]*LogGroup                    `json:"groups"`
-	Streams             map[string]map[string]*LogStream        `json:"streams"`
-	Events              map[string]map[string][]*OutputLogEvent `json:"events"`
-	SubscriptionFilters map[string][]*SubscriptionFilter        `json:"subscriptionFilters"`
-	ExportTasks         map[string]*ExportTask                  `json:"exportTasks,omitempty"`
-	ImportTasks         map[string]*ImportTask                  `json:"importTasks,omitempty"`
-	Deliveries          map[string]*Delivery                    `json:"deliveries,omitempty"`
-	LogAnomalyDetectors map[string]*LogAnomalyDetector          `json:"logAnomalyDetectors,omitempty"`
-	ScheduledQueries    map[string]*ScheduledQuery              `json:"scheduledQueries,omitempty"`
-	AccountPolicies     map[string]*AccountPolicy               `json:"accountPolicies,omitempty"`
-	KmsKeys             map[string]string                       `json:"kmsKeys,omitempty"`
-	S3TableIntegrations map[string]string                       `json:"s3TableIntegrations,omitempty"`
-	AccountID           string                                  `json:"accountID"`
-	Region              string                                  `json:"region"`
+	Groups                 map[string]*LogGroup                    `json:"groups"`
+	Streams                map[string]map[string]*LogStream        `json:"streams"`
+	Events                 map[string]map[string][]*OutputLogEvent `json:"events"`
+	SubscriptionFilters    map[string][]*SubscriptionFilter        `json:"subscriptionFilters"`
+	ExportTasks            map[string]*ExportTask                  `json:"exportTasks,omitempty"`
+	ImportTasks            map[string]*ImportTask                  `json:"importTasks,omitempty"`
+	Deliveries             map[string]*Delivery                    `json:"deliveries,omitempty"`
+	LogAnomalyDetectors    map[string]*LogAnomalyDetector          `json:"logAnomalyDetectors,omitempty"`
+	ScheduledQueries       map[string]*ScheduledQuery              `json:"scheduledQueries,omitempty"`
+	AccountPolicies        map[string]*AccountPolicy               `json:"accountPolicies,omitempty"`
+	KmsKeys                map[string]string                       `json:"kmsKeys,omitempty"`
+	S3TableIntegrations    map[string]string                       `json:"s3TableIntegrations,omitempty"`
+	MetricFilters          map[string]map[string]*MetricFilter     `json:"metricFilters,omitempty"`
+	QueryDefinitions       map[string]*QueryDefinition             `json:"queryDefinitions,omitempty"`
+	DataProtectionPolicies map[string]string                       `json:"dataProtectionPolicies,omitempty"`
+	ResourcePolicies       map[string]ResourcePolicy               `json:"resourcePolicies,omitempty"`
+	DeliveryDestinations   map[string]DeliveryDestination          `json:"deliveryDestinations,omitempty"`
+	DeliverySources        map[string]DeliverySource               `json:"deliverySources,omitempty"`
+	Destinations           map[string]CWLDestination               `json:"destinations,omitempty"`
+	IndexPolicies          map[string]IndexPolicy                  `json:"indexPolicies,omitempty"`
+	Transformers           map[string]Transformer                  `json:"transformers,omitempty"`
+	Integrations           map[string]CWLIntegration               `json:"integrations,omitempty"`
+	DeletionProtected      map[string]bool                         `json:"deletionProtected,omitempty"`
+	AccountID              string                                  `json:"accountID"`
+	Region                 string                                  `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -30,20 +41,31 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	defer b.mu.RUnlock()
 
 	snap := backendSnapshot{
-		Groups:              b.groups,
-		Streams:             b.streams,
-		Events:              b.events,
-		SubscriptionFilters: b.subscriptionFilters,
-		ExportTasks:         b.exportTasks,
-		ImportTasks:         b.importTasks,
-		Deliveries:          b.deliveries,
-		LogAnomalyDetectors: b.logAnomalyDetectors,
-		ScheduledQueries:    b.scheduledQueries,
-		AccountPolicies:     b.accountPolicies,
-		KmsKeys:             b.kmsKeys,
-		S3TableIntegrations: b.s3TableIntegrations,
-		AccountID:           b.accountID,
-		Region:              b.region,
+		Groups:                 b.groups,
+		Streams:                b.streams,
+		Events:                 b.events,
+		SubscriptionFilters:    b.subscriptionFilters,
+		ExportTasks:            b.exportTasks,
+		ImportTasks:            b.importTasks,
+		Deliveries:             b.deliveries,
+		LogAnomalyDetectors:    b.logAnomalyDetectors,
+		ScheduledQueries:       b.scheduledQueries,
+		AccountPolicies:        b.accountPolicies,
+		KmsKeys:                b.kmsKeys,
+		S3TableIntegrations:    b.s3TableIntegrations,
+		MetricFilters:          b.metricFilters,
+		QueryDefinitions:       b.queryDefinitions,
+		DataProtectionPolicies: b.dataProtectionPolicies,
+		ResourcePolicies:       b.resourcePolicies,
+		DeliveryDestinations:   b.deliveryDestinations,
+		DeliverySources:        b.deliverySources,
+		Destinations:           b.destinations,
+		IndexPolicies:          b.indexPolicies,
+		Transformers:           b.transformers,
+		Integrations:           b.integrations,
+		DeletionProtected:      b.deletionProtected,
+		AccountID:              b.accountID,
+		Region:                 b.region,
 	}
 
 	data, err := json.Marshal(snap)
@@ -114,6 +136,50 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		snap.S3TableIntegrations = make(map[string]string)
 	}
 
+	if snap.MetricFilters == nil {
+		snap.MetricFilters = make(map[string]map[string]*MetricFilter)
+	}
+
+	if snap.QueryDefinitions == nil {
+		snap.QueryDefinitions = make(map[string]*QueryDefinition)
+	}
+
+	if snap.DataProtectionPolicies == nil {
+		snap.DataProtectionPolicies = make(map[string]string)
+	}
+
+	if snap.ResourcePolicies == nil {
+		snap.ResourcePolicies = make(map[string]ResourcePolicy)
+	}
+
+	if snap.DeliveryDestinations == nil {
+		snap.DeliveryDestinations = make(map[string]DeliveryDestination)
+	}
+
+	if snap.DeliverySources == nil {
+		snap.DeliverySources = make(map[string]DeliverySource)
+	}
+
+	if snap.Destinations == nil {
+		snap.Destinations = make(map[string]CWLDestination)
+	}
+
+	if snap.IndexPolicies == nil {
+		snap.IndexPolicies = make(map[string]IndexPolicy)
+	}
+
+	if snap.Transformers == nil {
+		snap.Transformers = make(map[string]Transformer)
+	}
+
+	if snap.Integrations == nil {
+		snap.Integrations = make(map[string]CWLIntegration)
+	}
+
+	if snap.DeletionProtected == nil {
+		snap.DeletionProtected = make(map[string]bool)
+	}
+
 	b.groups = snap.Groups
 	b.streams = snap.Streams
 	b.events = snap.Events
@@ -126,6 +192,17 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.accountPolicies = snap.AccountPolicies
 	b.kmsKeys = snap.KmsKeys
 	b.s3TableIntegrations = snap.S3TableIntegrations
+	b.metricFilters = snap.MetricFilters
+	b.queryDefinitions = snap.QueryDefinitions
+	b.dataProtectionPolicies = snap.DataProtectionPolicies
+	b.resourcePolicies = snap.ResourcePolicies
+	b.deliveryDestinations = snap.DeliveryDestinations
+	b.deliverySources = snap.DeliverySources
+	b.destinations = snap.Destinations
+	b.indexPolicies = snap.IndexPolicies
+	b.transformers = snap.Transformers
+	b.integrations = snap.Integrations
+	b.deletionProtected = snap.DeletionProtected
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 

--- a/services/cloudwatchlogs/persistence.go
+++ b/services/cloudwatchlogs/persistence.go
@@ -85,100 +85,10 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		return err
 	}
 
+	initSnapshotNilMaps(&snap)
+
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
-
-	if snap.Groups == nil {
-		snap.Groups = make(map[string]*LogGroup)
-	}
-
-	if snap.Streams == nil {
-		snap.Streams = make(map[string]map[string]*LogStream)
-	}
-
-	if snap.Events == nil {
-		snap.Events = make(map[string]map[string][]*OutputLogEvent)
-	}
-
-	if snap.SubscriptionFilters == nil {
-		snap.SubscriptionFilters = make(map[string][]*SubscriptionFilter)
-	}
-
-	if snap.ExportTasks == nil {
-		snap.ExportTasks = make(map[string]*ExportTask)
-	}
-
-	if snap.ImportTasks == nil {
-		snap.ImportTasks = make(map[string]*ImportTask)
-	}
-
-	if snap.Deliveries == nil {
-		snap.Deliveries = make(map[string]*Delivery)
-	}
-
-	if snap.LogAnomalyDetectors == nil {
-		snap.LogAnomalyDetectors = make(map[string]*LogAnomalyDetector)
-	}
-
-	if snap.ScheduledQueries == nil {
-		snap.ScheduledQueries = make(map[string]*ScheduledQuery)
-	}
-
-	if snap.AccountPolicies == nil {
-		snap.AccountPolicies = make(map[string]*AccountPolicy)
-	}
-
-	if snap.KmsKeys == nil {
-		snap.KmsKeys = make(map[string]string)
-	}
-
-	if snap.S3TableIntegrations == nil {
-		snap.S3TableIntegrations = make(map[string]string)
-	}
-
-	if snap.MetricFilters == nil {
-		snap.MetricFilters = make(map[string]map[string]*MetricFilter)
-	}
-
-	if snap.QueryDefinitions == nil {
-		snap.QueryDefinitions = make(map[string]*QueryDefinition)
-	}
-
-	if snap.DataProtectionPolicies == nil {
-		snap.DataProtectionPolicies = make(map[string]string)
-	}
-
-	if snap.ResourcePolicies == nil {
-		snap.ResourcePolicies = make(map[string]ResourcePolicy)
-	}
-
-	if snap.DeliveryDestinations == nil {
-		snap.DeliveryDestinations = make(map[string]DeliveryDestination)
-	}
-
-	if snap.DeliverySources == nil {
-		snap.DeliverySources = make(map[string]DeliverySource)
-	}
-
-	if snap.Destinations == nil {
-		snap.Destinations = make(map[string]CWLDestination)
-	}
-
-	if snap.IndexPolicies == nil {
-		snap.IndexPolicies = make(map[string]IndexPolicy)
-	}
-
-	if snap.Transformers == nil {
-		snap.Transformers = make(map[string]Transformer)
-	}
-
-	if snap.Integrations == nil {
-		snap.Integrations = make(map[string]CWLIntegration)
-	}
-
-	if snap.DeletionProtected == nil {
-		snap.DeletionProtected = make(map[string]bool)
-	}
 
 	b.groups = snap.Groups
 	b.streams = snap.Streams
@@ -207,6 +117,88 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.region = snap.Region
 
 	return nil
+}
+
+// initSnapshotNilMaps replaces any nil map in snap with an empty map so the
+// restored backend never contains a nil map reference.
+func initSnapshotNilMaps(snap *backendSnapshot) {
+	initCoreNilMaps(snap)
+	initCompletenessNilMaps(snap)
+}
+
+func initCoreNilMaps(snap *backendSnapshot) {
+	if snap.Groups == nil {
+		snap.Groups = make(map[string]*LogGroup)
+	}
+	if snap.Streams == nil {
+		snap.Streams = make(map[string]map[string]*LogStream)
+	}
+	if snap.Events == nil {
+		snap.Events = make(map[string]map[string][]*OutputLogEvent)
+	}
+	if snap.SubscriptionFilters == nil {
+		snap.SubscriptionFilters = make(map[string][]*SubscriptionFilter)
+	}
+	if snap.ExportTasks == nil {
+		snap.ExportTasks = make(map[string]*ExportTask)
+	}
+	if snap.ImportTasks == nil {
+		snap.ImportTasks = make(map[string]*ImportTask)
+	}
+	if snap.Deliveries == nil {
+		snap.Deliveries = make(map[string]*Delivery)
+	}
+	if snap.LogAnomalyDetectors == nil {
+		snap.LogAnomalyDetectors = make(map[string]*LogAnomalyDetector)
+	}
+	if snap.ScheduledQueries == nil {
+		snap.ScheduledQueries = make(map[string]*ScheduledQuery)
+	}
+	if snap.AccountPolicies == nil {
+		snap.AccountPolicies = make(map[string]*AccountPolicy)
+	}
+	if snap.KmsKeys == nil {
+		snap.KmsKeys = make(map[string]string)
+	}
+	if snap.S3TableIntegrations == nil {
+		snap.S3TableIntegrations = make(map[string]string)
+	}
+}
+
+func initCompletenessNilMaps(snap *backendSnapshot) {
+	if snap.MetricFilters == nil {
+		snap.MetricFilters = make(map[string]map[string]*MetricFilter)
+	}
+	if snap.QueryDefinitions == nil {
+		snap.QueryDefinitions = make(map[string]*QueryDefinition)
+	}
+	if snap.DataProtectionPolicies == nil {
+		snap.DataProtectionPolicies = make(map[string]string)
+	}
+	if snap.ResourcePolicies == nil {
+		snap.ResourcePolicies = make(map[string]ResourcePolicy)
+	}
+	if snap.DeliveryDestinations == nil {
+		snap.DeliveryDestinations = make(map[string]DeliveryDestination)
+	}
+	if snap.DeliverySources == nil {
+		snap.DeliverySources = make(map[string]DeliverySource)
+	}
+	if snap.Destinations == nil {
+		snap.Destinations = make(map[string]CWLDestination)
+	}
+	if snap.IndexPolicies == nil {
+		snap.IndexPolicies = make(map[string]IndexPolicy)
+	}
+	if snap.Transformers == nil {
+		snap.Transformers = make(map[string]Transformer)
+	}
+	if snap.Integrations == nil {
+		snap.Integrations = make(map[string]CWLIntegration)
+	}
+	if snap.DeletionProtected == nil {
+		snap.DeletionProtected = make(map[string]bool)
+	}
 }
 
 // handlerSnapshot is the full persisted state for a Handler, combining both

--- a/services/cloudwatchlogs/persistence_test.go
+++ b/services/cloudwatchlogs/persistence_test.go
@@ -191,3 +191,201 @@ func TestInMemoryBackend_SnapshotRestore_PreservesRetention(t *testing.T) {
 	require.NotNil(t, groups[0].RetentionInDays)
 	assert.Equal(t, int32(14), *groups[0].RetentionInDays)
 }
+
+func TestInMemoryBackend_SnapshotRestore_CompletenessMapsSurvive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup  func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		verify func(t *testing.T, b *cloudwatchlogs.InMemoryBackend)
+		name   string
+	}{
+		{
+			name: "resource_policy_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutResourcePolicy("my-policy", `{"Version":"2012-10-17"}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeResourcePolicies()
+				require.Len(t, policies, 1)
+				assert.Equal(t, "my-policy", policies[0].PolicyName)
+			},
+		},
+		{
+			name: "delivery_destination_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliveryDestination("my-dest", "arn:aws:s3:::bucket", "JSON", nil)
+				require.NoError(t, err)
+				err = b.PutDeliveryDestinationPolicy("my-dest", `{"Statement":[]}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetDeliveryDestination("my-dest")
+				require.NoError(t, err)
+				assert.Equal(t, "arn:aws:s3:::bucket", got.TargetArn)
+				policy, err := b.GetDeliveryDestinationPolicy("my-dest")
+				require.NoError(t, err)
+				assert.Contains(t, policy, "Statement")
+			},
+		},
+		{
+			name: "delivery_source_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDeliverySource("my-src", "APPLICATION_LOGS", []string{"arn:aws:ec2:::i-1"}, nil)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				got, err := b.GetDeliverySource("my-src")
+				require.NoError(t, err)
+				assert.Equal(t, "APPLICATION_LOGS", got.LogType)
+			},
+		},
+		{
+			name: "destination_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutDestination("my-dest", "arn:aws:kinesis:::stream/s", "arn:aws:iam:::role/r")
+				require.NoError(t, err)
+				err = b.PutDestinationPolicy("my-dest", `{"Statement":[]}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				dests := b.DescribeDestinations("")
+				require.Len(t, dests, 1)
+				assert.Equal(t, "my-dest", dests[0].DestinationName)
+				assert.Contains(t, dests[0].AccessPolicy, "Statement")
+			},
+		},
+		{
+			name: "index_policy_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIndexPolicy("/aws/lambda/fn", `{"fields":["@message"]}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				policies := b.DescribeIndexPolicies()
+				require.Len(t, policies, 1)
+				assert.Equal(t, "/aws/lambda/fn", policies[0].LogGroupIdentifier)
+			},
+		},
+		{
+			name: "transformer_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutTransformer("/aws/lambda/fn", []map[string]any{{"parseJSON": map[string]any{}}})
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				tr, err := b.GetTransformer("/aws/lambda/fn")
+				require.NoError(t, err)
+				require.Len(t, tr.Processors, 1)
+			},
+		},
+		{
+			name: "integration_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutIntegration("my-opensearch", "OPENSEARCH")
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				ig, err := b.GetIntegration("my-opensearch")
+				require.NoError(t, err)
+				assert.Equal(t, "OPENSEARCH", ig.Type)
+			},
+		},
+		{
+			name: "deletion_protected_survives",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.SetLogGroupDeletionProtection("/aws/lambda/fn", true)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				assert.True(t, b.IsLogGroupDeletionProtected("/aws/lambda/fn"))
+			},
+		},
+		{
+			name: "metric_filters_survive",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.CreateLogGroup("/grp", "", "")
+				require.NoError(t, err)
+				err = b.PutMetricFilter("/grp", "my-filter", "ERROR",
+					[]cloudwatchlogs.MetricTransformation{{
+						MetricName: "ErrCount", MetricNamespace: "App", MetricValue: "1",
+					}})
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				filters, _, err := b.DescribeMetricFilters("/grp", "", "", "", "", 50)
+				require.NoError(t, err)
+				require.Len(t, filters, 1)
+				assert.Equal(t, "my-filter", filters[0].FilterName)
+			},
+		},
+		{
+			name: "query_definitions_survive",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				_, err := b.PutQueryDefinition("my-query", "fields @message | limit 20", "", nil)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				defs, _, err := b.DescribeQueryDefinitions("my-query", 100, "")
+				require.NoError(t, err)
+				require.Len(t, defs, 1)
+				assert.Equal(t, "my-query", defs[0].Name)
+			},
+		},
+		{
+			name: "data_protection_policies_survive",
+			setup: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				err := b.PutDataProtectionPolicy("/grp", `{"Name":"protect"}`)
+				require.NoError(t, err)
+			},
+			verify: func(t *testing.T, b *cloudwatchlogs.InMemoryBackend) {
+				t.Helper()
+				doc, err := b.GetDataProtectionPolicy("/grp")
+				require.NoError(t, err)
+				assert.Contains(t, doc, "protect")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			original := cloudwatchlogs.NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+			t.Cleanup(func() { original.Close() })
+
+			tt.setup(t, original)
+
+			snap := original.Snapshot()
+			require.NotNil(t, snap)
+
+			fresh := cloudwatchlogs.NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+			t.Cleanup(func() { fresh.Close() })
+			require.NoError(t, fresh.Restore(snap))
+
+			tt.verify(t, fresh)
+		})
+	}
+}


### PR DESCRIPTION
AWS-accuracy audit batch-2 for services/cloudwatchlogs — subscription filters, metric filters, query definitions, delivery sources/destinations, account-level subscriptions. Polecat: obsidian.