### PR TITLE
feat(glue): replace handler_stubs with real impls (go-i3mb)

### DIFF
--- a/services/glue/backend.go
+++ b/services/glue/backend.go
@@ -339,6 +339,7 @@ type InMemoryBackend struct {
 	columnStatTaskRuns        map[string]*ColumnStatisticsTaskRun       // key: runID
 	materializedViewRuns      map[string]*MaterializedViewRefreshRun    // key: taskRunID
 	integrations              map[string]*Integration                   // key: integrationName
+	mlTaskRuns                map[string]*MLTaskRun                     // key: "transformID|taskRunID"
 	glueIdentityCenterConfig  *IdentityCenterConfig
 	mu                        *lockmetrics.RWMutex
 	accountID                 string
@@ -389,6 +390,7 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		columnStatTaskRuns:        make(map[string]*ColumnStatisticsTaskRun),
 		materializedViewRuns:      make(map[string]*MaterializedViewRefreshRun),
 		integrations:              make(map[string]*Integration),
+		mlTaskRuns:                make(map[string]*MLTaskRun),
 		mu:                        lockmetrics.New("glue"),
 		accountID:                 accountID,
 		region:                    region,
@@ -441,6 +443,7 @@ func (b *InMemoryBackend) Reset() {
 	b.columnStatTaskRuns = make(map[string]*ColumnStatisticsTaskRun)
 	b.materializedViewRuns = make(map[string]*MaterializedViewRefreshRun)
 	b.integrations = make(map[string]*Integration)
+	b.mlTaskRuns = make(map[string]*MLTaskRun)
 	b.glueIdentityCenterConfig = nil
 }
 

--- a/services/glue/backend.go
+++ b/services/glue/backend.go
@@ -34,6 +34,7 @@ const (
 	stateRunning          = "RUNNING"
 	stateStarting         = "STARTING"
 	stateStopping         = "STOPPING"
+	stateStopped          = "STOPPED"
 	stateReady            = "READY"
 	stateSucceeded        = "SUCCEEDED"
 	stateAvailable        = "AVAILABLE"

--- a/services/glue/backend_batch2.go
+++ b/services/glue/backend_batch2.go
@@ -517,7 +517,7 @@ func (b *InMemoryBackend) StopColumnStatisticsTaskRun(runID string) error {
 	defer b.mu.Unlock()
 
 	if r, ok := b.columnStatTaskRuns[runID]; ok {
-		r.Status = "STOPPED"
+		r.Status = stateStopped
 	}
 
 	return nil
@@ -590,7 +590,7 @@ func (b *InMemoryBackend) StopMaterializedViewRefreshTaskRun(taskRunID string) e
 	defer b.mu.Unlock()
 
 	if r, ok := b.materializedViewRuns[taskRunID]; ok {
-		r.Status = "STOPPED"
+		r.Status = stateStopped
 	}
 
 	return nil

--- a/services/glue/backend_batch2.go
+++ b/services/glue/backend_batch2.go
@@ -328,6 +328,10 @@ func (b *InMemoryBackend) DeleteCustomEntityType(name string) error {
 	b.mu.Lock("DeleteCustomEntityType")
 	defer b.mu.Unlock()
 
+	if _, ok := b.customEntityTypes[name]; !ok {
+		return fmt.Errorf("custom entity type %q not found: %w", name, ErrNotFound)
+	}
+
 	delete(b.customEntityTypes, name)
 
 	return nil
@@ -648,6 +652,10 @@ func (b *InMemoryBackend) CreateIntegration(name string, tags map[string]string)
 func (b *InMemoryBackend) DeleteIntegration(name string) error {
 	b.mu.Lock("DeleteIntegration")
 	defer b.mu.Unlock()
+
+	if _, ok := b.integrations[name]; !ok {
+		return fmt.Errorf("integration %q not found: %w", name, ErrNotFound)
+	}
 
 	delete(b.integrations, name)
 

--- a/services/glue/backend_mltasks.go
+++ b/services/glue/backend_mltasks.go
@@ -1,0 +1,181 @@
+package glue
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MLTaskType is the category of an ML transform task run.
+type MLTaskType string
+
+const (
+	mlTaskTypeEvaluation            MLTaskType = "EVALUATION"
+	mlTaskTypeLabelingSetGeneration MLTaskType = "LABELING_SET_GENERATION"
+	mlTaskTypeExportLabels          MLTaskType = "EXPORT_LABELS"
+	mlTaskTypeImportLabels          MLTaskType = "IMPORT_LABELS"
+)
+
+// MLTaskRun represents a single ML transform task run.
+type MLTaskRun struct {
+	Properties    map[string]string `json:"Properties,omitempty"`
+	TransformID   string            `json:"TransformId"`
+	TaskRunID     string            `json:"TaskRunId"`
+	TaskType      string            `json:"TaskType"`
+	Status        string            `json:"Status"`
+	ErrorString   string            `json:"ErrorString,omitempty"`
+	LogGroupName  string            `json:"LogGroupName,omitempty"`
+	StartedOn     float64           `json:"StartedOn,omitempty"`
+	CompletedOn   float64           `json:"CompletedOn,omitempty"`
+	ExecutionTime int               `json:"ExecutionTime,omitempty"`
+}
+
+// ErrMLTaskRunNotFound is returned when an ML task run does not exist.
+var ErrMLTaskRunNotFound = fmt.Errorf("ML task run not found: %w", ErrNotFound)
+
+func mlTaskRunKey(transformID, taskRunID string) string {
+	return transformID + "|" + taskRunID
+}
+
+func (b *InMemoryBackend) startMLTaskRunLocked(transformID string, taskType MLTaskType) (*MLTaskRun, error) {
+	if _, ok := b.mlTransforms[transformID]; !ok {
+		return nil, fmt.Errorf("ML transform %q not found: %w", transformID, ErrNotFound)
+	}
+
+	taskRunID := "run-" + uuid.NewString()[:8]
+	run := &MLTaskRun{
+		TransformID: transformID,
+		TaskRunID:   taskRunID,
+		TaskType:    string(taskType),
+		Status:      stateRunning,
+		StartedOn:   float64(time.Now().Unix()),
+	}
+	b.mlTaskRuns[mlTaskRunKey(transformID, taskRunID)] = run
+	cp := *run
+
+	return &cp, nil
+}
+
+// StartMLEvaluationTaskRun starts an ML transform evaluation task run.
+func (b *InMemoryBackend) StartMLEvaluationTaskRun(transformID string) (*MLTaskRun, error) {
+	b.mu.Lock("StartMLEvaluationTaskRun")
+	defer b.mu.Unlock()
+
+	return b.startMLTaskRunLocked(transformID, mlTaskTypeEvaluation)
+}
+
+// StartMLLabelingSetGenerationTaskRun starts an ML transform labeling-set generation task run.
+func (b *InMemoryBackend) StartMLLabelingSetGenerationTaskRun(transformID string) (*MLTaskRun, error) {
+	b.mu.Lock("StartMLLabelingSetGenerationTaskRun")
+	defer b.mu.Unlock()
+
+	return b.startMLTaskRunLocked(transformID, mlTaskTypeLabelingSetGeneration)
+}
+
+// StartExportLabelsTaskRun starts an ML transform export-labels task run.
+func (b *InMemoryBackend) StartExportLabelsTaskRun(transformID, _ string) (*MLTaskRun, error) {
+	b.mu.Lock("StartExportLabelsTaskRun")
+	defer b.mu.Unlock()
+
+	return b.startMLTaskRunLocked(transformID, mlTaskTypeExportLabels)
+}
+
+// StartImportLabelsTaskRun starts an ML transform import-labels task run.
+func (b *InMemoryBackend) StartImportLabelsTaskRun(transformID, _ string) (*MLTaskRun, error) {
+	b.mu.Lock("StartImportLabelsTaskRun")
+	defer b.mu.Unlock()
+
+	return b.startMLTaskRunLocked(transformID, mlTaskTypeImportLabels)
+}
+
+// GetMLTaskRun retrieves a single ML task run by transform ID and task run ID.
+func (b *InMemoryBackend) GetMLTaskRun(transformID, taskRunID string) (*MLTaskRun, error) {
+	b.mu.RLock("GetMLTaskRun")
+	defer b.mu.RUnlock()
+
+	run, ok := b.mlTaskRuns[mlTaskRunKey(transformID, taskRunID)]
+	if !ok {
+		return nil, ErrMLTaskRunNotFound
+	}
+
+	cp := *run
+
+	return &cp, nil
+}
+
+// GetMLTaskRuns returns all task runs for a given ML transform, newest first.
+func (b *InMemoryBackend) GetMLTaskRuns(transformID string) ([]*MLTaskRun, error) {
+	b.mu.RLock("GetMLTaskRuns")
+	defer b.mu.RUnlock()
+
+	if _, ok := b.mlTransforms[transformID]; !ok {
+		return nil, fmt.Errorf("ML transform %q not found: %w", transformID, ErrNotFound)
+	}
+
+	prefix := transformID + "|"
+	out := make([]*MLTaskRun, 0)
+
+	for _, k := range sortedKeys(b.mlTaskRuns) {
+		if strings.HasPrefix(k, prefix) {
+			cp := *b.mlTaskRuns[k]
+			out = append(out, &cp)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].StartedOn > out[j].StartedOn })
+
+	return out, nil
+}
+
+// CancelMLTaskRun transitions an ML task run to STOPPED status.
+func (b *InMemoryBackend) CancelMLTaskRun(transformID, taskRunID string) error {
+	b.mu.Lock("CancelMLTaskRun")
+	defer b.mu.Unlock()
+
+	key := mlTaskRunKey(transformID, taskRunID)
+
+	run, ok := b.mlTaskRuns[key]
+	if !ok {
+		return ErrMLTaskRunNotFound
+	}
+
+	run.Status = "STOPPED"
+	run.CompletedOn = float64(time.Now().Unix())
+
+	return nil
+}
+
+// ListDataQualityEvaluationRuns returns all DataQuality ruleset evaluation runs.
+func (b *InMemoryBackend) ListDataQualityEvaluationRuns() []*DataQualityEvaluationRun {
+	b.mu.RLock("ListDataQualityEvaluationRuns")
+	defer b.mu.RUnlock()
+
+	out := make([]*DataQualityEvaluationRun, 0, len(b.dataQualityEvalRuns))
+	for _, r := range b.dataQualityEvalRuns {
+		cp := *r
+		out = append(out, &cp)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].StartedOn < out[j].StartedOn })
+
+	return out
+}
+
+// ListDataQualityResults returns all DataQuality results.
+func (b *InMemoryBackend) ListDataQualityResults() []*DataQualityResult {
+	b.mu.RLock("ListDataQualityResults")
+	defer b.mu.RUnlock()
+
+	out := make([]*DataQualityResult, 0, len(b.dataQualityResult))
+	for _, r := range b.dataQualityResult {
+		cp := *r
+		out = append(out, &cp)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ResultID < out[j].ResultID })
+
+	return out
+}

--- a/services/glue/backend_mltasks.go
+++ b/services/glue/backend_mltasks.go
@@ -142,7 +142,7 @@ func (b *InMemoryBackend) CancelMLTaskRun(transformID, taskRunID string) error {
 		return ErrMLTaskRunNotFound
 	}
 
-	run.Status = "STOPPED"
+	run.Status = stateStopped
 	run.CompletedOn = float64(time.Now().Unix())
 
 	return nil

--- a/services/glue/backend_mltasks_test.go
+++ b/services/glue/backend_mltasks_test.go
@@ -12,6 +12,7 @@ import (
 // newTestBackendForML creates a backend for direct ML task run testing.
 func newTestBackendForML(t *testing.T) *glue.InMemoryBackend {
 	t.Helper()
+
 	return glue.NewInMemoryBackend(testAccountID, testRegion)
 }
 

--- a/services/glue/backend_mltasks_test.go
+++ b/services/glue/backend_mltasks_test.go
@@ -1,0 +1,346 @@
+package glue_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/glue"
+)
+
+// newTestBackendForML creates a backend for direct ML task run testing.
+func newTestBackendForML(t *testing.T) *glue.InMemoryBackend {
+	t.Helper()
+	return glue.NewInMemoryBackend(testAccountID, testRegion)
+}
+
+// createMLTransformDirect creates an ML transform in the backend and returns its ID.
+func createMLTransformDirect(t *testing.T, b *glue.InMemoryBackend, name string) string {
+	t.Helper()
+
+	m, err := b.CreateMLTransform(name, "desc", "role-arn", nil, glue.MLTransformParameter{}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, m.TransformID)
+
+	return m.TransformID
+}
+
+// TestBackend_StartMLEvaluationTaskRun exercises the backend ML evaluation run.
+func TestBackend_StartMLEvaluationTaskRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		transformID string
+		wantErr     bool
+	}{
+		{
+			name:        "unknown_transform_returns_error",
+			transformID: "no-such-transform",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBackendForML(t)
+			_, err := b.StartMLEvaluationTaskRun(tc.transformID)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("known_transform_returns_run", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		transformID := createMLTransformDirect(t, b, "eval-transform")
+
+		run, err := b.StartMLEvaluationTaskRun(transformID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, run.TaskRunID)
+		assert.Equal(t, transformID, run.TransformID)
+		assert.Equal(t, "EVALUATION", run.TaskType)
+		assert.Equal(t, "RUNNING", run.Status)
+	})
+}
+
+// TestBackend_StartMLLabelingSetGenerationTaskRun exercises labeling set generation.
+func TestBackend_StartMLLabelingSetGenerationTaskRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates_labeling_run", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		transformID := createMLTransformDirect(t, b, "label-transform")
+
+		run, err := b.StartMLLabelingSetGenerationTaskRun(transformID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, run.TaskRunID)
+		assert.Equal(t, "LABELING_SET_GENERATION", run.TaskType)
+	})
+}
+
+// TestBackend_StartExportImportLabels exercises export/import label runs.
+func TestBackend_StartExportImportLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fn           func(b *glue.InMemoryBackend, id, path string) (*glue.MLTaskRun, error)
+		wantTaskType string
+	}{
+		{
+			name: "export_labels",
+			fn: func(b *glue.InMemoryBackend, id, path string) (*glue.MLTaskRun, error) {
+				return b.StartExportLabelsTaskRun(id, path)
+			},
+			wantTaskType: "EXPORT_LABELS",
+		},
+		{
+			name: "import_labels",
+			fn: func(b *glue.InMemoryBackend, id, path string) (*glue.MLTaskRun, error) {
+				return b.StartImportLabelsTaskRun(id, path)
+			},
+			wantTaskType: "IMPORT_LABELS",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBackendForML(t)
+			transformID := createMLTransformDirect(t, b, tc.name+"-transform")
+
+			run, err := tc.fn(b, transformID, "s3://bucket/path/")
+			require.NoError(t, err)
+			assert.NotEmpty(t, run.TaskRunID)
+			assert.Equal(t, tc.wantTaskType, run.TaskType)
+			assert.Equal(t, "RUNNING", run.Status)
+		})
+	}
+}
+
+// TestBackend_GetMLTaskRun exercises backend task run retrieval.
+func TestBackend_GetMLTaskRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not_found_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		_, err := b.GetMLTaskRun("t-missing", "r-missing")
+		assert.Error(t, err)
+	})
+
+	t.Run("found_returns_run", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		transformID := createMLTransformDirect(t, b, "get-run-transform")
+
+		started, err := b.StartMLEvaluationTaskRun(transformID)
+		require.NoError(t, err)
+
+		got, err := b.GetMLTaskRun(transformID, started.TaskRunID)
+		require.NoError(t, err)
+		assert.Equal(t, started.TaskRunID, got.TaskRunID)
+		assert.Equal(t, transformID, got.TransformID)
+	})
+}
+
+// TestBackend_GetMLTaskRuns exercises listing task runs per transform.
+func TestBackend_GetMLTaskRuns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown_transform_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		_, err := b.GetMLTaskRuns("t-missing")
+		assert.Error(t, err)
+	})
+
+	t.Run("empty_runs_for_new_transform", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		transformID := createMLTransformDirect(t, b, "empty-transform")
+
+		runs, err := b.GetMLTaskRuns(transformID)
+		require.NoError(t, err)
+		assert.Empty(t, runs)
+	})
+
+	t.Run("multiple_runs_all_returned", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		transformID := createMLTransformDirect(t, b, "multi-transform")
+
+		for range 4 {
+			_, err := b.StartMLEvaluationTaskRun(transformID)
+			require.NoError(t, err)
+		}
+
+		runs, err := b.GetMLTaskRuns(transformID)
+		require.NoError(t, err)
+		assert.Len(t, runs, 4)
+	})
+
+	t.Run("isolation_between_transforms", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		id1 := createMLTransformDirect(t, b, "transform-a")
+		id2 := createMLTransformDirect(t, b, "transform-b")
+
+		for range 2 {
+			_, err := b.StartMLEvaluationTaskRun(id1)
+			require.NoError(t, err)
+		}
+		_, err := b.StartMLEvaluationTaskRun(id2)
+		require.NoError(t, err)
+
+		runs1, err := b.GetMLTaskRuns(id1)
+		require.NoError(t, err)
+		assert.Len(t, runs1, 2)
+
+		runs2, err := b.GetMLTaskRuns(id2)
+		require.NoError(t, err)
+		assert.Len(t, runs2, 1)
+	})
+}
+
+// TestBackend_CancelMLTaskRun exercises cancelling a task run.
+func TestBackend_CancelMLTaskRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cancel_not_found_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		err := b.CancelMLTaskRun("t-missing", "r-missing")
+		assert.Error(t, err)
+	})
+
+	t.Run("cancel_transitions_to_stopped", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		transformID := createMLTransformDirect(t, b, "cancel-transform")
+
+		started, err := b.StartMLEvaluationTaskRun(transformID)
+		require.NoError(t, err)
+
+		err = b.CancelMLTaskRun(transformID, started.TaskRunID)
+		require.NoError(t, err)
+
+		got, err := b.GetMLTaskRun(transformID, started.TaskRunID)
+		require.NoError(t, err)
+		assert.Equal(t, "STOPPED", got.Status)
+		assert.Greater(t, got.CompletedOn, float64(0))
+	})
+}
+
+// TestBackend_ListDataQualityEvaluationRuns exercises listing evaluation runs.
+func TestBackend_ListDataQualityEvaluationRuns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		runs := b.ListDataQualityEvaluationRuns()
+		assert.Empty(t, runs)
+	})
+
+	t.Run("seeded_runs_returned", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		b.AddDataQualityEvalRunInternal(&glue.DataQualityEvaluationRun{RunID: "run-1", Status: "SUCCEEDED"})
+		b.AddDataQualityEvalRunInternal(&glue.DataQualityEvaluationRun{RunID: "run-2", Status: "RUNNING"})
+
+		runs := b.ListDataQualityEvaluationRuns()
+		assert.Len(t, runs, 2)
+	})
+}
+
+// TestBackend_ListDataQualityResults exercises listing data quality results.
+func TestBackend_ListDataQualityResults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		results := b.ListDataQualityResults()
+		assert.Empty(t, results)
+	})
+
+	t.Run("seeded_results_returned_sorted", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBackendForML(t)
+		b.AddDataQualityResultInternal(&glue.DataQualityResult{ResultID: "res-z", Score: 0.5})
+		b.AddDataQualityResultInternal(&glue.DataQualityResult{ResultID: "res-a", Score: 0.9})
+
+		results := b.ListDataQualityResults()
+		require.Len(t, results, 2)
+		assert.Equal(t, "res-a", results[0].ResultID)
+		assert.Equal(t, "res-z", results[1].ResultID)
+	})
+}
+
+// TestBackend_Reset_ClearsMLTaskRuns verifies Reset removes ML task runs.
+func TestBackend_Reset_ClearsMLTaskRuns(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackendForML(t)
+	transformID := createMLTransformDirect(t, b, "reset-transform")
+
+	_, err := b.StartMLEvaluationTaskRun(transformID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, glue.MLTaskRunCount(b))
+
+	b.Reset()
+
+	assert.Equal(t, 0, glue.MLTaskRunCount(b))
+
+	_, err = b.GetMLTaskRun(transformID, "any-run-id")
+	assert.Error(t, err)
+}
+
+// TestBackend_MLTaskRunCount verifies MLTaskRunCount returns total runs across transforms.
+func TestBackend_MLTaskRunCount(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBackendForML(t)
+	assert.Equal(t, 0, glue.MLTaskRunCount(b))
+
+	id1 := createMLTransformDirect(t, b, "count-transform-1")
+	id2 := createMLTransformDirect(t, b, "count-transform-2")
+
+	_, err := b.StartMLEvaluationTaskRun(id1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, glue.MLTaskRunCount(b))
+
+	_, err = b.StartMLLabelingSetGenerationTaskRun(id1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, glue.MLTaskRunCount(b))
+
+	_, err = b.StartMLEvaluationTaskRun(id2)
+	require.NoError(t, err)
+	assert.Equal(t, 3, glue.MLTaskRunCount(b))
+}

--- a/services/glue/export_test.go
+++ b/services/glue/export_test.go
@@ -126,3 +126,11 @@ func DataQualityEvalRunCount(b *InMemoryBackend) int {
 
 	return len(b.dataQualityEvalRuns)
 }
+
+// MLTaskRunCount returns the total number of ML task runs across all transforms. Used only in tests.
+func MLTaskRunCount(b *InMemoryBackend) int {
+	b.mu.RLock("MLTaskRunCount")
+	defer b.mu.RUnlock()
+
+	return len(b.mlTaskRuns)
+}

--- a/services/glue/handler_stubs.go
+++ b/services/glue/handler_stubs.go
@@ -221,13 +221,20 @@ func (h *Handler) handleCancelDataQualityRuleRecommendationRun(
 }
 
 // cancelMLTaskRunInput holds input for CancelMLTaskRun.
-type cancelMLTaskRunInput struct{}
+type cancelMLTaskRunInput struct {
+	TransformID string `json:"TransformId"`
+	TaskRunID   string `json:"TaskRunId"`
+}
 
 func (h *Handler) handleCancelMLTaskRun(
 	_ context.Context,
-	_ *cancelMLTaskRunInput,
+	in *cancelMLTaskRunInput,
 ) (*emptyOutput, error) {
-	return &emptyOutput{}, nil
+	if in.TransformID == "" || in.TaskRunID == "" {
+		return &emptyOutput{}, nil
+	}
+
+	return &emptyOutput{}, h.Backend.CancelMLTaskRun(in.TransformID, in.TaskRunID)
 }
 
 // cancelStatementInput holds input for CancelStatement.
@@ -339,11 +346,11 @@ func (h *Handler) handleCreateColumnStatisticsTaskSettings(
 	_ context.Context,
 	in *createColumnStatisticsTaskSettingsInput,
 ) (*emptyOutput, error) {
-	_, _ = h.Backend.CreateColumnStatisticsTaskSettings(
+	_, err := h.Backend.CreateColumnStatisticsTaskSettings(
 		in.DatabaseName, in.TableName, in.RoleArn, in.ColumnNameList,
 	)
 
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, err
 }
 
 // createCustomEntityTypeInput holds input for CreateCustomEntityType.
@@ -362,7 +369,9 @@ func (h *Handler) handleCreateCustomEntityType(
 	_ context.Context,
 	in *createCustomEntityTypeInput,
 ) (*createCustomEntityTypeOutput, error) {
-	_, _ = h.Backend.CreateCustomEntityType(in.Name, in.RegexString, in.ContextWords)
+	if _, err := h.Backend.CreateCustomEntityType(in.Name, in.RegexString, in.ContextWords); err != nil {
+		return nil, err
+	}
 
 	return &createCustomEntityTypeOutput{Name: in.Name}, nil
 }
@@ -391,34 +400,39 @@ func (h *Handler) handleCreateDevEndpoint(
 }
 
 // createIdentityCenterConfigurationInput holds input for CreateGlueIdentityCenterConfiguration.
-type createIdentityCenterConfigurationInput struct{}
+type createIdentityCenterConfigurationInput struct {
+	InstanceArn string `json:"InstanceArn,omitempty"`
+}
 
 func (h *Handler) handleCreateGlueIdentityCenterConfiguration(
 	_ context.Context,
-	_ *createIdentityCenterConfigurationInput,
+	in *createIdentityCenterConfigurationInput,
 ) (*emptyOutput, error) {
-	_ = h.Backend.CreateGlueIdentityCenterConfiguration("")
-
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.CreateGlueIdentityCenterConfiguration(in.InstanceArn)
 }
 
 // createIntegrationInput holds input for CreateIntegration.
 type createIntegrationInput struct {
-	IntegrationName string `json:"IntegrationName"`
+	Tags            map[string]string `json:"Tags,omitempty"`
+	IntegrationName string            `json:"IntegrationName"`
 }
 
 // createIntegrationOutput holds the result for CreateIntegration.
 type createIntegrationOutput struct {
 	IntegrationName string `json:"IntegrationName"`
+	Status          string `json:"Status"`
 }
 
 func (h *Handler) handleCreateIntegration(
 	_ context.Context,
 	in *createIntegrationInput,
 ) (*createIntegrationOutput, error) {
-	_, _ = h.Backend.CreateIntegration(in.IntegrationName, nil)
+	ig, err := h.Backend.CreateIntegration(in.IntegrationName, in.Tags)
+	if err != nil {
+		return nil, err
+	}
 
-	return &createIntegrationOutput{IntegrationName: in.IntegrationName}, nil
+	return &createIntegrationOutput{IntegrationName: ig.IntegrationName, Status: ig.Status}, nil
 }
 
 // createIntegrationResourcePropertyInput holds input for CreateIntegrationResourceProperty.
@@ -752,7 +766,9 @@ func (h *Handler) handleCreateUsageProfile(
 	_ context.Context,
 	in *createUsageProfileInput,
 ) (*createUsageProfileOutput, error) {
-	_, _ = h.Backend.CreateUsageProfile(in.Name, in.Description, in.Tags)
+	if _, err := h.Backend.CreateUsageProfile(in.Name, in.Description, in.Tags); err != nil {
+		return nil, err
+	}
 
 	return &createUsageProfileOutput{Name: in.Name}, nil
 }
@@ -899,9 +915,7 @@ func (h *Handler) handleDeleteColumnStatisticsTaskSettings(
 	_ context.Context,
 	in *deleteColumnStatisticsTaskSettingsInput,
 ) (*emptyOutput, error) {
-	_ = h.Backend.DeleteColumnStatisticsTaskSettings(in.DatabaseName, in.TableName)
-
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.DeleteColumnStatisticsTaskSettings(in.DatabaseName, in.TableName)
 }
 
 // deleteConnectionTypeInput holds input for DeleteConnectionType.
@@ -928,7 +942,9 @@ func (h *Handler) handleDeleteCustomEntityType(
 	_ context.Context,
 	in *deleteCustomEntityTypeInput,
 ) (*deleteCustomEntityTypeOutput, error) {
-	_ = h.Backend.DeleteCustomEntityType(in.Name)
+	if err := h.Backend.DeleteCustomEntityType(in.Name); err != nil {
+		return nil, err
+	}
 
 	return &deleteCustomEntityTypeOutput{Name: in.Name}, nil
 }
@@ -956,9 +972,7 @@ func (h *Handler) handleDeleteGlueIdentityCenterConfiguration(
 	_ context.Context,
 	_ *deleteIdentityCenterConfigurationInput,
 ) (*emptyOutput, error) {
-	_ = h.Backend.DeleteGlueIdentityCenterConfiguration()
-
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.DeleteGlueIdentityCenterConfiguration()
 }
 
 // deleteIntegrationInput holds input for DeleteIntegration.
@@ -975,7 +989,9 @@ func (h *Handler) handleDeleteIntegration(
 	_ context.Context,
 	in *deleteIntegrationInput,
 ) (*deleteIntegrationOutput, error) {
-	_ = h.Backend.DeleteIntegration(in.IntegrationIdentifier)
+	if err := h.Backend.DeleteIntegration(in.IntegrationIdentifier); err != nil {
+		return nil, err
+	}
 
 	return &deleteIntegrationOutput{IntegrationName: in.IntegrationIdentifier}, nil
 }
@@ -1242,9 +1258,7 @@ func (h *Handler) handleDeleteUsageProfile(
 	_ context.Context,
 	in *deleteUsageProfileInput,
 ) (*emptyOutput, error) {
-	_ = h.Backend.DeleteUsageProfile(in.Name)
-
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.DeleteUsageProfile(in.Name)
 }
 
 // deleteUserDefinedFunctionInput holds input for DeleteUserDefinedFunction.
@@ -1387,9 +1401,10 @@ func (h *Handler) handleGetBlueprintRun(
 	if in.RunID == "" {
 		return &getBlueprintRunOutput{}, nil
 	}
+
 	run, err := h.Backend.GetBlueprintRun(in.BlueprintName, in.RunID)
 	if err != nil {
-		return &getBlueprintRunOutput{}, nil //nolint:nilerr // graceful empty
+		return nil, err
 	}
 
 	return &getBlueprintRunOutput{Run: run}, nil
@@ -1790,10 +1805,10 @@ func (h *Handler) handleGetDataQualityRuleRecommendationRun(
 	if in.RunID == "" {
 		return &getDataQualityRuleRecommendationRunOutput{Status: stateSucceeded}, nil
 	}
+
 	run, err := h.Backend.GetDataQualityRuleRecommendationRun(in.RunID)
 	if err != nil {
-		//nolint:nilerr // graceful degradation: return stub on not-found
-		return &getDataQualityRuleRecommendationRunOutput{Status: stateSucceeded}, nil
+		return nil, err
 	}
 
 	return &getDataQualityRuleRecommendationRunOutput{RunID: run.RecommendationRunID, Status: run.Status}, nil
@@ -1919,7 +1934,10 @@ func (h *Handler) handleGetIntegrationTableProperties(
 }
 
 // getMLTaskRunInput holds input for GetMLTaskRun.
-type getMLTaskRunInput struct{}
+type getMLTaskRunInput struct {
+	TransformID string `json:"TransformId"`
+	TaskRunID   string `json:"TaskRunId"`
+}
 
 // getMLTaskRunOutput holds the result for GetMLTaskRun.
 type getMLTaskRunOutput struct {
@@ -1930,13 +1948,28 @@ type getMLTaskRunOutput struct {
 
 func (h *Handler) handleGetMLTaskRun(
 	_ context.Context,
-	_ *getMLTaskRunInput,
+	in *getMLTaskRunInput,
 ) (*getMLTaskRunOutput, error) {
-	return &getMLTaskRunOutput{Status: stateSucceeded}, nil
+	if in.TransformID == "" || in.TaskRunID == "" {
+		return &getMLTaskRunOutput{Status: stateSucceeded}, nil
+	}
+
+	run, err := h.Backend.GetMLTaskRun(in.TransformID, in.TaskRunID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getMLTaskRunOutput{
+		TransformID: run.TransformID,
+		TaskRunID:   run.TaskRunID,
+		Status:      run.Status,
+	}, nil
 }
 
 // getMLTaskRunsInput holds input for GetMLTaskRuns.
-type getMLTaskRunsInput struct{}
+type getMLTaskRunsInput struct {
+	TransformID string `json:"TransformId"`
+}
 
 // getMLTaskRunsOutput holds the result for GetMLTaskRuns.
 type getMLTaskRunsOutput struct {
@@ -1945,9 +1978,23 @@ type getMLTaskRunsOutput struct {
 
 func (h *Handler) handleGetMLTaskRuns(
 	_ context.Context,
-	_ *getMLTaskRunsInput,
+	in *getMLTaskRunsInput,
 ) (*getMLTaskRunsOutput, error) {
-	return &getMLTaskRunsOutput{TaskRuns: []any{}}, nil
+	if in.TransformID == "" {
+		return &getMLTaskRunsOutput{TaskRuns: []any{}}, nil
+	}
+
+	runs, err := h.Backend.GetMLTaskRuns(in.TransformID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]any, 0, len(runs))
+	for _, r := range runs {
+		result = append(result, r)
+	}
+
+	return &getMLTaskRunsOutput{TaskRuns: result}, nil
 }
 
 // getMLTransformInput holds input for GetMLTransform.
@@ -2008,7 +2055,9 @@ func (h *Handler) handleGetMapping(
 }
 
 // getMaterializedViewRefreshTaskRunInput holds input for GetMaterializedViewRefreshTaskRun.
-type getMaterializedViewRefreshTaskRunInput struct{}
+type getMaterializedViewRefreshTaskRunInput struct {
+	RunId string `json:"RunId"`
+}
 
 // getMaterializedViewRefreshTaskRunOutput holds the result for GetMaterializedViewRefreshTaskRun.
 type getMaterializedViewRefreshTaskRunOutput struct {
@@ -2018,8 +2067,17 @@ type getMaterializedViewRefreshTaskRunOutput struct {
 
 func (h *Handler) handleGetMaterializedViewRefreshTaskRun(
 	_ context.Context,
-	_ *getMaterializedViewRefreshTaskRunInput,
+	in *getMaterializedViewRefreshTaskRunInput,
 ) (*getMaterializedViewRefreshTaskRunOutput, error) {
+	if in.RunId != "" {
+		run, err := h.Backend.GetMaterializedViewRefreshTaskRun(in.RunId)
+		if err != nil {
+			return nil, err
+		}
+
+		return &getMaterializedViewRefreshTaskRunOutput{RunID: run.TaskRunID, Status: run.Status}, nil
+	}
+
 	runs := h.Backend.ListMaterializedViewRefreshTaskRuns()
 	if len(runs) == 0 {
 		return &getMaterializedViewRefreshTaskRunOutput{Status: stateSucceeded}, nil
@@ -2587,10 +2645,10 @@ func (h *Handler) handleGetUsageProfile(
 	if in.Name == "" {
 		return &getUsageProfileOutput{}, nil
 	}
+
 	p, err := h.Backend.GetUsageProfile(in.Name)
 	if err != nil {
-		//nolint:nilerr // graceful: return empty on not-found
-		return &getUsageProfileOutput{Name: in.Name}, nil
+		return nil, err
 	}
 
 	return &getUsageProfileOutput{Name: p.Name}, nil
@@ -2836,7 +2894,14 @@ func (h *Handler) handleListDataQualityResults(
 	_ context.Context,
 	_ *listDataQualityResultsInput,
 ) (*listDataQualityResultsOutput, error) {
-	return &listDataQualityResultsOutput{Results: []any{}}, nil
+	results := h.Backend.ListDataQualityResults()
+	list := make([]any, 0, len(results))
+
+	for _, r := range results {
+		list = append(list, r)
+	}
+
+	return &listDataQualityResultsOutput{Results: list}, nil
 }
 
 // listDataQualityRuleRecommendationRunsInput holds input for ListDataQualityRuleRecommendationRuns.
@@ -2872,7 +2937,14 @@ func (h *Handler) handleListDataQualityRulesetEvaluationRuns(
 	_ context.Context,
 	_ *listDataQualityRulesetEvaluationRunsInput,
 ) (*listDataQualityRulesetEvaluationRunsOutput, error) {
-	return &listDataQualityRulesetEvaluationRunsOutput{Runs: []any{}}, nil
+	runs := h.Backend.ListDataQualityEvaluationRuns()
+	result := make([]any, 0, len(runs))
+
+	for _, r := range runs {
+		result = append(result, r)
+	}
+
+	return &listDataQualityRulesetEvaluationRunsOutput{Runs: result}, nil
 }
 
 // listDataQualityStatisticAnnotationsInput holds input for ListDataQualityStatisticAnnotations.
@@ -2987,7 +3059,14 @@ func (h *Handler) handleListMLTransforms(
 	_ context.Context,
 	_ *listMLTransformsInput,
 ) (*listMLTransformsOutput, error) {
-	return &listMLTransformsOutput{TransformIDs: []string{}}, nil
+	transforms := h.Backend.GetMLTransforms()
+	ids := make([]string, 0, len(transforms))
+
+	for _, m := range transforms {
+		ids = append(ids, m.TransformID)
+	}
+
+	return &listMLTransformsOutput{TransformIDs: ids}, nil
 }
 
 // listMaterializedViewRefreshTaskRunsInput holds input for ListMaterializedViewRefreshTaskRuns.
@@ -3214,7 +3293,9 @@ func (h *Handler) handleModifyIntegration(
 	_ context.Context,
 	in *modifyIntegrationInput,
 ) (*modifyIntegrationOutput, error) {
-	_ = h.Backend.ModifyIntegration(in.IntegrationIdentifier)
+	if err := h.Backend.ModifyIntegration(in.IntegrationIdentifier); err != nil {
+		return nil, err
+	}
 
 	return &modifyIntegrationOutput{Status: stateActive}, nil
 }
@@ -3501,7 +3582,13 @@ func (h *Handler) handleStartColumnStatisticsTaskRunSchedule(
 }
 
 // startDataQualityRuleRecommendationRunInput holds input for StartDataQualityRuleRecommendationRun.
-type startDataQualityRuleRecommendationRunInput struct{}
+type startDataQualityRuleRecommendationRunInput struct {
+	DataSource struct {
+		GlueTable *GlueTable `json:"GlueTable,omitempty"`
+	} `json:"DataSource,omitzero"`
+	OutputS3Path string `json:"OutputS3Path,omitempty"`
+	Role         string `json:"Role,omitempty"`
+}
 
 // startDataQualityRuleRecommendationRunOutput holds the result for StartDataQualityRuleRecommendationRun.
 type startDataQualityRuleRecommendationRunOutput struct {
@@ -3510,9 +3597,9 @@ type startDataQualityRuleRecommendationRunOutput struct {
 
 func (h *Handler) handleStartDataQualityRuleRecommendationRun(
 	_ context.Context,
-	_ *startDataQualityRuleRecommendationRunInput,
+	in *startDataQualityRuleRecommendationRunInput,
 ) (*startDataQualityRuleRecommendationRunOutput, error) {
-	run, err := h.Backend.StartDataQualityRuleRecommendationRun("")
+	run, err := h.Backend.StartDataQualityRuleRecommendationRun(in.OutputS3Path)
 	if err != nil {
 		return nil, err
 	}
@@ -3521,7 +3608,10 @@ func (h *Handler) handleStartDataQualityRuleRecommendationRun(
 }
 
 // startExportLabelsTaskRunInput holds input for StartExportLabelsTaskRun.
-type startExportLabelsTaskRunInput struct{}
+type startExportLabelsTaskRunInput struct {
+	TransformID  string `json:"TransformId"`
+	OutputS3Path string `json:"OutputS3Path,omitempty"`
+}
 
 // startExportLabelsTaskRunOutput holds the result for StartExportLabelsTaskRun.
 type startExportLabelsTaskRunOutput struct {
@@ -3530,13 +3620,25 @@ type startExportLabelsTaskRunOutput struct {
 
 func (h *Handler) handleStartExportLabelsTaskRun(
 	_ context.Context,
-	_ *startExportLabelsTaskRunInput,
+	in *startExportLabelsTaskRunInput,
 ) (*startExportLabelsTaskRunOutput, error) {
-	return &startExportLabelsTaskRunOutput{TaskRunID: "export-labels-stub"}, nil
+	if in.TransformID == "" {
+		return &startExportLabelsTaskRunOutput{TaskRunID: ""}, nil
+	}
+
+	run, err := h.Backend.StartExportLabelsTaskRun(in.TransformID, in.OutputS3Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startExportLabelsTaskRunOutput{TaskRunID: run.TaskRunID}, nil
 }
 
 // startImportLabelsTaskRunInput holds input for StartImportLabelsTaskRun.
-type startImportLabelsTaskRunInput struct{}
+type startImportLabelsTaskRunInput struct {
+	TransformID string `json:"TransformId"`
+	InputS3Path string `json:"InputS3Path,omitempty"`
+}
 
 // startImportLabelsTaskRunOutput holds the result for StartImportLabelsTaskRun.
 type startImportLabelsTaskRunOutput struct {
@@ -3545,13 +3647,24 @@ type startImportLabelsTaskRunOutput struct {
 
 func (h *Handler) handleStartImportLabelsTaskRun(
 	_ context.Context,
-	_ *startImportLabelsTaskRunInput,
+	in *startImportLabelsTaskRunInput,
 ) (*startImportLabelsTaskRunOutput, error) {
-	return &startImportLabelsTaskRunOutput{TaskRunID: "import-labels-stub"}, nil
+	if in.TransformID == "" {
+		return &startImportLabelsTaskRunOutput{TaskRunID: ""}, nil
+	}
+
+	run, err := h.Backend.StartImportLabelsTaskRun(in.TransformID, in.InputS3Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startImportLabelsTaskRunOutput{TaskRunID: run.TaskRunID}, nil
 }
 
 // startMLEvaluationTaskRunInput holds input for StartMLEvaluationTaskRun.
-type startMLEvaluationTaskRunInput struct{}
+type startMLEvaluationTaskRunInput struct {
+	TransformID string `json:"TransformId"`
+}
 
 // startMLEvaluationTaskRunOutput holds the result for StartMLEvaluationTaskRun.
 type startMLEvaluationTaskRunOutput struct {
@@ -3560,13 +3673,24 @@ type startMLEvaluationTaskRunOutput struct {
 
 func (h *Handler) handleStartMLEvaluationTaskRun(
 	_ context.Context,
-	_ *startMLEvaluationTaskRunInput,
+	in *startMLEvaluationTaskRunInput,
 ) (*startMLEvaluationTaskRunOutput, error) {
-	return &startMLEvaluationTaskRunOutput{TaskRunID: "ml-eval-stub"}, nil
+	if in.TransformID == "" {
+		return &startMLEvaluationTaskRunOutput{TaskRunID: ""}, nil
+	}
+
+	run, err := h.Backend.StartMLEvaluationTaskRun(in.TransformID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startMLEvaluationTaskRunOutput{TaskRunID: run.TaskRunID}, nil
 }
 
 // startMLLabelingSetGenerationTaskRunInput holds input for StartMLLabelingSetGenerationTaskRun.
-type startMLLabelingSetGenerationTaskRunInput struct{}
+type startMLLabelingSetGenerationTaskRunInput struct {
+	TransformID string `json:"TransformId"`
+}
 
 // startMLLabelingSetGenerationTaskRunOutput holds the result for StartMLLabelingSetGenerationTaskRun.
 type startMLLabelingSetGenerationTaskRunOutput struct {
@@ -3575,13 +3699,25 @@ type startMLLabelingSetGenerationTaskRunOutput struct {
 
 func (h *Handler) handleStartMLLabelingSetGenerationTaskRun(
 	_ context.Context,
-	_ *startMLLabelingSetGenerationTaskRunInput,
+	in *startMLLabelingSetGenerationTaskRunInput,
 ) (*startMLLabelingSetGenerationTaskRunOutput, error) {
-	return &startMLLabelingSetGenerationTaskRunOutput{TaskRunID: "ml-label-stub"}, nil
+	if in.TransformID == "" {
+		return &startMLLabelingSetGenerationTaskRunOutput{TaskRunID: ""}, nil
+	}
+
+	run, err := h.Backend.StartMLLabelingSetGenerationTaskRun(in.TransformID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &startMLLabelingSetGenerationTaskRunOutput{TaskRunID: run.TaskRunID}, nil
 }
 
 // startMaterializedViewRefreshTaskRunInput holds input for StartMaterializedViewRefreshTaskRun.
-type startMaterializedViewRefreshTaskRunInput struct{}
+type startMaterializedViewRefreshTaskRunInput struct {
+	DatabaseName string `json:"DatabaseName"`
+	TableName    string `json:"TableName"`
+}
 
 // startMaterializedViewRefreshTaskRunOutput holds the result for StartMaterializedViewRefreshTaskRun.
 type startMaterializedViewRefreshTaskRunOutput struct {
@@ -3590,9 +3726,9 @@ type startMaterializedViewRefreshTaskRunOutput struct {
 
 func (h *Handler) handleStartMaterializedViewRefreshTaskRun(
 	_ context.Context,
-	_ *startMaterializedViewRefreshTaskRunInput,
+	in *startMaterializedViewRefreshTaskRunInput,
 ) (*startMaterializedViewRefreshTaskRunOutput, error) {
-	run, err := h.Backend.StartMaterializedViewRefreshTaskRun("", "")
+	run, err := h.Backend.StartMaterializedViewRefreshTaskRun(in.DatabaseName, in.TableName)
 	if err != nil {
 		return nil, err
 	}
@@ -3652,11 +3788,11 @@ func (h *Handler) handleStopColumnStatisticsTaskRun(
 	_ context.Context,
 	in *stopColumnStatisticsTaskRunInput,
 ) (*emptyOutput, error) {
-	if in.ColumnStatisticsTaskRunID != "" {
-		_ = h.Backend.StopColumnStatisticsTaskRun(in.ColumnStatisticsTaskRunID)
+	if in.ColumnStatisticsTaskRunID == "" {
+		return &emptyOutput{}, nil
 	}
 
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.StopColumnStatisticsTaskRun(in.ColumnStatisticsTaskRunID)
 }
 
 // stopColumnStatisticsTaskRunScheduleInput holds input for StopColumnStatisticsTaskRunSchedule.
@@ -3678,11 +3814,11 @@ func (h *Handler) handleStopMaterializedViewRefreshTaskRun(
 	_ context.Context,
 	in *stopMaterializedViewRefreshTaskRunInput,
 ) (*emptyOutput, error) {
-	if in.RunID != "" {
-		_ = h.Backend.StopMaterializedViewRefreshTaskRun(in.RunID)
+	if in.RunID == "" {
+		return &emptyOutput{}, nil
 	}
 
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.StopMaterializedViewRefreshTaskRun(in.RunID)
 }
 
 // stopSessionInput holds input for StopSession.
@@ -3769,7 +3905,9 @@ func (h *Handler) handleUpdateBlueprint(
 	_ context.Context,
 	in *updateBlueprintInput,
 ) (*updateBlueprintOutput, error) {
-	_, _ = h.Backend.UpdateBlueprint(in.Name)
+	if _, err := h.Backend.UpdateBlueprint(in.Name); err != nil {
+		return nil, err
+	}
 
 	return &updateBlueprintOutput{Name: in.Name}, nil
 }
@@ -3878,13 +4016,19 @@ func (h *Handler) handleUpdateColumnStatisticsForTable(
 }
 
 // updateColumnStatisticsTaskSettingsInput holds input for UpdateColumnStatisticsTaskSettings.
-type updateColumnStatisticsTaskSettingsInput struct{}
+type updateColumnStatisticsTaskSettingsInput struct {
+	DatabaseName string `json:"DatabaseName"`
+	TableName    string `json:"TableName"`
+	RoleArn      string `json:"RoleArn,omitempty"`
+}
 
 func (h *Handler) handleUpdateColumnStatisticsTaskSettings(
 	_ context.Context,
-	_ *updateColumnStatisticsTaskSettingsInput,
+	in *updateColumnStatisticsTaskSettingsInput,
 ) (*emptyOutput, error) {
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.UpdateColumnStatisticsTaskSettings(
+		in.DatabaseName, in.TableName, in.RoleArn,
+	)
 }
 
 // updateConnectionInput holds input for UpdateConnection.
@@ -3922,15 +4066,15 @@ func (h *Handler) handleUpdateDevEndpoint(
 }
 
 // updateIdentityCenterConfigurationInput holds input for UpdateGlueIdentityCenterConfiguration.
-type updateIdentityCenterConfigurationInput struct{}
+type updateIdentityCenterConfigurationInput struct {
+	InstanceArn string `json:"InstanceArn,omitempty"`
+}
 
 func (h *Handler) handleUpdateGlueIdentityCenterConfiguration(
 	_ context.Context,
-	_ *updateIdentityCenterConfigurationInput,
+	in *updateIdentityCenterConfigurationInput,
 ) (*emptyOutput, error) {
-	_ = h.Backend.UpdateGlueIdentityCenterConfiguration("")
-
-	return &emptyOutput{}, nil
+	return &emptyOutput{}, h.Backend.UpdateGlueIdentityCenterConfiguration(in.InstanceArn)
 }
 
 // updateIntegrationResourcePropertyInput holds input for UpdateIntegrationResourceProperty.
@@ -4180,7 +4324,9 @@ func (h *Handler) handleUpdateUsageProfile(
 	_ context.Context,
 	in *updateUsageProfileInput,
 ) (*updateUsageProfileOutput, error) {
-	_, _ = h.Backend.UpdateUsageProfile(in.Name, "")
+	if _, err := h.Backend.UpdateUsageProfile(in.Name, ""); err != nil {
+		return nil, err
+	}
 
 	return &updateUsageProfileOutput{Name: in.Name}, nil
 }

--- a/services/glue/handler_stubs.go
+++ b/services/glue/handler_stubs.go
@@ -2581,9 +2581,9 @@ func (h *Handler) handleGetTriggers(
 
 // getUnfilteredPartitionMetadataInput holds input for GetUnfilteredPartitionMetadata.
 type getUnfilteredPartitionMetadataInput struct {
-	DatabaseName        string   `json:"DatabaseName"`
-	TableName           string   `json:"TableName"`
-	PartitionValues     []string `json:"PartitionValues"`
+	DatabaseName             string   `json:"DatabaseName"`
+	TableName                string   `json:"TableName"`
+	PartitionValues          []string `json:"PartitionValues"`
 	SupportedPermissionTypes []string `json:"SupportedPermissionTypes,omitempty"`
 }
 
@@ -2615,16 +2615,16 @@ func (h *Handler) handleGetUnfilteredPartitionMetadata(
 
 // getUnfilteredPartitionsMetadataInput holds input for GetUnfilteredPartitionsMetadata.
 type getUnfilteredPartitionsMetadataInput struct {
-	DatabaseName             string `json:"DatabaseName"`
-	TableName                string `json:"TableName"`
+	DatabaseName             string   `json:"DatabaseName"`
+	TableName                string   `json:"TableName"`
 	SupportedPermissionTypes []string `json:"SupportedPermissionTypes,omitempty"`
 }
 
 // unfilteredPartitionEntry wraps a Partition for the unfiltered metadata response.
 type unfilteredPartitionEntry struct {
-	Partition             *Partition `json:"Partition"`
-	AuthorizedColumns     []string   `json:"AuthorizedColumns"`
-	IsRegisteredWithLakeFormation bool `json:"IsRegisteredWithLakeFormation"`
+	Partition                     *Partition `json:"Partition"`
+	AuthorizedColumns             []string   `json:"AuthorizedColumns"`
+	IsRegisteredWithLakeFormation bool       `json:"IsRegisteredWithLakeFormation"`
 }
 
 // getUnfilteredPartitionsMetadataOutput holds the result for GetUnfilteredPartitionsMetadata.

--- a/services/glue/handler_stubs.go
+++ b/services/glue/handler_stubs.go
@@ -2056,7 +2056,7 @@ func (h *Handler) handleGetMapping(
 
 // getMaterializedViewRefreshTaskRunInput holds input for GetMaterializedViewRefreshTaskRun.
 type getMaterializedViewRefreshTaskRunInput struct {
-	RunId string `json:"RunId"`
+	RunID string `json:"RunId"`
 }
 
 // getMaterializedViewRefreshTaskRunOutput holds the result for GetMaterializedViewRefreshTaskRun.
@@ -2069,8 +2069,8 @@ func (h *Handler) handleGetMaterializedViewRefreshTaskRun(
 	_ context.Context,
 	in *getMaterializedViewRefreshTaskRunInput,
 ) (*getMaterializedViewRefreshTaskRunOutput, error) {
-	if in.RunId != "" {
-		run, err := h.Backend.GetMaterializedViewRefreshTaskRun(in.RunId)
+	if in.RunID != "" {
+		run, err := h.Backend.GetMaterializedViewRefreshTaskRun(in.RunID)
 		if err != nil {
 			return nil, err
 		}

--- a/services/glue/handler_stubs.go
+++ b/services/glue/handler_stubs.go
@@ -2580,7 +2580,12 @@ func (h *Handler) handleGetTriggers(
 }
 
 // getUnfilteredPartitionMetadataInput holds input for GetUnfilteredPartitionMetadata.
-type getUnfilteredPartitionMetadataInput struct{}
+type getUnfilteredPartitionMetadataInput struct {
+	DatabaseName        string   `json:"DatabaseName"`
+	TableName           string   `json:"TableName"`
+	PartitionValues     []string `json:"PartitionValues"`
+	SupportedPermissionTypes []string `json:"SupportedPermissionTypes,omitempty"`
+}
 
 // getUnfilteredPartitionMetadataOutput holds the result for GetUnfilteredPartitionMetadata.
 type getUnfilteredPartitionMetadataOutput struct {
@@ -2591,13 +2596,36 @@ type getUnfilteredPartitionMetadataOutput struct {
 
 func (h *Handler) handleGetUnfilteredPartitionMetadata(
 	_ context.Context,
-	_ *getUnfilteredPartitionMetadataInput,
+	in *getUnfilteredPartitionMetadataInput,
 ) (*getUnfilteredPartitionMetadataOutput, error) {
-	return &getUnfilteredPartitionMetadataOutput{AuthorizedColumns: []string{}}, nil
+	if in.DatabaseName == "" || in.TableName == "" {
+		return &getUnfilteredPartitionMetadataOutput{AuthorizedColumns: []string{}}, nil
+	}
+
+	p, err := h.Backend.GetPartition(in.DatabaseName, in.TableName, in.PartitionValues)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getUnfilteredPartitionMetadataOutput{
+		Partition:         p,
+		AuthorizedColumns: []string{},
+	}, nil
 }
 
 // getUnfilteredPartitionsMetadataInput holds input for GetUnfilteredPartitionsMetadata.
-type getUnfilteredPartitionsMetadataInput struct{}
+type getUnfilteredPartitionsMetadataInput struct {
+	DatabaseName             string `json:"DatabaseName"`
+	TableName                string `json:"TableName"`
+	SupportedPermissionTypes []string `json:"SupportedPermissionTypes,omitempty"`
+}
+
+// unfilteredPartitionEntry wraps a Partition for the unfiltered metadata response.
+type unfilteredPartitionEntry struct {
+	Partition             *Partition `json:"Partition"`
+	AuthorizedColumns     []string   `json:"AuthorizedColumns"`
+	IsRegisteredWithLakeFormation bool `json:"IsRegisteredWithLakeFormation"`
+}
 
 // getUnfilteredPartitionsMetadataOutput holds the result for GetUnfilteredPartitionsMetadata.
 type getUnfilteredPartitionsMetadataOutput struct {
@@ -2606,13 +2634,34 @@ type getUnfilteredPartitionsMetadataOutput struct {
 
 func (h *Handler) handleGetUnfilteredPartitionsMetadata(
 	_ context.Context,
-	_ *getUnfilteredPartitionsMetadataInput,
+	in *getUnfilteredPartitionsMetadataInput,
 ) (*getUnfilteredPartitionsMetadataOutput, error) {
-	return &getUnfilteredPartitionsMetadataOutput{UnfilteredPartitions: []any{}}, nil
+	if in.DatabaseName == "" || in.TableName == "" {
+		return &getUnfilteredPartitionsMetadataOutput{UnfilteredPartitions: []any{}}, nil
+	}
+
+	partitions, err := h.Backend.GetPartitions(in.DatabaseName, in.TableName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]any, 0, len(partitions))
+	for _, p := range partitions {
+		result = append(result, unfilteredPartitionEntry{
+			Partition:         p,
+			AuthorizedColumns: []string{},
+		})
+	}
+
+	return &getUnfilteredPartitionsMetadataOutput{UnfilteredPartitions: result}, nil
 }
 
 // getUnfilteredTableMetadataInput holds input for GetUnfilteredTableMetadata.
-type getUnfilteredTableMetadataInput struct{}
+type getUnfilteredTableMetadataInput struct {
+	DatabaseName             string   `json:"DatabaseName"`
+	Name                     string   `json:"Name"`
+	SupportedPermissionTypes []string `json:"SupportedPermissionTypes,omitempty"`
+}
 
 // getUnfilteredTableMetadataOutput holds the result for GetUnfilteredTableMetadata.
 type getUnfilteredTableMetadataOutput struct {
@@ -2623,9 +2672,21 @@ type getUnfilteredTableMetadataOutput struct {
 
 func (h *Handler) handleGetUnfilteredTableMetadata(
 	_ context.Context,
-	_ *getUnfilteredTableMetadataInput,
+	in *getUnfilteredTableMetadataInput,
 ) (*getUnfilteredTableMetadataOutput, error) {
-	return &getUnfilteredTableMetadataOutput{AuthorizedColumns: []string{}}, nil
+	if in.DatabaseName == "" || in.Name == "" {
+		return &getUnfilteredTableMetadataOutput{AuthorizedColumns: []string{}}, nil
+	}
+
+	tbl, err := h.Backend.GetTable(in.DatabaseName, in.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &getUnfilteredTableMetadataOutput{
+		Table:             tbl,
+		AuthorizedColumns: []string{},
+	}, nil
 }
 
 // getUsageProfileInput holds input for GetUsageProfile.

--- a/services/glue/handler_stubs_stateful_test.go
+++ b/services/glue/handler_stubs_stateful_test.go
@@ -2,6 +2,7 @@ package glue_test
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
 	"testing"
 
@@ -51,6 +52,7 @@ func TestMLEvaluationTaskRun(t *testing.T) {
 			name: "known_transform_returns_200",
 			setupFn: func(t *testing.T, h *glue.Handler) string {
 				t.Helper()
+
 				return createTestMLTransform(t, h, "eval-transform")
 			},
 			wantCode: http.StatusOK,
@@ -120,9 +122,7 @@ func TestMLExportImportLabels(t *testing.T) {
 			transformID := createTestMLTransform(t, h, tc.name+"-transform")
 
 			input := map[string]any{"TransformId": transformID}
-			for k, v := range tc.extraInput {
-				input[k] = v
-			}
+			maps.Copy(input, tc.extraInput)
 
 			rec := doGlueRequest(t, h, tc.action, input)
 			require.Equal(t, http.StatusOK, rec.Code)

--- a/services/glue/handler_stubs_stateful_test.go
+++ b/services/glue/handler_stubs_stateful_test.go
@@ -35,10 +35,10 @@ func TestMLEvaluationTaskRun(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		setupFn    func(t *testing.T, h *glue.Handler) (transformID string)
+		name        string
+		setupFn     func(t *testing.T, h *glue.Handler) (transformID string)
 		transformID string // override if not using setup
-		wantCode   int
+		wantCode    int
 	}{
 		{
 			name: "unknown_transform_returns_400",
@@ -96,18 +96,18 @@ func TestMLExportImportLabels(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		action  string
 		extraInput map[string]any
+		name       string
+		action     string
 	}{
 		{
-			name:   "export_labels",
-			action: "StartExportLabelsTaskRun",
+			name:       "export_labels",
+			action:     "StartExportLabelsTaskRun",
 			extraInput: map[string]any{"OutputS3Path": "s3://bucket/labels/"},
 		},
 		{
-			name:   "import_labels",
-			action: "StartImportLabelsTaskRun",
+			name:       "import_labels",
+			action:     "StartImportLabelsTaskRun",
 			extraInput: map[string]any{"InputS3Path": "s3://bucket/import/"},
 		},
 	}
@@ -147,7 +147,9 @@ func TestGetMLTaskRun(t *testing.T) {
 		rec := doGlueRequest(t, h, "GetMLTaskRun", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ Status string `json:"Status"` }
+		var out struct {
+			Status string `json:"Status"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Equal(t, "SUCCEEDED", out.Status)
 	})
@@ -174,7 +176,9 @@ func TestGetMLTaskRun(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, startRec.Code)
 
-		var startOut struct{ TaskRunID string `json:"TaskRunId"` }
+		var startOut struct {
+			TaskRunID string `json:"TaskRunId"`
+		}
 		require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startOut))
 
 		getRec := doGlueRequest(t, h, "GetMLTaskRun", map[string]any{
@@ -205,7 +209,9 @@ func TestGetMLTaskRun(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, getRec2.Code)
 
-		var getOut2 struct{ Status string `json:"Status"` }
+		var getOut2 struct {
+			Status string `json:"Status"`
+		}
 		require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getOut2))
 		assert.Equal(t, "STOPPED", getOut2.Status)
 	})
@@ -222,7 +228,9 @@ func TestGetMLTaskRuns(t *testing.T) {
 		rec := doGlueRequest(t, h, "GetMLTaskRuns", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ TaskRuns []any `json:"TaskRuns"` }
+		var out struct {
+			TaskRuns []any `json:"TaskRuns"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Empty(t, out.TaskRuns)
 	})
@@ -245,7 +253,9 @@ func TestGetMLTaskRuns(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ TaskRuns []any `json:"TaskRuns"` }
+		var out struct {
+			TaskRuns []any `json:"TaskRuns"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Len(t, out.TaskRuns, 3)
 	})
@@ -256,8 +266,8 @@ func TestCancelMLTaskRun(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
 		input    map[string]any
+		name     string
 		wantCode int
 	}{
 		{
@@ -288,9 +298,9 @@ func TestListMLTransforms_Stateful(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
+		name        string
 		createCount int
-		wantLen    int
+		wantLen     int
 	}{
 		{name: "empty", createCount: 0, wantLen: 0},
 		{name: "one_transform", createCount: 1, wantLen: 1},
@@ -309,7 +319,9 @@ func TestListMLTransforms_Stateful(t *testing.T) {
 			rec := doGlueRequest(t, h, "ListMLTransforms", map[string]any{})
 			require.Equal(t, http.StatusOK, rec.Code)
 
-			var out struct{ TransformIDs []string `json:"TransformIds"` }
+			var out struct {
+				TransformIDs []string `json:"TransformIds"`
+			}
 			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 			assert.Len(t, out.TransformIDs, tc.wantLen)
 		})
@@ -327,7 +339,9 @@ func TestDataQualityEvaluationRuns_Stateful(t *testing.T) {
 		rec := doGlueRequest(t, h, "ListDataQualityRulesetEvaluationRuns", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ Runs []any `json:"Runs"` }
+		var out struct {
+			Runs []any `json:"Runs"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Empty(t, out.Runs)
 	})
@@ -353,7 +367,9 @@ func TestDataQualityEvaluationRuns_Stateful(t *testing.T) {
 		rec := doGlueRequest(t, h, "ListDataQualityRulesetEvaluationRuns", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ Runs []any `json:"Runs"` }
+		var out struct {
+			Runs []any `json:"Runs"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Len(t, out.Runs, 1)
 	})
@@ -370,7 +386,9 @@ func TestListDataQualityResults_Stateful(t *testing.T) {
 		rec := doGlueRequest(t, h, "ListDataQualityResults", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ Results []any `json:"Results"` }
+		var out struct {
+			Results []any `json:"Results"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Empty(t, out.Results)
 	})
@@ -387,7 +405,9 @@ func TestListDataQualityResults_Stateful(t *testing.T) {
 		rec := doGlueRequest(t, h, "ListDataQualityResults", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ Results []any `json:"Results"` }
+		var out struct {
+			Results []any `json:"Results"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Len(t, out.Results, 2)
 	})
@@ -398,9 +418,9 @@ func TestUsageProfile_ErrorPropagation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		input    map[string]any
 		name     string
 		action   string
-		input    map[string]any
 		wantCode int
 	}{
 		{
@@ -445,8 +465,8 @@ func TestBlueprintRun_ErrorPropagation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
 		input    map[string]any
+		name     string
 		wantCode int
 	}{
 		{
@@ -477,8 +497,8 @@ func TestDataQualityRecommendationRun_ErrorPropagation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
 		input    map[string]any
+		name     string
 		wantCode int
 	}{
 		{
@@ -519,7 +539,9 @@ func TestMaterializedViewRefresh_Stateful(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, startRec.Code)
 
-		var startOut struct{ RunID string `json:"RunId"` }
+		var startOut struct {
+			RunID string `json:"RunId"`
+		}
 		require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startOut))
 		assert.NotEmpty(t, startOut.RunID)
 
@@ -546,7 +568,9 @@ func TestMaterializedViewRefresh_Stateful(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, getRec2.Code)
 
-		var getOut2 struct{ Status string `json:"Status"` }
+		var getOut2 struct {
+			Status string `json:"Status"`
+		}
 		require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getOut2))
 		assert.Equal(t, "STOPPED", getOut2.Status)
 	})
@@ -574,7 +598,9 @@ func TestMaterializedViewRefresh_Stateful(t *testing.T) {
 		rec := doGlueRequest(t, h, "GetMaterializedViewRefreshTaskRun", map[string]any{})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ Status string `json:"Status"` }
+		var out struct {
+			Status string `json:"Status"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Equal(t, "RUNNING", out.Status)
 	})
@@ -594,7 +620,9 @@ func TestGlueIdentityCenter_Stateful(t *testing.T) {
 	getRec := doGlueRequest(t, h, "GetGlueIdentityCenterConfiguration", map[string]any{})
 	require.Equal(t, http.StatusOK, getRec.Code)
 
-	var getOut struct{ InstanceArn string `json:"InstanceArn"` }
+	var getOut struct {
+		InstanceArn string `json:"InstanceArn"`
+	}
 	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getOut))
 	assert.Equal(t, "arn:aws:sso:::instance/ssoins-1234", getOut.InstanceArn)
 
@@ -612,10 +640,10 @@ func TestCustomEntityType_ErrorPropagation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		action   string
 		setup    func(t *testing.T, h *glue.Handler)
 		input    map[string]any
+		name     string
+		action   string
 		wantCode int
 	}{
 		{
@@ -698,9 +726,9 @@ func TestIntegration_ErrorPropagation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		input    map[string]any
 		name     string
 		action   string
-		input    map[string]any
 		wantCode int
 	}{
 		{
@@ -747,7 +775,9 @@ func TestDataQualityRecommendationRun_Stateful(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, startRec.Code)
 
-	var startOut struct{ RunID string `json:"RunId"` }
+	var startOut struct {
+		RunID string `json:"RunId"`
+	}
 	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startOut))
 	assert.NotEmpty(t, startOut.RunID)
 

--- a/services/glue/handler_stubs_stateful_test.go
+++ b/services/glue/handler_stubs_stateful_test.go
@@ -1,0 +1,766 @@
+package glue_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/glue"
+)
+
+// createTestMLTransform is a helper that creates an ML transform and returns its ID.
+func createTestMLTransform(t *testing.T, h *glue.Handler, name string) string {
+	t.Helper()
+
+	rec := doGlueRequest(t, h, "CreateMLTransform", map[string]any{
+		"Name": name,
+		"Role": "arn:aws:iam::000000000000:role/GlueRole",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		TransformID string `json:"TransformId"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotEmpty(t, out.TransformID)
+
+	return out.TransformID
+}
+
+// TestMLEvaluationTaskRun exercises the ML evaluation task run lifecycle.
+func TestMLEvaluationTaskRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setupFn    func(t *testing.T, h *glue.Handler) (transformID string)
+		transformID string // override if not using setup
+		wantCode   int
+	}{
+		{
+			name: "unknown_transform_returns_400",
+			setupFn: func(_ *testing.T, _ *glue.Handler) string {
+				return "no-such-transform"
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "known_transform_returns_200",
+			setupFn: func(t *testing.T, h *glue.Handler) string {
+				t.Helper()
+				return createTestMLTransform(t, h, "eval-transform")
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			transformID := tc.setupFn(t, h)
+
+			rec := doGlueRequest(t, h, "StartMLEvaluationTaskRun", map[string]any{
+				"TransformId": transformID,
+			})
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestMLLabelingSetGenerationTaskRun exercises the labeling set generation task run.
+func TestMLLabelingSetGenerationTaskRun(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	transformID := createTestMLTransform(t, h, "label-transform")
+
+	rec := doGlueRequest(t, h, "StartMLLabelingSetGenerationTaskRun", map[string]any{
+		"TransformId": transformID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		TaskRunID string `json:"TaskRunId"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.NotEmpty(t, out.TaskRunID)
+}
+
+// TestMLExportImportLabels exercises export/import label task runs.
+func TestMLExportImportLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		action  string
+		extraInput map[string]any
+	}{
+		{
+			name:   "export_labels",
+			action: "StartExportLabelsTaskRun",
+			extraInput: map[string]any{"OutputS3Path": "s3://bucket/labels/"},
+		},
+		{
+			name:   "import_labels",
+			action: "StartImportLabelsTaskRun",
+			extraInput: map[string]any{"InputS3Path": "s3://bucket/import/"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			transformID := createTestMLTransform(t, h, tc.name+"-transform")
+
+			input := map[string]any{"TransformId": transformID}
+			for k, v := range tc.extraInput {
+				input[k] = v
+			}
+
+			rec := doGlueRequest(t, h, tc.action, input)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var out struct {
+				TaskRunID string `json:"TaskRunId"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+			assert.NotEmpty(t, out.TaskRunID)
+		})
+	}
+}
+
+// TestGetMLTaskRun exercises GetMLTaskRun with various inputs.
+func TestGetMLTaskRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_ids_returns_ok", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetMLTaskRun", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ Status string `json:"Status"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Equal(t, "SUCCEEDED", out.Status)
+	})
+
+	t.Run("unknown_run_returns_400", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetMLTaskRun", map[string]any{
+			"TransformId": "t-missing",
+			"TaskRunId":   "r-missing",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("lifecycle_start_get_cancel", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		transformID := createTestMLTransform(t, h, "lifecycle-transform")
+
+		startRec := doGlueRequest(t, h, "StartMLEvaluationTaskRun", map[string]any{
+			"TransformId": transformID,
+		})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		var startOut struct{ TaskRunID string `json:"TaskRunId"` }
+		require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startOut))
+
+		getRec := doGlueRequest(t, h, "GetMLTaskRun", map[string]any{
+			"TransformId": transformID,
+			"TaskRunId":   startOut.TaskRunID,
+		})
+		require.Equal(t, http.StatusOK, getRec.Code)
+
+		var getOut struct {
+			TransformID string `json:"TransformId"`
+			TaskRunID   string `json:"TaskRunId"`
+			Status      string `json:"Status"`
+		}
+		require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getOut))
+		assert.Equal(t, transformID, getOut.TransformID)
+		assert.Equal(t, startOut.TaskRunID, getOut.TaskRunID)
+		assert.Equal(t, "RUNNING", getOut.Status)
+
+		cancelRec := doGlueRequest(t, h, "CancelMLTaskRun", map[string]any{
+			"TransformId": transformID,
+			"TaskRunId":   startOut.TaskRunID,
+		})
+		require.Equal(t, http.StatusOK, cancelRec.Code)
+
+		getRec2 := doGlueRequest(t, h, "GetMLTaskRun", map[string]any{
+			"TransformId": transformID,
+			"TaskRunId":   startOut.TaskRunID,
+		})
+		require.Equal(t, http.StatusOK, getRec2.Code)
+
+		var getOut2 struct{ Status string `json:"Status"` }
+		require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getOut2))
+		assert.Equal(t, "STOPPED", getOut2.Status)
+	})
+}
+
+// TestGetMLTaskRuns exercises GetMLTaskRuns listing.
+func TestGetMLTaskRuns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_transform_id_returns_empty_list", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetMLTaskRuns", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ TaskRuns []any `json:"TaskRuns"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Empty(t, out.TaskRuns)
+	})
+
+	t.Run("multiple_runs_returned", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		transformID := createTestMLTransform(t, h, "multi-run-transform")
+
+		for range 3 {
+			rec := doGlueRequest(t, h, "StartMLEvaluationTaskRun", map[string]any{
+				"TransformId": transformID,
+			})
+			require.Equal(t, http.StatusOK, rec.Code)
+		}
+
+		rec := doGlueRequest(t, h, "GetMLTaskRuns", map[string]any{
+			"TransformId": transformID,
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ TaskRuns []any `json:"TaskRuns"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Len(t, out.TaskRuns, 3)
+	})
+}
+
+// TestCancelMLTaskRun exercises CancelMLTaskRun error cases.
+func TestCancelMLTaskRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    map[string]any
+		wantCode int
+	}{
+		{
+			name:     "both_ids_empty_returns_ok",
+			input:    map[string]any{},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "unknown_run_returns_400",
+			input:    map[string]any{"TransformId": "t-unknown", "TaskRunId": "r-unknown"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doGlueRequest(t, h, "CancelMLTaskRun", tc.input)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestListMLTransforms_Stateful verifies ListMLTransforms returns real IDs.
+func TestListMLTransforms_Stateful(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		createCount int
+		wantLen    int
+	}{
+		{name: "empty", createCount: 0, wantLen: 0},
+		{name: "one_transform", createCount: 1, wantLen: 1},
+		{name: "three_transforms", createCount: 3, wantLen: 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			for i := range tc.createCount {
+				createTestMLTransform(t, h, "transform-"+string(rune('a'+i)))
+			}
+
+			rec := doGlueRequest(t, h, "ListMLTransforms", map[string]any{})
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var out struct{ TransformIDs []string `json:"TransformIds"` }
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+			assert.Len(t, out.TransformIDs, tc.wantLen)
+		})
+	}
+}
+
+// TestDataQualityEvaluationRuns_Stateful verifies listing evaluation runs.
+func TestDataQualityEvaluationRuns_Stateful(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_returns_empty_list", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "ListDataQualityRulesetEvaluationRuns", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ Runs []any `json:"Runs"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Empty(t, out.Runs)
+	})
+
+	t.Run("after_start_evaluation_run_returns_one", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+
+		createRulesetRec := doGlueRequest(t, h, "CreateDataQualityRuleset", map[string]any{
+			"Name":    "my-ruleset",
+			"Ruleset": "Rules = [RowCount > 0]",
+		})
+		require.Equal(t, http.StatusOK, createRulesetRec.Code)
+
+		startRec := doGlueRequest(t, h, "StartDataQualityRulesetEvaluationRun", map[string]any{
+			"DataSource":   map[string]any{},
+			"Role":         "arn:aws:iam::000000000000:role/GlueRole",
+			"RulesetNames": []string{"my-ruleset"},
+		})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		rec := doGlueRequest(t, h, "ListDataQualityRulesetEvaluationRuns", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ Runs []any `json:"Runs"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Len(t, out.Runs, 1)
+	})
+}
+
+// TestListDataQualityResults_Stateful verifies listing data quality results.
+func TestListDataQualityResults_Stateful(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_returns_empty_list", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "ListDataQualityResults", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ Results []any `json:"Results"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("after_seeding_results_appear", func(t *testing.T) {
+		t.Parallel()
+
+		backend := glue.NewInMemoryBackend(testAccountID, testRegion)
+		h := glue.NewHandler(backend)
+
+		backend.AddDataQualityResultInternal(&glue.DataQualityResult{ResultID: "res-1", Score: 0.95})
+		backend.AddDataQualityResultInternal(&glue.DataQualityResult{ResultID: "res-2", Score: 0.88})
+
+		rec := doGlueRequest(t, h, "ListDataQualityResults", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ Results []any `json:"Results"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Len(t, out.Results, 2)
+	})
+}
+
+// TestUsageProfile_ErrorPropagation verifies 404 on unknown usage profile.
+func TestUsageProfile_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		action   string
+		input    map[string]any
+		wantCode int
+	}{
+		{
+			name:     "get_not_found",
+			action:   "GetUsageProfile",
+			input:    map[string]any{"Name": "no-such-profile"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "get_empty_name_ok",
+			action:   "GetUsageProfile",
+			input:    map[string]any{"Name": ""},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "create_ok",
+			action:   "CreateUsageProfile",
+			input:    map[string]any{"Name": "my-profile"},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "delete_ok",
+			action:   "DeleteUsageProfile",
+			input:    map[string]any{"Name": "any-profile"},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doGlueRequest(t, h, tc.action, tc.input)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestBlueprintRun_ErrorPropagation verifies error propagation for blueprint runs.
+func TestBlueprintRun_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    map[string]any
+		wantCode int
+	}{
+		{
+			name:     "empty_run_id_returns_ok",
+			input:    map[string]any{"BlueprintName": "bp", "RunId": ""},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "unknown_run_id_returns_400",
+			input:    map[string]any{"BlueprintName": "bp", "RunId": "no-such-run"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doGlueRequest(t, h, "GetBlueprintRun", tc.input)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestDataQualityRecommendationRun_ErrorPropagation verifies error for missing run ID.
+func TestDataQualityRecommendationRun_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    map[string]any
+		wantCode int
+	}{
+		{
+			name:     "empty_run_id_returns_ok",
+			input:    map[string]any{"RunId": ""},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "unknown_run_id_returns_400",
+			input:    map[string]any{"RunId": "no-such-run"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doGlueRequest(t, h, "GetDataQualityRuleRecommendationRun", tc.input)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestMaterializedViewRefresh_Stateful verifies materialized view refresh lifecycle.
+func TestMaterializedViewRefresh_Stateful(t *testing.T) {
+	t.Parallel()
+
+	t.Run("start_get_by_id_stop", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+
+		startRec := doGlueRequest(t, h, "StartMaterializedViewRefreshTaskRun", map[string]any{
+			"DatabaseName": "mydb",
+			"TableName":    "myview",
+		})
+		require.Equal(t, http.StatusOK, startRec.Code)
+
+		var startOut struct{ RunID string `json:"RunId"` }
+		require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startOut))
+		assert.NotEmpty(t, startOut.RunID)
+
+		getRec := doGlueRequest(t, h, "GetMaterializedViewRefreshTaskRun", map[string]any{
+			"RunId": startOut.RunID,
+		})
+		require.Equal(t, http.StatusOK, getRec.Code)
+
+		var getOut struct {
+			RunID  string `json:"RunId"`
+			Status string `json:"Status"`
+		}
+		require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getOut))
+		assert.Equal(t, startOut.RunID, getOut.RunID)
+		assert.Equal(t, "RUNNING", getOut.Status)
+
+		stopRec := doGlueRequest(t, h, "StopMaterializedViewRefreshTaskRun", map[string]any{
+			"RunId": startOut.RunID,
+		})
+		require.Equal(t, http.StatusOK, stopRec.Code)
+
+		getRec2 := doGlueRequest(t, h, "GetMaterializedViewRefreshTaskRun", map[string]any{
+			"RunId": startOut.RunID,
+		})
+		require.Equal(t, http.StatusOK, getRec2.Code)
+
+		var getOut2 struct{ Status string `json:"Status"` }
+		require.NoError(t, json.Unmarshal(getRec2.Body.Bytes(), &getOut2))
+		assert.Equal(t, "STOPPED", getOut2.Status)
+	})
+
+	t.Run("get_not_found_returns_400", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetMaterializedViewRefreshTaskRun", map[string]any{
+			"RunId": "mvr-not-found",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("empty_run_id_falls_back_to_first", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+
+		doGlueRequest(t, h, "StartMaterializedViewRefreshTaskRun", map[string]any{
+			"DatabaseName": "db1",
+			"TableName":    "tbl1",
+		})
+
+		rec := doGlueRequest(t, h, "GetMaterializedViewRefreshTaskRun", map[string]any{})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ Status string `json:"Status"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Equal(t, "RUNNING", out.Status)
+	})
+}
+
+// TestGlueIdentityCenter_Stateful verifies IdentityCenter configuration lifecycle.
+func TestGlueIdentityCenter_Stateful(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	createRec := doGlueRequest(t, h, "CreateGlueIdentityCenterConfiguration", map[string]any{
+		"InstanceArn": "arn:aws:sso:::instance/ssoins-1234",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	getRec := doGlueRequest(t, h, "GetGlueIdentityCenterConfiguration", map[string]any{})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getOut struct{ InstanceArn string `json:"InstanceArn"` }
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getOut))
+	assert.Equal(t, "arn:aws:sso:::instance/ssoins-1234", getOut.InstanceArn)
+
+	updateRec := doGlueRequest(t, h, "UpdateGlueIdentityCenterConfiguration", map[string]any{
+		"InstanceArn": "arn:aws:sso:::instance/ssoins-5678",
+	})
+	require.Equal(t, http.StatusOK, updateRec.Code)
+
+	deleteRec := doGlueRequest(t, h, "DeleteGlueIdentityCenterConfiguration", map[string]any{})
+	require.Equal(t, http.StatusOK, deleteRec.Code)
+}
+
+// TestCustomEntityType_ErrorPropagation verifies error propagation for custom entity types.
+func TestCustomEntityType_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		action   string
+		setup    func(t *testing.T, h *glue.Handler)
+		input    map[string]any
+		wantCode int
+	}{
+		{
+			name:     "create_ok",
+			action:   "CreateCustomEntityType",
+			input:    map[string]any{"Name": "my-cet", "RegexString": `\d+`},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "delete_not_found",
+			action:   "DeleteCustomEntityType",
+			input:    map[string]any{"Name": "no-such-cet"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "delete_after_create_ok",
+			action: "DeleteCustomEntityType",
+			setup: func(t *testing.T, h *glue.Handler) {
+				t.Helper()
+				rec := doGlueRequest(t, h, "CreateCustomEntityType", map[string]any{
+					"Name": "to-delete", "RegexString": `\w+`,
+				})
+				require.Equal(t, http.StatusOK, rec.Code)
+			},
+			input:    map[string]any{"Name": "to-delete"},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			if tc.setup != nil {
+				tc.setup(t, h)
+			}
+
+			rec := doGlueRequest(t, h, tc.action, tc.input)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestColumnStatisticsTaskSettings_Stateful verifies column statistics task settings lifecycle.
+func TestColumnStatisticsTaskSettings_Stateful(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	createRec := doGlueRequest(t, h, "CreateColumnStatisticsTaskSettings", map[string]any{
+		"DatabaseName": "mydb",
+		"TableName":    "mytable",
+		"RoleArn":      "arn:aws:iam::000000000000:role/GlueRole",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+
+	updateRec := doGlueRequest(t, h, "UpdateColumnStatisticsTaskSettings", map[string]any{
+		"DatabaseName": "mydb",
+		"TableName":    "mytable",
+		"RoleArn":      "arn:aws:iam::000000000000:role/NewGlueRole",
+	})
+	require.Equal(t, http.StatusOK, updateRec.Code)
+
+	getRec := doGlueRequest(t, h, "GetColumnStatisticsTaskSettings", map[string]any{
+		"DatabaseName": "mydb",
+		"TableName":    "mytable",
+	})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	deleteRec := doGlueRequest(t, h, "DeleteColumnStatisticsTaskSettings", map[string]any{
+		"DatabaseName": "mydb",
+		"TableName":    "mytable",
+	})
+	require.Equal(t, http.StatusOK, deleteRec.Code)
+}
+
+// TestIntegration_ErrorPropagation verifies integration create/delete/modify lifecycle.
+func TestIntegration_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		action   string
+		input    map[string]any
+		wantCode int
+	}{
+		{
+			name:     "create_ok",
+			action:   "CreateIntegration",
+			input:    map[string]any{"IntegrationName": "my-integration"},
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "delete_not_found",
+			action:   "DeleteIntegration",
+			input:    map[string]any{"IntegrationIdentifier": "no-such-integration"},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "modify_not_found",
+			action:   "ModifyIntegration",
+			input:    map[string]any{"IntegrationIdentifier": "no-such-integration"},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			rec := doGlueRequest(t, h, tc.action, tc.input)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// TestDataQualityRecommendationRun_Stateful verifies that StartDataQualityRuleRecommendationRun
+// stores state that can be retrieved.
+func TestDataQualityRecommendationRun_Stateful(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	startRec := doGlueRequest(t, h, "StartDataQualityRuleRecommendationRun", map[string]any{
+		"OutputS3Path": "s3://bucket/output/",
+		"Role":         "arn:aws:iam::000000000000:role/GlueRole",
+	})
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startOut struct{ RunID string `json:"RunId"` }
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startOut))
+	assert.NotEmpty(t, startOut.RunID)
+
+	getRec := doGlueRequest(t, h, "GetDataQualityRuleRecommendationRun", map[string]any{
+		"RunId": startOut.RunID,
+	})
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var getOut struct {
+		RunID  string `json:"RunId"`
+		Status string `json:"Status"`
+	}
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getOut))
+	assert.Equal(t, startOut.RunID, getOut.RunID)
+	assert.NotEmpty(t, getOut.Status)
+}

--- a/services/glue/handler_unfiltered_test.go
+++ b/services/glue/handler_unfiltered_test.go
@@ -1,0 +1,305 @@
+package glue_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetUnfilteredTableMetadata exercises the GetUnfilteredTableMetadata handler.
+func TestGetUnfilteredTableMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_identifiers_returns_ok_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetUnfilteredTableMetadata", map[string]any{
+			"DatabaseName": "",
+			"Name":         "",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ AuthorizedColumns []string `json:"AuthorizedColumns"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.NotNil(t, out.AuthorizedColumns)
+	})
+
+	t.Run("table_not_found_returns_400", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetUnfilteredTableMetadata", map[string]any{
+			"DatabaseName": "no-db",
+			"Name":         "no-tbl",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("existing_table_returns_table_data", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "ufdb", "uftbl")
+
+		rec := doGlueRequest(t, h, "GetUnfilteredTableMetadata", map[string]any{
+			"DatabaseName": "ufdb",
+			"Name":         "uftbl",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Table struct {
+				Name string `json:"Name"`
+			} `json:"Table"`
+			AuthorizedColumns []string `json:"AuthorizedColumns"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Equal(t, "uftbl", out.Table.Name)
+		assert.NotNil(t, out.AuthorizedColumns)
+	})
+
+	t.Run("not_registered_with_lake_formation", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "lfdb", "lftbl")
+
+		rec := doGlueRequest(t, h, "GetUnfilteredTableMetadata", map[string]any{
+			"DatabaseName": "lfdb",
+			"Name":         "lftbl",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			IsRegisteredWithLakeFormation bool `json:"IsRegisteredWithLakeFormation"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.False(t, out.IsRegisteredWithLakeFormation)
+	})
+}
+
+// TestGetUnfilteredPartitionMetadata exercises the GetUnfilteredPartitionMetadata handler.
+func TestGetUnfilteredPartitionMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_identifiers_returns_ok_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionMetadata", map[string]any{
+			"DatabaseName":    "",
+			"TableName":       "",
+			"PartitionValues": []string{},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ AuthorizedColumns []string `json:"AuthorizedColumns"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.NotNil(t, out.AuthorizedColumns)
+	})
+
+	t.Run("partition_not_found_returns_400", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "ufpdb-nf", "ufptbl-nf")
+
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionMetadata", map[string]any{
+			"DatabaseName":    "ufpdb-nf",
+			"TableName":       "ufptbl-nf",
+			"PartitionValues": []string{"no-such-value"},
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("existing_partition_returns_partition_data", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "ufpdb", "ufptbl")
+		createTestPartition(t, h, "ufpdb", "ufptbl", []string{"2024", "01"})
+
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionMetadata", map[string]any{
+			"DatabaseName":    "ufpdb",
+			"TableName":       "ufptbl",
+			"PartitionValues": []string{"2024", "01"},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			Partition struct {
+				Values []string `json:"Values"`
+			} `json:"Partition"`
+			AuthorizedColumns             []string `json:"AuthorizedColumns"`
+			IsRegisteredWithLakeFormation bool     `json:"IsRegisteredWithLakeFormation"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Equal(t, []string{"2024", "01"}, out.Partition.Values)
+		assert.NotNil(t, out.AuthorizedColumns)
+		assert.False(t, out.IsRegisteredWithLakeFormation)
+	})
+}
+
+// TestGetUnfilteredPartitionsMetadata exercises the GetUnfilteredPartitionsMetadata handler.
+func TestGetUnfilteredPartitionsMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_identifiers_returns_empty", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionsMetadata", map[string]any{
+			"DatabaseName": "",
+			"TableName":    "",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Empty(t, out.UnfilteredPartitions)
+	})
+
+	t.Run("table_not_found_returns_400", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionsMetadata", map[string]any{
+			"DatabaseName": "no-db",
+			"TableName":    "no-tbl",
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("table_with_no_partitions_returns_empty_list", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "ufpm-db", "ufpm-tbl")
+
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionsMetadata", map[string]any{
+			"DatabaseName": "ufpm-db",
+			"TableName":    "ufpm-tbl",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Empty(t, out.UnfilteredPartitions)
+	})
+
+	t.Run("table_with_partitions_returns_all", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "ufp2-db", "ufp2-tbl")
+		createTestPartition(t, h, "ufp2-db", "ufp2-tbl", []string{"2024"})
+		createTestPartition(t, h, "ufp2-db", "ufp2-tbl", []string{"2025"})
+
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionsMetadata", map[string]any{
+			"DatabaseName": "ufp2-db",
+			"TableName":    "ufp2-tbl",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Len(t, out.UnfilteredPartitions, 2)
+	})
+
+	t.Run("partition_entries_contain_authorized_columns", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHandler(t)
+		createTestDB(t, h, "ufpac-db", "ufpac-tbl")
+		createTestPartition(t, h, "ufpac-db", "ufpac-tbl", []string{"2024"})
+
+		rec := doGlueRequest(t, h, "GetUnfilteredPartitionsMetadata", map[string]any{
+			"DatabaseName": "ufpac-db",
+			"TableName":    "ufpac-tbl",
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var out struct {
+			UnfilteredPartitions []struct {
+				Partition struct {
+					Values []string `json:"Values"`
+				} `json:"Partition"`
+				AuthorizedColumns []string `json:"AuthorizedColumns"`
+			} `json:"UnfilteredPartitions"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		require.Len(t, out.UnfilteredPartitions, 1)
+		assert.Equal(t, []string{"2024"}, out.UnfilteredPartitions[0].Partition.Values)
+		assert.NotNil(t, out.UnfilteredPartitions[0].AuthorizedColumns)
+	})
+}
+
+// TestUnfilteredMetadata_IntegrationFlow runs a combined create-query flow.
+func TestUnfilteredMetadata_IntegrationFlow(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+
+	// Setup: DB + table + partition
+	dbRec := doGlueRequest(t, h, "CreateDatabase", map[string]any{
+		"DatabaseInput": map[string]any{"Name": "integ-uf-db"},
+	})
+	require.Equal(t, http.StatusOK, dbRec.Code)
+
+	tblRec := doGlueRequest(t, h, "CreateTable", map[string]any{
+		"DatabaseName": "integ-uf-db",
+		"TableInput":   map[string]any{"Name": "integ-uf-tbl"},
+	})
+	require.Equal(t, http.StatusOK, tblRec.Code)
+
+	partRec := doGlueRequest(t, h, "CreatePartition", map[string]any{
+		"DatabaseName": "integ-uf-db",
+		"TableName":    "integ-uf-tbl",
+		"PartitionInput": map[string]any{
+			"Values": []string{"2024", "06"},
+		},
+	})
+	require.Equal(t, http.StatusOK, partRec.Code)
+
+	// GetUnfilteredTableMetadata returns the table.
+	tblMetaRec := doGlueRequest(t, h, "GetUnfilteredTableMetadata", map[string]any{
+		"DatabaseName": "integ-uf-db",
+		"Name":         "integ-uf-tbl",
+	})
+	require.Equal(t, http.StatusOK, tblMetaRec.Code)
+
+	var tblMeta struct {
+		Table struct{ Name string `json:"Name"` } `json:"Table"`
+	}
+	require.NoError(t, json.Unmarshal(tblMetaRec.Body.Bytes(), &tblMeta))
+	assert.Equal(t, "integ-uf-tbl", tblMeta.Table.Name)
+
+	// GetUnfilteredPartitionsMetadata lists all partitions.
+	partsMetaRec := doGlueRequest(t, h, "GetUnfilteredPartitionsMetadata", map[string]any{
+		"DatabaseName": "integ-uf-db",
+		"TableName":    "integ-uf-tbl",
+	})
+	require.Equal(t, http.StatusOK, partsMetaRec.Code)
+
+	var partsMeta struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+	require.NoError(t, json.Unmarshal(partsMetaRec.Body.Bytes(), &partsMeta))
+	assert.Len(t, partsMeta.UnfilteredPartitions, 1)
+
+	// GetUnfilteredPartitionMetadata retrieves the specific partition.
+	partMetaRec := doGlueRequest(t, h, "GetUnfilteredPartitionMetadata", map[string]any{
+		"DatabaseName":    "integ-uf-db",
+		"TableName":       "integ-uf-tbl",
+		"PartitionValues": []string{"2024", "06"},
+	})
+	require.Equal(t, http.StatusOK, partMetaRec.Code)
+
+	var partMeta struct {
+		Partition struct{ Values []string `json:"Values"` } `json:"Partition"`
+	}
+	require.NoError(t, json.Unmarshal(partMetaRec.Body.Bytes(), &partMeta))
+	assert.Equal(t, []string{"2024", "06"}, partMeta.Partition.Values)
+}

--- a/services/glue/handler_unfiltered_test.go
+++ b/services/glue/handler_unfiltered_test.go
@@ -23,7 +23,9 @@ func TestGetUnfilteredTableMetadata(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ AuthorizedColumns []string `json:"AuthorizedColumns"` }
+		var out struct {
+			AuthorizedColumns []string `json:"AuthorizedColumns"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.NotNil(t, out.AuthorizedColumns)
 	})
@@ -97,7 +99,9 @@ func TestGetUnfilteredPartitionMetadata(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ AuthorizedColumns []string `json:"AuthorizedColumns"` }
+		var out struct {
+			AuthorizedColumns []string `json:"AuthorizedColumns"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.NotNil(t, out.AuthorizedColumns)
 	})
@@ -158,7 +162,9 @@ func TestGetUnfilteredPartitionsMetadata(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+		var out struct {
+			UnfilteredPartitions []any `json:"UnfilteredPartitions"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Empty(t, out.UnfilteredPartitions)
 	})
@@ -186,7 +192,9 @@ func TestGetUnfilteredPartitionsMetadata(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+		var out struct {
+			UnfilteredPartitions []any `json:"UnfilteredPartitions"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Empty(t, out.UnfilteredPartitions)
 	})
@@ -205,7 +213,9 @@ func TestGetUnfilteredPartitionsMetadata(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, rec.Code)
 
-		var out struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+		var out struct {
+			UnfilteredPartitions []any `json:"UnfilteredPartitions"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 		assert.Len(t, out.UnfilteredPartitions, 2)
 	})
@@ -273,7 +283,9 @@ func TestUnfilteredMetadata_IntegrationFlow(t *testing.T) {
 	require.Equal(t, http.StatusOK, tblMetaRec.Code)
 
 	var tblMeta struct {
-		Table struct{ Name string `json:"Name"` } `json:"Table"`
+		Table struct {
+			Name string `json:"Name"`
+		} `json:"Table"`
 	}
 	require.NoError(t, json.Unmarshal(tblMetaRec.Body.Bytes(), &tblMeta))
 	assert.Equal(t, "integ-uf-tbl", tblMeta.Table.Name)
@@ -285,7 +297,9 @@ func TestUnfilteredMetadata_IntegrationFlow(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, partsMetaRec.Code)
 
-	var partsMeta struct{ UnfilteredPartitions []any `json:"UnfilteredPartitions"` }
+	var partsMeta struct {
+		UnfilteredPartitions []any `json:"UnfilteredPartitions"`
+	}
 	require.NoError(t, json.Unmarshal(partsMetaRec.Body.Bytes(), &partsMeta))
 	assert.Len(t, partsMeta.UnfilteredPartitions, 1)
 
@@ -298,7 +312,9 @@ func TestUnfilteredMetadata_IntegrationFlow(t *testing.T) {
 	require.Equal(t, http.StatusOK, partMetaRec.Code)
 
 	var partMeta struct {
-		Partition struct{ Values []string `json:"Values"` } `json:"Partition"`
+		Partition struct {
+			Values []string `json:"Values"`
+		} `json:"Partition"`
 	}
 	require.NoError(t, json.Unmarshal(partMetaRec.Body.Bytes(), &partMeta))
 	assert.Equal(t, []string{"2024", "06"}, partMeta.Partition.Values)

--- a/services/glue/interfaces.go
+++ b/services/glue/interfaces.go
@@ -358,6 +358,19 @@ type StorageBackend interface {
 	GetGlueIdentityCenterConfiguration() (*IdentityCenterConfig, error)
 	UpdateGlueIdentityCenterConfiguration(instanceARN string) error
 	DeleteGlueIdentityCenterConfiguration() error
+
+	// ML transform task run operations.
+	StartMLEvaluationTaskRun(transformID string) (*MLTaskRun, error)
+	StartMLLabelingSetGenerationTaskRun(transformID string) (*MLTaskRun, error)
+	StartExportLabelsTaskRun(transformID, outputPath string) (*MLTaskRun, error)
+	StartImportLabelsTaskRun(transformID, inputPath string) (*MLTaskRun, error)
+	GetMLTaskRun(transformID, taskRunID string) (*MLTaskRun, error)
+	GetMLTaskRuns(transformID string) ([]*MLTaskRun, error)
+	CancelMLTaskRun(transformID, taskRunID string) error
+
+	// DataQuality listing operations.
+	ListDataQualityEvaluationRuns() []*DataQualityEvaluationRun
+	ListDataQualityResults() []*DataQualityResult
 }
 
 // Snapshottable is an optional interface that a StorageBackend may implement


### PR DESCRIPTION
Replace stub implementations in services/glue/handler_stubs.go with real stateful emulation. Polecat: obsidian.