### PR TITLE
fix(cognitoidp): remove omitempty from list/bool output fields (go-b0qa)

### DIFF
--- a/services/cognitoidp/accuracy_handler.go
+++ b/services/cognitoidp/accuracy_handler.go
@@ -801,7 +801,7 @@ type signUpAccurateInput struct {
 type signUpAccurateOutput struct {
 	CodeDeliveryDetails map[string]string `json:"CodeDeliveryDetails,omitempty"`
 	UserSub             string            `json:"UserSub,omitempty"`
-	UserConfirmed       bool              `json:"UserConfirmed,omitempty"`
+	UserConfirmed       bool              `json:"UserConfirmed"`
 }
 
 func (h *Handler) handleSignUpAccurate(
@@ -912,7 +912,7 @@ type listUserPoolClientsAccurateInput struct {
 }
 
 type listUserPoolClientsAccurateOutput struct {
-	UserPoolClients []clientDataAccurate `json:"UserPoolClients,omitempty"`
+	UserPoolClients []clientDataAccurate `json:"UserPoolClients"`
 }
 
 func (h *Handler) handleListUserPoolClientsAccurate(

--- a/services/cognitoidp/batch2_handler.go
+++ b/services/cognitoidp/batch2_handler.go
@@ -461,7 +461,7 @@ type listIdentityProvidersFullInput struct {
 
 type listIdentityProvidersFullOutput struct {
 	NextToken string                        `json:"NextToken,omitempty"`
-	Providers []identityProviderSummaryJSON `json:"Providers,omitempty"`
+	Providers []identityProviderSummaryJSON `json:"Providers"`
 }
 
 type identityProviderSummaryJSON struct {
@@ -1077,7 +1077,7 @@ type listGroupsFullInput struct {
 
 type listGroupsFullOutput struct {
 	NextToken string              `json:"NextToken,omitempty"`
-	Groups    []*groupFullSummary `json:"Groups,omitempty"`
+	Groups    []*groupFullSummary `json:"Groups"`
 }
 
 func (h *Handler) handleListGroupsFull(

--- a/services/cognitoidp/handler.go
+++ b/services/cognitoidp/handler.go
@@ -569,7 +569,7 @@ type listUserPoolsInput struct {
 }
 
 type listUserPoolsOutput struct {
-	UserPools []userPoolData `json:"UserPools,omitempty"`
+	UserPools []userPoolData `json:"UserPools"`
 }
 
 func (h *Handler) handleListUserPools(_ context.Context, _ *listUserPoolsInput) (*listUserPoolsOutput, error) {
@@ -707,7 +707,7 @@ type listUserPoolClientsInput struct {
 }
 
 type listUserPoolClientsOutput struct {
-	UserPoolClients []userPoolClientData `json:"UserPoolClients,omitempty"`
+	UserPoolClients []userPoolClientData `json:"UserPoolClients"`
 }
 
 func (h *Handler) handleListUserPoolClients(
@@ -742,7 +742,7 @@ type signUpInput struct {
 type signUpOutput struct {
 	CodeDeliveryDetails map[string]string `json:"CodeDeliveryDetails,omitempty"`
 	UserSub             string            `json:"UserSub,omitempty"`
-	UserConfirmed       bool              `json:"UserConfirmed,omitempty"`
+	UserConfirmed       bool              `json:"UserConfirmed"`
 }
 
 func (h *Handler) handleSignUp(_ context.Context, in *signUpInput) (*signUpOutput, error) {
@@ -913,7 +913,7 @@ type adminUserType struct {
 	UserStatus     string          `json:"UserStatus,omitempty"`
 	Attributes     []attributeType `json:"Attributes,omitempty"`
 	UserCreateDate float64         `json:"UserCreateDate,omitempty"`
-	Enabled        bool            `json:"Enabled,omitempty"`
+	Enabled        bool            `json:"Enabled"`
 }
 
 type adminCreateUserOutput struct {
@@ -970,7 +970,7 @@ type adminGetUserOutput struct {
 	UserAttributes       []attributeType `json:"UserAttributes,omitempty"`
 	UserCreateDate       float64         `json:"UserCreateDate,omitempty"`
 	UserLastModifiedDate float64         `json:"UserLastModifiedDate,omitempty"`
-	Enabled              bool            `json:"Enabled,omitempty"`
+	Enabled              bool            `json:"Enabled"`
 }
 
 func (h *Handler) handleAdminGetUser(_ context.Context, in *adminGetUserInput) (*adminGetUserOutput, error) {
@@ -1100,7 +1100,7 @@ type listUsersInput struct {
 }
 
 type listUsersOutput struct {
-	Users []*userSummary `json:"Users,omitempty"`
+	Users []*userSummary `json:"Users"`
 }
 
 type userSummary struct {
@@ -1109,7 +1109,7 @@ type userSummary struct {
 	Attributes       []attributeType `json:"Attributes,omitempty"`
 	UserCreateDate   float64         `json:"UserCreateDate,omitempty"`
 	UserLastModified float64         `json:"UserLastModifiedDate,omitempty"`
-	Enabled          bool            `json:"Enabled,omitempty"`
+	Enabled          bool            `json:"Enabled"`
 }
 
 func (h *Handler) handleListUsers(
@@ -1281,7 +1281,7 @@ type listGroupsInput struct {
 }
 
 type listGroupsOutput struct {
-	Groups []*groupSummary `json:"Groups,omitempty"`
+	Groups []*groupSummary `json:"Groups"`
 }
 
 func (h *Handler) handleListGroups(_ context.Context, in *listGroupsInput) (*listGroupsOutput, error) {
@@ -1342,7 +1342,7 @@ type adminListGroupsForUserInput struct {
 }
 
 type adminListGroupsForUserOutput struct {
-	Groups []*groupSummary `json:"Groups,omitempty"`
+	Groups []*groupSummary `json:"Groups"`
 }
 
 func (h *Handler) handleAdminListGroupsForUser(

--- a/services/cognitoidp/handler_completeness.go
+++ b/services/cognitoidp/handler_completeness.go
@@ -402,7 +402,7 @@ type identityProviderSummary struct {
 }
 
 type listIdentityProvidersOutput struct {
-	Providers []identityProviderSummary `json:"Providers,omitempty"`
+	Providers []identityProviderSummary `json:"Providers"`
 }
 
 func (h *Handler) handleListIdentityProviders(
@@ -739,7 +739,7 @@ type listTermsInput struct {
 }
 
 type listTermsOutput struct {
-	Terms []termsType `json:"Terms,omitempty"`
+	Terms []termsType `json:"Terms"`
 }
 
 func (h *Handler) handleListTerms(_ context.Context, in *listTermsInput) (*listTermsOutput, error) {
@@ -1435,7 +1435,7 @@ type listUserPoolClientSecretsInput struct {
 }
 
 type listUserPoolClientSecretsOutput struct {
-	Secrets []string `json:"Secrets,omitempty"`
+	Secrets []string `json:"Secrets"`
 }
 
 func (h *Handler) handleListUserPoolClientSecrets(


### PR DESCRIPTION
Cherry-picked cognitoidp fix from jasper's go-b0qa branch onto current parity-mega. Fixes unit panic (handler_test.go:3160) + e2e TestCognitoIDPDashboard. 4 files +16/-16. Unblocks #2213.