### PR TITLE
chore: tombstone QLDB + QLDBSession (AWS EOL)

### DIFF
--- a/services/qldb/README.md
+++ b/services/qldb/README.md
@@ -1,0 +1,11 @@
+# QLDB — REMOVED
+
+Amazon QLDB is **deprecated by AWS** (end-of-support **2025-07-31**) and is not
+supported by gopherstack.
+
+This package was removed. It will not be re-added. See [#2073](https://github.com/BlackbirdWorks/gopherstack/issues/2073) for the removal decision and [#1819](https://github.com/BlackbirdWorks/gopherstack/issues/1819) for the prior won't-fix audit.
+
+If you need a journaling database, migrate to Amazon Aurora PostgreSQL with the
+QLDB compatibility extension or another append-only store.
+
+Do not submit PRs reintroducing this service.

--- a/services/qldbsession/README.md
+++ b/services/qldbsession/README.md
@@ -1,0 +1,11 @@
+# QLDB Session — REMOVED
+
+Amazon QLDB Session is **deprecated by AWS** alongside QLDB (end-of-support
+**2025-07-31**) and is not supported by gopherstack.
+
+This package was removed. It will not be re-added. See [#2073](https://github.com/BlackbirdWorks/gopherstack/issues/2073) for the removal decision and [#1819](https://github.com/BlackbirdWorks/gopherstack/issues/1819) for the prior won't-fix audit.
+
+For PartiQL transactional access, use Amazon Aurora PostgreSQL or DynamoDB
+transactions instead.
+
+Do not submit PRs reintroducing this service.


### PR DESCRIPTION
Closes #2073. Adds README.md to services/qldb and services/qldbsession noting AWS EOL 2025-07-31 and policy of not re-adding.