### PR TITLE
fix(xray): route PutEncryptionConfig to its own SDK path

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -5,7 +5,7 @@ Audit performed against gopherstack `services/*` handlers vs the AWS SDK v2 surf
 ## Critical (wrong wire protocol — clients hard-fail)
 
 1. **DAX** — `services/dax/handler.go:71` routes on `X-Amz-Target: AmazonDAXV3.*`, but the AWS DAX SDK speaks a bespoke TLS/framed binary protocol on a non-HTTP listener. Real SDK never reaches this handler. (Surfaced via failing integration test.)
-2. **XRay** — `services/xray/handler.go:265` accepts `POST /EncryptionConfig` for `PutEncryptionConfig`, but the AWS SDK targets the operation-named path (`POST /PutEncryptionConfig`). Same handler returns HTML 400 to real SDK callers. (Surfaced via failing integration test.)
+2. **XRay** — the handler mapped `POST /EncryptionConfig` to `PutEncryptionConfig`, but the AWS SDK v2 sends `PutEncryptionConfig` to the operation-named path `POST /PutEncryptionConfig` and `GetEncryptionConfig` to `POST /EncryptionConfig`. Real SDK `PutEncryptionConfig` calls reached the wrong handler. (Fixed: `services/xray/handler.go` now serves `GetEncryptionConfig` on `POST /EncryptionConfig` and adds the `POST /PutEncryptionConfig` route; covered by `test/integration/xray_test.go`.)
 3. **ELBv2** — `AddTags`, `RemoveTags`, `RegisterTargets`, `DeregisterTargets` originally omitted the `*Result` XML wrapper required by AWS Query protocol. SDK deserialiser raised `… node not found`. (Fixed in this PR.)
 4. **Classic ELB** — `AddTags`, `RemoveTags` had the same missing `*Result` wrappers. (Fixed in this PR.)
 5. **Classic ELB `CreateLoadBalancer`** — ignored the `Tags.member.N` form parameters that AWS accepts at create time. Initial tags were silently dropped. (Fixed in this PR; subsequent `DescribeTags` now returns them.)

--- a/services/xray/audit_batch1_test.go
+++ b/services/xray/audit_batch1_test.go
@@ -1715,7 +1715,7 @@ func TestAudit_EncryptionConfig_KMSKeyIdFormats(t *testing.T) {
 				body["KeyId"] = tt.keyID
 			}
 
-			rec := doXrayRequest(t, h, "/EncryptionConfig", body)
+			rec := doXrayRequest(t, h, "/PutEncryptionConfig", body)
 			assert.Equal(t, tt.wantStatus, rec.Code)
 		})
 	}
@@ -1726,7 +1726,7 @@ func TestAudit_EncryptionConfig_UpdatingThenActiveStatus(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	putRec := doXrayRequest(t, h, "/EncryptionConfig", map[string]any{
+	putRec := doXrayRequest(t, h, "/PutEncryptionConfig", map[string]any{
 		"Type":  "KMS",
 		"KeyId": "alias/my-key",
 	})
@@ -1755,7 +1755,7 @@ func TestAudit_EncryptionConfig_NoneTypeAccepted(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	rec := doXrayRequest(t, h, "/EncryptionConfig", map[string]any{"Type": "NONE"})
+	rec := doXrayRequest(t, h, "/PutEncryptionConfig", map[string]any{"Type": "NONE"})
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var resp map[string]any
@@ -1772,7 +1772,7 @@ func TestAudit_EncryptionConfig_InvalidTypeRejected(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	rec := doXrayRequest(t, h, "/EncryptionConfig", map[string]any{"Type": "BOGUS"})
+	rec := doXrayRequest(t, h, "/PutEncryptionConfig", map[string]any{"Type": "BOGUS"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 

--- a/services/xray/handler.go
+++ b/services/xray/handler.go
@@ -31,7 +31,10 @@ const (
 	keyServices                = "Services"
 )
 
-const pathEncryptionConfig = "/EncryptionConfig"
+const (
+	pathEncryptionConfig    = "/EncryptionConfig"
+	pathPutEncryptionConfig = "/PutEncryptionConfig"
+)
 const (
 	pathTraceSegments                  = "/TraceSegments"
 	pathTelemetryRecords               = "/TelemetryRecords"
@@ -92,6 +95,7 @@ var xrayPaths = map[string]bool{ //nolint:gochecknoglobals // package-level rout
 	pathUpdateSamplingRule:             true,
 	pathDeleteSamplingRule:             true,
 	pathEncryptionConfig:               true,
+	pathPutEncryptionConfig:            true,
 	pathCancelTraceRetrieval:           true,
 	pathDeleteResourcePolicy:           true,
 	pathListResourcePolicies:           true,
@@ -132,7 +136,8 @@ var pathToOperation = map[string]string{ //nolint:gochecknoglobals // package-le
 	pathGetSamplingRules:               "GetSamplingRules",
 	pathUpdateSamplingRule:             "UpdateSamplingRule",
 	pathDeleteSamplingRule:             "DeleteSamplingRule",
-	pathEncryptionConfig:               opGetEncryptionConfig, // default; overridden by method
+	pathEncryptionConfig:               opGetEncryptionConfig,
+	pathPutEncryptionConfig:            "PutEncryptionConfig",
 	pathCancelTraceRetrieval:           "CancelTraceRetrieval",
 	pathDeleteResourcePolicy:           "DeleteResourcePolicy",
 	pathListResourcePolicies:           "ListResourcePolicies",
@@ -277,12 +282,10 @@ func (h *Handler) MatchPriority() int { return service.PriorityPathVersioned }
 func (h *Handler) ExtractOperation(c *echo.Context) string {
 	path := c.Request().URL.Path
 
+	// POST /EncryptionConfig and GET /EncryptionConfig both map to
+	// GetEncryptionConfig; PutEncryptionConfig uses POST /PutEncryptionConfig.
 	if path == pathEncryptionConfig {
-		if c.Request().Method == http.MethodGet {
-			return opGetEncryptionConfig
-		}
-
-		return "PutEncryptionConfig"
+		return opGetEncryptionConfig
 	}
 
 	op, ok := pathToOperation[path]
@@ -326,11 +329,11 @@ func (h *Handler) Handler() echo.HandlerFunc {
 			return c.String(http.StatusNotFound, "not found")
 		}
 
-		// /EncryptionConfig is special: GET → GetEncryptionConfig (no body), POST → PutEncryptionConfig
-		if path == pathEncryptionConfig {
-			if c.Request().Method == http.MethodGet {
-				return h.handleGetEncryptionConfig(c)
-			}
+		// GET /EncryptionConfig → GetEncryptionConfig (no body). POST /EncryptionConfig
+		// also maps to GetEncryptionConfig via the dispatch table; PutEncryptionConfig
+		// is served from the distinct /PutEncryptionConfig path.
+		if path == pathEncryptionConfig && c.Request().Method == http.MethodGet {
+			return h.handleGetEncryptionConfig(c)
 		}
 
 		body, err := httputils.ReadBody(c.Request())
@@ -373,7 +376,8 @@ var dispatchTable = map[string]xrayHandlerFn{ //nolint:gochecknoglobals // packa
 	pathGetSamplingRules:               (*Handler).handleGetSamplingRules,
 	pathUpdateSamplingRule:             (*Handler).handleUpdateSamplingRule,
 	pathDeleteSamplingRule:             (*Handler).handleDeleteSamplingRule,
-	pathEncryptionConfig:               (*Handler).handlePutEncryptionConfig,
+	pathEncryptionConfig:               (*Handler).handleGetEncryptionConfigBody,
+	pathPutEncryptionConfig:            (*Handler).handlePutEncryptionConfig,
 	pathCancelTraceRetrieval:           (*Handler).handleCancelTraceRetrieval,
 	pathDeleteResourcePolicy:           (*Handler).handleDeleteResourcePolicy,
 	pathListResourcePolicies:           (*Handler).handleListResourcePolicies,
@@ -1130,6 +1134,17 @@ func (h *Handler) handleGetEncryptionConfig(c *echo.Context) error {
 	cfg := h.Backend.GetEncryptionConfig()
 
 	return c.JSON(http.StatusOK, map[string]any{
+		"EncryptionConfig": cfg,
+	})
+}
+
+// handleGetEncryptionConfigBody serves GetEncryptionConfig via the table-driven
+// dispatch path. The AWS SDK sends GetEncryptionConfig as POST /EncryptionConfig
+// (PutEncryptionConfig uses the distinct POST /PutEncryptionConfig path).
+func (h *Handler) handleGetEncryptionConfigBody(_ context.Context, _ []byte) ([]byte, error) {
+	cfg := h.Backend.GetEncryptionConfig()
+
+	return json.Marshal(map[string]any{
 		"EncryptionConfig": cfg,
 	})
 }

--- a/services/xray/handler.go
+++ b/services/xray/handler.go
@@ -25,6 +25,7 @@ const (
 	opGetEncryptionConfig      = "GetEncryptionConfig"
 	errInvalidRequestException = "InvalidRequestException"
 	keyMessageField            = "message"
+	keyEncryptionConfig        = "EncryptionConfig"
 	keyGroup                   = "Group"
 	keyNextToken               = "NextToken"
 	keySamplingRuleRecord      = "SamplingRuleRecord"

--- a/services/xray/handler.go
+++ b/services/xray/handler.go
@@ -1135,7 +1135,7 @@ func (h *Handler) handleGetEncryptionConfig(c *echo.Context) error {
 	cfg := h.Backend.GetEncryptionConfig()
 
 	return c.JSON(http.StatusOK, map[string]any{
-		"EncryptionConfig": cfg,
+		keyEncryptionConfig: cfg,
 	})
 }
 
@@ -1146,7 +1146,7 @@ func (h *Handler) handleGetEncryptionConfigBody(_ context.Context, _ []byte) ([]
 	cfg := h.Backend.GetEncryptionConfig()
 
 	return json.Marshal(map[string]any{
-		"EncryptionConfig": cfg,
+		keyEncryptionConfig: cfg,
 	})
 }
 
@@ -1168,7 +1168,7 @@ func (h *Handler) handlePutEncryptionConfig(_ context.Context, body []byte) ([]b
 	}
 
 	return json.Marshal(map[string]any{
-		"EncryptionConfig": cfg,
+		keyEncryptionConfig: cfg,
 	})
 }
 

--- a/services/xray/handler_accuracy_test.go
+++ b/services/xray/handler_accuracy_test.go
@@ -459,7 +459,7 @@ func TestAccuracy_Encryption_KeyIdFormatValidation(t *testing.T) {
 				body["KeyId"] = tt.keyID
 			}
 
-			rec := doXrayRequest(t, h, "/EncryptionConfig", body)
+			rec := doXrayRequest(t, h, "/PutEncryptionConfig", body)
 			assert.Equal(t, tt.wantStatus, rec.Code)
 		})
 	}
@@ -472,7 +472,7 @@ func TestAccuracy_Encryption_UpdatingStatusAfterPut(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	putRec := doXrayRequest(t, h, "/EncryptionConfig", map[string]any{
+	putRec := doXrayRequest(t, h, "/PutEncryptionConfig", map[string]any{
 		"Type":  "KMS",
 		"KeyId": "alias/my-key",
 	})

--- a/services/xray/handler_refinement1_test.go
+++ b/services/xray/handler_refinement1_test.go
@@ -165,7 +165,7 @@ func TestRefinement1_PutEncryptionConfigHandler(t *testing.T) {
 			t.Parallel()
 
 			h := newTestHandler(t)
-			rec := doXrayRequest(t, h, "/EncryptionConfig", tt.body)
+			rec := doXrayRequest(t, h, "/PutEncryptionConfig", tt.body)
 			assert.Equal(t, tt.wantStatus, rec.Code)
 		})
 	}

--- a/services/xray/handler_refinement2_test.go
+++ b/services/xray/handler_refinement2_test.go
@@ -235,7 +235,7 @@ func TestRefinement2_PutEncryptionConfig_InvalidType(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	rec := doXrayRequest(t, h, "/EncryptionConfig", map[string]any{
+	rec := doXrayRequest(t, h, "/PutEncryptionConfig", map[string]any{
 		"Type": "INVALID_TYPE",
 	})
 	assert.Equal(t, http.StatusBadRequest, rec.Code, "invalid Type must return 400")

--- a/services/xray/handler_test.go
+++ b/services/xray/handler_test.go
@@ -882,7 +882,7 @@ func TestHandler_PutEncryptionConfig(t *testing.T) {
 			t.Parallel()
 
 			h := newTestHandler(t)
-			rec := doXrayRequest(t, h, "/EncryptionConfig", tt.body)
+			rec := doXrayRequest(t, h, "/PutEncryptionConfig", tt.body)
 
 			assert.Equal(t, tt.wantCode, rec.Code)
 			assert.Contains(t, rec.Body.String(), tt.wantContain)

--- a/test/integration/xray_test.go
+++ b/test/integration/xray_test.go
@@ -110,4 +110,12 @@ func TestIntegration_XRay_GroupAndSamplingRuleLifecycle(t *testing.T) {
 	getEncOut, err := client.GetEncryptionConfig(ctx, &xraysdk.GetEncryptionConfigInput{})
 	require.NoError(t, err)
 	require.NotNil(t, getEncOut.EncryptionConfig)
+
+	// PutEncryptionConfig - exercises the POST /PutEncryptionConfig wire path,
+	// which is distinct from GetEncryptionConfig's POST /EncryptionConfig path.
+	putEncOut, err := client.PutEncryptionConfig(ctx, &xraysdk.PutEncryptionConfigInput{
+		Type: xraytypes.EncryptionType("NONE"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, putEncOut.EncryptionConfig)
 }


### PR DESCRIPTION
## Summary

Fixes a LocalStack/AWS wire-protocol parity bug in the X-Ray handler (PARITY.md "Critical" item #2).

The AWS SDK v2 binds the two encryption-config operations to **different** HTTP paths:

| Operation | SDK request |
| --- | --- |
| `GetEncryptionConfig` | `POST /EncryptionConfig` |
| `PutEncryptionConfig` | `POST /PutEncryptionConfig` |

(Confirmed against `aws-sdk-go-v2/service/xray@v1.36.20` serializers: Get uses `SplitURI("/EncryptionConfig")`, Put uses `SplitURI("/PutEncryptionConfig")`.)

The handler previously mapped **`POST /EncryptionConfig` → `PutEncryptionConfig`**, so real SDK `PutEncryptionConfig` calls (which hit `/PutEncryptionConfig`) never reached the Put handler, while SDK `GetEncryptionConfig` calls were misrouted to Put.

## Changes

- `services/xray/handler.go`
  - Added the `/PutEncryptionConfig` route (path set, op map, dispatch table).
  - `POST /EncryptionConfig` now serves `GetEncryptionConfig` (matching `GET`), via a new body-signature `handleGetEncryptionConfigBody`.
  - Simplified `ExtractOperation` accordingly.
- Updated unit tests that POST Put bodies to use `/PutEncryptionConfig`.
- `test/integration/xray_test.go`: added a real-SDK `PutEncryptionConfig` call to exercise the corrected wire path.
- Updated `PARITY.md`.

## Testing

- `go test ./services/xray/... -short` ✅
- `go test ./services/... -short` ✅ (full suite)
- `go vet ./services/xray/...` ✅
- Integration test compiles (runtime needs Docker, unavailable here).

https://claude.ai/code/session_01Pbsn5yqvpyxwLeWVALoNXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbsn5yqvpyxwLeWVALoNXa)_