### PR TITLE
feat(route53): batch-2 AWS-accuracy audit (go-4mpk)

### DIFF
--- a/services/route53/backend.go
+++ b/services/route53/backend.go
@@ -676,12 +676,9 @@ func validateRoutingPolicy(rrs ResourceRecordSet) error {
 	return nil
 }
 
-// validateGeoProximityLocation enforces AWS constraints on GeoProximityLocation routing config.
-func validateGeoProximityLocation(gpl *GeoProximityLocation) error {
-	if gpl == nil {
-		return nil
-	}
-
+// geoProximityLocationFieldCount counts how many of the three mutually exclusive
+// routing fields are set on a GeoProximityLocation.
+func geoProximityLocationFieldCount(gpl *GeoProximityLocation) int {
 	count := 0
 	if gpl.AWSRegion != "" {
 		count++
@@ -692,6 +689,45 @@ func validateGeoProximityLocation(gpl *GeoProximityLocation) error {
 	if gpl.LocalZoneGroup != "" {
 		count++
 	}
+
+	return count
+}
+
+// validateGeoProximityCoordinates validates the lat/lon values inside a Coordinates block.
+func validateGeoProximityCoordinates(coords *GeoProximityCoordinates) error {
+	const (
+		latMin = -90.0
+		latMax = 90.0
+		lonMin = -180.0
+		lonMax = 180.0
+	)
+
+	lat, err := strconv.ParseFloat(coords.Latitude, 64)
+	if err != nil || lat < latMin || lat > latMax {
+		return fmt.Errorf(
+			"%w: GeoProximityLocation Coordinates Latitude must be a number in [%g, %g]",
+			ErrInvalidInput, latMin, latMax,
+		)
+	}
+
+	lon, err := strconv.ParseFloat(coords.Longitude, 64)
+	if err != nil || lon < lonMin || lon > lonMax {
+		return fmt.Errorf(
+			"%w: GeoProximityLocation Coordinates Longitude must be a number in [%g, %g]",
+			ErrInvalidInput, lonMin, lonMax,
+		)
+	}
+
+	return nil
+}
+
+// validateGeoProximityLocation enforces AWS constraints on GeoProximityLocation routing config.
+func validateGeoProximityLocation(gpl *GeoProximityLocation) error {
+	if gpl == nil {
+		return nil
+	}
+
+	count := geoProximityLocationFieldCount(gpl)
 
 	if count == 0 {
 		return fmt.Errorf(
@@ -710,10 +746,6 @@ func validateGeoProximityLocation(gpl *GeoProximityLocation) error {
 	const (
 		biasMin = -99
 		biasMax = 99
-		latMin  = -90.0
-		latMax  = 90.0
-		lonMin  = -180.0
-		lonMax  = 180.0
 	)
 
 	if gpl.Bias < biasMin || gpl.Bias > biasMax {
@@ -724,21 +756,7 @@ func validateGeoProximityLocation(gpl *GeoProximityLocation) error {
 	}
 
 	if gpl.Coordinates != nil {
-		lat, err := strconv.ParseFloat(gpl.Coordinates.Latitude, 64)
-		if err != nil || lat < latMin || lat > latMax {
-			return fmt.Errorf(
-				"%w: GeoProximityLocation Coordinates Latitude must be a number in [%g, %g]",
-				ErrInvalidInput, latMin, latMax,
-			)
-		}
-
-		lon, err := strconv.ParseFloat(gpl.Coordinates.Longitude, 64)
-		if err != nil || lon < lonMin || lon > lonMax {
-			return fmt.Errorf(
-				"%w: GeoProximityLocation Coordinates Longitude must be a number in [%g, %g]",
-				ErrInvalidInput, lonMin, lonMax,
-			)
-		}
+		return validateGeoProximityCoordinates(gpl.Coordinates)
 	}
 
 	return nil
@@ -762,7 +780,7 @@ func validateHealthCheckConfig(cfg HealthCheckConfig) error {
 
 	if cfg.InsufficientDataHealthStatus != "" {
 		switch cfg.InsufficientDataHealthStatus {
-		case "Healthy", "Unhealthy", "LastKnownStatus":
+		case defaultHealthStatus, "Unhealthy", "LastKnownStatus":
 		default:
 			return fmt.Errorf(
 				"%w: InsufficientDataHealthStatus must be Healthy, Unhealthy, or LastKnownStatus",

--- a/services/route53/backend.go
+++ b/services/route53/backend.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +44,9 @@ var (
 	ErrInvalidMXRecord                 = errors.New("invalid MX record value")
 	ErrInvalidSRVRecord                = errors.New("invalid SRV record value")
 	ErrInvalidCAARecord                = errors.New("invalid CAA record value")
+	ErrTrafficPolicyInUse              = errors.New("TrafficPolicyInUse")
+	ErrKeySigningKeyNotInactive        = errors.New("KeySigningKeyNotInactive")
+	ErrTrafficPolicyAlreadyExists      = errors.New("TrafficPolicyAlreadyExists")
 )
 
 const (
@@ -336,6 +340,12 @@ type TrafficPolicyInstance struct {
 	State                string `json:"state"`
 	TTL                  int64  `json:"ttl"`
 	TrafficPolicyVersion int32  `json:"trafficPolicyVersion"`
+}
+
+// TrafficPolicySummary is returned by ListTrafficPolicies and includes the version count.
+type TrafficPolicySummary struct {
+	TrafficPolicy
+	VersionCount int32
 }
 
 // vpcAssociation records a VPC associated with a hosted zone.
@@ -659,6 +669,108 @@ func validateRoutingPolicy(rrs ResourceRecordSet) error {
 		return fmt.Errorf("%w: Weight must be in range [0, 255]", ErrInvalidInput)
 	}
 
+	if err := validateGeoProximityLocation(rrs.GeoProximityLocation); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateGeoProximityLocation enforces AWS constraints on GeoProximityLocation routing config.
+func validateGeoProximityLocation(gpl *GeoProximityLocation) error {
+	if gpl == nil {
+		return nil
+	}
+
+	count := 0
+	if gpl.AWSRegion != "" {
+		count++
+	}
+	if gpl.Coordinates != nil {
+		count++
+	}
+	if gpl.LocalZoneGroup != "" {
+		count++
+	}
+
+	if count == 0 {
+		return fmt.Errorf(
+			"%w: GeoProximityLocation requires one of AWSRegion, Coordinates, or LocalZoneGroup",
+			ErrInvalidInput,
+		)
+	}
+
+	if count > 1 {
+		return fmt.Errorf(
+			"%w: GeoProximityLocation must specify exactly one of AWSRegion, Coordinates, or LocalZoneGroup",
+			ErrInvalidInput,
+		)
+	}
+
+	const (
+		biasMin = -99
+		biasMax = 99
+		latMin  = -90.0
+		latMax  = 90.0
+		lonMin  = -180.0
+		lonMax  = 180.0
+	)
+
+	if gpl.Bias < biasMin || gpl.Bias > biasMax {
+		return fmt.Errorf(
+			"%w: GeoProximityLocation Bias must be in range [%d, %d]",
+			ErrInvalidInput, biasMin, biasMax,
+		)
+	}
+
+	if gpl.Coordinates != nil {
+		lat, err := strconv.ParseFloat(gpl.Coordinates.Latitude, 64)
+		if err != nil || lat < latMin || lat > latMax {
+			return fmt.Errorf(
+				"%w: GeoProximityLocation Coordinates Latitude must be a number in [%g, %g]",
+				ErrInvalidInput, latMin, latMax,
+			)
+		}
+
+		lon, err := strconv.ParseFloat(gpl.Coordinates.Longitude, 64)
+		if err != nil || lon < lonMin || lon > lonMax {
+			return fmt.Errorf(
+				"%w: GeoProximityLocation Coordinates Longitude must be a number in [%g, %g]",
+				ErrInvalidInput, lonMin, lonMax,
+			)
+		}
+	}
+
+	return nil
+}
+
+// validateHealthCheckConfig enforces AWS type-specific constraints on a HealthCheckConfig.
+func validateHealthCheckConfig(cfg HealthCheckConfig) error {
+	if cfg.Type == HealthCheckTypeCloudWatchMetric && cfg.AlarmIdentifier == nil {
+		return fmt.Errorf(
+			"%w: CLOUDWATCH_METRIC health checks require AlarmIdentifier",
+			ErrInvalidInput,
+		)
+	}
+
+	if cfg.Type == HealthCheckTypeRecoveryControl && cfg.RoutingControlArn == "" {
+		return fmt.Errorf(
+			"%w: RECOVERY_CONTROL health checks require RoutingControlArn",
+			ErrInvalidInput,
+		)
+	}
+
+	if cfg.InsufficientDataHealthStatus != "" {
+		switch cfg.InsufficientDataHealthStatus {
+		case "Healthy", "Unhealthy", "LastKnownStatus":
+		default:
+			return fmt.Errorf(
+				"%w: InsufficientDataHealthStatus must be Healthy, Unhealthy, or LastKnownStatus",
+				ErrInvalidInput,
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -951,6 +1063,10 @@ func (b *InMemoryBackend) CreateHealthCheck(
 		return nil, fmt.Errorf("%w: health check type is required", ErrInvalidInput)
 	}
 
+	if err := validateHealthCheckConfig(cfg); err != nil {
+		return nil, err
+	}
+
 	b.mu.Lock("CreateHealthCheck")
 	defer b.mu.Unlock()
 
@@ -1214,17 +1330,27 @@ func (b *InMemoryBackend) DeactivateKeySigningKey(
 }
 
 // DeleteKeySigningKey deletes a key signing key.
+// The KSK must be INACTIVE; deleting an ACTIVE KSK returns ErrKeySigningKeyNotInactive.
 func (b *InMemoryBackend) DeleteKeySigningKey(hostedZoneID, name string) error {
 	b.mu.Lock("DeleteKeySigningKey")
 	defer b.mu.Unlock()
 
 	key := kskKey(hostedZoneID, name)
-	if _, ok := b.keySigningKeys[key]; !ok {
+	ksk, ok := b.keySigningKeys[key]
+	if !ok {
 		return fmt.Errorf(
 			"%w: key signing key %s not found in zone %s",
 			ErrKeySigningKeyNotFound,
 			name,
 			hostedZoneID,
+		)
+	}
+
+	if ksk.Status == kskStatusActive {
+		return fmt.Errorf(
+			"%w: key signing key %s must be INACTIVE before deletion",
+			ErrKeySigningKeyNotInactive,
+			name,
 		)
 	}
 
@@ -1829,6 +1955,16 @@ func (b *InMemoryBackend) CreateTrafficPolicy(
 	b.mu.Lock("CreateTrafficPolicy")
 	defer b.mu.Unlock()
 
+	for _, versions := range b.trafficPolicies {
+		if len(versions) > 0 && versions[0].Name == name {
+			return nil, fmt.Errorf(
+				"%w: traffic policy with name %s already exists",
+				ErrTrafficPolicyAlreadyExists,
+				name,
+			)
+		}
+	}
+
 	id := randomTrafficPolicyID()
 	tp := &TrafficPolicy{
 		ID:       id,
@@ -1902,6 +2038,10 @@ func (b *InMemoryBackend) CreateTrafficPolicyInstance(
 
 	if tpID == "" {
 		return nil, fmt.Errorf("%w: trafficPolicyId is required", ErrInvalidInput)
+	}
+
+	if ttl < 1 {
+		return nil, fmt.Errorf("%w: TTL must be >= 1 for traffic policy instances", ErrInvalidInput)
 	}
 
 	b.mu.Lock("CreateTrafficPolicyInstance")
@@ -1980,6 +2120,18 @@ func (b *InMemoryBackend) DeleteTrafficPolicy(id string, version int32) error {
 		)
 	}
 
+	for _, inst := range b.trafficPolicyInstances {
+		if inst.TrafficPolicyID == id && inst.TrafficPolicyVersion == version {
+			return fmt.Errorf(
+				"%w: traffic policy %s version %d is still in use by instance %s",
+				ErrTrafficPolicyInUse,
+				id,
+				version,
+				inst.ID,
+			)
+		}
+	}
+
 	if len(versions) == 1 {
 		delete(b.trafficPolicies, id)
 
@@ -2054,19 +2206,52 @@ func (b *InMemoryBackend) GetTrafficPolicyInstance(id string) (*TrafficPolicyIns
 	return &cp, nil
 }
 
-// ListTrafficPolicies returns the latest version of each traffic policy.
-func (b *InMemoryBackend) ListTrafficPolicies() ([]*TrafficPolicy, error) {
+// UpdateTrafficPolicyComment updates the comment on a specific version of a traffic policy.
+func (b *InMemoryBackend) UpdateTrafficPolicyComment(
+	id string, version int32, comment string,
+) (*TrafficPolicy, error) {
+	b.mu.Lock("UpdateTrafficPolicyComment")
+	defer b.mu.Unlock()
+
+	versions, ok := b.trafficPolicies[id]
+	if !ok || len(versions) == 0 {
+		return nil, fmt.Errorf("%w: traffic policy %s not found", ErrTrafficPolicyNotFound, id)
+	}
+
+	for _, tp := range versions {
+		if tp.Version == version {
+			tp.Comment = comment
+			cp := *tp
+
+			return &cp, nil
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"%w: traffic policy %s version %d not found",
+		ErrTrafficPolicyNotFound,
+		id,
+		version,
+	)
+}
+
+// ListTrafficPolicies returns the latest version of each traffic policy with its version count.
+func (b *InMemoryBackend) ListTrafficPolicies() ([]*TrafficPolicySummary, error) {
 	b.mu.RLock("ListTrafficPolicies")
 	defer b.mu.RUnlock()
 
-	result := make([]*TrafficPolicy, 0, len(b.trafficPolicies))
+	result := make([]*TrafficPolicySummary, 0, len(b.trafficPolicies))
 	for _, versions := range b.trafficPolicies {
 		if len(versions) == 0 {
 			continue
 		}
 
-		cp := *versions[len(versions)-1]
-		result = append(result, &cp)
+		latest := versions[len(versions)-1]
+		cp := *latest
+		result = append(result, &TrafficPolicySummary{
+			TrafficPolicy: cp,
+			VersionCount:  int32(len(versions)), //nolint:gosec // version count fits in int32
+		})
 	}
 
 	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })

--- a/services/route53/handler.go
+++ b/services/route53/handler.go
@@ -1637,6 +1637,12 @@ func handleBackendError(c *echo.Context, err error) error {
 		return xmlError(c, http.StatusNotFound, "VPCAssociationAuthorizationNotFound", err.Error())
 	case errors.Is(err, ErrKeySigningKeyWithActiveStatusNF):
 		return xmlError(c, http.StatusBadRequest, "KeySigningKeyWithActiveStatusNotFound", err.Error())
+	case errors.Is(err, ErrTrafficPolicyInUse):
+		return xmlError(c, http.StatusBadRequest, "TrafficPolicyInUse", err.Error())
+	case errors.Is(err, ErrKeySigningKeyNotInactive):
+		return xmlError(c, http.StatusBadRequest, "KeySigningKeyNotInactive", err.Error())
+	case errors.Is(err, ErrTrafficPolicyAlreadyExists):
+		return xmlError(c, http.StatusBadRequest, "TrafficPolicyAlreadyExists", err.Error())
 	default:
 		return xmlError(c, http.StatusInternalServerError, "InternalError", err.Error())
 	}
@@ -1819,16 +1825,30 @@ func (h *Handler) createHealthCheck(c *echo.Context) error {
 	}
 
 	cfg := HealthCheckConfig{
-		IPAddress:                req.Config.IPAddress,
-		FullyQualifiedDomainName: req.Config.FullyQualifiedDomainName,
-		ResourcePath:             req.Config.ResourcePath,
-		Type:                     HealthCheckType(req.Config.Type),
-		Port:                     req.Config.Port,
-		RequestInterval:          req.Config.RequestInterval,
-		FailureThreshold:         req.Config.FailureThreshold,
-		HealthThreshold:          req.Config.HealthThreshold,
-		Inverted:                 req.Config.Inverted,
-		ChildHealthChecks:        req.Config.ChildHealthChecks,
+		IPAddress:                    req.Config.IPAddress,
+		FullyQualifiedDomainName:     req.Config.FullyQualifiedDomainName,
+		ResourcePath:                 req.Config.ResourcePath,
+		SearchString:                 req.Config.SearchString,
+		InsufficientDataHealthStatus: req.Config.InsufficientDataHealthStatus,
+		RoutingControlArn:            req.Config.RoutingControlArn,
+		Type:                         HealthCheckType(req.Config.Type),
+		Port:                         req.Config.Port,
+		RequestInterval:              req.Config.RequestInterval,
+		FailureThreshold:             req.Config.FailureThreshold,
+		HealthThreshold:              req.Config.HealthThreshold,
+		EnableSNI:                    req.Config.EnableSNI,
+		MeasureLatency:               req.Config.MeasureLatency,
+		Disabled:                     req.Config.Disabled,
+		Inverted:                     req.Config.Inverted,
+		ChildHealthChecks:            req.Config.ChildHealthChecks,
+		Regions:                      req.Config.Regions,
+	}
+
+	if req.Config.AlarmIdentifier != nil {
+		cfg.AlarmIdentifier = &AlarmIdentifier{
+			Name:   req.Config.AlarmIdentifier.Name,
+			Region: req.Config.AlarmIdentifier.Region,
+		}
 	}
 
 	hc, err := h.Backend.CreateHealthCheck(req.CallerReference, cfg)
@@ -3211,7 +3231,7 @@ func (h *Handler) listTrafficPolicies(c *echo.Context) error {
 			Name:               p.Name,
 			Type:               p.Type,
 			LatestVersion:      p.Version,
-			TrafficPolicyCount: 1,
+			TrafficPolicyCount: p.VersionCount,
 		})
 	}
 

--- a/services/route53/handler_accuracy_test.go
+++ b/services/route53/handler_accuracy_test.go
@@ -1093,3 +1093,609 @@ func TestListHostedZonesByVPC(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, zones)
 }
+
+// ----------------------------------------
+// Batch-2 Gap B1: CreateHealthCheck maps all config fields
+// ----------------------------------------
+
+func TestCreateHealthCheck_AllConfigFields(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ref-full</CallerReference>
+  <HealthCheckConfig>
+    <Type>HTTP</Type>
+    <IPAddress>1.2.3.4</IPAddress>
+    <Port>80</Port>
+    <ResourcePath>/health</ResourcePath>
+    <FullyQualifiedDomainName>example.com</FullyQualifiedDomainName>
+    <SearchString>OK</SearchString>
+    <RequestInterval>30</RequestInterval>
+    <FailureThreshold>3</FailureThreshold>
+    <EnableSNI>true</EnableSNI>
+    <Disabled>false</Disabled>
+    <MeasureLatency>true</MeasureLatency>
+    <InsufficientDataHealthStatus>Healthy</InsufficientDataHealthStatus>
+    <Regions>
+      <Region>us-east-1</Region>
+      <Region>eu-west-1</Region>
+    </Regions>
+  </HealthCheckConfig>
+</CreateHealthCheckRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/healthcheck", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Extract health check ID from Location header.
+	loc := rec.Header().Get("Location")
+	require.NotEmpty(t, loc)
+	id := loc[strings.LastIndex(loc, "/")+1:]
+
+	// Get the health check back and verify all fields round-tripped.
+	rec = send(t, h, http.MethodGet, "/2013-04-01/healthcheck/"+id, "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	body2 := rec.Body.String()
+
+	assert.Contains(t, body2, "1.2.3.4")
+	assert.Contains(t, body2, "/health")
+	assert.Contains(t, body2, "OK")
+	assert.Contains(t, body2, "<EnableSNI>true</EnableSNI>")
+	assert.Contains(t, body2, "<MeasureLatency>true</MeasureLatency>")
+	assert.Contains(t, body2, "<InsufficientDataHealthStatus>Healthy</InsufficientDataHealthStatus>")
+	assert.Contains(t, body2, "us-east-1")
+	assert.Contains(t, body2, "eu-west-1")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B2: CLOUDWATCH_METRIC requires AlarmIdentifier
+// ----------------------------------------
+
+func TestCreateHealthCheck_CloudWatchMetric_RequiresAlarmIdentifier(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	// Missing AlarmIdentifier.
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ref-cw</CallerReference>
+  <HealthCheckConfig>
+    <Type>CLOUDWATCH_METRIC</Type>
+  </HealthCheckConfig>
+</CreateHealthCheckRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/healthcheck", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+func TestCreateHealthCheck_CloudWatchMetric_WithAlarmIdentifier(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ref-cw2</CallerReference>
+  <HealthCheckConfig>
+    <Type>CLOUDWATCH_METRIC</Type>
+    <AlarmIdentifier>
+      <Name>my-alarm</Name>
+      <Region>us-east-1</Region>
+    </AlarmIdentifier>
+    <InsufficientDataHealthStatus>Unhealthy</InsufficientDataHealthStatus>
+  </HealthCheckConfig>
+</CreateHealthCheckRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/healthcheck", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	assert.Contains(t, rec.Body.String(), "my-alarm")
+	assert.Contains(t, rec.Body.String(), "Unhealthy")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B3: RECOVERY_CONTROL requires RoutingControlArn
+// ----------------------------------------
+
+func TestCreateHealthCheck_RecoveryControl_RequiresRoutingControlArn(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ref-rc</CallerReference>
+  <HealthCheckConfig>
+    <Type>RECOVERY_CONTROL</Type>
+  </HealthCheckConfig>
+</CreateHealthCheckRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/healthcheck", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+func TestCreateHealthCheck_RecoveryControl_WithArn(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ref-rc2</CallerReference>
+  <HealthCheckConfig>
+    <Type>RECOVERY_CONTROL</Type>
+    <RoutingControlArn>arn:aws:route53-recovery-control::123:controlpanel/abc/routingcontrol/xyz</RoutingControlArn>
+  </HealthCheckConfig>
+</CreateHealthCheckRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/healthcheck", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	assert.Contains(t, rec.Body.String(), "RECOVERY_CONTROL")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B4: InsufficientDataHealthStatus validation
+// ----------------------------------------
+
+func TestCreateHealthCheck_InsufficientDataHealthStatus_Invalid(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateHealthCheckRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ref-idhs</CallerReference>
+  <HealthCheckConfig>
+    <Type>HTTP</Type>
+    <IPAddress>1.2.3.4</IPAddress>
+    <Port>80</Port>
+    <InsufficientDataHealthStatus>BadValue</InsufficientDataHealthStatus>
+  </HealthCheckConfig>
+</CreateHealthCheckRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/healthcheck", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B5: CreateTrafficPolicy name uniqueness
+// ----------------------------------------
+
+func TestCreateTrafficPolicy_NameUniqueness(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Name>unique-policy</Name>
+  <Document>{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{},"Rules":{}}</Document>
+</CreateTrafficPolicyRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Second attempt with same name must fail.
+	rec = send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TrafficPolicyAlreadyExists")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B6: DeleteTrafficPolicy with active instances returns TrafficPolicyInUse
+// ----------------------------------------
+
+func TestDeleteTrafficPolicy_InUse(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	// Create zone, traffic policy, and instance.
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	tpBody := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Name>inuse-policy</Name>
+  <Document>{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{},"Rules":{}}</Document>
+</CreateTrafficPolicyRequest>`
+
+	rec = send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy", tpBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	type tpResp struct {
+		TrafficPolicy struct {
+			ID string `xml:"Id"`
+		} `xml:"TrafficPolicy"`
+	}
+
+	var tpr tpResp
+	require.NoError(t, xml.Unmarshal(rec.Body.Bytes(), &tpr))
+	tpID := tpr.TrafficPolicy.ID
+
+	instBody := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyInstanceRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <HostedZoneId>%s</HostedZoneId>
+  <Name>www.example.com</Name>
+  <TrafficPolicyId>%s</TrafficPolicyId>
+  <TrafficPolicyVersion>1</TrafficPolicyVersion>
+  <TTL>60</TTL>
+</CreateTrafficPolicyInstanceRequest>`, zoneID, tpID)
+
+	rec = send(t, h, http.MethodPost, "/2013-04-01/trafficpolicyinstance", instBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Now attempt to delete the policy version that is in use.
+	rec = send(t, h, http.MethodDelete,
+		fmt.Sprintf("/2013-04-01/trafficpolicy/%s/1", tpID), "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TrafficPolicyInUse")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B7: DeleteKeySigningKey requires INACTIVE
+// ----------------------------------------
+
+func TestDeleteKeySigningKey_RequiresInactive(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	kskBody := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<CreateKeySigningKeyRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <CallerReference>ksk-ref-del</CallerReference>
+  <HostedZoneId>%s</HostedZoneId>
+  <KeyManagementServiceArn>arn:aws:kms:us-east-1:123456789012:key/mrk-abc</KeyManagementServiceArn>
+  <Name>active-key</Name>
+  <Status>ACTIVE</Status>
+</CreateKeySigningKeyRequest>`, zoneID)
+
+	rec = send(t, h, http.MethodPost, "/2013-04-01/keysigningkey", kskBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Delete without deactivating first — must fail.
+	rec = send(t, h, http.MethodDelete,
+		"/2013-04-01/keysigningkey/"+zoneID+"/active-key", "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "KeySigningKeyNotInactive")
+
+	// Deactivate then delete — must succeed.
+	rec = send(t, h, http.MethodPost,
+		"/2013-04-01/keysigningkey/"+zoneID+"/active-key/deactivate", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = send(t, h, http.MethodDelete,
+		"/2013-04-01/keysigningkey/"+zoneID+"/active-key", "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "DeleteKeySigningKeyResponse")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B8: GeoProximityLocation validation
+// ----------------------------------------
+
+func TestGeoProximityLocation_RequiresOneField(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	// No AWSRegion/Coordinates/LocalZoneGroup — must fail.
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <ChangeBatch>
+    <Changes>
+      <Change>
+        <Action>CREATE</Action>
+        <ResourceRecordSet>
+          <Name>geo.example.com</Name>
+          <Type>A</Type>
+          <TTL>300</TTL>
+          <SetIdentifier>reg1</SetIdentifier>
+          <GeoProximityLocation>
+            <Bias>0</Bias>
+          </GeoProximityLocation>
+          <ResourceRecords>
+            <ResourceRecord><Value>1.2.3.4</Value></ResourceRecord>
+          </ResourceRecords>
+        </ResourceRecordSet>
+      </Change>
+    </Changes>
+  </ChangeBatch>
+</ChangeResourceRecordSetsRequest>`
+
+	rec = send(t, h, http.MethodPost,
+		"/2013-04-01/hostedzone/"+zoneID+"/rrset", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+func TestGeoProximityLocation_BiasTooLarge(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <ChangeBatch>
+    <Changes>
+      <Change>
+        <Action>CREATE</Action>
+        <ResourceRecordSet>
+          <Name>geo.example.com</Name>
+          <Type>A</Type>
+          <TTL>300</TTL>
+          <SetIdentifier>reg1</SetIdentifier>
+          <GeoProximityLocation>
+            <AWSRegion>us-east-1</AWSRegion>
+            <Bias>100</Bias>
+          </GeoProximityLocation>
+          <ResourceRecords>
+            <ResourceRecord><Value>1.2.3.4</Value></ResourceRecord>
+          </ResourceRecords>
+        </ResourceRecordSet>
+      </Change>
+    </Changes>
+  </ChangeBatch>
+</ChangeResourceRecordSetsRequest>`
+
+	rec = send(t, h, http.MethodPost,
+		"/2013-04-01/hostedzone/"+zoneID+"/rrset", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+func TestGeoProximityLocation_ValidAWSRegion(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <ChangeBatch>
+    <Changes>
+      <Change>
+        <Action>CREATE</Action>
+        <ResourceRecordSet>
+          <Name>geo.example.com</Name>
+          <Type>A</Type>
+          <TTL>300</TTL>
+          <SetIdentifier>reg1</SetIdentifier>
+          <GeoProximityLocation>
+            <AWSRegion>us-east-1</AWSRegion>
+            <Bias>10</Bias>
+          </GeoProximityLocation>
+          <ResourceRecords>
+            <ResourceRecord><Value>1.2.3.4</Value></ResourceRecord>
+          </ResourceRecords>
+        </ResourceRecordSet>
+      </Change>
+    </Changes>
+  </ChangeBatch>
+</ChangeResourceRecordSetsRequest>`
+
+	rec = send(t, h, http.MethodPost,
+		"/2013-04-01/hostedzone/"+zoneID+"/rrset", body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestGeoProximityLocation_InvalidCoordinateLatitude(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <ChangeBatch>
+    <Changes>
+      <Change>
+        <Action>CREATE</Action>
+        <ResourceRecordSet>
+          <Name>geo.example.com</Name>
+          <Type>A</Type>
+          <TTL>300</TTL>
+          <SetIdentifier>reg1</SetIdentifier>
+          <GeoProximityLocation>
+            <Coordinates>
+              <Latitude>91.5</Latitude>
+              <Longitude>0.0</Longitude>
+            </Coordinates>
+          </GeoProximityLocation>
+          <ResourceRecords>
+            <ResourceRecord><Value>1.2.3.4</Value></ResourceRecord>
+          </ResourceRecords>
+        </ResourceRecordSet>
+      </Change>
+    </Changes>
+  </ChangeBatch>
+</ChangeResourceRecordSetsRequest>`
+
+	rec = send(t, h, http.MethodPost,
+		"/2013-04-01/hostedzone/"+zoneID+"/rrset", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B9: CreateTrafficPolicyInstance TTL >= 1
+// ----------------------------------------
+
+func TestCreateTrafficPolicyInstance_TTLValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/hostedzone", createZoneXML)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	zoneID := extractZoneID(t, rec.Body.String())
+
+	tpBody := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Name>ttl-test-policy</Name>
+  <Document>{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{},"Rules":{}}</Document>
+</CreateTrafficPolicyRequest>`
+
+	rec = send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy", tpBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var tpr struct {
+		TrafficPolicy struct {
+			ID string `xml:"Id"`
+		} `xml:"TrafficPolicy"`
+	}
+
+	require.NoError(t, xml.Unmarshal(rec.Body.Bytes(), &tpr))
+	tpID := tpr.TrafficPolicy.ID
+
+	// TTL = 0 must fail.
+	instBody := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyInstanceRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <HostedZoneId>%s</HostedZoneId>
+  <Name>www.example.com</Name>
+  <TrafficPolicyId>%s</TrafficPolicyId>
+  <TrafficPolicyVersion>1</TrafficPolicyVersion>
+  <TTL>0</TTL>
+</CreateTrafficPolicyInstanceRequest>`, zoneID, tpID)
+
+	rec = send(t, h, http.MethodPost, "/2013-04-01/trafficpolicyinstance", instBody)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "InvalidInput")
+}
+
+// ----------------------------------------
+// Batch-2 Gap B10: UpdateTrafficPolicyComment stores comment
+// ----------------------------------------
+
+func TestUpdateTrafficPolicyComment(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	tpBody := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Name>comment-policy</Name>
+  <Document>{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{},"Rules":{}}</Document>
+  <Comment>original comment</Comment>
+</CreateTrafficPolicyRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy", tpBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var tpr struct {
+		TrafficPolicy struct {
+			ID string `xml:"Id"`
+		} `xml:"TrafficPolicy"`
+	}
+
+	require.NoError(t, xml.Unmarshal(rec.Body.Bytes(), &tpr))
+	tpID := tpr.TrafficPolicy.ID
+
+	// Update the comment.
+	updateBody := `<?xml version="1.0" encoding="UTF-8"?>
+<UpdateTrafficPolicyCommentRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Comment>updated comment</Comment>
+</UpdateTrafficPolicyCommentRequest>`
+
+	rec = send(t, h, http.MethodPost,
+		fmt.Sprintf("/2013-04-01/trafficpolicy/%s/1", tpID), updateBody)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "UpdateTrafficPolicyCommentResponse")
+	assert.Contains(t, rec.Body.String(), "updated comment")
+
+	// Verify persisted by getting the policy.
+	rec = send(t, h, http.MethodGet,
+		fmt.Sprintf("/2013-04-01/trafficpolicy/%s/1", tpID), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "updated comment")
+}
+
+func TestUpdateTrafficPolicyComment_NotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<UpdateTrafficPolicyCommentRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Comment>nope</Comment>
+</UpdateTrafficPolicyCommentRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy/NONEXISTENT/1", body)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ----------------------------------------
+// Batch-2 Gap B11: ListTrafficPolicies TrafficPolicyCount
+// ----------------------------------------
+
+func TestListTrafficPolicies_VersionCount(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(t)
+
+	// Create a policy and add two more versions.
+	tpBody := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Name>versioned-policy</Name>
+  <Document>{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{},"Rules":{}}</Document>
+</CreateTrafficPolicyRequest>`
+
+	rec := send(t, h, http.MethodPost, "/2013-04-01/trafficpolicy", tpBody)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var tpr struct {
+		TrafficPolicy struct {
+			ID string `xml:"Id"`
+		} `xml:"TrafficPolicy"`
+	}
+
+	require.NoError(t, xml.Unmarshal(rec.Body.Bytes(), &tpr))
+	tpID := tpr.TrafficPolicy.ID
+
+	// Create version 2.
+	v2Body := `<?xml version="1.0" encoding="UTF-8"?>
+<CreateTrafficPolicyVersionRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Document>{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{},"Rules":{}}</Document>
+</CreateTrafficPolicyVersionRequest>`
+
+	rec = send(t, h, http.MethodPost,
+		fmt.Sprintf("/2013-04-01/trafficpolicy/%s", tpID), v2Body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Create version 3.
+	rec = send(t, h, http.MethodPost,
+		fmt.Sprintf("/2013-04-01/trafficpolicy/%s", tpID), v2Body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// ListTrafficPolicies should show LatestVersion=3 and TrafficPolicyCount=3.
+	rec = send(t, h, http.MethodGet, "/2013-04-01/trafficpolicies", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	body2 := rec.Body.String()
+
+	assert.Contains(t, body2, "<LatestVersion>3</LatestVersion>")
+	assert.Contains(t, body2, "<TrafficPolicyCount>3</TrafficPolicyCount>")
+}

--- a/services/route53/handler_completeness.go
+++ b/services/route53/handler_completeness.go
@@ -759,16 +759,51 @@ func (h *Handler) listTrafficPolicyInstancesByPolicy(c *echo.Context) error {
 	})
 }
 
-type updateTPCommentResponse struct {
-	XMLName       xml.Name                `xml:"UpdateTrafficPolicyCommentResponse"`
-	Xmlns         string                  `xml:"xmlns,attr"`
-	TrafficPolicy xmlTrafficPolicySummary `xml:"TrafficPolicy"`
+type updateTPCommentRequest struct {
+	XMLName xml.Name `xml:"UpdateTrafficPolicyCommentRequest"`
+	Comment string   `xml:"Comment"`
 }
 
-func (h *Handler) updateTrafficPolicyComment(c *echo.Context, _ string) error {
+type updateTPCommentResponse struct {
+	XMLName       xml.Name         `xml:"UpdateTrafficPolicyCommentResponse"`
+	Xmlns         string           `xml:"xmlns,attr"`
+	TrafficPolicy xmlTrafficPolicy `xml:"TrafficPolicy"`
+}
+
+func (h *Handler) updateTrafficPolicyComment(c *echo.Context, path string) error {
+	// path: /2013-04-01/trafficpolicy/{id}/{version}
+	rest := strings.TrimPrefix(path, route53TrafficPolicyPrefix)
+	parts := strings.SplitN(rest, "/", 2) //nolint:mnd // split id and version
+
+	if len(parts) != 2 { //nolint:mnd // path has two segments: id and version
+		return xmlError(c, http.StatusBadRequest, "InvalidInput", "invalid traffic policy path")
+	}
+
+	id := parts[0]
+
+	version64, err := strconv.ParseInt(parts[1], 10, 32)
+	if err != nil {
+		return xmlError(c, http.StatusBadRequest, "InvalidInput", "invalid version number")
+	}
+
+	body, err := httputils.ReadBody(c.Request())
+	if err != nil {
+		return xmlError(c, http.StatusBadRequest, "InvalidInput", "failed to read request body")
+	}
+
+	var req updateTPCommentRequest
+	if err = xml.Unmarshal(body, &req); err != nil {
+		return xmlError(c, http.StatusBadRequest, "InvalidInput", "failed to parse XML: "+err.Error())
+	}
+
+	tp, err := h.Backend.UpdateTrafficPolicyComment(id, int32(version64), req.Comment)
+	if err != nil {
+		return handleBackendError(c, err)
+	}
+
 	return writeXML(c, http.StatusOK, updateTPCommentResponse{
 		Xmlns:         route53Namespace,
-		TrafficPolicy: xmlTrafficPolicySummary{},
+		TrafficPolicy: toXMLTrafficPolicy(tp),
 	})
 }
 

--- a/services/route53/handler_ops_test.go
+++ b/services/route53/handler_ops_test.go
@@ -245,6 +245,10 @@ func TestRoute53_DeactivateDeleteKeySigningKey(t *testing.T) {
 				zoneID := createZoneForOpsTest(t, h)
 				kskName := "delkey"
 				createKSKForOpsTest(t, h, zoneID, kskName)
+				// Must deactivate before delete (AWS requirement).
+				rec := send(t, h, http.MethodPost,
+					"/2013-04-01/keysigningkey/"+zoneID+"/"+kskName+"/deactivate", "")
+				require.Equal(t, http.StatusOK, rec.Code)
 
 				return zoneID, kskName
 			},

--- a/services/route53/interfaces.go
+++ b/services/route53/interfaces.go
@@ -78,11 +78,12 @@ type StorageBackend interface {
 		ttl int64,
 	) (*TrafficPolicyInstance, error)
 	UpdateTrafficPolicyInstance(id, tpID string, tpVersion int32, ttl int64) (*TrafficPolicyInstance, error)
+	UpdateTrafficPolicyComment(id string, version int32, comment string) (*TrafficPolicy, error)
 	DeleteTrafficPolicy(id string, version int32) error
 	GetTrafficPolicy(id string, version int32) (*TrafficPolicy, error)
 	DeleteTrafficPolicyInstance(id string) error
 	GetTrafficPolicyInstance(id string) (*TrafficPolicyInstance, error)
-	ListTrafficPolicies() ([]*TrafficPolicy, error)
+	ListTrafficPolicies() ([]*TrafficPolicySummary, error)
 	ListTrafficPolicyVersions(id string) ([]*TrafficPolicy, error)
 	ListTrafficPolicyInstances() ([]*TrafficPolicyInstance, error)
 	ListTrafficPolicyInstancesByHostedZone(hostedZoneID string) ([]*TrafficPolicyInstance, error)


### PR DESCRIPTION
Route53 batch-2 — traffic policies, KSK/DNSSEC, query logging, recovery groups, geoproximity. Polecat: quartz.