### PR TITLE
feat(eks): batch-2 AWS-accuracy audit (go-rra3)

### DIFF
--- a/services/eks/backend.go
+++ b/services/eks/backend.go
@@ -361,17 +361,7 @@ func (b *InMemoryBackend) CreateCluster(
 
 	var vpcCopy *VpcConfig
 	if vpcConfig != nil {
-		cp := *vpcConfig
-		cp.SubnetIDs = cloneStrings(vpcConfig.SubnetIDs)
-		cp.SecurityGroupIDs = cloneStrings(vpcConfig.SecurityGroupIDs)
-		cp.PublicAccessCIDRs = cloneStrings(vpcConfig.PublicAccessCIDRs)
-		if cp.ClusterSecurityGroupID == "" {
-			cp.ClusterSecurityGroupID = "sg-" + stableID(name)
-		}
-		if cp.VpcID == "" {
-			cp.VpcID = "vpc-" + stableID(name)
-		}
-		vpcCopy = &cp
+		vpcCopy = cloneVpcConfig(vpcConfig, name)
 	}
 
 	var netCopy *KubernetesNetworkConfig
@@ -442,6 +432,21 @@ func (b *InMemoryBackend) CreateCluster(
 	cp := *c
 
 	return &cp, nil
+}
+
+func cloneVpcConfig(src *VpcConfig, clusterName string) *VpcConfig {
+	cp := *src
+	cp.SubnetIDs = cloneStrings(src.SubnetIDs)
+	cp.SecurityGroupIDs = cloneStrings(src.SecurityGroupIDs)
+	cp.PublicAccessCIDRs = cloneStrings(src.PublicAccessCIDRs)
+	if cp.ClusterSecurityGroupID == "" {
+		cp.ClusterSecurityGroupID = "sg-" + stableID(clusterName)
+	}
+	if cp.VpcID == "" {
+		cp.VpcID = "vpc-" + stableID(clusterName)
+	}
+
+	return &cp
 }
 
 // DescribeCluster returns a cluster by name.
@@ -734,7 +739,10 @@ type NodegroupConfigUpdate struct {
 
 // UpdateNodegroupConfig updates the configuration of a node group including scaling,
 // labels, taints, and update strategy.
-func (b *InMemoryBackend) UpdateNodegroupConfig(clusterName, nodegroupName string, upd NodegroupConfigUpdate) (*Nodegroup, error) {
+func (b *InMemoryBackend) UpdateNodegroupConfig(
+	clusterName, nodegroupName string,
+	upd NodegroupConfigUpdate,
+) (*Nodegroup, error) {
 	b.mu.Lock("UpdateNodegroupConfig")
 	defer b.mu.Unlock()
 

--- a/services/eks/backend.go
+++ b/services/eks/backend.go
@@ -728,13 +728,13 @@ func (b *InMemoryBackend) DeleteNodegroup(clusterName, nodegroupName string) (*N
 // NodegroupConfigUpdate holds the mutable fields for UpdateNodegroupConfig.
 type NodegroupConfigUpdate struct {
 	AddOrUpdateLabels map[string]string
-	RemoveLabels      []string
-	AddOrUpdateTaints []NodegroupTaint
-	RemoveTaints      []NodegroupTaint
 	UpdateConfig      *NodegroupUpdateConfig
 	DesiredSize       *int32
 	MinSize           *int32
 	MaxSize           *int32
+	RemoveLabels      []string
+	AddOrUpdateTaints []NodegroupTaint
+	RemoveTaints      []NodegroupTaint
 }
 
 // UpdateNodegroupConfig updates the configuration of a node group including scaling,

--- a/services/eks/backend.go
+++ b/services/eks/backend.go
@@ -551,6 +551,7 @@ type NodegroupInput struct {
 	Labels         map[string]string
 	RemoteAccess   *RemoteAccess
 	LaunchTemplate *LaunchTemplate
+	UpdateConfig   *NodegroupUpdateConfig
 	Subnets        []string
 	Taints         []NodegroupTaint
 	DiskSize       int32
@@ -618,6 +619,12 @@ func (b *InMemoryBackend) CreateNodegroup(
 
 	asgName := "eks-" + nodegroupName + "-" + stableID(clusterName+"/"+nodegroupName)
 
+	var updateCfg *NodegroupUpdateConfig
+	if input.UpdateConfig != nil {
+		uc := *input.UpdateConfig
+		updateCfg = &uc
+	}
+
 	ng := &Nodegroup{
 		NodegroupName:  nodegroupName,
 		ClusterName:    clusterName,
@@ -638,6 +645,7 @@ func (b *InMemoryBackend) CreateNodegroup(
 		Taints:         cloneTaints(input.Taints),
 		RemoteAccess:   cloneRemoteAccess(input.RemoteAccess),
 		LaunchTemplate: cloneLaunchTemplate(input.LaunchTemplate),
+		UpdateConfig:   updateCfg,
 		Resources: &NodegroupResources{
 			AutoScalingGroups: []AutoScalingGroup{{Name: asgName}},
 		},

--- a/services/eks/backend.go
+++ b/services/eks/backend.go
@@ -42,6 +42,39 @@ type VpcConfig struct {
 	EndpointPublicAccess   bool     `json:"endpointPublicAccess"`
 }
 
+// AccessConfig holds the cluster authentication mode configuration.
+type AccessConfig struct {
+	AuthenticationMode                      string `json:"authenticationMode,omitempty"`
+	BootstrapClusterCreatorAdminPermissions bool   `json:"bootstrapClusterCreatorAdminPermissions"`
+}
+
+// ComputeConfig holds the EKS Auto Mode compute configuration.
+type ComputeConfig struct {
+	NodeRoleARN string   `json:"nodeRoleArn,omitempty"`
+	NodePools   []string `json:"nodePools,omitempty"`
+	Enabled     bool     `json:"enabled"`
+}
+
+// BlockStorageConfig holds EKS Auto Mode block storage settings.
+type BlockStorageConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+// StorageConfig holds the EKS Auto Mode storage configuration.
+type StorageConfig struct {
+	BlockStorage *BlockStorageConfig `json:"blockStorage,omitempty"`
+}
+
+// ElasticLoadBalancingConfig holds EKS Auto Mode load balancer settings.
+type ElasticLoadBalancingConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+// NetworkingConfig holds the EKS Auto Mode networking configuration.
+type NetworkingConfig struct {
+	ElasticLoadBalancing *ElasticLoadBalancingConfig `json:"elasticLoadBalancing,omitempty"`
+}
+
 // KubernetesNetworkConfig captures cluster networking parameters.
 type KubernetesNetworkConfig struct {
 	IPFamily        string `json:"ipFamily,omitempty"`
@@ -64,6 +97,10 @@ type Cluster struct {
 	Tags                    *tags.Tags               `json:"tags,omitempty"`
 	VpcConfig               *VpcConfig               `json:"resourcesVpcConfig,omitempty"`
 	KubernetesNetworkConfig *KubernetesNetworkConfig `json:"kubernetesNetworkConfig,omitempty"`
+	AccessConfig            *AccessConfig            `json:"accessConfig,omitempty"`
+	ComputeConfig           *ComputeConfig           `json:"computeConfig,omitempty"`
+	StorageConfig           *StorageConfig           `json:"storageConfig,omitempty"`
+	NetworkingConfig        *NetworkingConfig        `json:"networkingConfig,omitempty"`
 	// EncryptionConfig holds the current cluster encryption config, kept in sync
 	// with b.encryptionConfigs. Populated by AssociateEncryptionConfig.
 	EncryptionConfig []EncryptionConfig `json:"encryptionConfig,omitempty"`
@@ -110,35 +147,42 @@ type NodegroupResources struct {
 	AutoScalingGroups []AutoScalingGroup `json:"autoScalingGroups,omitempty"`
 }
 
+// NodegroupUpdateConfig holds the nodegroup update strategy settings.
+type NodegroupUpdateConfig struct {
+	MaxUnavailable           *int32 `json:"maxUnavailable,omitempty"`
+	MaxUnavailablePercentage *int32 `json:"maxUnavailablePercentage,omitempty"`
+}
+
 // Nodegroup represents an EKS managed node group.
 //
 // The Tags field is backend-owned. Callers must treat the returned pointer as
 // read-only; mutate tags only via TagResource / CreateNodegroup.
 type Nodegroup struct {
-	CreatedAt      time.Time           `json:"createdAt"`
-	Tags           *tags.Tags          `json:"tags,omitempty"`
-	Labels         map[string]string   `json:"labels,omitempty"`
-	RemoteAccess   *RemoteAccess       `json:"remoteAccess,omitempty"`
-	LaunchTemplate *LaunchTemplate     `json:"launchTemplate,omitempty"`
-	Resources      *NodegroupResources `json:"resources,omitempty"`
-	CapacityType   string              `json:"capacityType,omitempty"`
-	Region         string              `json:"region"`
-	ARN            string              `json:"nodegroupArn"`
-	NodeRole       string              `json:"nodeRole,omitempty"`
-	Status         string              `json:"status"`
-	AMIType        string              `json:"amiType,omitempty"`
-	NodegroupName  string              `json:"nodegroupName"`
-	ClusterName    string              `json:"clusterName"`
-	Version        string              `json:"version,omitempty"`
-	ReleaseVersion string              `json:"releaseVersion,omitempty"`
-	AccountID      string              `json:"accountId"`
-	Taints         []NodegroupTaint    `json:"taints,omitempty"`
-	InstanceTypes  []string            `json:"instanceTypes,omitempty"`
-	Subnets        []string            `json:"subnets,omitempty"`
-	DesiredSize    int32               `json:"desiredSize"`
-	MinSize        int32               `json:"minSize"`
-	MaxSize        int32               `json:"maxSize"`
-	DiskSize       int32               `json:"diskSize,omitempty"`
+	CreatedAt      time.Time              `json:"createdAt"`
+	Tags           *tags.Tags             `json:"tags,omitempty"`
+	Labels         map[string]string      `json:"labels,omitempty"`
+	RemoteAccess   *RemoteAccess          `json:"remoteAccess,omitempty"`
+	LaunchTemplate *LaunchTemplate        `json:"launchTemplate,omitempty"`
+	Resources      *NodegroupResources    `json:"resources,omitempty"`
+	UpdateConfig   *NodegroupUpdateConfig `json:"updateConfig,omitempty"`
+	CapacityType   string                 `json:"capacityType,omitempty"`
+	Region         string                 `json:"region"`
+	ARN            string                 `json:"nodegroupArn"`
+	NodeRole       string                 `json:"nodeRole,omitempty"`
+	Status         string                 `json:"status"`
+	AMIType        string                 `json:"amiType,omitempty"`
+	NodegroupName  string                 `json:"nodegroupName"`
+	ClusterName    string                 `json:"clusterName"`
+	Version        string                 `json:"version,omitempty"`
+	ReleaseVersion string                 `json:"releaseVersion,omitempty"`
+	AccountID      string                 `json:"accountId"`
+	Taints         []NodegroupTaint       `json:"taints,omitempty"`
+	InstanceTypes  []string               `json:"instanceTypes,omitempty"`
+	Subnets        []string               `json:"subnets,omitempty"`
+	DesiredSize    int32                  `json:"desiredSize"`
+	MinSize        int32                  `json:"minSize"`
+	MaxSize        int32                  `json:"maxSize"`
+	DiskSize       int32                  `json:"diskSize,omitempty"`
 }
 
 // InMemoryBackend is the in-memory store for EKS resources.
@@ -282,12 +326,21 @@ func (b *InMemoryBackend) Reset() {
 	b.subscriptions = make(map[string]*AnywhereSubscription)
 }
 
+// ClusterOptionalConfig groups optional cluster configuration for CreateCluster.
+type ClusterOptionalConfig struct {
+	AccessConfig     *AccessConfig
+	ComputeConfig    *ComputeConfig
+	StorageConfig    *StorageConfig
+	NetworkingConfig *NetworkingConfig
+}
+
 // CreateCluster creates a new EKS cluster.
 func (b *InMemoryBackend) CreateCluster(
 	name, version, roleARN string,
 	vpcConfig *VpcConfig,
 	networkConfig *KubernetesNetworkConfig,
 	kv map[string]string,
+	opts ...ClusterOptionalConfig,
 ) (*Cluster, error) {
 	b.mu.Lock("CreateCluster")
 	defer b.mu.Unlock()
@@ -327,6 +380,36 @@ func (b *InMemoryBackend) CreateCluster(
 		netCopy = &cp
 	}
 
+	var opt ClusterOptionalConfig
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	var accessCfg *AccessConfig
+	if opt.AccessConfig != nil {
+		cp := *opt.AccessConfig
+		accessCfg = &cp
+	}
+
+	var computeCfg *ComputeConfig
+	if opt.ComputeConfig != nil {
+		cp := *opt.ComputeConfig
+		cp.NodePools = cloneStrings(opt.ComputeConfig.NodePools)
+		computeCfg = &cp
+	}
+
+	var storageCfg *StorageConfig
+	if opt.StorageConfig != nil {
+		cp := *opt.StorageConfig
+		storageCfg = &cp
+	}
+
+	var networkingCfg *NetworkingConfig
+	if opt.NetworkingConfig != nil {
+		cp := *opt.NetworkingConfig
+		networkingCfg = &cp
+	}
+
 	c := &Cluster{
 		Name:                    name,
 		ARN:                     clusterARN,
@@ -342,6 +425,10 @@ func (b *InMemoryBackend) CreateCluster(
 		Tags:                    t,
 		VpcConfig:               vpcCopy,
 		KubernetesNetworkConfig: netCopy,
+		AccessConfig:            accessCfg,
+		ComputeConfig:           computeCfg,
+		StorageConfig:           storageCfg,
+		NetworkingConfig:        networkingCfg,
 	}
 	b.clusters[name] = c
 	b.nodegroups[name] = make(map[string]*Nodegroup)
@@ -625,11 +712,21 @@ func (b *InMemoryBackend) DeleteNodegroup(clusterName, nodegroupName string) (*N
 	return cp, nil
 }
 
-// UpdateNodegroupConfig updates the scaling configuration of a node group.
-func (b *InMemoryBackend) UpdateNodegroupConfig(
-	clusterName, nodegroupName string,
-	desiredSize, minSize, maxSize *int32,
-) (*Nodegroup, error) {
+// NodegroupConfigUpdate holds the mutable fields for UpdateNodegroupConfig.
+type NodegroupConfigUpdate struct {
+	AddOrUpdateLabels map[string]string
+	RemoveLabels      []string
+	AddOrUpdateTaints []NodegroupTaint
+	RemoveTaints      []NodegroupTaint
+	UpdateConfig      *NodegroupUpdateConfig
+	DesiredSize       *int32
+	MinSize           *int32
+	MaxSize           *int32
+}
+
+// UpdateNodegroupConfig updates the configuration of a node group including scaling,
+// labels, taints, and update strategy.
+func (b *InMemoryBackend) UpdateNodegroupConfig(clusterName, nodegroupName string, upd NodegroupConfigUpdate) (*Nodegroup, error) {
 	b.mu.Lock("UpdateNodegroupConfig")
 	defer b.mu.Unlock()
 
@@ -647,19 +744,94 @@ func (b *InMemoryBackend) UpdateNodegroupConfig(
 		return nil, fmt.Errorf("%w: nodegroup %s not found in cluster %s", ErrNotFound, nodegroupName, clusterName)
 	}
 
-	if desiredSize != nil {
-		ng.DesiredSize = *desiredSize
+	if upd.DesiredSize != nil {
+		ng.DesiredSize = *upd.DesiredSize
 	}
 
-	if minSize != nil {
-		ng.MinSize = *minSize
+	if upd.MinSize != nil {
+		ng.MinSize = *upd.MinSize
 	}
 
-	if maxSize != nil {
-		ng.MaxSize = *maxSize
+	if upd.MaxSize != nil {
+		ng.MaxSize = *upd.MaxSize
+	}
+
+	if len(upd.AddOrUpdateLabels) > 0 {
+		if ng.Labels == nil {
+			ng.Labels = make(map[string]string)
+		}
+
+		for k, v := range upd.AddOrUpdateLabels {
+			ng.Labels[k] = v
+		}
+	}
+
+	for _, k := range upd.RemoveLabels {
+		delete(ng.Labels, k)
+	}
+
+	if len(upd.AddOrUpdateTaints) > 0 {
+		ng.Taints = mergeTaints(ng.Taints, upd.AddOrUpdateTaints)
+	}
+
+	if len(upd.RemoveTaints) > 0 {
+		ng.Taints = removeTaints(ng.Taints, upd.RemoveTaints)
+	}
+
+	if upd.UpdateConfig != nil {
+		uc := *upd.UpdateConfig
+		ng.UpdateConfig = &uc
 	}
 
 	return deepCopyNodegroup(ng), nil
+}
+
+// mergeTaints adds or updates taints in the existing slice.
+func mergeTaints(existing []NodegroupTaint, updates []NodegroupTaint) []NodegroupTaint {
+	result := make([]NodegroupTaint, len(existing))
+	copy(result, existing)
+
+	for _, upd := range updates {
+		found := false
+
+		for i, t := range result {
+			if t.Key == upd.Key {
+				result[i] = upd
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			result = append(result, upd)
+		}
+	}
+
+	return result
+}
+
+// removeTaints removes taints matching by key+effect from the slice.
+func removeTaints(existing []NodegroupTaint, toRemove []NodegroupTaint) []NodegroupTaint {
+	result := existing[:0:len(existing)]
+
+	for _, t := range existing {
+		removed := false
+
+		for _, r := range toRemove {
+			if t.Key == r.Key && t.Effect == r.Effect {
+				removed = true
+
+				break
+			}
+		}
+
+		if !removed {
+			result = append(result, t)
+		}
+	}
+
+	return result
 }
 
 // findTagInNodegroupsLocked searches nodegroupsfor a resource with the given ARN.
@@ -1006,6 +1178,11 @@ func deepCopyNodegroup(ng *Nodegroup) *Nodegroup {
 		resCp.AutoScalingGroups = make([]AutoScalingGroup, len(ng.Resources.AutoScalingGroups))
 		copy(resCp.AutoScalingGroups, ng.Resources.AutoScalingGroups)
 		cp.Resources = &resCp
+	}
+
+	if ng.UpdateConfig != nil {
+		uc := *ng.UpdateConfig
+		cp.UpdateConfig = &uc
 	}
 
 	return &cp

--- a/services/eks/backend.go
+++ b/services/eks/backend.go
@@ -777,9 +777,7 @@ func (b *InMemoryBackend) UpdateNodegroupConfig(
 			ng.Labels = make(map[string]string)
 		}
 
-		for k, v := range upd.AddOrUpdateLabels {
-			ng.Labels[k] = v
-		}
+		maps.Copy(ng.Labels, upd.AddOrUpdateLabels)
 	}
 
 	for _, k := range upd.RemoveLabels {
@@ -804,8 +802,8 @@ func (b *InMemoryBackend) UpdateNodegroupConfig(
 
 // mergeTaints adds or updates taints in the existing slice.
 func mergeTaints(existing []NodegroupTaint, updates []NodegroupTaint) []NodegroupTaint {
-	result := make([]NodegroupTaint, len(existing))
-	copy(result, existing)
+	result := make([]NodegroupTaint, 0, len(existing)+len(updates))
+	result = append(result, existing...)
 
 	for _, upd := range updates {
 		found := false

--- a/services/eks/backend_new_ops.go
+++ b/services/eks/backend_new_ops.go
@@ -15,12 +15,12 @@ import (
 type AccessEntry struct {
 	CreatedAt        time.Time  `json:"createdAt"`
 	Tags             *tags.Tags `json:"tags,omitempty"`
-	KubernetesGroups []string   `json:"kubernetesGroups,omitempty"`
 	PrincipalARN     string     `json:"principalArn"`
 	ClusterName      string     `json:"clusterName"`
 	ARN              string     `json:"accessEntryArn"`
 	Type             string     `json:"type"`
 	Username         string     `json:"username,omitempty"`
+	KubernetesGroups []string   `json:"kubernetesGroups,omitempty"`
 }
 
 // AccessPolicyAssociation represents an access policy associated with an access entry.

--- a/services/eks/backend_new_ops.go
+++ b/services/eks/backend_new_ops.go
@@ -5,19 +5,22 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/blackbirdworks/gopherstack/pkgs/arn"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
 // AccessEntry represents an EKS access entry that grants a principal access to a cluster.
 type AccessEntry struct {
-	CreatedAt    time.Time  `json:"createdAt"`
-	Tags         *tags.Tags `json:"tags,omitempty"`
-	PrincipalARN string     `json:"principalArn"`
-	ClusterName  string     `json:"clusterName"`
-	ARN          string     `json:"accessEntryArn"`
-	Type         string     `json:"type"`
-	Username     string     `json:"username,omitempty"`
+	CreatedAt        time.Time  `json:"createdAt"`
+	Tags             *tags.Tags `json:"tags,omitempty"`
+	KubernetesGroups []string   `json:"kubernetesGroups,omitempty"`
+	PrincipalARN     string     `json:"principalArn"`
+	ClusterName      string     `json:"clusterName"`
+	ARN              string     `json:"accessEntryArn"`
+	Type             string     `json:"type"`
+	Username         string     `json:"username,omitempty"`
 }
 
 // AccessPolicyAssociation represents an access policy associated with an access entry.
@@ -96,6 +99,7 @@ type FargateProfileSelector struct {
 type FargateProfile struct {
 	CreatedAt           time.Time                `json:"createdAt"`
 	Tags                *tags.Tags               `json:"tags,omitempty"`
+	Subnets             []string                 `json:"subnets,omitempty"`
 	ClusterName         string                   `json:"clusterName"`
 	FargateProfileName  string                   `json:"fargateProfileName"`
 	ARN                 string                   `json:"fargateProfileArn"`
@@ -114,11 +118,13 @@ type PodIdentityAssociation struct {
 	Namespace      string     `json:"namespace"`
 	ServiceAccount string     `json:"serviceAccount"`
 	RoleARN        string     `json:"roleArn,omitempty"`
+	OwnerARN       string     `json:"ownerArn,omitempty"`
 }
 
 // CreateAccessEntry creates an access entry that grants a principal access to a cluster.
 func (b *InMemoryBackend) CreateAccessEntry(
 	clusterName, principalARN, entryType, username string,
+	kubernetesGroups []string,
 	kv map[string]string,
 ) (*AccessEntry, error) {
 	b.mu.Lock("CreateAccessEntry")
@@ -158,13 +164,14 @@ func (b *InMemoryBackend) CreateAccessEntry(
 	}
 
 	entry := &AccessEntry{
-		PrincipalARN: principalARN,
-		ClusterName:  clusterName,
-		ARN:          entryARN,
-		Type:         entryType,
-		Username:     username,
-		CreatedAt:    time.Now().UTC(),
-		Tags:         t,
+		PrincipalARN:     principalARN,
+		ClusterName:      clusterName,
+		ARN:              entryARN,
+		Type:             entryType,
+		Username:         username,
+		KubernetesGroups: cloneStrings(kubernetesGroups),
+		CreatedAt:        time.Now().UTC(),
+		Tags:             t,
 	}
 	b.accessEntries[clusterName][principalARN] = entry
 	cp := *entry
@@ -491,6 +498,7 @@ func (b *InMemoryBackend) CreateEksAnywhereSubscription(
 func (b *InMemoryBackend) CreateFargateProfile(
 	clusterName, profileName, podExecutionRoleARN string,
 	selectors []FargateProfileSelector,
+	subnets []string,
 	kv map[string]string,
 ) (*FargateProfile, error) {
 	b.mu.Lock("CreateFargateProfile")
@@ -535,6 +543,7 @@ func (b *InMemoryBackend) CreateFargateProfile(
 		PodExecutionRoleARN: podExecutionRoleARN,
 		Status:              statusActive,
 		Selectors:           sels,
+		Subnets:             cloneStrings(subnets),
 		CreatedAt:           time.Now().UTC(),
 		Tags:                t,
 	}
@@ -542,6 +551,7 @@ func (b *InMemoryBackend) CreateFargateProfile(
 	cp := *profile
 	cp.Selectors = make([]FargateProfileSelector, len(profile.Selectors))
 	copy(cp.Selectors, profile.Selectors)
+	cp.Subnets = cloneStrings(profile.Subnets)
 
 	return &cp, nil
 }
@@ -562,7 +572,7 @@ func (b *InMemoryBackend) CreatePodIdentityAssociation(
 		b.podIdentityAssociations[clusterName] = make(map[string]*PodIdentityAssociation)
 	}
 
-	assocID := stableID(clusterName + "/" + namespace + "/" + serviceAccount)
+	assocID := uuid.NewString()
 	assocARN := arn.Build("eks", b.region, b.accountID, "podidentityassociation/"+clusterName+"/"+assocID)
 
 	t := tags.New("eks.podidentity." + clusterName + "." + assocID + ".tags")

--- a/services/eks/backend_remaining_ops.go
+++ b/services/eks/backend_remaining_ops.go
@@ -1056,11 +1056,11 @@ func (b *InMemoryBackend) DescribeInsightsRefresh(clusterName, refreshID string)
 
 // ClusterConfigUpdate holds mutable cluster config fields for UpdateClusterConfig.
 type ClusterConfigUpdate struct {
-	LogEntries    []ClusterLogEntry
-	SubnetIDs     []string
 	AccessConfig  *AccessConfig
 	ComputeConfig *ComputeConfig
 	StorageConfig *StorageConfig
+	LogEntries    []ClusterLogEntry
+	SubnetIDs     []string
 }
 
 // UpdateClusterConfig updates the cluster configuration including logging, subnets, and access settings.

--- a/services/eks/backend_remaining_ops.go
+++ b/services/eks/backend_remaining_ops.go
@@ -591,6 +591,16 @@ func (b *InMemoryBackend) UpdatePodIdentityAssociation(
 
 // --- Fargate Profile CRUD ---
 
+// deepCopyFargateProfile returns a deep copy of a FargateProfile.
+func deepCopyFargateProfile(p *FargateProfile) *FargateProfile {
+	cp := *p
+	cp.Selectors = make([]FargateProfileSelector, len(p.Selectors))
+	copy(cp.Selectors, p.Selectors)
+	cp.Subnets = cloneStrings(p.Subnets)
+
+	return &cp
+}
+
 // DeleteFargateProfile removes a Fargate profile from a cluster.
 func (b *InMemoryBackend) DeleteFargateProfile(clusterName, profileName string) (*FargateProfile, error) {
 	b.mu.Lock("DeleteFargateProfile")
@@ -610,9 +620,7 @@ func (b *InMemoryBackend) DeleteFargateProfile(clusterName, profileName string) 
 		return nil, fmt.Errorf("%w: fargate profile %s not found in cluster %s", ErrNotFound, profileName, clusterName)
 	}
 
-	cp := *profile
-	cp.Selectors = make([]FargateProfileSelector, len(profile.Selectors))
-	copy(cp.Selectors, profile.Selectors)
+	cp := deepCopyFargateProfile(profile)
 
 	if profile.Tags != nil {
 		profile.Tags.Close()
@@ -622,7 +630,7 @@ func (b *InMemoryBackend) DeleteFargateProfile(clusterName, profileName string) 
 
 	cp.Status = statusDeleting
 
-	return &cp, nil
+	return cp, nil
 }
 
 // DescribeFargateProfile returns a Fargate profile by name.
@@ -644,11 +652,7 @@ func (b *InMemoryBackend) DescribeFargateProfile(clusterName, profileName string
 		return nil, fmt.Errorf("%w: fargate profile %s not found in cluster %s", ErrNotFound, profileName, clusterName)
 	}
 
-	cp := *profile
-	cp.Selectors = make([]FargateProfileSelector, len(profile.Selectors))
-	copy(cp.Selectors, profile.Selectors)
-
-	return &cp, nil
+	return deepCopyFargateProfile(profile), nil
 }
 
 // ListFargateProfiles returns all Fargate profile names in a cluster sorted alphabetically.
@@ -729,8 +733,14 @@ func (b *InMemoryBackend) ListAccessEntries(clusterName string) ([]string, error
 	return arns, nil
 }
 
-// UpdateAccessEntry updates an access entry's username.
-func (b *InMemoryBackend) UpdateAccessEntry(clusterName, principalARN, username string) (*AccessEntry, error) {
+// AccessEntryUpdate holds the mutable fields for UpdateAccessEntry.
+type AccessEntryUpdate struct {
+	Username         string
+	KubernetesGroups []string
+}
+
+// UpdateAccessEntry updates an access entry's username and kubernetes groups.
+func (b *InMemoryBackend) UpdateAccessEntry(clusterName, principalARN string, upd AccessEntryUpdate) (*AccessEntry, error) {
 	b.mu.Lock("UpdateAccessEntry")
 	defer b.mu.Unlock()
 
@@ -758,8 +768,12 @@ func (b *InMemoryBackend) UpdateAccessEntry(clusterName, principalARN, username 
 		)
 	}
 
-	if username != "" {
-		entry.Username = username
+	if upd.Username != "" {
+		entry.Username = upd.Username
+	}
+
+	if upd.KubernetesGroups != nil {
+		entry.KubernetesGroups = cloneStrings(upd.KubernetesGroups)
 	}
 
 	cp := *entry
@@ -1037,9 +1051,17 @@ func (b *InMemoryBackend) DescribeInsightsRefresh(clusterName, refreshID string)
 
 // --- Cluster updates ---
 
-// UpdateClusterConfig updates the cluster configuration including logging settings.
-// logEntries may be nil (no change) or a structured list of log type groups.
-func (b *InMemoryBackend) UpdateClusterConfig(clusterName string, logEntries []ClusterLogEntry) (*Update, error) {
+// ClusterConfigUpdate holds mutable cluster config fields for UpdateClusterConfig.
+type ClusterConfigUpdate struct {
+	LogEntries    []ClusterLogEntry
+	SubnetIDs     []string
+	AccessConfig  *AccessConfig
+	ComputeConfig *ComputeConfig
+	StorageConfig *StorageConfig
+}
+
+// UpdateClusterConfig updates the cluster configuration including logging, subnets, and access settings.
+func (b *InMemoryBackend) UpdateClusterConfig(clusterName string, upd ClusterConfigUpdate) (*Update, error) {
 	b.mu.Lock("UpdateClusterConfig")
 	defer b.mu.Unlock()
 
@@ -1048,8 +1070,36 @@ func (b *InMemoryBackend) UpdateClusterConfig(clusterName string, logEntries []C
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterName)
 	}
 
-	if logEntries != nil {
-		c.ClusterLogging = mergeClusterLogEntries(c.ClusterLogging, logEntries)
+	if upd.LogEntries != nil {
+		c.ClusterLogging = mergeClusterLogEntries(c.ClusterLogging, upd.LogEntries)
+	}
+
+	if len(upd.SubnetIDs) > 0 {
+		if c.VpcConfig == nil {
+			c.VpcConfig = &VpcConfig{}
+		}
+
+		c.VpcConfig.SubnetIDs = cloneStrings(upd.SubnetIDs)
+	}
+
+	if upd.AccessConfig != nil {
+		if c.AccessConfig == nil {
+			c.AccessConfig = &AccessConfig{}
+		}
+
+		if upd.AccessConfig.AuthenticationMode != "" {
+			c.AccessConfig.AuthenticationMode = upd.AccessConfig.AuthenticationMode
+		}
+
+		c.AccessConfig.BootstrapClusterCreatorAdminPermissions = upd.AccessConfig.BootstrapClusterCreatorAdminPermissions
+	}
+
+	if upd.ComputeConfig != nil {
+		c.ComputeConfig = upd.ComputeConfig
+	}
+
+	if upd.StorageConfig != nil {
+		c.StorageConfig = upd.StorageConfig
 	}
 
 	return &Update{

--- a/services/eks/backend_remaining_ops.go
+++ b/services/eks/backend_remaining_ops.go
@@ -740,7 +740,10 @@ type AccessEntryUpdate struct {
 }
 
 // UpdateAccessEntry updates an access entry's username and kubernetes groups.
-func (b *InMemoryBackend) UpdateAccessEntry(clusterName, principalARN string, upd AccessEntryUpdate) (*AccessEntry, error) {
+func (b *InMemoryBackend) UpdateAccessEntry(
+	clusterName, principalARN string,
+	upd AccessEntryUpdate,
+) (*AccessEntry, error) {
 	b.mu.Lock("UpdateAccessEntry")
 	defer b.mu.Unlock()
 

--- a/services/eks/batch1_accuracy_test.go
+++ b/services/eks/batch1_accuracy_test.go
@@ -843,7 +843,7 @@ func TestBatch1_FargateProfile_Status_ACTIVE_On_Create(t *testing.T) {
 
 	fp, err := b.CreateFargateProfile("fp-status-cluster", "fp1",
 		"arn:aws:iam::123:role/fargate",
-		[]eks.FargateProfileSelector{{Namespace: "default"}}, nil)
+		[]eks.FargateProfileSelector{{Namespace: "default"}}, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "ACTIVE", fp.Status)
 }
@@ -856,7 +856,7 @@ func TestBatch1_FargateProfile_Status_DELETING_On_Delete(t *testing.T) {
 
 	_, _ = b.CreateFargateProfile("fp-del-cluster", "fp1",
 		"arn:aws:iam::123:role/fargate",
-		[]eks.FargateProfileSelector{{Namespace: "default"}}, nil)
+		[]eks.FargateProfileSelector{{Namespace: "default"}}, nil, nil)
 
 	deleted, err := b.DeleteFargateProfile("fp-del-cluster", "fp1")
 	require.NoError(t, err)
@@ -922,7 +922,7 @@ func TestBatch1_FargateProfile_ARN_Format(t *testing.T) {
 
 	fp, err := b.CreateFargateProfile("arn-fp-cluster", "my-fargate",
 		"arn:aws:iam::123:role/fargate",
-		[]eks.FargateProfileSelector{{Namespace: "default"}}, nil)
+		[]eks.FargateProfileSelector{{Namespace: "default"}}, nil, nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, fp.ARN, "arn:aws:eks:")
@@ -961,7 +961,7 @@ func TestBatch1_Logging_AllFiveTypes_Accepted(t *testing.T) {
 		entries = append(entries, eks.ClusterLogEntry{Types: []string{lt}, Enabled: true})
 	}
 
-	_, err := b.UpdateClusterConfig("logging-5types", entries)
+	_, err := b.UpdateClusterConfig("logging-5types", eks.ClusterConfigUpdate{LogEntries: entries})
 	require.NoError(t, err)
 
 	c, err := b.DescribeCluster("logging-5types")
@@ -988,15 +988,15 @@ func TestBatch1_Logging_Disable_Single_Type(t *testing.T) {
 	mustCreateClusterNoVpc(t, b, "logging-disable")
 
 	// Enable all.
-	_, err := b.UpdateClusterConfig("logging-disable", []eks.ClusterLogEntry{
+	_, err := b.UpdateClusterConfig("logging-disable", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api", "audit", "authenticator"}, Enabled: true},
-	})
+	}})
 	require.NoError(t, err)
 
 	// Disable just "audit".
-	_, err = b.UpdateClusterConfig("logging-disable", []eks.ClusterLogEntry{
+	_, err = b.UpdateClusterConfig("logging-disable", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"audit"}, Enabled: false},
-	})
+	}})
 	require.NoError(t, err)
 
 	c, err := b.DescribeCluster("logging-disable")
@@ -1183,7 +1183,7 @@ func TestBatch1_RBAC_CreateDescribeList(t *testing.T) {
 	mustCreateClusterNoVpc(t, b, "rbac-cluster")
 
 	entry, err := b.CreateAccessEntry("rbac-cluster",
-		"arn:aws:iam::123:role/DevRole", "STANDARD", "dev-user", nil)
+		"arn:aws:iam::123:role/DevRole", "STANDARD", "dev-user", nil, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, entry.ARN)
 
@@ -1202,7 +1202,7 @@ func TestBatch1_RBAC_AssociatePolicy(t *testing.T) {
 	b := newB1Backend(t)
 	mustCreateClusterNoVpc(t, b, "rbac-policy-cluster")
 
-	_, _ = b.CreateAccessEntry("rbac-policy-cluster", "arn:aws:iam::123:role/R1", "STANDARD", "", nil)
+	_, _ = b.CreateAccessEntry("rbac-policy-cluster", "arn:aws:iam::123:role/R1", "STANDARD", "", nil, nil)
 
 	scope := map[string]any{"type": "cluster"}
 	assoc, err := b.AssociateAccessPolicy(
@@ -1234,7 +1234,7 @@ func TestBatch1_RBAC_DisassociatePolicy(t *testing.T) {
 	b := newB1Backend(t)
 	mustCreateClusterNoVpc(t, b, "rbac-dis-cluster")
 
-	_, _ = b.CreateAccessEntry("rbac-dis-cluster", "arn:aws:iam::123:role/R2", "STANDARD", "", nil)
+	_, _ = b.CreateAccessEntry("rbac-dis-cluster", "arn:aws:iam::123:role/R2", "STANDARD", "", nil, nil)
 	policyARN := "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
 	_, _ = b.AssociateAccessPolicy("rbac-dis-cluster", "arn:aws:iam::123:role/R2", policyARN,
 		map[string]any{"type": "cluster"})
@@ -1504,9 +1504,9 @@ func TestBatch1_UpdateClusterConfig_Status_InProgress(t *testing.T) {
 	b := newB1Backend(t)
 	mustCreateClusterNoVpc(t, b, "upd-inprog-cluster")
 
-	upd, err := b.UpdateClusterConfig("upd-inprog-cluster", []eks.ClusterLogEntry{
+	upd, err := b.UpdateClusterConfig("upd-inprog-cluster", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api"}, Enabled: true},
-	})
+	}})
 	require.NoError(t, err)
 	assert.Equal(t, "InProgress", upd.Status)
 }

--- a/services/eks/batch2_accuracy_test.go
+++ b/services/eks/batch2_accuracy_test.go
@@ -27,10 +27,10 @@ func TestBatch2_ComputeConfig_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		wantValue any
 		body      map[string]any
 		name      string
 		wantField string
-		wantValue any
 	}{
 		{
 			name: "compute_config_enabled",
@@ -341,8 +341,8 @@ func TestBatch2_AccessEntry_KubernetesGroups_Create(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		groups []string
 		name   string
+		groups []string
 	}{
 		{name: "with_groups", groups: []string{"system:masters", "ops-team"}},
 		{name: "no_groups", groups: nil},
@@ -467,10 +467,10 @@ func TestBatch2_Nodegroup_UpdateConfig_Via_UpdateNodegroupConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
 		body       map[string]any
 		wantMaxU   *float64
 		wantMaxPct *float64
+		name       string
 	}{
 		{
 			name: "set_max_unavailable",
@@ -708,8 +708,8 @@ func TestBatch2_FargateProfile_Subnets_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		subnets []string
 		name    string
+		subnets []string
 	}{
 		{name: "with_subnets", subnets: []string{"subnet-fp-1", "subnet-fp-2"}},
 		{name: "no_subnets", subnets: nil},
@@ -871,8 +871,8 @@ func TestBatch2_RegisterCluster_ConnectorConfig_Nested(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
 		body map[string]any
+		name string
 	}{
 		{
 			name: "with_connector_config",

--- a/services/eks/batch2_accuracy_test.go
+++ b/services/eks/batch2_accuracy_test.go
@@ -1,0 +1,1017 @@
+package eks_test
+
+// batch2_accuracy_test.go — AWS-accuracy audit batch-2 for EKS (go-rra3).
+//
+// Covers: EKS Auto Mode (computeConfig/storageConfig/networkingConfig), accessConfig,
+// nodegroup updateConfig, labels/taints via UpdateNodegroupConfig, access entry
+// kubernetesGroups, fargate profile subnets, PodIdentity UUID assocId, insight
+// insightStatus object, control plane subnet updates, connectorConfig nested parsing,
+// ownerArn in pod identity response.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/config"
+	"github.com/blackbirdworks/gopherstack/services/eks"
+)
+
+// ---------------------------------------------------------------------------
+// Gap 1: EKS Auto Mode — computeConfig round-trip
+// ---------------------------------------------------------------------------
+
+func TestBatch2_ComputeConfig_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body      map[string]any
+		name      string
+		wantField string
+		wantValue any
+	}{
+		{
+			name: "compute_config_enabled",
+			body: map[string]any{
+				"name": "auto-cluster",
+				"computeConfig": map[string]any{
+					"enabled":     true,
+					"nodeRoleArn": "arn:aws:iam::123456789012:role/eks-node",
+					"nodePools":   []string{"general-purpose", "system"},
+				},
+			},
+			wantField: "enabled",
+			wantValue: true,
+		},
+		{
+			name: "compute_config_disabled",
+			body: map[string]any{
+				"name": "manual-cluster",
+				"computeConfig": map[string]any{
+					"enabled": false,
+				},
+			},
+			wantField: "enabled",
+			wantValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			rec := doREST(t, h, http.MethodPost, "/clusters", tt.body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			resp := parseResp(t, rec)
+			cluster, ok := resp["cluster"].(map[string]any)
+			require.True(t, ok)
+
+			cc, ok := cluster["computeConfig"].(map[string]any)
+			require.True(t, ok, "computeConfig must be present in response")
+			assert.Equal(t, tt.wantValue, cc[tt.wantField])
+		})
+	}
+}
+
+func TestBatch2_ComputeConfig_NodeRoleArn_And_NodePools(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	rec := doREST(t, h, http.MethodPost, "/clusters", map[string]any{
+		"name": "auto-full",
+		"computeConfig": map[string]any{
+			"enabled":     true,
+			"nodeRoleArn": "arn:aws:iam::123456789012:role/eks-node",
+			"nodePools":   []string{"general-purpose"},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/auto-full", nil)
+	require.Equal(t, http.StatusOK, desc.Code)
+	cluster := parseResp(t, desc)["cluster"].(map[string]any)
+
+	cc := cluster["computeConfig"].(map[string]any)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/eks-node", cc["nodeRoleArn"])
+
+	pools, _ := cc["nodePools"].([]any)
+	assert.Equal(t, "general-purpose", pools[0])
+}
+
+// ---------------------------------------------------------------------------
+// Gap 2: EKS Auto Mode — storageConfig and networkingConfig round-trip
+// ---------------------------------------------------------------------------
+
+func TestBatch2_StorageConfig_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body        map[string]any
+		name        string
+		wantEnabled bool
+	}{
+		{
+			name: "storage_enabled",
+			body: map[string]any{
+				"name": "storage-on",
+				"storageConfig": map[string]any{
+					"blockStorage": map[string]any{"enabled": true},
+				},
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "storage_disabled",
+			body: map[string]any{
+				"name": "storage-off",
+				"storageConfig": map[string]any{
+					"blockStorage": map[string]any{"enabled": false},
+				},
+			},
+			wantEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			rec := doREST(t, h, http.MethodPost, "/clusters", tt.body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			desc := doREST(t, h, http.MethodGet, "/clusters/"+tt.body["name"].(string), nil)
+			cluster := parseResp(t, desc)["cluster"].(map[string]any)
+
+			sc, ok := cluster["storageConfig"].(map[string]any)
+			require.True(t, ok, "storageConfig must be present")
+			bs := sc["blockStorage"].(map[string]any)
+			assert.Equal(t, tt.wantEnabled, bs["enabled"])
+		})
+	}
+}
+
+func TestBatch2_NetworkingConfig_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	rec := doREST(t, h, http.MethodPost, "/clusters", map[string]any{
+		"name": "net-cluster",
+		"networkingConfig": map[string]any{
+			"elasticLoadBalancing": map[string]any{"enabled": true},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/net-cluster", nil)
+	cluster := parseResp(t, desc)["cluster"].(map[string]any)
+
+	nc, ok := cluster["networkingConfig"].(map[string]any)
+	require.True(t, ok, "networkingConfig must be present")
+	elb := nc["elasticLoadBalancing"].(map[string]any)
+	assert.Equal(t, true, elb["enabled"])
+}
+
+// ---------------------------------------------------------------------------
+// Gap 3: accessConfig round-trip
+// ---------------------------------------------------------------------------
+
+func TestBatch2_AccessConfig_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body             map[string]any
+		name             string
+		wantAuthMode     string
+		wantBootstrap    bool
+	}{
+		{
+			name: "access_config_api_mode",
+			body: map[string]any{
+				"name": "api-cluster",
+				"accessConfig": map[string]any{
+					"authenticationMode":                      "API",
+					"bootstrapClusterCreatorAdminPermissions": true,
+				},
+			},
+			wantAuthMode:  "API",
+			wantBootstrap: true,
+		},
+		{
+			name: "access_config_config_map",
+			body: map[string]any{
+				"name": "cm-cluster",
+				"accessConfig": map[string]any{
+					"authenticationMode":                      "CONFIG_MAP",
+					"bootstrapClusterCreatorAdminPermissions": false,
+				},
+			},
+			wantAuthMode:  "CONFIG_MAP",
+			wantBootstrap: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			rec := doREST(t, h, http.MethodPost, "/clusters", tt.body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			desc := doREST(t, h, http.MethodGet, "/clusters/"+tt.body["name"].(string), nil)
+			cluster := parseResp(t, desc)["cluster"].(map[string]any)
+
+			ac, ok := cluster["accessConfig"].(map[string]any)
+			require.True(t, ok, "accessConfig must be present in response")
+			assert.Equal(t, tt.wantAuthMode, ac["authenticationMode"])
+			assert.Equal(t, tt.wantBootstrap, ac["bootstrapClusterCreatorAdminPermissions"])
+		})
+	}
+}
+
+func TestBatch2_AccessConfig_Absent_When_Not_Provided(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "no-ac"})
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/no-ac", nil)
+	cluster := parseResp(t, desc)["cluster"].(map[string]any)
+	_, hasAC := cluster["accessConfig"]
+	assert.False(t, hasAC, "accessConfig must be absent when not provided")
+}
+
+// ---------------------------------------------------------------------------
+// Gap 4: UpdateClusterConfig updates accessConfig, computeConfig, subnetIds
+// ---------------------------------------------------------------------------
+
+func TestBatch2_UpdateClusterConfig_AccessConfig(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("upd-ac", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = b.UpdateClusterConfig("upd-ac", eks.ClusterConfigUpdate{
+		AccessConfig: &eks.AccessConfig{AuthenticationMode: "API_AND_CONFIG_MAP"},
+	})
+	require.NoError(t, err)
+
+	c, err := b.DescribeCluster("upd-ac")
+	require.NoError(t, err)
+	require.NotNil(t, c.AccessConfig)
+	assert.Equal(t, "API_AND_CONFIG_MAP", c.AccessConfig.AuthenticationMode)
+}
+
+func TestBatch2_UpdateClusterConfig_SubnetIDs(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("upd-subnets", "1.32", "", &eks.VpcConfig{
+		SubnetIDs: []string{"subnet-old"},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	_, err = b.UpdateClusterConfig("upd-subnets", eks.ClusterConfigUpdate{
+		SubnetIDs: []string{"subnet-new-1", "subnet-new-2"},
+	})
+	require.NoError(t, err)
+
+	c, err := b.DescribeCluster("upd-subnets")
+	require.NoError(t, err)
+	require.NotNil(t, c.VpcConfig)
+	assert.Equal(t, []string{"subnet-new-1", "subnet-new-2"}, c.VpcConfig.SubnetIDs)
+}
+
+func TestBatch2_UpdateClusterConfig_SubnetIDs_Via_Handler(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{
+		"name": "upd-sub-cluster",
+		"resourcesVpcConfig": map[string]any{
+			"subnetIds": []string{"subnet-orig"},
+		},
+	})
+
+	rec := doREST(t, h, http.MethodPut, "/clusters/upd-sub-cluster", map[string]any{
+		"resourcesVpcConfig": map[string]any{
+			"subnetIds": []string{"subnet-a", "subnet-b"},
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/upd-sub-cluster", nil)
+	cluster := parseResp(t, desc)["cluster"].(map[string]any)
+	vpc := cluster["resourcesVpcConfig"].(map[string]any)
+	subs, _ := vpc["subnetIds"].([]any)
+	require.Len(t, subs, 2)
+	assert.Equal(t, "subnet-a", subs[0])
+}
+
+func TestBatch2_UpdateClusterConfig_ComputeConfig(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("upd-compute", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = b.UpdateClusterConfig("upd-compute", eks.ClusterConfigUpdate{
+		ComputeConfig: &eks.ComputeConfig{Enabled: true, NodeRoleARN: "arn:aws:iam::123:role/node"},
+	})
+	require.NoError(t, err)
+
+	c, err := b.DescribeCluster("upd-compute")
+	require.NoError(t, err)
+	require.NotNil(t, c.ComputeConfig)
+	assert.True(t, c.ComputeConfig.Enabled)
+	assert.Equal(t, "arn:aws:iam::123:role/node", c.ComputeConfig.NodeRoleARN)
+}
+
+// ---------------------------------------------------------------------------
+// Gap 5: AccessEntry — kubernetesGroups in create and update
+// ---------------------------------------------------------------------------
+
+func TestBatch2_AccessEntry_KubernetesGroups_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		groups []string
+		name   string
+	}{
+		{name: "with_groups", groups: []string{"system:masters", "ops-team"}},
+		{name: "no_groups", groups: nil},
+		{name: "empty_groups", groups: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ae-cluster-" + tt.name})
+
+			body := map[string]any{
+				"principalArn": "arn:aws:iam::123456789012:role/my-role",
+				"type":         "STANDARD",
+			}
+			if tt.groups != nil {
+				body["kubernetesGroups"] = tt.groups
+			}
+
+			rec := doREST(t, h, http.MethodPost, "/clusters/ae-cluster-"+tt.name+"/access-entries", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			entry := parseResp(t, rec)["accessEntry"].(map[string]any)
+			groups, _ := entry["kubernetesGroups"].([]any)
+
+			if len(tt.groups) > 0 {
+				require.Len(t, groups, len(tt.groups))
+				assert.Equal(t, tt.groups[0], groups[0])
+			} else {
+				assert.Empty(t, groups, "kubernetesGroups should be empty array when not set")
+			}
+		})
+	}
+}
+
+func TestBatch2_AccessEntry_KubernetesGroups_Update(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ae-upd-cluster"})
+	doREST(t, h, http.MethodPost, "/clusters/ae-upd-cluster/access-entries", map[string]any{
+		"principalArn": "arn:aws:iam::123456789012:role/my-role",
+	})
+
+	rec := doREST(t, h, http.MethodPut,
+		"/clusters/ae-upd-cluster/access-entries/arn:aws:iam::123456789012:role/my-role",
+		map[string]any{
+			"kubernetesGroups": []string{"system:masters"},
+		},
+	)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	entry := parseResp(t, rec)["accessEntry"].(map[string]any)
+	groups, _ := entry["kubernetesGroups"].([]any)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "system:masters", groups[0])
+}
+
+func TestBatch2_AccessEntry_KubernetesGroups_Backend_DirectCreate(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	entry, err := b.CreateAccessEntry("c1",
+		"arn:aws:iam::123456789012:role/r1",
+		"STANDARD", "",
+		[]string{"system:masters", "devs"},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"system:masters", "devs"}, entry.KubernetesGroups)
+}
+
+func TestBatch2_AccessEntry_KubernetesGroups_Backend_Update(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r1", "STANDARD", "", nil, nil)
+	require.NoError(t, err)
+
+	updated, err := b.UpdateAccessEntry("c1", "arn:aws:iam::123:role/r1", eks.AccessEntryUpdate{
+		KubernetesGroups: []string{"ops-team"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ops-team"}, updated.KubernetesGroups)
+}
+
+// ---------------------------------------------------------------------------
+// Gap 6: Nodegroup — updateConfig round-trip
+// ---------------------------------------------------------------------------
+
+func TestBatch2_Nodegroup_UpdateConfig_Create(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ng-uc-cluster"})
+
+	maxUnavail := int32(2)
+	rec := doREST(t, h, http.MethodPost, "/clusters/ng-uc-cluster/node-groups", map[string]any{
+		"nodegroupName": "ng1",
+		"nodeRole":      "arn:aws:iam::123456789012:role/ng",
+		"scalingConfig": map[string]any{"desiredSize": 3, "minSize": 1, "maxSize": 5},
+		"subnets":       []string{"subnet-aaa"},
+		"updateConfig":  map[string]any{"maxUnavailable": maxUnavail},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	ng := parseResp(t, rec)["nodegroup"].(map[string]any)
+	uc, ok := ng["updateConfig"].(map[string]any)
+	require.True(t, ok, "updateConfig must be present")
+	assert.Equal(t, float64(2), uc["maxUnavailable"])
+}
+
+func TestBatch2_Nodegroup_UpdateConfig_Via_UpdateNodegroupConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       map[string]any
+		wantMaxU   *float64
+		wantMaxPct *float64
+	}{
+		{
+			name: "set_max_unavailable",
+			body: map[string]any{
+				"updateConfig": map[string]any{"maxUnavailable": 2},
+			},
+			wantMaxU: pFloat64(2),
+		},
+		{
+			name: "set_max_unavailable_percentage",
+			body: map[string]any{
+				"updateConfig": map[string]any{"maxUnavailablePercentage": 25},
+			},
+			wantMaxPct: pFloat64(25),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ng-uc-upd-" + tt.name})
+			doREST(t, h, http.MethodPost, "/clusters/ng-uc-upd-"+tt.name+"/node-groups", map[string]any{
+				"nodegroupName": "ng1",
+				"subnets":       []string{"subnet-x"},
+			})
+
+			rec := doREST(t, h, http.MethodPost, "/clusters/ng-uc-upd-"+tt.name+"/node-groups/ng1", tt.body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			desc := doREST(t, h, http.MethodGet, "/clusters/ng-uc-upd-"+tt.name+"/node-groups/ng1", nil)
+			ng := parseResp(t, desc)["nodegroup"].(map[string]any)
+			uc, ok := ng["updateConfig"].(map[string]any)
+			require.True(t, ok, "updateConfig must be present after update")
+
+			if tt.wantMaxU != nil {
+				assert.Equal(t, *tt.wantMaxU, uc["maxUnavailable"])
+			}
+
+			if tt.wantMaxPct != nil {
+				assert.Equal(t, *tt.wantMaxPct, uc["maxUnavailablePercentage"])
+			}
+		})
+	}
+}
+
+func pFloat64(f float64) *float64 { return &f }
+
+// ---------------------------------------------------------------------------
+// Gap 7: UpdateNodegroupConfig — labels and taints
+// ---------------------------------------------------------------------------
+
+func TestBatch2_UpdateNodegroupConfig_Labels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup       map[string]any
+		update      map[string]any
+		name        string
+		wantLabel   string
+		wantValue   string
+		wantMissing string
+	}{
+		{
+			name: "add_label",
+			setup: map[string]any{
+				"nodegroupName": "ng1",
+				"subnets":       []string{"subnet-x"},
+				"labels":        map[string]any{"existing": "value"},
+			},
+			update: map[string]any{
+				"labels": map[string]any{
+					"addOrUpdateLabels": map[string]any{"env": "prod"},
+				},
+			},
+			wantLabel: "env",
+			wantValue: "prod",
+		},
+		{
+			name: "remove_label",
+			setup: map[string]any{
+				"nodegroupName": "ng1",
+				"subnets":       []string{"subnet-x"},
+				"labels":        map[string]any{"to-remove": "bye"},
+			},
+			update: map[string]any{
+				"labels": map[string]any{
+					"removeLabels": []string{"to-remove"},
+				},
+			},
+			wantMissing: "to-remove",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterName := "ng-lbl-" + tt.name
+			h := newTestEKSHandler()
+			doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": clusterName})
+			doREST(t, h, http.MethodPost, "/clusters/"+clusterName+"/node-groups", tt.setup)
+
+			rec := doREST(t, h, http.MethodPost, "/clusters/"+clusterName+"/node-groups/ng1", tt.update)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			desc := doREST(t, h, http.MethodGet, "/clusters/"+clusterName+"/node-groups/ng1", nil)
+			ng := parseResp(t, desc)["nodegroup"].(map[string]any)
+			labels, _ := ng["labels"].(map[string]any)
+
+			if tt.wantLabel != "" {
+				assert.Equal(t, tt.wantValue, labels[tt.wantLabel])
+			}
+
+			if tt.wantMissing != "" {
+				_, hasKey := labels[tt.wantMissing]
+				assert.False(t, hasKey, "label %q should have been removed", tt.wantMissing)
+			}
+		})
+	}
+}
+
+func TestBatch2_UpdateNodegroupConfig_Taints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup      map[string]any
+		update     map[string]any
+		name       string
+		wantTaints int
+	}{
+		{
+			name: "add_taint",
+			setup: map[string]any{
+				"nodegroupName": "ng1",
+				"subnets":       []string{"subnet-x"},
+			},
+			update: map[string]any{
+				"taints": map[string]any{
+					"addOrUpdateTaints": []any{
+						map[string]any{"key": "dedicated", "value": "gpu", "effect": "NO_SCHEDULE"},
+					},
+				},
+			},
+			wantTaints: 1,
+		},
+		{
+			name: "remove_taint",
+			setup: map[string]any{
+				"nodegroupName": "ng1",
+				"subnets":       []string{"subnet-x"},
+				"taints": []any{
+					map[string]any{"key": "spot", "effect": "NO_SCHEDULE"},
+				},
+			},
+			update: map[string]any{
+				"taints": map[string]any{
+					"removeTaints": []any{
+						map[string]any{"key": "spot", "effect": "NO_SCHEDULE"},
+					},
+				},
+			},
+			wantTaints: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterName := "ng-tnt-" + tt.name
+			h := newTestEKSHandler()
+			doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": clusterName})
+			doREST(t, h, http.MethodPost, "/clusters/"+clusterName+"/node-groups", tt.setup)
+
+			rec := doREST(t, h, http.MethodPost, "/clusters/"+clusterName+"/node-groups/ng1", tt.update)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			desc := doREST(t, h, http.MethodGet, "/clusters/"+clusterName+"/node-groups/ng1", nil)
+			ng := parseResp(t, desc)["nodegroup"].(map[string]any)
+			taints, _ := ng["taints"].([]any)
+			assert.Len(t, taints, tt.wantTaints)
+		})
+	}
+}
+
+func TestBatch2_UpdateNodegroupConfig_Backend_Taints(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = b.CreateNodegroup("c1", "ng1", "", "", "", "", "", nil, 1, 1, 3,
+		eks.NodegroupInput{
+			Taints: []eks.NodegroupTaint{
+				{Key: "env", Value: "prod", Effect: "NO_SCHEDULE"},
+			},
+		},
+		nil)
+	require.NoError(t, err)
+
+	upd := eks.NodegroupConfigUpdate{
+		AddOrUpdateTaints: []eks.NodegroupTaint{
+			{Key: "env", Value: "staging", Effect: "NO_SCHEDULE"},
+			{Key: "spot", Effect: "PREFER_NO_SCHEDULE"},
+		},
+	}
+	ng, err := b.UpdateNodegroupConfig("c1", "ng1", upd)
+	require.NoError(t, err)
+	assert.Len(t, ng.Taints, 2)
+
+	var envTaint eks.NodegroupTaint
+	for _, taint := range ng.Taints {
+		if taint.Key == "env" {
+			envTaint = taint
+		}
+	}
+	assert.Equal(t, "staging", envTaint.Value, "taint value should be updated")
+
+	// Remove by key+effect
+	ng2, err := b.UpdateNodegroupConfig("c1", "ng1", eks.NodegroupConfigUpdate{
+		RemoveTaints: []eks.NodegroupTaint{{Key: "spot", Effect: "PREFER_NO_SCHEDULE"}},
+	})
+	require.NoError(t, err)
+	assert.Len(t, ng2.Taints, 1)
+}
+
+// ---------------------------------------------------------------------------
+// Gap 8: FargateProfile — subnets round-trip
+// ---------------------------------------------------------------------------
+
+func TestBatch2_FargateProfile_Subnets_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		subnets []string
+		name    string
+	}{
+		{name: "with_subnets", subnets: []string{"subnet-fp-1", "subnet-fp-2"}},
+		{name: "no_subnets", subnets: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "fp-sub-" + tt.name})
+
+			body := map[string]any{
+				"fargateProfileName":  "fp1",
+				"podExecutionRoleArn": "arn:aws:iam::123:role/fp",
+			}
+			if tt.subnets != nil {
+				body["subnets"] = tt.subnets
+			}
+
+			rec := doREST(t, h, http.MethodPost,
+				"/clusters/fp-sub-"+tt.name+"/fargate-profiles", body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			profile := parseResp(t, rec)["fargateProfile"].(map[string]any)
+			subs, _ := profile["subnets"].([]any)
+
+			if len(tt.subnets) > 0 {
+				require.Len(t, subs, len(tt.subnets))
+				assert.Equal(t, tt.subnets[0], subs[0])
+			} else {
+				assert.Empty(t, subs)
+			}
+		})
+	}
+}
+
+func TestBatch2_FargateProfile_Subnets_Describe(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	fp, err := b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/fp",
+		nil, []string{"subnet-a", "subnet-b"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"subnet-a", "subnet-b"}, fp.Subnets)
+
+	described, err := b.DescribeFargateProfile("c1", "fp1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"subnet-a", "subnet-b"}, described.Subnets)
+}
+
+func TestBatch2_FargateProfile_Subnets_DeepCopy(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	subs := []string{"subnet-a"}
+	fp, err := b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/fp", nil, subs, nil)
+	require.NoError(t, err)
+
+	fp.Subnets[0] = "mutated"
+
+	described, err := b.DescribeFargateProfile("c1", "fp1")
+	require.NoError(t, err)
+	assert.Equal(t, "subnet-a", described.Subnets[0], "subnets must be deep-copied")
+}
+
+// ---------------------------------------------------------------------------
+// Gap 9: PodIdentityAssociation — UUID-based associationId
+// ---------------------------------------------------------------------------
+
+func TestBatch2_PodIdentity_AssocID_IsUUID(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "pi-uuid-cluster"})
+
+	rec := doREST(t, h, http.MethodPost, "/clusters/pi-uuid-cluster/pod-identity-associations", map[string]any{
+		"namespace":      "default",
+		"serviceAccount": "my-sa",
+		"roleArn":        "arn:aws:iam::123456789012:role/my-pod-role",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assoc := parseResp(t, rec)["association"].(map[string]any)
+	assocID, _ := assoc["associationId"].(string)
+	require.NotEmpty(t, assocID)
+	assert.Len(t, assocID, 36, "associationId should be a UUID (36 chars with hyphens)")
+}
+
+func TestBatch2_PodIdentity_DifferentAssocIDs_SameNamespaceSA(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	a1, err := b.CreatePodIdentityAssociation("c1", "default", "my-sa", "arn:aws:iam::123:role/r1", nil)
+	require.NoError(t, err)
+
+	a2, err := b.CreatePodIdentityAssociation("c1", "default", "my-sa", "arn:aws:iam::123:role/r2", nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a1.AssociationID, a2.AssociationID,
+		"each call must produce a unique associationId")
+}
+
+// ---------------------------------------------------------------------------
+// Gap 10: Insight — insightStatus as object
+// ---------------------------------------------------------------------------
+
+func TestBatch2_Insights_InsightStatus_Object(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ins-cluster"})
+
+	rec := doREST(t, h, http.MethodGet, "/clusters/ins-cluster/insights", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+	insights, _ := resp["insights"].([]any)
+	require.NotEmpty(t, insights)
+
+	for _, ins := range insights {
+		insight := ins.(map[string]any)
+		insightStatus, ok := insight["insightStatus"].(map[string]any)
+		require.True(t, ok, "insightStatus must be an object, not a flat field")
+		_, hasStatus := insightStatus["status"]
+		assert.True(t, hasStatus, "insightStatus must have a 'status' field")
+	}
+}
+
+func TestBatch2_DescribeInsight_InsightStatus_Object(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "di-cluster"})
+
+	rec := doREST(t, h, http.MethodGet, "/clusters/di-cluster/insights/some-insight-id", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	insight := parseResp(t, rec)["insight"].(map[string]any)
+	insightStatus, ok := insight["insightStatus"].(map[string]any)
+	require.True(t, ok, "insightStatus must be an object")
+	assert.NotEmpty(t, insightStatus["status"])
+}
+
+// ---------------------------------------------------------------------------
+// Gap 11: RegisterCluster — connectorConfig nested object parsing
+// ---------------------------------------------------------------------------
+
+func TestBatch2_RegisterCluster_ConnectorConfig_Nested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "with_connector_config",
+			body: map[string]any{
+				"name": "reg-cluster-1",
+				"connectorConfig": map[string]any{
+					"provider": "EKS_ANYWHERE",
+					"roleArn":  "arn:aws:iam::123456789012:role/connector",
+				},
+			},
+		},
+		{
+			name: "without_connector_config",
+			body: map[string]any{
+				"name": "reg-cluster-2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestEKSHandler()
+			// RegisterCluster path is POST /clusters/{placeholder}/register
+			// The cluster name comes from the request body, not the path.
+			rec := doREST(t, h, http.MethodPost, "/clusters/placeholder/register", tt.body)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			cluster := parseResp(t, rec)["cluster"].(map[string]any)
+			assert.Equal(t, tt.body["name"], cluster["name"])
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gap 12: FargateProfile — subnets preserved in Delete
+// ---------------------------------------------------------------------------
+
+func TestBatch2_FargateProfile_Subnets_Preserved_On_Delete(t *testing.T) {
+	t.Parallel()
+
+	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
+	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/fp",
+		nil, []string{"subnet-del"}, nil)
+	require.NoError(t, err)
+
+	deleted, err := b.DeleteFargateProfile("c1", "fp1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"subnet-del"}, deleted.Subnets)
+	assert.Equal(t, "DELETING", deleted.Status)
+}
+
+// ---------------------------------------------------------------------------
+// Gap 13: AccessEntry — kubernetesGroups field always present in response
+// ---------------------------------------------------------------------------
+
+func TestBatch2_AccessEntry_KubernetesGroups_AlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ae-always-cluster"})
+	doREST(t, h, http.MethodPost, "/clusters/ae-always-cluster/access-entries", map[string]any{
+		"principalArn": "arn:aws:iam::123456789012:role/r1",
+	})
+
+	rec := doREST(t, h, http.MethodGet,
+		"/clusters/ae-always-cluster/access-entries/arn:aws:iam::123456789012:role/r1", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	entry := parseResp(t, rec)["accessEntry"].(map[string]any)
+	_, ok := entry["kubernetesGroups"]
+	assert.True(t, ok, "kubernetesGroups must always be present in access entry response")
+}
+
+// ---------------------------------------------------------------------------
+// Gap 14: Nodegroup — updateConfig present after creation via createNodegroup
+// ---------------------------------------------------------------------------
+
+func TestBatch2_Nodegroup_UpdateConfig_AbsentWhenNotSet(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "ng-no-uc-cluster"})
+	doREST(t, h, http.MethodPost, "/clusters/ng-no-uc-cluster/node-groups", map[string]any{
+		"nodegroupName": "ng1",
+		"subnets":       []string{"subnet-x"},
+	})
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/ng-no-uc-cluster/node-groups/ng1", nil)
+	ng := parseResp(t, desc)["nodegroup"].(map[string]any)
+	_, hasUC := ng["updateConfig"]
+	assert.False(t, hasUC, "updateConfig should be absent when not set at creation")
+}
+
+// ---------------------------------------------------------------------------
+// Gap 15: UpdateClusterConfig via handler — accessConfig and computeConfig
+// ---------------------------------------------------------------------------
+
+func TestBatch2_UpdateClusterConfig_Handler_AccessConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "upd-ac-handler"})
+
+	rec := doREST(t, h, http.MethodPut, "/clusters/upd-ac-handler", map[string]any{
+		"accessConfig": map[string]any{
+			"authenticationMode": "API",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/upd-ac-handler", nil)
+	cluster := parseResp(t, desc)["cluster"].(map[string]any)
+	ac, ok := cluster["accessConfig"].(map[string]any)
+	require.True(t, ok, "accessConfig must be present after update")
+	assert.Equal(t, "API", ac["authenticationMode"])
+}
+
+func TestBatch2_UpdateClusterConfig_Handler_ComputeConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newTestEKSHandler()
+	doREST(t, h, http.MethodPost, "/clusters", map[string]any{"name": "upd-cc-handler"})
+
+	rec := doREST(t, h, http.MethodPut, "/clusters/upd-cc-handler", map[string]any{
+		"computeConfig": map[string]any{
+			"enabled":     true,
+			"nodeRoleArn": "arn:aws:iam::123:role/node",
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	desc := doREST(t, h, http.MethodGet, "/clusters/upd-cc-handler", nil)
+	cluster := parseResp(t, desc)["cluster"].(map[string]any)
+	cc, ok := cluster["computeConfig"].(map[string]any)
+	require.True(t, ok, "computeConfig must be present after update")
+	assert.Equal(t, true, cc["enabled"])
+}

--- a/services/eks/batch2_accuracy_test.go
+++ b/services/eks/batch2_accuracy_test.go
@@ -184,10 +184,10 @@ func TestBatch2_AccessConfig_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		body             map[string]any
-		name             string
-		wantAuthMode     string
-		wantBootstrap    bool
+		body          map[string]any
+		name          string
+		wantAuthMode  string
+		wantBootstrap bool
 	}{
 		{
 			name: "access_config_api_mode",

--- a/services/eks/batch2_accuracy_test.go
+++ b/services/eks/batch2_accuracy_test.go
@@ -460,7 +460,7 @@ func TestBatch2_Nodegroup_UpdateConfig_Create(t *testing.T) {
 	ng := parseResp(t, rec)["nodegroup"].(map[string]any)
 	uc, ok := ng["updateConfig"].(map[string]any)
 	require.True(t, ok, "updateConfig must be present")
-	assert.Equal(t, float64(2), uc["maxUnavailable"])
+	assert.InDelta(t, float64(2), uc["maxUnavailable"], 0.001)
 }
 
 func TestBatch2_Nodegroup_UpdateConfig_Via_UpdateNodegroupConfig(t *testing.T) {
@@ -477,14 +477,14 @@ func TestBatch2_Nodegroup_UpdateConfig_Via_UpdateNodegroupConfig(t *testing.T) {
 			body: map[string]any{
 				"updateConfig": map[string]any{"maxUnavailable": 2},
 			},
-			wantMaxU: pFloat64(2),
+			wantMaxU: &[]float64{2}[0],
 		},
 		{
 			name: "set_max_unavailable_percentage",
 			body: map[string]any{
 				"updateConfig": map[string]any{"maxUnavailablePercentage": 25},
 			},
-			wantMaxPct: pFloat64(25),
+			wantMaxPct: &[]float64{25}[0],
 		},
 	}
 
@@ -508,17 +508,15 @@ func TestBatch2_Nodegroup_UpdateConfig_Via_UpdateNodegroupConfig(t *testing.T) {
 			require.True(t, ok, "updateConfig must be present after update")
 
 			if tt.wantMaxU != nil {
-				assert.Equal(t, *tt.wantMaxU, uc["maxUnavailable"])
+				assert.InDelta(t, *tt.wantMaxU, uc["maxUnavailable"], 0.001)
 			}
 
 			if tt.wantMaxPct != nil {
-				assert.Equal(t, *tt.wantMaxPct, uc["maxUnavailablePercentage"])
+				assert.InDelta(t, *tt.wantMaxPct, uc["maxUnavailablePercentage"], 0.001)
 			}
 		})
 	}
 }
-
-func pFloat64(f float64) *float64 { return &f }
 
 // ---------------------------------------------------------------------------
 // Gap 7: UpdateNodegroupConfig — labels and taints

--- a/services/eks/eks_coverage_test.go
+++ b/services/eks/eks_coverage_test.go
@@ -100,6 +100,7 @@ func TestEKS_FargateProfile_Lifecycle(t *testing.T) {
 		"arn:aws:iam::123:role/fp",
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "my-profile", fp.FargateProfileName)
@@ -141,6 +142,7 @@ func TestEKS_FargateProfile_Handler(t *testing.T) {
 		"fg-h-cluster",
 		"test-fp",
 		"arn:aws:iam::123:role/fp",
+		nil,
 		nil,
 		nil,
 	)
@@ -580,7 +582,7 @@ func TestEKS_Persistence_SubscriptionAndFargate(t *testing.T) {
 	_, err = b.CreateEksAnywhereSubscription("my-sub", 3, "Cluster", nil)
 	require.NoError(t, err)
 
-	_, err = b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/fp", nil, nil)
+	_, err = b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/fp", nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = b.CreatePodIdentityAssociation("c1", "default", "sa1", "arn:aws:iam::123:role/sa", nil)

--- a/services/eks/handler.go
+++ b/services/eks/handler.go
@@ -1176,14 +1176,14 @@ type kubernetesNetworkConfigJSON struct {
 }
 
 type accessConfigJSON struct {
-	AuthenticationMode                      string `json:"authenticationMode"`
 	BootstrapClusterCreatorAdminPermissions *bool  `json:"bootstrapClusterCreatorAdminPermissions,omitempty"`
+	AuthenticationMode                      string `json:"authenticationMode"`
 }
 
 type computeConfigJSON struct {
+	Enabled     *bool    `json:"enabled,omitempty"`
 	NodeRoleArn string   `json:"nodeRoleArn,omitempty"`
 	NodePools   []string `json:"nodePools,omitempty"`
-	Enabled     *bool    `json:"enabled,omitempty"`
 }
 
 type blockStorageConfigJSON struct {
@@ -1612,10 +1612,10 @@ func (h *Handler) handleUpdateNodegroupConfig(
 
 type createAccessEntryBody struct {
 	Tags             map[string]string `json:"tags"`
-	KubernetesGroups []string          `json:"kubernetesGroups"`
 	PrincipalArn     string            `json:"principalArn"`
 	Type             string            `json:"type"`
 	Username         string            `json:"username"`
+	KubernetesGroups []string          `json:"kubernetesGroups"`
 }
 
 func accessEntryToJSON(entry *AccessEntry) map[string]any {

--- a/services/eks/handler.go
+++ b/services/eks/handler.go
@@ -29,6 +29,7 @@ const (
 	keySubscription   = "subscription"
 	keyFargateProfile = "fargateProfile"
 	keyTags           = "tags"
+	keyEnabled        = "enabled"
 )
 
 const (
@@ -951,78 +952,80 @@ func clusterToJSON(c *Cluster) map[string]any {
 		m["roleArn"] = c.RoleARN
 	}
 	if c.OIDCIssuer != "" {
-		m["identity"] = map[string]any{
-			"oidc": map[string]string{
-				"issuer": c.OIDCIssuer,
-			},
-		}
+		m["identity"] = map[string]any{"oidc": map[string]string{"issuer": c.OIDCIssuer}}
 	}
-
 	if c.VpcConfig != nil {
 		m["resourcesVpcConfig"] = clusterVpcConfigJSON(c.VpcConfig)
 	}
-
-	if c.KubernetesNetworkConfig != nil {
-		net := map[string]any{}
-		if c.KubernetesNetworkConfig.IPFamily != "" {
-			net["ipFamily"] = c.KubernetesNetworkConfig.IPFamily
-		}
-		if c.KubernetesNetworkConfig.ServiceIPv4CIDR != "" {
-			net["serviceIpv4Cidr"] = c.KubernetesNetworkConfig.ServiceIPv4CIDR
-		}
-		if c.KubernetesNetworkConfig.ServiceIPv6CIDR != "" {
-			net["serviceIpv6Cidr"] = c.KubernetesNetworkConfig.ServiceIPv6CIDR
-		}
-		if len(net) > 0 {
-			m["kubernetesNetworkConfig"] = net
-		}
+	if net := clusterNetConfigJSON(c.KubernetesNetworkConfig); net != nil {
+		m["kubernetesNetworkConfig"] = net
 	}
-
 	if len(c.ClusterLogging) > 0 {
-		entries := make([]map[string]any, len(c.ClusterLogging))
-		for i, e := range c.ClusterLogging {
-			entries[i] = map[string]any{
-				"types":   e.Types,
-				"enabled": e.Enabled,
-			}
-		}
-		m["logging"] = map[string]any{"clusterLogging": entries}
+		m["logging"] = map[string]any{"clusterLogging": clusterLoggingJSON(c.ClusterLogging)}
 	}
-
 	if len(c.EncryptionConfig) > 0 {
 		m["encryptionConfig"] = c.EncryptionConfig
 	}
-
 	if c.AccessConfig != nil {
 		m["accessConfig"] = map[string]any{
 			"authenticationMode":                      c.AccessConfig.AuthenticationMode,
 			"bootstrapClusterCreatorAdminPermissions": c.AccessConfig.BootstrapClusterCreatorAdminPermissions,
 		}
 	}
-
 	if c.ComputeConfig != nil {
-		cc := map[string]any{"enabled": c.ComputeConfig.Enabled}
-		if c.ComputeConfig.NodeRoleARN != "" {
-			cc["nodeRoleArn"] = c.ComputeConfig.NodeRoleARN
-		}
-
-		if len(c.ComputeConfig.NodePools) > 0 {
-			cc["nodePools"] = c.ComputeConfig.NodePools
-		}
-
-		m["computeConfig"] = cc
+		m["computeConfig"] = clusterComputeConfigJSON(c.ComputeConfig)
 	}
-
 	if c.StorageConfig != nil && c.StorageConfig.BlockStorage != nil {
 		m["storageConfig"] = map[string]any{
-			"blockStorage": map[string]any{"enabled": c.StorageConfig.BlockStorage.Enabled},
+			"blockStorage": map[string]any{keyEnabled: c.StorageConfig.BlockStorage.Enabled},
+		}
+	}
+	if c.NetworkingConfig != nil && c.NetworkingConfig.ElasticLoadBalancing != nil {
+		m["networkingConfig"] = map[string]any{
+			"elasticLoadBalancing": map[string]any{keyEnabled: c.NetworkingConfig.ElasticLoadBalancing.Enabled},
 		}
 	}
 
-	if c.NetworkingConfig != nil && c.NetworkingConfig.ElasticLoadBalancing != nil {
-		m["networkingConfig"] = map[string]any{
-			"elasticLoadBalancing": map[string]any{"enabled": c.NetworkingConfig.ElasticLoadBalancing.Enabled},
-		}
+	return m
+}
+
+func clusterNetConfigJSON(cfg *KubernetesNetworkConfig) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	net := map[string]any{}
+	if cfg.IPFamily != "" {
+		net["ipFamily"] = cfg.IPFamily
+	}
+	if cfg.ServiceIPv4CIDR != "" {
+		net["serviceIpv4Cidr"] = cfg.ServiceIPv4CIDR
+	}
+	if cfg.ServiceIPv6CIDR != "" {
+		net["serviceIpv6Cidr"] = cfg.ServiceIPv6CIDR
+	}
+	if len(net) == 0 {
+		return nil
+	}
+
+	return net
+}
+
+func clusterLoggingJSON(entries []ClusterLogEntry) []map[string]any {
+	out := make([]map[string]any, len(entries))
+	for i, e := range entries {
+		out[i] = map[string]any{"types": e.Types, keyEnabled: e.Enabled}
+	}
+
+	return out
+}
+
+func clusterComputeConfigJSON(cc *ComputeConfig) map[string]any {
+	m := map[string]any{keyEnabled: cc.Enabled}
+	if cc.NodeRoleARN != "" {
+		m["nodeRoleArn"] = cc.NodeRoleARN
+	}
+	if len(cc.NodePools) > 0 {
+		m["nodePools"] = cc.NodePools
 	}
 
 	return m
@@ -1242,13 +1245,32 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 		}
 	}
 
+	cluster, err := h.Backend.CreateCluster(
+		in.Name,
+		in.Version,
+		in.RoleArn,
+		vpcCfg,
+		netCfg,
+		in.Tags,
+		buildClusterOptConfig(in),
+	)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyCluster: clusterToJSON(cluster),
+	})
+}
+
+func buildClusterOptConfig(in createClusterBody) ClusterOptionalConfig {
 	var opt ClusterOptionalConfig
+
 	if in.AccessConfig != nil {
 		ac := &AccessConfig{AuthenticationMode: in.AccessConfig.AuthenticationMode}
 		if in.AccessConfig.BootstrapClusterCreatorAdminPermissions != nil {
 			ac.BootstrapClusterCreatorAdminPermissions = *in.AccessConfig.BootstrapClusterCreatorAdminPermissions
 		}
-
 		opt.AccessConfig = ac
 	}
 
@@ -1257,7 +1279,6 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 		if in.ComputeConfig.Enabled != nil {
 			cc.Enabled = *in.ComputeConfig.Enabled
 		}
-
 		opt.ComputeConfig = cc
 	}
 
@@ -1266,7 +1287,6 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 		if in.StorageConfig.BlockStorage.Enabled != nil {
 			sc.BlockStorage.Enabled = *in.StorageConfig.BlockStorage.Enabled
 		}
-
 		opt.StorageConfig = sc
 	}
 
@@ -1275,18 +1295,10 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 		if in.NetworkingConfig.ElasticLoadBalancing.Enabled != nil {
 			nc.ElasticLoadBalancing.Enabled = *in.NetworkingConfig.ElasticLoadBalancing.Enabled
 		}
-
 		opt.NetworkingConfig = nc
 	}
 
-	cluster, err := h.Backend.CreateCluster(in.Name, in.Version, in.RoleArn, vpcCfg, netCfg, in.Tags, opt)
-	if err != nil {
-		return h.handleError(c, err)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{
-		keyCluster: clusterToJSON(cluster),
-	})
+	return opt
 }
 
 func (h *Handler) handleDescribeCluster(c *echo.Context, name string) error {
@@ -1350,22 +1362,22 @@ type nodegroupUpdateConfigJSON struct {
 }
 
 type createNodegroupBody struct {
-	Tags           map[string]string       `json:"tags"`
-	Labels         map[string]string       `json:"labels"`
-	RemoteAccess   *remoteAccessJSON       `json:"remoteAccess"`
-	LaunchTemplate *launchTemplateJSON     `json:"launchTemplate"`
+	Tags           map[string]string          `json:"tags"`
+	Labels         map[string]string          `json:"labels"`
+	RemoteAccess   *remoteAccessJSON          `json:"remoteAccess"`
+	LaunchTemplate *launchTemplateJSON        `json:"launchTemplate"`
 	UpdateConfig   *nodegroupUpdateConfigJSON `json:"updateConfig"`
-	NodegroupName  string                  `json:"nodegroupName"`
-	NodeRole       string                  `json:"nodeRole"`
-	AMIType        string                  `json:"amiType"`
-	CapacityType   string                  `json:"capacityType"`
-	Version        string                  `json:"version"`
-	ReleaseVersion string                  `json:"releaseVersion"`
-	InstanceTypes  []string                `json:"instanceTypes"`
-	Subnets        []string                `json:"subnets"`
-	Taints         []nodegroupTaintJSON    `json:"taints"`
-	ScalingConfig  scalingConfigJSON       `json:"scalingConfig"`
-	DiskSize       int32                   `json:"diskSize"`
+	NodegroupName  string                     `json:"nodegroupName"`
+	NodeRole       string                     `json:"nodeRole"`
+	AMIType        string                     `json:"amiType"`
+	CapacityType   string                     `json:"capacityType"`
+	Version        string                     `json:"version"`
+	ReleaseVersion string                     `json:"releaseVersion"`
+	InstanceTypes  []string                   `json:"instanceTypes"`
+	Subnets        []string                   `json:"subnets"`
+	Taints         []nodegroupTaintJSON       `json:"taints"`
+	ScalingConfig  scalingConfigJSON          `json:"scalingConfig"`
+	DiskSize       int32                      `json:"diskSize"`
 }
 
 func (h *Handler) handleCreateNodegroup(c *echo.Context, clusterName string, body []byte) error {
@@ -1641,7 +1653,14 @@ func (h *Handler) handleCreateAccessEntry(c *echo.Context, clusterName string, b
 		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterException", "principalArn is required"))
 	}
 
-	entry, err := h.Backend.CreateAccessEntry(clusterName, in.PrincipalArn, in.Type, in.Username, in.KubernetesGroups, in.Tags)
+	entry, err := h.Backend.CreateAccessEntry(
+		clusterName,
+		in.PrincipalArn,
+		in.Type,
+		in.Username,
+		in.KubernetesGroups,
+		in.Tags,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}

--- a/services/eks/handler.go
+++ b/services/eks/handler.go
@@ -1344,22 +1344,28 @@ type launchTemplateJSON struct {
 	Version string `json:"version,omitempty"`
 }
 
+type nodegroupUpdateConfigJSON struct {
+	MaxUnavailable           *int32 `json:"maxUnavailable,omitempty"`
+	MaxUnavailablePercentage *int32 `json:"maxUnavailablePercentage,omitempty"`
+}
+
 type createNodegroupBody struct {
-	Tags           map[string]string    `json:"tags"`
-	Labels         map[string]string    `json:"labels"`
-	RemoteAccess   *remoteAccessJSON    `json:"remoteAccess"`
-	LaunchTemplate *launchTemplateJSON  `json:"launchTemplate"`
-	NodegroupName  string               `json:"nodegroupName"`
-	NodeRole       string               `json:"nodeRole"`
-	AMIType        string               `json:"amiType"`
-	CapacityType   string               `json:"capacityType"`
-	Version        string               `json:"version"`
-	ReleaseVersion string               `json:"releaseVersion"`
-	InstanceTypes  []string             `json:"instanceTypes"`
-	Subnets        []string             `json:"subnets"`
-	Taints         []nodegroupTaintJSON `json:"taints"`
-	ScalingConfig  scalingConfigJSON    `json:"scalingConfig"`
-	DiskSize       int32                `json:"diskSize"`
+	Tags           map[string]string       `json:"tags"`
+	Labels         map[string]string       `json:"labels"`
+	RemoteAccess   *remoteAccessJSON       `json:"remoteAccess"`
+	LaunchTemplate *launchTemplateJSON     `json:"launchTemplate"`
+	UpdateConfig   *nodegroupUpdateConfigJSON `json:"updateConfig"`
+	NodegroupName  string                  `json:"nodegroupName"`
+	NodeRole       string                  `json:"nodeRole"`
+	AMIType        string                  `json:"amiType"`
+	CapacityType   string                  `json:"capacityType"`
+	Version        string                  `json:"version"`
+	ReleaseVersion string                  `json:"releaseVersion"`
+	InstanceTypes  []string                `json:"instanceTypes"`
+	Subnets        []string                `json:"subnets"`
+	Taints         []nodegroupTaintJSON    `json:"taints"`
+	ScalingConfig  scalingConfigJSON       `json:"scalingConfig"`
+	DiskSize       int32                   `json:"diskSize"`
 }
 
 func (h *Handler) handleCreateNodegroup(c *echo.Context, clusterName string, body []byte) error {
@@ -1394,6 +1400,14 @@ func (h *Handler) handleCreateNodegroup(c *echo.Context, clusterName string, bod
 		}
 	}
 
+	var ngUpdateCfg *NodegroupUpdateConfig
+	if in.UpdateConfig != nil {
+		ngUpdateCfg = &NodegroupUpdateConfig{
+			MaxUnavailable:           in.UpdateConfig.MaxUnavailable,
+			MaxUnavailablePercentage: in.UpdateConfig.MaxUnavailablePercentage,
+		}
+	}
+
 	ng, err := h.Backend.CreateNodegroup(
 		clusterName, in.NodegroupName, in.NodeRole,
 		in.AMIType, in.CapacityType, in.Version, in.ReleaseVersion,
@@ -1406,6 +1420,7 @@ func (h *Handler) handleCreateNodegroup(c *echo.Context, clusterName string, bod
 			Subnets:        in.Subnets,
 			Taints:         taints,
 			DiskSize:       in.DiskSize,
+			UpdateConfig:   ngUpdateCfg,
 		},
 		in.Tags,
 	)

--- a/services/eks/handler.go
+++ b/services/eks/handler.go
@@ -993,6 +993,38 @@ func clusterToJSON(c *Cluster) map[string]any {
 		m["encryptionConfig"] = c.EncryptionConfig
 	}
 
+	if c.AccessConfig != nil {
+		m["accessConfig"] = map[string]any{
+			"authenticationMode":                      c.AccessConfig.AuthenticationMode,
+			"bootstrapClusterCreatorAdminPermissions": c.AccessConfig.BootstrapClusterCreatorAdminPermissions,
+		}
+	}
+
+	if c.ComputeConfig != nil {
+		cc := map[string]any{"enabled": c.ComputeConfig.Enabled}
+		if c.ComputeConfig.NodeRoleARN != "" {
+			cc["nodeRoleArn"] = c.ComputeConfig.NodeRoleARN
+		}
+
+		if len(c.ComputeConfig.NodePools) > 0 {
+			cc["nodePools"] = c.ComputeConfig.NodePools
+		}
+
+		m["computeConfig"] = cc
+	}
+
+	if c.StorageConfig != nil && c.StorageConfig.BlockStorage != nil {
+		m["storageConfig"] = map[string]any{
+			"blockStorage": map[string]any{"enabled": c.StorageConfig.BlockStorage.Enabled},
+		}
+	}
+
+	if c.NetworkingConfig != nil && c.NetworkingConfig.ElasticLoadBalancing != nil {
+		m["networkingConfig"] = map[string]any{
+			"elasticLoadBalancing": map[string]any{"enabled": c.NetworkingConfig.ElasticLoadBalancing.Enabled},
+		}
+	}
+
 	return m
 }
 
@@ -1069,6 +1101,18 @@ func appendNodegroupOptionalFields(ng *Nodegroup, m map[string]any) {
 	if ng.Resources != nil && len(ng.Resources.AutoScalingGroups) > 0 {
 		m["resources"] = nodegroupResourcesToJSON(ng.Resources)
 	}
+	if ng.UpdateConfig != nil {
+		uc := map[string]any{}
+		if ng.UpdateConfig.MaxUnavailable != nil {
+			uc["maxUnavailable"] = *ng.UpdateConfig.MaxUnavailable
+		}
+
+		if ng.UpdateConfig.MaxUnavailablePercentage != nil {
+			uc["maxUnavailablePercentage"] = *ng.UpdateConfig.MaxUnavailablePercentage
+		}
+
+		m["updateConfig"] = uc
+	}
 	if ng.Tags != nil {
 		m[keyTags] = ng.Tags.Clone()
 	} else {
@@ -1128,10 +1172,41 @@ type kubernetesNetworkConfigJSON struct {
 	ServiceIPv6CIDR string `json:"serviceIpv6Cidr"`
 }
 
+type accessConfigJSON struct {
+	AuthenticationMode                      string `json:"authenticationMode"`
+	BootstrapClusterCreatorAdminPermissions *bool  `json:"bootstrapClusterCreatorAdminPermissions,omitempty"`
+}
+
+type computeConfigJSON struct {
+	NodeRoleArn string   `json:"nodeRoleArn,omitempty"`
+	NodePools   []string `json:"nodePools,omitempty"`
+	Enabled     *bool    `json:"enabled,omitempty"`
+}
+
+type blockStorageConfigJSON struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type storageConfigJSON struct {
+	BlockStorage *blockStorageConfigJSON `json:"blockStorage,omitempty"`
+}
+
+type elasticLoadBalancingConfigJSON struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type networkingConfigJSON struct {
+	ElasticLoadBalancing *elasticLoadBalancingConfigJSON `json:"elasticLoadBalancing,omitempty"`
+}
+
 type createClusterBody struct {
 	Tags                    map[string]string            `json:"tags"`
 	ResourcesVpcConfig      *vpcConfigJSON               `json:"resourcesVpcConfig"`
 	KubernetesNetworkConfig *kubernetesNetworkConfigJSON `json:"kubernetesNetworkConfig"`
+	AccessConfig            *accessConfigJSON            `json:"accessConfig"`
+	ComputeConfig           *computeConfigJSON           `json:"computeConfig"`
+	StorageConfig           *storageConfigJSON           `json:"storageConfig"`
+	NetworkingConfig        *networkingConfigJSON        `json:"networkingConfig"`
 	Name                    string                       `json:"name"`
 	Version                 string                       `json:"version"`
 	RoleArn                 string                       `json:"roleArn"`
@@ -1167,7 +1242,44 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 		}
 	}
 
-	cluster, err := h.Backend.CreateCluster(in.Name, in.Version, in.RoleArn, vpcCfg, netCfg, in.Tags)
+	var opt ClusterOptionalConfig
+	if in.AccessConfig != nil {
+		ac := &AccessConfig{AuthenticationMode: in.AccessConfig.AuthenticationMode}
+		if in.AccessConfig.BootstrapClusterCreatorAdminPermissions != nil {
+			ac.BootstrapClusterCreatorAdminPermissions = *in.AccessConfig.BootstrapClusterCreatorAdminPermissions
+		}
+
+		opt.AccessConfig = ac
+	}
+
+	if in.ComputeConfig != nil {
+		cc := &ComputeConfig{NodeRoleARN: in.ComputeConfig.NodeRoleArn, NodePools: in.ComputeConfig.NodePools}
+		if in.ComputeConfig.Enabled != nil {
+			cc.Enabled = *in.ComputeConfig.Enabled
+		}
+
+		opt.ComputeConfig = cc
+	}
+
+	if in.StorageConfig != nil && in.StorageConfig.BlockStorage != nil {
+		sc := &StorageConfig{BlockStorage: &BlockStorageConfig{}}
+		if in.StorageConfig.BlockStorage.Enabled != nil {
+			sc.BlockStorage.Enabled = *in.StorageConfig.BlockStorage.Enabled
+		}
+
+		opt.StorageConfig = sc
+	}
+
+	if in.NetworkingConfig != nil && in.NetworkingConfig.ElasticLoadBalancing != nil {
+		nc := &NetworkingConfig{ElasticLoadBalancing: &ElasticLoadBalancingConfig{}}
+		if in.NetworkingConfig.ElasticLoadBalancing.Enabled != nil {
+			nc.ElasticLoadBalancing.Enabled = *in.NetworkingConfig.ElasticLoadBalancing.Enabled
+		}
+
+		opt.NetworkingConfig = nc
+	}
+
+	cluster, err := h.Backend.CreateCluster(in.Name, in.Version, in.RoleArn, vpcCfg, netCfg, in.Tags, opt)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1383,12 +1495,32 @@ func (h *Handler) handleListTagsForResource(c *echo.Context, resourceARN string)
 	})
 }
 
+type updateNodegroupScalingConfigJSON struct {
+	DesiredSize *int32 `json:"desiredSize,omitempty"`
+	MinSize     *int32 `json:"minSize,omitempty"`
+	MaxSize     *int32 `json:"maxSize,omitempty"`
+}
+
+type updateNodegroupLabelsPayload struct {
+	AddOrUpdateLabels map[string]string `json:"addOrUpdateLabels,omitempty"`
+	RemoveLabels      []string          `json:"removeLabels,omitempty"`
+}
+
+type updateNodegroupTaintsPayload struct {
+	AddOrUpdateTaints []nodegroupTaintJSON `json:"addOrUpdateTaints,omitempty"`
+	RemoveTaints      []nodegroupTaintJSON `json:"removeTaints,omitempty"`
+}
+
+type updateNodegroupUpdateConfigJSON struct {
+	MaxUnavailable           *int32 `json:"maxUnavailable,omitempty"`
+	MaxUnavailablePercentage *int32 `json:"maxUnavailablePercentage,omitempty"`
+}
+
 type updateNodegroupConfigInput struct {
-	ScalingConfig *struct {
-		DesiredSize *int32 `json:"desiredSize,omitempty"`
-		MinSize     *int32 `json:"minSize,omitempty"`
-		MaxSize     *int32 `json:"maxSize,omitempty"`
-	} `json:"scalingConfig,omitempty"`
+	ScalingConfig *updateNodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	Labels        *updateNodegroupLabelsPayload     `json:"labels,omitempty"`
+	Taints        *updateNodegroupTaintsPayload     `json:"taints,omitempty"`
+	UpdateConfig  *updateNodegroupUpdateConfigJSON  `json:"updateConfig,omitempty"`
 }
 
 func (h *Handler) handleUpdateNodegroupConfig(
@@ -1403,14 +1535,36 @@ func (h *Handler) handleUpdateNodegroupConfig(
 		}
 	}
 
-	var desiredSize, minSize, maxSize *int32
+	upd := NodegroupConfigUpdate{}
 	if in.ScalingConfig != nil {
-		desiredSize = in.ScalingConfig.DesiredSize
-		minSize = in.ScalingConfig.MinSize
-		maxSize = in.ScalingConfig.MaxSize
+		upd.DesiredSize = in.ScalingConfig.DesiredSize
+		upd.MinSize = in.ScalingConfig.MinSize
+		upd.MaxSize = in.ScalingConfig.MaxSize
 	}
 
-	ng, err := h.Backend.UpdateNodegroupConfig(clusterName, nodegroupName, desiredSize, minSize, maxSize)
+	if in.Labels != nil {
+		upd.AddOrUpdateLabels = in.Labels.AddOrUpdateLabels
+		upd.RemoveLabels = in.Labels.RemoveLabels
+	}
+
+	if in.Taints != nil {
+		for _, t := range in.Taints.AddOrUpdateTaints {
+			upd.AddOrUpdateTaints = append(upd.AddOrUpdateTaints, NodegroupTaint(t))
+		}
+
+		for _, t := range in.Taints.RemoveTaints {
+			upd.RemoveTaints = append(upd.RemoveTaints, NodegroupTaint(t))
+		}
+	}
+
+	if in.UpdateConfig != nil {
+		upd.UpdateConfig = &NodegroupUpdateConfig{
+			MaxUnavailable:           in.UpdateConfig.MaxUnavailable,
+			MaxUnavailablePercentage: in.UpdateConfig.MaxUnavailablePercentage,
+		}
+	}
+
+	ng, err := h.Backend.UpdateNodegroupConfig(clusterName, nodegroupName, upd)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1430,10 +1584,11 @@ func (h *Handler) handleUpdateNodegroupConfig(
 // --- New operation handlers ---
 
 type createAccessEntryBody struct {
-	Tags         map[string]string `json:"tags"`
-	PrincipalArn string            `json:"principalArn"`
-	Type         string            `json:"type"`
-	Username     string            `json:"username"`
+	Tags             map[string]string `json:"tags"`
+	KubernetesGroups []string          `json:"kubernetesGroups"`
+	PrincipalArn     string            `json:"principalArn"`
+	Type             string            `json:"type"`
+	Username         string            `json:"username"`
 }
 
 func accessEntryToJSON(entry *AccessEntry) map[string]any {
@@ -1445,6 +1600,13 @@ func accessEntryToJSON(entry *AccessEntry) map[string]any {
 		keyUsername:       entry.Username,
 		keyCreatedAt:      entry.CreatedAt.Unix(),
 	}
+
+	if len(entry.KubernetesGroups) > 0 {
+		m["kubernetesGroups"] = entry.KubernetesGroups
+	} else {
+		m["kubernetesGroups"] = []string{}
+	}
+
 	if entry.Tags != nil {
 		m[keyTags] = entry.Tags.Clone()
 	} else {
@@ -1464,7 +1626,7 @@ func (h *Handler) handleCreateAccessEntry(c *echo.Context, clusterName string, b
 		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterException", "principalArn is required"))
 	}
 
-	entry, err := h.Backend.CreateAccessEntry(clusterName, in.PrincipalArn, in.Type, in.Username, in.Tags)
+	entry, err := h.Backend.CreateAccessEntry(clusterName, in.PrincipalArn, in.Type, in.Username, in.KubernetesGroups, in.Tags)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1713,6 +1875,7 @@ type fargateProfileSelectorJSON struct {
 
 type createFargateProfileBody struct {
 	Tags                map[string]string            `json:"tags"`
+	Subnets             []string                     `json:"subnets"`
 	FargateProfileName  string                       `json:"fargateProfileName"`
 	PodExecutionRoleArn string                       `json:"podExecutionRoleArn"`
 	Selectors           []fargateProfileSelectorJSON `json:"selectors"`
@@ -1738,6 +1901,7 @@ func (h *Handler) handleCreateFargateProfile(c *echo.Context, clusterName string
 		in.FargateProfileName,
 		in.PodExecutionRoleArn,
 		selectors,
+		in.Subnets,
 		in.Tags,
 	)
 	if err != nil {

--- a/services/eks/handler_accuracy_test.go
+++ b/services/eks/handler_accuracy_test.go
@@ -604,9 +604,9 @@ func TestAccuracy_Logging_EnableAndDisable_PerType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable api and audit.
-	_, err = b.UpdateClusterConfig("c1", []eks.ClusterLogEntry{
+	_, err = b.UpdateClusterConfig("c1", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api", "audit"}, Enabled: true},
-	})
+	}})
 	require.NoError(t, err)
 
 	c, err := b.DescribeCluster("c1")
@@ -616,9 +616,9 @@ func TestAccuracy_Logging_EnableAndDisable_PerType(t *testing.T) {
 	assert.True(t, c.ClusterLogging[0].Enabled)
 
 	// Disable api.
-	_, err = b.UpdateClusterConfig("c1", []eks.ClusterLogEntry{
+	_, err = b.UpdateClusterConfig("c1", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api"}, Enabled: false},
-	})
+	}})
 	require.NoError(t, err)
 
 	c2, err := b.DescribeCluster("c1")
@@ -634,14 +634,14 @@ func TestAccuracy_Logging_DisableAll_ClearsLogging(t *testing.T) {
 	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
 	require.NoError(t, err)
 
-	_, err = b.UpdateClusterConfig("c1", []eks.ClusterLogEntry{
+	_, err = b.UpdateClusterConfig("c1", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api"}, Enabled: true},
-	})
+	}})
 	require.NoError(t, err)
 
-	_, err = b.UpdateClusterConfig("c1", []eks.ClusterLogEntry{
+	_, err = b.UpdateClusterConfig("c1", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api"}, Enabled: false},
-	})
+	}})
 	require.NoError(t, err)
 
 	c, err := b.DescribeCluster("c1")
@@ -656,13 +656,13 @@ func TestAccuracy_Logging_NilEntries_NoChange(t *testing.T) {
 	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
 	require.NoError(t, err)
 
-	_, err = b.UpdateClusterConfig("c1", []eks.ClusterLogEntry{
+	_, err = b.UpdateClusterConfig("c1", eks.ClusterConfigUpdate{LogEntries: []eks.ClusterLogEntry{
 		{Types: []string{"api"}, Enabled: true},
-	})
+	}})
 	require.NoError(t, err)
 
 	// Nil entries must not change existing logging.
-	_, err = b.UpdateClusterConfig("c1", nil)
+	_, err = b.UpdateClusterConfig("c1", eks.ClusterConfigUpdate{})
 	require.NoError(t, err)
 
 	c, err := b.DescribeCluster("c1")
@@ -757,7 +757,7 @@ func TestAccuracy_AssociateAccessPolicy_Dedup(t *testing.T) {
 	b := eks.NewInMemoryBackend("123456789012", config.DefaultRegion)
 	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
 	require.NoError(t, err)
-	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123456789012:role/r1", "", "", nil)
+	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123456789012:role/r1", "", "", nil, nil)
 	require.NoError(t, err)
 
 	policyARN := "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"

--- a/services/eks/handler_new_ops_test.go
+++ b/services/eks/handler_new_ops_test.go
@@ -690,7 +690,7 @@ func TestEKS_NewOps_PersistenceRoundTrip(t *testing.T) {
 	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
 	require.NoError(t, err)
 
-	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123456789012:role/r1", "STANDARD", "", nil)
+	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123456789012:role/r1", "STANDARD", "", nil, nil)
 	require.NoError(t, err)
 
 	// Create addon.
@@ -698,7 +698,7 @@ func TestEKS_NewOps_PersistenceRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create fargate profile.
-	_, err = b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123456789012:role/fargate", nil, nil)
+	_, err = b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123456789012:role/fargate", nil, nil, nil)
 	require.NoError(t, err)
 
 	// Create pod identity association.

--- a/services/eks/handler_refinement1_test.go
+++ b/services/eks/handler_refinement1_test.go
@@ -167,7 +167,7 @@ func TestRefinement1_CreateClusterInitsAllMaps(t *testing.T) {
 	require.NoError(t, err)
 
 	// These should not panic even before any resources have been added.
-	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r", "STANDARD", "", nil)
+	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r", "STANDARD", "", nil, nil)
 	require.NoError(t, err)
 
 	_, err = b.CreateAddon("c1", "coredns", "v1.0", "", "", "", nil)
@@ -237,7 +237,7 @@ func TestRefinement1_DeleteClusterCascade(t *testing.T) {
 	_, err = b.CreateNodegroup("c1", "ng1", "", "", "", "", "", nil, 1, 1, 2, eks.NodegroupInput{}, nil)
 	require.NoError(t, err)
 
-	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r", "STANDARD", "", nil)
+	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r", "STANDARD", "", nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, b.NodegroupCount())
@@ -414,7 +414,7 @@ func TestRefinement1_TagResourceOnFargateProfile(t *testing.T) {
 	_, err := b.CreateCluster("c1", "1.32", "", nil, nil, nil)
 	require.NoError(t, err)
 
-	fp, err := b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/r", nil, nil)
+	fp, err := b.CreateFargateProfile("c1", "fp1", "arn:aws:iam::123:role/r", nil, nil, nil)
 	require.NoError(t, err)
 
 	err = b.TagResource(fp.ARN, map[string]string{"env": "staging"})
@@ -505,13 +505,13 @@ func TestRefinement1_ResetWithTaggedResources(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r", "STANDARD", "", nil)
+	_, err = b.CreateAccessEntry("c1", "arn:aws:iam::123:role/r", "STANDARD", "", nil, nil)
 	require.NoError(t, err)
 
 	_, err = b.CreateAddon("c1", "coredns", "", "", "", "", map[string]string{"c": "3"})
 	require.NoError(t, err)
 
-	_, err = b.CreateFargateProfile("c1", "fp1", "", nil, map[string]string{"d": "4"})
+	_, err = b.CreateFargateProfile("c1", "fp1", "", nil, nil, map[string]string{"d": "4"})
 	require.NoError(t, err)
 
 	// Reset should not panic even with tagged resources.

--- a/services/eks/handler_remaining_ops.go
+++ b/services/eks/handler_remaining_ops.go
@@ -423,6 +423,13 @@ func fargateProfileToJSON(p *FargateProfile) map[string]any {
 		"selectors":           p.Selectors,
 		keyCreatedAt:          p.CreatedAt.Unix(),
 	}
+
+	if len(p.Subnets) > 0 {
+		m["subnets"] = p.Subnets
+	} else {
+		m["subnets"] = []string{}
+	}
+
 	if p.Tags != nil {
 		m["tags"] = p.Tags.Clone()
 	} else {
@@ -519,6 +526,11 @@ func podIdentityToJSON(a *PodIdentityAssociation) map[string]any {
 		"roleArn":        a.RoleARN,
 		keyCreatedAt:     a.CreatedAt.Unix(),
 	}
+
+	if a.OwnerARN != "" {
+		m["ownerArn"] = a.OwnerARN
+	}
+
 	if a.Tags != nil {
 		m["tags"] = a.Tags.Clone()
 	} else {
@@ -572,7 +584,8 @@ func (h *Handler) handleListAccessEntries(c *echo.Context, clusterName string) e
 }
 
 type updateAccessEntryBody struct {
-	Username string `json:"username"`
+	KubernetesGroups []string `json:"kubernetesGroups"`
+	Username         string   `json:"username"`
 }
 
 func (h *Handler) handleUpdateAccessEntry(c *echo.Context, clusterName, principalARN string, body []byte) error {
@@ -583,7 +596,10 @@ func (h *Handler) handleUpdateAccessEntry(c *echo.Context, clusterName, principa
 		}
 	}
 
-	entry, err := h.Backend.UpdateAccessEntry(clusterName, principalARN, in.Username)
+	entry, err := h.Backend.UpdateAccessEntry(clusterName, principalARN, AccessEntryUpdate{
+		Username:         in.Username,
+		KubernetesGroups: in.KubernetesGroups,
+	})
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -798,7 +814,7 @@ func insightToJSON(ins *Insight) map[string]any {
 		"id":                 ins.ID,
 		keyClusterName:       ins.ClusterName,
 		"category":           ins.Category,
-		keyStatusField:       ins.Status,
+		"insightStatus":      map[string]any{"status": ins.Status, "reason": ins.Recommendation},
 		"lastRefreshTime":    ins.LastRefreshTime.Unix(),
 		"lastTransitionTime": ins.LastTransition.Unix(),
 	}
@@ -847,6 +863,7 @@ type updateClusterConfigLogging struct {
 }
 
 type updateClusterConfigVpcConfig struct {
+	SubnetIDs             []string `json:"subnetIds"`
 	EndpointPublicAccess  *bool    `json:"endpointPublicAccess"`
 	EndpointPrivateAccess *bool    `json:"endpointPrivateAccess"`
 	PublicAccessCidrs     []string `json:"publicAccessCidrs"`
@@ -855,26 +872,61 @@ type updateClusterConfigVpcConfig struct {
 type updateClusterConfigBody struct {
 	Logging            *updateClusterConfigLogging   `json:"logging"`
 	ResourcesVpcConfig *updateClusterConfigVpcConfig `json:"resourcesVpcConfig"`
+	AccessConfig       *accessConfigJSON             `json:"accessConfig"`
+	ComputeConfig      *computeConfigJSON            `json:"computeConfig"`
+	StorageConfig      *storageConfigJSON            `json:"storageConfig"`
 }
 
 func (h *Handler) handleUpdateClusterConfig(c *echo.Context, clusterName string, body []byte) error {
 	var in updateClusterConfigBody
-	var logEntries []ClusterLogEntry
 
 	if len(body) > 0 {
 		if err := json.Unmarshal(body, &in); err != nil {
 			return c.JSON(http.StatusBadRequest, errResp("InvalidParameterException", err.Error()))
 		}
+	}
 
-		if in.Logging != nil {
-			logEntries = make([]ClusterLogEntry, len(in.Logging.ClusterLogging))
-			for i, entry := range in.Logging.ClusterLogging {
-				logEntries[i] = ClusterLogEntry{Types: entry.Types, Enabled: entry.Enabled}
-			}
+	cfgUpd := ClusterConfigUpdate{}
+
+	if in.Logging != nil {
+		cfgUpd.LogEntries = make([]ClusterLogEntry, len(in.Logging.ClusterLogging))
+		for i, entry := range in.Logging.ClusterLogging {
+			cfgUpd.LogEntries[i] = ClusterLogEntry{Types: entry.Types, Enabled: entry.Enabled}
 		}
 	}
 
-	update, err := h.Backend.UpdateClusterConfig(clusterName, logEntries)
+	if in.ResourcesVpcConfig != nil && len(in.ResourcesVpcConfig.SubnetIDs) > 0 {
+		cfgUpd.SubnetIDs = in.ResourcesVpcConfig.SubnetIDs
+	}
+
+	if in.AccessConfig != nil {
+		ac := &AccessConfig{AuthenticationMode: in.AccessConfig.AuthenticationMode}
+		if in.AccessConfig.BootstrapClusterCreatorAdminPermissions != nil {
+			ac.BootstrapClusterCreatorAdminPermissions = *in.AccessConfig.BootstrapClusterCreatorAdminPermissions
+		}
+
+		cfgUpd.AccessConfig = ac
+	}
+
+	if in.ComputeConfig != nil {
+		cc := &ComputeConfig{NodeRoleARN: in.ComputeConfig.NodeRoleArn, NodePools: in.ComputeConfig.NodePools}
+		if in.ComputeConfig.Enabled != nil {
+			cc.Enabled = *in.ComputeConfig.Enabled
+		}
+
+		cfgUpd.ComputeConfig = cc
+	}
+
+	if in.StorageConfig != nil && in.StorageConfig.BlockStorage != nil {
+		sc := &StorageConfig{BlockStorage: &BlockStorageConfig{}}
+		if in.StorageConfig.BlockStorage.Enabled != nil {
+			sc.BlockStorage.Enabled = *in.StorageConfig.BlockStorage.Enabled
+		}
+
+		cfgUpd.StorageConfig = sc
+	}
+
+	update, err := h.Backend.UpdateClusterConfig(clusterName, cfgUpd)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -885,11 +937,15 @@ func (h *Handler) handleUpdateClusterConfig(c *echo.Context, clusterName string,
 			EndpointPrivateAccess: in.ResourcesVpcConfig.EndpointPrivateAccess,
 			PublicAccessCIDRs:     in.ResourcesVpcConfig.PublicAccessCidrs,
 		}
-		vpcUpdate, vpcErr := h.Backend.UpdateClusterVpcEndpoint(clusterName, vpcUpd)
-		if vpcErr != nil {
-			return h.handleError(c, vpcErr)
+
+		if vpcUpd.EndpointPublicAccess != nil || vpcUpd.EndpointPrivateAccess != nil || vpcUpd.PublicAccessCIDRs != nil {
+			vpcUpdate, vpcErr := h.Backend.UpdateClusterVpcEndpoint(clusterName, vpcUpd)
+			if vpcErr != nil {
+				return h.handleError(c, vpcErr)
+			}
+
+			update.Params = append(update.Params, vpcUpdate.Params...)
 		}
-		update.Params = append(update.Params, vpcUpdate.Params...)
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
@@ -963,11 +1019,15 @@ func (h *Handler) handleListUpdates(c *echo.Context, clusterName string) error {
 	})
 }
 
+type connectorConfigJSON struct {
+	Provider string `json:"provider"`
+	RoleArn  string `json:"roleArn"`
+}
+
 type registerClusterBody struct {
-	Tags                    map[string]string `json:"tags"`
-	Name                    string            `json:"name"`
-	ConnectorConfigProvider string            `json:"connectorConfig.provider"`
-	ConnectorConfigRoleArn  string            `json:"connectorConfig.roleArn"`
+	Tags            map[string]string    `json:"tags"`
+	ConnectorConfig *connectorConfigJSON `json:"connectorConfig"`
+	Name            string               `json:"name"`
 }
 
 func (h *Handler) handleRegisterCluster(c *echo.Context, body []byte) error {
@@ -980,7 +1040,13 @@ func (h *Handler) handleRegisterCluster(c *echo.Context, body []byte) error {
 		return c.JSON(http.StatusBadRequest, errResp("InvalidParameterException", "name is required"))
 	}
 
-	cluster, err := h.Backend.RegisterCluster(in.Name, in.ConnectorConfigProvider, in.ConnectorConfigRoleArn, in.Tags)
+	var provider, roleArn string
+	if in.ConnectorConfig != nil {
+		provider = in.ConnectorConfig.Provider
+		roleArn = in.ConnectorConfig.RoleArn
+	}
+
+	cluster, err := h.Backend.RegisterCluster(in.Name, provider, roleArn, in.Tags)
 	if err != nil {
 		return h.handleError(c, err)
 	}

--- a/services/eks/handler_remaining_ops.go
+++ b/services/eks/handler_remaining_ops.go
@@ -584,8 +584,8 @@ func (h *Handler) handleListAccessEntries(c *echo.Context, clusterName string) e
 }
 
 type updateAccessEntryBody struct {
-	KubernetesGroups []string `json:"kubernetesGroups"`
 	Username         string   `json:"username"`
+	KubernetesGroups []string `json:"kubernetesGroups"`
 }
 
 func (h *Handler) handleUpdateAccessEntry(c *echo.Context, clusterName, principalARN string, body []byte) error {

--- a/services/eks/handler_remaining_ops.go
+++ b/services/eks/handler_remaining_ops.go
@@ -886,6 +886,23 @@ func (h *Handler) handleUpdateClusterConfig(c *echo.Context, clusterName string,
 		}
 	}
 
+	cfgUpd := buildClusterConfigUpdate(in)
+
+	update, err := h.Backend.UpdateClusterConfig(clusterName, cfgUpd)
+	if err != nil {
+		return h.handleError(c, err)
+	}
+
+	if vpcErr := h.applyVpcEndpointUpdate(c, clusterName, in.ResourcesVpcConfig, update); vpcErr != nil {
+		return vpcErr
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{
+		keyUpdate: updateToJSON(update),
+	})
+}
+
+func buildClusterConfigUpdate(in updateClusterConfigBody) ClusterConfigUpdate {
 	cfgUpd := ClusterConfigUpdate{}
 
 	if in.Logging != nil {
@@ -904,7 +921,6 @@ func (h *Handler) handleUpdateClusterConfig(c *echo.Context, clusterName string,
 		if in.AccessConfig.BootstrapClusterCreatorAdminPermissions != nil {
 			ac.BootstrapClusterCreatorAdminPermissions = *in.AccessConfig.BootstrapClusterCreatorAdminPermissions
 		}
-
 		cfgUpd.AccessConfig = ac
 	}
 
@@ -913,7 +929,6 @@ func (h *Handler) handleUpdateClusterConfig(c *echo.Context, clusterName string,
 		if in.ComputeConfig.Enabled != nil {
 			cc.Enabled = *in.ComputeConfig.Enabled
 		}
-
 		cfgUpd.ComputeConfig = cc
 	}
 
@@ -922,35 +937,34 @@ func (h *Handler) handleUpdateClusterConfig(c *echo.Context, clusterName string,
 		if in.StorageConfig.BlockStorage.Enabled != nil {
 			sc.BlockStorage.Enabled = *in.StorageConfig.BlockStorage.Enabled
 		}
-
 		cfgUpd.StorageConfig = sc
 	}
 
-	update, err := h.Backend.UpdateClusterConfig(clusterName, cfgUpd)
+	return cfgUpd
+}
+
+func (h *Handler) applyVpcEndpointUpdate(
+	c *echo.Context, clusterName string,
+	vpcIn *updateClusterConfigVpcConfig, update *Update,
+) error {
+	if vpcIn == nil {
+		return nil
+	}
+	vpcUpd := VpcEndpointUpdate{
+		EndpointPublicAccess:  vpcIn.EndpointPublicAccess,
+		EndpointPrivateAccess: vpcIn.EndpointPrivateAccess,
+		PublicAccessCIDRs:     vpcIn.PublicAccessCidrs,
+	}
+	if vpcUpd.EndpointPublicAccess == nil && vpcUpd.EndpointPrivateAccess == nil && vpcUpd.PublicAccessCIDRs == nil {
+		return nil
+	}
+	vpcUpdate, err := h.Backend.UpdateClusterVpcEndpoint(clusterName, vpcUpd)
 	if err != nil {
 		return h.handleError(c, err)
 	}
+	update.Params = append(update.Params, vpcUpdate.Params...)
 
-	if in.ResourcesVpcConfig != nil {
-		vpcUpd := VpcEndpointUpdate{
-			EndpointPublicAccess:  in.ResourcesVpcConfig.EndpointPublicAccess,
-			EndpointPrivateAccess: in.ResourcesVpcConfig.EndpointPrivateAccess,
-			PublicAccessCIDRs:     in.ResourcesVpcConfig.PublicAccessCidrs,
-		}
-
-		if vpcUpd.EndpointPublicAccess != nil || vpcUpd.EndpointPrivateAccess != nil || vpcUpd.PublicAccessCIDRs != nil {
-			vpcUpdate, vpcErr := h.Backend.UpdateClusterVpcEndpoint(clusterName, vpcUpd)
-			if vpcErr != nil {
-				return h.handleError(c, vpcErr)
-			}
-
-			update.Params = append(update.Params, vpcUpdate.Params...)
-		}
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{
-		keyUpdate: updateToJSON(update),
-	})
+	return nil
 }
 
 type updateClusterVersionBody struct {

--- a/services/eks/handler_remaining_ops.go
+++ b/services/eks/handler_remaining_ops.go
@@ -596,10 +596,7 @@ func (h *Handler) handleUpdateAccessEntry(c *echo.Context, clusterName, principa
 		}
 	}
 
-	entry, err := h.Backend.UpdateAccessEntry(clusterName, principalARN, AccessEntryUpdate{
-		Username:         in.Username,
-		KubernetesGroups: in.KubernetesGroups,
-	})
+	entry, err := h.Backend.UpdateAccessEntry(clusterName, principalARN, AccessEntryUpdate(in))
 	if err != nil {
 		return h.handleError(c, err)
 	}


### PR DESCRIPTION
EKS batch-2 — pod identity, access entries, fargate, auto mode, addon configs. Polecat: quartz.