### PR TITLE
fix(elasticbeanstalk): respect Severity/StartTime/EnvironmentId filters in DescribeEvents

### DIFF
--- a/services/elasticbeanstalk/handler.go
+++ b/services/elasticbeanstalk/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v5"
 
@@ -1002,16 +1003,47 @@ type describeEventsResponse struct {
 	DescribeEventsResult describeEventsResult `xml:"DescribeEventsResult"`
 }
 
-// handleDescribeEvents returns stored events, filtered by ApplicationName and EnvironmentName.
-// The Terraform provider calls DescribeEvents to poll environment creation and termination status.
+// handleDescribeEvents returns stored events, filtered by ApplicationName, EnvironmentName,
+// EnvironmentId, Severity, and StartTime. The Terraform provider calls DescribeEvents with
+// Severity=ERROR and StartTime to poll for errors after environment creation/update.
 func (h *Handler) handleDescribeEvents(vals url.Values) (any, error) {
 	appName := vals.Get("ApplicationName")
 	envName := vals.Get("EnvironmentName")
+
+	// EnvironmentId filter: resolve to app/env name for backend lookup.
+	if envID := vals.Get("EnvironmentId"); envID != "" {
+		envs := h.Backend.DescribeEnvironments("", nil, []string{envID})
+		if len(envs) > 0 {
+			appName = envs[0].ApplicationName
+			envName = envs[0].EnvironmentName
+		}
+	}
+
+	// Severity filter: only return events matching the requested severity.
+	severityFilter := vals.Get("Severity")
+
+	// StartTime filter: only return events with EventDate >= StartTime.
+	var startTime time.Time
+	if s := vals.Get("StartTime"); s != "" {
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			startTime = t
+		}
+	}
 
 	records := h.Backend.DescribeEvents(appName, envName)
 	members := make([]eventDescType, 0, len(records))
 
 	for _, r := range records {
+		if severityFilter != "" && r.Severity != severityFilter {
+			continue
+		}
+
+		if !startTime.IsZero() {
+			if t, err := time.Parse(time.RFC3339, r.EventDate); err == nil && t.Before(startTime) {
+				continue
+			}
+		}
+
 		members = append(members, eventDescType{
 			ApplicationName: r.ApplicationName,
 			EnvironmentName: r.EnvironmentName,

--- a/services/elasticbeanstalk/handler_audit1_test.go
+++ b/services/elasticbeanstalk/handler_audit1_test.go
@@ -333,3 +333,95 @@ func TestAudit1_PersistenceRoundTrip_Events(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "Successfully launched environment: env1.")
 }
+
+// TestAudit1_DescribeEvents_SeverityFilter verifies that Severity=ERROR filters out INFO events.
+// The Terraform provider sends Severity=ERROR when polling for errors after environment creation;
+// returning INFO events (like "Successfully launched environment") as if they were errors was
+// the root cause of the chronic terraform EB test flake on PRs #2106 and #2122.
+func TestAudit1_DescribeEvents_SeverityFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filter   string
+		contains []string
+		absent   []string
+	}{
+		{
+			name:   "Severity=ERROR excludes INFO launch event",
+			filter: "&Severity=ERROR",
+			absent: []string{"Successfully launched environment"},
+		},
+		{
+			name:     "Severity=INFO returns INFO launch event",
+			filter:   "&Severity=INFO",
+			contains: []string{"Successfully launched environment: env1."},
+		},
+		{
+			name:     "no Severity filter returns all events",
+			filter:   "",
+			contains: []string{"Successfully launched environment: env1."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler()
+			postEBForm(t, h, "Version=2010-12-01&Action=CreateEnvironment&ApplicationName=app&EnvironmentName=env1")
+
+			rec := postEBForm(t, h, "Version=2010-12-01&Action=DescribeEvents"+tt.filter)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			for _, s := range tt.contains {
+				assert.Contains(t, rec.Body.String(), s)
+			}
+
+			for _, s := range tt.absent {
+				assert.NotContains(t, rec.Body.String(), s)
+			}
+		})
+	}
+}
+
+// TestAudit1_DescribeEvents_StartTimeFilter verifies that StartTime filters out older events.
+func TestAudit1_DescribeEvents_StartTimeFilter(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler()
+	postEBForm(t, h, "Version=2010-12-01&Action=CreateEnvironment&ApplicationName=app&EnvironmentName=env1")
+
+	// StartTime after the fixed event date (2026-01-01) should exclude the event.
+	rec := postEBForm(t, h, "Version=2010-12-01&Action=DescribeEvents&StartTime=2026-06-01T00:00:00Z")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "Successfully launched environment")
+
+	// StartTime before the fixed event date should include the event.
+	rec = postEBForm(t, h, "Version=2010-12-01&Action=DescribeEvents&StartTime=2025-01-01T00:00:00Z")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Successfully launched environment: env1.")
+}
+
+// TestAudit1_DescribeEvents_EnvironmentIdFilter verifies that EnvironmentId filters events
+// to the correct environment, matching how the Terraform provider queries for errors by ID.
+func TestAudit1_DescribeEvents_EnvironmentIdFilter(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler()
+	postEBForm(t, h, "Version=2010-12-01&Action=CreateEnvironment&ApplicationName=app&EnvironmentName=env1")
+	postEBForm(t, h, "Version=2010-12-01&Action=CreateEnvironment&ApplicationName=app&EnvironmentName=env2")
+
+	// env1 gets e-00000001, env2 gets e-00000002.
+	rec := postEBForm(t, h, "Version=2010-12-01&Action=DescribeEvents&EnvironmentId=e-00000001")
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Successfully launched environment: env1.")
+	assert.NotContains(t, body, "env2")
+
+	rec = postEBForm(t, h, "Version=2010-12-01&Action=DescribeEvents&EnvironmentId=e-00000002")
+	require.Equal(t, http.StatusOK, rec.Code)
+	body = rec.Body.String()
+	assert.Contains(t, body, "Successfully launched environment: env2.")
+	assert.NotContains(t, body, "env1.")
+}


### PR DESCRIPTION
Fixes chronic tf flake on PRs #2106 #2122. Refinery: Auto-merge enabled