### PR TITLE
fix(routing): scope MediaTailor/MediaPackage /tags/ matchers to own ARNs (go-pvuj)

### DIFF
--- a/services/mediapackage/handler.go
+++ b/services/mediapackage/handler.go
@@ -101,6 +101,7 @@ func (h *Handler) RouteMatcher() service.Matcher {
 // steal their requests. MediaPackage ARNs always contain ":mediapackage:".
 func isMediaPackageTagPath(path string) bool {
 	arn, ok := strings.CutPrefix(path, pathTags)
+
 	return ok && strings.Contains(arn, ":mediapackage:")
 }
 

--- a/services/mediapackage/handler.go
+++ b/services/mediapackage/handler.go
@@ -92,8 +92,16 @@ func (h *Handler) RouteMatcher() service.Matcher {
 			strings.HasPrefix(path, pathOriginEndpoints+"/") ||
 			path == pathHarvestJobs ||
 			strings.HasPrefix(path, pathHarvestJobs+"/") ||
-			strings.HasPrefix(path, pathTags)
+			isMediaPackageTagPath(path)
 	}
+}
+
+// isMediaPackageTagPath reports whether path is a /tags/{arn} path for a MediaPackage ARN.
+// Other services (e.g. FIS) also expose /tags/{arn} at the same path prefix; we must not
+// steal their requests. MediaPackage ARNs always contain ":mediapackage:".
+func isMediaPackageTagPath(path string) bool {
+	arn, ok := strings.CutPrefix(path, pathTags)
+	return ok && strings.Contains(arn, ":mediapackage:")
 }
 
 // MatchPriority returns the routing priority.

--- a/services/mediatailor/handler.go
+++ b/services/mediatailor/handler.go
@@ -135,6 +135,7 @@ func isMediaTailorPath(path string) bool {
 // steal their requests. MediaTailor ARNs always contain ":mediatailor:".
 func isMediaTailorTagPath(path string) bool {
 	arn, ok := strings.CutPrefix(path, pathTags)
+
 	return ok && strings.Contains(arn, ":mediatailor:")
 }
 

--- a/services/mediatailor/handler.go
+++ b/services/mediatailor/handler.go
@@ -127,7 +127,15 @@ func isMediaTailorPath(path string) bool {
 		strings.HasPrefix(path, pathChannel) ||
 		path == pathSourceLocations ||
 		strings.HasPrefix(path, pathSourceLocation) ||
-		strings.HasPrefix(path, pathTags)
+		isMediaTailorTagPath(path)
+}
+
+// isMediaTailorTagPath reports whether path is a /tags/{arn} path for a MediaTailor ARN.
+// Other services (e.g. FIS) also expose /tags/{arn} at the same path prefix; we must not
+// steal their requests. MediaTailor ARNs always contain ":mediatailor:".
+func isMediaTailorTagPath(path string) bool {
+	arn, ok := strings.CutPrefix(path, pathTags)
+	return ok && strings.Contains(arn, ":mediatailor:")
 }
 
 // MatchPriority returns the routing priority.


### PR DESCRIPTION
Found via Personalize PR FIS test failures. MediaTailor+MediaPackage unscoped /tags/ matchers were swallowing FIS tag requests. Auto-merge enabled.