### PR TITLE
parity: region isolation (context-based, batched) — WIP, DO NOT MERGE

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -13,6 +13,7 @@ package bench_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -283,7 +284,7 @@ func BenchmarkSecretsManager_CreateSecret(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := range b.N {
-		_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         fmt.Sprintf("bench-secret-%d", i),
 			SecretString: `{"key":"value"}`,
 		})
@@ -293,7 +294,7 @@ func BenchmarkSecretsManager_CreateSecret(b *testing.B) {
 
 func BenchmarkSecretsManager_GetSecretValue(b *testing.B) {
 	backend := secretsmanager.NewInMemoryBackend()
-	_, setupErr := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, setupErr := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "bench-secret",
 		SecretString: `{"key":"value"}`,
 	})
@@ -303,7 +304,7 @@ func BenchmarkSecretsManager_GetSecretValue(b *testing.B) {
 	b.ReportAllocs()
 
 	for range b.N {
-		_, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		_, err := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 			SecretID: "bench-secret",
 		})
 		require.NoError(b, err)

--- a/cli.go
+++ b/cli.go
@@ -3206,6 +3206,7 @@ type kinesisReaderAdapter struct {
 
 func (a *kinesisReaderAdapter) GetShardIDs(streamName string) ([]string, error) {
 	out, err := a.backend.DescribeStream(
+		context.Background(),
 		&kinesisbackend.DescribeStreamInput{StreamName: streamName},
 	)
 	if err != nil {
@@ -3223,7 +3224,7 @@ func (a *kinesisReaderAdapter) GetShardIDs(streamName string) ([]string, error) 
 func (a *kinesisReaderAdapter) GetShardIterator(
 	streamName, shardID, iteratorType, startingSeqNum string,
 ) (string, error) {
-	out, err := a.backend.GetShardIterator(&kinesisbackend.GetShardIteratorInput{
+	out, err := a.backend.GetShardIterator(context.Background(), &kinesisbackend.GetShardIteratorInput{
 		StreamName:             streamName,
 		ShardID:                shardID,
 		ShardIteratorType:      iteratorType,
@@ -3240,7 +3241,7 @@ func (a *kinesisReaderAdapter) GetRecords(
 	iteratorToken string,
 	limit int,
 ) ([]lambdabackend.KinesisRecord, string, error) {
-	out, err := a.backend.GetRecords(&kinesisbackend.GetRecordsInput{
+	out, err := a.backend.GetRecords(context.Background(), &kinesisbackend.GetRecordsInput{
 		ShardIterator: iteratorToken,
 		Limit:         limit,
 	})
@@ -3712,7 +3713,7 @@ func (d *cwlogsSubscriptionDeliverer) DeliverLogEvents(
 		}
 		// resource is "stream/<name>"
 		streamName := strings.TrimPrefix(resource, "stream/")
-		_, err := d.kinesis.PutRecord(&kinesisbackend.PutRecordInput{
+		_, err := d.kinesis.PutRecord(ctx, &kinesisbackend.PutRecordInput{
 			StreamName:   streamName,
 			PartitionKey: "cwlogs",
 			Data:         payload,

--- a/demo/load_test.go
+++ b/demo/load_test.go
@@ -363,7 +363,7 @@ func TestLoadCodePipeline(t *testing.T) {
 			err = demo.LoadData(t.Context(), loadClients)
 			require.NoError(t, err)
 
-			pipelines := cpHandler.Backend.ListPipelines()
+			pipelines := cpHandler.Backend.ListPipelines(t.Context())
 			assert.Len(t, pipelines, tt.wantPipelineLen)
 		})
 	}

--- a/services/acm/backend.go
+++ b/services/acm/backend.go
@@ -1,6 +1,7 @@
 package acm
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	cryptorand "crypto/rand"
@@ -21,6 +22,18 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/page"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 var (
 	ErrCertNotFound      = errors.New("ResourceNotFoundException")
@@ -171,35 +184,83 @@ type RenewalSummary struct {
 }
 
 // InMemoryBackend is the in-memory store for ACM certificates.
+// InMemoryBackend stores ACM state. All resource maps are nested by region
+// (outer key = region) so that certificates are isolated per region.
 type InMemoryBackend struct {
-	timers map[string]*time.Timer
-	certs  map[string]*Certificate
-	// idempotencyMap maps RequestCertificate idempotency tokens to cert info.
-	idempotencyMap map[string]certIdempotencyEntry
-	// accountIdempotency maps PutAccountConfiguration tokens to their applied settings.
-	accountIdempotency map[string]accountIdempotencyEntry
-	mu                 *lockmetrics.RWMutex
-	accountID          string
-	region             string
-	accountConfig      AccountConfig
+	timers map[string]map[string]*time.Timer
+	certs  map[string]map[string]*Certificate
+	// idempotencyMap maps RequestCertificate idempotency tokens to cert info (per region).
+	idempotencyMap map[string]map[string]certIdempotencyEntry
+	// accountIdempotency maps PutAccountConfiguration tokens to their applied settings (per region).
+	accountIdempotency map[string]map[string]accountIdempotencyEntry
+	// accountConfig holds the account-level configuration per region.
+	accountConfig map[string]AccountConfig
+	mu            *lockmetrics.RWMutex
+	accountID     string
+	region        string
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		certs:              make(map[string]*Certificate),
-		timers:             make(map[string]*time.Timer),
-		idempotencyMap:     make(map[string]certIdempotencyEntry),
-		accountIdempotency: make(map[string]accountIdempotencyEntry),
+		certs:              make(map[string]map[string]*Certificate),
+		timers:             make(map[string]map[string]*time.Timer),
+		idempotencyMap:     make(map[string]map[string]certIdempotencyEntry),
+		accountIdempotency: make(map[string]map[string]accountIdempotencyEntry),
+		accountConfig:      make(map[string]AccountConfig),
 		accountID:          accountID,
 		region:             region,
 		mu:                 lockmetrics.New("acm"),
-		accountConfig:      AccountConfig{DaysBeforeExpiry: defaultDaysBeforeExpiry},
 	}
 }
 
 // Region returns the AWS region this backend is configured for.
 func (b *InMemoryBackend) Region() string { return b.region }
+
+// The *Store helpers return the per-region inner map, lazily creating it.
+// Callers must hold b.mu.
+
+func (b *InMemoryBackend) certsStore(region string) map[string]*Certificate {
+	if b.certs[region] == nil {
+		b.certs[region] = make(map[string]*Certificate)
+	}
+
+	return b.certs[region]
+}
+
+func (b *InMemoryBackend) timersStore(region string) map[string]*time.Timer {
+	if b.timers[region] == nil {
+		b.timers[region] = make(map[string]*time.Timer)
+	}
+
+	return b.timers[region]
+}
+
+func (b *InMemoryBackend) idempotencyStore(region string) map[string]certIdempotencyEntry {
+	if b.idempotencyMap[region] == nil {
+		b.idempotencyMap[region] = make(map[string]certIdempotencyEntry)
+	}
+
+	return b.idempotencyMap[region]
+}
+
+func (b *InMemoryBackend) accountIdempotencyStore(region string) map[string]accountIdempotencyEntry {
+	if b.accountIdempotency[region] == nil {
+		b.accountIdempotency[region] = make(map[string]accountIdempotencyEntry)
+	}
+
+	return b.accountIdempotency[region]
+}
+
+// accountConfigFor returns the account config for the region, defaulting when unset.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) accountConfigFor(region string) AccountConfig {
+	if cfg, ok := b.accountConfig[region]; ok {
+		return cfg
+	}
+
+	return AccountConfig{DaysBeforeExpiry: defaultDaysBeforeExpiry}
+}
 
 // RequestCertificate creates a new certificate for the given domain.
 // When validationMethod is "DNS" or "EMAIL" the certificate starts in
@@ -207,6 +268,7 @@ func (b *InMemoryBackend) Region() string { return b.region }
 // idempotencyToken, if non-empty, deduplicates the request — repeated calls with
 // the same token return the previously created certificate ARN.
 func (b *InMemoryBackend) RequestCertificate(
+	ctx context.Context,
 	domainName, certType, validationMethod, idempotencyToken, keyAlgorithm, caArn, optionsPref string,
 	sans []string,
 ) (*Certificate, error) {
@@ -223,11 +285,15 @@ func (b *InMemoryBackend) RequestCertificate(
 		keyAlgorithm = keyAlgorithmEC
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RequestCertificate")
 	defer b.mu.Unlock()
 
 	// Idempotency: return existing cert if same token was already used.
-	existing, found, checkErr := b.checkIdempotency(idempotencyToken, domainName, validationMethod, keyAlgorithm, sans)
+	existing, found, checkErr := b.checkIdempotency(
+		region, idempotencyToken, domainName, validationMethod, keyAlgorithm, sans,
+	)
 	if checkErr != nil {
 		return nil, checkErr
 	} else if found {
@@ -235,7 +301,7 @@ func (b *InMemoryBackend) RequestCertificate(
 	}
 
 	id := fmt.Sprintf("%x", time.Now().UnixNano())
-	certARN := arn.Build("acm", b.region, b.accountID, "certificate/"+id)
+	certARN := arn.Build("acm", region, b.accountID, "certificate/"+id)
 
 	if certType == "" {
 		certType = "AMAZON_ISSUED"
@@ -287,39 +353,45 @@ func (b *InMemoryBackend) RequestCertificate(
 		CertificateTransparencyLoggingPref: optionsPref,
 		CertificateAuthorityArn:            caArn,
 	}
-	b.certs[certARN] = cert
-
-	if idempotencyToken != "" {
-		b.idempotencyMap[idempotencyToken] = certIdempotencyEntry{
-			ARN:       certARN,
-			CreatedAt: now,
-		}
-	}
-
-	if status == statusPendingValidation {
-		t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func() { b.autoValidate(certARN) })
-		b.timers[certARN] = t
-	}
+	b.certsStore(region)[certARN] = cert
+	b.recordNewCert(region, certARN, idempotencyToken, status, now)
 
 	cp := copyCert(cert)
 
 	return &cp, nil
 }
 
+// recordNewCert records the idempotency-token mapping for a newly created certificate and
+// schedules its auto-validation timer when the certificate is pending validation.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) recordNewCert(region, certARN, idempotencyToken, status string, now time.Time) {
+	if idempotencyToken != "" {
+		b.idempotencyStore(region)[idempotencyToken] = certIdempotencyEntry{
+			ARN:       certARN,
+			CreatedAt: now,
+		}
+	}
+
+	if status == statusPendingValidation {
+		t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func() { b.autoValidate(region, certARN) })
+		b.timersStore(region)[certARN] = t
+	}
+}
+
 func (b *InMemoryBackend) checkIdempotency(
-	idempotencyToken, domainName, validationMethod, keyAlgorithm string,
+	region, idempotencyToken, domainName, validationMethod, keyAlgorithm string,
 	sans []string,
 ) (*Certificate, bool, error) {
 	if idempotencyToken == "" {
 		return nil, false, nil
 	}
 
-	entry, ok := b.idempotencyMap[idempotencyToken]
+	entry, ok := b.idempotencyStore(region)[idempotencyToken]
 	if !ok {
 		return nil, false, nil
 	}
 
-	c, exists := b.certs[entry.ARN]
+	c, exists := b.certsStore(region)[entry.ARN]
 	if !exists {
 		return nil, false, nil
 	}
@@ -495,13 +567,13 @@ func copyCert(c *Certificate) Certificate {
 
 // autoValidate transitions a certificate from PENDING_VALIDATION to ISSUED after a
 // short delay, simulating the DNS/email validation workflow.
-func (b *InMemoryBackend) autoValidate(certARN string) {
+func (b *InMemoryBackend) autoValidate(region, certARN string) {
 	b.mu.Lock("autoValidate")
 	defer b.mu.Unlock()
 
-	delete(b.timers, certARN)
+	delete(b.timersStore(region), certARN)
 
-	c, ok := b.certs[certARN]
+	c, ok := b.certsStore(region)[certARN]
 	if !ok || c.Status != statusPendingValidation {
 		return
 	}
@@ -517,13 +589,13 @@ func (b *InMemoryBackend) autoValidate(certARN string) {
 
 // autoValidateRenewal transitions a certificate's RenewalSummary from PENDING_VALIDATION to SUCCESS after a
 // short delay, simulating the DNS/email validation workflow for managed renewals.
-func (b *InMemoryBackend) autoValidateRenewal(certARN string) {
+func (b *InMemoryBackend) autoValidateRenewal(region, certARN string) {
 	b.mu.Lock("autoValidateRenewal")
 	defer b.mu.Unlock()
 
-	delete(b.timers, certARN)
+	delete(b.timersStore(region), certARN)
 
-	c, ok := b.certs[certARN]
+	c, ok := b.certsStore(region)[certARN]
 	if !ok || c.RenewalSummary == nil || c.RenewalSummary.RenewalStatus != renewalStatusPendingValidation {
 		return
 	}
@@ -540,6 +612,7 @@ func (b *InMemoryBackend) autoValidateRenewal(certARN string) {
 // (re-import), matching AWS behavior where CertificateArn may be passed to replace
 // an existing imported certificate.
 func (b *InMemoryBackend) ImportCertificate(
+	ctx context.Context,
 	certBody, privateKey, certChain, certARNToUpdate string,
 ) (*Certificate, error) {
 	if certBody == "" {
@@ -557,12 +630,16 @@ func (b *InMemoryBackend) ImportCertificate(
 
 	now := time.Now().UTC()
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ImportCertificate")
 	defer b.mu.Unlock()
 
+	certs := b.certsStore(region)
+
 	// Re-import: update existing certificate in-place.
 	if certARNToUpdate != "" {
-		existing, ok := b.certs[certARNToUpdate]
+		existing, ok := certs[certARNToUpdate]
 		if !ok {
 			return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARNToUpdate)
 		}
@@ -588,7 +665,7 @@ func (b *InMemoryBackend) ImportCertificate(
 	}
 
 	id := fmt.Sprintf("%x", time.Now().UnixNano())
-	certARN := arn.Build("acm", b.region, b.accountID, "certificate/"+id)
+	certARN := arn.Build("acm", region, b.accountID, "certificate/"+id)
 
 	cert := &Certificate{
 		ARN:                                certARN,
@@ -612,7 +689,7 @@ func (b *InMemoryBackend) ImportCertificate(
 		ExtendedKeyUsage:                   meta.extKeyUsage,
 		CertificateTransparencyLoggingPref: transparencyLoggingEnabled,
 	}
-	b.certs[certARN] = cert
+	certs[certARN] = cert
 
 	cp := copyCert(cert)
 
@@ -622,11 +699,13 @@ func (b *InMemoryBackend) ImportCertificate(
 // RenewCertificate regenerates the certificate material for an AMAZON_ISSUED certificate,
 // extending its validity by one year. Returns ErrNotEligible for IMPORTED certificates,
 // as AWS ACM does not support renewing imported certificates.
-func (b *InMemoryBackend) RenewCertificate(certARN string) error {
+func (b *InMemoryBackend) RenewCertificate(ctx context.Context, certARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RenewCertificate")
 	defer b.mu.Unlock()
 
-	c, exists := b.certs[certARN]
+	c, exists := b.certsStore(region)[certARN]
 	if !exists {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -670,14 +749,15 @@ func (b *InMemoryBackend) RenewCertificate(certARN string) error {
 	}
 
 	if status == statusPendingValidation {
-		t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func() { b.autoValidateRenewal(certARN) })
+		t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func() { b.autoValidateRenewal(region, certARN) })
 		// We can share the timer map, because normal validation is done
 		// if a renewal is happening (a cert must be issued to be renewed).
 		// Wait, if there's an existing timer, stop it first.
-		if oldT, ok := b.timers[certARN]; ok {
+		timers := b.timersStore(region)
+		if oldT, ok := timers[certARN]; ok {
 			oldT.Stop()
 		}
-		b.timers[certARN] = t
+		timers[certARN] = t
 	}
 
 	return nil
@@ -711,11 +791,15 @@ const fakeCertChain = "-----BEGIN CERTIFICATE-----\n" +
 // When the stored certificate has no associated chain, a fake chain (intermediate + root)
 // is returned in PEM format to simulate AWS ACM behaviour.
 // If passphrase is non-nil and non-empty, the private key is returned encrypted using AES-256.
-func (b *InMemoryBackend) ExportCertificate(certARN string, passphrase []byte) (*Certificate, error) {
+func (b *InMemoryBackend) ExportCertificate(
+	ctx context.Context, certARN string, passphrase []byte,
+) (*Certificate, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ExportCertificate")
 	defer b.mu.RUnlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -744,11 +828,13 @@ func (b *InMemoryBackend) ExportCertificate(certARN string, passphrase []byte) (
 }
 
 // GetCertificate returns the PEM certificate body and chain for any certificate.
-func (b *InMemoryBackend) GetCertificate(certARN string) (string, string, error) {
+func (b *InMemoryBackend) GetCertificate(ctx context.Context, certARN string) (string, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetCertificate")
 	defer b.mu.RUnlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return "", "", fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -762,11 +848,13 @@ func (b *InMemoryBackend) GetCertificate(certARN string) (string, string, error)
 }
 
 // DescribeCertificate returns the certificate with the given ARN.
-func (b *InMemoryBackend) DescribeCertificate(arn string) (*Certificate, error) {
+func (b *InMemoryBackend) DescribeCertificate(ctx context.Context, arn string) (*Certificate, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeCertificate")
 	defer b.mu.RUnlock()
 
-	cert, exists := b.certs[arn]
+	cert, exists := b.certsStore(region)[arn]
 	if !exists {
 		return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, arn)
 	}
@@ -851,18 +939,23 @@ func (f listCertFilters) matches(c *Certificate) bool {
 
 // ListCertificates returns a paginated list of certificates, with optional
 // filtering and sorting.
-func (b *InMemoryBackend) ListCertificates(p ListCertificatesParams) (page.Page[Certificate], error) {
+func (b *InMemoryBackend) ListCertificates(
+	ctx context.Context, p ListCertificatesParams,
+) (page.Page[Certificate], error) {
 	if err := page.ValidateToken(p.NextToken); err != nil {
 		return page.Page[Certificate]{}, fmt.Errorf("%w: invalid NextToken", ErrInvalidParameter)
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.RLock("ListCertificates")
 	defer b.mu.RUnlock()
 
 	filters := buildListCertFilters(p)
-	certs := make([]Certificate, 0, len(b.certs))
+	regionCerts := b.certsStore(region)
+	certs := make([]Certificate, 0, len(regionCerts))
 
-	for _, c := range b.certs {
+	for _, c := range regionCerts {
 		if filters.matches(c) {
 			certs = append(certs, copyCert(c))
 		}
@@ -908,22 +1001,26 @@ func matchesAny(values []string, set map[string]struct{}) bool {
 
 // CertExists reports whether a certificate with the given ARN exists in the backend.
 // This is used by the handler to validate tag operations.
-func (b *InMemoryBackend) CertExists(certARN string) bool {
+func (b *InMemoryBackend) CertExists(ctx context.Context, certARN string) bool {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("CertExists")
 	defer b.mu.RUnlock()
 
-	_, ok := b.certs[certARN]
+	_, ok := b.certsStore(region)[certARN]
 
 	return ok
 }
 
 // AddInUseBy records that a resource ARN is using the certificate. It is a no-op
 // if the certificate does not exist or the ARN is already present.
-func (b *InMemoryBackend) AddInUseBy(certARN, resourceARN string) {
+func (b *InMemoryBackend) AddInUseBy(ctx context.Context, certARN, resourceARN string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddInUseBy")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return
 	}
@@ -937,11 +1034,13 @@ func (b *InMemoryBackend) AddInUseBy(certARN, resourceARN string) {
 
 // RemoveInUseBy removes a resource ARN from the certificate's InUseBy list. It is a no-op
 // if the certificate does not exist or the ARN is not present.
-func (b *InMemoryBackend) RemoveInUseBy(certARN, resourceARN string) {
+func (b *InMemoryBackend) RemoveInUseBy(ctx context.Context, certARN, resourceARN string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveInUseBy")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return
 	}
@@ -958,11 +1057,14 @@ func (b *InMemoryBackend) RemoveInUseBy(certARN, resourceARN string) {
 }
 
 // DeleteCertificate removes the certificate with the given ARN.
-func (b *InMemoryBackend) DeleteCertificate(certARN string) error {
+func (b *InMemoryBackend) DeleteCertificate(ctx context.Context, certARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteCertificate")
 	defer b.mu.Unlock()
 
-	cert, exists := b.certs[certARN]
+	certs := b.certsStore(region)
+	cert, exists := certs[certARN]
 	if !exists {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -971,18 +1073,20 @@ func (b *InMemoryBackend) DeleteCertificate(certARN string) error {
 		return fmt.Errorf("%w: certificate %s is in use", ErrResourceInUse, certARN)
 	}
 
-	if t, ok := b.timers[certARN]; ok {
+	timers := b.timersStore(region)
+	if t, ok := timers[certARN]; ok {
 		t.Stop()
-		delete(b.timers, certARN)
+		delete(timers, certARN)
 	}
 
-	delete(b.certs, certARN)
+	delete(certs, certARN)
 
 	// Drop any idempotency-token entries that pointed at this cert so the
 	// map cannot grow unbounded for long-running backends.
-	for tok, entry := range b.idempotencyMap {
+	idempotency := b.idempotencyStore(region)
+	for tok, entry := range idempotency {
 		if entry.ARN == certARN {
-			delete(b.idempotencyMap, tok)
+			delete(idempotency, tok)
 		}
 	}
 
@@ -1269,30 +1373,36 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, t := range b.timers {
-		t.Stop()
+	for _, regionTimers := range b.timers {
+		for _, t := range regionTimers {
+			t.Stop()
+		}
 	}
 
-	b.certs = make(map[string]*Certificate)
-	b.timers = make(map[string]*time.Timer)
-	b.idempotencyMap = make(map[string]certIdempotencyEntry)
-	b.accountIdempotency = make(map[string]accountIdempotencyEntry)
-	b.accountConfig = AccountConfig{DaysBeforeExpiry: defaultDaysBeforeExpiry}
+	b.certs = make(map[string]map[string]*Certificate)
+	b.timers = make(map[string]map[string]*time.Timer)
+	b.idempotencyMap = make(map[string]map[string]certIdempotencyEntry)
+	b.accountIdempotency = make(map[string]map[string]accountIdempotencyEntry)
+	b.accountConfig = make(map[string]AccountConfig)
 }
 
-// GetAccountConfiguration returns the account-level ACM configuration.
-func (b *InMemoryBackend) GetAccountConfiguration() AccountConfig {
+// GetAccountConfiguration returns the account-level ACM configuration for the request region.
+func (b *InMemoryBackend) GetAccountConfiguration(ctx context.Context) AccountConfig {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetAccountConfiguration")
 	defer b.mu.RUnlock()
 
-	return b.accountConfig
+	return b.accountConfigFor(region)
 }
 
 // PutAccountConfiguration stores the account-level ACM configuration.
 // idempotencyToken must be non-empty; repeated calls with the same token are
 // silently accepted only when the configuration is identical (AWS behavior).
 // A conflicting call with the same token but different settings returns ErrConflict.
-func (b *InMemoryBackend) PutAccountConfiguration(idempotencyToken string, daysBeforeExpiry *int32) error {
+func (b *InMemoryBackend) PutAccountConfiguration(
+	ctx context.Context, idempotencyToken string, daysBeforeExpiry *int32,
+) error {
 	if idempotencyToken == "" {
 		return fmt.Errorf("%w: IdempotencyToken is required", ErrInvalidParameter)
 	}
@@ -1306,10 +1416,13 @@ func (b *InMemoryBackend) PutAccountConfiguration(idempotencyToken string, daysB
 		wantDays = *daysBeforeExpiry
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutAccountConfiguration")
 	defer b.mu.Unlock()
 
-	if prev, seen := b.accountIdempotency[idempotencyToken]; seen {
+	accountIdempotency := b.accountIdempotencyStore(region)
+	if prev, seen := accountIdempotency[idempotencyToken]; seen {
 		if prev.DaysBeforeExpiry != wantDays {
 			return fmt.Errorf(
 				"%w: IdempotencyToken %q was already used with different settings",
@@ -1320,18 +1433,18 @@ func (b *InMemoryBackend) PutAccountConfiguration(idempotencyToken string, daysB
 		return nil
 	}
 
-	b.accountIdempotency[idempotencyToken] = accountIdempotencyEntry{
+	accountIdempotency[idempotencyToken] = accountIdempotencyEntry{
 		DaysBeforeExpiry: wantDays,
 		CreatedAt:        time.Now().UTC(),
 	}
-	b.accountConfig.DaysBeforeExpiry = wantDays
+	b.accountConfig[region] = AccountConfig{DaysBeforeExpiry: wantDays}
 
 	return nil
 }
 
 // ResendValidationEmail re-triggers the EMAIL validation flow for a certificate
 // that is still in PENDING_VALIDATION status with EMAIL validation method.
-func (b *InMemoryBackend) ResendValidationEmail(certARN, domain, validationDomain string) error {
+func (b *InMemoryBackend) ResendValidationEmail(ctx context.Context, certARN, domain, validationDomain string) error {
 	if certARN == "" {
 		return fmt.Errorf("%w: CertificateArn is required", ErrInvalidParameter)
 	}
@@ -1344,10 +1457,12 @@ func (b *InMemoryBackend) ResendValidationEmail(certARN, domain, validationDomai
 		return fmt.Errorf("%w: ValidationDomain is required", ErrInvalidParameter)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ResendValidationEmail")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1373,13 +1488,14 @@ func (b *InMemoryBackend) ResendValidationEmail(certARN, domain, validationDomai
 	}
 
 	// Reset the auto-validate timer to simulate email resend triggering re-validation.
-	if t, exists := b.timers[certARN]; exists {
+	timers := b.timersStore(region)
+	if t, exists := timers[certARN]; exists {
 		t.Stop()
-		delete(b.timers, certARN)
+		delete(timers, certARN)
 	}
 
-	t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func() { b.autoValidate(certARN) })
-	b.timers[certARN] = t
+	t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func() { b.autoValidate(region, certARN) })
+	timers[certARN] = t
 
 	return nil
 }
@@ -1399,7 +1515,7 @@ func validRevocationReason(r string) bool {
 // RevokeCertificate marks the certificate as REVOKED with the given reason.
 // Returns ErrAlreadyRevoked if the certificate is already revoked.
 // Only ISSUED certificates can be revoked; PENDING_VALIDATION certs return ErrInvalidParameter.
-func (b *InMemoryBackend) RevokeCertificate(certARN, revocationReason string) error {
+func (b *InMemoryBackend) RevokeCertificate(ctx context.Context, certARN, revocationReason string) error {
 	if certARN == "" {
 		return fmt.Errorf("%w: CertificateArn is required", ErrInvalidParameter)
 	}
@@ -1412,10 +1528,12 @@ func (b *InMemoryBackend) RevokeCertificate(certARN, revocationReason string) er
 		return fmt.Errorf("%w: invalid RevocationReason %q", ErrInvalidParameter, revocationReason)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RevokeCertificate")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1437,9 +1555,10 @@ func (b *InMemoryBackend) RevokeCertificate(certARN, revocationReason string) er
 	cert.RevokedAt = &now
 
 	// Stop any pending auto-validate timer.
-	if t, exists := b.timers[certARN]; exists {
+	timers := b.timersStore(region)
+	if t, exists := timers[certARN]; exists {
 		t.Stop()
-		delete(b.timers, certARN)
+		delete(timers, certARN)
 	}
 
 	return nil
@@ -1452,7 +1571,7 @@ func validTransparencyPreference(p string) bool {
 
 // UpdateCertificateOptions sets the CertificateTransparencyLoggingPreference for
 // a certificate. Only ISSUED certificates may be updated.
-func (b *InMemoryBackend) UpdateCertificateOptions(certARN, transparencyLoggingPref string) error {
+func (b *InMemoryBackend) UpdateCertificateOptions(ctx context.Context, certARN, transparencyLoggingPref string) error {
 	if certARN == "" {
 		return fmt.Errorf("%w: CertificateArn is required", ErrInvalidParameter)
 	}
@@ -1469,10 +1588,12 @@ func (b *InMemoryBackend) UpdateCertificateOptions(certARN, transparencyLoggingP
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateCertificateOptions")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1489,11 +1610,13 @@ func (b *InMemoryBackend) UpdateCertificateOptions(certARN, transparencyLoggingP
 // ExpireCertificate transitions an ISSUED certificate to EXPIRED status.
 // Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
 // certificate is not in ISSUED status.
-func (b *InMemoryBackend) ExpireCertificate(certARN string) error {
+func (b *InMemoryBackend) ExpireCertificate(ctx context.Context, certARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ExpireCertificate")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1510,11 +1633,13 @@ func (b *InMemoryBackend) ExpireCertificate(certARN string) error {
 // InactivateCertificate transitions an ISSUED certificate to INACTIVE status.
 // Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
 // certificate is not in ISSUED status.
-func (b *InMemoryBackend) InactivateCertificate(certARN string) error {
+func (b *InMemoryBackend) InactivateCertificate(ctx context.Context, certARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("InactivateCertificate")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1531,11 +1656,13 @@ func (b *InMemoryBackend) InactivateCertificate(certARN string) error {
 // TimeoutPendingValidation transitions a PENDING_VALIDATION certificate to VALIDATION_TIMED_OUT.
 // Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
 // certificate is not in PENDING_VALIDATION status.
-func (b *InMemoryBackend) TimeoutPendingValidation(certARN string) error {
+func (b *InMemoryBackend) TimeoutPendingValidation(ctx context.Context, certARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TimeoutPendingValidation")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1548,9 +1675,10 @@ func (b *InMemoryBackend) TimeoutPendingValidation(certARN string) error {
 	}
 
 	// Stop any pending auto-validate timer.
-	if t, exists := b.timers[certARN]; exists {
+	timers := b.timersStore(region)
+	if t, exists := timers[certARN]; exists {
 		t.Stop()
-		delete(b.timers, certARN)
+		delete(timers, certARN)
 	}
 
 	cert.Status = statusValidationTimedOut
@@ -1562,11 +1690,13 @@ func (b *InMemoryBackend) TimeoutPendingValidation(certARN string) error {
 // the given failure reason.
 // Returns ErrCertNotFound if no such certificate exists, ErrInvalidParameter if the
 // certificate is not in PENDING_VALIDATION status.
-func (b *InMemoryBackend) FailCertificate(certARN, reason string) error {
+func (b *InMemoryBackend) FailCertificate(ctx context.Context, certARN, reason string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("FailCertificate")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -1579,9 +1709,10 @@ func (b *InMemoryBackend) FailCertificate(certARN, reason string) error {
 	}
 
 	// Stop any pending auto-validate timer.
-	if t, exists := b.timers[certARN]; exists {
+	timers := b.timersStore(region)
+	if t, exists := timers[certARN]; exists {
 		t.Stop()
-		delete(b.timers, certARN)
+		delete(timers, certARN)
 	}
 
 	cert.Status = statusFailed

--- a/services/acm/backend_test.go
+++ b/services/acm/backend_test.go
@@ -1,6 +1,7 @@
 package acm_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -61,7 +62,17 @@ func TestACMBackend_RequestCertificate(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			cert, err := b.RequestCertificate(tt.domain, "", tt.validationMethod, "", "", "", "", nil)
+			cert, err := b.RequestCertificate(
+				context.Background(),
+				tt.domain,
+				"",
+				tt.validationMethod,
+				"",
+				"",
+				"",
+				"",
+				nil,
+			)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -80,7 +91,7 @@ func TestACMBackend_RequestCertificate(t *testing.T) {
 			if tt.wantPendingFirst {
 				// Wait for auto-validation
 				require.Eventually(t, func() bool {
-					c, descErr := b.DescribeCertificate(cert.ARN)
+					c, descErr := b.DescribeCertificate(context.Background(), cert.ARN)
 
 					return descErr == nil && c.Status == "ISSUED"
 				}, 2*time.Second, 50*time.Millisecond, "certificate should transition to ISSUED")
@@ -138,7 +149,7 @@ func TestACMBackend_RequestCertificate_Extended(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			cert, err := b.RequestCertificate(tt.domain, "", "DNS", "", "", "", "", tt.sans)
+			cert, err := b.RequestCertificate(context.Background(), tt.domain, "", "DNS", "", "", "", "", tt.sans)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantDomain, cert.DomainName)
@@ -190,7 +201,7 @@ func TestACMBackend_DescribeCertificate(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			_, err := b.DescribeCertificate(tt.arn)
+			_, err := b.DescribeCertificate(context.Background(), tt.arn)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -216,7 +227,7 @@ func TestACMBackend_DeleteCertificate(t *testing.T) {
 			name: "success",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("delete-me.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(context.Background(), "delete-me.com", "", "", "", "", "", "", nil)
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -235,7 +246,7 @@ func TestACMBackend_DeleteCertificate(t *testing.T) {
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 			arn := tt.setup(t, b)
-			err := b.DeleteCertificate(arn)
+			err := b.DeleteCertificate(context.Background(), arn)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -265,9 +276,9 @@ func TestACMBackend_ListCertificates(t *testing.T) {
 			name: "two_certs",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.RequestCertificate("a.com", "", "", "", "", "", "", nil)
+				_, err := b.RequestCertificate(context.Background(), "a.com", "", "", "", "", "", "", nil)
 				require.NoError(t, err)
-				_, err = b.RequestCertificate("b.com", "", "", "", "", "", "", nil)
+				_, err = b.RequestCertificate(context.Background(), "b.com", "", "", "", "", "", "", nil)
 				require.NoError(t, err)
 			},
 			wantCount: 2,
@@ -283,7 +294,7 @@ func TestACMBackend_ListCertificates(t *testing.T) {
 				tt.setup(t, b)
 			}
 
-			p, _ := b.ListCertificates(acm.ListCertificatesParams{})
+			p, _ := b.ListCertificates(context.Background(), acm.ListCertificatesParams{})
 			certs := p.Data
 			assert.Len(t, certs, tt.wantCount)
 		})
@@ -338,7 +349,7 @@ func TestACMBackend_ImportCertificate(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			cert, err := b.ImportCertificate(tt.certBody, tt.privateKey, tt.certChain, "")
+			cert, err := b.ImportCertificate(context.Background(), tt.certBody, tt.privateKey, tt.certChain, "")
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -373,7 +384,17 @@ func TestACMBackend_RenewCertificate(t *testing.T) {
 			name: "success_amazon_issued",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("renew.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"renew.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -384,7 +405,7 @@ func TestACMBackend_RenewCertificate(t *testing.T) {
 			name: "imported_not_eligible",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+				cert, err := b.ImportCertificate(context.Background(), certPEM, keyPEM, "", "")
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -408,13 +429,13 @@ func TestACMBackend_RenewCertificate(t *testing.T) {
 			var originalBody string
 			var originalNotAfter time.Time
 			if tt.wantNewCert {
-				orig, err := b.DescribeCertificate(certARN)
+				orig, err := b.DescribeCertificate(context.Background(), certARN)
 				require.NoError(t, err)
 				originalBody = orig.CertificateBody
 				originalNotAfter = orig.NotAfter
 			}
 
-			err := b.RenewCertificate(certARN)
+			err := b.RenewCertificate(context.Background(), certARN)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -426,7 +447,7 @@ func TestACMBackend_RenewCertificate(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.wantNewCert {
-				renewed, descErr := b.DescribeCertificate(certARN)
+				renewed, descErr := b.DescribeCertificate(context.Background(), certARN)
 				require.NoError(t, descErr)
 				assert.NotEmpty(t, renewed.CertificateBody)
 				assert.NotEqual(t, originalBody, renewed.CertificateBody, "cert body should be regenerated")
@@ -453,7 +474,7 @@ func TestACMBackend_ExportCertificate(t *testing.T) {
 			name: "success_imported",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+				cert, err := b.ImportCertificate(context.Background(), certPEM, keyPEM, "", "")
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -463,7 +484,17 @@ func TestACMBackend_ExportCertificate(t *testing.T) {
 			name: "fails_amazon_issued",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("amazon.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"amazon.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -483,7 +514,7 @@ func TestACMBackend_ExportCertificate(t *testing.T) {
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 			certARN := tt.setup(t, b)
-			cert, err := b.ExportCertificate(certARN, nil)
+			cert, err := b.ExportCertificate(context.Background(), certARN, nil)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -511,7 +542,7 @@ func TestACMBackend_GetCertificate(t *testing.T) {
 			name: "success_amazon_issued",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("get.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(context.Background(), "get.example.com", "", "", "", "", "", "", nil)
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -530,7 +561,7 @@ func TestACMBackend_GetCertificate(t *testing.T) {
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 			certARN := tt.setup(t, b)
-			certBody, _, err := b.GetCertificate(certARN)
+			certBody, _, err := b.GetCertificate(context.Background(), certARN)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
@@ -552,16 +583,16 @@ func generateTestCert(t *testing.T) (string, string) {
 	t.Helper()
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	cert, err := b.RequestCertificate("test.example.com", "", "", "", "", "", "", nil)
+	cert, err := b.RequestCertificate(context.Background(), "test.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	// Retrieve stored PEM data via GetCertificate
-	certBody, _, getCertErr := b.GetCertificate(cert.ARN)
+	certBody, _, getCertErr := b.GetCertificate(context.Background(), cert.ARN)
 	require.NoError(t, getCertErr)
 	require.NotEmpty(t, certBody)
 
 	// Use cert body from describe to get PEM and key
-	described, descErr := b.DescribeCertificate(cert.ARN)
+	described, descErr := b.DescribeCertificate(context.Background(), cert.ARN)
 	require.NoError(t, descErr)
 
 	return described.CertificateBody, described.PrivateKey
@@ -572,13 +603,13 @@ func TestACMBackend_AutoValidation(t *testing.T) {
 	t.Parallel()
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	cert, err := b.RequestCertificate("auto.example.com", "", "DNS", "", "", "", "", nil)
+	cert, err := b.RequestCertificate(context.Background(), "auto.example.com", "", "DNS", "", "", "", "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "PENDING_VALIDATION", cert.Status)
 
 	// Wait for auto-validation (should happen within 500ms)
 	require.Eventually(t, func() bool {
-		c, descErr := b.DescribeCertificate(cert.ARN)
+		c, descErr := b.DescribeCertificate(context.Background(), cert.ARN)
 		if descErr != nil {
 			return false
 		}
@@ -602,7 +633,7 @@ func TestACMBackend_CertificateBodyIsPEM(t *testing.T) {
 	t.Parallel()
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	cert, err := b.RequestCertificate("pem.example.com", "", "", "", "", "", "", nil)
+	cert, err := b.RequestCertificate(context.Background(), "pem.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	assert.True(t, strings.HasPrefix(cert.CertificateBody, "-----BEGIN CERTIFICATE-----"))
@@ -626,13 +657,23 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "issued_to_expired",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("expire-me.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"expire-me.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.ExpireCertificate(certARN)
+				return b.ExpireCertificate(context.Background(), certARN)
 			},
 			wantStatus: "EXPIRED",
 		},
@@ -640,13 +681,13 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "issued_to_inactive",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+				cert, err := b.ImportCertificate(context.Background(), certPEM, keyPEM, "", "")
 				require.NoError(t, err)
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.InactivateCertificate(certARN)
+				return b.InactivateCertificate(context.Background(), certARN)
 			},
 			wantStatus: "INACTIVE",
 		},
@@ -654,14 +695,24 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "pending_to_validation_timed_out",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("timeout.example.com", "", "DNS", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"timeout.example.com",
+					"",
+					"DNS",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 				require.Equal(t, "PENDING_VALIDATION", cert.Status)
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.TimeoutPendingValidation(certARN)
+				return b.TimeoutPendingValidation(context.Background(), certARN)
 			},
 			wantStatus: "VALIDATION_TIMED_OUT",
 		},
@@ -669,14 +720,24 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "pending_to_failed",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("fail-me.example.com", "", "EMAIL", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"fail-me.example.com",
+					"",
+					"EMAIL",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 				require.Equal(t, "PENDING_VALIDATION", cert.Status)
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.FailCertificate(certARN, "NO_AVAILABLE_CONTACTS")
+				return b.FailCertificate(context.Background(), certARN, "NO_AVAILABLE_CONTACTS")
 			},
 			wantStatus: "FAILED",
 		},
@@ -686,7 +747,7 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 				return "arn:aws:acm:us-east-1:000000000000:certificate/nonexistent"
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.ExpireCertificate(certARN)
+				return b.ExpireCertificate(context.Background(), certARN)
 			},
 			wantErr: acm.ErrCertNotFound,
 		},
@@ -694,14 +755,24 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "expire_wrong_status",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("already-revoked.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"already-revoked.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.RevokeCertificate(cert.ARN, "UNSPECIFIED"))
+				require.NoError(t, b.RevokeCertificate(context.Background(), cert.ARN, "UNSPECIFIED"))
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.ExpireCertificate(certARN)
+				return b.ExpireCertificate(context.Background(), certARN)
 			},
 			wantErr: acm.ErrInvalidParameter,
 		},
@@ -709,14 +780,24 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "timeout_already_issued",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("already-issued.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"already-issued.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 				require.Equal(t, "ISSUED", cert.Status)
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.TimeoutPendingValidation(certARN)
+				return b.TimeoutPendingValidation(context.Background(), certARN)
 			},
 			wantErr: acm.ErrInvalidParameter,
 		},
@@ -724,13 +805,23 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 			name: "fail_already_issued",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("already-issued2.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"already-issued2.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.FailCertificate(certARN, "DOMAIN_NOT_ALLOWED")
+				return b.FailCertificate(context.Background(), certARN, "DOMAIN_NOT_ALLOWED")
 			},
 			wantErr: acm.ErrInvalidParameter,
 		},
@@ -740,7 +831,7 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 				return "arn:aws:acm:us-east-1:000000000000:certificate/ghost"
 			},
 			transition: func(_ *testing.T, b *acm.InMemoryBackend, certARN string) error {
-				return b.InactivateCertificate(certARN)
+				return b.InactivateCertificate(context.Background(), certARN)
 			},
 			wantErr: acm.ErrCertNotFound,
 		},
@@ -763,7 +854,7 @@ func TestACMBackend_StatusLifecycle(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cert, descErr := b.DescribeCertificate(certARN)
+			cert, descErr := b.DescribeCertificate(context.Background(), certARN)
 			require.NoError(t, descErr)
 			assert.Equal(t, tt.wantStatus, cert.Status)
 		})
@@ -789,12 +880,22 @@ func TestACMBackend_FailCertificate_FailureReason(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			cert, err := b.RequestCertificate("fail.example.com", "", "EMAIL", "", "", "", "", nil)
+			cert, err := b.RequestCertificate(
+				context.Background(),
+				"fail.example.com",
+				"",
+				"EMAIL",
+				"",
+				"",
+				"",
+				"",
+				nil,
+			)
 			require.NoError(t, err)
 
-			require.NoError(t, b.FailCertificate(cert.ARN, tt.reason))
+			require.NoError(t, b.FailCertificate(context.Background(), cert.ARN, tt.reason))
 
-			described, descErr := b.DescribeCertificate(cert.ARN)
+			described, descErr := b.DescribeCertificate(context.Background(), cert.ARN)
 			require.NoError(t, descErr)
 			assert.Equal(t, "FAILED", described.Status)
 			assert.Equal(t, tt.reason, described.FailureReason)
@@ -839,10 +940,10 @@ func TestACMBackend_ExportCertificate_Passphrase(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			imported, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+			imported, err := b.ImportCertificate(context.Background(), certPEM, keyPEM, "", "")
 			require.NoError(t, err)
 
-			exported, exportErr := b.ExportCertificate(imported.ARN, tt.passphrase)
+			exported, exportErr := b.ExportCertificate(context.Background(), imported.ARN, tt.passphrase)
 			require.NoError(t, exportErr)
 
 			assert.True(t, strings.HasPrefix(exported.PrivateKey, tt.wantKeyHeader),
@@ -885,10 +986,13 @@ func TestACMBackend_ListCertificates_KeyUsageFilter(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			_, err := b.RequestCertificate("ku.example.com", "", "", "", "", "", "", nil)
+			_, err := b.RequestCertificate(context.Background(), "ku.example.com", "", "", "", "", "", "", nil)
 			require.NoError(t, err)
 
-			result, _ := b.ListCertificates(acm.ListCertificatesParams{KeyUsage: tt.filterKeyUsage})
+			result, _ := b.ListCertificates(
+				context.Background(),
+				acm.ListCertificatesParams{KeyUsage: tt.filterKeyUsage},
+			)
 
 			if tt.wantNonEmpty {
 				assert.NotEmpty(t, result.Data)
@@ -931,10 +1035,13 @@ func TestACMBackend_ListCertificates_ExtendedKeyUsageFilter(t *testing.T) {
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			_, err := b.RequestCertificate("eku.example.com", "", "", "", "", "", "", nil)
+			_, err := b.RequestCertificate(context.Background(), "eku.example.com", "", "", "", "", "", "", nil)
 			require.NoError(t, err)
 
-			result, _ := b.ListCertificates(acm.ListCertificatesParams{ExtendedKeyUsage: tt.filterExtKeyUsage})
+			result, _ := b.ListCertificates(
+				context.Background(),
+				acm.ListCertificatesParams{ExtendedKeyUsage: tt.filterExtKeyUsage},
+			)
 
 			if tt.wantNonEmpty {
 				assert.NotEmpty(t, result.Data)
@@ -952,10 +1059,10 @@ func TestACMBackend_ImportCertificate_KeyUsageParsed(t *testing.T) {
 	certPEM, keyPEM := generateTestCert(t)
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+	cert, err := b.ImportCertificate(context.Background(), certPEM, keyPEM, "", "")
 	require.NoError(t, err)
 
-	described, descErr := b.DescribeCertificate(cert.ARN)
+	described, descErr := b.DescribeCertificate(context.Background(), cert.ARN)
 	require.NoError(t, descErr)
 
 	assert.NotEmpty(t, described.KeyUsage, "imported cert should have key usages parsed from X.509")
@@ -980,7 +1087,17 @@ func TestACMBackend_ValidityAndEligibility(t *testing.T) {
 			name: "amazon_issued_eligible",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("validity.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"validity.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -991,7 +1108,7 @@ func TestACMBackend_ValidityAndEligibility(t *testing.T) {
 			name: "imported_ineligible",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.ImportCertificate(certPEM, keyPEM, "", "")
+				cert, err := b.ImportCertificate(context.Background(), certPEM, keyPEM, "", "")
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -1007,7 +1124,7 @@ func TestACMBackend_ValidityAndEligibility(t *testing.T) {
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 			certARN := tt.setup(t, b)
 
-			cert, err := b.DescribeCertificate(certARN)
+			cert, err := b.DescribeCertificate(context.Background(), certARN)
 			require.NoError(t, err)
 
 			assert.False(t, cert.NotBefore.IsZero(), "NotBefore should be set")

--- a/services/acm/batch2_audit_test.go
+++ b/services/acm/batch2_audit_test.go
@@ -1,6 +1,7 @@
 package acm_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -72,10 +73,20 @@ func TestBatch2_RenewCertificate_Imported_Returns_RequestInProgressException(t *
 			t.Parallel()
 
 			b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-			src, err := b.RequestCertificate("renew-noteligible.example.com", "", "", "", "", "", "", nil)
+			src, err := b.RequestCertificate(
+				context.Background(),
+				"renew-noteligible.example.com",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				nil,
+			)
 			require.NoError(t, err)
 
-			imported, err := b.ImportCertificate(src.CertificateBody, src.PrivateKey, "", "")
+			imported, err := b.ImportCertificate(context.Background(), src.CertificateBody, src.PrivateKey, "", "")
 			require.NoError(t, err)
 
 			h := acm.NewHandler(b)
@@ -110,7 +121,17 @@ func TestBatch2_GetCertificate_NonIssuedStates_Returns_RequestInProgressExceptio
 			name: "pending_validation",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("get-pending.example.com", "", "DNS", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"get-pending.example.com",
+					"",
+					"DNS",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 				require.Equal(t, "PENDING_VALIDATION", cert.Status)
 
@@ -121,9 +142,19 @@ func TestBatch2_GetCertificate_NonIssuedStates_Returns_RequestInProgressExceptio
 			name: "validation_timed_out",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("get-timedout.example.com", "", "DNS", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"get-timedout.example.com",
+					"",
+					"DNS",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.TimeoutPendingValidation(cert.ARN))
+				require.NoError(t, b.TimeoutPendingValidation(context.Background(), cert.ARN))
 
 				return cert.ARN
 			},
@@ -132,9 +163,19 @@ func TestBatch2_GetCertificate_NonIssuedStates_Returns_RequestInProgressExceptio
 			name: "failed",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("get-failed.example.com", "", "EMAIL", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"get-failed.example.com",
+					"",
+					"EMAIL",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.FailCertificate(cert.ARN, "CAA_ERROR"))
+				require.NoError(t, b.FailCertificate(context.Background(), cert.ARN, "CAA_ERROR"))
 
 				return cert.ARN
 			},
@@ -259,10 +300,20 @@ func TestBatch2_UpdateCertificateOptions_NonIssued_Returns_InvalidStateException
 			name: "revoked_cert",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("update-opts-revoked.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"update-opts-revoked.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
-				err = b.RevokeCertificate(cert.ARN, "UNSPECIFIED")
+				err = b.RevokeCertificate(context.Background(), cert.ARN, "UNSPECIFIED")
 				require.NoError(t, err)
 
 				return cert.ARN
@@ -272,10 +323,20 @@ func TestBatch2_UpdateCertificateOptions_NonIssued_Returns_InvalidStateException
 			name: "expired_cert",
 			setup: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("update-opts-expired.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"update-opts-expired.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
-				err = b.ExpireCertificate(cert.ARN)
+				err = b.ExpireCertificate(context.Background(), cert.ARN)
 				require.NoError(t, err)
 
 				return cert.ARN

--- a/services/acm/handler.go
+++ b/services/acm/handler.go
@@ -464,19 +464,24 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // Handler returns the Echo handler function.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+		ctx := context.WithValue(c.Request().Context(), regionContextKey{}, region)
+
 		return service.HandleTarget(
-			c, logger.Load(c.Request().Context()),
+			c, logger.Load(ctx),
 			"ACM", "application/x-amz-json-1.1",
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(_ context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(ctx, action, body)
+			},
 			h.handleError,
 		)
 	}
 }
 
 // dispatch routes the operation to the appropriate handler and marshals the response.
-func (h *Handler) dispatch(_ context.Context, action string, body []byte) ([]byte, error) {
-	resp, err := h.dispatchJSON(action, body)
+func (h *Handler) dispatch(ctx context.Context, action string, body []byte) ([]byte, error) {
+	resp, err := h.dispatchJSON(ctx, action, body)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +505,7 @@ var errUnknownACMAction = errors.New("unknown ACM action")
 // acmDispatchTable maps ACM action names to their JSON handler functions.
 //
 //nolint:gochecknoglobals // read-only dispatch table initialized once at startup
-var acmDispatchTable = map[string]func(*Handler, []byte) (any, error){
+var acmDispatchTable = map[string]func(*Handler, context.Context, []byte) (any, error){
 	"RequestCertificate":        (*Handler).jsonRequestCertificate,
 	"DescribeCertificate":       (*Handler).jsonDescribeCertificate,
 	"ListCertificates":          (*Handler).jsonListCertificates,
@@ -520,15 +525,15 @@ var acmDispatchTable = map[string]func(*Handler, []byte) (any, error){
 }
 
 // dispatchJSON routes a JSON-protocol ACM action to the appropriate handler.
-func (h *Handler) dispatchJSON(action string, body []byte) (any, error) {
+func (h *Handler) dispatchJSON(ctx context.Context, action string, body []byte) (any, error) {
 	if fn, ok := acmDispatchTable[action]; ok {
-		return fn(h, body)
+		return fn(h, ctx, body)
 	}
 
 	return nil, errUnknownACMAction
 }
 
-func (h *Handler) jsonRequestCertificate(body []byte) (any, error) {
+func (h *Handler) jsonRequestCertificate(ctx context.Context, body []byte) (any, error) {
 	var input requestCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
@@ -543,6 +548,7 @@ func (h *Handler) jsonRequestCertificate(body []byte) (any, error) {
 	}
 
 	cert, err := h.Backend.RequestCertificate(
+		ctx,
 		input.DomainName,
 		certType,
 		input.ValidationMethod,
@@ -573,12 +579,12 @@ func (h *Handler) jsonRequestCertificate(body []byte) (any, error) {
 	return &requestCertificateOutput{CertificateArn: cert.ARN}, nil
 }
 
-func (h *Handler) jsonDescribeCertificate(body []byte) (any, error) {
+func (h *Handler) jsonDescribeCertificate(ctx context.Context, body []byte) (any, error) {
 	var input describeCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
-	cert, err := h.Backend.DescribeCertificate(input.CertificateArn)
+	cert, err := h.Backend.DescribeCertificate(ctx, input.CertificateArn)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +678,7 @@ func (h *Handler) jsonDescribeCertificate(body []byte) (any, error) {
 }
 
 // jsonListCertificates handles the ListCertificates operation.
-func (h *Handler) jsonListCertificates(body []byte) (any, error) {
+func (h *Handler) jsonListCertificates(ctx context.Context, body []byte) (any, error) {
 	var input listCertificatesInput
 	_ = json.Unmarshal(body, &input)
 
@@ -690,7 +696,7 @@ func (h *Handler) jsonListCertificates(body []byte) (any, error) {
 		params.ExtendedKeyUsage = input.Includes.ExtendedKeyUsage
 	}
 
-	p, err := h.Backend.ListCertificates(params)
+	p, err := h.Backend.ListCertificates(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -726,12 +732,12 @@ func (h *Handler) jsonListCertificates(body []byte) (any, error) {
 	return &listCertificatesOutput{CertificateSummaryList: summaries, NextToken: p.Next}, nil
 }
 
-func (h *Handler) jsonDeleteCertificate(body []byte) (any, error) {
+func (h *Handler) jsonDeleteCertificate(ctx context.Context, body []byte) (any, error) {
 	var input deleteCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
-	if err := h.Backend.DeleteCertificate(input.CertificateArn); err != nil {
+	if err := h.Backend.DeleteCertificate(ctx, input.CertificateArn); err != nil {
 		return nil, err
 	}
 	h.cleanupTags(input.CertificateArn)
@@ -739,26 +745,26 @@ func (h *Handler) jsonDeleteCertificate(body []byte) (any, error) {
 	return &deleteCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonListTagsForCertificate(body []byte) (any, error) {
+func (h *Handler) jsonListTagsForCertificate(ctx context.Context, body []byte) (any, error) {
 	var input listTagsForCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if !h.Backend.CertExists(input.CertificateArn) {
+	if !h.Backend.CertExists(ctx, input.CertificateArn) {
 		return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, input.CertificateArn)
 	}
 
 	return &listTagsForCertificateOutput{Tags: h.getTags(input.CertificateArn)}, nil
 }
 
-func (h *Handler) jsonAddTagsToCertificate(body []byte) (any, error) {
+func (h *Handler) jsonAddTagsToCertificate(ctx context.Context, body []byte) (any, error) {
 	var input addTagsToCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if !h.Backend.CertExists(input.CertificateArn) {
+	if !h.Backend.CertExists(ctx, input.CertificateArn) {
 		return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, input.CertificateArn)
 	}
 
@@ -773,13 +779,13 @@ func (h *Handler) jsonAddTagsToCertificate(body []byte) (any, error) {
 	return &addTagsToCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonRemoveTagsFromCertificate(body []byte) (any, error) {
+func (h *Handler) jsonRemoveTagsFromCertificate(ctx context.Context, body []byte) (any, error) {
 	var input removeTagsFromCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if !h.Backend.CertExists(input.CertificateArn) {
+	if !h.Backend.CertExists(ctx, input.CertificateArn) {
 		return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, input.CertificateArn)
 	}
 
@@ -792,12 +798,13 @@ func (h *Handler) jsonRemoveTagsFromCertificate(body []byte) (any, error) {
 	return &removeTagsFromCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonImportCertificate(body []byte) (any, error) {
+func (h *Handler) jsonImportCertificate(ctx context.Context, body []byte) (any, error) {
 	var input importCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 	cert, err := h.Backend.ImportCertificate(
+		ctx,
 		input.Certificate,
 		input.PrivateKey,
 		input.CertificateChain,
@@ -810,19 +817,19 @@ func (h *Handler) jsonImportCertificate(body []byte) (any, error) {
 	return &importCertificateOutput{CertificateArn: cert.ARN}, nil
 }
 
-func (h *Handler) jsonRenewCertificate(body []byte) (any, error) {
+func (h *Handler) jsonRenewCertificate(ctx context.Context, body []byte) (any, error) {
 	var input renewCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
-	if err := h.Backend.RenewCertificate(input.CertificateArn); err != nil {
+	if err := h.Backend.RenewCertificate(ctx, input.CertificateArn); err != nil {
 		return nil, err
 	}
 
 	return &renewCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonExportCertificate(body []byte) (any, error) {
+func (h *Handler) jsonExportCertificate(ctx context.Context, body []byte) (any, error) {
 	var input exportCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
@@ -841,7 +848,7 @@ func (h *Handler) jsonExportCertificate(body []byte) (any, error) {
 		}
 	}
 
-	cert, err := h.Backend.ExportCertificate(input.CertificateArn, passphrase)
+	cert, err := h.Backend.ExportCertificate(ctx, input.CertificateArn, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -853,12 +860,12 @@ func (h *Handler) jsonExportCertificate(body []byte) (any, error) {
 	}, nil
 }
 
-func (h *Handler) jsonGetCertificate(body []byte) (any, error) {
+func (h *Handler) jsonGetCertificate(ctx context.Context, body []byte) (any, error) {
 	var input getCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
-	certBody, certChain, err := h.Backend.GetCertificate(input.CertificateArn)
+	certBody, certChain, err := h.Backend.GetCertificate(ctx, input.CertificateArn)
 	if err != nil {
 		return nil, err
 	}
@@ -870,8 +877,8 @@ func (h *Handler) jsonGetCertificate(body []byte) (any, error) {
 }
 
 // jsonGetAccountConfiguration handles the GetAccountConfiguration operation.
-func (h *Handler) jsonGetAccountConfiguration(_ []byte) (any, error) {
-	cfg := h.Backend.GetAccountConfiguration()
+func (h *Handler) jsonGetAccountConfiguration(ctx context.Context, _ []byte) (any, error) {
+	cfg := h.Backend.GetAccountConfiguration(ctx)
 	days := cfg.DaysBeforeExpiry
 
 	return &getAccountConfigurationOutput{
@@ -879,7 +886,7 @@ func (h *Handler) jsonGetAccountConfiguration(_ []byte) (any, error) {
 	}, nil
 }
 
-func (h *Handler) jsonPutAccountConfiguration(body []byte) (any, error) {
+func (h *Handler) jsonPutAccountConfiguration(ctx context.Context, body []byte) (any, error) {
 	var input putAccountConfigurationInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
@@ -890,46 +897,48 @@ func (h *Handler) jsonPutAccountConfiguration(body []byte) (any, error) {
 		days = input.ExpiryEvents.DaysBeforeExpiry
 	}
 
-	if err := h.Backend.PutAccountConfiguration(input.IdempotencyToken, days); err != nil {
+	if err := h.Backend.PutAccountConfiguration(ctx, input.IdempotencyToken, days); err != nil {
 		return nil, err
 	}
 
 	return &putAccountConfigurationOutput{}, nil
 }
 
-func (h *Handler) jsonResendValidationEmail(body []byte) (any, error) {
+func (h *Handler) jsonResendValidationEmail(ctx context.Context, body []byte) (any, error) {
 	var input resendValidationEmailInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.ResendValidationEmail(input.CertificateArn, input.Domain, input.ValidationDomain); err != nil {
+	err := h.Backend.ResendValidationEmail(ctx, input.CertificateArn, input.Domain, input.ValidationDomain)
+	if err != nil {
 		return nil, err
 	}
 
 	return &resendValidationEmailOutput{}, nil
 }
 
-func (h *Handler) jsonRevokeCertificate(body []byte) (any, error) {
+func (h *Handler) jsonRevokeCertificate(ctx context.Context, body []byte) (any, error) {
 	var input revokeCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.RevokeCertificate(input.CertificateArn, input.RevocationReason); err != nil {
+	if err := h.Backend.RevokeCertificate(ctx, input.CertificateArn, input.RevocationReason); err != nil {
 		return nil, err
 	}
 
 	return &revokeCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonUpdateCertificateOptions(body []byte) (any, error) {
+func (h *Handler) jsonUpdateCertificateOptions(ctx context.Context, body []byte) (any, error) {
 	var input updateCertificateOptionsInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	if err := h.Backend.UpdateCertificateOptions(
+		ctx,
 		input.CertificateArn,
 		input.Options.CertificateTransparencyLoggingPreference,
 	); err != nil {

--- a/services/acm/handler_test.go
+++ b/services/acm/handler_test.go
@@ -1,6 +1,7 @@
 package acm_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -229,7 +230,7 @@ func TestACMHandler_ImportCertificate(t *testing.T) {
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 	// Request cert to get a PEM body and key
-	cert, err := b.RequestCertificate("import-test.example.com", "", "", "", "", "", "", nil)
+	cert, err := b.RequestCertificate(context.Background(), "import-test.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	certPEM := cert.CertificateBody
@@ -314,10 +315,10 @@ func TestACMHandler_ExportCertificate(t *testing.T) {
 	t.Parallel()
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	cert, err := b.RequestCertificate("export-test.example.com", "", "", "", "", "", "", nil)
+	cert, err := b.RequestCertificate(context.Background(), "export-test.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
-	importedCert, err := b.ImportCertificate(cert.CertificateBody, cert.PrivateKey, "", "")
+	importedCert, err := b.ImportCertificate(context.Background(), cert.CertificateBody, cert.PrivateKey, "", "")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1058,7 +1059,7 @@ func TestACMHandler_ImportCertificate_RealistFields(t *testing.T) {
 
 	// First create a cert to get PEM material
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	src, err := b.RequestCertificate("import-realism.example.com", "", "", "", "", "", "", nil)
+	src, err := b.RequestCertificate(context.Background(), "import-realism.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	body, _ := json.Marshal(map[string]string{
@@ -1096,9 +1097,9 @@ func TestACMHandler_ImportCertificate_ReImport(t *testing.T) {
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
 
 	// Create two certs to get two sets of PEM material
-	src1, err := b.RequestCertificate("reimport.example.com", "", "", "", "", "", "", nil)
+	src1, err := b.RequestCertificate(context.Background(), "reimport.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
-	src2, err := b.RequestCertificate("reimport2.example.com", "", "", "", "", "", "", nil)
+	src2, err := b.RequestCertificate(context.Background(), "reimport2.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	// Import first cert
@@ -1581,10 +1582,10 @@ func TestACMHandler_ExportCertificate_PassphraseRequired(t *testing.T) {
 	t.Parallel()
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	src, err := b.RequestCertificate("export-pass.example.com", "", "", "", "", "", "", nil)
+	src, err := b.RequestCertificate(context.Background(), "export-pass.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
-	importedCert, err := b.ImportCertificate(src.CertificateBody, src.PrivateKey, "", "")
+	importedCert, err := b.ImportCertificate(context.Background(), src.CertificateBody, src.PrivateKey, "", "")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1729,14 +1730,24 @@ func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
 			name: "issued_to_expired",
 			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("lifecycle-expire.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"lifecycle-expire.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
 			},
 			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
 				t.Helper()
-				require.NoError(t, b.ExpireCertificate(certARN))
+				require.NoError(t, b.ExpireCertificate(context.Background(), certARN))
 			},
 			wantStatus: "EXPIRED",
 		},
@@ -1744,14 +1755,24 @@ func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
 			name: "issued_to_inactive",
 			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("lifecycle-inactive.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"lifecycle-inactive.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 
 				return cert.ARN
 			},
 			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
 				t.Helper()
-				require.NoError(t, b.InactivateCertificate(certARN))
+				require.NoError(t, b.InactivateCertificate(context.Background(), certARN))
 			},
 			wantStatus: "INACTIVE",
 		},
@@ -1759,7 +1780,17 @@ func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
 			name: "pending_to_validation_timed_out",
 			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("lifecycle-timeout.example.com", "", "DNS", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"lifecycle-timeout.example.com",
+					"",
+					"DNS",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 				require.Equal(t, "PENDING_VALIDATION", cert.Status)
 
@@ -1767,7 +1798,7 @@ func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
 			},
 			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
 				t.Helper()
-				require.NoError(t, b.TimeoutPendingValidation(certARN))
+				require.NoError(t, b.TimeoutPendingValidation(context.Background(), certARN))
 			},
 			wantStatus: "VALIDATION_TIMED_OUT",
 		},
@@ -1775,7 +1806,17 @@ func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
 			name: "pending_to_failed",
 			setupCert: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("lifecycle-fail.example.com", "", "EMAIL", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"lifecycle-fail.example.com",
+					"",
+					"EMAIL",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
 				require.Equal(t, "PENDING_VALIDATION", cert.Status)
 
@@ -1783,7 +1824,7 @@ func TestACMHandler_StatusLifecycle_DescribeReflectsNewStatus(t *testing.T) {
 			},
 			transition: func(t *testing.T, b *acm.InMemoryBackend, certARN string) {
 				t.Helper()
-				require.NoError(t, b.FailCertificate(certARN, "NO_AVAILABLE_CONTACTS"))
+				require.NoError(t, b.FailCertificate(context.Background(), certARN, "NO_AVAILABLE_CONTACTS"))
 			},
 			wantStatus: "FAILED",
 		},
@@ -1829,9 +1870,19 @@ func TestACMHandler_ListCertificates_StatusFilter_AllStatuses(t *testing.T) {
 			name: "filter_expired_status",
 			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("expired-list.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"expired-list.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.ExpireCertificate(cert.ARN))
+				require.NoError(t, b.ExpireCertificate(context.Background(), cert.ARN))
 
 				return cert.ARN
 			},
@@ -1842,9 +1893,19 @@ func TestACMHandler_ListCertificates_StatusFilter_AllStatuses(t *testing.T) {
 			name: "filter_inactive_status",
 			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("inactive-list.example.com", "", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"inactive-list.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.InactivateCertificate(cert.ARN))
+				require.NoError(t, b.InactivateCertificate(context.Background(), cert.ARN))
 
 				return cert.ARN
 			},
@@ -1855,9 +1916,19 @@ func TestACMHandler_ListCertificates_StatusFilter_AllStatuses(t *testing.T) {
 			name: "filter_timed_out_status",
 			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("timeout-list.example.com", "", "DNS", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"timeout-list.example.com",
+					"",
+					"DNS",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.TimeoutPendingValidation(cert.ARN))
+				require.NoError(t, b.TimeoutPendingValidation(context.Background(), cert.ARN))
 
 				return cert.ARN
 			},
@@ -1868,9 +1939,19 @@ func TestACMHandler_ListCertificates_StatusFilter_AllStatuses(t *testing.T) {
 			name: "filter_failed_status",
 			setupAndTransition: func(t *testing.T, b *acm.InMemoryBackend) string {
 				t.Helper()
-				cert, err := b.RequestCertificate("failed-list.example.com", "", "EMAIL", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"failed-list.example.com",
+					"",
+					"EMAIL",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.FailCertificate(cert.ARN, "CAA_ERROR"))
+				require.NoError(t, b.FailCertificate(context.Background(), cert.ARN, "CAA_ERROR"))
 
 				return cert.ARN
 			},
@@ -1914,11 +1995,11 @@ func TestACMHandler_ExportCertificate_CertificateChainAlwaysPresent(t *testing.T
 	t.Parallel()
 
 	b := acm.NewInMemoryBackend("000000000000", "us-east-1")
-	src, err := b.RequestCertificate("chain-test.example.com", "", "", "", "", "", "", nil)
+	src, err := b.RequestCertificate(context.Background(), "chain-test.example.com", "", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	// Import without chain
-	imported, err := b.ImportCertificate(src.CertificateBody, src.PrivateKey, "", "")
+	imported, err := b.ImportCertificate(context.Background(), src.CertificateBody, src.PrivateKey, "", "")
 	require.NoError(t, err)
 
 	h := acm.NewHandler(b)

--- a/services/acm/isolation_test.go
+++ b/services/acm/isolation_test.go
@@ -1,0 +1,77 @@
+package acm //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func acmCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func TestACMRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := acmCtxRegion("us-east-1")
+	ctxWest := acmCtxRegion("us-west-2")
+
+	// 1. Request a certificate for the same domain in us-east-1.
+	eastCert, err := backend.RequestCertificate(ctxEast, "example.com", "", "", "", "", "", "", nil)
+	require.NoError(t, err)
+	assert.Contains(t, eastCert.ARN, "us-east-1")
+
+	// 2. Request a certificate for the SAME domain in us-west-2.
+	westCert, err := backend.RequestCertificate(ctxWest, "example.com", "", "", "", "", "", "", nil)
+	require.NoError(t, err)
+	assert.Contains(t, westCert.ARN, "us-west-2")
+
+	// 3. us-east-1 sees only its own certificate.
+	eastList, err := backend.ListCertificates(ctxEast, ListCertificatesParams{})
+	require.NoError(t, err)
+	require.Len(t, eastList.Data, 1)
+	assert.Equal(t, eastCert.ARN, eastList.Data[0].ARN)
+
+	// 4. us-west-2 sees only its own certificate.
+	westList, err := backend.ListCertificates(ctxWest, ListCertificatesParams{})
+	require.NoError(t, err)
+	require.Len(t, westList.Data, 1)
+	assert.Equal(t, westCert.ARN, westList.Data[0].ARN)
+
+	// 5. A cert created in us-east-1 is not describable from us-west-2.
+	_, err = backend.DescribeCertificate(ctxWest, eastCert.ARN)
+	require.Error(t, err)
+
+	got, err := backend.DescribeCertificate(ctxEast, eastCert.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, eastCert.ARN, got.ARN)
+
+	// Deleting in us-east-1 leaves us-west-2's cert intact.
+	require.NoError(t, backend.DeleteCertificate(ctxEast, eastCert.ARN))
+
+	_, err = backend.DescribeCertificate(ctxEast, eastCert.ARN)
+	require.Error(t, err)
+
+	_, err = backend.DescribeCertificate(ctxWest, westCert.ARN)
+	require.NoError(t, err)
+}
+
+func TestACMAccountConfigurationRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := acmCtxRegion("us-east-1")
+	ctxWest := acmCtxRegion("us-west-2")
+
+	days := int32(30)
+	require.NoError(t, backend.PutAccountConfiguration(ctxEast, "tok-east", &days))
+
+	// us-east-1 reflects the new value; us-west-2 keeps the default.
+	assert.Equal(t, int32(30), backend.GetAccountConfiguration(ctxEast).DaysBeforeExpiry)
+	assert.Equal(t, defaultDaysBeforeExpiry, backend.GetAccountConfiguration(ctxWest).DaysBeforeExpiry)
+}

--- a/services/acm/janitor.go
+++ b/services/acm/janitor.go
@@ -36,33 +36,10 @@ func (b *InMemoryBackend) sweepIdempotencyMaps(ctx context.Context) {
 	cutoffIdempotency := now.Add(-defaultIdempotencyRetention)
 	removedCount := 0
 
-	for token, entry := range b.idempotencyMap {
-		if entry.CreatedAt.Before(cutoffIdempotency) {
-			delete(b.idempotencyMap, token)
-			removedCount++
-		}
-	}
+	removedCount += sweepCertTokens(b.idempotencyMap, cutoffIdempotency)
+	removedCount += sweepAccountTokens(b.accountIdempotency, cutoffIdempotency)
 
-	for token, entry := range b.accountIdempotency {
-		if entry.CreatedAt.Before(cutoffIdempotency) {
-			delete(b.accountIdempotency, token)
-			removedCount++
-		}
-	}
-
-	// Abandoned pending validations (72h limit in AWS)
-	cutoffPending := now.Add(-72 * time.Hour)
-
-	for _, cert := range b.certs {
-		if cert.Status == statusPendingValidation && cert.CreatedAt.Before(cutoffPending) {
-			cert.Status = statusValidationTimedOut
-			cert.FailureReason = "VALIDATION_TIMED_OUT"
-		}
-
-		if cert.Status == statusIssued && !cert.NotAfter.IsZero() && cert.NotAfter.Before(now) {
-			cert.Status = statusExpired
-		}
-	}
+	b.sweepStaleCerts(now)
 
 	removedCount += b.sweepTimers()
 
@@ -74,25 +51,81 @@ func (b *InMemoryBackend) sweepIdempotencyMaps(ctx context.Context) {
 	telemetry.RecordWorkerTask("acm", "AcmJanitor", "success")
 }
 
+// sweepCertTokens removes expired RequestCertificate idempotency tokens across all
+// regions and returns the number removed.
+func sweepCertTokens(m map[string]map[string]certIdempotencyEntry, cutoff time.Time) int {
+	removed := 0
+	for _, regionTokens := range m {
+		for token, entry := range regionTokens {
+			if entry.CreatedAt.Before(cutoff) {
+				delete(regionTokens, token)
+				removed++
+			}
+		}
+	}
+
+	return removed
+}
+
+// sweepAccountTokens removes expired PutAccountConfiguration idempotency tokens across
+// all regions and returns the number removed.
+func sweepAccountTokens(m map[string]map[string]accountIdempotencyEntry, cutoff time.Time) int {
+	removed := 0
+	for _, regionTokens := range m {
+		for token, entry := range regionTokens {
+			if entry.CreatedAt.Before(cutoff) {
+				delete(regionTokens, token)
+				removed++
+			}
+		}
+	}
+
+	return removed
+}
+
+// sweepStaleCerts times out abandoned pending validations and expires certificates whose
+// NotAfter has passed, across all regions. Callers must hold b.mu.
+func (b *InMemoryBackend) sweepStaleCerts(now time.Time) {
+	// Abandoned pending validations (72h limit in AWS).
+	cutoffPending := now.Add(-72 * time.Hour)
+
+	for _, regionCerts := range b.certs {
+		for _, cert := range regionCerts {
+			if cert.Status == statusPendingValidation && cert.CreatedAt.Before(cutoffPending) {
+				cert.Status = statusValidationTimedOut
+				cert.FailureReason = "VALIDATION_TIMED_OUT"
+			}
+
+			if cert.Status == statusIssued && !cert.NotAfter.IsZero() && cert.NotAfter.Before(now) {
+				cert.Status = statusExpired
+			}
+		}
+	}
+}
+
 func (b *InMemoryBackend) sweepTimers() int {
 	removedCount := 0
-	for arn, timer := range b.timers {
-		cert, ok := b.certs[arn]
-		if !ok {
-			timer.Stop()
-			delete(b.timers, arn)
-			removedCount++
+	for region, regionTimers := range b.timers {
+		certs := b.certs[region]
+		for arn, timer := range regionTimers {
+			cert, ok := certs[arn]
+			if !ok {
+				timer.Stop()
+				delete(regionTimers, arn)
+				removedCount++
 
-			continue
-		}
+				continue
+			}
 
-		isPending := cert.Status == statusPendingValidation
-		hasRenewal := cert.RenewalSummary != nil && cert.RenewalSummary.RenewalStatus == renewalStatusPendingValidation
+			isPending := cert.Status == statusPendingValidation
+			hasRenewal := cert.RenewalSummary != nil &&
+				cert.RenewalSummary.RenewalStatus == renewalStatusPendingValidation
 
-		if !isPending && !hasRenewal {
-			timer.Stop()
-			delete(b.timers, arn)
-			removedCount++
+			if !isPending && !hasRenewal {
+				timer.Stop()
+				delete(regionTimers, arn)
+				removedCount++
+			}
 		}
 	}
 

--- a/services/acm/persistence.go
+++ b/services/acm/persistence.go
@@ -7,13 +7,14 @@ import (
 	svcTags "github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
+// backendSnapshot mirrors the region-nested backend maps (outer key = region).
 type backendSnapshot struct {
-	Certs              map[string]*Certificate            `json:"certs"`
-	IdempotencyMap     map[string]certIdempotencyEntry    `json:"idempotencyMap,omitempty"`
-	AccountIdempotency map[string]accountIdempotencyEntry `json:"accountIdempotency,omitempty"`
-	AccountID          string                             `json:"accountID"`
-	Region             string                             `json:"region"`
-	AccountConfig      AccountConfig                      `json:"accountConfig"`
+	Certs              map[string]map[string]*Certificate            `json:"certs"`
+	IdempotencyMap     map[string]map[string]certIdempotencyEntry    `json:"idempotencyMap,omitempty"`
+	AccountIdempotency map[string]map[string]accountIdempotencyEntry `json:"accountIdempotency,omitempty"`
+	AccountConfig      map[string]AccountConfig                      `json:"accountConfig"`
+	AccountID          string                                        `json:"accountID"`
+	Region             string                                        `json:"region"`
 }
 
 type handlerSnapshot struct {
@@ -57,20 +58,19 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	defer b.mu.Unlock()
 
 	if snap.Certs == nil {
-		snap.Certs = make(map[string]*Certificate)
+		snap.Certs = make(map[string]map[string]*Certificate)
 	}
 
 	if snap.IdempotencyMap == nil {
-		snap.IdempotencyMap = make(map[string]certIdempotencyEntry)
+		snap.IdempotencyMap = make(map[string]map[string]certIdempotencyEntry)
 	}
 
 	if snap.AccountIdempotency == nil {
-		snap.AccountIdempotency = make(map[string]accountIdempotencyEntry)
+		snap.AccountIdempotency = make(map[string]map[string]accountIdempotencyEntry)
 	}
 
-	// Preserve default if snapshot was taken before accountConfig was tracked.
-	if snap.AccountConfig.DaysBeforeExpiry == 0 {
-		snap.AccountConfig.DaysBeforeExpiry = defaultDaysBeforeExpiry
+	if snap.AccountConfig == nil {
+		snap.AccountConfig = make(map[string]AccountConfig)
 	}
 
 	b.certs = snap.Certs
@@ -79,19 +79,24 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.accountConfig = snap.AccountConfig
 	b.accountID = snap.AccountID
 	b.region = snap.Region
+	b.timers = make(map[string]map[string]*time.Timer)
 
-	// Restart timers for pending validations.
-	for arn, cert := range b.certs {
-		if cert.Status == statusPendingValidation {
-			t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func(a string) func() {
-				return func() { b.autoValidate(a) }
-			}(arn))
-			b.timers[arn] = t
-		} else if cert.RenewalSummary != nil && cert.RenewalSummary.RenewalStatus == renewalStatusPendingValidation {
-			t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func(a string) func() {
-				return func() { b.autoValidateRenewal(a) }
-			}(arn))
-			b.timers[arn] = t
+	// Restart timers for pending validations, per region.
+	for region, regionCerts := range b.certs {
+		for arn, cert := range regionCerts {
+			switch {
+			case cert.Status == statusPendingValidation:
+				t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func(r, a string) func() {
+					return func() { b.autoValidate(r, a) }
+				}(region, arn))
+				b.timersStore(region)[arn] = t
+			case cert.RenewalSummary != nil &&
+				cert.RenewalSummary.RenewalStatus == renewalStatusPendingValidation:
+				t := time.AfterFunc(autoValidateDelayMS*time.Millisecond, func(r, a string) func() {
+					return func() { b.autoValidateRenewal(r, a) }
+				}(region, arn))
+				b.timersStore(region)[arn] = t
+			}
 		}
 	}
 

--- a/services/acm/persistence_test.go
+++ b/services/acm/persistence_test.go
@@ -1,6 +1,7 @@
 package acm_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,7 +25,17 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "round_trip_preserves_state",
 			setup: func(b *acm.InMemoryBackend) string {
-				cert, err := b.RequestCertificate("example.com", "AMAZON_ISSUED", "", "", "", "", "", nil)
+				cert, err := b.RequestCertificate(
+					context.Background(),
+					"example.com",
+					"AMAZON_ISSUED",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				if err != nil {
 					return ""
 				}
@@ -34,7 +45,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *acm.InMemoryBackend, id string) {
 				t.Helper()
 
-				cert, err := b.DescribeCertificate(id)
+				cert, err := b.DescribeCertificate(context.Background(), id)
 				require.NoError(t, err)
 				assert.Equal(t, "example.com", cert.DomainName)
 				assert.Equal(t, id, cert.ARN)
@@ -44,11 +55,21 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "round_trip_preserves_imported_cert",
 			setup: func(b *acm.InMemoryBackend) string {
-				src, err := b.RequestCertificate("imported.example.com", "", "", "", "", "", "", nil)
+				src, err := b.RequestCertificate(
+					context.Background(),
+					"imported.example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					nil,
+				)
 				if err != nil {
 					return ""
 				}
-				imported, err := b.ImportCertificate(src.CertificateBody, src.PrivateKey, "", "")
+				imported, err := b.ImportCertificate(context.Background(), src.CertificateBody, src.PrivateKey, "", "")
 				if err != nil {
 					return ""
 				}
@@ -58,7 +79,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *acm.InMemoryBackend, id string) {
 				t.Helper()
 
-				cert, err := b.DescribeCertificate(id)
+				cert, err := b.DescribeCertificate(context.Background(), id)
 				require.NoError(t, err)
 				assert.Equal(t, "IMPORTED", cert.Type)
 				assert.NotEmpty(t, cert.CertificateBody)
@@ -71,7 +92,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *acm.InMemoryBackend, _ string) {
 				t.Helper()
 
-				p, _ := b.ListCertificates(acm.ListCertificatesParams{})
+				p, _ := b.ListCertificates(context.Background(), acm.ListCertificatesParams{})
 				certs := p.Data
 				assert.Empty(t, certs)
 			},
@@ -111,7 +132,7 @@ func TestACMHandler_Persistence(t *testing.T) {
 	h := acm.NewHandler(backend)
 
 	// Create a cert
-	_, err := backend.RequestCertificate("example.com", "AMAZON_ISSUED", "", "", "", "", "", nil)
+	_, err := backend.RequestCertificate(context.Background(), "example.com", "AMAZON_ISSUED", "", "", "", "", "", nil)
 	require.NoError(t, err)
 
 	// Test Handler.Snapshot/Restore delegation
@@ -122,7 +143,7 @@ func TestACMHandler_Persistence(t *testing.T) {
 	freshH := acm.NewHandler(fresh)
 	require.NoError(t, freshH.Restore(snap))
 
-	p, _ := fresh.ListCertificates(acm.ListCertificatesParams{})
+	p, _ := fresh.ListCertificates(context.Background(), acm.ListCertificatesParams{})
 	certs := p.Data
 	assert.Len(t, certs, 1)
 }

--- a/services/acmpca/acmpca_coverage_test.go
+++ b/services/acmpca/acmpca_coverage_test.go
@@ -1,6 +1,7 @@
 package acmpca_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -137,13 +138,13 @@ func TestACMPCAHandler_IssueCertAndRevoke(t *testing.T) {
 	h := acmpca.NewHandler(b)
 
 	// Create CA
-	ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
+	ca, err := b.CreateCertificateAuthority(context.Background(), "ROOT", acmpca.CertificateAuthorityConfiguration{
 		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test Issue CA"},
 	})
 	require.NoError(t, err)
 
 	// Get CSR from backend
-	csrPEM, err := b.GetCertificateAuthorityCsr(ca.ARN)
+	csrPEM, err := b.GetCertificateAuthorityCsr(context.Background(), ca.ARN)
 	require.NoError(t, err)
 
 	// IssueCertificate using the actual CSR
@@ -160,7 +161,7 @@ func TestACMPCAHandler_IssueCertAndRevoke(t *testing.T) {
 	require.NotEmpty(t, certARN)
 
 	// GetCertificate via backend
-	cert, err := b.GetCertificate(ca.ARN, certARN)
+	cert, err := b.GetCertificate(context.Background(), ca.ARN, certARN)
 	require.NoError(t, err)
 	assert.NotEmpty(t, cert.ARN)
 
@@ -172,7 +173,7 @@ func TestACMPCAHandler_IssueCertAndRevoke(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 
 	// RevokeCertificate - cert exists but serial lookup uses backend directly
-	issuedCert, err := b.GetCertificate(ca.ARN, certARN)
+	issuedCert, err := b.GetCertificate(context.Background(), ca.ARN, certARN)
 	require.NoError(t, err)
 
 	rec = doACMPCARequest(t, h, "RevokeCertificate", map[string]any{
@@ -371,18 +372,22 @@ func TestACMPCAHandler_ToCAOutput(t *testing.T) {
 	h := newACMPCAHandler()
 
 	// Create CA with full subject
-	ca, err := h.Backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-		Subject: acmpca.CertificateAuthoritySubject{
-			CommonName:         "Full CA",
-			Country:            "US",
-			Organization:       "Test Org",
-			OrganizationalUnit: "Test Unit",
-			State:              "CA",
-			Locality:           "SF",
+	ca, err := h.Backend.CreateCertificateAuthority(
+		context.Background(),
+		"ROOT",
+		acmpca.CertificateAuthorityConfiguration{
+			Subject: acmpca.CertificateAuthoritySubject{
+				CommonName:         "Full CA",
+				Country:            "US",
+				Organization:       "Test Org",
+				OrganizationalUnit: "Test Unit",
+				State:              "CA",
+				Locality:           "SF",
+			},
+			KeyAlgorithm:     "RSA_2048",
+			SigningAlgorithm: "SHA256WITHRSA",
 		},
-		KeyAlgorithm:     "RSA_2048",
-		SigningAlgorithm: "SHA256WITHRSA",
-	})
+	)
 	require.NoError(t, err)
 
 	// Describe - exercises toCAOutput

--- a/services/acmpca/backend.go
+++ b/services/acmpca/backend.go
@@ -1,6 +1,7 @@
 package acmpca
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	cryptorand "crypto/rand"
@@ -21,6 +22,18 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/page"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 var (
 	// ErrCANotFound is returned when a Certificate Authority is not found.
@@ -150,13 +163,15 @@ type AuditReport struct {
 }
 
 // InMemoryBackend is the in-memory store for ACM PCA resources.
+// InMemoryBackend stores ACM PCA state. All resource maps are nested by region
+// (outer key = region) so that resources are isolated per region.
 type InMemoryBackend struct {
-	cas             map[string]*CertificateAuthority
-	certs           map[string]*IssuedCertificate
-	certsByCASerial map[string]string // caARN+"#"+serial → certARN (O(1) RevokeCertificate)
-	permissions     map[string]*Permission
-	auditReports    map[string]*AuditReport
-	policies        map[string]string
+	cas             map[string]map[string]*CertificateAuthority
+	certs           map[string]map[string]*IssuedCertificate
+	certsByCASerial map[string]map[string]string // region → caARN+"#"+serial → certARN
+	permissions     map[string]map[string]*Permission
+	auditReports    map[string]map[string]*AuditReport
+	policies        map[string]map[string]string
 	mu              *lockmetrics.RWMutex
 	accountID       string
 	region          string
@@ -165,12 +180,12 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		cas:             make(map[string]*CertificateAuthority),
-		certs:           make(map[string]*IssuedCertificate),
-		certsByCASerial: make(map[string]string),
-		permissions:     make(map[string]*Permission),
-		auditReports:    make(map[string]*AuditReport),
-		policies:        make(map[string]string),
+		cas:             make(map[string]map[string]*CertificateAuthority),
+		certs:           make(map[string]map[string]*IssuedCertificate),
+		certsByCASerial: make(map[string]map[string]string),
+		permissions:     make(map[string]map[string]*Permission),
+		auditReports:    make(map[string]map[string]*AuditReport),
+		policies:        make(map[string]map[string]string),
 		accountID:       accountID,
 		region:          region,
 		mu:              lockmetrics.New("acmpca"),
@@ -180,8 +195,60 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 // Region returns the AWS region this backend is configured for.
 func (b *InMemoryBackend) Region() string { return b.region }
 
+// The *Store helpers return the per-region inner map, lazily creating it.
+// Callers must hold b.mu.
+
+func (b *InMemoryBackend) casStore(region string) map[string]*CertificateAuthority {
+	if b.cas[region] == nil {
+		b.cas[region] = make(map[string]*CertificateAuthority)
+	}
+
+	return b.cas[region]
+}
+
+func (b *InMemoryBackend) certsStore(region string) map[string]*IssuedCertificate {
+	if b.certs[region] == nil {
+		b.certs[region] = make(map[string]*IssuedCertificate)
+	}
+
+	return b.certs[region]
+}
+
+func (b *InMemoryBackend) certsByCASerialStore(region string) map[string]string {
+	if b.certsByCASerial[region] == nil {
+		b.certsByCASerial[region] = make(map[string]string)
+	}
+
+	return b.certsByCASerial[region]
+}
+
+func (b *InMemoryBackend) permissionsStore(region string) map[string]*Permission {
+	if b.permissions[region] == nil {
+		b.permissions[region] = make(map[string]*Permission)
+	}
+
+	return b.permissions[region]
+}
+
+func (b *InMemoryBackend) auditReportsStore(region string) map[string]*AuditReport {
+	if b.auditReports[region] == nil {
+		b.auditReports[region] = make(map[string]*AuditReport)
+	}
+
+	return b.auditReports[region]
+}
+
+func (b *InMemoryBackend) policiesStore(region string) map[string]string {
+	if b.policies[region] == nil {
+		b.policies[region] = make(map[string]string)
+	}
+
+	return b.policies[region]
+}
+
 // CreateCertificateAuthority creates a new Certificate Authority.
 func (b *InMemoryBackend) CreateCertificateAuthority(
+	ctx context.Context,
 	caType string,
 	cfg CertificateAuthorityConfiguration,
 ) (*CertificateAuthority, error) {
@@ -193,6 +260,8 @@ func (b *InMemoryBackend) CreateCertificateAuthority(
 		return nil, fmt.Errorf("%w: CertificateAuthorityType must be ROOT or SUBORDINATE", ErrInvalidParameter)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateCertificateAuthority")
 	defer b.mu.Unlock()
 
@@ -201,7 +270,7 @@ func (b *InMemoryBackend) CreateCertificateAuthority(
 		return nil, err
 	}
 
-	caARN := arn.Build("acm-pca", b.region, b.accountID, caResourceIDPrefix+id)
+	caARN := arn.Build("acm-pca", region, b.accountID, caResourceIDPrefix+id)
 
 	if cfg.KeyAlgorithm == "" {
 		cfg.KeyAlgorithm = defaultKeyAlgorithm
@@ -232,7 +301,7 @@ func (b *InMemoryBackend) CreateCertificateAuthority(
 		privKey:                           privKey,
 	}
 
-	b.cas[caARN] = ca
+	b.casStore(region)[caARN] = ca
 
 	// For ROOT CAs we auto-sign and activate to make Terraform apply succeed without
 	// requiring a multi-step workflow.
@@ -268,11 +337,13 @@ func (b *InMemoryBackend) selfSignAndActivate(ca *CertificateAuthority, now time
 }
 
 // verifyCertificateAuthorityActive checks that the CA exists and is not DELETED.
-func (b *InMemoryBackend) verifyCertificateAuthorityActive(caARN string) error {
+func (b *InMemoryBackend) verifyCertificateAuthorityActive(ctx context.Context, caARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("verifyCertificateAuthorityActive")
 	defer b.mu.RUnlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -285,15 +356,19 @@ func (b *InMemoryBackend) verifyCertificateAuthorityActive(caARN string) error {
 }
 
 // DescribeCertificateAuthority returns the CA with the given ARN.
-func (b *InMemoryBackend) DescribeCertificateAuthority(caARN string) (*CertificateAuthority, error) {
+func (b *InMemoryBackend) DescribeCertificateAuthority(
+	ctx context.Context, caARN string,
+) (*CertificateAuthority, error) {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeCertificateAuthority")
 	defer b.mu.RUnlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return nil, fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -304,11 +379,16 @@ func (b *InMemoryBackend) DescribeCertificateAuthority(caARN string) (*Certifica
 }
 
 // ListCertificateAuthorities returns a paginated list of CAs sorted by ARN.
-func (b *InMemoryBackend) ListCertificateAuthorities(nextToken string, maxItems int) page.Page[CertificateAuthority] {
+func (b *InMemoryBackend) ListCertificateAuthorities(
+	ctx context.Context, nextToken string, maxItems int,
+) page.Page[CertificateAuthority] {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListCertificateAuthorities")
 
-	cas := make([]CertificateAuthority, 0, len(b.cas))
-	for _, ca := range b.cas {
+	casMap := b.casStore(region)
+	cas := make([]CertificateAuthority, 0, len(casMap))
+	for _, ca := range casMap {
 		cas = append(cas, copyCA(ca))
 	}
 	b.mu.RUnlock()
@@ -319,7 +399,9 @@ func (b *InMemoryBackend) ListCertificateAuthorities(nextToken string, maxItems 
 }
 
 // DeleteCertificateAuthority marks the CA as DELETED.
-func (b *InMemoryBackend) DeleteCertificateAuthority(caARN string, permanentDeletionDays int32) error {
+func (b *InMemoryBackend) DeleteCertificateAuthority(
+	ctx context.Context, caARN string, permanentDeletionDays int32,
+) error {
 	if permanentDeletionDays != 0 &&
 		(permanentDeletionDays < permanentDeletionMinDays || permanentDeletionDays > permanentDeletionMaxDays) {
 		return fmt.Errorf(
@@ -330,10 +412,12 @@ func (b *InMemoryBackend) DeleteCertificateAuthority(caARN string, permanentDele
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteCertificateAuthority")
 	defer b.mu.Unlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -355,7 +439,7 @@ func (b *InMemoryBackend) DeleteCertificateAuthority(caARN string, permanentDele
 }
 
 // UpdateCertificateAuthority updates the CA status.
-func (b *InMemoryBackend) UpdateCertificateAuthority(caARN, status string) error {
+func (b *InMemoryBackend) UpdateCertificateAuthority(ctx context.Context, caARN, status string) error {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return err
 	}
@@ -364,10 +448,12 @@ func (b *InMemoryBackend) UpdateCertificateAuthority(caARN, status string) error
 		return fmt.Errorf("%w: status must be ACTIVE or DISABLED", ErrInvalidParameter)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateCertificateAuthority")
 	defer b.mu.Unlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -380,15 +466,17 @@ func (b *InMemoryBackend) UpdateCertificateAuthority(caARN, status string) error
 }
 
 // GetCertificateAuthorityCsr returns the CSR PEM for the given CA.
-func (b *InMemoryBackend) GetCertificateAuthorityCsr(caARN string) (string, error) {
+func (b *InMemoryBackend) GetCertificateAuthorityCsr(ctx context.Context, caARN string) (string, error) {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return "", err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetCertificateAuthorityCsr")
 	defer b.mu.RUnlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return "", fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -398,15 +486,19 @@ func (b *InMemoryBackend) GetCertificateAuthorityCsr(caARN string) (string, erro
 
 // ImportCertificateAuthorityCertificate imports a signed certificate for the CA, activating it.
 // It parses the certificate to extract NotBefore/NotAfter and stores the optional chain.
-func (b *InMemoryBackend) ImportCertificateAuthorityCertificate(caARN, certPEM, chainPEM string) error {
+func (b *InMemoryBackend) ImportCertificateAuthorityCertificate(
+	ctx context.Context, caARN, certPEM, chainPEM string,
+) error {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ImportCertificateAuthorityCertificate")
 	defer b.mu.Unlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -432,15 +524,19 @@ func (b *InMemoryBackend) ImportCertificateAuthorityCertificate(caARN, certPEM, 
 }
 
 // GetCertificateAuthorityCertificate returns the certificate body and chain PEM for the given CA.
-func (b *InMemoryBackend) GetCertificateAuthorityCertificate(caARN string) (string, string, error) {
+func (b *InMemoryBackend) GetCertificateAuthorityCertificate(
+	ctx context.Context, caARN string,
+) (string, string, error) {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return "", "", err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetCertificateAuthorityCertificate")
 	defer b.mu.RUnlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return "", "", fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -453,7 +549,9 @@ func (b *InMemoryBackend) GetCertificateAuthorityCertificate(caARN string) (stri
 }
 
 // IssueCertificate issues a new certificate signed by the given CA.
-func (b *InMemoryBackend) IssueCertificate(caARN, csrPEM string, validityDays int) (*IssuedCertificate, error) {
+func (b *InMemoryBackend) IssueCertificate(
+	ctx context.Context, caARN, csrPEM string, validityDays int,
+) (*IssuedCertificate, error) {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return nil, err
 	}
@@ -462,10 +560,12 @@ func (b *InMemoryBackend) IssueCertificate(caARN, csrPEM string, validityDays in
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("IssueCertificate")
 	defer b.mu.Unlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return nil, fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -488,7 +588,7 @@ func (b *InMemoryBackend) IssueCertificate(caARN, csrPEM string, validityDays in
 		return nil, err
 	}
 
-	certARN := arn.Build("acm-pca", b.region, b.accountID,
+	certARN := arn.Build("acm-pca", region, b.accountID,
 		caResourceIDPrefix+extractCAID(caARN)+"/"+certResourceIDPrefix+id)
 
 	now := time.Now().UTC()
@@ -503,8 +603,8 @@ func (b *InMemoryBackend) IssueCertificate(caARN, csrPEM string, validityDays in
 		NotAfter:  now.Add(time.Duration(validityDays) * 24 * time.Hour),
 	}
 
-	b.certs[certARN] = cert
-	b.certsByCASerial[caARN+"#"+serial] = certARN
+	b.certsStore(region)[certARN] = cert
+	b.certsByCASerialStore(region)[caARN+"#"+serial] = certARN
 
 	cp := *cert
 
@@ -513,11 +613,13 @@ func (b *InMemoryBackend) IssueCertificate(caARN, csrPEM string, validityDays in
 
 // GetCertificate returns the certificate for the given CA and certificate ARN.
 // It validates that the certificate belongs to the specified CA.
-func (b *InMemoryBackend) GetCertificate(caARN, certARN string) (*IssuedCertificate, error) {
+func (b *InMemoryBackend) GetCertificate(ctx context.Context, caARN, certARN string) (*IssuedCertificate, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetCertificate")
 	defer b.mu.RUnlock()
 
-	cert, ok := b.certs[certARN]
+	cert, ok := b.certsStore(region)[certARN]
 	if !ok {
 		return nil, fmt.Errorf("%w: certificate %s not found", ErrCertNotFound, certARN)
 	}
@@ -532,7 +634,7 @@ func (b *InMemoryBackend) GetCertificate(caARN, certARN string) (*IssuedCertific
 }
 
 // RevokeCertificate revokes the given certificate using the O(1) serial index.
-func (b *InMemoryBackend) RevokeCertificate(caARN, serial, revocationReason string) error {
+func (b *InMemoryBackend) RevokeCertificate(ctx context.Context, caARN, serial, revocationReason string) error {
 	if revocationReason != "" {
 		switch revocationReason {
 		case revocationReasonUnspecified, revocationReasonKeyCompromise, revocationReasonCACompromise,
@@ -544,10 +646,13 @@ func (b *InMemoryBackend) RevokeCertificate(caARN, serial, revocationReason stri
 		}
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RevokeCertificate")
 	defer b.mu.Unlock()
 
-	ca, ok := b.cas[caARN]
+	cas := b.casStore(region)
+	ca, ok := cas[caARN]
 	if !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -556,30 +661,34 @@ func (b *InMemoryBackend) RevokeCertificate(caARN, serial, revocationReason stri
 		return fmt.Errorf("%w: CA %s is DELETED", ErrInvalidState, caARN)
 	}
 
-	certARN, ok := b.certsByCASerial[caARN+"#"+serial]
+	certARN, ok := b.certsByCASerialStore(region)[caARN+"#"+serial]
 	if !ok {
 		return fmt.Errorf("%w: certificate with serial %s not found", ErrCertNotFound, serial)
 	}
 
-	b.certs[certARN].Status = certStatusRevoked
+	certs := b.certsStore(region)
+	certs[certARN].Status = certStatusRevoked
 	now := time.Now().UTC()
-	b.certs[certARN].RevokedAt = &now
-	b.certs[certARN].RevocationReason = revocationReason
+	certs[certARN].RevokedAt = &now
+	certs[certARN].RevocationReason = revocationReason
 
 	return nil
 }
 
 // ListCertificates returns a paginated list of certificates issued by the given CA.
 func (b *InMemoryBackend) ListCertificates(
+	ctx context.Context,
 	caARN string,
 	nextToken string,
 	maxItems int,
 ) page.Page[IssuedCertificate] {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListCertificates")
 	defer b.mu.RUnlock()
 
 	var certs []IssuedCertificate
-	for _, c := range b.certs {
+	for _, c := range b.certsStore(region) {
 		if c.CAARN == caARN {
 			certs = append(certs, *c)
 		}
@@ -592,6 +701,7 @@ func (b *InMemoryBackend) ListCertificates(
 
 // CreateCertificateAuthorityAuditReport creates a new audit report for the given CA.
 func (b *InMemoryBackend) CreateCertificateAuthorityAuditReport(
+	ctx context.Context,
 	caARN string,
 	s3BucketName string,
 	responseFormat string,
@@ -609,10 +719,12 @@ func (b *InMemoryBackend) CreateCertificateAuthorityAuditReport(
 		return nil, fmt.Errorf("%w: AuditReportResponseFormat must be JSON or CSV", ErrInvalidParameter)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateCertificateAuthorityAuditReport")
 	defer b.mu.Unlock()
 
-	auditCA, ok := b.cas[caARN]
+	auditCA, ok := b.casStore(region)[caARN]
 	if !ok {
 		return nil, fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -634,7 +746,7 @@ func (b *InMemoryBackend) CreateCertificateAuthorityAuditReport(
 		S3Key:                   fmt.Sprintf("%s%s.%s", reportResourcePrefix, id, strings.ToLower(format)),
 		Status:                  auditReportStatus,
 	}
-	b.auditReports[id] = report
+	b.auditReportsStore(region)[id] = report
 
 	cp := copyAuditReport(report)
 
@@ -643,6 +755,7 @@ func (b *InMemoryBackend) CreateCertificateAuthorityAuditReport(
 
 // DescribeCertificateAuthorityAuditReport returns the audit report for the given CA.
 func (b *InMemoryBackend) DescribeCertificateAuthorityAuditReport(
+	ctx context.Context,
 	caARN string,
 	auditReportID string,
 ) (*AuditReport, error) {
@@ -654,14 +767,16 @@ func (b *InMemoryBackend) DescribeCertificateAuthorityAuditReport(
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeCertificateAuthorityAuditReport")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return nil, fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
-	report, ok := b.auditReports[auditReportID]
+	report, ok := b.auditReportsStore(region)[auditReportID]
 	if !ok || report.CertificateAuthorityArn != caARN {
 		return nil, fmt.Errorf("%w: audit report %s not found", ErrAuditReportNotFound, auditReportID)
 	}
@@ -673,6 +788,7 @@ func (b *InMemoryBackend) DescribeCertificateAuthorityAuditReport(
 
 // CreatePermission creates a permission on the given CA.
 func (b *InMemoryBackend) CreatePermission(
+	ctx context.Context,
 	caARN string,
 	principal string,
 	sourceAccount string,
@@ -698,10 +814,12 @@ func (b *InMemoryBackend) CreatePermission(
 		}
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreatePermission")
 	defer b.mu.Unlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return nil, fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
@@ -713,7 +831,7 @@ func (b *InMemoryBackend) CreatePermission(
 		Principal:               principal,
 		SourceAccount:           sourceAccount,
 	}
-	b.permissions[key] = permission
+	b.permissionsStore(region)[key] = permission
 
 	cp := copyPermission(permission)
 
@@ -721,7 +839,7 @@ func (b *InMemoryBackend) CreatePermission(
 }
 
 // DeletePermission deletes a permission on the given CA.
-func (b *InMemoryBackend) DeletePermission(caARN, principal, sourceAccount string) error {
+func (b *InMemoryBackend) DeletePermission(ctx context.Context, caARN, principal, sourceAccount string) error {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return err
 	}
@@ -730,38 +848,46 @@ func (b *InMemoryBackend) DeletePermission(caARN, principal, sourceAccount strin
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeletePermission")
 	defer b.mu.Unlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
 	key := permissionKey(caARN, principal, sourceAccount)
-	if _, ok := b.permissions[key]; !ok {
+	permissions := b.permissionsStore(region)
+	if _, ok := permissions[key]; !ok {
 		return fmt.Errorf("%w: permission for principal %s not found", ErrPermissionNotFound, principal)
 	}
 
-	delete(b.permissions, key)
+	delete(permissions, key)
 
 	return nil
 }
 
 // ListPermissions lists permissions on the given CA.
-func (b *InMemoryBackend) ListPermissions(caARN, nextToken string, maxItems int) (page.Page[Permission], error) {
+func (b *InMemoryBackend) ListPermissions(
+	ctx context.Context, caARN, nextToken string, maxItems int,
+) (page.Page[Permission], error) {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return page.Page[Permission]{}, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListPermissions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return page.Page[Permission]{}, fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
-	perms := make([]Permission, 0, len(b.permissions))
-	for _, perm := range b.permissions {
+	permissions := b.permissionsStore(region)
+	perms := make([]Permission, 0, len(permissions))
+	for _, perm := range permissions {
 		if perm.CertificateAuthorityArn == caARN {
 			perms = append(perms, copyPermission(perm))
 		}
@@ -779,7 +905,7 @@ func (b *InMemoryBackend) ListPermissions(caARN, nextToken string, maxItems int)
 }
 
 // PutPolicy stores a resource policy on the given CA.
-func (b *InMemoryBackend) PutPolicy(caARN, policy string) error {
+func (b *InMemoryBackend) PutPolicy(ctx context.Context, caARN, policy string) error {
 	if err := validateRequiredParameter(caARN, "ResourceArn"); err != nil {
 		return err
 	}
@@ -788,32 +914,36 @@ func (b *InMemoryBackend) PutPolicy(caARN, policy string) error {
 		return fmt.Errorf("%w: Policy is required", ErrInvalidParameter)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
-	b.policies[caARN] = policy
+	b.policiesStore(region)[caARN] = policy
 
 	return nil
 }
 
 // GetPolicy returns the resource policy for the given CA.
-func (b *InMemoryBackend) GetPolicy(caARN string) (string, error) {
+func (b *InMemoryBackend) GetPolicy(ctx context.Context, caARN string) (string, error) {
 	if err := validateRequiredParameter(caARN, "ResourceArn"); err != nil {
 		return "", err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return "", fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
-	policy, ok := b.policies[caARN]
+	policy, ok := b.policiesStore(region)[caARN]
 	if !ok {
 		return "", fmt.Errorf("%w: policy for CA %s not found", ErrPolicyNotFound, caARN)
 	}
@@ -822,37 +952,42 @@ func (b *InMemoryBackend) GetPolicy(caARN string) (string, error) {
 }
 
 // DeletePolicy deletes the resource policy for the given CA.
-func (b *InMemoryBackend) DeletePolicy(caARN string) error {
+func (b *InMemoryBackend) DeletePolicy(ctx context.Context, caARN string) error {
 	if err := validateRequiredParameter(caARN, "ResourceArn"); err != nil {
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeletePolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.cas[caARN]; !ok {
+	if _, ok := b.casStore(region)[caARN]; !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
 
-	if _, ok := b.policies[caARN]; !ok {
+	policies := b.policiesStore(region)
+	if _, ok := policies[caARN]; !ok {
 		return fmt.Errorf("%w: policy for CA %s not found", ErrPolicyNotFound, caARN)
 	}
 
-	delete(b.policies, caARN)
+	delete(policies, caARN)
 
 	return nil
 }
 
 // RestoreCertificateAuthority restores a deleted CA into the DISABLED state.
-func (b *InMemoryBackend) RestoreCertificateAuthority(caARN string) error {
+func (b *InMemoryBackend) RestoreCertificateAuthority(ctx context.Context, caARN string) error {
 	if err := validateRequiredParameter(caARN, "CertificateAuthorityArn"); err != nil {
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RestoreCertificateAuthority")
 	defer b.mu.Unlock()
 
-	ca, ok := b.cas[caARN]
+	ca, ok := b.casStore(region)[caARN]
 	if !ok {
 		return fmt.Errorf("%w: CA %s not found", ErrCANotFound, caARN)
 	}
@@ -1087,10 +1222,10 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.cas = make(map[string]*CertificateAuthority)
-	b.certs = make(map[string]*IssuedCertificate)
-	b.certsByCASerial = make(map[string]string)
-	b.permissions = make(map[string]*Permission)
-	b.auditReports = make(map[string]*AuditReport)
-	b.policies = make(map[string]string)
+	b.cas = make(map[string]map[string]*CertificateAuthority)
+	b.certs = make(map[string]map[string]*IssuedCertificate)
+	b.certsByCASerial = make(map[string]map[string]string)
+	b.permissions = make(map[string]map[string]*Permission)
+	b.auditReports = make(map[string]map[string]*AuditReport)
+	b.policies = make(map[string]map[string]string)
 }

--- a/services/acmpca/backend_test.go
+++ b/services/acmpca/backend_test.go
@@ -1,6 +1,7 @@
 package acmpca_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +67,7 @@ func TestInMemoryBackend_CreateCertificateAuthority(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBackend()
-			ca, err := b.CreateCertificateAuthority(tt.caType, tt.cfg)
+			ca, err := b.CreateCertificateAuthority(context.Background(), tt.caType, tt.cfg)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -109,16 +110,20 @@ func TestInMemoryBackend_DescribeCertificateAuthority(t *testing.T) {
 			var caARN string
 
 			if tt.caARN == "" {
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+					},
+				)
 				require.NoError(t, err)
 				caARN = ca.ARN
 			} else {
 				caARN = tt.caARN
 			}
 
-			ca, err := b.DescribeCertificateAuthority(caARN)
+			ca, err := b.DescribeCertificateAuthority(context.Background(), caARN)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -159,13 +164,17 @@ func TestInMemoryBackend_ListCertificateAuthorities(t *testing.T) {
 			b := newTestBackend()
 
 			for i := range tt.createN {
-				_, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-				})
+				_, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+					},
+				)
 				require.NoError(t, err, "creating CA %d", i)
 			}
 
-			p := b.ListCertificateAuthorities("", 0)
+			p := b.ListCertificateAuthorities(context.Background(), "", 0)
 			assert.Len(t, p.Data, tt.wantCount)
 		})
 	}
@@ -205,17 +214,25 @@ func TestInMemoryBackend_DeleteCertificateAuthority(t *testing.T) {
 
 			switch tt.caARN {
 			case "":
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+					},
+				)
 				require.NoError(t, err)
 				caARN = ca.ARN
 				// Disable the CA first (AWS requirement before deletion).
-				require.NoError(t, b.UpdateCertificateAuthority(caARN, "DISABLED"))
+				require.NoError(t, b.UpdateCertificateAuthority(context.Background(), caARN, "DISABLED"))
 			case "active":
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Active CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Active CA"},
+					},
+				)
 				require.NoError(t, err)
 				caARN = ca.ARN
 				// Do NOT disable — deletion should fail.
@@ -223,7 +240,7 @@ func TestInMemoryBackend_DeleteCertificateAuthority(t *testing.T) {
 				caARN = tt.caARN
 			}
 
-			err := b.DeleteCertificateAuthority(caARN, 0)
+			err := b.DeleteCertificateAuthority(context.Background(), caARN, 0)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -233,7 +250,7 @@ func TestInMemoryBackend_DeleteCertificateAuthority(t *testing.T) {
 
 			require.NoError(t, err)
 
-			ca, err := b.DescribeCertificateAuthority(caARN)
+			ca, err := b.DescribeCertificateAuthority(context.Background(), caARN)
 			require.NoError(t, err)
 			assert.Equal(t, "DELETED", ca.Status)
 		})
@@ -258,12 +275,16 @@ func TestInMemoryBackend_GetCertificateAuthorityCsr(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBackend()
-			ca, err := b.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"SUBORDINATE",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			csr, err := b.GetCertificateAuthorityCsr(ca.ARN)
+			csr, err := b.GetCertificateAuthorityCsr(context.Background(), ca.ARN)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -302,21 +323,29 @@ func TestInMemoryBackend_IssueCertificate(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBackend()
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test Root CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test Root CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			// Get the CA's CSR as the cert to issue (for simplicity we reuse the self-signed CA cert's pub key)
-			subCA, err := b.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test Sub CA"},
-			})
+			subCA, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"SUBORDINATE",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test Sub CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			csr, err := b.GetCertificateAuthorityCsr(subCA.ARN)
+			csr, err := b.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 			require.NoError(t, err)
 
-			cert, err := b.IssueCertificate(ca.ARN, csr, tt.validityDays)
+			cert, err := b.IssueCertificate(context.Background(), ca.ARN, csr, tt.validityDays)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -357,9 +386,13 @@ func TestInMemoryBackend_TagOperations(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBackend()
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Tag CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Tag CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			h := acmpca.NewHandler(b)
@@ -387,6 +420,7 @@ func TestInMemoryBackend_PermissionsAndPolicies(t *testing.T) {
 				t.Helper()
 
 				created, err := b.CreatePermission(
+					context.Background(),
 					caARN,
 					"acm.amazonaws.com",
 					testAccountID,
@@ -396,13 +430,13 @@ func TestInMemoryBackend_PermissionsAndPolicies(t *testing.T) {
 				assert.Equal(t, caARN, created.CertificateAuthorityArn)
 				assert.Equal(t, "acm.amazonaws.com", created.Principal)
 
-				list, err := b.ListPermissions(caARN, "", 0)
+				list, err := b.ListPermissions(context.Background(), caARN, "", 0)
 				require.NoError(t, err)
 				require.Len(t, list.Data, 1)
 				assert.Equal(t, []string{"IssueCertificate", "GetCertificate"}, list.Data[0].Actions)
 
-				require.NoError(t, b.DeletePermission(caARN, "acm.amazonaws.com", testAccountID))
-				list, err = b.ListPermissions(caARN, "", 0)
+				require.NoError(t, b.DeletePermission(context.Background(), caARN, "acm.amazonaws.com", testAccountID))
+				list, err = b.ListPermissions(context.Background(), caARN, "", 0)
 				require.NoError(t, err)
 				assert.Empty(t, list.Data)
 			},
@@ -413,14 +447,14 @@ func TestInMemoryBackend_PermissionsAndPolicies(t *testing.T) {
 				t.Helper()
 
 				policy := `{"Version":"2012-10-17","Statement":[]}`
-				require.NoError(t, b.PutPolicy(caARN, policy))
+				require.NoError(t, b.PutPolicy(context.Background(), caARN, policy))
 
-				got, err := b.GetPolicy(caARN)
+				got, err := b.GetPolicy(context.Background(), caARN)
 				require.NoError(t, err)
 				assert.Equal(t, policy, got)
 
-				require.NoError(t, b.DeletePolicy(caARN))
-				_, err = b.GetPolicy(caARN)
+				require.NoError(t, b.DeletePolicy(context.Background(), caARN))
+				_, err = b.GetPolicy(context.Background(), caARN)
 				require.Error(t, err)
 			},
 		},
@@ -429,20 +463,20 @@ func TestInMemoryBackend_PermissionsAndPolicies(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend, caARN string) {
 				t.Helper()
 
-				report, err := b.CreateCertificateAuthorityAuditReport(caARN, "bucket", "JSON")
+				report, err := b.CreateCertificateAuthorityAuditReport(context.Background(), caARN, "bucket", "JSON")
 				require.NoError(t, err)
 				assert.Equal(t, "SUCCESS", report.Status)
 				assert.Contains(t, report.S3Key, ".json")
 
-				got, err := b.DescribeCertificateAuthorityAuditReport(caARN, report.AuditReportID)
+				got, err := b.DescribeCertificateAuthorityAuditReport(context.Background(), caARN, report.AuditReportID)
 				require.NoError(t, err)
 				assert.Equal(t, report.AuditReportID, got.AuditReportID)
 
-				require.NoError(t, b.UpdateCertificateAuthority(caARN, "DISABLED"))
-				require.NoError(t, b.DeleteCertificateAuthority(caARN, 0))
-				require.NoError(t, b.RestoreCertificateAuthority(caARN))
+				require.NoError(t, b.UpdateCertificateAuthority(context.Background(), caARN, "DISABLED"))
+				require.NoError(t, b.DeleteCertificateAuthority(context.Background(), caARN, 0))
+				require.NoError(t, b.RestoreCertificateAuthority(context.Background(), caARN))
 
-				ca, err := b.DescribeCertificateAuthority(caARN)
+				ca, err := b.DescribeCertificateAuthority(context.Background(), caARN)
 				require.NoError(t, err)
 				assert.Equal(t, "DISABLED", ca.Status)
 			},
@@ -454,9 +488,13 @@ func TestInMemoryBackend_PermissionsAndPolicies(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBackend()
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Ops CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Ops CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			tt.run(t, b, ca.ARN)
@@ -476,7 +514,13 @@ func TestInMemoryBackend_NewOperationValidation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				_, err := b.CreatePermission("", "acm.amazonaws.com", testAccountID, []string{"IssueCertificate"})
+				_, err := b.CreatePermission(
+					context.Background(),
+					"",
+					"acm.amazonaws.com",
+					testAccountID,
+					[]string{"IssueCertificate"},
+				)
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -486,6 +530,7 @@ func TestInMemoryBackend_NewOperationValidation(t *testing.T) {
 				t.Helper()
 
 				err := b.DeletePermission(
+					context.Background(),
 					"arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test",
 					"",
 					testAccountID,
@@ -499,6 +544,7 @@ func TestInMemoryBackend_NewOperationValidation(t *testing.T) {
 				t.Helper()
 
 				_, err := b.ListPermissions(
+					context.Background(),
 					"arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/missing",
 					"",
 					0,
@@ -511,12 +557,16 @@ func TestInMemoryBackend_NewOperationValidation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Validate CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Validate CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				_, err = b.DescribeCertificateAuthorityAuditReport(ca.ARN, "")
+				_, err = b.DescribeCertificateAuthorityAuditReport(context.Background(), ca.ARN, "")
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -525,7 +575,7 @@ func TestInMemoryBackend_NewOperationValidation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				_, err := b.GetPolicy("")
+				_, err := b.GetPolicy(context.Background(), "")
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -534,7 +584,7 @@ func TestInMemoryBackend_NewOperationValidation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				err := b.RestoreCertificateAuthority("")
+				err := b.RestoreCertificateAuthority(context.Background(), "")
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -561,26 +611,34 @@ func TestInMemoryBackend_ValidationAndRevocation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Revoke CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Revoke CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				subCA, err := b.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
-				})
+				subCA, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"SUBORDINATE",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				csr, err := b.GetCertificateAuthorityCsr(subCA.ARN)
+				csr, err := b.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 				require.NoError(t, err)
 
-				cert, err := b.IssueCertificate(ca.ARN, csr, 365)
+				cert, err := b.IssueCertificate(context.Background(), ca.ARN, csr, 365)
 				require.NoError(t, err)
 
-				err = b.RevokeCertificate(ca.ARN, cert.Serial, "KEY_COMPROMISE")
+				err = b.RevokeCertificate(context.Background(), ca.ARN, cert.Serial, "KEY_COMPROMISE")
 				require.NoError(t, err)
 
-				got, err := b.GetCertificate(ca.ARN, cert.ARN)
+				got, err := b.GetCertificate(context.Background(), ca.ARN, cert.ARN)
 				require.NoError(t, err)
 				assert.Equal(t, "REVOKED", got.Status)
 				assert.NotNil(t, got.RevokedAt)
@@ -592,12 +650,16 @@ func TestInMemoryBackend_ValidationAndRevocation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Revoke CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Revoke CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				err = b.RevokeCertificate(ca.ARN, "doesNotMatter", "INVALID_REASON")
+				err = b.RevokeCertificate(context.Background(), ca.ARN, "doesNotMatter", "INVALID_REASON")
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -607,16 +669,20 @@ func TestInMemoryBackend_ValidationAndRevocation(t *testing.T) {
 				t.Helper()
 
 				// SUBORDINATE CAs start in PENDING_CERTIFICATE state (no auto-sign).
-				ca, err := b.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Pending CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"SUBORDINATE",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Pending CA"},
+					},
+				)
 				require.NoError(t, err)
 				assert.Equal(t, "PENDING_CERTIFICATE", ca.Status)
 
-				err = b.DeleteCertificateAuthority(ca.ARN, 0)
+				err = b.DeleteCertificateAuthority(context.Background(), ca.ARN, 0)
 				require.NoError(t, err)
 
-				got, err := b.DescribeCertificateAuthority(ca.ARN)
+				got, err := b.DescribeCertificateAuthority(context.Background(), ca.ARN)
 				require.NoError(t, err)
 				assert.Equal(t, "DELETED", got.Status)
 			},
@@ -626,12 +692,16 @@ func TestInMemoryBackend_ValidationAndRevocation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				err = b.DeleteCertificateAuthority(ca.ARN, 5)
+				err = b.DeleteCertificateAuthority(context.Background(), ca.ARN, 5)
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -640,12 +710,16 @@ func TestInMemoryBackend_ValidationAndRevocation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				err = b.UpdateCertificateAuthority(ca.ARN, "INVALID_STATUS")
+				err = b.UpdateCertificateAuthority(context.Background(), ca.ARN, "INVALID_STATUS")
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},
@@ -654,12 +728,16 @@ func TestInMemoryBackend_ValidationAndRevocation(t *testing.T) {
 			run: func(t *testing.T, b *acmpca.InMemoryBackend) {
 				t.Helper()
 
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+					},
+				)
 				require.NoError(t, err)
 
-				_, err = b.IssueCertificate(ca.ARN, "", 365)
+				_, err = b.IssueCertificate(context.Background(), ca.ARN, "", 365)
 				require.ErrorIs(t, err, acmpca.ErrInvalidParameter)
 			},
 		},

--- a/services/acmpca/handler.go
+++ b/services/acmpca/handler.go
@@ -188,19 +188,24 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // Handler returns the Echo handler function.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+		ctx := context.WithValue(c.Request().Context(), regionContextKey{}, region)
+
 		return service.HandleTarget(
-			c, logger.Load(c.Request().Context()),
+			c, logger.Load(ctx),
 			"ACMPCA", "application/x-amz-json-1.1",
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(_ context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(ctx, action, body)
+			},
 			h.handleError,
 		)
 	}
 }
 
 // dispatch routes the operation to the appropriate handler and marshals the response.
-func (h *Handler) dispatch(_ context.Context, action string, body []byte) ([]byte, error) {
-	resp, err := h.dispatchJSON(action, body)
+func (h *Handler) dispatch(ctx context.Context, action string, body []byte) ([]byte, error) {
+	resp, err := h.dispatchJSON(ctx, action, body)
 	if err != nil {
 		return nil, err
 	}
@@ -481,74 +486,74 @@ type listTagsOutput struct {
 
 // ---- dispatch ----
 
-func (h *Handler) dispatchJSON(action string, body []byte) (any, error) {
+func (h *Handler) dispatchJSON(ctx context.Context, action string, body []byte) (any, error) {
 	switch action {
 	case "CreateCertificateAuthority":
-		return h.jsonCreateCA(body)
+		return h.jsonCreateCA(ctx, body)
 	case "DescribeCertificateAuthority":
-		return h.jsonDescribeCA(body)
+		return h.jsonDescribeCA(ctx, body)
 	case "ListCertificateAuthorities":
-		return h.jsonListCAs(body)
+		return h.jsonListCAs(ctx, body)
 	case "DeleteCertificateAuthority":
-		return h.jsonDeleteCA(body)
+		return h.jsonDeleteCA(ctx, body)
 	case "UpdateCertificateAuthority":
-		return h.jsonUpdateCA(body)
+		return h.jsonUpdateCA(ctx, body)
 	case "GetCertificateAuthorityCsr":
-		return h.jsonGetCsr(body)
+		return h.jsonGetCsr(ctx, body)
 	case "ImportCertificateAuthorityCertificate":
-		return h.jsonImportCACert(body)
+		return h.jsonImportCACert(ctx, body)
 	case "GetCertificateAuthorityCertificate":
-		return h.jsonGetCACert(body)
+		return h.jsonGetCACert(ctx, body)
 	default:
-		return h.dispatchCertAndTagOps(action, body)
+		return h.dispatchCertAndTagOps(ctx, action, body)
 	}
 }
 
-func (h *Handler) dispatchCertAndTagOps(action string, body []byte) (any, error) {
+func (h *Handler) dispatchCertAndTagOps(ctx context.Context, action string, body []byte) (any, error) {
 	switch action {
 	case "IssueCertificate":
-		return h.jsonIssueCert(body)
+		return h.jsonIssueCert(ctx, body)
 	case "GetCertificate":
-		return h.jsonGetCert(body)
+		return h.jsonGetCert(ctx, body)
 	case "RevokeCertificate":
-		return h.jsonRevokeCert(body)
+		return h.jsonRevokeCert(ctx, body)
 	case "ListPermissions":
-		return h.jsonListPermissions(body)
+		return h.jsonListPermissions(ctx, body)
 	case "TagCertificateAuthority":
-		return h.jsonTagCA(body)
+		return h.jsonTagCA(ctx, body)
 	case "UntagCertificateAuthority":
-		return h.jsonUntagCA(body)
+		return h.jsonUntagCA(ctx, body)
 	case "ListTagsForCertificateAuthority", "ListTags":
-		return h.jsonListTags(body)
+		return h.jsonListTags(ctx, body)
 	default:
-		return h.dispatchPermissionAndAuditOps(action, body)
+		return h.dispatchPermissionAndAuditOps(ctx, action, body)
 	}
 }
 
-func (h *Handler) dispatchPermissionAndAuditOps(action string, body []byte) (any, error) {
+func (h *Handler) dispatchPermissionAndAuditOps(ctx context.Context, action string, body []byte) (any, error) {
 	switch action {
 	case "CreateCertificateAuthorityAuditReport":
-		return h.jsonCreateAuditReport(body)
+		return h.jsonCreateAuditReport(ctx, body)
 	case "CreatePermission":
-		return h.jsonCreatePermission(body)
+		return h.jsonCreatePermission(ctx, body)
 	case "DeletePermission":
-		return h.jsonDeletePermission(body)
+		return h.jsonDeletePermission(ctx, body)
 	case "DeletePolicy":
-		return h.jsonDeletePolicy(body)
+		return h.jsonDeletePolicy(ctx, body)
 	case "DescribeCertificateAuthorityAuditReport":
-		return h.jsonDescribeAuditReport(body)
+		return h.jsonDescribeAuditReport(ctx, body)
 	case "GetPolicy":
-		return h.jsonGetPolicy(body)
+		return h.jsonGetPolicy(ctx, body)
 	case "PutPolicy":
-		return h.jsonPutPolicy(body)
+		return h.jsonPutPolicy(ctx, body)
 	case "RestoreCertificateAuthority":
-		return h.jsonRestoreCA(body)
+		return h.jsonRestoreCA(ctx, body)
 	default:
 		return nil, errUnknownACMPCAAction
 	}
 }
 
-func (h *Handler) jsonCreateCA(body []byte) (any, error) {
+func (h *Handler) jsonCreateCA(ctx context.Context, body []byte) (any, error) {
 	var input createCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
@@ -567,7 +572,7 @@ func (h *Handler) jsonCreateCA(body []byte) (any, error) {
 		SigningAlgorithm: input.CertificateAuthorityConfiguration.SigningAlgorithm,
 	}
 
-	ca, err := h.Backend.CreateCertificateAuthority(input.CertificateAuthorityType, cfg)
+	ca, err := h.Backend.CreateCertificateAuthority(ctx, input.CertificateAuthorityType, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -584,13 +589,13 @@ func (h *Handler) jsonCreateCA(body []byte) (any, error) {
 	return &createCertificateAuthorityOutput{CertificateAuthorityArn: ca.ARN}, nil
 }
 
-func (h *Handler) jsonDescribeCA(body []byte) (any, error) {
+func (h *Handler) jsonDescribeCA(ctx context.Context, body []byte) (any, error) {
 	var input describeCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	ca, err := h.Backend.DescribeCertificateAuthority(input.CertificateAuthorityArn)
+	ca, err := h.Backend.DescribeCertificateAuthority(ctx, input.CertificateAuthorityArn)
 	if err != nil {
 		return nil, err
 	}
@@ -598,11 +603,11 @@ func (h *Handler) jsonDescribeCA(body []byte) (any, error) {
 	return &describeCertificateAuthorityOutput{CertificateAuthority: toCAOutput(ca)}, nil
 }
 
-func (h *Handler) jsonListCAs(body []byte) (any, error) {
+func (h *Handler) jsonListCAs(ctx context.Context, body []byte) (any, error) {
 	var input listCertificateAuthoritiesInput
 	_ = json.Unmarshal(body, &input)
 
-	p := h.Backend.ListCertificateAuthorities(input.NextToken, input.MaxResults)
+	p := h.Backend.ListCertificateAuthorities(ctx, input.NextToken, input.MaxResults)
 	cas := make([]certAuthorityOutput, 0, len(p.Data))
 
 	for _, ca := range p.Data {
@@ -615,13 +620,14 @@ func (h *Handler) jsonListCAs(body []byte) (any, error) {
 	}, nil
 }
 
-func (h *Handler) jsonDeleteCA(body []byte) (any, error) {
+func (h *Handler) jsonDeleteCA(ctx context.Context, body []byte) (any, error) {
 	var input deleteCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	if err := h.Backend.DeleteCertificateAuthority(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.PermanentDeletionTimeInDays,
 	); err != nil {
@@ -633,26 +639,26 @@ func (h *Handler) jsonDeleteCA(body []byte) (any, error) {
 	return &deleteCertificateAuthorityOutput{}, nil
 }
 
-func (h *Handler) jsonUpdateCA(body []byte) (any, error) {
+func (h *Handler) jsonUpdateCA(ctx context.Context, body []byte) (any, error) {
 	var input updateCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.UpdateCertificateAuthority(input.CertificateAuthorityArn, input.Status); err != nil {
+	if err := h.Backend.UpdateCertificateAuthority(ctx, input.CertificateAuthorityArn, input.Status); err != nil {
 		return nil, err
 	}
 
 	return &updateCertificateAuthorityOutput{}, nil
 }
 
-func (h *Handler) jsonGetCsr(body []byte) (any, error) {
+func (h *Handler) jsonGetCsr(ctx context.Context, body []byte) (any, error) {
 	var input getCertificateAuthorityCsrInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	csr, err := h.Backend.GetCertificateAuthorityCsr(input.CertificateAuthorityArn)
+	csr, err := h.Backend.GetCertificateAuthorityCsr(ctx, input.CertificateAuthorityArn)
 	if err != nil {
 		return nil, err
 	}
@@ -660,13 +666,14 @@ func (h *Handler) jsonGetCsr(body []byte) (any, error) {
 	return &getCertificateAuthorityCsrOutput{Csr: csr}, nil
 }
 
-func (h *Handler) jsonImportCACert(body []byte) (any, error) {
+func (h *Handler) jsonImportCACert(ctx context.Context, body []byte) (any, error) {
 	var input importCertificateAuthorityCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	if err := h.Backend.ImportCertificateAuthorityCertificate(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.Certificate,
 		input.CertificateChain,
@@ -677,13 +684,13 @@ func (h *Handler) jsonImportCACert(body []byte) (any, error) {
 	return &importCertificateAuthorityCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonGetCACert(body []byte) (any, error) {
+func (h *Handler) jsonGetCACert(ctx context.Context, body []byte) (any, error) {
 	var input getCertificateAuthorityCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	certPEM, chainPEM, err := h.Backend.GetCertificateAuthorityCertificate(input.CertificateAuthorityArn)
+	certPEM, chainPEM, err := h.Backend.GetCertificateAuthorityCertificate(ctx, input.CertificateAuthorityArn)
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +698,7 @@ func (h *Handler) jsonGetCACert(body []byte) (any, error) {
 	return &getCertificateAuthorityCertificateOutput{Certificate: certPEM, CertificateChain: chainPEM}, nil
 }
 
-func (h *Handler) jsonIssueCert(body []byte) (any, error) {
+func (h *Handler) jsonIssueCert(ctx context.Context, body []byte) (any, error) {
 	var input issueCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
@@ -710,7 +717,7 @@ func (h *Handler) jsonIssueCert(body []byte) (any, error) {
 			ErrInvalidParameter, input.Validity.Type)
 	}
 
-	cert, err := h.Backend.IssueCertificate(input.CertificateAuthorityArn, input.Csr, days)
+	cert, err := h.Backend.IssueCertificate(ctx, input.CertificateAuthorityArn, input.Csr, days)
 	if err != nil {
 		return nil, err
 	}
@@ -718,19 +725,20 @@ func (h *Handler) jsonIssueCert(body []byte) (any, error) {
 	return &issueCertificateOutput{CertificateArn: cert.ARN}, nil
 }
 
-func (h *Handler) jsonGetCert(body []byte) (any, error) {
+func (h *Handler) jsonGetCert(ctx context.Context, body []byte) (any, error) {
 	var input getCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	cert, err := h.Backend.GetCertificate(input.CertificateAuthorityArn, input.CertificateArn)
+	cert, err := h.Backend.GetCertificate(ctx, input.CertificateAuthorityArn, input.CertificateArn)
 	if err != nil {
 		return nil, err
 	}
 
 	caChain := ""
 	if certPEM, _, chainErr := h.Backend.GetCertificateAuthorityCertificate(
+		ctx,
 		input.CertificateAuthorityArn,
 	); chainErr == nil &&
 		certPEM != "" {
@@ -740,13 +748,14 @@ func (h *Handler) jsonGetCert(body []byte) (any, error) {
 	return &getCertificateOutput{Certificate: cert.CertBody, CertificateChain: caChain}, nil
 }
 
-func (h *Handler) jsonRevokeCert(body []byte) (any, error) {
+func (h *Handler) jsonRevokeCert(ctx context.Context, body []byte) (any, error) {
 	var input revokeCertificateInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	if err := h.Backend.RevokeCertificate(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.CertificateSerial,
 		input.RevocationReason,
@@ -757,13 +766,13 @@ func (h *Handler) jsonRevokeCert(body []byte) (any, error) {
 	return &revokeCertificateOutput{}, nil
 }
 
-func (h *Handler) jsonListPermissions(body []byte) (any, error) {
+func (h *Handler) jsonListPermissions(ctx context.Context, body []byte) (any, error) {
 	var input listPermissionsInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	p, err := h.Backend.ListPermissions(input.CertificateAuthorityArn, input.NextToken, input.MaxResults)
+	p, err := h.Backend.ListPermissions(ctx, input.CertificateAuthorityArn, input.NextToken, input.MaxResults)
 	if err != nil {
 		return nil, err
 	}
@@ -789,13 +798,14 @@ func (h *Handler) jsonListPermissions(body []byte) (any, error) {
 	}, nil
 }
 
-func (h *Handler) jsonCreatePermission(body []byte) (any, error) {
+func (h *Handler) jsonCreatePermission(ctx context.Context, body []byte) (any, error) {
 	var input createPermissionInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	if _, err := h.Backend.CreatePermission(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.Principal,
 		input.SourceAccount,
@@ -807,13 +817,14 @@ func (h *Handler) jsonCreatePermission(body []byte) (any, error) {
 	return &createPermissionOutput{}, nil
 }
 
-func (h *Handler) jsonDeletePermission(body []byte) (any, error) {
+func (h *Handler) jsonDeletePermission(ctx context.Context, body []byte) (any, error) {
 	var input deletePermissionInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	if err := h.Backend.DeletePermission(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.Principal,
 		input.SourceAccount,
@@ -824,13 +835,14 @@ func (h *Handler) jsonDeletePermission(body []byte) (any, error) {
 	return &deletePermissionOutput{}, nil
 }
 
-func (h *Handler) jsonCreateAuditReport(body []byte) (any, error) {
+func (h *Handler) jsonCreateAuditReport(ctx context.Context, body []byte) (any, error) {
 	var input createCertificateAuthorityAuditReportInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	report, err := h.Backend.CreateCertificateAuthorityAuditReport(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.S3BucketName,
 		input.AuditReportResponseFormat,
@@ -845,13 +857,14 @@ func (h *Handler) jsonCreateAuditReport(body []byte) (any, error) {
 	}, nil
 }
 
-func (h *Handler) jsonDescribeAuditReport(body []byte) (any, error) {
+func (h *Handler) jsonDescribeAuditReport(ctx context.Context, body []byte) (any, error) {
 	var input describeCertificateAuthorityAuditReportInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
 	report, err := h.Backend.DescribeCertificateAuthorityAuditReport(
+		ctx,
 		input.CertificateAuthorityArn,
 		input.AuditReportID,
 	)
@@ -871,13 +884,13 @@ func (h *Handler) jsonDescribeAuditReport(body []byte) (any, error) {
 	return out, nil
 }
 
-func (h *Handler) jsonGetPolicy(body []byte) (any, error) {
+func (h *Handler) jsonGetPolicy(ctx context.Context, body []byte) (any, error) {
 	var input getPolicyInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	policy, err := h.Backend.GetPolicy(input.ResourceArn)
+	policy, err := h.Backend.GetPolicy(ctx, input.ResourceArn)
 	if err != nil {
 		return nil, err
 	}
@@ -885,52 +898,52 @@ func (h *Handler) jsonGetPolicy(body []byte) (any, error) {
 	return &getPolicyOutput{Policy: policy}, nil
 }
 
-func (h *Handler) jsonPutPolicy(body []byte) (any, error) {
+func (h *Handler) jsonPutPolicy(ctx context.Context, body []byte) (any, error) {
 	var input putPolicyInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.PutPolicy(input.ResourceArn, input.Policy); err != nil {
+	if err := h.Backend.PutPolicy(ctx, input.ResourceArn, input.Policy); err != nil {
 		return nil, err
 	}
 
 	return &putPolicyOutput{}, nil
 }
 
-func (h *Handler) jsonDeletePolicy(body []byte) (any, error) {
+func (h *Handler) jsonDeletePolicy(ctx context.Context, body []byte) (any, error) {
 	var input deletePolicyInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.DeletePolicy(input.ResourceArn); err != nil {
+	if err := h.Backend.DeletePolicy(ctx, input.ResourceArn); err != nil {
 		return nil, err
 	}
 
 	return &deletePolicyOutput{}, nil
 }
 
-func (h *Handler) jsonRestoreCA(body []byte) (any, error) {
+func (h *Handler) jsonRestoreCA(ctx context.Context, body []byte) (any, error) {
 	var input restoreCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.RestoreCertificateAuthority(input.CertificateAuthorityArn); err != nil {
+	if err := h.Backend.RestoreCertificateAuthority(ctx, input.CertificateAuthorityArn); err != nil {
 		return nil, err
 	}
 
 	return &restoreCertificateAuthorityOutput{}, nil
 }
 
-func (h *Handler) jsonTagCA(body []byte) (any, error) {
+func (h *Handler) jsonTagCA(ctx context.Context, body []byte) (any, error) {
 	var input tagCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.verifyCertificateAuthorityActive(input.CertificateAuthorityArn); err != nil {
+	if err := h.Backend.verifyCertificateAuthorityActive(ctx, input.CertificateAuthorityArn); err != nil {
 		return nil, err
 	}
 
@@ -944,13 +957,13 @@ func (h *Handler) jsonTagCA(body []byte) (any, error) {
 	return &tagCertificateAuthorityOutput{}, nil
 }
 
-func (h *Handler) jsonUntagCA(body []byte) (any, error) {
+func (h *Handler) jsonUntagCA(ctx context.Context, body []byte) (any, error) {
 	var input untagCertificateAuthorityInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.verifyCertificateAuthorityActive(input.CertificateAuthorityArn); err != nil {
+	if err := h.Backend.verifyCertificateAuthorityActive(ctx, input.CertificateAuthorityArn); err != nil {
 		return nil, err
 	}
 
@@ -964,13 +977,13 @@ func (h *Handler) jsonUntagCA(body []byte) (any, error) {
 	return &untagCertificateAuthorityOutput{}, nil
 }
 
-func (h *Handler) jsonListTags(body []byte) (any, error) {
+func (h *Handler) jsonListTags(ctx context.Context, body []byte) (any, error) {
 	var input listTagsInput
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, ErrInvalidParameter
 	}
 
-	if err := h.Backend.verifyCertificateAuthorityActive(input.CertificateAuthorityArn); err != nil {
+	if err := h.Backend.verifyCertificateAuthorityActive(ctx, input.CertificateAuthorityArn); err != nil {
 		return nil, err
 	}
 

--- a/services/acmpca/handler_accuracy_batch1_test.go
+++ b/services/acmpca/handler_accuracy_batch1_test.go
@@ -1,6 +1,7 @@
 package acmpca_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -87,9 +88,13 @@ func TestACMPCA_Accuracy_GetCertificateAuthorityCertificate_NoCert(t *testing.T)
 			t.Parallel()
 
 			h := newACMPCAHandler()
-			ca, err := h.Backend.CreateCertificateAuthority(tt.caType, acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-			})
+			ca, err := h.Backend.CreateCertificateAuthority(
+				context.Background(),
+				tt.caType,
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			rec := doACMPCARequest(t, h, "GetCertificateAuthorityCertificate", map[string]any{
@@ -113,14 +118,22 @@ func TestACMPCA_Accuracy_GetCertificateAuthorityCertificate_AfterImport(t *testi
 	h := newACMPCAHandler()
 
 	// Use a ROOT CA (auto-signed, ACTIVE) to issue a cert for a SUBORDINATE CA.
-	rootCA, err := h.Backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Root CA"},
-	})
+	rootCA, err := h.Backend.CreateCertificateAuthority(
+		context.Background(),
+		"ROOT",
+		acmpca.CertificateAuthorityConfiguration{
+			Subject: acmpca.CertificateAuthoritySubject{CommonName: "Root CA"},
+		},
+	)
 	require.NoError(t, err)
 
-	subCA, err := h.Backend.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
-	})
+	subCA, err := h.Backend.CreateCertificateAuthority(
+		context.Background(),
+		"SUBORDINATE",
+		acmpca.CertificateAuthorityConfiguration{
+			Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
+		},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, "PENDING_CERTIFICATE", subCA.Status)
 
@@ -131,14 +144,14 @@ func TestACMPCA_Accuracy_GetCertificateAuthorityCertificate_AfterImport(t *testi
 	assert.Equal(t, http.StatusBadRequest, noCertRec.Code)
 
 	// Issue a cert for the subordinate CA from the root CA.
-	csrPEM, err := h.Backend.GetCertificateAuthorityCsr(subCA.ARN)
+	csrPEM, err := h.Backend.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 	require.NoError(t, err)
 
-	issuedCert, err := h.Backend.IssueCertificate(rootCA.ARN, csrPEM, 365)
+	issuedCert, err := h.Backend.IssueCertificate(context.Background(), rootCA.ARN, csrPEM, 365)
 	require.NoError(t, err)
 
 	// Get the cert PEM from the issued cert.
-	gotCert, err := h.Backend.GetCertificate(rootCA.ARN, issuedCert.ARN)
+	gotCert, err := h.Backend.GetCertificate(context.Background(), rootCA.ARN, issuedCert.ARN)
 	require.NoError(t, err)
 
 	// Import the cert to activate the subordinate CA.
@@ -191,25 +204,33 @@ func TestACMPCA_Accuracy_RevokeCertificate_DeletedCA(t *testing.T) {
 			b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 			h := acmpca.NewHandler(b)
 
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			subCA, err := b.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
-			})
+			subCA, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"SUBORDINATE",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			csrPEM, err := b.GetCertificateAuthorityCsr(subCA.ARN)
+			csrPEM, err := b.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 			require.NoError(t, err)
 
-			issuedCert, err := b.IssueCertificate(ca.ARN, csrPEM, 365)
+			issuedCert, err := b.IssueCertificate(context.Background(), ca.ARN, csrPEM, 365)
 			require.NoError(t, err)
 
 			if tt.deleted {
-				require.NoError(t, b.UpdateCertificateAuthority(ca.ARN, "DISABLED"))
-				require.NoError(t, b.DeleteCertificateAuthority(ca.ARN, 0))
+				require.NoError(t, b.UpdateCertificateAuthority(context.Background(), ca.ARN, "DISABLED"))
+				require.NoError(t, b.DeleteCertificateAuthority(context.Background(), ca.ARN, 0))
 			}
 
 			rec := doACMPCARequest(t, h, "RevokeCertificate", map[string]any{
@@ -256,9 +277,13 @@ func TestACMPCA_Accuracy_CreateAuditReport_RequiresActiveCA(t *testing.T) {
 			t.Parallel()
 
 			h := newACMPCAHandler()
-			ca, err := h.Backend.CreateCertificateAuthority(tt.caType, acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-			})
+			ca, err := h.Backend.CreateCertificateAuthority(
+				context.Background(),
+				tt.caType,
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			rec := doACMPCARequest(t, h, "CreateCertificateAuthorityAuditReport", map[string]any{
@@ -299,17 +324,25 @@ func TestACMPCA_Accuracy_IssueCertificate_ValidityTypes(t *testing.T) {
 			b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 			h := acmpca.NewHandler(b)
 
-			rootCA, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Root CA"},
-			})
+			rootCA, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Root CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			subCA, err := b.CreateCertificateAuthority("SUBORDINATE", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
-			})
+			subCA, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"SUBORDINATE",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			csrPEM, err := b.GetCertificateAuthorityCsr(subCA.ARN)
+			csrPEM, err := b.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 			require.NoError(t, err)
 
 			rec := doACMPCARequest(t, h, "IssueCertificate", map[string]any{
@@ -365,13 +398,17 @@ func TestACMPCA_Accuracy_DeleteCA_StateMachine(t *testing.T) {
 			t.Parallel()
 
 			h := newACMPCAHandler()
-			ca, err := h.Backend.CreateCertificateAuthority(tt.caType, acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-			})
+			ca, err := h.Backend.CreateCertificateAuthority(
+				context.Background(),
+				tt.caType,
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			if tt.disableCA {
-				require.NoError(t, h.Backend.UpdateCertificateAuthority(ca.ARN, "DISABLED"))
+				require.NoError(t, h.Backend.UpdateCertificateAuthority(context.Background(), ca.ARN, "DISABLED"))
 			}
 
 			rec := doACMPCARequest(t, h, "DeleteCertificateAuthority", map[string]any{
@@ -394,13 +431,17 @@ func TestACMPCA_Accuracy_RestoreCA_AfterDelete(t *testing.T) {
 
 	h := newACMPCAHandler()
 
-	ca, err := h.Backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Restore CA"},
-	})
+	ca, err := h.Backend.CreateCertificateAuthority(
+		context.Background(),
+		"ROOT",
+		acmpca.CertificateAuthorityConfiguration{
+			Subject: acmpca.CertificateAuthoritySubject{CommonName: "Restore CA"},
+		},
+	)
 	require.NoError(t, err)
 
-	require.NoError(t, h.Backend.UpdateCertificateAuthority(ca.ARN, "DISABLED"))
-	require.NoError(t, h.Backend.DeleteCertificateAuthority(ca.ARN, 0))
+	require.NoError(t, h.Backend.UpdateCertificateAuthority(context.Background(), ca.ARN, "DISABLED"))
+	require.NoError(t, h.Backend.DeleteCertificateAuthority(context.Background(), ca.ARN, 0))
 
 	rec := doACMPCARequest(t, h, "RestoreCertificateAuthority", map[string]any{
 		"CertificateAuthorityArn": ca.ARN,
@@ -450,12 +491,16 @@ func TestACMPCA_Accuracy_PermanentDeletionTimeInDays(t *testing.T) {
 			t.Parallel()
 
 			h := newACMPCAHandler()
-			ca, err := h.Backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-			})
+			ca, err := h.Backend.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			require.NoError(t, h.Backend.UpdateCertificateAuthority(ca.ARN, "DISABLED"))
+			require.NoError(t, h.Backend.UpdateCertificateAuthority(context.Background(), ca.ARN, "DISABLED"))
 
 			rec := doACMPCARequest(t, h, "DeleteCertificateAuthority", map[string]any{
 				"CertificateAuthorityArn":     ca.ARN,
@@ -480,9 +525,13 @@ func TestACMPCA_Accuracy_ListCertificateAuthorities_Pagination(t *testing.T) {
 
 	// Create 3 CAs.
 	for range 3 {
-		_, err := h.Backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-			Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
-		})
+		_, err := h.Backend.CreateCertificateAuthority(
+			context.Background(),
+			"ROOT",
+			acmpca.CertificateAuthorityConfiguration{
+				Subject: acmpca.CertificateAuthoritySubject{CommonName: "CA"},
+			},
+		)
 		require.NoError(t, err)
 	}
 

--- a/services/acmpca/handler_test.go
+++ b/services/acmpca/handler_test.go
@@ -2,6 +2,7 @@ package acmpca_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -54,9 +55,13 @@ func parseACMPCAResponse(t *testing.T, rec *httptest.ResponseRecorder) map[strin
 func createHandlerCA(t *testing.T, h *acmpca.Handler) string {
 	t.Helper()
 
-	ca, err := h.Backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Handler CA"},
-	})
+	ca, err := h.Backend.CreateCertificateAuthority(
+		context.Background(),
+		"ROOT",
+		acmpca.CertificateAuthorityConfiguration{
+			Subject: acmpca.CertificateAuthoritySubject{CommonName: "Handler CA"},
+		},
+	)
 	require.NoError(t, err)
 
 	return ca.ARN
@@ -154,8 +159,8 @@ func TestACMPCAHandler_MissingOperations(t *testing.T) {
 				describeResp := parseACMPCAResponse(t, describeAuditRec)
 				assert.Equal(t, "SUCCESS", describeResp["AuditReportStatus"])
 
-				require.NoError(t, h.Backend.UpdateCertificateAuthority(caARN, "DISABLED"))
-				require.NoError(t, h.Backend.DeleteCertificateAuthority(caARN, 0))
+				require.NoError(t, h.Backend.UpdateCertificateAuthority(context.Background(), caARN, "DISABLED"))
+				require.NoError(t, h.Backend.DeleteCertificateAuthority(context.Background(), caARN, 0))
 
 				restoreRec := doACMPCARequest(t, h, "RestoreCertificateAuthority", map[string]any{
 					"CertificateAuthorityArn": caARN,
@@ -294,6 +299,7 @@ func TestACMPCAHandler_TagValidationAndCertificateChain(t *testing.T) {
 				caARN := createHandlerCA(t, h)
 
 				subCA, err := h.Backend.CreateCertificateAuthority(
+					context.Background(),
 					"SUBORDINATE",
 					acmpca.CertificateAuthorityConfiguration{
 						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
@@ -301,7 +307,7 @@ func TestACMPCAHandler_TagValidationAndCertificateChain(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				csr, err := h.Backend.GetCertificateAuthorityCsr(subCA.ARN)
+				csr, err := h.Backend.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 				require.NoError(t, err)
 
 				rec := doACMPCARequest(t, h, "IssueCertificate", map[string]any{
@@ -323,6 +329,7 @@ func TestACMPCAHandler_TagValidationAndCertificateChain(t *testing.T) {
 				caARN := createHandlerCA(t, h)
 
 				subCA, err := h.Backend.CreateCertificateAuthority(
+					context.Background(),
 					"SUBORDINATE",
 					acmpca.CertificateAuthorityConfiguration{
 						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Sub CA"},
@@ -330,10 +337,10 @@ func TestACMPCAHandler_TagValidationAndCertificateChain(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				csr, err := h.Backend.GetCertificateAuthorityCsr(subCA.ARN)
+				csr, err := h.Backend.GetCertificateAuthorityCsr(context.Background(), subCA.ARN)
 				require.NoError(t, err)
 
-				cert, err := h.Backend.IssueCertificate(caARN, csr, 365)
+				cert, err := h.Backend.IssueCertificate(context.Background(), caARN, csr, 365)
 				require.NoError(t, err)
 
 				rec := doACMPCARequest(t, h, "GetCertificate", map[string]any{

--- a/services/acmpca/isolation_test.go
+++ b/services/acmpca/isolation_test.go
@@ -1,0 +1,84 @@
+package acmpca //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func pcaCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func TestACMPCARegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := pcaCtxRegion("us-east-1")
+	ctxWest := pcaCtxRegion("us-west-2")
+
+	cfg := CertificateAuthorityConfiguration{
+		Subject: CertificateAuthoritySubject{CommonName: "example.com"},
+	}
+
+	// 1. Create a ROOT CA in us-east-1 (auto-activated).
+	eastCA, err := backend.CreateCertificateAuthority(ctxEast, "ROOT", cfg)
+	require.NoError(t, err)
+	assert.Contains(t, eastCA.ARN, "us-east-1")
+
+	// 2. Create a ROOT CA in us-west-2.
+	westCA, err := backend.CreateCertificateAuthority(ctxWest, "ROOT", cfg)
+	require.NoError(t, err)
+	assert.Contains(t, westCA.ARN, "us-west-2")
+
+	// 3. us-east-1 sees only its own CA.
+	eastList := backend.ListCertificateAuthorities(ctxEast, "", 0)
+	require.Len(t, eastList.Data, 1)
+	assert.Equal(t, eastCA.ARN, eastList.Data[0].ARN)
+
+	// 4. us-west-2 sees only its own CA.
+	westList := backend.ListCertificateAuthorities(ctxWest, "", 0)
+	require.Len(t, westList.Data, 1)
+	assert.Equal(t, westCA.ARN, westList.Data[0].ARN)
+
+	// 5. A CA created in us-east-1 is not visible from us-west-2 (cross-region lookup fails).
+	_, err = backend.DescribeCertificateAuthority(ctxWest, eastCA.ARN)
+	require.Error(t, err)
+
+	got, err := backend.DescribeCertificateAuthority(ctxEast, eastCA.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, eastCA.ARN, got.ARN)
+}
+
+func TestACMPCACertificateRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := pcaCtxRegion("us-east-1")
+	ctxWest := pcaCtxRegion("us-west-2")
+
+	cfg := CertificateAuthorityConfiguration{
+		Subject: CertificateAuthoritySubject{CommonName: "example.com"},
+	}
+
+	eastCA, err := backend.CreateCertificateAuthority(ctxEast, "ROOT", cfg)
+	require.NoError(t, err)
+
+	csr, err := backend.GetCertificateAuthorityCsr(ctxEast, eastCA.ARN)
+	require.NoError(t, err)
+
+	cert, err := backend.IssueCertificate(ctxEast, eastCA.ARN, csr, 90)
+	require.NoError(t, err)
+
+	// Certificate is retrievable in us-east-1 but not in us-west-2.
+	got, err := backend.GetCertificate(ctxEast, eastCA.ARN, cert.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, cert.ARN, got.ARN)
+
+	_, err = backend.GetCertificate(ctxWest, eastCA.ARN, cert.ARN)
+	require.Error(t, err)
+}

--- a/services/acmpca/persistence.go
+++ b/services/acmpca/persistence.go
@@ -52,14 +52,15 @@ func unmarshalPrivKey(pemStr string) (*ecdsa.PrivateKey, error) {
 	return ecKey, nil
 }
 
+// backendSnapshot mirrors the region-nested backend maps (outer key = region).
 type backendSnapshot struct {
-	CAs          map[string]*caSnapshot        `json:"cas"`
-	Certs        map[string]*IssuedCertificate `json:"certs"`
-	Permissions  map[string]*Permission        `json:"permissions"`
-	AuditReports map[string]*AuditReport       `json:"auditReports"`
-	Policies     map[string]string             `json:"policies"`
-	AccountID    string                        `json:"accountID"`
-	Region       string                        `json:"region"`
+	CAs          map[string]map[string]*caSnapshot        `json:"cas"`
+	Certs        map[string]map[string]*IssuedCertificate `json:"certs"`
+	Permissions  map[string]map[string]*Permission        `json:"permissions"`
+	AuditReports map[string]map[string]*AuditReport       `json:"auditReports"`
+	Policies     map[string]map[string]string             `json:"policies"`
+	AccountID    string                                   `json:"accountID"`
+	Region       string                                   `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -67,15 +68,19 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	cas := make(map[string]*caSnapshot, len(b.cas))
-	for k, ca := range b.cas {
-		snap := &caSnapshot{CertificateAuthority: *ca}
-		snap.privKey = nil
-		pemStr, err := marshalPrivKey(ca.privKey)
-		if err == nil {
-			snap.PrivKeyPEM = pemStr
+	cas := make(map[string]map[string]*caSnapshot, len(b.cas))
+	for region, regionCAs := range b.cas {
+		regionMap := make(map[string]*caSnapshot, len(regionCAs))
+		for k, ca := range regionCAs {
+			snap := &caSnapshot{CertificateAuthority: *ca}
+			snap.privKey = nil
+			pemStr, err := marshalPrivKey(ca.privKey)
+			if err == nil {
+				snap.PrivKeyPEM = pemStr
+			}
+			regionMap[k] = snap
 		}
-		cas[k] = snap
+		cas[region] = regionMap
 	}
 
 	data, err := json.Marshal(backendSnapshot{
@@ -105,40 +110,40 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
-	if snap.CAs == nil {
-		snap.CAs = make(map[string]*caSnapshot)
-	}
-
 	if snap.Certs == nil {
-		snap.Certs = make(map[string]*IssuedCertificate)
+		snap.Certs = make(map[string]map[string]*IssuedCertificate)
 	}
 
 	if snap.Permissions == nil {
-		snap.Permissions = make(map[string]*Permission)
+		snap.Permissions = make(map[string]map[string]*Permission)
 	}
 
 	if snap.AuditReports == nil {
-		snap.AuditReports = make(map[string]*AuditReport)
+		snap.AuditReports = make(map[string]map[string]*AuditReport)
 	}
 
 	if snap.Policies == nil {
-		snap.Policies = make(map[string]string)
+		snap.Policies = make(map[string]map[string]string)
 	}
 
-	cas := make(map[string]*CertificateAuthority, len(snap.CAs))
-	for k, s := range snap.CAs {
-		ca := s.CertificateAuthority
+	cas := make(map[string]map[string]*CertificateAuthority, len(snap.CAs))
+	for region, regionCAs := range snap.CAs {
+		regionMap := make(map[string]*CertificateAuthority, len(regionCAs))
+		for k, s := range regionCAs {
+			ca := s.CertificateAuthority
 
-		if s.PrivKeyPEM != "" {
-			privKey, err := unmarshalPrivKey(s.PrivKeyPEM)
-			if err != nil {
-				return fmt.Errorf("restore CA %s private key: %w", k, err)
+			if s.PrivKeyPEM != "" {
+				privKey, err := unmarshalPrivKey(s.PrivKeyPEM)
+				if err != nil {
+					return fmt.Errorf("restore CA %s private key: %w", k, err)
+				}
+
+				ca.privKey = privKey
 			}
 
-			ca.privKey = privKey
+			regionMap[k] = &ca
 		}
-
-		cas[k] = &ca
+		cas[region] = regionMap
 	}
 
 	b.cas = cas
@@ -149,10 +154,14 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 
-	// Rebuild certsByCASerial index from restored certificates.
-	b.certsByCASerial = make(map[string]string, len(b.certs))
-	for certARN, cert := range b.certs {
-		b.certsByCASerial[cert.CAARN+"#"+cert.Serial] = certARN
+	// Rebuild the per-region certsByCASerial index from restored certificates.
+	b.certsByCASerial = make(map[string]map[string]string, len(b.certs))
+	for region, regionCerts := range b.certs {
+		idx := make(map[string]string, len(regionCerts))
+		for certARN, cert := range regionCerts {
+			idx[cert.CAARN+"#"+cert.Serial] = certARN
+		}
+		b.certsByCASerial[region] = idx
 	}
 
 	return nil

--- a/services/acmpca/persistence_test.go
+++ b/services/acmpca/persistence_test.go
@@ -1,6 +1,7 @@
 package acmpca_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,9 +21,13 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "root_ca_round_trip",
 			setup: func(b *acmpca.InMemoryBackend) string {
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+					},
+				)
 				if err != nil {
 					return ""
 				}
@@ -32,7 +37,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *acmpca.InMemoryBackend, id string) {
 				t.Helper()
 
-				ca, err := b.DescribeCertificateAuthority(id)
+				ca, err := b.DescribeCertificateAuthority(context.Background(), id)
 				require.NoError(t, err)
 				assert.Equal(t, "ACTIVE", ca.Status)
 				assert.Equal(t, "ROOT", ca.Type)
@@ -41,19 +46,23 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "issued_cert_round_trip",
 			setup: func(b *acmpca.InMemoryBackend) string {
-				ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-				})
+				ca, err := b.CreateCertificateAuthority(
+					context.Background(),
+					"ROOT",
+					acmpca.CertificateAuthorityConfiguration{
+						Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+					},
+				)
 				if err != nil {
 					return ""
 				}
 
-				csr, err := b.GetCertificateAuthorityCsr(ca.ARN)
+				csr, err := b.GetCertificateAuthorityCsr(context.Background(), ca.ARN)
 				if err != nil {
 					return ""
 				}
 
-				cert, err := b.IssueCertificate(ca.ARN, csr, 365)
+				cert, err := b.IssueCertificate(context.Background(), ca.ARN, csr, 365)
 				if err != nil {
 					return ""
 				}
@@ -65,10 +74,10 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 
 				// IssuedCertificate ARN contains the CA ARN as a prefix
 				// Find the cert by listing all CAs first
-				cas := b.ListCertificateAuthorities("", 0).Data
+				cas := b.ListCertificateAuthorities(context.Background(), "", 0).Data
 				require.NotEmpty(t, cas)
 
-				certs := b.ListCertificates(cas[0].ARN, "", 0).Data
+				certs := b.ListCertificates(context.Background(), cas[0].ARN, "", 0).Data
 				require.NotEmpty(t, certs, "issued certificate should be restored")
 			},
 		},
@@ -78,7 +87,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *acmpca.InMemoryBackend, _ string) {
 				t.Helper()
 
-				cas := b.ListCertificateAuthorities("", 0).Data
+				cas := b.ListCertificateAuthorities(context.Background(), "", 0).Data
 				assert.Empty(t, cas)
 			},
 		},
@@ -127,23 +136,27 @@ func TestInMemoryBackend_GetCertificate(t *testing.T) {
 
 			b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			csr, err := b.GetCertificateAuthorityCsr(ca.ARN)
+			csr, err := b.GetCertificateAuthorityCsr(context.Background(), ca.ARN)
 			require.NoError(t, err)
 
-			issuedCert, err := b.IssueCertificate(ca.ARN, csr, 365)
+			issuedCert, err := b.IssueCertificate(context.Background(), ca.ARN, csr, 365)
 			require.NoError(t, err)
 
 			if tt.wantErr {
-				_, err = b.GetCertificate(ca.ARN, "nonexistent-arn")
+				_, err = b.GetCertificate(context.Background(), ca.ARN, "nonexistent-arn")
 				require.Error(t, err)
 			} else {
 				var cert *acmpca.IssuedCertificate
-				cert, err = b.GetCertificate(ca.ARN, issuedCert.ARN)
+				cert, err = b.GetCertificate(context.Background(), ca.ARN, issuedCert.ARN)
 				require.NoError(t, err)
 				assert.Equal(t, issuedCert.ARN, cert.ARN)
 				assert.Equal(t, ca.ARN, cert.CAARN)
@@ -170,15 +183,19 @@ func TestInMemoryBackend_RevokeCertificate(t *testing.T) {
 
 			b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			csr, err := b.GetCertificateAuthorityCsr(ca.ARN)
+			csr, err := b.GetCertificateAuthorityCsr(context.Background(), ca.ARN)
 			require.NoError(t, err)
 
-			cert, err := b.IssueCertificate(ca.ARN, csr, 365)
+			cert, err := b.IssueCertificate(context.Background(), ca.ARN, csr, 365)
 			require.NoError(t, err)
 
 			serial := tt.serial
@@ -186,7 +203,7 @@ func TestInMemoryBackend_RevokeCertificate(t *testing.T) {
 				serial = cert.Serial
 			}
 
-			err = b.RevokeCertificate(ca.ARN, serial, "KEY_COMPROMISE")
+			err = b.RevokeCertificate(context.Background(), ca.ARN, serial, "KEY_COMPROMISE")
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -194,7 +211,7 @@ func TestInMemoryBackend_RevokeCertificate(t *testing.T) {
 				require.NoError(t, err)
 
 				var got *acmpca.IssuedCertificate
-				got, err = b.GetCertificate(ca.ARN, cert.ARN)
+				got, err = b.GetCertificate(context.Background(), ca.ARN, cert.ARN)
 				require.NoError(t, err)
 				assert.Equal(t, "REVOKED", got.Status)
 			}
@@ -207,22 +224,22 @@ func TestInMemoryBackend_ListCertificates(t *testing.T) {
 
 	b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 
-	ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
+	ca, err := b.CreateCertificateAuthority(context.Background(), "ROOT", acmpca.CertificateAuthorityConfiguration{
 		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
 	})
 	require.NoError(t, err)
 
-	csr, err := b.GetCertificateAuthorityCsr(ca.ARN)
+	csr, err := b.GetCertificateAuthorityCsr(context.Background(), ca.ARN)
 	require.NoError(t, err)
 
-	_, err = b.IssueCertificate(ca.ARN, csr, 365)
+	_, err = b.IssueCertificate(context.Background(), ca.ARN, csr, 365)
 	require.NoError(t, err)
 
-	certs := b.ListCertificates(ca.ARN, "", 0).Data
+	certs := b.ListCertificates(context.Background(), ca.ARN, "", 0).Data
 	assert.Len(t, certs, 1)
 
 	// Non-existent CA returns empty list.
-	empty := b.ListCertificates("nonexistent", "", 0).Data
+	empty := b.ListCertificates(context.Background(), "nonexistent", "", 0).Data
 	assert.Empty(t, empty)
 }
 
@@ -245,9 +262,13 @@ func TestInMemoryBackend_UpdateCertificateAuthority(t *testing.T) {
 
 			b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 
-			ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
-			})
+			ca, err := b.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
+				},
+			)
 			require.NoError(t, err)
 
 			caARN := tt.caARN
@@ -255,7 +276,7 @@ func TestInMemoryBackend_UpdateCertificateAuthority(t *testing.T) {
 				caARN = ca.ARN
 			}
 
-			err = b.UpdateCertificateAuthority(caARN, tt.status)
+			err = b.UpdateCertificateAuthority(context.Background(), caARN, tt.status)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -263,7 +284,7 @@ func TestInMemoryBackend_UpdateCertificateAuthority(t *testing.T) {
 				require.NoError(t, err)
 
 				var got *acmpca.CertificateAuthority
-				got, err = b.DescribeCertificateAuthority(caARN)
+				got, err = b.DescribeCertificateAuthority(context.Background(), caARN)
 				require.NoError(t, err)
 				assert.Equal(t, tt.status, got.Status)
 			}
@@ -277,12 +298,12 @@ func TestInMemoryBackend_ImportCertificateAuthorityCertificate(t *testing.T) {
 	b := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 
 	// For a ROOT CA, self-sign is automatic. Test that GetCertificateAuthorityCertificate works.
-	ca, err := b.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
+	ca, err := b.CreateCertificateAuthority(context.Background(), "ROOT", acmpca.CertificateAuthorityConfiguration{
 		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Root CA"},
 	})
 	require.NoError(t, err)
 
-	certPEM, chainPEM, err := b.GetCertificateAuthorityCertificate(ca.ARN)
+	certPEM, chainPEM, err := b.GetCertificateAuthorityCertificate(context.Background(), ca.ARN)
 	require.NoError(t, err)
 	assert.NotEmpty(t, certPEM)
 	assert.Empty(t, chainPEM) // Root CA has no chain
@@ -301,7 +322,7 @@ func TestACMPCAHandler_Persistence(t *testing.T) {
 	backend := acmpca.NewInMemoryBackend(testAccountID, testRegion)
 	h := acmpca.NewHandler(backend)
 
-	_, err := backend.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
+	_, err := backend.CreateCertificateAuthority(context.Background(), "ROOT", acmpca.CertificateAuthorityConfiguration{
 		Subject: acmpca.CertificateAuthoritySubject{CommonName: "Test CA"},
 	})
 	require.NoError(t, err)
@@ -313,7 +334,7 @@ func TestACMPCAHandler_Persistence(t *testing.T) {
 	freshH := acmpca.NewHandler(fresh)
 	require.NoError(t, freshH.Restore(snap))
 
-	cas := fresh.ListCertificateAuthorities("", 0).Data
+	cas := fresh.ListCertificateAuthorities(context.Background(), "", 0).Data
 	assert.Len(t, cas, 1)
 }
 
@@ -329,16 +350,16 @@ func TestInMemoryBackend_SnapshotRestore_AdditionalState(t *testing.T) {
 			verify: func(t *testing.T, b *acmpca.InMemoryBackend, caARN, reportID string) {
 				t.Helper()
 
-				perms, err := b.ListPermissions(caARN, "", 0)
+				perms, err := b.ListPermissions(context.Background(), caARN, "", 0)
 				require.NoError(t, err)
 				require.Len(t, perms.Data, 1)
 				assert.Equal(t, "acm.amazonaws.com", perms.Data[0].Principal)
 
-				policy, err := b.GetPolicy(caARN)
+				policy, err := b.GetPolicy(context.Background(), caARN)
 				require.NoError(t, err)
 				assert.JSONEq(t, `{"Version":"2012-10-17","Statement":[]}`, policy)
 
-				report, err := b.DescribeCertificateAuthorityAuditReport(caARN, reportID)
+				report, err := b.DescribeCertificateAuthorityAuditReport(context.Background(), caARN, reportID)
 				require.NoError(t, err)
 				assert.Equal(t, "audit-bucket", report.S3BucketName)
 			},
@@ -350,16 +371,34 @@ func TestInMemoryBackend_SnapshotRestore_AdditionalState(t *testing.T) {
 			t.Parallel()
 
 			original := acmpca.NewInMemoryBackend(testAccountID, testRegion)
-			ca, err := original.CreateCertificateAuthority("ROOT", acmpca.CertificateAuthorityConfiguration{
-				Subject: acmpca.CertificateAuthoritySubject{CommonName: "Persist CA"},
-			})
+			ca, err := original.CreateCertificateAuthority(
+				context.Background(),
+				"ROOT",
+				acmpca.CertificateAuthorityConfiguration{
+					Subject: acmpca.CertificateAuthoritySubject{CommonName: "Persist CA"},
+				},
+			)
 			require.NoError(t, err)
 
-			_, err = original.CreatePermission(ca.ARN, "acm.amazonaws.com", testAccountID, []string{"IssueCertificate"})
+			_, err = original.CreatePermission(
+				context.Background(),
+				ca.ARN,
+				"acm.amazonaws.com",
+				testAccountID,
+				[]string{"IssueCertificate"},
+			)
 			require.NoError(t, err)
-			require.NoError(t, original.PutPolicy(ca.ARN, `{"Version":"2012-10-17","Statement":[]}`))
+			require.NoError(
+				t,
+				original.PutPolicy(context.Background(), ca.ARN, `{"Version":"2012-10-17","Statement":[]}`),
+			)
 
-			report, err := original.CreateCertificateAuthorityAuditReport(ca.ARN, "audit-bucket", "JSON")
+			report, err := original.CreateCertificateAuthorityAuditReport(
+				context.Background(),
+				ca.ARN,
+				"audit-bucket",
+				"JSON",
+			)
 			require.NoError(t, err)
 
 			fresh := acmpca.NewInMemoryBackend(testAccountID, testRegion)

--- a/services/batch/backend.go
+++ b/services/batch/backend.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"maps"
@@ -20,6 +21,18 @@ import (
 const (
 	statusValid = "VALID"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 var (
 	// ErrNotFound is returned when a requested resource does not exist.
@@ -685,19 +698,23 @@ type FrontOfQueueJob struct {
 }
 
 // InMemoryBackend stores AWS Batch state in memory.
+//
+// All resource maps (including the cross-index maps jobsByQueue, jobsByARN and
+// schedulingPolicyByName) are nested by region (outer key = region) so that
+// same-named resources in different regions are fully isolated.
 type InMemoryBackend struct {
-	computeEnvironments    map[string]*ComputeEnvironment
-	jobQueues              map[string]*JobQueue
-	jobDefinitions         map[string]*JobDefinition
-	jobs                   map[string]*Job     // job ID → Job
-	jobsByQueue            map[string][]string // queue name → []jobID
-	jobDefRevisions        map[string]int32
-	consumableResources    map[string]*ConsumableResource
-	schedulingPolicies     map[string]*SchedulingPolicy // ARN → SchedulingPolicy
-	serviceEnvironments    map[string]*ServiceEnvironment
-	serviceJobs            map[string]*ServiceJob // serviceJobID → ServiceJob
-	schedulingPolicyByName map[string]string      // name → ARN
-	jobsByARN              map[string]string      // job ARN → job ID
+	computeEnvironments    map[string]map[string]*ComputeEnvironment // region → name → CE
+	jobQueues              map[string]map[string]*JobQueue           // region → name → JQ
+	jobDefinitions         map[string]map[string]*JobDefinition      // region → ARN → JobDefinition
+	jobs                   map[string]map[string]*Job                // region → job ID → Job
+	jobsByQueue            map[string]map[string][]string            // region → queue name → []jobID
+	jobDefRevisions        map[string]map[string]int32               // region → name → revision counter
+	consumableResources    map[string]map[string]*ConsumableResource // region → name → CR
+	schedulingPolicies     map[string]map[string]*SchedulingPolicy   // region → ARN → SchedulingPolicy
+	serviceEnvironments    map[string]map[string]*ServiceEnvironment // region → name → SE
+	serviceJobs            map[string]map[string]*ServiceJob         // region → serviceJobID → ServiceJob
+	schedulingPolicyByName map[string]map[string]string              // region → name → ARN
+	jobsByARN              map[string]map[string]string              // region → job ARN → job ID
 	mu                     *lockmetrics.RWMutex
 	accountID              string
 	region                 string
@@ -705,23 +722,129 @@ type InMemoryBackend struct {
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
-	return &InMemoryBackend{
-		computeEnvironments:    make(map[string]*ComputeEnvironment),
-		jobQueues:              make(map[string]*JobQueue),
-		jobDefinitions:         make(map[string]*JobDefinition),
-		jobs:                   make(map[string]*Job),
-		jobsByQueue:            make(map[string][]string),
-		jobDefRevisions:        make(map[string]int32),
-		consumableResources:    make(map[string]*ConsumableResource),
-		schedulingPolicies:     make(map[string]*SchedulingPolicy),
-		serviceEnvironments:    make(map[string]*ServiceEnvironment),
-		serviceJobs:            make(map[string]*ServiceJob),
-		schedulingPolicyByName: make(map[string]string),
-		jobsByARN:              make(map[string]string),
-		accountID:              accountID,
-		region:                 region,
-		mu:                     lockmetrics.New("batch"),
+	b := &InMemoryBackend{
+		mu:        lockmetrics.New("batch"),
+		accountID: accountID,
+		region:    region,
 	}
+	b.initMaps()
+
+	return b
+}
+
+// initMaps initialises all top-level region maps. Callers must hold b.mu (or be
+// in single-threaded setup).
+func (b *InMemoryBackend) initMaps() {
+	b.computeEnvironments = make(map[string]map[string]*ComputeEnvironment)
+	b.jobQueues = make(map[string]map[string]*JobQueue)
+	b.jobDefinitions = make(map[string]map[string]*JobDefinition)
+	b.jobs = make(map[string]map[string]*Job)
+	b.jobsByQueue = make(map[string]map[string][]string)
+	b.jobDefRevisions = make(map[string]map[string]int32)
+	b.consumableResources = make(map[string]map[string]*ConsumableResource)
+	b.schedulingPolicies = make(map[string]map[string]*SchedulingPolicy)
+	b.serviceEnvironments = make(map[string]map[string]*ServiceEnvironment)
+	b.serviceJobs = make(map[string]map[string]*ServiceJob)
+	b.schedulingPolicyByName = make(map[string]map[string]string)
+	b.jobsByARN = make(map[string]map[string]string)
+}
+
+// --- lazy per-region store helpers (callers must hold b.mu) ---
+
+func (b *InMemoryBackend) computeEnvironmentsStore(region string) map[string]*ComputeEnvironment {
+	if b.computeEnvironments[region] == nil {
+		b.computeEnvironments[region] = make(map[string]*ComputeEnvironment)
+	}
+
+	return b.computeEnvironments[region]
+}
+
+func (b *InMemoryBackend) jobQueuesStore(region string) map[string]*JobQueue {
+	if b.jobQueues[region] == nil {
+		b.jobQueues[region] = make(map[string]*JobQueue)
+	}
+
+	return b.jobQueues[region]
+}
+
+func (b *InMemoryBackend) jobDefinitionsStore(region string) map[string]*JobDefinition {
+	if b.jobDefinitions[region] == nil {
+		b.jobDefinitions[region] = make(map[string]*JobDefinition)
+	}
+
+	return b.jobDefinitions[region]
+}
+
+func (b *InMemoryBackend) jobsStore(region string) map[string]*Job {
+	if b.jobs[region] == nil {
+		b.jobs[region] = make(map[string]*Job)
+	}
+
+	return b.jobs[region]
+}
+
+func (b *InMemoryBackend) jobsByQueueStore(region string) map[string][]string {
+	if b.jobsByQueue[region] == nil {
+		b.jobsByQueue[region] = make(map[string][]string)
+	}
+
+	return b.jobsByQueue[region]
+}
+
+func (b *InMemoryBackend) jobDefRevisionsStore(region string) map[string]int32 {
+	if b.jobDefRevisions[region] == nil {
+		b.jobDefRevisions[region] = make(map[string]int32)
+	}
+
+	return b.jobDefRevisions[region]
+}
+
+func (b *InMemoryBackend) consumableResourcesStore(region string) map[string]*ConsumableResource {
+	if b.consumableResources[region] == nil {
+		b.consumableResources[region] = make(map[string]*ConsumableResource)
+	}
+
+	return b.consumableResources[region]
+}
+
+func (b *InMemoryBackend) schedulingPoliciesStore(region string) map[string]*SchedulingPolicy {
+	if b.schedulingPolicies[region] == nil {
+		b.schedulingPolicies[region] = make(map[string]*SchedulingPolicy)
+	}
+
+	return b.schedulingPolicies[region]
+}
+
+func (b *InMemoryBackend) serviceEnvironmentsStore(region string) map[string]*ServiceEnvironment {
+	if b.serviceEnvironments[region] == nil {
+		b.serviceEnvironments[region] = make(map[string]*ServiceEnvironment)
+	}
+
+	return b.serviceEnvironments[region]
+}
+
+func (b *InMemoryBackend) serviceJobsStore(region string) map[string]*ServiceJob {
+	if b.serviceJobs[region] == nil {
+		b.serviceJobs[region] = make(map[string]*ServiceJob)
+	}
+
+	return b.serviceJobs[region]
+}
+
+func (b *InMemoryBackend) schedulingPolicyByNameStore(region string) map[string]string {
+	if b.schedulingPolicyByName[region] == nil {
+		b.schedulingPolicyByName[region] = make(map[string]string)
+	}
+
+	return b.schedulingPolicyByName[region]
+}
+
+func (b *InMemoryBackend) jobsByARNStore(region string) map[string]string {
+	if b.jobsByARN[region] == nil {
+		b.jobsByARN[region] = make(map[string]string)
+	}
+
+	return b.jobsByARN[region]
 }
 
 // Reset clears all state from the backend.
@@ -729,31 +852,21 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.computeEnvironments = make(map[string]*ComputeEnvironment)
-	b.jobQueues = make(map[string]*JobQueue)
-	b.jobDefinitions = make(map[string]*JobDefinition)
-	b.jobs = make(map[string]*Job)
-	b.jobsByQueue = make(map[string][]string)
-	b.jobDefRevisions = make(map[string]int32)
-	b.consumableResources = make(map[string]*ConsumableResource)
-	b.schedulingPolicies = make(map[string]*SchedulingPolicy)
-	b.serviceEnvironments = make(map[string]*ServiceEnvironment)
-	b.serviceJobs = make(map[string]*ServiceJob)
-	b.schedulingPolicyByName = make(map[string]string)
-	b.jobsByARN = make(map[string]string)
+	b.initMaps()
 }
 
 // Region returns the AWS region this backend is configured for.
 func (b *InMemoryBackend) Region() string { return b.region }
 
-// lookupCEByNameOrARN returns a compute environment by name or ARN.
+// lookupCEByNameOrARN returns a compute environment by name or ARN within region.
 // Caller must hold at least a read lock.
-func (b *InMemoryBackend) lookupCEByNameOrARN(nameOrARN string) (*ComputeEnvironment, bool) {
-	if ce, ok := b.computeEnvironments[nameOrARN]; ok {
+func (b *InMemoryBackend) lookupCEByNameOrARN(region, nameOrARN string) (*ComputeEnvironment, bool) {
+	ces := b.computeEnvironmentsStore(region)
+	if ce, ok := ces[nameOrARN]; ok {
 		return ce, true
 	}
 
-	for _, ce := range b.computeEnvironments {
+	for _, ce := range ces {
 		if ce.ComputeEnvironmentArn == nameOrARN {
 			return ce, true
 		}
@@ -762,14 +875,15 @@ func (b *InMemoryBackend) lookupCEByNameOrARN(nameOrARN string) (*ComputeEnviron
 	return nil, false
 }
 
-// lookupJQByNameOrARN returns a job queue by name or ARN.
+// lookupJQByNameOrARN returns a job queue by name or ARN within region.
 // Caller must hold at least a read lock.
-func (b *InMemoryBackend) lookupJQByNameOrARN(nameOrARN string) (*JobQueue, bool) {
-	if jq, ok := b.jobQueues[nameOrARN]; ok {
+func (b *InMemoryBackend) lookupJQByNameOrARN(region, nameOrARN string) (*JobQueue, bool) {
+	jqs := b.jobQueuesStore(region)
+	if jq, ok := jqs[nameOrARN]; ok {
 		return jq, true
 	}
 
-	for _, jq := range b.jobQueues {
+	for _, jq := range jqs {
 		if jq.JobQueueArn == nameOrARN {
 			return jq, true
 		}
@@ -778,15 +892,16 @@ func (b *InMemoryBackend) lookupJQByNameOrARN(nameOrARN string) (*JobQueue, bool
 	return nil, false
 }
 
-// lookupJobByIDOrARN returns a job by ID or ARN using the jobsByARN index for O(1) ARN lookup.
-// Caller must hold at least a read lock.
-func (b *InMemoryBackend) lookupJobByIDOrARN(idOrARN string) (*Job, bool) {
-	if j, ok := b.jobs[idOrARN]; ok {
+// lookupJobByIDOrARN returns a job by ID or ARN within region using the jobsByARN
+// index for O(1) ARN lookup. Caller must hold at least a read lock.
+func (b *InMemoryBackend) lookupJobByIDOrARN(region, idOrARN string) (*Job, bool) {
+	jobs := b.jobsStore(region)
+	if j, ok := jobs[idOrARN]; ok {
 		return j, true
 	}
 
-	if jobID, ok := b.jobsByARN[idOrARN]; ok {
-		if j, found := b.jobs[jobID]; found {
+	if jobID, ok := b.jobsByARNStore(region)[idOrARN]; ok {
+		if j, found := jobs[jobID]; found {
 			return j, true
 		}
 	}
@@ -798,6 +913,7 @@ func (b *InMemoryBackend) lookupJobByIDOrARN(idOrARN string) (*Job, bool) {
 //
 //nolint:gocognit,cyclop,funlen // Too complex to refactor given time constraints
 func (b *InMemoryBackend) CreateComputeEnvironment(
+	ctx context.Context,
 	name, ceType, state string,
 	tags map[string]string,
 	serviceRole string,
@@ -805,6 +921,8 @@ func (b *InMemoryBackend) CreateComputeEnvironment(
 	eksConfig *EksConfiguration,
 	updatePolicy *UpdatePolicy,
 ) (*ComputeEnvironment, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateComputeEnvironment")
 	defer b.mu.Unlock()
 
@@ -862,11 +980,12 @@ func (b *InMemoryBackend) CreateComputeEnvironment(
 		return nil, err
 	}
 
-	if _, ok := b.computeEnvironments[name]; ok {
+	ces := b.computeEnvironmentsStore(region)
+	if _, ok := ces[name]; ok {
 		return nil, fmt.Errorf("%w: compute environment %s already exists", ErrAlreadyExists, name)
 	}
 
-	ceARN := arn.Build("batch", b.region, b.accountID, "compute-environment/"+name)
+	ceARN := arn.Build("batch", region, b.accountID, "compute-environment/"+name)
 
 	tagsCopy := make(map[string]string, len(tags))
 	maps.Copy(tagsCopy, tags)
@@ -901,7 +1020,7 @@ func (b *InMemoryBackend) CreateComputeEnvironment(
 		EksConfiguration:       eksCopy,
 		UpdatePolicy:           upCopy,
 	}
-	b.computeEnvironments[name] = ce
+	ces[name] = ce
 	cp := *ce
 
 	return &cp, nil
@@ -932,18 +1051,23 @@ func cloneComputeResources(cr *ComputeResources) *ComputeResources {
 //
 //nolint:dupl // Boilerplate pagination logic is similar to DescribeJobQueues
 func (b *InMemoryBackend) DescribeComputeEnvironments(
+	ctx context.Context,
 	names []string,
 	maxResults int32,
 	nextToken string,
 ) ([]*ComputeEnvironment, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeComputeEnvironments")
 	defer b.mu.RUnlock()
+
+	ces := b.computeEnvironmentsStore(region)
 
 	if len(names) > 0 {
 		list := make([]*ComputeEnvironment, 0, len(names))
 
 		for _, nameOrARN := range names {
-			if ce, ok := b.lookupCEByNameOrARN(nameOrARN); ok {
+			if ce, ok := b.lookupCEByNameOrARN(region, nameOrARN); ok {
 				cp := *ce
 				cp.Tags = tagsCloneOrEmpty(ce.Tags)
 				list = append(list, &cp)
@@ -953,8 +1077,8 @@ func (b *InMemoryBackend) DescribeComputeEnvironments(
 		return list, ""
 	}
 
-	all := make([]*ComputeEnvironment, 0, len(b.computeEnvironments))
-	for _, ce := range b.computeEnvironments {
+	all := make([]*ComputeEnvironment, 0, len(ces))
+	for _, ce := range ces {
 		cp := *ce
 		cp.Tags = tagsCloneOrEmpty(ce.Tags)
 		all = append(all, &cp)
@@ -967,14 +1091,17 @@ func (b *InMemoryBackend) DescribeComputeEnvironments(
 
 // UpdateComputeEnvironment updates the state, service role, compute resources, and/or update policy.
 func (b *InMemoryBackend) UpdateComputeEnvironment(
+	ctx context.Context,
 	nameOrARN, state, serviceRole string,
 	computeResources *ComputeResources,
 	updatePolicy *UpdatePolicy,
 ) (*ComputeEnvironment, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateComputeEnvironment")
 	defer b.mu.Unlock()
 
-	ce, ok := b.lookupCEByNameOrARN(nameOrARN)
+	ce, ok := b.lookupCEByNameOrARN(region, nameOrARN)
 	if !ok {
 		return nil, fmt.Errorf("%w: compute environment %s not found", ErrNotFound, nameOrARN)
 	}
@@ -1006,11 +1133,13 @@ func (b *InMemoryBackend) UpdateComputeEnvironment(
 }
 
 // DeleteComputeEnvironment removes a compute environment.
-func (b *InMemoryBackend) DeleteComputeEnvironment(nameOrARN string) error {
+func (b *InMemoryBackend) DeleteComputeEnvironment(ctx context.Context, nameOrARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteComputeEnvironment")
 	defer b.mu.Unlock()
 
-	ce, ok := b.lookupCEByNameOrARN(nameOrARN)
+	ce, ok := b.lookupCEByNameOrARN(region, nameOrARN)
 	if !ok {
 		return fmt.Errorf("%w: compute environment %s not found", ErrNotFound, nameOrARN)
 	}
@@ -1024,7 +1153,7 @@ func (b *InMemoryBackend) DeleteComputeEnvironment(nameOrARN string) error {
 	}
 
 	// Check if referenced by any job queue.
-	for _, jq := range b.jobQueues {
+	for _, jq := range b.jobQueuesStore(region) {
 		for _, ceOrder := range jq.ComputeEnvironmentOrder {
 			if ceOrder.ComputeEnvironment == ce.ComputeEnvironmentName ||
 				ceOrder.ComputeEnvironment == ce.ComputeEnvironmentArn {
@@ -1037,13 +1166,14 @@ func (b *InMemoryBackend) DeleteComputeEnvironment(nameOrARN string) error {
 		}
 	}
 
-	delete(b.computeEnvironments, ce.ComputeEnvironmentName)
+	delete(b.computeEnvironmentsStore(region), ce.ComputeEnvironmentName)
 
 	return nil
 }
 
 // CreateJobQueue creates a new job queue.
 func (b *InMemoryBackend) CreateJobQueue(
+	ctx context.Context,
 	name string,
 	priority int32,
 	state string,
@@ -1052,6 +1182,8 @@ func (b *InMemoryBackend) CreateJobQueue(
 	schedulingPolicyArn string,
 	jobStateTimeLimitActions []JobStateTimeLimitAction,
 ) (*JobQueue, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateJobQueue")
 	defer b.mu.Unlock()
 
@@ -1062,7 +1194,8 @@ func (b *InMemoryBackend) CreateJobQueue(
 		)
 	}
 
-	if _, ok := b.jobQueues[name]; ok {
+	jqs := b.jobQueuesStore(region)
+	if _, ok := jqs[name]; ok {
 		return nil, fmt.Errorf("%w: job queue %s already exists", ErrAlreadyExists, name)
 	}
 
@@ -1070,7 +1203,7 @@ func (b *InMemoryBackend) CreateJobQueue(
 		return nil, err
 	}
 
-	jqARN := arn.Build("batch", b.region, b.accountID, "job-queue/"+name)
+	jqARN := arn.Build("batch", region, b.accountID, "job-queue/"+name)
 
 	tagsCopy := make(map[string]string, len(tags))
 	maps.Copy(tagsCopy, tags)
@@ -1095,7 +1228,7 @@ func (b *InMemoryBackend) CreateJobQueue(
 		SchedulingPolicyArn:      schedulingPolicyArn,
 		JobStateTimeLimitActions: actionsCopy,
 	}
-	b.jobQueues[name] = jq
+	jqs[name] = jq
 	cp := *jq
 
 	return &cp, nil
@@ -1106,15 +1239,24 @@ func (b *InMemoryBackend) CreateJobQueue(
 // When names is empty, results are paginated using maxResults and nextToken.
 //
 //nolint:dupl // Boilerplate pagination logic is similar to DescribeComputeEnvironments
-func (b *InMemoryBackend) DescribeJobQueues(names []string, maxResults int32, nextToken string) ([]*JobQueue, string) {
+func (b *InMemoryBackend) DescribeJobQueues(
+	ctx context.Context,
+	names []string,
+	maxResults int32,
+	nextToken string,
+) ([]*JobQueue, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeJobQueues")
 	defer b.mu.RUnlock()
+
+	jqs := b.jobQueuesStore(region)
 
 	if len(names) > 0 {
 		list := make([]*JobQueue, 0, len(names))
 
 		for _, nameOrARN := range names {
-			if jq, ok := b.lookupJQByNameOrARN(nameOrARN); ok {
+			if jq, ok := b.lookupJQByNameOrARN(region, nameOrARN); ok {
 				cp := *jq
 				cp.Tags = tagsCloneOrEmpty(jq.Tags)
 				list = append(list, &cp)
@@ -1124,8 +1266,8 @@ func (b *InMemoryBackend) DescribeJobQueues(names []string, maxResults int32, ne
 		return list, ""
 	}
 
-	all := make([]*JobQueue, 0, len(b.jobQueues))
-	for _, jq := range b.jobQueues {
+	all := make([]*JobQueue, 0, len(jqs))
+	for _, jq := range jqs {
 		cp := *jq
 		cp.Tags = tagsCloneOrEmpty(jq.Tags)
 		all = append(all, &cp)
@@ -1138,16 +1280,19 @@ func (b *InMemoryBackend) DescribeJobQueues(names []string, maxResults int32, ne
 
 // UpdateJobQueue updates a job queue's state, priority, CE order, and/or time-limit actions.
 func (b *InMemoryBackend) UpdateJobQueue(
+	ctx context.Context,
 	nameOrARN string,
 	priority *int32,
 	state string,
 	ceOrder []ComputeEnvironmentOrder,
 	jobStateTimeLimitActions []JobStateTimeLimitAction,
 ) (*JobQueue, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateJobQueue")
 	defer b.mu.Unlock()
 
-	jq, ok := b.lookupJQByNameOrARN(nameOrARN)
+	jq, ok := b.lookupJQByNameOrARN(region, nameOrARN)
 	if !ok {
 		return nil, fmt.Errorf("%w: job queue %s not found", ErrNotFound, nameOrARN)
 	}
@@ -1183,11 +1328,13 @@ func (b *InMemoryBackend) UpdateJobQueue(
 
 // DeleteJobQueue removes a job queue and all associated jobs.
 // The queue must be in DISABLED state before deletion.
-func (b *InMemoryBackend) DeleteJobQueue(nameOrARN string) error {
+func (b *InMemoryBackend) DeleteJobQueue(ctx context.Context, nameOrARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteJobQueue")
 	defer b.mu.Unlock()
 
-	jq, ok := b.lookupJQByNameOrARN(nameOrARN)
+	jq, ok := b.lookupJQByNameOrARN(region, nameOrARN)
 	if !ok {
 		return fmt.Errorf("%w: job queue %s not found", ErrNotFound, nameOrARN)
 	}
@@ -1198,22 +1345,27 @@ func (b *InMemoryBackend) DeleteJobQueue(nameOrARN string) error {
 
 	queueName := jq.JobQueueName
 
-	for _, jobID := range b.jobsByQueue[queueName] {
-		if j, ok2 := b.jobs[jobID]; ok2 {
-			delete(b.jobsByARN, j.JobARN)
+	jobs := b.jobsStore(region)
+	jobsByARN := b.jobsByARNStore(region)
+	jobsByQueue := b.jobsByQueueStore(region)
+
+	for _, jobID := range jobsByQueue[queueName] {
+		if j, ok2 := jobs[jobID]; ok2 {
+			delete(jobsByARN, j.JobARN)
 		}
 
-		delete(b.jobs, jobID)
+		delete(jobs, jobID)
 	}
 
-	delete(b.jobsByQueue, queueName)
-	delete(b.jobQueues, queueName)
+	delete(jobsByQueue, queueName)
+	delete(b.jobQueuesStore(region), queueName)
 
 	return nil
 }
 
 // RegisterJobDefinition registers a new job definition (or a new revision).
 func (b *InMemoryBackend) RegisterJobDefinition(
+	ctx context.Context,
 	name, defType string,
 	tags map[string]string,
 	platformCapabilities []string,
@@ -1227,6 +1379,8 @@ func (b *InMemoryBackend) RegisterJobDefinition(
 	parameters map[string]string,
 	propagateTags bool,
 ) (*JobDefinition, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RegisterJobDefinition")
 	defer b.mu.Unlock()
 
@@ -1241,10 +1395,11 @@ func (b *InMemoryBackend) RegisterJobDefinition(
 		return nil, err
 	}
 
-	b.jobDefRevisions[name]++
-	revision := b.jobDefRevisions[name]
+	revisions := b.jobDefRevisionsStore(region)
+	revisions[name]++
+	revision := revisions[name]
 
-	jdARN := arn.Build("batch", b.region, b.accountID, fmt.Sprintf("job-definition/%s:%d", name, revision))
+	jdARN := arn.Build("batch", region, b.accountID, fmt.Sprintf("job-definition/%s:%d", name, revision))
 
 	tagsCopy := make(map[string]string, len(tags))
 	maps.Copy(tagsCopy, tags)
@@ -1273,7 +1428,7 @@ func (b *InMemoryBackend) RegisterJobDefinition(
 		Parameters:                   maps.Clone(parameters),
 		PropagateTags:                propagateTags,
 	}
-	b.jobDefinitions[jdARN] = jd
+	b.jobDefinitionsStore(region)[jdARN] = jd
 	cp := *jd
 
 	return &cp, nil
@@ -1282,31 +1437,35 @@ func (b *InMemoryBackend) RegisterJobDefinition(
 // DescribeJobDefinitions returns job definitions, optionally filtered by names/ARNs.
 // When names is empty, results are paginated via maxResults/nextToken.
 func (b *InMemoryBackend) DescribeJobDefinitions(
+	ctx context.Context,
 	names []string,
 	status, jobDefinitionName string,
 	maxResults int32,
 	nextToken string,
 ) ([]*JobDefinition, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeJobDefinitions")
 	defer b.mu.RUnlock()
 
 	if len(names) == 0 {
-		return b.describeAllJobDefinitions(status, jobDefinitionName, maxResults, nextToken)
+		return b.describeAllJobDefinitions(region, status, jobDefinitionName, maxResults, nextToken)
 	}
 
-	list := b.describeJobDefinitionsByNames(names, status)
+	list := b.describeJobDefinitionsByNames(region, names, status)
 
 	return list, ""
 }
 
 func (b *InMemoryBackend) describeAllJobDefinitions(
-	status, jobDefinitionName string,
+	region, status, jobDefinitionName string,
 	maxResults int32,
 	nextToken string,
 ) ([]*JobDefinition, string) {
-	all := make([]*JobDefinition, 0, len(b.jobDefinitions))
+	defs := b.jobDefinitionsStore(region)
+	all := make([]*JobDefinition, 0, len(defs))
 
-	for _, jd := range b.jobDefinitions {
+	for _, jd := range defs {
 		if status != "" && jd.Status != status {
 			continue
 		}
@@ -1346,12 +1505,13 @@ func (b *InMemoryBackend) describeAllJobDefinitions(
 	return page, outToken
 }
 
-func (b *InMemoryBackend) describeJobDefinitionsByNames(names []string, status string) []*JobDefinition {
+func (b *InMemoryBackend) describeJobDefinitionsByNames(region string, names []string, status string) []*JobDefinition {
+	defs := b.jobDefinitionsStore(region)
 	seen := make(map[string]bool)
 	list := make([]*JobDefinition, 0, len(names))
 
 	for _, nameOrARN := range names {
-		if jd, ok := b.jobDefinitions[nameOrARN]; ok {
+		if jd, ok := defs[nameOrARN]; ok {
 			if !seen[jd.JobDefinitionArn] && (status == "" || jd.Status == status) {
 				seen[jd.JobDefinitionArn] = true
 				cp := *jd
@@ -1364,7 +1524,7 @@ func (b *InMemoryBackend) describeJobDefinitionsByNames(names []string, status s
 
 		baseName, _, _ := strings.Cut(nameOrARN, ":")
 
-		for _, jd := range b.jobDefinitions {
+		for _, jd := range defs {
 			if jd.JobDefinitionName == baseName && !seen[jd.JobDefinitionArn] && (status == "" || jd.Status == status) {
 				seen[jd.JobDefinitionArn] = true
 				cp := *jd
@@ -1384,14 +1544,18 @@ func (b *InMemoryBackend) describeJobDefinitionsByNames(names []string, status s
 // DeregisterJobDefinition marks a job definition as INACTIVE by ARN or name:revision.
 // INACTIVE definitions remain visible in DescribeJobDefinitions (matching AWS behavior)
 // and are swept by the janitor after the configured TTL.
-func (b *InMemoryBackend) DeregisterJobDefinition(arnOrNameRev string) error {
+func (b *InMemoryBackend) DeregisterJobDefinition(ctx context.Context, arnOrNameRev string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeregisterJobDefinition")
 	defer b.mu.Unlock()
 
 	now := time.Now()
 
+	defs := b.jobDefinitionsStore(region)
+
 	// Try direct ARN lookup first.
-	if jd, ok := b.jobDefinitions[arnOrNameRev]; ok {
+	if jd, ok := defs[arnOrNameRev]; ok {
 		jd.Status = jobDefStatusInactive
 		jd.DeregisteredAt = &now
 
@@ -1399,7 +1563,7 @@ func (b *InMemoryBackend) DeregisterJobDefinition(arnOrNameRev string) error {
 	}
 
 	// Fall back to name:revision lookup (e.g. "my-job:3").
-	for _, jd := range b.jobDefinitions {
+	for _, jd := range defs {
 		nameRev := fmt.Sprintf("%s:%d", jd.JobDefinitionName, jd.Revision)
 		if nameRev == arnOrNameRev {
 			jd.Status = jobDefStatusInactive
@@ -1413,11 +1577,13 @@ func (b *InMemoryBackend) DeregisterJobDefinition(arnOrNameRev string) error {
 }
 
 // ListTagsForResource returns the tags for a resource identified by ARN.
-func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]string, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	if tags, ok := b.findTagsByARN(resourceARN); ok {
+	if tags, ok := b.findTagsByARN(region, resourceARN); ok {
 		out := make(map[string]string, len(tags))
 		maps.Copy(out, tags)
 
@@ -1428,18 +1594,20 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]st
 }
 
 // TagResource adds or updates tags on a resource identified by ARN.
-func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceARN string, tags map[string]string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	existing, ok := b.findTagsByARN(resourceARN)
+	existing, ok := b.findTagsByARN(region, resourceARN)
 	if !ok {
 		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
 	}
 
 	if existing == nil {
-		b.initTagsByARN(resourceARN)
-		existing, _ = b.findTagsByARN(resourceARN)
+		b.initTagsByARN(region, resourceARN)
+		existing, _ = b.findTagsByARN(region, resourceARN)
 	}
 
 	// Validate combined tag count (new keys only).
@@ -1464,11 +1632,13 @@ func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string
 }
 
 // UntagResource removes tags from a resource identified by ARN.
-func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	existing, ok := b.findTagsByARN(resourceARN)
+	existing, ok := b.findTagsByARN(region, resourceARN)
 	if !ok {
 		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
 	}
@@ -1482,38 +1652,38 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) er
 
 // findTagsByARN looks up the tags map for a resource by ARN.
 // Caller must hold at least a read lock.
-func (b *InMemoryBackend) findTagsByARN(resourceARN string) (map[string]string, bool) {
-	if tags, ok := b.findTagsInCoreResources(resourceARN); ok {
+func (b *InMemoryBackend) findTagsByARN(region, resourceARN string) (map[string]string, bool) {
+	if tags, ok := b.findTagsInCoreResources(region, resourceARN); ok {
 		return tags, true
 	}
 
-	return b.findTagsInPolicyResources(resourceARN)
+	return b.findTagsInPolicyResources(region, resourceARN)
 }
 
-func (b *InMemoryBackend) findTagsInCoreResources(resourceARN string) (map[string]string, bool) {
-	for _, ce := range b.computeEnvironments {
+func (b *InMemoryBackend) findTagsInCoreResources(region, resourceARN string) (map[string]string, bool) {
+	for _, ce := range b.computeEnvironmentsStore(region) {
 		if ce.ComputeEnvironmentArn == resourceARN {
 			return ce.Tags, true
 		}
 	}
 
-	for _, jq := range b.jobQueues {
+	for _, jq := range b.jobQueuesStore(region) {
 		if jq.JobQueueArn == resourceARN {
 			return jq.Tags, true
 		}
 	}
 
-	if jd, ok := b.jobDefinitions[resourceARN]; ok {
+	if jd, ok := b.jobDefinitionsStore(region)[resourceARN]; ok {
 		return jd.Tags, true
 	}
 
-	for _, j := range b.jobs {
+	for _, j := range b.jobsStore(region) {
 		if j.JobARN == resourceARN {
 			return j.Tags, true
 		}
 	}
 
-	for _, cr := range b.consumableResources {
+	for _, cr := range b.consumableResourcesStore(region) {
 		if cr.ConsumableResourceArn == resourceARN {
 			return cr.Tags, true
 		}
@@ -1522,20 +1692,20 @@ func (b *InMemoryBackend) findTagsInCoreResources(resourceARN string) (map[strin
 	return nil, false
 }
 
-func (b *InMemoryBackend) findTagsInPolicyResources(resourceARN string) (map[string]string, bool) {
-	for _, sp := range b.schedulingPolicies {
+func (b *InMemoryBackend) findTagsInPolicyResources(region, resourceARN string) (map[string]string, bool) {
+	for _, sp := range b.schedulingPoliciesStore(region) {
 		if sp.Arn == resourceARN {
 			return sp.Tags, true
 		}
 	}
 
-	for _, se := range b.serviceEnvironments {
+	for _, se := range b.serviceEnvironmentsStore(region) {
 		if se.ServiceEnvironmentArn == resourceARN {
 			return se.Tags, true
 		}
 	}
 
-	for _, sj := range b.serviceJobs {
+	for _, sj := range b.serviceJobsStore(region) {
 		if sj.ServiceJobArn == resourceARN {
 			return sj.Tags, true
 		}
@@ -1546,16 +1716,16 @@ func (b *InMemoryBackend) findTagsInPolicyResources(resourceARN string) (map[str
 
 // initTagsByARN ensures a resource has an initialised tags map.
 // Caller must hold the write lock.
-func (b *InMemoryBackend) initTagsByARN(resourceARN string) {
-	if b.initTagsInCoreResources(resourceARN) {
+func (b *InMemoryBackend) initTagsByARN(region, resourceARN string) {
+	if b.initTagsInCoreResources(region, resourceARN) {
 		return
 	}
 
-	b.initTagsInPolicyResources(resourceARN)
+	b.initTagsInPolicyResources(region, resourceARN)
 }
 
-func (b *InMemoryBackend) initTagsInCoreResources(resourceARN string) bool {
-	for _, ce := range b.computeEnvironments {
+func (b *InMemoryBackend) initTagsInCoreResources(region, resourceARN string) bool {
+	for _, ce := range b.computeEnvironmentsStore(region) {
 		if ce.ComputeEnvironmentArn == resourceARN {
 			ce.Tags = make(map[string]string)
 
@@ -1563,7 +1733,7 @@ func (b *InMemoryBackend) initTagsInCoreResources(resourceARN string) bool {
 		}
 	}
 
-	for _, jq := range b.jobQueues {
+	for _, jq := range b.jobQueuesStore(region) {
 		if jq.JobQueueArn == resourceARN {
 			jq.Tags = make(map[string]string)
 
@@ -1571,13 +1741,13 @@ func (b *InMemoryBackend) initTagsInCoreResources(resourceARN string) bool {
 		}
 	}
 
-	if jd, ok := b.jobDefinitions[resourceARN]; ok {
+	if jd, ok := b.jobDefinitionsStore(region)[resourceARN]; ok {
 		jd.Tags = make(map[string]string)
 
 		return true
 	}
 
-	for _, j := range b.jobs {
+	for _, j := range b.jobsStore(region) {
 		if j.JobARN == resourceARN {
 			j.Tags = make(map[string]string)
 
@@ -1585,7 +1755,7 @@ func (b *InMemoryBackend) initTagsInCoreResources(resourceARN string) bool {
 		}
 	}
 
-	for _, cr := range b.consumableResources {
+	for _, cr := range b.consumableResourcesStore(region) {
 		if cr.ConsumableResourceArn == resourceARN {
 			cr.Tags = make(map[string]string)
 
@@ -1596,8 +1766,8 @@ func (b *InMemoryBackend) initTagsInCoreResources(resourceARN string) bool {
 	return false
 }
 
-func (b *InMemoryBackend) initTagsInPolicyResources(resourceARN string) {
-	for _, sp := range b.schedulingPolicies {
+func (b *InMemoryBackend) initTagsInPolicyResources(region, resourceARN string) {
+	for _, sp := range b.schedulingPoliciesStore(region) {
 		if sp.Arn == resourceARN {
 			sp.Tags = make(map[string]string)
 
@@ -1605,7 +1775,7 @@ func (b *InMemoryBackend) initTagsInPolicyResources(resourceARN string) {
 		}
 	}
 
-	for _, se := range b.serviceEnvironments {
+	for _, se := range b.serviceEnvironmentsStore(region) {
 		if se.ServiceEnvironmentArn == resourceARN {
 			se.Tags = make(map[string]string)
 
@@ -1613,7 +1783,7 @@ func (b *InMemoryBackend) initTagsInPolicyResources(resourceARN string) {
 		}
 	}
 
-	for _, sj := range b.serviceJobs {
+	for _, sj := range b.serviceJobsStore(region) {
 		if sj.ServiceJobArn == resourceARN {
 			sj.Tags = make(map[string]string)
 
@@ -1626,6 +1796,7 @@ func (b *InMemoryBackend) initTagsInPolicyResources(resourceARN string) {
 //
 //nolint:funlen // Too complex to refactor given time constraints
 func (b *InMemoryBackend) SubmitJob(
+	ctx context.Context,
 	name, queue, jobDefinition string,
 	tags map[string]string,
 	parameters map[string]string,
@@ -1639,6 +1810,8 @@ func (b *InMemoryBackend) SubmitJob(
 	schedulingPriorityOverride int32,
 	propagateTags bool,
 ) (*Job, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("SubmitJob")
 	defer b.mu.Unlock()
 
@@ -1646,7 +1819,7 @@ func (b *InMemoryBackend) SubmitJob(
 		return nil, fmt.Errorf("%w: jobName must be between 1 and %d characters", ErrValidation, maxJobNameLength)
 	}
 
-	jq, ok := b.lookupJQByNameOrARN(queue)
+	jq, ok := b.lookupJQByNameOrARN(region, queue)
 	if !ok {
 		return nil, fmt.Errorf("%w: job queue %s not found", ErrNotFound, queue)
 	}
@@ -1708,7 +1881,7 @@ func (b *InMemoryBackend) SubmitJob(
 
 	now := time.Now().UnixMilli()
 	jobID := uuid.NewString()
-	jobARN := arn.Build("batch", b.region, b.accountID, "job/"+jobID)
+	jobARN := arn.Build("batch", region, b.accountID, "job/"+jobID)
 
 	j := &Job{
 		JobID:                        jobID,
@@ -1730,9 +1903,10 @@ func (b *InMemoryBackend) SubmitJob(
 		SchedulingPriorityOverride:   schedulingPriorityOverride,
 		PropagateTags:                propagateTags,
 	}
-	b.jobs[jobID] = j
-	b.jobsByARN[jobARN] = jobID
-	b.jobsByQueue[jq.JobQueueName] = append(b.jobsByQueue[jq.JobQueueName], jobID)
+	b.jobsStore(region)[jobID] = j
+	b.jobsByARNStore(region)[jobARN] = jobID
+	jobsByQueue := b.jobsByQueueStore(region)
+	jobsByQueue[jq.JobQueueName] = append(jobsByQueue[jq.JobQueueName], jobID)
 
 	cp := *j
 	cp.Tags = tagsCloneOrEmpty(j.Tags)
@@ -1740,11 +1914,12 @@ func (b *InMemoryBackend) SubmitJob(
 	return &cp, nil
 }
 
-// listAllJobs returns all jobs across all queues filtered by status.
-func (b *InMemoryBackend) listAllJobs(status string) []*Job {
-	all := make([]*Job, 0, len(b.jobs))
+// listAllJobs returns all jobs across all queues in region filtered by status.
+func (b *InMemoryBackend) listAllJobs(region, status string) []*Job {
+	jobs := b.jobsStore(region)
+	all := make([]*Job, 0, len(jobs))
 
-	for _, j := range b.jobs {
+	for _, j := range jobs {
 		if status != "" && j.Status != status {
 			continue
 		}
@@ -1759,18 +1934,19 @@ func (b *InMemoryBackend) listAllJobs(status string) []*Job {
 	return all
 }
 
-// listQueueJobs returns jobs in the given queue filtered by status.
-func (b *InMemoryBackend) listQueueJobs(queue, status string) ([]*Job, error) {
-	jq, ok := b.lookupJQByNameOrARN(queue)
+// listQueueJobs returns jobs in the given queue in region filtered by status.
+func (b *InMemoryBackend) listQueueJobs(region, queue, status string) ([]*Job, error) {
+	jq, ok := b.lookupJQByNameOrARN(region, queue)
 	if !ok {
 		return nil, fmt.Errorf("%w: job queue %s not found", ErrNotFound, queue)
 	}
 
-	ids := b.jobsByQueue[jq.JobQueueName]
+	jobs := b.jobsStore(region)
+	ids := b.jobsByQueueStore(region)[jq.JobQueueName]
 	all := make([]*Job, 0, len(ids))
 
 	for _, id := range ids {
-		j, exists := b.jobs[id]
+		j, exists := jobs[id]
 		if !exists {
 			continue
 		}
@@ -1789,7 +1965,13 @@ func (b *InMemoryBackend) listQueueJobs(queue, status string) ([]*Job, error) {
 
 // ListJobs returns job summaries for a queue, optionally filtered by status.
 // Pagination is controlled via maxResults and nextToken (token encodes an integer offset).
-func (b *InMemoryBackend) ListJobs(queue, status, nextToken string, maxResults int32) ([]*Job, string, error) {
+func (b *InMemoryBackend) ListJobs(
+	ctx context.Context,
+	queue, status, nextToken string,
+	maxResults int32,
+) ([]*Job, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListJobs")
 	defer b.mu.RUnlock()
 
@@ -1806,9 +1988,9 @@ func (b *InMemoryBackend) ListJobs(queue, status, nextToken string, maxResults i
 	)
 
 	if queue == "" {
-		all = b.listAllJobs(status)
+		all = b.listAllJobs(region, status)
 	} else {
-		all, err = b.listQueueJobs(queue, status)
+		all, err = b.listQueueJobs(region, queue, status)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1830,14 +2012,16 @@ func (b *InMemoryBackend) ListJobs(queue, status, nextToken string, maxResults i
 }
 
 // DescribeJobs returns full job details for the given job IDs or ARNs.
-func (b *InMemoryBackend) DescribeJobs(jobIDs []string) []*Job {
+func (b *InMemoryBackend) DescribeJobs(ctx context.Context, jobIDs []string) []*Job {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeJobs")
 	defer b.mu.RUnlock()
 
 	out := make([]*Job, 0, len(jobIDs))
 
 	for _, id := range jobIDs {
-		j, ok := b.lookupJobByIDOrARN(id)
+		j, ok := b.lookupJobByIDOrARN(region, id)
 		if !ok {
 			continue
 		}
@@ -1852,11 +2036,13 @@ func (b *InMemoryBackend) DescribeJobs(jobIDs []string) []*Job {
 
 // TerminateJob marks a job as FAILED with the given reason.
 // Valid for any non-terminal state. Accepts job ID or ARN.
-func (b *InMemoryBackend) TerminateJob(idOrARN, reason string) error {
+func (b *InMemoryBackend) TerminateJob(ctx context.Context, idOrARN, reason string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TerminateJob")
 	defer b.mu.Unlock()
 
-	j, ok := b.lookupJobByIDOrARN(idOrARN)
+	j, ok := b.lookupJobByIDOrARN(region, idOrARN)
 	if !ok {
 		return fmt.Errorf("%w: job %s not found", ErrNotFound, idOrARN)
 	}
@@ -1875,11 +2061,13 @@ func (b *InMemoryBackend) TerminateJob(idOrARN, reason string) error {
 
 // CancelJob cancels a job in SUBMITTED, PENDING, or RUNNABLE state.
 // Accepts job ID or ARN.
-func (b *InMemoryBackend) CancelJob(idOrARN, reason string) error {
+func (b *InMemoryBackend) CancelJob(ctx context.Context, idOrARN, reason string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CancelJob")
 	defer b.mu.Unlock()
 
-	j, ok := b.lookupJobByIDOrARN(idOrARN)
+	j, ok := b.lookupJobByIDOrARN(region, idOrARN)
 	if !ok {
 		return fmt.Errorf("%w: job %s not found", ErrNotFound, idOrARN)
 	}
@@ -1899,14 +2087,18 @@ func (b *InMemoryBackend) CancelJob(idOrARN, reason string) error {
 
 // CreateConsumableResource creates a new consumable resource.
 func (b *InMemoryBackend) CreateConsumableResource(
+	ctx context.Context,
 	name, resourceType string,
 	totalQuantity int64,
 	tags map[string]string,
 ) (*ConsumableResource, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateConsumableResource")
 	defer b.mu.Unlock()
 
-	if _, ok := b.consumableResources[name]; ok {
+	crs := b.consumableResourcesStore(region)
+	if _, ok := crs[name]; ok {
 		return nil, fmt.Errorf("%w: consumable resource %s already exists", ErrAlreadyExists, name)
 	}
 
@@ -1922,7 +2114,7 @@ func (b *InMemoryBackend) CreateConsumableResource(
 		return nil, err
 	}
 
-	crARN := arn.Build("batch", b.region, b.accountID, "consumable-resource/"+name)
+	crARN := arn.Build("batch", region, b.accountID, "consumable-resource/"+name)
 
 	cr := &ConsumableResource{
 		ConsumableResourceName: name,
@@ -1934,33 +2126,40 @@ func (b *InMemoryBackend) CreateConsumableResource(
 		CreatedAt:              time.Now().UnixMilli(),
 		Tags:                   tagsCloneOrEmpty(tags),
 	}
-	b.consumableResources[name] = cr
+	crs[name] = cr
 	cp := *cr
 
 	return &cp, nil
 }
 
 // DeleteConsumableResource removes a consumable resource by name or ARN.
-func (b *InMemoryBackend) DeleteConsumableResource(nameOrARN string) error {
+func (b *InMemoryBackend) DeleteConsumableResource(ctx context.Context, nameOrARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteConsumableResource")
 	defer b.mu.Unlock()
 
-	cr, ok := b.lookupConsumableResourceByNameOrARN(nameOrARN)
+	cr, ok := b.lookupConsumableResourceByNameOrARN(region, nameOrARN)
 	if !ok {
 		return fmt.Errorf("%w: consumable resource %s not found", ErrNotFound, nameOrARN)
 	}
 
-	delete(b.consumableResources, cr.ConsumableResourceName)
+	delete(b.consumableResourcesStore(region), cr.ConsumableResourceName)
 
 	return nil
 }
 
 // DescribeConsumableResource returns details for a consumable resource identified by name or ARN.
-func (b *InMemoryBackend) DescribeConsumableResource(nameOrARN string) (*ConsumableResource, error) {
+func (b *InMemoryBackend) DescribeConsumableResource(
+	ctx context.Context,
+	nameOrARN string,
+) (*ConsumableResource, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeConsumableResource")
 	defer b.mu.RUnlock()
 
-	cr, ok := b.lookupConsumableResourceByNameOrARN(nameOrARN)
+	cr, ok := b.lookupConsumableResourceByNameOrARN(region, nameOrARN)
 	if !ok {
 		return nil, fmt.Errorf("%w: consumable resource %s not found", ErrNotFound, nameOrARN)
 	}
@@ -1973,12 +2172,13 @@ func (b *InMemoryBackend) DescribeConsumableResource(nameOrARN string) (*Consuma
 
 // lookupConsumableResourceByNameOrARN returns a consumable resource by name or ARN.
 // Caller must hold at least a read lock.
-func (b *InMemoryBackend) lookupConsumableResourceByNameOrARN(nameOrARN string) (*ConsumableResource, bool) {
-	if cr, ok := b.consumableResources[nameOrARN]; ok {
+func (b *InMemoryBackend) lookupConsumableResourceByNameOrARN(region, nameOrARN string) (*ConsumableResource, bool) {
+	crs := b.consumableResourcesStore(region)
+	if cr, ok := crs[nameOrARN]; ok {
 		return cr, true
 	}
 
-	for _, cr := range b.consumableResources {
+	for _, cr := range crs {
 		if cr.ConsumableResourceArn == nameOrARN {
 			return cr, true
 		}
@@ -1989,10 +2189,13 @@ func (b *InMemoryBackend) lookupConsumableResourceByNameOrARN(nameOrARN string) 
 
 // CreateSchedulingPolicy creates a new scheduling policy.
 func (b *InMemoryBackend) CreateSchedulingPolicy(
+	ctx context.Context,
 	name string,
 	tags map[string]string,
 	fairsharePolicy *FairsharePolicy,
 ) (*SchedulingPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateSchedulingPolicy")
 	defer b.mu.Unlock()
 
@@ -2004,11 +2207,11 @@ func (b *InMemoryBackend) CreateSchedulingPolicy(
 		return nil, err
 	}
 
-	if _, ok := b.schedulingPolicyByName[name]; ok {
+	if _, ok := b.schedulingPolicyByNameStore(region)[name]; ok {
 		return nil, fmt.Errorf("%w: scheduling policy %s already exists", ErrAlreadyExists, name)
 	}
 
-	policyARN := arn.Build("batch", b.region, b.accountID, "scheduling-policy/"+name)
+	policyARN := arn.Build("batch", region, b.accountID, "scheduling-policy/"+name)
 
 	sp := &SchedulingPolicy{
 		Arn:             policyARN,
@@ -2016,8 +2219,8 @@ func (b *InMemoryBackend) CreateSchedulingPolicy(
 		Tags:            tagsCloneOrEmpty(tags),
 		FairsharePolicy: cloneFairsharePolicy(fairsharePolicy),
 	}
-	b.schedulingPolicies[policyARN] = sp
-	b.schedulingPolicyByName[name] = policyARN
+	b.schedulingPoliciesStore(region)[policyARN] = sp
+	b.schedulingPolicyByNameStore(region)[name] = policyARN
 	cp := *sp
 
 	return &cp, nil
@@ -2040,34 +2243,41 @@ func cloneFairsharePolicy(fp *FairsharePolicy) *FairsharePolicy {
 }
 
 // DeleteSchedulingPolicy removes a scheduling policy by ARN.
-func (b *InMemoryBackend) DeleteSchedulingPolicy(policyARN string) error {
+func (b *InMemoryBackend) DeleteSchedulingPolicy(ctx context.Context, policyARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteSchedulingPolicy")
 	defer b.mu.Unlock()
 
-	sp, ok := b.schedulingPolicies[policyARN]
+	policies := b.schedulingPoliciesStore(region)
+	sp, ok := policies[policyARN]
 	if !ok {
 		return fmt.Errorf("%w: scheduling policy %s not found", ErrNotFound, policyARN)
 	}
 
-	delete(b.schedulingPolicyByName, sp.Name)
-	delete(b.schedulingPolicies, policyARN)
+	delete(b.schedulingPolicyByNameStore(region), sp.Name)
+	delete(policies, policyARN)
 
 	return nil
 }
 
 // CreateServiceEnvironment creates a new service environment.
 func (b *InMemoryBackend) CreateServiceEnvironment(
+	ctx context.Context,
 	name, envType, state string,
 	tags map[string]string,
 ) (*ServiceEnvironment, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateServiceEnvironment")
 	defer b.mu.Unlock()
 
-	if _, ok := b.serviceEnvironments[name]; ok {
+	ses := b.serviceEnvironmentsStore(region)
+	if _, ok := ses[name]; ok {
 		return nil, fmt.Errorf("%w: service environment %s already exists", ErrAlreadyExists, name)
 	}
 
-	seARN := arn.Build("batch", b.region, b.accountID, "service-environment/"+name)
+	seARN := arn.Build("batch", region, b.accountID, "service-environment/"+name)
 
 	if state == "" {
 		state = stateEnabled
@@ -2081,35 +2291,38 @@ func (b *InMemoryBackend) CreateServiceEnvironment(
 		Status:                 statusValid,
 		Tags:                   tagsCloneOrEmpty(tags),
 	}
-	b.serviceEnvironments[name] = se
+	ses[name] = se
 	cp := *se
 
 	return &cp, nil
 }
 
 // DeleteServiceEnvironment removes a service environment by name or ARN.
-func (b *InMemoryBackend) DeleteServiceEnvironment(nameOrARN string) error {
+func (b *InMemoryBackend) DeleteServiceEnvironment(ctx context.Context, nameOrARN string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteServiceEnvironment")
 	defer b.mu.Unlock()
 
-	se, ok := b.lookupServiceEnvironmentByNameOrARN(nameOrARN)
+	se, ok := b.lookupServiceEnvironmentByNameOrARN(region, nameOrARN)
 	if !ok {
 		return fmt.Errorf("%w: service environment %s not found", ErrNotFound, nameOrARN)
 	}
 
-	delete(b.serviceEnvironments, se.ServiceEnvironmentName)
+	delete(b.serviceEnvironmentsStore(region), se.ServiceEnvironmentName)
 
 	return nil
 }
 
-// lookupServiceEnvironmentByNameOrARN returns a service environment by name or ARN.
+// lookupServiceEnvironmentByNameOrARN returns a service environment by name or ARN within region.
 // Caller must hold at least a read lock.
-func (b *InMemoryBackend) lookupServiceEnvironmentByNameOrARN(nameOrARN string) (*ServiceEnvironment, bool) {
-	if se, ok := b.serviceEnvironments[nameOrARN]; ok {
+func (b *InMemoryBackend) lookupServiceEnvironmentByNameOrARN(region, nameOrARN string) (*ServiceEnvironment, bool) {
+	ses := b.serviceEnvironmentsStore(region)
+	if se, ok := ses[nameOrARN]; ok {
 		return se, true
 	}
 
-	for _, se := range b.serviceEnvironments {
+	for _, se := range ses {
 		if se.ServiceEnvironmentArn == nameOrARN {
 			return se, true
 		}
@@ -2120,13 +2333,16 @@ func (b *InMemoryBackend) lookupServiceEnvironmentByNameOrARN(nameOrARN string) 
 
 // UpdateConsumableResource updates the quantity of a consumable resource.
 func (b *InMemoryBackend) UpdateConsumableResource(
+	ctx context.Context,
 	nameOrARN, operation string,
 	quantity int64,
 ) (*ConsumableResource, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateConsumableResource")
 	defer b.mu.Unlock()
 
-	cr, ok := b.lookupConsumableResourceByNameOrARN(nameOrARN)
+	cr, ok := b.lookupConsumableResourceByNameOrARN(region, nameOrARN)
 	if !ok {
 		return nil, fmt.Errorf("%w: consumable resource %s not found", ErrNotFound, nameOrARN)
 	}
@@ -2178,13 +2394,16 @@ func (b *InMemoryBackend) UpdateConsumableResource(
 }
 
 // ListConsumableResources returns all consumable resources sorted by name.
-func (b *InMemoryBackend) ListConsumableResources() []*ConsumableResource {
+func (b *InMemoryBackend) ListConsumableResources(ctx context.Context) []*ConsumableResource {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListConsumableResources")
 	defer b.mu.RUnlock()
 
-	list := make([]*ConsumableResource, 0, len(b.consumableResources))
+	crs := b.consumableResourcesStore(region)
+	list := make([]*ConsumableResource, 0, len(crs))
 
-	for _, cr := range b.consumableResources {
+	for _, cr := range crs {
 		cp := *cr
 		cp.Tags = tagsCloneOrEmpty(cr.Tags)
 		list = append(list, &cp)
@@ -2198,13 +2417,16 @@ func (b *InMemoryBackend) ListConsumableResources() []*ConsumableResource {
 }
 
 // ListSchedulingPolicies returns all scheduling policies sorted by ARN.
-func (b *InMemoryBackend) ListSchedulingPolicies() []*SchedulingPolicy {
+func (b *InMemoryBackend) ListSchedulingPolicies(ctx context.Context) []*SchedulingPolicy {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSchedulingPolicies")
 	defer b.mu.RUnlock()
 
-	list := make([]*SchedulingPolicy, 0, len(b.schedulingPolicies))
+	policies := b.schedulingPoliciesStore(region)
+	list := make([]*SchedulingPolicy, 0, len(policies))
 
-	for _, sp := range b.schedulingPolicies {
+	for _, sp := range policies {
 		cp := *sp
 		cp.Tags = tagsCloneOrEmpty(sp.Tags)
 		list = append(list, &cp)
@@ -2216,13 +2438,17 @@ func (b *InMemoryBackend) ListSchedulingPolicies() []*SchedulingPolicy {
 }
 
 // DescribeSchedulingPolicies returns scheduling policies, optionally filtered by ARNs.
-func (b *InMemoryBackend) DescribeSchedulingPolicies(arns []string) []*SchedulingPolicy {
+func (b *InMemoryBackend) DescribeSchedulingPolicies(ctx context.Context, arns []string) []*SchedulingPolicy {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeSchedulingPolicies")
 	defer b.mu.RUnlock()
 
+	policies := b.schedulingPoliciesStore(region)
+
 	if len(arns) == 0 {
-		list := make([]*SchedulingPolicy, 0, len(b.schedulingPolicies))
-		for _, sp := range b.schedulingPolicies {
+		list := make([]*SchedulingPolicy, 0, len(policies))
+		for _, sp := range policies {
 			cp := *sp
 			cp.Tags = tagsCloneOrEmpty(sp.Tags)
 			list = append(list, &cp)
@@ -2236,7 +2462,7 @@ func (b *InMemoryBackend) DescribeSchedulingPolicies(arns []string) []*Schedulin
 	list := make([]*SchedulingPolicy, 0, len(arns))
 
 	for _, a := range arns {
-		if sp, ok := b.schedulingPolicies[a]; ok {
+		if sp, ok := policies[a]; ok {
 			cp := *sp
 			cp.Tags = tagsCloneOrEmpty(sp.Tags)
 			list = append(list, &cp)
@@ -2247,13 +2473,16 @@ func (b *InMemoryBackend) DescribeSchedulingPolicies(arns []string) []*Schedulin
 }
 
 // DescribeServiceEnvironments returns service environments, optionally filtered by names/ARNs.
-func (b *InMemoryBackend) DescribeServiceEnvironments(names []string) []*ServiceEnvironment {
+func (b *InMemoryBackend) DescribeServiceEnvironments(ctx context.Context, names []string) []*ServiceEnvironment {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeServiceEnvironments")
 	defer b.mu.RUnlock()
 
 	if len(names) == 0 {
-		list := make([]*ServiceEnvironment, 0, len(b.serviceEnvironments))
-		for _, se := range b.serviceEnvironments {
+		ses := b.serviceEnvironmentsStore(region)
+		list := make([]*ServiceEnvironment, 0, len(ses))
+		for _, se := range ses {
 			cp := *se
 			cp.Tags = tagsCloneOrEmpty(se.Tags)
 			list = append(list, &cp)
@@ -2269,7 +2498,7 @@ func (b *InMemoryBackend) DescribeServiceEnvironments(names []string) []*Service
 	list := make([]*ServiceEnvironment, 0, len(names))
 
 	for _, nameOrARN := range names {
-		if se, ok := b.lookupServiceEnvironmentByNameOrARN(nameOrARN); ok {
+		if se, ok := b.lookupServiceEnvironmentByNameOrARN(region, nameOrARN); ok {
 			cp := *se
 			cp.Tags = tagsCloneOrEmpty(se.Tags)
 			list = append(list, &cp)
@@ -2280,11 +2509,17 @@ func (b *InMemoryBackend) DescribeServiceEnvironments(names []string) []*Service
 }
 
 // UpdateSchedulingPolicy updates a scheduling policy's fairshare configuration.
-func (b *InMemoryBackend) UpdateSchedulingPolicy(policyARN string, fairsharePolicy *FairsharePolicy) error {
+func (b *InMemoryBackend) UpdateSchedulingPolicy(
+	ctx context.Context,
+	policyARN string,
+	fairsharePolicy *FairsharePolicy,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateSchedulingPolicy")
 	defer b.mu.Unlock()
 
-	sp, ok := b.schedulingPolicies[policyARN]
+	sp, ok := b.schedulingPoliciesStore(region)[policyARN]
 	if !ok {
 		return fmt.Errorf("%w: scheduling policy %s not found", ErrNotFound, policyARN)
 	}
@@ -2297,11 +2532,16 @@ func (b *InMemoryBackend) UpdateSchedulingPolicy(policyARN string, fairsharePoli
 }
 
 // UpdateServiceEnvironment updates the state of a service environment.
-func (b *InMemoryBackend) UpdateServiceEnvironment(nameOrARN, state string) (*ServiceEnvironment, error) {
+func (b *InMemoryBackend) UpdateServiceEnvironment(
+	ctx context.Context,
+	nameOrARN, state string,
+) (*ServiceEnvironment, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateServiceEnvironment")
 	defer b.mu.Unlock()
 
-	se, ok := b.lookupServiceEnvironmentByNameOrARN(nameOrARN)
+	se, ok := b.lookupServiceEnvironmentByNameOrARN(region, nameOrARN)
 	if !ok {
 		return nil, fmt.Errorf("%w: service environment %s not found", ErrNotFound, nameOrARN)
 	}
@@ -2317,14 +2557,20 @@ func (b *InMemoryBackend) UpdateServiceEnvironment(nameOrARN, state string) (*Se
 }
 
 // SubmitServiceJob creates a new service job in SUBMITTED status.
-func (b *InMemoryBackend) SubmitServiceJob(name, serviceEnv string, tags map[string]string) (*ServiceJob, error) {
+func (b *InMemoryBackend) SubmitServiceJob(
+	ctx context.Context,
+	name, serviceEnv string,
+	tags map[string]string,
+) (*ServiceJob, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("SubmitServiceJob")
 	defer b.mu.Unlock()
 
 	tagsCopy := tagsCloneOrEmpty(tags)
 	now := time.Now().UnixMilli()
 	jobID := uuid.NewString()
-	jobARN := arn.Build("batch", b.region, b.accountID, "service-job/"+jobID)
+	jobARN := arn.Build("batch", region, b.accountID, "service-job/"+jobID)
 
 	sj := &ServiceJob{
 		ServiceJobID:       jobID,
@@ -2335,18 +2581,20 @@ func (b *InMemoryBackend) SubmitServiceJob(name, serviceEnv string, tags map[str
 		CreatedAt:          now,
 		Tags:               tagsCopy,
 	}
-	b.serviceJobs[jobID] = sj
+	b.serviceJobsStore(region)[jobID] = sj
 	cp := *sj
 
 	return &cp, nil
 }
 
 // DescribeServiceJob returns a single service job by ID.
-func (b *InMemoryBackend) DescribeServiceJob(serviceJobID string) (*ServiceJob, error) {
+func (b *InMemoryBackend) DescribeServiceJob(ctx context.Context, serviceJobID string) (*ServiceJob, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeServiceJob")
 	defer b.mu.RUnlock()
 
-	sj, ok := b.serviceJobs[serviceJobID]
+	sj, ok := b.serviceJobsStore(region)[serviceJobID]
 	if !ok {
 		return nil, fmt.Errorf("%w: service job %s not found", ErrNotFound, serviceJobID)
 	}
@@ -2358,13 +2606,16 @@ func (b *InMemoryBackend) DescribeServiceJob(serviceJobID string) (*ServiceJob, 
 }
 
 // ListServiceJobs returns service jobs, optionally filtered by service environment.
-func (b *InMemoryBackend) ListServiceJobs(serviceEnv string) ([]*ServiceJob, error) {
+func (b *InMemoryBackend) ListServiceJobs(ctx context.Context, serviceEnv string) ([]*ServiceJob, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListServiceJobs")
 	defer b.mu.RUnlock()
 
-	list := make([]*ServiceJob, 0, len(b.serviceJobs))
+	sjs := b.serviceJobsStore(region)
+	list := make([]*ServiceJob, 0, len(sjs))
 
-	for _, sj := range b.serviceJobs {
+	for _, sj := range sjs {
 		if serviceEnv != "" && sj.ServiceEnvironment != serviceEnv {
 			continue
 		}
@@ -2379,11 +2630,13 @@ func (b *InMemoryBackend) ListServiceJobs(serviceEnv string) ([]*ServiceJob, err
 }
 
 // TerminateServiceJob marks a service job as FAILED.
-func (b *InMemoryBackend) TerminateServiceJob(serviceJobID, reason string) error {
+func (b *InMemoryBackend) TerminateServiceJob(ctx context.Context, serviceJobID, reason string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TerminateServiceJob")
 	defer b.mu.Unlock()
 
-	sj, ok := b.serviceJobs[serviceJobID]
+	sj, ok := b.serviceJobsStore(region)[serviceJobID]
 	if !ok {
 		return fmt.Errorf("%w: service job %s not found", ErrNotFound, serviceJobID)
 	}
@@ -2397,20 +2650,23 @@ func (b *InMemoryBackend) TerminateServiceJob(serviceJobID, reason string) error
 }
 
 // GetJobQueueSnapshot returns a snapshot of the front of a job queue.
-func (b *InMemoryBackend) GetJobQueueSnapshot(jobQueue string) (*JobQueueSnapshot, error) {
+func (b *InMemoryBackend) GetJobQueueSnapshot(ctx context.Context, jobQueue string) (*JobQueueSnapshot, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetJobQueueSnapshot")
 	defer b.mu.RUnlock()
 
-	jq, ok := b.lookupJQByNameOrARN(jobQueue)
+	jq, ok := b.lookupJQByNameOrARN(region, jobQueue)
 	if !ok {
 		return nil, fmt.Errorf("%w: job queue %s not found", ErrNotFound, jobQueue)
 	}
 
-	ids := b.jobsByQueue[jq.JobQueueName]
+	jobs := b.jobsStore(region)
+	ids := b.jobsByQueueStore(region)[jq.JobQueueName]
 	runnableJobs := make([]*Job, 0, len(ids))
 
 	for _, id := range ids {
-		j, ok2 := b.jobs[id]
+		j, ok2 := jobs[id]
 		if !ok2 {
 			continue
 		}
@@ -2446,13 +2702,18 @@ func (b *InMemoryBackend) GetJobQueueSnapshot(jobQueue string) (*JobQueueSnapsho
 
 // ListJobsByConsumableResource returns jobs that reference the named consumable resource
 // via their ConsumableResourceProperties.
-func (b *InMemoryBackend) ListJobsByConsumableResource(consumableResource string) ([]*Job, error) {
+func (b *InMemoryBackend) ListJobsByConsumableResource(
+	ctx context.Context,
+	consumableResource string,
+) ([]*Job, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListJobsByConsumableResource")
 	defer b.mu.RUnlock()
 
 	list := make([]*Job, 0)
 
-	for _, j := range b.jobs {
+	for _, j := range b.jobsStore(region) {
 		if jobReferencesConsumableResource(j, consumableResource) {
 			cp := *j
 			cp.Tags = tagsCloneOrEmpty(j.Tags)

--- a/services/batch/deregister_test.go
+++ b/services/batch/deregister_test.go
@@ -37,6 +37,7 @@ func TestDeregisterJobDefinition_MarksInactive(t *testing.T) {
 			backend := batch.NewInMemoryBackend("123456789012", "us-east-1")
 
 			jd, err := backend.RegisterJobDefinition(
+				context.Background(),
 				"my-job",
 				"container",
 				nil,
@@ -54,13 +55,20 @@ func TestDeregisterJobDefinition_MarksInactive(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "ACTIVE", jd.Status)
 
-			err = backend.DeregisterJobDefinition(tt.deregisterWith(jd))
+			err = backend.DeregisterJobDefinition(context.Background(), tt.deregisterWith(jd))
 			require.NoError(t, err)
 
 			// Definition should still exist (AWS behavior) but be INACTIVE.
 			assert.Equal(t, 1, backend.JobDefinitionCount(), "definition should remain visible after deregister")
 
-			defs, _ := backend.DescribeJobDefinitions([]string{jd.JobDefinitionName}, "", "", 0, "")
+			defs, _ := backend.DescribeJobDefinitions(
+				context.Background(),
+				[]string{jd.JobDefinitionName},
+				"",
+				"",
+				0,
+				"",
+			)
 			require.Len(t, defs, 1)
 			assert.Equal(t, "INACTIVE", defs[0].Status)
 		})
@@ -75,6 +83,7 @@ func TestDeregisterJobDefinition_RevisionCounterPreserved(t *testing.T) {
 	backend := batch.NewInMemoryBackend("123456789012", "us-east-1")
 
 	jd1, err := backend.RegisterJobDefinition(
+		context.Background(),
 		"my-job",
 		"container",
 		nil,
@@ -92,11 +101,12 @@ func TestDeregisterJobDefinition_RevisionCounterPreserved(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), jd1.Revision)
 
-	err = backend.DeregisterJobDefinition(jd1.JobDefinitionArn)
+	err = backend.DeregisterJobDefinition(context.Background(), jd1.JobDefinitionArn)
 	require.NoError(t, err)
 
 	// Re-register: should get revision 2.
 	jd2, err := backend.RegisterJobDefinition(
+		context.Background(),
 		"my-job",
 		"container",
 		nil,
@@ -125,7 +135,10 @@ func TestDeregisterJobDefinition_NotFound(t *testing.T) {
 
 	backend := batch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	err := backend.DeregisterJobDefinition("arn:aws:batch:us-east-1:123456789012:job-definition/missing:1")
+	err := backend.DeregisterJobDefinition(
+		context.Background(),
+		"arn:aws:batch:us-east-1:123456789012:job-definition/missing:1",
+	)
 	assert.ErrorIs(t, err, batch.ErrNotFound)
 }
 
@@ -171,6 +184,7 @@ func TestBatchJanitor_SweepInactiveJobDefinitions(t *testing.T) {
 			backend := batch.NewInMemoryBackend("123456789012", "us-east-1")
 
 			jd, err := backend.RegisterJobDefinition(
+				context.Background(),
 				"sweep-job",
 				"container",
 				nil,
@@ -189,7 +203,7 @@ func TestBatchJanitor_SweepInactiveJobDefinitions(t *testing.T) {
 
 			if tt.deregisteredDelay != 0 {
 				// Deregister the definition.
-				err = backend.DeregisterJobDefinition(jd.JobDefinitionArn)
+				err = backend.DeregisterJobDefinition(context.Background(), jd.JobDefinitionArn)
 				require.NoError(t, err)
 
 				// Override DeregisteredAt for TTL testing.
@@ -200,7 +214,14 @@ func TestBatchJanitor_SweepInactiveJobDefinitions(t *testing.T) {
 			janitor := batch.NewJanitor(backend, time.Hour, tt.ttl, 24*time.Hour)
 			janitor.SweepOnce(t.Context())
 
-			defs, _ := backend.DescribeJobDefinitions([]string{jd.JobDefinitionName}, "", "", 0, "")
+			defs, _ := backend.DescribeJobDefinitions(
+				context.Background(),
+				[]string{jd.JobDefinitionName},
+				"",
+				"",
+				0,
+				"",
+			)
 
 			if tt.wantEvicted {
 				assert.Empty(t, defs, "definition should be evicted after TTL")

--- a/services/batch/export_test.go
+++ b/services/batch/export_test.go
@@ -20,7 +20,7 @@ func (b *InMemoryBackend) JobDefinitionCount() int {
 	b.mu.RLock("JobDefinitionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.jobDefinitions)
+	return len(b.jobDefinitionsStore(b.region))
 }
 
 // RevisionFor returns the current revision counter for the given job definition name.
@@ -30,7 +30,7 @@ func (b *InMemoryBackend) RevisionFor(name string) int32 {
 	b.mu.RLock("RevisionFor")
 	defer b.mu.RUnlock()
 
-	return b.jobDefRevisions[name]
+	return b.jobDefRevisionsStore(b.region)[name]
 }
 
 // HasRevisionCounter reports whether a revision counter exists for name.
@@ -39,7 +39,7 @@ func (b *InMemoryBackend) HasRevisionCounter(name string) bool {
 	b.mu.RLock("HasRevisionCounter")
 	defer b.mu.RUnlock()
 
-	_, ok := b.jobDefRevisions[name]
+	_, ok := b.jobDefRevisionsStore(b.region)[name]
 
 	return ok
 }
@@ -50,13 +50,14 @@ func (b *InMemoryBackend) SetJobDefinitionDeregisteredAt(arnOrNameRev string, ti
 	b.mu.Lock("SetJobDefinitionDeregisteredAt")
 	defer b.mu.Unlock()
 
-	if jd, ok := b.jobDefinitions[arnOrNameRev]; ok {
+	defs := b.jobDefinitionsStore(b.region)
+	if jd, ok := defs[arnOrNameRev]; ok {
 		jd.DeregisteredAt = &timestamp
 
 		return
 	}
 
-	for _, jd := range b.jobDefinitions {
+	for _, jd := range defs {
 		nameRev := fmt.Sprintf("%s:%d", jd.JobDefinitionName, jd.Revision)
 		if nameRev == arnOrNameRev {
 			jd.DeregisteredAt = &timestamp
@@ -112,7 +113,7 @@ func (b *InMemoryBackend) SetJobStoppedAtForTest(jobID, status string, stoppedAt
 	b.mu.Lock("SetJobStoppedAtForTest")
 	defer b.mu.Unlock()
 
-	j, ok := b.jobs[jobID]
+	j, ok := b.jobsStore(b.region)[jobID]
 	if !ok {
 		return
 	}
@@ -127,7 +128,7 @@ func (b *InMemoryBackend) SetJobStoppedAtForTest(jobID, status string, stoppedAt
 func (b *InMemoryBackend) ForceJobStatus(jobID, status string) {
 	b.mu.Lock("ForceJobStatus")
 	defer b.mu.Unlock()
-	if j, ok := b.jobs[jobID]; ok {
+	if j, ok := b.jobsStore(b.region)[jobID]; ok {
 		j.Status = status
 	}
 }

--- a/services/batch/handler.go
+++ b/services/batch/handler.go
@@ -230,15 +230,24 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 	return ""
 }
 
+// contextWithRegion returns the request context with the resolved AWS region attached
+// under regionContextKey so that backend operations are routed to the correct region.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
+}
+
 // Handler returns the Echo handler function for Batch requests.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
 		r := c.Request()
 		path := r.URL.Path
-		log := logger.Load(r.Context())
+		ctx := h.contextWithRegion(c)
+		log := logger.Load(ctx)
 
 		if strings.HasPrefix(path, tagsPrefix) {
-			return h.handleTags(c, log)
+			return h.handleTags(ctx, c, log)
 		}
 
 		if r.Method != http.MethodPost {
@@ -247,7 +256,7 @@ func (h *Handler) Handler() echo.HandlerFunc {
 
 		body, err := httputils.ReadBody(r)
 		if err != nil {
-			log.ErrorContext(r.Context(), "batch: failed to read request body", "error", err)
+			log.ErrorContext(ctx, "batch: failed to read request body", "error", err)
 
 			return c.JSON(http.StatusInternalServerError, errorResponse("InternalFailure", "internal server error"))
 		}
@@ -260,14 +269,14 @@ func (h *Handler) Handler() echo.HandlerFunc {
 			)
 		}
 
-		result, opErr := fn(r.Context(), body)
+		result, opErr := fn(ctx, body)
 		if opErr != nil {
 			return h.writeError(c, opErr)
 		}
 
 		out, marshalErr := json.Marshal(result)
 		if marshalErr != nil {
-			log.ErrorContext(r.Context(), "batch: failed to marshal response", "error", marshalErr)
+			log.ErrorContext(ctx, "batch: failed to marshal response", "error", marshalErr)
 
 			return c.JSON(http.StatusInternalServerError, errorResponse("InternalFailure", "internal server error"))
 		}
@@ -317,7 +326,7 @@ func (h *Handler) buildOps() map[string]service.JSONOpFunc {
 	}
 }
 
-func (h *Handler) handleTags(c *echo.Context, log *slog.Logger) error {
+func (h *Handler) handleTags(ctx context.Context, c *echo.Context, log *slog.Logger) error {
 	r := c.Request()
 	resourceARN, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, tagsPrefix))
 
@@ -327,18 +336,18 @@ func (h *Handler) handleTags(c *echo.Context, log *slog.Logger) error {
 
 	switch r.Method {
 	case http.MethodGet:
-		return h.handleListTagsForResource(c, resourceARN)
+		return h.handleListTagsForResource(ctx, c, resourceARN)
 	case http.MethodPost:
 		body, readErr := httputils.ReadBody(r)
 		if readErr != nil {
-			log.ErrorContext(r.Context(), "batch: failed to read tags body", "error", readErr)
+			log.ErrorContext(ctx, "batch: failed to read tags body", "error", readErr)
 
 			return c.JSON(http.StatusInternalServerError, errorResponse("InternalFailure", "internal server error"))
 		}
 
-		return h.handleTagResource(c, resourceARN, body)
+		return h.handleTagResource(ctx, c, resourceARN, body)
 	case http.MethodDelete:
-		return h.handleUntagResource(c, resourceARN, r.URL.Query())
+		return h.handleUntagResource(ctx, c, resourceARN, r.URL.Query())
 	default:
 		return c.JSON(http.StatusMethodNotAllowed, errorResponse("ValidationException", "method not allowed"))
 	}
@@ -547,7 +556,7 @@ func updatePolicyFromInput(in *updatePolicyInput) *UpdatePolicy {
 }
 
 func (h *Handler) handleCreateComputeEnvironment(
-	_ context.Context,
+	ctx context.Context,
 	in *createComputeEnvironmentInput,
 ) (*createComputeEnvironmentOutput, error) {
 	state := in.State
@@ -556,6 +565,7 @@ func (h *Handler) handleCreateComputeEnvironment(
 	}
 
 	ce, err := h.Backend.CreateComputeEnvironment(
+		ctx,
 		in.ComputeEnvironmentName, in.Type, state, in.Tags, in.ServiceRole,
 		computeResourcesFromInput(in.ComputeResources),
 		eksConfigFromInput(in.EksConfiguration),
@@ -583,7 +593,7 @@ type describeComputeEnvironmentsOutput struct {
 }
 
 func (h *Handler) handleDescribeComputeEnvironments(
-	_ context.Context,
+	ctx context.Context,
 	in *describeComputeEnvironmentsInput,
 ) (*describeComputeEnvironmentsOutput, error) {
 	var maxResults int32
@@ -596,7 +606,7 @@ func (h *Handler) handleDescribeComputeEnvironments(
 		nextToken = *in.NextToken
 	}
 
-	ces, outToken := h.Backend.DescribeComputeEnvironments(in.ComputeEnvironments, maxResults, nextToken)
+	ces, outToken := h.Backend.DescribeComputeEnvironments(ctx, in.ComputeEnvironments, maxResults, nextToken)
 	out := &describeComputeEnvironmentsOutput{ComputeEnvironments: ces}
 
 	if outToken != "" {
@@ -620,10 +630,11 @@ type updateComputeEnvironmentOutput struct {
 }
 
 func (h *Handler) handleUpdateComputeEnvironment(
-	_ context.Context,
+	ctx context.Context,
 	in *updateComputeEnvironmentInput,
 ) (*updateComputeEnvironmentOutput, error) {
 	ce, err := h.Backend.UpdateComputeEnvironment(
+		ctx,
 		in.ComputeEnvironment, in.State, in.ServiceRole,
 		computeResourcesFromInput(in.ComputeResources),
 		updatePolicyFromInput(in.UpdatePolicy),
@@ -645,10 +656,10 @@ type deleteComputeEnvironmentInput struct {
 type emptyOutput struct{}
 
 func (h *Handler) handleDeleteComputeEnvironment(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteComputeEnvironmentInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.DeleteComputeEnvironment(in.ComputeEnvironment); err != nil {
+	if err := h.Backend.DeleteComputeEnvironment(ctx, in.ComputeEnvironment); err != nil {
 		return nil, err
 	}
 
@@ -691,7 +702,7 @@ func jobStateTimeLimitActionsFromInput(in []jobStateTimeLimitActionInput) []JobS
 }
 
 func (h *Handler) handleCreateJobQueue(
-	_ context.Context,
+	ctx context.Context,
 	in *createJobQueueInput,
 ) (*createJobQueueOutput, error) {
 	state := in.State
@@ -700,6 +711,7 @@ func (h *Handler) handleCreateJobQueue(
 	}
 
 	jq, err := h.Backend.CreateJobQueue(
+		ctx,
 		in.JobQueueName,
 		in.Priority,
 		state,
@@ -730,7 +742,7 @@ type describeJobQueuesOutput struct {
 }
 
 func (h *Handler) handleDescribeJobQueues(
-	_ context.Context,
+	ctx context.Context,
 	in *describeJobQueuesInput,
 ) (*describeJobQueuesOutput, error) {
 	var maxResults int32
@@ -743,7 +755,7 @@ func (h *Handler) handleDescribeJobQueues(
 		nextToken = *in.NextToken
 	}
 
-	jqs, outToken := h.Backend.DescribeJobQueues(in.JobQueues, maxResults, nextToken)
+	jqs, outToken := h.Backend.DescribeJobQueues(ctx, in.JobQueues, maxResults, nextToken)
 	out := &describeJobQueuesOutput{JobQueues: jqs}
 
 	if outToken != "" {
@@ -768,10 +780,11 @@ type updateJobQueueOutput struct {
 }
 
 func (h *Handler) handleUpdateJobQueue(
-	_ context.Context,
+	ctx context.Context,
 	in *updateJobQueueInput,
 ) (*updateJobQueueOutput, error) {
 	jq, err := h.Backend.UpdateJobQueue(
+		ctx,
 		in.JobQueue, in.Priority, in.State, in.ComputeEnvironmentOrder,
 		jobStateTimeLimitActionsFromInput(in.JobStateTimeLimitActions),
 	)
@@ -790,10 +803,10 @@ type deleteJobQueueInput struct {
 }
 
 func (h *Handler) handleDeleteJobQueue(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteJobQueueInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.DeleteJobQueue(in.JobQueue); err != nil {
+	if err := h.Backend.DeleteJobQueue(ctx, in.JobQueue); err != nil {
 		return nil, err
 	}
 
@@ -1106,7 +1119,7 @@ func consumableResourcePropertiesFromInput(in []consumableResourcePropertyInput)
 }
 
 func (h *Handler) handleRegisterJobDefinition(
-	_ context.Context,
+	ctx context.Context,
 	in *registerJobDefinitionInput,
 ) (*registerJobDefinitionOutput, error) {
 	var timeoutSeconds int32
@@ -1115,6 +1128,7 @@ func (h *Handler) handleRegisterJobDefinition(
 	}
 
 	jd, err := h.Backend.RegisterJobDefinition(
+		ctx,
 		in.JobDefinitionName,
 		in.Type,
 		in.Tags,
@@ -1155,7 +1169,7 @@ type describeJobDefinitionsOutput struct {
 }
 
 func (h *Handler) handleDescribeJobDefinitions(
-	_ context.Context,
+	ctx context.Context,
 	in *describeJobDefinitionsInput,
 ) (*describeJobDefinitionsOutput, error) {
 	var maxResults int32
@@ -1169,6 +1183,7 @@ func (h *Handler) handleDescribeJobDefinitions(
 	}
 
 	jds, outToken := h.Backend.DescribeJobDefinitions(
+		ctx,
 		in.JobDefinitions,
 		in.Status,
 		in.JobDefinitionName,
@@ -1189,10 +1204,10 @@ type deregisterJobDefinitionInput struct {
 }
 
 func (h *Handler) handleDeregisterJobDefinition(
-	_ context.Context,
+	ctx context.Context,
 	in *deregisterJobDefinitionInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.DeregisterJobDefinition(in.JobDefinition); err != nil {
+	if err := h.Backend.DeregisterJobDefinition(ctx, in.JobDefinition); err != nil {
 		return nil, err
 	}
 
@@ -1221,7 +1236,7 @@ type listJobsOutput struct {
 	JobSummaryList []jobSummary `json:"jobSummaryList"`
 }
 
-func (h *Handler) handleListJobs(_ context.Context, in *listJobsInput) (*listJobsOutput, error) {
+func (h *Handler) handleListJobs(ctx context.Context, in *listJobsInput) (*listJobsOutput, error) {
 	var maxResults int32
 	if in.MaxResults != nil {
 		maxResults = *in.MaxResults
@@ -1232,7 +1247,7 @@ func (h *Handler) handleListJobs(_ context.Context, in *listJobsInput) (*listJob
 		nextToken = *in.NextToken
 	}
 
-	jobs, outToken, err := h.Backend.ListJobs(in.JobQueue, in.JobStatus, nextToken, maxResults)
+	jobs, outToken, err := h.Backend.ListJobs(ctx, in.JobQueue, in.JobStatus, nextToken, maxResults)
 	if err != nil {
 		return nil, err
 	}
@@ -1278,8 +1293,8 @@ type describeJobsOutput struct {
 	Jobs []jobDetail `json:"jobs"`
 }
 
-func (h *Handler) handleDescribeJobs(_ context.Context, in *describeJobsInput) (*describeJobsOutput, error) {
-	jobs := h.Backend.DescribeJobs(in.Jobs)
+func (h *Handler) handleDescribeJobs(ctx context.Context, in *describeJobsInput) (*describeJobsOutput, error) {
+	jobs := h.Backend.DescribeJobs(ctx, in.Jobs)
 
 	details := make([]jobDetail, 0, len(jobs))
 	for _, j := range jobs {
@@ -1328,7 +1343,7 @@ type submitJobOutput struct {
 	JobName string `json:"jobName"`
 }
 
-func (h *Handler) handleSubmitJob(_ context.Context, in *submitJobInput) (*submitJobOutput, error) {
+func (h *Handler) handleSubmitJob(ctx context.Context, in *submitJobInput) (*submitJobOutput, error) {
 	var overrides *ContainerOverrides
 	if in.ContainerOverrides != nil {
 		env := make([]KeyValuePair, len(in.ContainerOverrides.Environment))
@@ -1342,6 +1357,7 @@ func (h *Handler) handleSubmitJob(_ context.Context, in *submitJobInput) (*submi
 	}
 
 	j, err := h.Backend.SubmitJob(
+		ctx,
 		in.JobName,
 		in.JobQueue,
 		in.JobDefinition,
@@ -1372,8 +1388,8 @@ type terminateJobInput struct {
 	Reason string `json:"reason"`
 }
 
-func (h *Handler) handleTerminateJob(_ context.Context, in *terminateJobInput) (*emptyOutput, error) {
-	if err := h.Backend.TerminateJob(in.JobID, in.Reason); err != nil {
+func (h *Handler) handleTerminateJob(ctx context.Context, in *terminateJobInput) (*emptyOutput, error) {
+	if err := h.Backend.TerminateJob(ctx, in.JobID, in.Reason); err != nil {
 		return nil, err
 	}
 
@@ -1385,8 +1401,8 @@ type cancelJobInput struct {
 	Reason string `json:"reason"`
 }
 
-func (h *Handler) handleCancelJob(_ context.Context, in *cancelJobInput) (*emptyOutput, error) {
-	if err := h.Backend.CancelJob(in.JobID, in.Reason); err != nil {
+func (h *Handler) handleCancelJob(ctx context.Context, in *cancelJobInput) (*emptyOutput, error) {
+	if err := h.Backend.CancelJob(ctx, in.JobID, in.Reason); err != nil {
 		return nil, err
 	}
 
@@ -1399,8 +1415,8 @@ type listTagsForResourceOutput struct {
 	Tags map[string]string `json:"tags"`
 }
 
-func (h *Handler) handleListTagsForResource(c *echo.Context, resourceARN string) error {
-	tags, err := h.Backend.ListTagsForResource(resourceARN)
+func (h *Handler) handleListTagsForResource(ctx context.Context, c *echo.Context, resourceARN string) error {
+	tags, err := h.Backend.ListTagsForResource(ctx, resourceARN)
 	if err != nil {
 		return h.writeError(c, err)
 	}
@@ -1416,7 +1432,7 @@ type tagResourceInput struct {
 	Tags map[string]string `json:"tags"`
 }
 
-func (h *Handler) handleTagResource(c *echo.Context, resourceARN string, body []byte) error {
+func (h *Handler) handleTagResource(ctx context.Context, c *echo.Context, resourceARN string, body []byte) error {
 	var in tagResourceInput
 	if len(body) > 0 {
 		if err := json.Unmarshal(body, &in); err != nil {
@@ -1424,16 +1440,21 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceARN string, body []
 		}
 	}
 
-	if err := h.Backend.TagResource(resourceARN, in.Tags); err != nil {
+	if err := h.Backend.TagResource(ctx, resourceARN, in.Tags); err != nil {
 		return h.writeError(c, err)
 	}
 
 	return c.JSON(http.StatusOK, emptyOutput{})
 }
 
-func (h *Handler) handleUntagResource(c *echo.Context, resourceARN string, query url.Values) error {
+func (h *Handler) handleUntagResource(
+	ctx context.Context,
+	c *echo.Context,
+	resourceARN string,
+	query url.Values,
+) error {
 	tagKeys := query["tagKeys"]
-	if err := h.Backend.UntagResource(resourceARN, tagKeys); err != nil {
+	if err := h.Backend.UntagResource(ctx, resourceARN, tagKeys); err != nil {
 		return h.writeError(c, err)
 	}
 
@@ -1455,14 +1476,20 @@ type createConsumableResourceOutput struct {
 }
 
 func (h *Handler) handleCreateConsumableResource(
-	_ context.Context,
+	ctx context.Context,
 	in *createConsumableResourceInput,
 ) (*createConsumableResourceOutput, error) {
 	if in.ConsumableResourceName == "" {
 		return nil, fmt.Errorf("%w: consumableResourceName is required", ErrValidation)
 	}
 
-	cr, err := h.Backend.CreateConsumableResource(in.ConsumableResourceName, in.ResourceType, in.TotalQuantity, in.Tags)
+	cr, err := h.Backend.CreateConsumableResource(
+		ctx,
+		in.ConsumableResourceName,
+		in.ResourceType,
+		in.TotalQuantity,
+		in.Tags,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1478,14 +1505,14 @@ type deleteConsumableResourceInput struct {
 }
 
 func (h *Handler) handleDeleteConsumableResource(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteConsumableResourceInput,
 ) (*emptyOutput, error) {
 	if in.ConsumableResource == "" {
 		return nil, fmt.Errorf("%w: consumableResource is required", ErrValidation)
 	}
 
-	if err := h.Backend.DeleteConsumableResource(in.ConsumableResource); err != nil {
+	if err := h.Backend.DeleteConsumableResource(ctx, in.ConsumableResource); err != nil {
 		return nil, err
 	}
 
@@ -1508,14 +1535,14 @@ type describeConsumableResourceOutput struct {
 }
 
 func (h *Handler) handleDescribeConsumableResource(
-	_ context.Context,
+	ctx context.Context,
 	in *describeConsumableResourceInput,
 ) (*describeConsumableResourceOutput, error) {
 	if in.ConsumableResource == "" {
 		return nil, fmt.Errorf("%w: consumableResource is required", ErrValidation)
 	}
 
-	cr, err := h.Backend.DescribeConsumableResource(in.ConsumableResource)
+	cr, err := h.Backend.DescribeConsumableResource(ctx, in.ConsumableResource)
 	if err != nil {
 		return nil, err
 	}
@@ -1545,14 +1572,14 @@ type createSchedulingPolicyOutput struct {
 }
 
 func (h *Handler) handleCreateSchedulingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *createSchedulingPolicyInput,
 ) (*createSchedulingPolicyOutput, error) {
 	if in.Name == "" {
 		return nil, fmt.Errorf("%w: name is required", ErrValidation)
 	}
 
-	sp, err := h.Backend.CreateSchedulingPolicy(in.Name, in.Tags, nil)
+	sp, err := h.Backend.CreateSchedulingPolicy(ctx, in.Name, in.Tags, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1568,14 +1595,14 @@ type deleteSchedulingPolicyInput struct {
 }
 
 func (h *Handler) handleDeleteSchedulingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteSchedulingPolicyInput,
 ) (*emptyOutput, error) {
 	if in.Arn == "" {
 		return nil, fmt.Errorf("%w: arn is required", ErrValidation)
 	}
 
-	if err := h.Backend.DeleteSchedulingPolicy(in.Arn); err != nil {
+	if err := h.Backend.DeleteSchedulingPolicy(ctx, in.Arn); err != nil {
 		return nil, err
 	}
 
@@ -1597,7 +1624,7 @@ type createServiceEnvironmentOutput struct {
 }
 
 func (h *Handler) handleCreateServiceEnvironment(
-	_ context.Context,
+	ctx context.Context,
 	in *createServiceEnvironmentInput,
 ) (*createServiceEnvironmentOutput, error) {
 	if in.ServiceEnvironmentName == "" {
@@ -1609,6 +1636,7 @@ func (h *Handler) handleCreateServiceEnvironment(
 	}
 
 	se, err := h.Backend.CreateServiceEnvironment(
+		ctx,
 		in.ServiceEnvironmentName,
 		in.ServiceEnvironmentType,
 		in.State,
@@ -1629,14 +1657,14 @@ type deleteServiceEnvironmentInput struct {
 }
 
 func (h *Handler) handleDeleteServiceEnvironment(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteServiceEnvironmentInput,
 ) (*emptyOutput, error) {
 	if in.ServiceEnvironment == "" {
 		return nil, fmt.Errorf("%w: serviceEnvironment is required", ErrValidation)
 	}
 
-	if err := h.Backend.DeleteServiceEnvironment(in.ServiceEnvironment); err != nil {
+	if err := h.Backend.DeleteServiceEnvironment(ctx, in.ServiceEnvironment); err != nil {
 		return nil, err
 	}
 
@@ -1663,14 +1691,14 @@ type updateConsumableResourceOutput struct {
 }
 
 func (h *Handler) handleUpdateConsumableResource(
-	_ context.Context,
+	ctx context.Context,
 	in *updateConsumableResourceInput,
 ) (*updateConsumableResourceOutput, error) {
 	if in.ConsumableResource == "" {
 		return nil, fmt.Errorf("%w: consumableResource is required", ErrValidation)
 	}
 
-	cr, err := h.Backend.UpdateConsumableResource(in.ConsumableResource, in.Operation, in.Quantity)
+	cr, err := h.Backend.UpdateConsumableResource(ctx, in.ConsumableResource, in.Operation, in.Quantity)
 	if err != nil {
 		return nil, err
 	}
@@ -1694,10 +1722,10 @@ type listConsumableResourcesOutput struct {
 }
 
 func (h *Handler) handleListConsumableResources(
-	_ context.Context,
+	ctx context.Context,
 	_ *struct{},
 ) (*listConsumableResourcesOutput, error) {
-	list := h.Backend.ListConsumableResources()
+	list := h.Backend.ListConsumableResources(ctx)
 
 	return &listConsumableResourcesOutput{ConsumableResourceSummaryList: list}, nil
 }
@@ -1713,10 +1741,10 @@ type describeSchedulingPoliciesOutput struct {
 }
 
 func (h *Handler) handleDescribeSchedulingPolicies(
-	_ context.Context,
+	ctx context.Context,
 	in *describeSchedulingPoliciesInput,
 ) (*describeSchedulingPoliciesOutput, error) {
-	list := h.Backend.DescribeSchedulingPolicies(in.Arns)
+	list := h.Backend.DescribeSchedulingPolicies(ctx, in.Arns)
 
 	return &describeSchedulingPoliciesOutput{SchedulingPolicies: list}, nil
 }
@@ -1728,10 +1756,10 @@ type listSchedulingPoliciesOutput struct {
 }
 
 func (h *Handler) handleListSchedulingPolicies(
-	_ context.Context,
+	ctx context.Context,
 	_ *struct{},
 ) (*listSchedulingPoliciesOutput, error) {
-	list := h.Backend.ListSchedulingPolicies()
+	list := h.Backend.ListSchedulingPolicies(ctx)
 
 	return &listSchedulingPoliciesOutput{SchedulingPolicies: list}, nil
 }
@@ -1743,14 +1771,14 @@ type updateSchedulingPolicyInput struct {
 }
 
 func (h *Handler) handleUpdateSchedulingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *updateSchedulingPolicyInput,
 ) (*emptyOutput, error) {
 	if in.Arn == "" {
 		return nil, fmt.Errorf("%w: arn is required", ErrValidation)
 	}
 
-	if err := h.Backend.UpdateSchedulingPolicy(in.Arn, nil); err != nil {
+	if err := h.Backend.UpdateSchedulingPolicy(ctx, in.Arn, nil); err != nil {
 		return nil, err
 	}
 
@@ -1768,10 +1796,10 @@ type describeServiceEnvironmentsOutput struct {
 }
 
 func (h *Handler) handleDescribeServiceEnvironments(
-	_ context.Context,
+	ctx context.Context,
 	in *describeServiceEnvironmentsInput,
 ) (*describeServiceEnvironmentsOutput, error) {
-	list := h.Backend.DescribeServiceEnvironments(in.ServiceEnvironments)
+	list := h.Backend.DescribeServiceEnvironments(ctx, in.ServiceEnvironments)
 
 	return &describeServiceEnvironmentsOutput{ServiceEnvironments: list}, nil
 }
@@ -1789,14 +1817,14 @@ type updateServiceEnvironmentOutput struct {
 }
 
 func (h *Handler) handleUpdateServiceEnvironment(
-	_ context.Context,
+	ctx context.Context,
 	in *updateServiceEnvironmentInput,
 ) (*updateServiceEnvironmentOutput, error) {
 	if in.ServiceEnvironment == "" {
 		return nil, fmt.Errorf("%w: serviceEnvironment is required", ErrValidation)
 	}
 
-	se, err := h.Backend.UpdateServiceEnvironment(in.ServiceEnvironment, in.State)
+	se, err := h.Backend.UpdateServiceEnvironment(ctx, in.ServiceEnvironment, in.State)
 	if err != nil {
 		return nil, err
 	}
@@ -1821,14 +1849,14 @@ type submitServiceJobOutput struct {
 }
 
 func (h *Handler) handleSubmitServiceJob(
-	_ context.Context,
+	ctx context.Context,
 	in *submitServiceJobInput,
 ) (*submitServiceJobOutput, error) {
 	if in.ServiceJobName == "" {
 		return nil, fmt.Errorf("%w: serviceJobName is required", ErrValidation)
 	}
 
-	sj, err := h.Backend.SubmitServiceJob(in.ServiceJobName, in.ServiceEnvironment, in.Tags)
+	sj, err := h.Backend.SubmitServiceJob(ctx, in.ServiceJobName, in.ServiceEnvironment, in.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -1857,14 +1885,14 @@ type describeServiceJobOutput struct {
 }
 
 func (h *Handler) handleDescribeServiceJob(
-	_ context.Context,
+	ctx context.Context,
 	in *describeServiceJobInput,
 ) (*describeServiceJobOutput, error) {
 	if in.ServiceJob == "" {
 		return nil, fmt.Errorf("%w: serviceJob is required", ErrValidation)
 	}
 
-	sj, err := h.Backend.DescribeServiceJob(in.ServiceJob)
+	sj, err := h.Backend.DescribeServiceJob(ctx, in.ServiceJob)
 	if err != nil {
 		return nil, err
 	}
@@ -1891,8 +1919,8 @@ type listServiceJobsOutput struct {
 	ServiceJobs []*ServiceJob `json:"serviceJobs"`
 }
 
-func (h *Handler) handleListServiceJobs(_ context.Context, in *listServiceJobsInput) (*listServiceJobsOutput, error) {
-	list, err := h.Backend.ListServiceJobs(in.ServiceEnvironment)
+func (h *Handler) handleListServiceJobs(ctx context.Context, in *listServiceJobsInput) (*listServiceJobsOutput, error) {
+	list, err := h.Backend.ListServiceJobs(ctx, in.ServiceEnvironment)
 	if err != nil {
 		return nil, err
 	}
@@ -1905,12 +1933,12 @@ type terminateServiceJobInput struct {
 	Reason     string `json:"reason"`
 }
 
-func (h *Handler) handleTerminateServiceJob(_ context.Context, in *terminateServiceJobInput) (*emptyOutput, error) {
+func (h *Handler) handleTerminateServiceJob(ctx context.Context, in *terminateServiceJobInput) (*emptyOutput, error) {
 	if in.ServiceJob == "" {
 		return nil, fmt.Errorf("%w: serviceJob is required", ErrValidation)
 	}
 
-	if err := h.Backend.TerminateServiceJob(in.ServiceJob, in.Reason); err != nil {
+	if err := h.Backend.TerminateServiceJob(ctx, in.ServiceJob, in.Reason); err != nil {
 		return nil, err
 	}
 
@@ -1922,14 +1950,14 @@ type getJobQueueSnapshotInput struct {
 }
 
 func (h *Handler) handleGetJobQueueSnapshot(
-	_ context.Context,
+	ctx context.Context,
 	in *getJobQueueSnapshotInput,
 ) (*JobQueueSnapshot, error) {
 	if in.JobQueue == "" {
 		return nil, fmt.Errorf("%w: jobQueue is required", ErrValidation)
 	}
 
-	return h.Backend.GetJobQueueSnapshot(in.JobQueue)
+	return h.Backend.GetJobQueueSnapshot(ctx, in.JobQueue)
 }
 
 type listJobsByConsumableResourceInput struct {
@@ -1941,10 +1969,10 @@ type listJobsByConsumableResourceOutput struct {
 }
 
 func (h *Handler) handleListJobsByConsumableResource(
-	_ context.Context,
+	ctx context.Context,
 	in *listJobsByConsumableResourceInput,
 ) (*listJobsByConsumableResourceOutput, error) {
-	jobs, err := h.Backend.ListJobsByConsumableResource(in.ConsumableResource)
+	jobs, err := h.Backend.ListJobsByConsumableResource(ctx, in.ConsumableResource)
 	if err != nil {
 		return nil, err
 	}

--- a/services/batch/handler_test.go
+++ b/services/batch/handler_test.go
@@ -2,6 +2,7 @@ package batch_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1385,7 +1386,8 @@ func TestBatch_PersistenceSnapshotRestore(t *testing.T) {
 	b := batch.NewInMemoryBackend("000000000000", "us-east-1")
 
 	// Create compute environment.
-	ce, err := b.CreateComputeEnvironment("test-ce", "MANAGED", "ENABLED", nil, "", nil, nil, nil)
+	ce, err := b.CreateComputeEnvironment(
+		context.Background(), "test-ce", "MANAGED", "ENABLED", nil, "", nil, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, ce.ComputeEnvironmentArn)
 
@@ -1393,17 +1395,19 @@ func TestBatch_PersistenceSnapshotRestore(t *testing.T) {
 	ceOrder := []batch.ComputeEnvironmentOrder{
 		{ComputeEnvironment: ce.ComputeEnvironmentArn, Order: 1},
 	}
-	jq, err := b.CreateJobQueue("test-jq", 10, "ENABLED", ceOrder, nil, "", nil)
+	jq, err := b.CreateJobQueue(context.Background(), "test-jq", 10, "ENABLED", ceOrder, nil, "", nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, jq.JobQueueArn)
 
 	// Register job definition.
-	jd, err := b.RegisterJobDefinition("test-jd", "container", nil, nil, 0, 0, nil, nil, nil, nil, nil, nil, false)
+	jd, err := b.RegisterJobDefinition(
+		context.Background(), "test-jd", "container", nil, nil, 0, 0, nil, nil, nil, nil, nil, nil, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, jd.JobDefinitionArn)
 
 	// Submit a job.
 	job, err := b.SubmitJob(
+		context.Background(),
 		"test-job",
 		jq.JobQueueName,
 		jd.JobDefinitionArn,
@@ -1432,28 +1436,28 @@ func TestBatch_PersistenceSnapshotRestore(t *testing.T) {
 	require.NoError(t, h2.Restore(snap))
 
 	// Compute environment is restored.
-	ces, _ := b2.DescribeComputeEnvironments([]string{"test-ce"}, 0, "")
+	ces, _ := b2.DescribeComputeEnvironments(context.Background(), []string{"test-ce"}, 0, "")
 	require.Len(t, ces, 1)
 	assert.Equal(t, "test-ce", ces[0].ComputeEnvironmentName)
 
 	// Job queue is restored.
-	jqs, _ := b2.DescribeJobQueues([]string{"test-jq"}, 0, "")
+	jqs, _ := b2.DescribeJobQueues(context.Background(), []string{"test-jq"}, 0, "")
 	require.Len(t, jqs, 1)
 	assert.Equal(t, "test-jq", jqs[0].JobQueueName)
 
 	// Job definition is restored.
-	jds, _ := b2.DescribeJobDefinitions([]string{"test-jd"}, "", "", 0, "")
+	jds, _ := b2.DescribeJobDefinitions(context.Background(), []string{"test-jd"}, "", "", 0, "")
 	require.NotEmpty(t, jds)
 	assert.Equal(t, "test-jd", jds[0].JobDefinitionName)
 
 	// Submitted job is restored.
-	jobs := b2.DescribeJobs([]string{job.JobID})
+	jobs := b2.DescribeJobs(context.Background(), []string{job.JobID})
 	require.Len(t, jobs, 1)
 	assert.Equal(t, "test-job", jobs[0].JobName)
 	assert.Equal(t, jq.JobQueueName, jobs[0].JobQueue)
 
 	// jobsByQueue index is rebuilt — ListJobs must return the submitted job.
-	listed, _, err := b2.ListJobs(jq.JobQueueName, "", "", 0)
+	listed, _, err := b2.ListJobs(context.Background(), jq.JobQueueName, "", "", 0)
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
 	assert.Equal(t, job.JobID, listed[0].JobID)

--- a/services/batch/isolation_test.go
+++ b/services/batch/isolation_test.go
@@ -1,0 +1,196 @@
+package batch //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region under the backend's
+// region context key, mimicking what the HTTP handler injects from SigV4.
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestBatchComputeEnvironmentRegionIsolation verifies that compute environments,
+// job queues, job definitions and jobs with the SAME NAME in two different
+// regions are fully isolated from each other.
+func TestBatchComputeEnvironmentRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// 1. Create a compute environment named "ce1" in us-east-1.
+	eastCE, err := backend.CreateComputeEnvironment(ctxEast, "ce1", "MANAGED", "ENABLED", nil, "", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, eastCE.ComputeEnvironmentArn, "us-east-1")
+
+	// 2. Create a CE with the SAME NAME in us-west-2 — must not collide.
+	westCE, err := backend.CreateComputeEnvironment(ctxWest, "ce1", "MANAGED", "ENABLED", nil, "", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, westCE.ComputeEnvironmentArn, "us-west-2")
+	assert.NotEqual(t, eastCE.ComputeEnvironmentArn, westCE.ComputeEnvironmentArn)
+
+	// 3. Each region sees only its own CE.
+	eastList, _ := backend.DescribeComputeEnvironments(ctxEast, nil, 0, "")
+	require.Len(t, eastList, 1)
+	assert.Contains(t, eastList[0].ComputeEnvironmentArn, "us-east-1")
+
+	westList, _ := backend.DescribeComputeEnvironments(ctxWest, nil, 0, "")
+	require.Len(t, westList, 1)
+	assert.Contains(t, westList[0].ComputeEnvironmentArn, "us-west-2")
+
+	// 4. Deleting the CE in us-east-1 (after disabling) leaves us-west-2 intact.
+	_, err = backend.UpdateComputeEnvironment(ctxEast, "ce1", "DISABLED", "", nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, backend.DeleteComputeEnvironment(ctxEast, "ce1"))
+
+	eastAfter, _ := backend.DescribeComputeEnvironments(ctxEast, nil, 0, "")
+	assert.Empty(t, eastAfter)
+
+	westAfter, _ := backend.DescribeComputeEnvironments(ctxWest, nil, 0, "")
+	assert.Len(t, westAfter, 1)
+}
+
+// TestBatchJobRegionIsolation verifies that the cross-index maps (jobsByQueue,
+// jobsByARN) stay region-scoped: a job submitted to a same-named queue in one
+// region is invisible from another region.
+func TestBatchJobRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// Same-named queue in each region.
+	_, err := backend.CreateJobQueue(ctxEast, "queue1", 1, "ENABLED", nil, nil, "", nil)
+	require.NoError(t, err)
+
+	_, err = backend.CreateJobQueue(ctxWest, "queue1", 1, "ENABLED", nil, nil, "", nil)
+	require.NoError(t, err)
+
+	// Same-named job definition in each region.
+	_, err = backend.RegisterJobDefinition(
+		ctxEast,
+		"jd1",
+		"container",
+		nil,
+		nil,
+		0,
+		0,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	_, err = backend.RegisterJobDefinition(
+		ctxWest,
+		"jd1",
+		"container",
+		nil,
+		nil,
+		0,
+		0,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	// Submit a job to queue1 in us-east-1 only.
+	eastJob, err := backend.SubmitJob(
+		ctxEast, "job1", "queue1", "jd1",
+		nil, nil, nil, nil, nil, nil, nil, nil, "", 0, false,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, eastJob.JobARN, "us-east-1")
+
+	// us-east-1 sees the job; us-west-2 does not (cross-index isolation).
+	eastJobs, _, err := backend.ListJobs(ctxEast, "queue1", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, eastJobs, 1)
+	assert.Equal(t, "job1", eastJobs[0].JobName)
+
+	westJobs, _, err := backend.ListJobs(ctxWest, "queue1", "", "", 0)
+	require.NoError(t, err)
+	assert.Empty(t, westJobs)
+
+	// The job ARN is resolvable in its own region but not the other (jobsByARN).
+	eastDescribe := backend.DescribeJobs(ctxEast, []string{eastJob.JobARN})
+	require.Len(t, eastDescribe, 1)
+
+	westDescribe := backend.DescribeJobs(ctxWest, []string{eastJob.JobARN})
+	assert.Empty(t, westDescribe)
+}
+
+// TestBatchSchedulingPolicyRegionIsolation verifies the schedulingPolicyByName
+// cross-index map is region-scoped: a same-named policy can exist in two regions.
+func TestBatchSchedulingPolicyRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	eastSP, err := backend.CreateSchedulingPolicy(ctxEast, "policy1", nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, eastSP.Arn, "us-east-1")
+
+	// Same name in us-west-2 must succeed (no collision via name index).
+	westSP, err := backend.CreateSchedulingPolicy(ctxWest, "policy1", nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, westSP.Arn, "us-west-2")
+
+	eastPolicies := backend.ListSchedulingPolicies(ctxEast)
+	require.Len(t, eastPolicies, 1)
+	assert.Contains(t, eastPolicies[0].Arn, "us-east-1")
+
+	westPolicies := backend.ListSchedulingPolicies(ctxWest)
+	require.Len(t, westPolicies, 1)
+	assert.Contains(t, westPolicies[0].Arn, "us-west-2")
+
+	// Deleting in us-east-1 frees the name there but leaves us-west-2 intact,
+	// and lets us-east-1 recreate the same name.
+	require.NoError(t, backend.DeleteSchedulingPolicy(ctxEast, eastSP.Arn))
+
+	assert.Empty(t, backend.ListSchedulingPolicies(ctxEast))
+	assert.Len(t, backend.ListSchedulingPolicies(ctxWest), 1)
+
+	_, err = backend.CreateSchedulingPolicy(ctxEast, "policy1", nil, nil)
+	require.NoError(t, err)
+}
+
+// TestBatchDefaultRegionFallback verifies that an empty context falls back to the
+// backend's configured default region (single-region behaviour is unchanged).
+func TestBatchDefaultRegionFallback(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	// No region in context → uses default region us-east-1.
+	ce, err := backend.CreateComputeEnvironment(
+		context.Background(), "ce1", "MANAGED", "ENABLED", nil, "", nil, nil, nil,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, ce.ComputeEnvironmentArn, "us-east-1")
+
+	// A context explicitly carrying the default region sees the same resource.
+	list, _ := backend.DescribeComputeEnvironments(ctxRegion("us-east-1"), nil, 0, "")
+	require.Len(t, list, 1)
+}

--- a/services/batch/janitor.go
+++ b/services/batch/janitor.go
@@ -98,26 +98,32 @@ func (j *Janitor) sweepInactiveJobDefinitions(ctx context.Context) {
 
 	var swept []string
 
-	for arnKey, jd := range j.Backend.jobDefinitions {
-		if jd.Status == jobDefStatusInactive && jd.DeregisteredAt != nil && jd.DeregisteredAt.Before(cutoff) {
-			swept = append(swept, arnKey)
-			delete(j.Backend.jobDefinitions, arnKey)
+	// Job definitions are nested by region; sweep each region independently so
+	// expired INACTIVE definitions and orphaned revision counters are cleaned up
+	// per region.
+	for region, defs := range j.Backend.jobDefinitions {
+		for arnKey, jd := range defs {
+			if jd.Status == jobDefStatusInactive && jd.DeregisteredAt != nil && jd.DeregisteredAt.Before(cutoff) {
+				swept = append(swept, arnKey)
+				delete(defs, arnKey)
+			}
 		}
-	}
 
-	// Remove revision counters for names that no longer have any definition
-	// (ACTIVE or INACTIVE). This prevents the jobDefRevisions map from growing
-	// without bound as job definition names cycle through their lifetimes.
-	// Build a set of names with surviving definitions first for O(n+m) complexity.
-	surviving := make(map[string]struct{}, len(j.Backend.jobDefinitions))
+		// Remove revision counters for names that no longer have any definition
+		// (ACTIVE or INACTIVE) in this region. This prevents the jobDefRevisions
+		// map from growing without bound as job definition names cycle through
+		// their lifetimes. Build a set of surviving names first for O(n+m).
+		surviving := make(map[string]struct{}, len(defs))
 
-	for _, jd := range j.Backend.jobDefinitions {
-		surviving[jd.JobDefinitionName] = struct{}{}
-	}
+		for _, jd := range defs {
+			surviving[jd.JobDefinitionName] = struct{}{}
+		}
 
-	for name := range j.Backend.jobDefRevisions {
-		if _, ok := surviving[name]; !ok {
-			delete(j.Backend.jobDefRevisions, name)
+		revisions := j.Backend.jobDefRevisions[region]
+		for name := range revisions {
+			if _, ok := surviving[name]; !ok {
+				delete(revisions, name)
+			}
 		}
 	}
 
@@ -146,18 +152,25 @@ func (j *Janitor) sweepCompletedJobs(ctx context.Context) {
 
 	var swept []string
 
-	for id, job := range j.Backend.jobs {
-		if !isTerminalJobStatus(job.Status) {
-			continue
-		}
+	// Jobs are nested by region; sweep completed/failed jobs in every region.
+	for region, jobs := range j.Backend.jobs {
+		for id, job := range jobs {
+			if !isTerminalJobStatus(job.Status) {
+				continue
+			}
 
-		if job.StoppedAt == nil {
-			continue
-		}
+			if job.StoppedAt == nil {
+				continue
+			}
 
-		if *job.StoppedAt < cutoffMs {
-			swept = append(swept, id)
-			delete(j.Backend.jobs, id)
+			if *job.StoppedAt < cutoffMs {
+				swept = append(swept, id)
+				delete(jobs, id)
+
+				if jobsByARN := j.Backend.jobsByARN[region]; jobsByARN != nil {
+					delete(jobsByARN, job.JobARN)
+				}
+			}
 		}
 	}
 

--- a/services/batch/janitor_test.go
+++ b/services/batch/janitor_test.go
@@ -103,6 +103,7 @@ func TestBatchJanitor_SweepOnce_WithTaskTimeout(t *testing.T) {
 	b := batch.NewInMemoryBackend("000000000000", "us-east-1")
 
 	_, err := b.RegisterJobDefinition(
+		context.Background(),
 		"sweep-timeout-test",
 		"container",
 		nil,
@@ -119,7 +120,7 @@ func TestBatchJanitor_SweepOnce_WithTaskTimeout(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, b.DeregisterJobDefinition("sweep-timeout-test:1"))
+	require.NoError(t, b.DeregisterJobDefinition(context.Background(), "sweep-timeout-test:1"))
 
 	// Set DeregisteredAt in the past so it will be swept.
 	b.SetJobDefinitionDeregisteredAt("sweep-timeout-test:1", time.Now().Add(-25*time.Hour))
@@ -182,10 +183,11 @@ func TestBatchJanitor_SweepCompletedJobs(t *testing.T) {
 
 			b := batch.NewInMemoryBackend("000000000000", "us-east-1")
 
-			queue, err := b.CreateJobQueue("test-queue", 1, "ENABLED", nil, nil, "", nil)
+			queue, err := b.CreateJobQueue(context.Background(), "test-queue", 1, "ENABLED", nil, nil, "", nil)
 			require.NoError(t, err)
 
 			_, err = b.RegisterJobDefinition(
+				context.Background(),
 				"test-jd",
 				"container",
 				nil,
@@ -203,6 +205,7 @@ func TestBatchJanitor_SweepCompletedJobs(t *testing.T) {
 			require.NoError(t, err)
 
 			job, err := b.SubmitJob(
+				context.Background(),
 				"test-job",
 				queue.JobQueueName,
 				"test-jd:1",
@@ -226,7 +229,7 @@ func TestBatchJanitor_SweepCompletedJobs(t *testing.T) {
 			j := batch.NewJanitor(b, time.Minute, 24*time.Hour, tt.ttl)
 			j.SweepOnce(t.Context())
 
-			jobs, _, err := b.ListJobs(queue.JobQueueName, tt.status, "", 0)
+			jobs, _, err := b.ListJobs(context.Background(), queue.JobQueueName, tt.status, "", 0)
 			require.NoError(t, err)
 
 			if tt.wantEvicted {

--- a/services/batch/persistence.go
+++ b/services/batch/persistence.go
@@ -2,18 +2,21 @@ package batch
 
 import "encoding/json"
 
+// backendSnapshot is the serialisation form of the backend. All resource maps are
+// nested by region (outer key = region) so that region isolation survives a
+// snapshot/restore round-trip.
 type backendSnapshot struct {
-	ComputeEnvironments map[string]*ComputeEnvironment `json:"computeEnvironments"`
-	JobQueues           map[string]*JobQueue           `json:"jobQueues"`
-	JobDefinitions      map[string]*JobDefinition      `json:"jobDefinitions"`
-	Jobs                map[string]*Job                `json:"jobs"`
-	JobsByQueue         map[string][]string            `json:"jobsByQueue"`
-	JobDefRevisions     map[string]int32               `json:"jobDefRevisions"`
-	ConsumableResources map[string]*ConsumableResource `json:"consumableResources"`
-	SchedulingPolicies  map[string]*SchedulingPolicy   `json:"schedulingPolicies"`
-	ServiceEnvironments map[string]*ServiceEnvironment `json:"serviceEnvironments"`
-	AccountID           string                         `json:"accountID"`
-	Region              string                         `json:"region"`
+	ComputeEnvironments map[string]map[string]*ComputeEnvironment `json:"computeEnvironments"`
+	JobQueues           map[string]map[string]*JobQueue           `json:"jobQueues"`
+	JobDefinitions      map[string]map[string]*JobDefinition      `json:"jobDefinitions"`
+	Jobs                map[string]map[string]*Job                `json:"jobs"`
+	JobsByQueue         map[string]map[string][]string            `json:"jobsByQueue"`
+	JobDefRevisions     map[string]map[string]int32               `json:"jobDefRevisions"`
+	ConsumableResources map[string]map[string]*ConsumableResource `json:"consumableResources"`
+	SchedulingPolicies  map[string]map[string]*SchedulingPolicy   `json:"schedulingPolicies"`
+	ServiceEnvironments map[string]map[string]*ServiceEnvironment `json:"serviceEnvironments"`
+	AccountID           string                                    `json:"accountID"`
+	Region              string                                    `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -51,61 +54,72 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
-	if snap.ComputeEnvironments == nil {
-		snap.ComputeEnvironments = make(map[string]*ComputeEnvironment)
+	b.initMaps()
+
+	if snap.ComputeEnvironments != nil {
+		b.computeEnvironments = snap.ComputeEnvironments
 	}
 
-	if snap.JobQueues == nil {
-		snap.JobQueues = make(map[string]*JobQueue)
+	if snap.JobQueues != nil {
+		b.jobQueues = snap.JobQueues
 	}
 
-	if snap.JobDefinitions == nil {
-		snap.JobDefinitions = make(map[string]*JobDefinition)
+	if snap.JobDefinitions != nil {
+		b.jobDefinitions = snap.JobDefinitions
 	}
 
-	if snap.Jobs == nil {
-		snap.Jobs = make(map[string]*Job)
+	if snap.Jobs != nil {
+		b.jobs = snap.Jobs
 	}
 
-	if snap.JobsByQueue == nil {
-		snap.JobsByQueue = make(map[string][]string)
+	if snap.JobsByQueue != nil {
+		b.jobsByQueue = snap.JobsByQueue
 	}
 
-	if snap.JobDefRevisions == nil {
-		snap.JobDefRevisions = make(map[string]int32)
+	if snap.JobDefRevisions != nil {
+		b.jobDefRevisions = snap.JobDefRevisions
 	}
 
-	if snap.ConsumableResources == nil {
-		snap.ConsumableResources = make(map[string]*ConsumableResource)
+	if snap.ConsumableResources != nil {
+		b.consumableResources = snap.ConsumableResources
 	}
 
-	if snap.SchedulingPolicies == nil {
-		snap.SchedulingPolicies = make(map[string]*SchedulingPolicy)
+	if snap.SchedulingPolicies != nil {
+		b.schedulingPolicies = snap.SchedulingPolicies
 	}
 
-	if snap.ServiceEnvironments == nil {
-		snap.ServiceEnvironments = make(map[string]*ServiceEnvironment)
+	if snap.ServiceEnvironments != nil {
+		b.serviceEnvironments = snap.ServiceEnvironments
 	}
 
-	b.computeEnvironments = snap.ComputeEnvironments
-	b.jobQueues = snap.JobQueues
-	b.jobDefinitions = snap.JobDefinitions
-	b.jobs = snap.Jobs
-	b.jobsByQueue = snap.JobsByQueue
-	b.jobDefRevisions = snap.JobDefRevisions
-	b.consumableResources = snap.ConsumableResources
-	b.schedulingPolicies = snap.SchedulingPolicies
-	b.serviceEnvironments = snap.ServiceEnvironments
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 
-	// Rebuild the name → ARN index from the restored scheduling policies.
-	b.schedulingPolicyByName = make(map[string]string, len(b.schedulingPolicies))
-	for arn, sp := range b.schedulingPolicies {
-		b.schedulingPolicyByName[sp.Name] = arn
-	}
+	// Rebuild the per-region name → ARN index and the job ARN → ID index from the
+	// restored state (these cross-index maps are not persisted directly).
+	b.rebuildIndexes()
 
 	return nil
+}
+
+// rebuildIndexes reconstructs the schedulingPolicyByName and jobsByARN cross-index
+// maps from the restored resource maps. Callers must hold the write lock.
+func (b *InMemoryBackend) rebuildIndexes() {
+	b.schedulingPolicyByName = make(map[string]map[string]string, len(b.schedulingPolicies))
+	for region, policies := range b.schedulingPolicies {
+		byName := b.schedulingPolicyByNameStore(region)
+		for policyARN, sp := range policies {
+			byName[sp.Name] = policyARN
+		}
+	}
+
+	b.jobsByARN = make(map[string]map[string]string, len(b.jobs))
+	for region, jobs := range b.jobs {
+		byARN := b.jobsByARNStore(region)
+		for jobID, j := range jobs {
+			byARN[j.JobARN] = jobID
+		}
+	}
 }
 
 // Snapshot implements persistence.Persistable by delegating to the backend.

--- a/services/cloudformation/dynamic_refs_test.go
+++ b/services/cloudformation/dynamic_refs_test.go
@@ -461,7 +461,7 @@ func TestBackend_CreateStack_DynamicRefs_SecretsManager(t *testing.T) {
 		{
 			name: "secretsmanager_ref_resolved",
 			setupSM: func(b *secretsmanager.InMemoryBackend) {
-				_, _ = b.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, _ = b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "my-db-secret",
 					SecretString: "db-password-value",
 				})
@@ -652,12 +652,12 @@ func TestNewDynamicRefResolver_RealSecretsManager(t *testing.T) {
 	t.Parallel()
 
 	smBackend := secretsmanager.NewInMemoryBackendWithConfig("000000000000", "us-east-1")
-	_, _ = smBackend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, _ = smBackend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "my-secret",
 		SecretString: "top-secret",
 	})
 
-	_, _ = smBackend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, _ = smBackend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "json-secret",
 		SecretString: `{"password":"p@ss","user":"admin"}`,
 	})

--- a/services/cloudformation/resources.go
+++ b/services/cloudformation/resources.go
@@ -1641,11 +1641,13 @@ func (rc *ResourceCreator) createSecretsManagerSecret(
 	}
 	description := strProp(props, "Description", params, physicalIDs)
 	secretString := strProp(props, "SecretString", params, physicalIDs)
-	out, err := rc.backends.SecretsManager.Backend.CreateSecret(&secretsmanagerbackend.CreateSecretInput{
-		Name:         name,
-		Description:  description,
-		SecretString: secretString,
-	})
+	out, err := rc.backends.SecretsManager.Backend.CreateSecret(
+		context.Background(),
+		&secretsmanagerbackend.CreateSecretInput{
+			Name:         name,
+			Description:  description,
+			SecretString: secretString,
+		})
 	if err != nil {
 		return "", fmt.Errorf("failed to create secret %s: %w", name, err)
 	}
@@ -1657,10 +1659,12 @@ func (rc *ResourceCreator) deleteSecretsManagerSecret(_ context.Context, physica
 	if rc.backends.SecretsManager == nil {
 		return nil
 	}
-	_, err := rc.backends.SecretsManager.Backend.DeleteSecret(&secretsmanagerbackend.DeleteSecretInput{
-		SecretID:                   physicalID,
-		ForceDeleteWithoutRecovery: true,
-	})
+	_, err := rc.backends.SecretsManager.Backend.DeleteSecret(
+		context.Background(),
+		&secretsmanagerbackend.DeleteSecretInput{
+			SecretID:                   physicalID,
+			ForceDeleteWithoutRecovery: true,
+		})
 
 	return err
 }
@@ -1933,7 +1937,9 @@ func (r *serviceBackendsResolver) ResolveSecret(secretID, jsonKey string) (strin
 		return "", fmt.Errorf("%w: SecretsManager backend is not available", ErrDynamicRefFailed)
 	}
 
-	out, err := r.sm.Backend.GetSecretValue(&secretsmanagerbackend.GetSecretValueInput{SecretID: secretID})
+	out, err := r.sm.Backend.GetSecretValue(
+		context.Background(),
+		&secretsmanagerbackend.GetSecretValueInput{SecretID: secretID})
 	if err != nil {
 		return "", err
 	}

--- a/services/cloudformation/resources_extended.go
+++ b/services/cloudformation/resources_extended.go
@@ -1077,6 +1077,7 @@ func (rc *ResourceCreator) createSchedulerSchedule(
 	}
 
 	sched, err := rc.backends.Scheduler.Backend.CreateSchedule(
+		context.Background(),
 		name,
 		"",
 		scheduleExpression,
@@ -1100,7 +1101,7 @@ func (rc *ResourceCreator) deleteSchedulerSchedule(arn string) error {
 
 	name := resourceNameFromARN(arn)
 
-	return rc.backends.Scheduler.Backend.DeleteSchedule(name, "")
+	return rc.backends.Scheduler.Backend.DeleteSchedule(context.Background(), name, "")
 }
 
 // ---- helpers ----

--- a/services/cloudformation/resources_extended.go
+++ b/services/cloudformation/resources_extended.go
@@ -738,14 +738,17 @@ func (rc *ResourceCreator) createKinesisStream(
 		return "", fmt.Errorf("create Kinesis stream %s (got %d): %w", name, shardCount, ErrShardCountOutOfRange)
 	}
 
-	if err := rc.backends.Kinesis.Backend.CreateStream(&kinesisbackend.CreateStreamInput{
+	if err := rc.backends.Kinesis.Backend.CreateStream(context.Background(), &kinesisbackend.CreateStreamInput{
 		StreamName: name,
 		ShardCount: shardCount,
 	}); err != nil {
 		return "", fmt.Errorf("create Kinesis stream %s: %w", name, err)
 	}
 
-	out, err := rc.backends.Kinesis.Backend.DescribeStream(&kinesisbackend.DescribeStreamInput{StreamName: name})
+	out, err := rc.backends.Kinesis.Backend.DescribeStream(
+		context.Background(),
+		&kinesisbackend.DescribeStreamInput{StreamName: name},
+	)
 	if err != nil {
 		// Fall back to stream name if describe fails; ARN may not be available yet.
 		return name, nil //nolint:nilerr // describe can fail; stream was created, return name
@@ -761,7 +764,10 @@ func (rc *ResourceCreator) deleteKinesisStream(arn string) error {
 
 	name := streamNameFromARN(arn)
 
-	return rc.backends.Kinesis.Backend.DeleteStream(&kinesisbackend.DeleteStreamInput{StreamName: name})
+	return rc.backends.Kinesis.Backend.DeleteStream(
+		context.Background(),
+		&kinesisbackend.DeleteStreamInput{StreamName: name},
+	)
 }
 
 // ---- CloudWatch ----

--- a/services/cloudformation/resources_phase2.go
+++ b/services/cloudformation/resources_phase2.go
@@ -1056,6 +1056,7 @@ func (rc *ResourceCreator) createACMCertificate(
 	}
 
 	cert, err := rc.backends.ACM.Backend.RequestCertificate(
+		context.Background(),
 		domainName,
 		"AMAZON_ISSUED",
 		validationMethod,
@@ -1077,7 +1078,7 @@ func (rc *ResourceCreator) deleteACMCertificate(arn string) error {
 		return nil
 	}
 
-	return rc.backends.ACM.Backend.DeleteCertificate(arn)
+	return rc.backends.ACM.Backend.DeleteCertificate(context.Background(), arn)
 }
 
 // ---- Cognito ----

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -1297,7 +1297,7 @@ func (rc *ResourceCreator) createEMRCluster(
 		releaseLabel = "emr-6.0.0"
 	}
 
-	cluster, err := rc.backends.EMR.Backend.RunJobFlow(emr.RunJobFlowParams{
+	cluster, err := rc.backends.EMR.Backend.RunJobFlow(context.Background(), emr.RunJobFlowParams{
 		Name:         name,
 		ReleaseLabel: releaseLabel,
 	})
@@ -1315,7 +1315,7 @@ func (rc *ResourceCreator) deleteEMRCluster(arn string) error {
 
 	id := resourceNameFromARN(arn)
 
-	return rc.backends.EMR.Backend.TerminateJobFlows([]string{id})
+	return rc.backends.EMR.Backend.TerminateJobFlows(context.Background(), []string{id})
 }
 
 // ---- CloudWatch Dashboard ----

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -220,6 +220,7 @@ func (rc *ResourceCreator) createBatchComputeEnvironment(
 	}
 
 	ce, err := rc.backends.Batch.Backend.CreateComputeEnvironment(
+		context.Background(),
 		name,
 		ceType,
 		"ENABLED",
@@ -242,11 +243,14 @@ func (rc *ResourceCreator) deleteBatchComputeEnvironment(arnOrName string) error
 	}
 
 	// AWS requires DISABLED state before deletion.
-	if _, err := rc.backends.Batch.Backend.UpdateComputeEnvironment(arnOrName, "DISABLED", "", nil, nil); err != nil {
+	_, err := rc.backends.Batch.Backend.UpdateComputeEnvironment(
+		context.Background(), arnOrName, "DISABLED", "", nil, nil,
+	)
+	if err != nil {
 		return fmt.Errorf("disable Batch compute environment %s: %w", arnOrName, err)
 	}
 
-	return rc.backends.Batch.Backend.DeleteComputeEnvironment(arnOrName)
+	return rc.backends.Batch.Backend.DeleteComputeEnvironment(context.Background(), arnOrName)
 }
 
 func (rc *ResourceCreator) createBatchJobQueue(
@@ -289,7 +293,16 @@ func (rc *ResourceCreator) createBatchJobQueue(
 		}
 	}
 
-	jq, err := rc.backends.Batch.Backend.CreateJobQueue(name, priority, "ENABLED", ceOrder, nil, "", nil)
+	jq, err := rc.backends.Batch.Backend.CreateJobQueue(
+		context.Background(),
+		name,
+		priority,
+		"ENABLED",
+		ceOrder,
+		nil,
+		"",
+		nil,
+	)
 	if err != nil {
 		return "", fmt.Errorf("create Batch job queue %s: %w", name, err)
 	}
@@ -304,11 +317,13 @@ func (rc *ResourceCreator) deleteBatchJobQueue(arnOrName string) error {
 
 	// AWS requires DISABLED state before deletion.
 	disabled := "DISABLED"
-	if _, err := rc.backends.Batch.Backend.UpdateJobQueue(arnOrName, nil, disabled, nil, nil); err != nil {
+	if _, err := rc.backends.Batch.Backend.UpdateJobQueue(
+		context.Background(), arnOrName, nil, disabled, nil, nil,
+	); err != nil {
 		return fmt.Errorf("disable Batch job queue %s: %w", arnOrName, err)
 	}
 
-	return rc.backends.Batch.Backend.DeleteJobQueue(arnOrName)
+	return rc.backends.Batch.Backend.DeleteJobQueue(context.Background(), arnOrName)
 }
 
 func (rc *ResourceCreator) createBatchJobDefinition(
@@ -331,6 +346,7 @@ func (rc *ResourceCreator) createBatchJobDefinition(
 	}
 
 	jd, err := rc.backends.Batch.Backend.RegisterJobDefinition(
+		context.Background(),
 		name,
 		defType,
 		nil,
@@ -357,7 +373,7 @@ func (rc *ResourceCreator) deleteBatchJobDefinition(arnOrNameRev string) error {
 		return nil
 	}
 
-	return rc.backends.Batch.Backend.DeregisterJobDefinition(arnOrNameRev)
+	return rc.backends.Batch.Backend.DeregisterJobDefinition(context.Background(), arnOrNameRev)
 }
 
 // ---- CloudFront ----

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -1,6 +1,7 @@
 package cloudformation
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -145,7 +146,7 @@ func (rc *ResourceCreator) createEFSFileSystem(
 
 	token := logicalID + "-token"
 
-	fs, err := rc.backends.EFS.Backend.CreateFileSystem(efsbackend.CreateFileSystemRequest{
+	fs, err := rc.backends.EFS.Backend.CreateFileSystem(context.Background(), efsbackend.CreateFileSystemRequest{
 		CreationToken:   token,
 		PerformanceMode: performanceMode,
 		ThroughputMode:  throughputMode,
@@ -163,7 +164,7 @@ func (rc *ResourceCreator) deleteEFSFileSystem(id string) error {
 		return nil
 	}
 
-	return rc.backends.EFS.Backend.DeleteFileSystem(id)
+	return rc.backends.EFS.Backend.DeleteFileSystem(context.Background(), id)
 }
 
 func (rc *ResourceCreator) createEFSMountTarget(
@@ -178,7 +179,7 @@ func (rc *ResourceCreator) createEFSMountTarget(
 	fileSystemID := strProp(props, "FileSystemId", params, physicalIDs)
 	subnetID := strProp(props, "SubnetId", params, physicalIDs)
 
-	mt, err := rc.backends.EFS.Backend.CreateMountTarget(efsbackend.CreateMountTargetRequest{
+	mt, err := rc.backends.EFS.Backend.CreateMountTarget(context.Background(), efsbackend.CreateMountTargetRequest{
 		FileSystemID: fileSystemID,
 		SubnetID:     subnetID,
 	})
@@ -194,7 +195,7 @@ func (rc *ResourceCreator) deleteEFSMountTarget(id string) error {
 		return nil
 	}
 
-	return rc.backends.EFS.Backend.DeleteMountTarget(id)
+	return rc.backends.EFS.Backend.DeleteMountTarget(context.Background(), id)
 }
 
 // ---- Batch ----

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -892,7 +892,9 @@ func (rc *ResourceCreator) createNeptuneCluster(
 
 	paramGroupName := strProp(props, "DBClusterParameterGroupName", params, physicalIDs)
 
-	cluster, err := rc.backends.Neptune.Backend.CreateDBCluster(id, paramGroupName, 0, neptune.DBClusterCreateOptions{})
+	cluster, err := rc.backends.Neptune.Backend.CreateDBCluster(
+		context.Background(), id, paramGroupName, 0, neptune.DBClusterCreateOptions{},
+	)
 	if err != nil {
 		return "", fmt.Errorf("create Neptune cluster %s: %w", id, err)
 	}
@@ -907,7 +909,7 @@ func (rc *ResourceCreator) deleteNeptuneCluster(arn string) error {
 
 	id := resourceNameFromARN(arn)
 
-	_, err := rc.backends.Neptune.Backend.DeleteDBCluster(id)
+	_, err := rc.backends.Neptune.Backend.DeleteDBCluster(context.Background(), id)
 
 	return err
 }
@@ -930,7 +932,7 @@ func (rc *ResourceCreator) createNeptuneInstance(
 	instanceClass := strProp(props, "DBInstanceClass", params, physicalIDs)
 
 	instance, err := rc.backends.Neptune.Backend.CreateDBInstance(
-		id, clusterID, instanceClass, neptune.DBInstanceCreateOptions{},
+		context.Background(), id, clusterID, instanceClass, neptune.DBInstanceCreateOptions{},
 	)
 	if err != nil {
 		return "", fmt.Errorf("create Neptune instance %s: %w", id, err)
@@ -946,7 +948,7 @@ func (rc *ResourceCreator) deleteNeptuneInstance(arn string) error {
 
 	id := resourceNameFromARN(arn)
 
-	_, err := rc.backends.Neptune.Backend.DeleteDBInstance(id)
+	_, err := rc.backends.Neptune.Backend.DeleteDBInstance(context.Background(), id)
 
 	return err
 }

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -1132,7 +1132,7 @@ func (rc *ResourceCreator) createCodePipelinePipeline(
 		decl.Name = name
 	}
 
-	pipeline, err := rc.backends.CodePipeline.Backend.CreatePipeline(decl, nil)
+	pipeline, err := rc.backends.CodePipeline.Backend.CreatePipeline(context.Background(), decl, nil)
 	if err != nil {
 		return "", fmt.Errorf("create CodePipeline pipeline %s: %w", name, err)
 	}
@@ -1147,7 +1147,7 @@ func (rc *ResourceCreator) deleteCodePipelinePipeline(arn string) error {
 
 	name := resourceNameFromARN(arn)
 
-	return rc.backends.CodePipeline.Backend.DeletePipeline(name)
+	return rc.backends.CodePipeline.Backend.DeletePipeline(context.Background(), name)
 }
 
 // ---- IoT ----

--- a/services/cloudformation/resources_phase3.go
+++ b/services/cloudformation/resources_phase3.go
@@ -987,7 +987,9 @@ func (rc *ResourceCreator) createMSKCluster(
 		brokerInfo.InstanceType = "kafka.m5.large"
 	}
 
-	cluster, err := rc.backends.Kafka.Backend.CreateCluster(name, kafkaVersion, numBrokers, brokerInfo, nil, nil)
+	cluster, err := rc.backends.Kafka.Backend.CreateCluster(
+		context.Background(), name, kafkaVersion, numBrokers, brokerInfo, nil, nil,
+	)
 	if err != nil {
 		return "", fmt.Errorf("create MSK cluster %s: %w", name, err)
 	}
@@ -1000,7 +1002,7 @@ func (rc *ResourceCreator) deleteMSKCluster(arn string) error {
 		return nil
 	}
 
-	return rc.backends.Kafka.Backend.DeleteCluster(arn)
+	return rc.backends.Kafka.Backend.DeleteCluster(context.Background(), arn)
 }
 
 // ---- Transfer ----

--- a/services/codeartifact/backend.go
+++ b/services/codeartifact/backend.go
@@ -1,6 +1,7 @@
 package codeartifact
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"sort"
@@ -14,6 +15,18 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 var (
 	// ErrNotFound is returned when a requested resource does not exist.
@@ -114,15 +127,17 @@ type DomainPermissionsPolicy struct {
 }
 
 // InMemoryBackend is the in-memory store for CodeArtifact resources.
+// All resource maps are nested by region (outer key = region) so that same-named
+// resources in different regions are fully isolated.
 type InMemoryBackend struct {
-	domains             map[string]*Domain
-	repositories        map[string]*Repository                  // key: domainName/repoName
-	packageGroups       map[string]*PackageGroup                // key: domainName/pattern
-	packages            map[string]*Package                     // key: domainName/repoName/format/namespace/name
-	packageVersions     map[string]*PackageVersion              // key: domainName/repoName/format/namespace/name/version
-	externalConnections map[string][]ExternalConnection         // key: domainName/repoName
-	repositoryPolicies  map[string]*RepositoryPermissionsPolicy // key: domainName/repoName
-	domainPolicies      map[string]*DomainPermissionsPolicy     // key: domainName
+	domains             map[string]map[string]*Domain
+	repositories        map[string]map[string]*Repository                  // region → domainName/repoName
+	packageGroups       map[string]map[string]*PackageGroup                // region → domainName/pattern
+	packages            map[string]map[string]*Package                     // region → dom/repo/fmt/ns/name
+	packageVersions     map[string]map[string]*PackageVersion              // region → dom/repo/fmt/ns/name/version
+	externalConnections map[string]map[string][]ExternalConnection         // region → domainName/repoName
+	repositoryPolicies  map[string]map[string]*RepositoryPermissionsPolicy // region → domainName/repoName
+	domainPolicies      map[string]map[string]*DomainPermissionsPolicy     // region → domainName
 	mu                  *lockmetrics.RWMutex
 	accountID           string
 	region              string
@@ -131,14 +146,14 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new in-memory CodeArtifact backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		domains:             make(map[string]*Domain),
-		repositories:        make(map[string]*Repository),
-		packageGroups:       make(map[string]*PackageGroup),
-		packages:            make(map[string]*Package),
-		packageVersions:     make(map[string]*PackageVersion),
-		externalConnections: make(map[string][]ExternalConnection),
-		repositoryPolicies:  make(map[string]*RepositoryPermissionsPolicy),
-		domainPolicies:      make(map[string]*DomainPermissionsPolicy),
+		domains:             make(map[string]map[string]*Domain),
+		repositories:        make(map[string]map[string]*Repository),
+		packageGroups:       make(map[string]map[string]*PackageGroup),
+		packages:            make(map[string]map[string]*Package),
+		packageVersions:     make(map[string]map[string]*PackageVersion),
+		externalConnections: make(map[string]map[string][]ExternalConnection),
+		repositoryPolicies:  make(map[string]map[string]*RepositoryPermissionsPolicy),
+		domainPolicies:      make(map[string]map[string]*DomainPermissionsPolicy),
 		accountID:           accountID,
 		region:              region,
 		mu:                  lockmetrics.New("codeartifact"),
@@ -148,16 +163,88 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 // Region returns the AWS region this backend is configured for.
 func (b *InMemoryBackend) Region() string { return b.region }
 
+// The *Store helpers return the per-region inner map, lazily creating it.
+// Callers must hold b.mu.
+
+func (b *InMemoryBackend) domainsStore(region string) map[string]*Domain {
+	if b.domains[region] == nil {
+		b.domains[region] = make(map[string]*Domain)
+	}
+
+	return b.domains[region]
+}
+
+func (b *InMemoryBackend) repositoriesStore(region string) map[string]*Repository {
+	if b.repositories[region] == nil {
+		b.repositories[region] = make(map[string]*Repository)
+	}
+
+	return b.repositories[region]
+}
+
+func (b *InMemoryBackend) packageGroupsStore(region string) map[string]*PackageGroup {
+	if b.packageGroups[region] == nil {
+		b.packageGroups[region] = make(map[string]*PackageGroup)
+	}
+
+	return b.packageGroups[region]
+}
+
+func (b *InMemoryBackend) packagesStore(region string) map[string]*Package {
+	if b.packages[region] == nil {
+		b.packages[region] = make(map[string]*Package)
+	}
+
+	return b.packages[region]
+}
+
+func (b *InMemoryBackend) packageVersionsStore(region string) map[string]*PackageVersion {
+	if b.packageVersions[region] == nil {
+		b.packageVersions[region] = make(map[string]*PackageVersion)
+	}
+
+	return b.packageVersions[region]
+}
+
+func (b *InMemoryBackend) externalConnectionsStore(region string) map[string][]ExternalConnection {
+	if b.externalConnections[region] == nil {
+		b.externalConnections[region] = make(map[string][]ExternalConnection)
+	}
+
+	return b.externalConnections[region]
+}
+
+func (b *InMemoryBackend) repositoryPoliciesStore(region string) map[string]*RepositoryPermissionsPolicy {
+	if b.repositoryPolicies[region] == nil {
+		b.repositoryPolicies[region] = make(map[string]*RepositoryPermissionsPolicy)
+	}
+
+	return b.repositoryPolicies[region]
+}
+
+func (b *InMemoryBackend) domainPoliciesStore(region string) map[string]*DomainPermissionsPolicy {
+	if b.domainPolicies[region] == nil {
+		b.domainPolicies[region] = make(map[string]*DomainPermissionsPolicy)
+	}
+
+	return b.domainPolicies[region]
+}
+
 // CreateDomain creates a new CodeArtifact domain.
-func (b *InMemoryBackend) CreateDomain(name, encryptionKey string, kv map[string]string) (*Domain, error) {
+func (b *InMemoryBackend) CreateDomain(
+	ctx context.Context, name, encryptionKey string, kv map[string]string,
+) (*Domain, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateDomain")
 	defer b.mu.Unlock()
 
-	if _, ok := b.domains[name]; ok {
+	domains := b.domainsStore(region)
+	if _, ok := domains[name]; ok {
 		return nil, fmt.Errorf("%w: domain %s already exists", ErrAlreadyExists, name)
 	}
 
-	domainARN := arn.Build("codeartifact", b.region, b.accountID, "domain/"+name)
+	domainARN := arn.Build("codeartifact", region, b.accountID, "domain/"+name)
 	t := tags.New("codeartifact.domain." + name + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -167,24 +254,26 @@ func (b *InMemoryBackend) CreateDomain(name, encryptionKey string, kv map[string
 		ARN:           domainARN,
 		EncryptionKey: encryptionKey,
 		Owner:         b.accountID,
-		Region:        b.region,
+		Region:        region,
 		Status:        "Active",
 		S3BucketARN:   "arn:aws:s3:::assets-" + uuid.NewString()[:8],
 		CreatedTime:   time.Now().UTC(),
 		Tags:          t,
 	}
-	b.domains[name] = d
+	domains[name] = d
 	cp := *d
 
 	return &cp, nil
 }
 
 // DescribeDomain returns a domain by name.
-func (b *InMemoryBackend) DescribeDomain(name string) (*Domain, error) {
+func (b *InMemoryBackend) DescribeDomain(ctx context.Context, name string) (*Domain, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeDomain")
 	defer b.mu.RUnlock()
 
-	d, ok := b.domains[name]
+	d, ok := b.domainsStore(region)[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, name)
 	}
@@ -194,12 +283,15 @@ func (b *InMemoryBackend) DescribeDomain(name string) (*Domain, error) {
 }
 
 // ListDomains returns all domains sorted by name.
-func (b *InMemoryBackend) ListDomains() []*Domain {
+func (b *InMemoryBackend) ListDomains(ctx context.Context) []*Domain {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListDomains")
 	defer b.mu.RUnlock()
 
-	list := make([]*Domain, 0, len(b.domains))
-	for _, d := range b.domains {
+	domains := b.domainsStore(region)
+	list := make([]*Domain, 0, len(domains))
+	for _, d := range domains {
 		cp := *d
 		list = append(list, &cp)
 	}
@@ -212,40 +304,49 @@ func (b *InMemoryBackend) ListDomains() []*Domain {
 
 // DeleteDomain deletes a domain by name, cascade-deleting all its repositories,
 // packages, package versions, external connections, policies, and Tags.
-func (b *InMemoryBackend) DeleteDomain(name string) (*Domain, error) {
+func (b *InMemoryBackend) DeleteDomain(ctx context.Context, name string) (*Domain, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteDomain")
 	defer b.mu.Unlock()
 
-	d, ok := b.domains[name]
+	domains := b.domainsStore(region)
+	d, ok := domains[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, name)
 	}
 	cp := *d
 
+	repositories := b.repositoriesStore(region)
+	packages := b.packagesStore(region)
+	packageVersions := b.packageVersionsStore(region)
+	externalConnections := b.externalConnectionsStore(region)
+	repositoryPolicies := b.repositoryPoliciesStore(region)
+
 	// Cascade: delete all repositories in this domain plus their dependents.
-	for key, r := range b.repositories {
+	for key, r := range repositories {
 		if r.DomainName != name {
 			continue
 		}
 		prefix := key + "/"
-		for k := range b.packages {
+		for k := range packages {
 			if strings.HasPrefix(k, prefix) {
-				delete(b.packages, k)
+				delete(packages, k)
 			}
 		}
-		for k := range b.packageVersions {
+		for k := range packageVersions {
 			if strings.HasPrefix(k, prefix) {
-				delete(b.packageVersions, k)
+				delete(packageVersions, k)
 			}
 		}
-		delete(b.externalConnections, key)
-		delete(b.repositoryPolicies, key)
+		delete(externalConnections, key)
+		delete(repositoryPolicies, key)
 		r.Tags.Close()
-		delete(b.repositories, key)
+		delete(repositories, key)
 	}
 
-	delete(b.domainPolicies, name)
-	delete(b.domains, name)
+	delete(b.domainPoliciesStore(region), name)
+	delete(domains, name)
 	d.Tags.Close()
 
 	return &cp, nil
@@ -256,24 +357,30 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, d := range b.domains {
-		d.Tags.Close()
+	for _, regionDomains := range b.domains {
+		for _, d := range regionDomains {
+			d.Tags.Close()
+		}
 	}
-	for _, r := range b.repositories {
-		r.Tags.Close()
+	for _, regionRepos := range b.repositories {
+		for _, r := range regionRepos {
+			r.Tags.Close()
+		}
 	}
-	for _, pg := range b.packageGroups {
-		pg.Tags.Close()
+	for _, regionPGs := range b.packageGroups {
+		for _, pg := range regionPGs {
+			pg.Tags.Close()
+		}
 	}
 
-	b.domains = make(map[string]*Domain)
-	b.repositories = make(map[string]*Repository)
-	b.packageGroups = make(map[string]*PackageGroup)
-	b.packages = make(map[string]*Package)
-	b.packageVersions = make(map[string]*PackageVersion)
-	b.externalConnections = make(map[string][]ExternalConnection)
-	b.repositoryPolicies = make(map[string]*RepositoryPermissionsPolicy)
-	b.domainPolicies = make(map[string]*DomainPermissionsPolicy)
+	b.domains = make(map[string]map[string]*Domain)
+	b.repositories = make(map[string]map[string]*Repository)
+	b.packageGroups = make(map[string]map[string]*PackageGroup)
+	b.packages = make(map[string]map[string]*Package)
+	b.packageVersions = make(map[string]map[string]*PackageVersion)
+	b.externalConnections = make(map[string]map[string][]ExternalConnection)
+	b.repositoryPolicies = make(map[string]map[string]*RepositoryPermissionsPolicy)
+	b.domainPolicies = make(map[string]map[string]*DomainPermissionsPolicy)
 }
 
 // repoKey returns the map key for a repository.
@@ -283,22 +390,26 @@ func repoKey(domainName, repoName string) string {
 
 // CreateRepository creates a new CodeArtifact repository.
 func (b *InMemoryBackend) CreateRepository(
+	ctx context.Context,
 	domainName, repoName, description string,
 	kv map[string]string,
 ) (*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateRepository")
 	defer b.mu.Unlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
 	key := repoKey(domainName, repoName)
-	if _, ok := b.repositories[key]; ok {
+	repositories := b.repositoriesStore(region)
+	if _, ok := repositories[key]; ok {
 		return nil, fmt.Errorf("%w: repository %s already exists in domain %s", ErrAlreadyExists, repoName, domainName)
 	}
 
-	repoARN := arn.Build("codeartifact", b.region, b.accountID, "repository/"+domainName+"/"+repoName)
+	repoARN := arn.Build("codeartifact", region, b.accountID, "repository/"+domainName+"/"+repoName)
 	t := tags.New("codeartifact.repository." + key + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -310,22 +421,24 @@ func (b *InMemoryBackend) CreateRepository(
 		DomainOwner:          b.accountID,
 		Description:          description,
 		AdministratorAccount: b.accountID,
-		Region:               b.region,
+		Region:               region,
 		CreatedTime:          time.Now().UTC(),
 		Tags:                 t,
 	}
-	b.repositories[key] = r
+	repositories[key] = r
 	cp := *r
 
 	return &cp, nil
 }
 
 // DescribeRepository returns a repository by domain and name.
-func (b *InMemoryBackend) DescribeRepository(domainName, repoName string) (*Repository, error) {
+func (b *InMemoryBackend) DescribeRepository(ctx context.Context, domainName, repoName string) (*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeRepository")
 	defer b.mu.RUnlock()
 
-	r, ok := b.repositories[repoKey(domainName, repoName)]
+	r, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]
 	if !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
@@ -336,16 +449,19 @@ func (b *InMemoryBackend) DescribeRepository(domainName, repoName string) (*Repo
 
 // ListRepositoriesInDomain returns all repositories in a domain, sorted by name.
 // Returns ErrNotFound if the domain does not exist.
-func (b *InMemoryBackend) ListRepositoriesInDomain(domainName string) ([]*Repository, error) {
+func (b *InMemoryBackend) ListRepositoriesInDomain(ctx context.Context, domainName string) ([]*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListRepositoriesInDomain")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
-	list := make([]*Repository, 0, len(b.repositories))
-	for _, r := range b.repositories {
+	repositories := b.repositoriesStore(region)
+	list := make([]*Repository, 0, len(repositories))
+	for _, r := range repositories {
 		if r.DomainName == domainName {
 			cp := *r
 			list = append(list, &cp)
@@ -359,12 +475,15 @@ func (b *InMemoryBackend) ListRepositoriesInDomain(domainName string) ([]*Reposi
 }
 
 // ListRepositories returns all repositories across all domains, sorted by name.
-func (b *InMemoryBackend) ListRepositories() []*Repository {
+func (b *InMemoryBackend) ListRepositories(ctx context.Context) []*Repository {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListRepositories")
 	defer b.mu.RUnlock()
 
-	list := make([]*Repository, 0, len(b.repositories))
-	for _, r := range b.repositories {
+	repositories := b.repositoriesStore(region)
+	list := make([]*Repository, 0, len(repositories))
+	for _, r := range repositories {
 		cp := *r
 		list = append(list, &cp)
 	}
@@ -377,56 +496,63 @@ func (b *InMemoryBackend) ListRepositories() []*Repository {
 
 // DeleteRepository deletes a repository by domain and name, cascade-deleting all
 // its packages, package versions, external connections, permissions policy, and Tags.
-func (b *InMemoryBackend) DeleteRepository(domainName, repoName string) (*Repository, error) {
+func (b *InMemoryBackend) DeleteRepository(ctx context.Context, domainName, repoName string) (*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteRepository")
 	defer b.mu.Unlock()
 
 	key := repoKey(domainName, repoName)
-	r, ok := b.repositories[key]
+	repositories := b.repositoriesStore(region)
+	r, ok := repositories[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 	cp := *r
 
+	packages := b.packagesStore(region)
+	packageVersions := b.packageVersionsStore(region)
 	prefix := key + "/"
-	for k := range b.packages {
+	for k := range packages {
 		if strings.HasPrefix(k, prefix) {
-			delete(b.packages, k)
+			delete(packages, k)
 		}
 	}
-	for k := range b.packageVersions {
+	for k := range packageVersions {
 		if strings.HasPrefix(k, prefix) {
-			delete(b.packageVersions, k)
+			delete(packageVersions, k)
 		}
 	}
-	delete(b.externalConnections, key)
-	delete(b.repositoryPolicies, key)
-	delete(b.repositories, key)
+	delete(b.externalConnectionsStore(region), key)
+	delete(b.repositoryPoliciesStore(region), key)
+	delete(repositories, key)
 	r.Tags.Close()
 
 	return &cp, nil
 }
 
 // TagResource adds or replaces tags on a resource by ARN.
-func (b *InMemoryBackend) TagResource(resourceARN string, kv map[string]string) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceARN string, kv map[string]string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	for _, d := range b.domains {
+	for _, d := range b.domainsStore(region) {
 		if d.ARN == resourceARN {
 			d.Tags.Merge(kv)
 
 			return nil
 		}
 	}
-	for _, r := range b.repositories {
+	for _, r := range b.repositoriesStore(region) {
 		if r.ARN == resourceARN {
 			r.Tags.Merge(kv)
 
 			return nil
 		}
 	}
-	for _, pg := range b.packageGroups {
+	for _, pg := range b.packageGroupsStore(region) {
 		if pg.ARN == resourceARN {
 			pg.Tags.Merge(kv)
 
@@ -438,25 +564,27 @@ func (b *InMemoryBackend) TagResource(resourceARN string, kv map[string]string) 
 }
 
 // UntagResource removes tags from a resource by ARN.
-func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	for _, d := range b.domains {
+	for _, d := range b.domainsStore(region) {
 		if d.ARN == resourceARN {
 			d.Tags.DeleteKeys(tagKeys)
 
 			return nil
 		}
 	}
-	for _, r := range b.repositories {
+	for _, r := range b.repositoriesStore(region) {
 		if r.ARN == resourceARN {
 			r.Tags.DeleteKeys(tagKeys)
 
 			return nil
 		}
 	}
-	for _, pg := range b.packageGroups {
+	for _, pg := range b.packageGroupsStore(region) {
 		if pg.ARN == resourceARN {
 			pg.Tags.DeleteKeys(tagKeys)
 
@@ -468,21 +596,23 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) er
 }
 
 // ListTagsForResource returns tags for a resource by ARN.
-func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]string, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	for _, d := range b.domains {
+	for _, d := range b.domainsStore(region) {
 		if d.ARN == resourceARN {
 			return d.Tags.Clone(), nil
 		}
 	}
-	for _, r := range b.repositories {
+	for _, r := range b.repositoriesStore(region) {
 		if r.ARN == resourceARN {
 			return r.Tags.Clone(), nil
 		}
 	}
-	for _, pg := range b.packageGroups {
+	for _, pg := range b.packageGroupsStore(region) {
 		if pg.ARN == resourceARN {
 			return pg.Tags.Clone(), nil
 		}
@@ -500,18 +630,22 @@ func packageGroupKey(domainName, pattern string) string {
 
 // CreatePackageGroup creates a new CodeArtifact package group.
 func (b *InMemoryBackend) CreatePackageGroup(
+	ctx context.Context,
 	domainName, pattern, description, contactInfo string,
 	kv map[string]string,
 ) (*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreatePackageGroup")
 	defer b.mu.Unlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
 	key := packageGroupKey(domainName, pattern)
-	if _, ok := b.packageGroups[key]; ok {
+	packageGroups := b.packageGroupsStore(region)
+	if _, ok := packageGroups[key]; ok {
 		return nil, fmt.Errorf(
 			"%w: package group %s already exists in domain %s",
 			ErrAlreadyExists,
@@ -520,7 +654,7 @@ func (b *InMemoryBackend) CreatePackageGroup(
 		)
 	}
 
-	pgARN := arn.Build("codeartifact", b.region, b.accountID, "package-group/"+domainName+pattern)
+	pgARN := arn.Build("codeartifact", region, b.accountID, "package-group/"+domainName+pattern)
 	t := tags.New("codeartifact.package-group." + key + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -535,18 +669,20 @@ func (b *InMemoryBackend) CreatePackageGroup(
 		CreatedTime: time.Now().UTC(),
 		Tags:        t,
 	}
-	b.packageGroups[key] = pg
+	packageGroups[key] = pg
 	cp := *pg
 
 	return &cp, nil
 }
 
 // DescribePackageGroup returns a package group by domain and pattern.
-func (b *InMemoryBackend) DescribePackageGroup(domainName, pattern string) (*PackageGroup, error) {
+func (b *InMemoryBackend) DescribePackageGroup(ctx context.Context, domainName, pattern string) (*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribePackageGroup")
 	defer b.mu.RUnlock()
 
-	pg, ok := b.packageGroups[packageGroupKey(domainName, pattern)]
+	pg, ok := b.packageGroupsStore(region)[packageGroupKey(domainName, pattern)]
 	if !ok {
 		return nil, fmt.Errorf("%w: package group %s not found in domain %s", ErrNotFound, pattern, domainName)
 	}
@@ -556,17 +692,20 @@ func (b *InMemoryBackend) DescribePackageGroup(domainName, pattern string) (*Pac
 }
 
 // DeletePackageGroup deletes a package group by domain and pattern.
-func (b *InMemoryBackend) DeletePackageGroup(domainName, pattern string) (*PackageGroup, error) {
+func (b *InMemoryBackend) DeletePackageGroup(ctx context.Context, domainName, pattern string) (*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeletePackageGroup")
 	defer b.mu.Unlock()
 
 	key := packageGroupKey(domainName, pattern)
-	pg, ok := b.packageGroups[key]
+	packageGroups := b.packageGroupsStore(region)
+	pg, ok := packageGroups[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: package group %s not found in domain %s", ErrNotFound, pattern, domainName)
 	}
 	cp := *pg
-	delete(b.packageGroups, key)
+	delete(packageGroups, key)
 	pg.Tags.Close()
 
 	return &cp, nil
@@ -583,16 +722,21 @@ func packageKey(domainName, repoName, format, namespace, name string) string {
 // If the package does not already exist in the store, a stub entry is created on the fly so
 // that callers (e.g. Terraform providers) can always retrieve metadata about packages that
 // were published directly to the repository.
-func (b *InMemoryBackend) DescribePackage(domainName, repoName, format, namespace, name string) (*Package, error) {
+func (b *InMemoryBackend) DescribePackage(
+	ctx context.Context, domainName, repoName, format, namespace, name string,
+) (*Package, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DescribePackage")
 	defer b.mu.Unlock()
 
-	if _, ok := b.repositories[repoKey(domainName, repoName)]; !ok {
+	if _, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]; !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
 	key := packageKey(domainName, repoName, format, namespace, name)
-	pkg, ok := b.packages[key]
+	packages := b.packagesStore(region)
+	pkg, ok := packages[key]
 	if !ok {
 		// Auto-create a stub package entry.
 		pkg = &Package{
@@ -603,7 +747,7 @@ func (b *InMemoryBackend) DescribePackage(domainName, repoName, format, namespac
 			Namespace:   namespace,
 			Name:        name,
 		}
-		b.packages[key] = pkg
+		packages[key] = pkg
 	}
 	cp := *pkg
 
@@ -611,27 +755,33 @@ func (b *InMemoryBackend) DescribePackage(domainName, repoName, format, namespac
 }
 
 // DeletePackage deletes a package and all its versions from a repository.
-func (b *InMemoryBackend) DeletePackage(domainName, repoName, format, namespace, name string) (*Package, error) {
+func (b *InMemoryBackend) DeletePackage(
+	ctx context.Context, domainName, repoName, format, namespace, name string,
+) (*Package, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeletePackage")
 	defer b.mu.Unlock()
 
-	if _, ok := b.repositories[repoKey(domainName, repoName)]; !ok {
+	if _, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]; !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
 	key := packageKey(domainName, repoName, format, namespace, name)
-	pkg, ok := b.packages[key]
+	packages := b.packagesStore(region)
+	pkg, ok := packages[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: package %s not found", ErrNotFound, name)
 	}
 	cp := *pkg
-	delete(b.packages, key)
+	delete(packages, key)
 
 	// Remove all associated package versions.
+	packageVersions := b.packageVersionsStore(region)
 	prefix := key + "/"
-	for k := range b.packageVersions {
+	for k := range packageVersions {
 		if strings.HasPrefix(k, prefix) {
-			delete(b.packageVersions, k)
+			delete(packageVersions, k)
 		}
 	}
 
@@ -648,17 +798,21 @@ func packageVersionKey(domainName, repoName, format, namespace, name, version st
 // DescribePackageVersion returns a specific version of a package.
 // As with DescribePackage, stub entries are created on demand.
 func (b *InMemoryBackend) DescribePackageVersion(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, version string,
 ) (*PackageVersion, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DescribePackageVersion")
 	defer b.mu.Unlock()
 
-	if _, ok := b.repositories[repoKey(domainName, repoName)]; !ok {
+	if _, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]; !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
 	vKey := packageVersionKey(domainName, repoName, format, namespace, name, version)
-	pv, ok := b.packageVersions[vKey]
+	packageVersions := b.packageVersionsStore(region)
+	pv, ok := packageVersions[vKey]
 	if !ok {
 		// Auto-create a stub version entry.
 		pv = &PackageVersion{
@@ -672,12 +826,13 @@ func (b *InMemoryBackend) DescribePackageVersion(
 			PublishedAt: time.Now().UTC(),
 			Revision:    uuid.NewString()[:8],
 		}
-		b.packageVersions[vKey] = pv
+		packageVersions[vKey] = pv
 
 		// Ensure the parent package record exists too.
 		pKey := packageKey(domainName, repoName, format, namespace, name)
-		if _, exists := b.packages[pKey]; !exists {
-			b.packages[pKey] = &Package{
+		packages := b.packagesStore(region)
+		if _, exists := packages[pKey]; !exists {
+			packages[pKey] = &Package{
 				DomainName:  domainName,
 				DomainOwner: b.accountID,
 				Repository:  repoName,
@@ -695,25 +850,29 @@ func (b *InMemoryBackend) DescribePackageVersion(
 // DeletePackageVersions deletes specified versions of a package and returns a
 // map of version→errorCode for any versions that could not be deleted.
 func (b *InMemoryBackend) DeletePackageVersions(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name string,
 	versions []string,
 ) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeletePackageVersions")
 	defer b.mu.Unlock()
 
-	if _, ok := b.repositories[repoKey(domainName, repoName)]; !ok {
+	if _, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]; !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
+	packageVersions := b.packageVersionsStore(region)
 	failed := make(map[string]string)
 	for _, v := range versions {
 		vKey := packageVersionKey(domainName, repoName, format, namespace, name, v)
-		if _, ok := b.packageVersions[vKey]; !ok {
+		if _, ok := packageVersions[vKey]; !ok {
 			failed[v] = "RESOURCE_NOT_FOUND"
 
 			continue
 		}
-		delete(b.packageVersions, vKey)
+		delete(packageVersions, vKey)
 	}
 
 	return failed, nil
@@ -722,41 +881,47 @@ func (b *InMemoryBackend) DeletePackageVersions(
 // CopyPackageVersions copies specified package versions from a source repository
 // to a destination repository in the same domain.
 func (b *InMemoryBackend) CopyPackageVersions(
+	ctx context.Context,
 	domainName, srcRepo, dstRepo, format, namespace, name string,
 	versions []string,
 ) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CopyPackageVersions")
 	defer b.mu.Unlock()
 
-	if _, ok := b.repositories[repoKey(domainName, srcRepo)]; !ok {
+	repositories := b.repositoriesStore(region)
+	if _, ok := repositories[repoKey(domainName, srcRepo)]; !ok {
 		return nil, fmt.Errorf("%w: source repository %s not found in domain %s", ErrNotFound, srcRepo, domainName)
 	}
-	if _, ok := b.repositories[repoKey(domainName, dstRepo)]; !ok {
+	if _, ok := repositories[repoKey(domainName, dstRepo)]; !ok {
 		return nil, fmt.Errorf("%w: destination repository %s not found in domain %s", ErrNotFound, dstRepo, domainName)
 	}
 
+	packageVersions := b.packageVersionsStore(region)
+	packages := b.packagesStore(region)
 	failed := make(map[string]string)
 	for _, v := range versions {
 		srcKey := packageVersionKey(domainName, srcRepo, format, namespace, name, v)
-		src, ok := b.packageVersions[srcKey]
+		src, ok := packageVersions[srcKey]
 		if !ok {
 			failed[v] = "RESOURCE_NOT_FOUND"
 
 			continue
 		}
 		dstKey := packageVersionKey(domainName, dstRepo, format, namespace, name, v)
-		if _, exists := b.packageVersions[dstKey]; exists {
+		if _, exists := packageVersions[dstKey]; exists {
 			failed[v] = "ALREADY_EXISTS"
 
 			continue
 		}
 		copied := *src
 		copied.Repository = dstRepo
-		b.packageVersions[dstKey] = &copied
+		packageVersions[dstKey] = &copied
 		// Ensure destination package record exists.
 		dstPkgKey := packageKey(domainName, dstRepo, format, namespace, name)
-		if _, exists := b.packages[dstPkgKey]; !exists {
-			b.packages[dstPkgKey] = &Package{
+		if _, exists := packages[dstPkgKey]; !exists {
+			packages[dstPkgKey] = &Package{
 				DomainName:  domainName,
 				DomainOwner: b.accountID,
 				Repository:  dstRepo,
@@ -793,24 +958,28 @@ func externalConnectionFormat(connectionName string) string {
 
 // AssociateExternalConnection associates an external connection with a repository.
 func (b *InMemoryBackend) AssociateExternalConnection(
+	ctx context.Context,
 	domainName, repoName, connectionName string,
 ) (*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AssociateExternalConnection")
 	defer b.mu.Unlock()
 
-	r, ok := b.repositories[repoKey(domainName, repoName)]
+	r, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]
 	if !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
 	key := repoKey(domainName, repoName)
-	for _, ec := range b.externalConnections[key] {
+	externalConnections := b.externalConnectionsStore(region)
+	for _, ec := range externalConnections[key] {
 		if ec.ExternalConnectionName == connectionName {
 			return nil, fmt.Errorf("%w: external connection %s already associated", ErrAlreadyExists, connectionName)
 		}
 	}
 
-	b.externalConnections[key] = append(b.externalConnections[key], ExternalConnection{
+	externalConnections[key] = append(externalConnections[key], ExternalConnection{
 		ExternalConnectionName: connectionName,
 		PackageFormat:          externalConnectionFormat(connectionName),
 		Status:                 "AVAILABLE",
@@ -824,34 +993,41 @@ func (b *InMemoryBackend) AssociateExternalConnection(
 
 // DeleteRepositoryPermissionsPolicy removes the permissions policy from a repository.
 func (b *InMemoryBackend) DeleteRepositoryPermissionsPolicy(
+	ctx context.Context,
 	domainName, repoName string,
 ) (*RepositoryPermissionsPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteRepositoryPermissionsPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.repositories[repoKey(domainName, repoName)]; !ok {
+	if _, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]; !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
 	key := repoKey(domainName, repoName)
-	pol, ok := b.repositoryPolicies[key]
+	repositoryPolicies := b.repositoryPoliciesStore(region)
+	pol, ok := repositoryPolicies[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: no permissions policy found for repository %s", ErrNotFound, repoName)
 	}
 	cp := *pol
-	delete(b.repositoryPolicies, key)
+	delete(repositoryPolicies, key)
 
 	return &cp, nil
 }
 
 // PutRepositoryPermissionsPolicy stores a permissions policy for a repository.
 func (b *InMemoryBackend) PutRepositoryPermissionsPolicy(
+	ctx context.Context,
 	domainName, repoName, document string,
 ) (*RepositoryPermissionsPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutRepositoryPermissionsPolicy")
 	defer b.mu.Unlock()
 
-	r, ok := b.repositories[repoKey(domainName, repoName)]
+	r, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]
 	if !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
@@ -862,7 +1038,7 @@ func (b *InMemoryBackend) PutRepositoryPermissionsPolicy(
 		Revision:    uuid.NewString()[:8],
 		ResourceARN: r.ARN,
 	}
-	b.repositoryPolicies[key] = pol
+	b.repositoryPoliciesStore(region)[key] = pol
 	cp := *pol
 
 	return &cp, nil
@@ -870,17 +1046,20 @@ func (b *InMemoryBackend) PutRepositoryPermissionsPolicy(
 
 // GetRepositoryPermissionsPolicy retrieves the permissions policy for a repository.
 func (b *InMemoryBackend) GetRepositoryPermissionsPolicy(
+	ctx context.Context,
 	domainName, repoName string,
 ) (*RepositoryPermissionsPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetRepositoryPermissionsPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.repositories[repoKey(domainName, repoName)]; !ok {
+	if _, ok := b.repositoriesStore(region)[repoKey(domainName, repoName)]; !ok {
 		return nil, fmt.Errorf("%w: repository %s not found in domain %s", ErrNotFound, repoName, domainName)
 	}
 
 	key := repoKey(domainName, repoName)
-	pol, ok := b.repositoryPolicies[key]
+	pol, ok := b.repositoryPoliciesStore(region)[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: no permissions policy found for repository %s", ErrNotFound, repoName)
 	}
@@ -893,15 +1072,19 @@ func (b *InMemoryBackend) GetRepositoryPermissionsPolicy(
 
 // GetDomainPermissionsPolicy retrieves the permissions policy for a domain.
 // Returns ErrNotFound if the domain does not exist or if no policy has been set.
-func (b *InMemoryBackend) GetDomainPermissionsPolicy(domainName string) (*DomainPermissionsPolicy, error) {
+func (b *InMemoryBackend) GetDomainPermissionsPolicy(
+	ctx context.Context, domainName string,
+) (*DomainPermissionsPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetDomainPermissionsPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
-	pol, ok := b.domainPolicies[domainName]
+	pol, ok := b.domainPoliciesStore(region)[domainName]
 	if !ok {
 		return nil, fmt.Errorf("%w: no permissions policy found for domain %s", ErrNotFound, domainName)
 	}
@@ -911,11 +1094,15 @@ func (b *InMemoryBackend) GetDomainPermissionsPolicy(domainName string) (*Domain
 }
 
 // PutDomainPermissionsPolicy stores a permissions policy for a domain.
-func (b *InMemoryBackend) PutDomainPermissionsPolicy(domainName, document string) (*DomainPermissionsPolicy, error) {
+func (b *InMemoryBackend) PutDomainPermissionsPolicy(
+	ctx context.Context, domainName, document string,
+) (*DomainPermissionsPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutDomainPermissionsPolicy")
 	defer b.mu.Unlock()
 
-	d, ok := b.domains[domainName]
+	d, ok := b.domainsStore(region)[domainName]
 	if !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
@@ -925,7 +1112,7 @@ func (b *InMemoryBackend) PutDomainPermissionsPolicy(domainName, document string
 		Revision:    uuid.NewString()[:8],
 		ResourceARN: d.ARN,
 	}
-	b.domainPolicies[domainName] = pol
+	b.domainPoliciesStore(region)[domainName] = pol
 	cp := *pol
 
 	return &cp, nil
@@ -933,37 +1120,47 @@ func (b *InMemoryBackend) PutDomainPermissionsPolicy(domainName, document string
 
 // DeleteDomainPermissionsPolicy removes the permissions policy from a domain.
 // Returns ErrNotFound if the domain does not exist or if no policy has been set.
-func (b *InMemoryBackend) DeleteDomainPermissionsPolicy(domainName string) (*DomainPermissionsPolicy, error) {
+func (b *InMemoryBackend) DeleteDomainPermissionsPolicy(
+	ctx context.Context, domainName string,
+) (*DomainPermissionsPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteDomainPermissionsPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
-	pol, ok := b.domainPolicies[domainName]
+	domainPolicies := b.domainPoliciesStore(region)
+	pol, ok := domainPolicies[domainName]
 	if !ok {
 		return nil, fmt.Errorf("%w: no permissions policy found for domain %s", ErrNotFound, domainName)
 	}
 	cp := *pol
-	delete(b.domainPolicies, domainName)
+	delete(domainPolicies, domainName)
 
 	return &cp, nil
 }
 
 // DisassociateExternalConnection removes an external connection from a repository.
 func (b *InMemoryBackend) DisassociateExternalConnection(
+	ctx context.Context,
 	domainName, repoName, connectionName string,
 ) (*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisassociateExternalConnection")
 	defer b.mu.Unlock()
 
 	key := repoKey(domainName, repoName)
-	if _, ok := b.repositories[key]; !ok {
+	repositories := b.repositoriesStore(region)
+	if _, ok := repositories[key]; !ok {
 		return nil, fmt.Errorf("%w: repository %s/%s not found", ErrNotFound, domainName, repoName)
 	}
 
-	conns := b.externalConnections[key]
+	externalConnections := b.externalConnectionsStore(region)
+	conns := externalConnections[key]
 	filtered := conns[:0]
 
 	for _, c := range conns {
@@ -972,25 +1169,29 @@ func (b *InMemoryBackend) DisassociateExternalConnection(
 		}
 	}
 
-	b.externalConnections[key] = filtered
-	cp := *b.repositories[key]
+	externalConnections[key] = filtered
+	cp := *repositories[key]
 
 	return &cp, nil
 }
 
 // DisposePackageVersions moves specified versions of a package to the Disposed status.
 func (b *InMemoryBackend) DisposePackageVersions(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name string,
 	versions []string,
 ) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisposePackageVersions")
 	defer b.mu.Unlock()
 
+	packageVersions := b.packageVersionsStore(region)
 	results := make(map[string]string, len(versions))
 
 	for _, v := range versions {
 		key := packageVersionKey(domainName, repoName, format, namespace, name, v)
-		if pv, ok := b.packageVersions[key]; ok {
+		if pv, ok := packageVersions[key]; ok {
 			pv.Status = "Disposed"
 			results[v] = "SUCCESS"
 		} else {
@@ -1003,12 +1204,15 @@ func (b *InMemoryBackend) DisposePackageVersions(
 
 // GetAssociatedPackageGroup returns the most specific package group associated with a package.
 func (b *InMemoryBackend) GetAssociatedPackageGroup(
+	ctx context.Context,
 	domainName, format, namespace, name string,
 ) (*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetAssociatedPackageGroup")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
@@ -1021,17 +1225,20 @@ func (b *InMemoryBackend) GetAssociatedPackageGroup(
 }
 
 // ListPackageGroups returns all package groups in a domain, optionally filtered by prefix.
-func (b *InMemoryBackend) ListPackageGroups(domainName, prefix string) ([]*PackageGroup, error) {
+func (b *InMemoryBackend) ListPackageGroups(ctx context.Context, domainName, prefix string) ([]*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListPackageGroups")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
-	result := make([]*PackageGroup, 0, len(b.packageGroups))
+	packageGroups := b.packageGroupsStore(region)
+	result := make([]*PackageGroup, 0, len(packageGroups))
 
-	for _, pg := range b.packageGroups {
+	for _, pg := range packageGroups {
 		if pg.DomainName != domainName {
 			continue
 		}
@@ -1052,19 +1259,25 @@ func (b *InMemoryBackend) ListPackageGroups(domainName, prefix string) ([]*Packa
 }
 
 // ListSubPackageGroups returns sub-package groups of a given package group pattern.
-func (b *InMemoryBackend) ListSubPackageGroups(domainName, pattern string) ([]*PackageGroup, error) {
+func (b *InMemoryBackend) ListSubPackageGroups(
+	ctx context.Context,
+	domainName, pattern string,
+) ([]*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSubPackageGroups")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
-	result := make([]*PackageGroup, 0, len(b.packageGroups))
+	packageGroups := b.packageGroupsStore(region)
+	result := make([]*PackageGroup, 0, len(packageGroups))
 
 	parentRoot := strings.TrimSuffix(pattern, "*")
 
-	for _, pg := range b.packageGroups {
+	for _, pg := range packageGroups {
 		if pg.DomainName != domainName {
 			continue
 		}
@@ -1086,13 +1299,16 @@ func (b *InMemoryBackend) ListSubPackageGroups(domainName, pattern string) ([]*P
 
 // UpdatePackageGroup updates description or contact info of a package group.
 func (b *InMemoryBackend) UpdatePackageGroup(
+	ctx context.Context,
 	domainName, pattern, description, contactInfo string,
 ) (*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdatePackageGroup")
 	defer b.mu.Unlock()
 
 	key := packageGroupKey(domainName, pattern)
-	pg, ok := b.packageGroups[key]
+	pg, ok := b.packageGroupsStore(region)[key]
 
 	if !ok {
 		return nil, fmt.Errorf("%w: package group %s not found", ErrNotFound, pattern)
@@ -1113,13 +1329,16 @@ func (b *InMemoryBackend) UpdatePackageGroup(
 
 // UpdatePackageGroupOriginConfiguration is a stub that accepts origin config changes.
 func (b *InMemoryBackend) UpdatePackageGroupOriginConfiguration(
+	ctx context.Context,
 	domainName, pattern string,
 ) (*PackageGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("UpdatePackageGroupOriginConfiguration")
 	defer b.mu.RUnlock()
 
 	key := packageGroupKey(domainName, pattern)
-	pg, ok := b.packageGroups[key]
+	pg, ok := b.packageGroupsStore(region)[key]
 
 	if !ok {
 		return nil, fmt.Errorf("%w: package group %s not found", ErrNotFound, pattern)
@@ -1132,12 +1351,15 @@ func (b *InMemoryBackend) UpdatePackageGroupOriginConfiguration(
 
 // ListAllowedRepositoriesForGroup is a stub returning allowed repositories for a package group.
 func (b *InMemoryBackend) ListAllowedRepositoriesForGroup(
+	ctx context.Context,
 	domainName, pattern string,
 ) ([]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListAllowedRepositoriesForGroup")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
@@ -1147,11 +1369,13 @@ func (b *InMemoryBackend) ListAllowedRepositoriesForGroup(
 }
 
 // ListAssociatedPackages lists packages associated with a package group.
-func (b *InMemoryBackend) ListAssociatedPackages(domainName, pattern string) ([]*Package, error) {
+func (b *InMemoryBackend) ListAssociatedPackages(ctx context.Context, domainName, pattern string) ([]*Package, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListAssociatedPackages")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.domains[domainName]; !ok {
+	if _, ok := b.domainsStore(region)[domainName]; !ok {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrNotFound, domainName)
 	}
 
@@ -1161,18 +1385,23 @@ func (b *InMemoryBackend) ListAssociatedPackages(domainName, pattern string) ([]
 }
 
 // ListPackages lists packages in a repository.
-func (b *InMemoryBackend) ListPackages(domainName, repoName, format, namespace string) ([]*Package, error) {
+func (b *InMemoryBackend) ListPackages(
+	ctx context.Context, domainName, repoName, format, namespace string,
+) ([]*Package, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListPackages")
 	defer b.mu.RUnlock()
 
 	key := repoKey(domainName, repoName)
-	if _, ok := b.repositories[key]; !ok {
+	if _, ok := b.repositoriesStore(region)[key]; !ok {
 		return nil, fmt.Errorf("%w: repository %s/%s not found", ErrNotFound, domainName, repoName)
 	}
 
-	result := make([]*Package, 0, len(b.packages))
+	packages := b.packagesStore(region)
+	result := make([]*Package, 0, len(packages))
 
-	for _, pv := range b.packageVersions {
+	for _, pv := range b.packageVersionsStore(region) {
 		if pv.DomainName != domainName || pv.Repository != repoName {
 			continue
 		}
@@ -1217,19 +1446,23 @@ func (b *InMemoryBackend) ListPackages(domainName, repoName, format, namespace s
 
 // ListPackageVersions lists all versions of a package in a repository.
 func (b *InMemoryBackend) ListPackageVersions(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name string,
 ) ([]*PackageVersion, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListPackageVersions")
 	defer b.mu.RUnlock()
 
 	key := repoKey(domainName, repoName)
-	if _, ok := b.repositories[key]; !ok {
+	if _, ok := b.repositoriesStore(region)[key]; !ok {
 		return nil, fmt.Errorf("%w: repository %s/%s not found", ErrNotFound, domainName, repoName)
 	}
 
-	result := make([]*PackageVersion, 0, len(b.packageVersions))
+	packageVersions := b.packageVersionsStore(region)
+	result := make([]*PackageVersion, 0, len(packageVersions))
 
-	for _, pv := range b.packageVersions {
+	for _, pv := range packageVersions {
 		if pv.DomainName != domainName || pv.Repository != repoName {
 			continue
 		}
@@ -1259,13 +1492,16 @@ func (b *InMemoryBackend) ListPackageVersions(
 
 // ListPackageVersionAssets is a stub returning asset list for a package version.
 func (b *InMemoryBackend) ListPackageVersionAssets(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, version string,
 ) ([]map[string]any, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListPackageVersionAssets")
 	defer b.mu.RUnlock()
 
 	key := packageVersionKey(domainName, repoName, format, namespace, name, version)
-	if _, ok := b.packageVersions[key]; !ok {
+	if _, ok := b.packageVersionsStore(region)[key]; !ok {
 		return nil, fmt.Errorf("%w: package version not found", ErrNotFound)
 	}
 
@@ -1274,13 +1510,16 @@ func (b *InMemoryBackend) ListPackageVersionAssets(
 
 // ListPackageVersionDependencies is a stub returning empty dependencies.
 func (b *InMemoryBackend) ListPackageVersionDependencies(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, version string,
 ) ([]map[string]any, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListPackageVersionDependencies")
 	defer b.mu.RUnlock()
 
 	key := packageVersionKey(domainName, repoName, format, namespace, name, version)
-	if _, ok := b.packageVersions[key]; !ok {
+	if _, ok := b.packageVersionsStore(region)[key]; !ok {
 		return nil, fmt.Errorf("%w: package version not found", ErrNotFound)
 	}
 
@@ -1289,13 +1528,16 @@ func (b *InMemoryBackend) ListPackageVersionDependencies(
 
 // GetPackageVersionAsset is a stub that returns empty asset data.
 func (b *InMemoryBackend) GetPackageVersionAsset(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, version, asset string,
 ) ([]byte, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetPackageVersionAsset")
 	defer b.mu.RUnlock()
 
 	key := packageVersionKey(domainName, repoName, format, namespace, name, version)
-	if _, ok := b.packageVersions[key]; !ok {
+	if _, ok := b.packageVersionsStore(region)[key]; !ok {
 		return nil, fmt.Errorf("%w: package version not found", ErrNotFound)
 	}
 
@@ -1306,13 +1548,16 @@ func (b *InMemoryBackend) GetPackageVersionAsset(
 
 // GetPackageVersionReadme is a stub that returns empty README content.
 func (b *InMemoryBackend) GetPackageVersionReadme(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, version string,
 ) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetPackageVersionReadme")
 	defer b.mu.RUnlock()
 
 	key := packageVersionKey(domainName, repoName, format, namespace, name, version)
-	if _, ok := b.packageVersions[key]; !ok {
+	if _, ok := b.packageVersionsStore(region)[key]; !ok {
 		return "", fmt.Errorf("%w: package version not found", ErrNotFound)
 	}
 
@@ -1321,14 +1566,18 @@ func (b *InMemoryBackend) GetPackageVersionReadme(
 
 // PublishPackageVersion creates or updates a package version in the backend.
 func (b *InMemoryBackend) PublishPackageVersion(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, version string,
 ) (*PackageVersion, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PublishPackageVersion")
 	defer b.mu.Unlock()
 
 	key := packageVersionKey(domainName, repoName, format, namespace, name, version)
 
-	if existing, ok := b.packageVersions[key]; ok {
+	packageVersions := b.packageVersionsStore(region)
+	if existing, ok := packageVersions[key]; ok {
 		cp := *existing
 
 		return &cp, nil
@@ -1345,7 +1594,7 @@ func (b *InMemoryBackend) PublishPackageVersion(
 		Revision:    uuid.NewString()[:8],
 		PublishedAt: time.Now().UTC(),
 	}
-	b.packageVersions[key] = pv
+	packageVersions[key] = pv
 
 	cp := *pv
 
@@ -1354,17 +1603,21 @@ func (b *InMemoryBackend) PublishPackageVersion(
 
 // UpdatePackageVersionsStatus updates the status of specified package versions.
 func (b *InMemoryBackend) UpdatePackageVersionsStatus(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name, targetStatus string,
 	versions []string,
 ) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdatePackageVersionsStatus")
 	defer b.mu.Unlock()
 
+	packageVersions := b.packageVersionsStore(region)
 	results := make(map[string]string, len(versions))
 
 	for _, v := range versions {
 		key := packageVersionKey(domainName, repoName, format, namespace, name, v)
-		if pv, ok := b.packageVersions[key]; ok {
+		if pv, ok := packageVersions[key]; ok {
 			pv.Status = targetStatus
 			results[v] = "SUCCESS"
 		} else {
@@ -1377,13 +1630,16 @@ func (b *InMemoryBackend) UpdatePackageVersionsStatus(
 
 // PutPackageOriginConfiguration is a stub accepting package origin configuration.
 func (b *InMemoryBackend) PutPackageOriginConfiguration(
+	ctx context.Context,
 	domainName, repoName, format, namespace, name string,
 ) (*Package, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("PutPackageOriginConfiguration")
 	defer b.mu.RUnlock()
 
 	key := repoKey(domainName, repoName)
-	if _, ok := b.repositories[key]; !ok {
+	if _, ok := b.repositoriesStore(region)[key]; !ok {
 		return nil, fmt.Errorf("%w: repository %s/%s not found", ErrNotFound, domainName, repoName)
 	}
 
@@ -1398,12 +1654,16 @@ func (b *InMemoryBackend) PutPackageOriginConfiguration(
 }
 
 // UpdateRepository updates repository description or upstreams.
-func (b *InMemoryBackend) UpdateRepository(domainName, repoName, description string) (*Repository, error) {
+func (b *InMemoryBackend) UpdateRepository(
+	ctx context.Context, domainName, repoName, description string,
+) (*Repository, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateRepository")
 	defer b.mu.Unlock()
 
 	key := repoKey(domainName, repoName)
-	repo, ok := b.repositories[key]
+	repo, ok := b.repositoriesStore(region)[key]
 
 	if !ok {
 		return nil, fmt.Errorf("%w: repository %s/%s not found", ErrNotFound, domainName, repoName)
@@ -1421,12 +1681,14 @@ func (b *InMemoryBackend) UpdateRepository(domainName, repoName, description str
 // --- Additional query methods ---
 
 // CountRepositoriesInDomain returns the number of repositories in a domain.
-func (b *InMemoryBackend) CountRepositoriesInDomain(domainName string) int {
+func (b *InMemoryBackend) CountRepositoriesInDomain(ctx context.Context, domainName string) int {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("CountRepositoriesInDomain")
 	defer b.mu.RUnlock()
 
 	count := 0
-	for _, r := range b.repositories {
+	for _, r := range b.repositoriesStore(region) {
 		if r.DomainName == domainName {
 			count++
 		}
@@ -1436,12 +1698,16 @@ func (b *InMemoryBackend) CountRepositoriesInDomain(domainName string) int {
 }
 
 // GetExternalConnections returns a copy of the external connections for a repository.
-func (b *InMemoryBackend) GetExternalConnections(domainName, repoName string) []ExternalConnection {
+func (b *InMemoryBackend) GetExternalConnections(
+	ctx context.Context, domainName, repoName string,
+) []ExternalConnection {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetExternalConnections")
 	defer b.mu.RUnlock()
 
 	key := repoKey(domainName, repoName)
-	conns := b.externalConnections[key]
+	conns := b.externalConnectionsStore(region)[key]
 	result := make([]ExternalConnection, len(conns))
 	copy(result, conns)
 

--- a/services/codeartifact/codeartifact_coverage_test.go
+++ b/services/codeartifact/codeartifact_coverage_test.go
@@ -1,6 +1,7 @@
 package codeartifact_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -238,14 +239,14 @@ func TestBackend_GetAssociatedPackageGroup(t *testing.T) {
 	t.Parallel()
 
 	b := codeartifact.NewInMemoryBackend(config.DefaultAccountID, config.DefaultRegion)
-	_, err := b.CreateDomain("apg-domain", "", nil)
+	_, err := b.CreateDomain(context.Background(), "apg-domain", "", nil)
 	require.NoError(t, err)
 
-	pg, err := b.GetAssociatedPackageGroup("apg-domain", "npm", "", "lodash")
+	pg, err := b.GetAssociatedPackageGroup(context.Background(), "apg-domain", "npm", "", "lodash")
 	require.NoError(t, err)
 	assert.Nil(t, pg)
 
-	_, err = b.GetAssociatedPackageGroup("nonexistent", "npm", "", "lodash")
+	_, err = b.GetAssociatedPackageGroup(context.Background(), "nonexistent", "npm", "", "lodash")
 	require.Error(t, err)
 }
 
@@ -1011,14 +1012,14 @@ func TestBackend_ListSubPackageGroups(t *testing.T) {
 	t.Parallel()
 
 	b := codeartifact.NewInMemoryBackend(config.DefaultAccountID, config.DefaultRegion)
-	_, err := b.CreateDomain("lspg-domain", "", nil)
+	_, err := b.CreateDomain(context.Background(), "lspg-domain", "", nil)
 	require.NoError(t, err)
 
-	groups, err := b.ListSubPackageGroups("lspg-domain", "/")
+	groups, err := b.ListSubPackageGroups(context.Background(), "lspg-domain", "/")
 	require.NoError(t, err)
 	assert.NotNil(t, groups)
 
-	_, err = b.ListSubPackageGroups("nonexistent", "/")
+	_, err = b.ListSubPackageGroups(context.Background(), "nonexistent", "/")
 	require.Error(t, err)
 }
 
@@ -1495,10 +1496,10 @@ func TestCABackend_PersistenceRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	b := codeartifact.NewInMemoryBackend(config.DefaultAccountID, config.DefaultRegion)
-	_, err := b.CreateDomain("snap-domain", "", nil)
+	_, err := b.CreateDomain(context.Background(), "snap-domain", "", nil)
 	require.NoError(t, err)
 
-	_, err = b.CreateRepository("snap-domain", "snap-repo", "", nil)
+	_, err = b.CreateRepository(context.Background(), "snap-domain", "snap-repo", "", nil)
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
@@ -1508,6 +1509,6 @@ func TestCABackend_PersistenceRoundTrip(t *testing.T) {
 	err = b2.Restore(snap)
 	require.NoError(t, err)
 
-	doms := b2.ListDomains()
+	doms := b2.ListDomains(context.Background())
 	require.Len(t, doms, 1)
 }

--- a/services/codeartifact/handler.go
+++ b/services/codeartifact/handler.go
@@ -1,6 +1,7 @@
 package codeartifact
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
 	"github.com/blackbirdworks/gopherstack/pkgs/service"
 )
@@ -481,7 +483,13 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // Handler returns the Echo handler function for CodeArtifact requests.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
-		log := logger.Load(c.Request().Context())
+		// Attach the resolved region to the request context so backend operations
+		// are routed to the correct region.
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+		ctx := context.WithValue(c.Request().Context(), regionContextKey{}, region)
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		log := logger.Load(ctx)
 		path := c.Request().URL.Path
 		route := parseCodeArtifactPath(c.Request().Method, path)
 
@@ -875,7 +883,7 @@ func (h *Handler) handleCreateDomain(c *echo.Context, name string, body []byte) 
 		}
 	}
 
-	d, err := h.Backend.CreateDomain(name, in.EncryptionKey, tagsFromSlice(in.Tags))
+	d, err := h.Backend.CreateDomain(c.Request().Context(), name, in.EncryptionKey, tagsFromSlice(in.Tags))
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -890,12 +898,12 @@ func (h *Handler) handleDescribeDomain(c *echo.Context, name string) error {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain name is required"))
 	}
 
-	d, err := h.Backend.DescribeDomain(name)
+	d, err := h.Backend.DescribeDomain(c.Request().Context(), name)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
-	repoCount := h.Backend.CountRepositoriesInDomain(name)
+	repoCount := h.Backend.CountRepositoriesInDomain(c.Request().Context(), name)
 
 	return c.JSON(http.StatusOK, map[string]any{
 		keyDomain: domainToMap(d, repoCount),
@@ -903,7 +911,7 @@ func (h *Handler) handleDescribeDomain(c *echo.Context, name string) error {
 }
 
 func (h *Handler) handleListDomains(c *echo.Context) error {
-	domains := h.Backend.ListDomains()
+	domains := h.Backend.ListDomains(c.Request().Context())
 	items := make([]map[string]any, 0, len(domains))
 
 	for _, d := range domains {
@@ -920,9 +928,9 @@ func (h *Handler) handleDeleteDomain(c *echo.Context, name string) error {
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain name is required"))
 	}
 
-	repoCount := h.Backend.CountRepositoriesInDomain(name)
+	repoCount := h.Backend.CountRepositoriesInDomain(c.Request().Context(), name)
 
-	d, err := h.Backend.DeleteDomain(name)
+	d, err := h.Backend.DeleteDomain(c.Request().Context(), name)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -979,13 +987,19 @@ func (h *Handler) handleCreateRepository(c *echo.Context, domainName, repoName s
 		}
 	}
 
-	r, err := h.Backend.CreateRepository(domainName, repoName, in.Description, tagsFromSlice(in.Tags))
+	r, err := h.Backend.CreateRepository(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		in.Description,
+		tagsFromSlice(in.Tags),
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		keyRepository: repoToMap(r, h.Backend.GetExternalConnections(domainName, repoName)),
+		keyRepository: repoToMap(r, h.Backend.GetExternalConnections(c.Request().Context(), domainName, repoName)),
 	})
 }
 
@@ -997,13 +1011,13 @@ func (h *Handler) handleDescribeRepository(c *echo.Context, domainName, repoName
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
 	}
 
-	r, err := h.Backend.DescribeRepository(domainName, repoName)
+	r, err := h.Backend.DescribeRepository(c.Request().Context(), domainName, repoName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		keyRepository: repoToMap(r, h.Backend.GetExternalConnections(domainName, repoName)),
+		keyRepository: repoToMap(r, h.Backend.GetExternalConnections(c.Request().Context(), domainName, repoName)),
 	})
 }
 
@@ -1015,9 +1029,9 @@ func (h *Handler) handleDeleteRepository(c *echo.Context, domainName, repoName s
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
 	}
 
-	conns := h.Backend.GetExternalConnections(domainName, repoName)
+	conns := h.Backend.GetExternalConnections(c.Request().Context(), domainName, repoName)
 
-	r, err := h.Backend.DeleteRepository(domainName, repoName)
+	r, err := h.Backend.DeleteRepository(c.Request().Context(), domainName, repoName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1032,7 +1046,7 @@ func (h *Handler) handleListRepositoriesInDomain(c *echo.Context, domainName str
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
 
-	repos, err := h.Backend.ListRepositoriesInDomain(domainName)
+	repos, err := h.Backend.ListRepositoriesInDomain(c.Request().Context(), domainName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1054,7 +1068,7 @@ func (h *Handler) handleListRepositoriesInDomain(c *echo.Context, domainName str
 }
 
 func (h *Handler) handleListRepositories(c *echo.Context) error {
-	repos := h.Backend.ListRepositories()
+	repos := h.Backend.ListRepositories(c.Request().Context())
 	items := make([]map[string]any, 0, len(repos))
 
 	for _, r := range repos {
@@ -1082,7 +1096,7 @@ func (h *Handler) handleGetRepositoryEndpoint(c *echo.Context, domainName, repoN
 		format = "generic"
 	}
 
-	_, err := h.Backend.DescribeRepository(domainName, repoName)
+	_, err := h.Backend.DescribeRepository(c.Request().Context(), domainName, repoName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1102,7 +1116,7 @@ func (h *Handler) handleGetAuthorizationToken(c *echo.Context, domainName string
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
 
-	_, err := h.Backend.DescribeDomain(domainName)
+	_, err := h.Backend.DescribeDomain(c.Request().Context(), domainName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1129,7 +1143,7 @@ func (h *Handler) handleListTagsForResource(c *echo.Context, resourceARN string)
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "resourceArn is required"))
 	}
 
-	kv, err := h.Backend.ListTagsForResource(resourceARN)
+	kv, err := h.Backend.ListTagsForResource(c.Request().Context(), resourceARN)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1157,7 +1171,7 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceARN string, body []
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "invalid request body"))
 	}
 
-	if err := h.Backend.TagResource(resourceARN, tagsFromSlice(in.Tags)); err != nil {
+	if err := h.Backend.TagResource(c.Request().Context(), resourceARN, tagsFromSlice(in.Tags)); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1174,7 +1188,7 @@ func (h *Handler) handleUntagResource(c *echo.Context, resourceARN string, body 
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "invalid request body"))
 	}
 
-	if err := h.Backend.UntagResource(resourceARN, in.TagKeys); err != nil {
+	if err := h.Backend.UntagResource(c.Request().Context(), resourceARN, in.TagKeys); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1188,7 +1202,7 @@ func (h *Handler) handleGetDomainPermissionsPolicy(c *echo.Context, domainName s
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
 
-	pol, err := h.Backend.GetDomainPermissionsPolicy(domainName)
+	pol, err := h.Backend.GetDomainPermissionsPolicy(c.Request().Context(), domainName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1222,7 +1236,7 @@ func (h *Handler) handlePutDomainPermissionsPolicy(c *echo.Context, domainName s
 		in.PolicyDocument = `{"Version":"2012-10-17","Statement":[]}`
 	}
 
-	pol, err := h.Backend.PutDomainPermissionsPolicy(domainName, in.PolicyDocument)
+	pol, err := h.Backend.PutDomainPermissionsPolicy(c.Request().Context(), domainName, in.PolicyDocument)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1241,7 +1255,7 @@ func (h *Handler) handleDeleteDomainPermissionsPolicy(c *echo.Context, domainNam
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
 
-	pol, err := h.Backend.DeleteDomainPermissionsPolicy(domainName)
+	pol, err := h.Backend.DeleteDomainPermissionsPolicy(c.Request().Context(), domainName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1298,7 +1312,14 @@ func (h *Handler) handleCreatePackageGroup(c *echo.Context, domainName string, b
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "pattern is required"))
 	}
 
-	pg, err := h.Backend.CreatePackageGroup(domainName, pattern, in.Description, in.ContactInfo, tagsFromSlice(in.Tags))
+	pg, err := h.Backend.CreatePackageGroup(
+		c.Request().Context(),
+		domainName,
+		pattern,
+		in.Description,
+		in.ContactInfo,
+		tagsFromSlice(in.Tags),
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1316,7 +1337,7 @@ func (h *Handler) handleDescribePackageGroup(c *echo.Context, domainName, patter
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
-	pg, err := h.Backend.DescribePackageGroup(domainName, pattern)
+	pg, err := h.Backend.DescribePackageGroup(c.Request().Context(), domainName, pattern)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1334,7 +1355,7 @@ func (h *Handler) handleDeletePackageGroup(c *echo.Context, domainName, pattern 
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
-	pg, err := h.Backend.DeletePackageGroup(domainName, pattern)
+	pg, err := h.Backend.DeletePackageGroup(c.Request().Context(), domainName, pattern)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1375,7 +1396,7 @@ func (h *Handler) handleDescribePackage(c *echo.Context, domainName, repoName, f
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
-	pkg, err := h.Backend.DescribePackage(domainName, repoName, format, namespace, name)
+	pkg, err := h.Backend.DescribePackage(c.Request().Context(), domainName, repoName, format, namespace, name)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1399,7 +1420,7 @@ func (h *Handler) handleDeletePackage(c *echo.Context, domainName, repoName, for
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
-	pkg, err := h.Backend.DeletePackage(domainName, repoName, format, namespace, name)
+	pkg, err := h.Backend.DeletePackage(c.Request().Context(), domainName, repoName, format, namespace, name)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1446,7 +1467,15 @@ func (h *Handler) handleDescribePackageVersion(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
 	}
 
-	pv, err := h.Backend.DescribePackageVersion(domainName, repoName, format, namespace, name, version)
+	pv, err := h.Backend.DescribePackageVersion(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		version,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1485,7 +1514,15 @@ func (h *Handler) handleDeletePackageVersions(
 		}
 	}
 
-	failed, err := h.Backend.DeletePackageVersions(domainName, repoName, format, namespace, name, in.Versions)
+	failed, err := h.Backend.DeletePackageVersions(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		in.Versions,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1540,7 +1577,16 @@ func (h *Handler) handleCopyPackageVersions(
 		}
 	}
 
-	failed, err := h.Backend.CopyPackageVersions(domainName, srcRepo, dstRepo, format, namespace, name, in.Versions)
+	failed, err := h.Backend.CopyPackageVersions(
+		c.Request().Context(),
+		domainName,
+		srcRepo,
+		dstRepo,
+		format,
+		namespace,
+		name,
+		in.Versions,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1579,13 +1625,13 @@ func (h *Handler) handleAssociateExternalConnection(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "externalConnection is required"))
 	}
 
-	r, err := h.Backend.AssociateExternalConnection(domainName, repoName, connectionName)
+	r, err := h.Backend.AssociateExternalConnection(c.Request().Context(), domainName, repoName, connectionName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		keyRepository: repoToMap(r, h.Backend.GetExternalConnections(domainName, repoName)),
+		keyRepository: repoToMap(r, h.Backend.GetExternalConnections(c.Request().Context(), domainName, repoName)),
 	})
 }
 
@@ -1599,7 +1645,7 @@ func (h *Handler) handleGetRepositoryPermissionsPolicy(c *echo.Context, domainNa
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
 	}
 
-	pol, err := h.Backend.GetRepositoryPermissionsPolicy(domainName, repoName)
+	pol, err := h.Backend.GetRepositoryPermissionsPolicy(c.Request().Context(), domainName, repoName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1640,7 +1686,7 @@ func (h *Handler) handlePutRepositoryPermissionsPolicy(
 		in.PolicyDocument = `{"Version":"2012-10-17","Statement":[]}`
 	}
 
-	pol, err := h.Backend.PutRepositoryPermissionsPolicy(domainName, repoName, in.PolicyDocument)
+	pol, err := h.Backend.PutRepositoryPermissionsPolicy(c.Request().Context(), domainName, repoName, in.PolicyDocument)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1662,7 +1708,7 @@ func (h *Handler) handleDeleteRepositoryPermissionsPolicy(c *echo.Context, domai
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
 	}
 
-	pol, err := h.Backend.DeleteRepositoryPermissionsPolicy(domainName, repoName)
+	pol, err := h.Backend.DeleteRepositoryPermissionsPolicy(c.Request().Context(), domainName, repoName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1691,12 +1737,12 @@ func (h *Handler) handleDisassociateExternalConnection(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "externalConnection is required"))
 	}
 
-	r, err := h.Backend.DisassociateExternalConnection(domainName, repoName, connectionName)
+	r, err := h.Backend.DisassociateExternalConnection(c.Request().Context(), domainName, repoName, connectionName)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
-	extConns := h.Backend.GetExternalConnections(domainName, repoName)
+	extConns := h.Backend.GetExternalConnections(c.Request().Context(), domainName, repoName)
 
 	return c.JSON(http.StatusOK, map[string]any{keyRepository: repoToMap(r, extConns)})
 }
@@ -1726,7 +1772,15 @@ func (h *Handler) handleDisposePackageVersions(
 		_ = json.Unmarshal(body, &in)
 	}
 
-	results, err := h.Backend.DisposePackageVersions(domainName, repoName, format, namespace, name, in.Versions)
+	results, err := h.Backend.DisposePackageVersions(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		in.Versions,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1745,7 +1799,7 @@ func (h *Handler) handleGetAssociatedPackageGroup(c *echo.Context, domainName, f
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
-	pg, err := h.Backend.GetAssociatedPackageGroup(domainName, format, namespace, name)
+	pg, err := h.Backend.GetAssociatedPackageGroup(c.Request().Context(), domainName, format, namespace, name)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1779,7 +1833,16 @@ func (h *Handler) handleGetPackageVersionAsset(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "asset is required"))
 	}
 
-	data, err := h.Backend.GetPackageVersionAsset(domainName, repoName, format, namespace, name, version, asset)
+	data, err := h.Backend.GetPackageVersionAsset(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		version,
+		asset,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1817,7 +1880,15 @@ func (h *Handler) handleGetPackageVersionReadme(
 		return err
 	}
 
-	readme, err := h.Backend.GetPackageVersionReadme(domainName, repoName, format, namespace, name, version)
+	readme, err := h.Backend.GetPackageVersionReadme(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		version,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1833,7 +1904,7 @@ func (h *Handler) handleListAllowedRepositoriesForGroup(c *echo.Context, domainN
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
-	repos, err := h.Backend.ListAllowedRepositoriesForGroup(domainName, pattern)
+	repos, err := h.Backend.ListAllowedRepositoriesForGroup(c.Request().Context(), domainName, pattern)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1849,7 +1920,7 @@ func (h *Handler) handleListAssociatedPackages(c *echo.Context, domainName, patt
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
-	pkgs, err := h.Backend.ListAssociatedPackages(domainName, pattern)
+	pkgs, err := h.Backend.ListAssociatedPackages(c.Request().Context(), domainName, pattern)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1867,7 +1938,7 @@ func (h *Handler) handleListPackageGroups(c *echo.Context, domainName, prefix st
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "domain is required"))
 	}
 
-	groups, err := h.Backend.ListPackageGroups(domainName, prefix)
+	groups, err := h.Backend.ListPackageGroups(c.Request().Context(), domainName, prefix)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1887,7 +1958,15 @@ func (h *Handler) handleListPackageVersionAssets(
 		return err
 	}
 
-	assets, err := h.Backend.ListPackageVersionAssets(domainName, repoName, format, namespace, name, version)
+	assets, err := h.Backend.ListPackageVersionAssets(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		version,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1902,7 +1981,15 @@ func (h *Handler) handleListPackageVersionDependencies(
 		return err
 	}
 
-	deps, err := h.Backend.ListPackageVersionDependencies(domainName, repoName, format, namespace, name, version)
+	deps, err := h.Backend.ListPackageVersionDependencies(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		version,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1926,7 +2013,7 @@ func (h *Handler) handleListPackageVersions(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
-	versions, err := h.Backend.ListPackageVersions(domainName, repoName, format, namespace, name)
+	versions, err := h.Backend.ListPackageVersions(c.Request().Context(), domainName, repoName, format, namespace, name)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1947,7 +2034,7 @@ func (h *Handler) handleListPackages(c *echo.Context, domainName, repoName, form
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "repository is required"))
 	}
 
-	pkgs, err := h.Backend.ListPackages(domainName, repoName, format, namespace)
+	pkgs, err := h.Backend.ListPackages(c.Request().Context(), domainName, repoName, format, namespace)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1968,7 +2055,7 @@ func (h *Handler) handleListSubPackageGroups(c *echo.Context, domainName, patter
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
-	groups, err := h.Backend.ListSubPackageGroups(domainName, pattern)
+	groups, err := h.Backend.ListSubPackageGroups(c.Request().Context(), domainName, pattern)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -2000,7 +2087,15 @@ func (h *Handler) handlePublishPackageVersion(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "version is required"))
 	}
 
-	pv, err := h.Backend.PublishPackageVersion(domainName, repoName, format, namespace, name, version)
+	pv, err := h.Backend.PublishPackageVersion(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+		version,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -2024,7 +2119,14 @@ func (h *Handler) handlePutPackageOriginConfiguration(
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "package is required"))
 	}
 
-	pkg, err := h.Backend.PutPackageOriginConfiguration(domainName, repoName, format, namespace, name)
+	pkg, err := h.Backend.PutPackageOriginConfiguration(
+		c.Request().Context(),
+		domainName,
+		repoName,
+		format,
+		namespace,
+		name,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -2053,7 +2155,7 @@ func (h *Handler) handleUpdatePackageGroup(c *echo.Context, domainName string, b
 		pattern = in.PackageGroup
 	}
 
-	pg, err := h.Backend.UpdatePackageGroup(domainName, pattern, in.Description, in.ContactInfo)
+	pg, err := h.Backend.UpdatePackageGroup(c.Request().Context(), domainName, pattern, in.Description, in.ContactInfo)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -2069,7 +2171,7 @@ func (h *Handler) handleUpdatePackageGroupOriginConfiguration(c *echo.Context, d
 		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "packageGroup is required"))
 	}
 
-	pg, err := h.Backend.UpdatePackageGroupOriginConfiguration(domainName, pattern)
+	pg, err := h.Backend.UpdatePackageGroupOriginConfiguration(c.Request().Context(), domainName, pattern)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -2108,7 +2210,7 @@ func (h *Handler) handleUpdatePackageVersionsStatus(
 	}
 
 	results, err := h.Backend.UpdatePackageVersionsStatus(
-		domainName, repoName, format, namespace, name, in.TargetStatus, in.Versions,
+		c.Request().Context(), domainName, repoName, format, namespace, name, in.TargetStatus, in.Versions,
 	)
 	if err != nil {
 		return h.handleError(c, err)
@@ -2134,12 +2236,12 @@ func (h *Handler) handleUpdateRepository(c *echo.Context, domainName, repoName s
 		_ = json.Unmarshal(body, &in)
 	}
 
-	r, err := h.Backend.UpdateRepository(domainName, repoName, in.Description)
+	r, err := h.Backend.UpdateRepository(c.Request().Context(), domainName, repoName, in.Description)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
-	extConns := h.Backend.GetExternalConnections(domainName, repoName)
+	extConns := h.Backend.GetExternalConnections(c.Request().Context(), domainName, repoName)
 
 	return c.JSON(http.StatusOK, map[string]any{keyRepository: repoToMap(r, extConns)})
 }

--- a/services/codeartifact/handler_test.go
+++ b/services/codeartifact/handler_test.go
@@ -2,6 +2,7 @@ package codeartifact_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -1655,18 +1656,18 @@ func TestBackend_Reset(t *testing.T) {
 
 	b := codeartifact.NewInMemoryBackend(config.DefaultAccountID, config.DefaultRegion)
 
-	_, err := b.CreateDomain("reset-domain", "", nil)
+	_, err := b.CreateDomain(context.Background(), "reset-domain", "", nil)
 	require.NoError(t, err)
 
-	_, err = b.CreateRepository("reset-domain", "reset-repo", "", nil)
+	_, err = b.CreateRepository(context.Background(), "reset-domain", "reset-repo", "", nil)
 	require.NoError(t, err)
 
 	b.Reset()
 
-	_, err = b.DescribeDomain("reset-domain")
+	_, err = b.DescribeDomain(context.Background(), "reset-domain")
 	require.Error(t, err)
 
-	_, err = b.DescribeRepository("reset-domain", "reset-repo")
+	_, err = b.DescribeRepository(context.Background(), "reset-domain", "reset-repo")
 	require.Error(t, err)
 }
 

--- a/services/codeartifact/isolation_test.go
+++ b/services/codeartifact/isolation_test.go
@@ -1,0 +1,97 @@
+package codeartifact //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func caCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func TestCodeArtifactRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := caCtxRegion("us-east-1")
+	ctxWest := caCtxRegion("us-west-2")
+
+	// 1. Create a domain named "shared" in us-east-1.
+	eastDomain, err := backend.CreateDomain(ctxEast, "shared", "", nil)
+	require.NoError(t, err)
+	assert.Contains(t, eastDomain.ARN, "us-east-1")
+	assert.Equal(t, "us-east-1", eastDomain.Region)
+
+	// 2. Create a domain with the SAME NAME in us-west-2.
+	westDomain, err := backend.CreateDomain(ctxWest, "shared", "", nil)
+	require.NoError(t, err)
+	assert.Contains(t, westDomain.ARN, "us-west-2")
+	assert.Equal(t, "us-west-2", westDomain.Region)
+
+	// 3. us-east-1 sees only its own domain.
+	eastList := backend.ListDomains(ctxEast)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, "shared", eastList[0].Name)
+	assert.Contains(t, eastList[0].ARN, "us-east-1")
+
+	// 4. us-west-2 sees only its own domain.
+	westList := backend.ListDomains(ctxWest)
+	require.Len(t, westList, 1)
+	assert.Equal(t, "shared", westList[0].Name)
+	assert.Contains(t, westList[0].ARN, "us-west-2")
+
+	// 5. Delete in us-east-1; us-west-2's domain remains.
+	_, err = backend.DeleteDomain(ctxEast, "shared")
+	require.NoError(t, err)
+
+	_, err = backend.DescribeDomain(ctxEast, "shared")
+	require.Error(t, err)
+
+	stillThere, err := backend.DescribeDomain(ctxWest, "shared")
+	require.NoError(t, err)
+	assert.Equal(t, "shared", stillThere.Name)
+	assert.Contains(t, stillThere.ARN, "us-west-2")
+}
+
+func TestCodeArtifactRepositoryRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := caCtxRegion("us-east-1")
+	ctxWest := caCtxRegion("us-west-2")
+
+	_, err := backend.CreateDomain(ctxEast, "d", "", nil)
+	require.NoError(t, err)
+	_, err = backend.CreateDomain(ctxWest, "d", "", nil)
+	require.NoError(t, err)
+
+	_, err = backend.CreateRepository(ctxEast, "d", "repo", "east repo", nil)
+	require.NoError(t, err)
+	_, err = backend.CreateRepository(ctxWest, "d", "repo", "west repo", nil)
+	require.NoError(t, err)
+
+	eastRepo, err := backend.DescribeRepository(ctxEast, "d", "repo")
+	require.NoError(t, err)
+	assert.Equal(t, "east repo", eastRepo.Description)
+	assert.Contains(t, eastRepo.ARN, "us-east-1")
+
+	westRepo, err := backend.DescribeRepository(ctxWest, "d", "repo")
+	require.NoError(t, err)
+	assert.Equal(t, "west repo", westRepo.Description)
+	assert.Contains(t, westRepo.ARN, "us-west-2")
+
+	// Deleting the repo in us-east-1 leaves us-west-2's repo intact.
+	_, err = backend.DeleteRepository(ctxEast, "d", "repo")
+	require.NoError(t, err)
+
+	_, err = backend.DescribeRepository(ctxEast, "d", "repo")
+	require.Error(t, err)
+
+	_, err = backend.DescribeRepository(ctxWest, "d", "repo")
+	require.NoError(t, err)
+}

--- a/services/codeartifact/persistence.go
+++ b/services/codeartifact/persistence.go
@@ -4,17 +4,18 @@ import (
 	"encoding/json"
 )
 
+// backendSnapshot mirrors the region-nested backend maps (outer key = region).
 type backendSnapshot struct {
-	Domains             map[string]*Domain                      `json:"domains"`
-	Repositories        map[string]*Repository                  `json:"repositories"`
-	PackageGroups       map[string]*PackageGroup                `json:"packageGroups"`
-	Packages            map[string]*Package                     `json:"packages"`
-	PackageVersions     map[string]*PackageVersion              `json:"packageVersions"`
-	ExternalConnections map[string][]ExternalConnection         `json:"externalConnections"`
-	RepositoryPolicies  map[string]*RepositoryPermissionsPolicy `json:"repositoryPolicies"`
-	DomainPolicies      map[string]*DomainPermissionsPolicy     `json:"domainPolicies"`
-	AccountID           string                                  `json:"accountID"`
-	Region              string                                  `json:"region"`
+	Domains             map[string]map[string]*Domain                      `json:"domains"`
+	Repositories        map[string]map[string]*Repository                  `json:"repositories"`
+	PackageGroups       map[string]map[string]*PackageGroup                `json:"packageGroups"`
+	Packages            map[string]map[string]*Package                     `json:"packages"`
+	PackageVersions     map[string]map[string]*PackageVersion              `json:"packageVersions"`
+	ExternalConnections map[string]map[string][]ExternalConnection         `json:"externalConnections"`
+	RepositoryPolicies  map[string]map[string]*RepositoryPermissionsPolicy `json:"repositoryPolicies"`
+	DomainPolicies      map[string]map[string]*DomainPermissionsPolicy     `json:"domainPolicies"`
+	AccountID           string                                             `json:"accountID"`
+	Region              string                                             `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -57,28 +58,28 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	defer b.mu.Unlock()
 
 	if snap.Domains == nil {
-		snap.Domains = make(map[string]*Domain)
+		snap.Domains = make(map[string]map[string]*Domain)
 	}
 	if snap.Repositories == nil {
-		snap.Repositories = make(map[string]*Repository)
+		snap.Repositories = make(map[string]map[string]*Repository)
 	}
 	if snap.PackageGroups == nil {
-		snap.PackageGroups = make(map[string]*PackageGroup)
+		snap.PackageGroups = make(map[string]map[string]*PackageGroup)
 	}
 	if snap.Packages == nil {
-		snap.Packages = make(map[string]*Package)
+		snap.Packages = make(map[string]map[string]*Package)
 	}
 	if snap.PackageVersions == nil {
-		snap.PackageVersions = make(map[string]*PackageVersion)
+		snap.PackageVersions = make(map[string]map[string]*PackageVersion)
 	}
 	if snap.ExternalConnections == nil {
-		snap.ExternalConnections = make(map[string][]ExternalConnection)
+		snap.ExternalConnections = make(map[string]map[string][]ExternalConnection)
 	}
 	if snap.RepositoryPolicies == nil {
-		snap.RepositoryPolicies = make(map[string]*RepositoryPermissionsPolicy)
+		snap.RepositoryPolicies = make(map[string]map[string]*RepositoryPermissionsPolicy)
 	}
 	if snap.DomainPolicies == nil {
-		snap.DomainPolicies = make(map[string]*DomainPermissionsPolicy)
+		snap.DomainPolicies = make(map[string]map[string]*DomainPermissionsPolicy)
 	}
 
 	b.domains = snap.Domains

--- a/services/codepipeline/action_executions_test.go
+++ b/services/codepipeline/action_executions_test.go
@@ -1,6 +1,7 @@
 package codepipeline_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,21 +52,25 @@ func TestListActionExecutions_TracksExecutions(t *testing.T) {
 			b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 
 			if tt.unknownPipe {
-				_, err := b.ListActionExecutions("missing", "")
+				_, err := b.ListActionExecutions(context.Background(), "missing", "")
 				require.Error(t, err)
 
 				return
 			}
 
-			_, err := b.CreatePipeline(samplePipeline("ae-pipeline"), nil)
+			_, err := b.CreatePipeline(context.Background(), samplePipeline("ae-pipeline"), nil)
 			require.NoError(t, err)
 
-			exec1, err := b.StartPipelineExecution("ae-pipeline")
+			exec1, err := b.StartPipelineExecution(context.Background(), "ae-pipeline")
 			require.NoError(t, err)
-			_, err = b.StartPipelineExecution("ae-pipeline")
+			_, err = b.StartPipelineExecution(context.Background(), "ae-pipeline")
 			require.NoError(t, err)
 
-			items, err := b.ListActionExecutions("ae-pipeline", tt.filterFn(exec1.PipelineExecutionID))
+			items, err := b.ListActionExecutions(
+				context.Background(),
+				"ae-pipeline",
+				tt.filterFn(exec1.PipelineExecutionID),
+			)
 			require.NoError(t, err)
 			assert.Len(t, items, tt.wantCount)
 
@@ -105,13 +110,13 @@ func TestListRuleExecutions_KnownAndUnknownPipeline(t *testing.T) {
 
 	b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.ListRuleExecutions("missing")
+	_, err := b.ListRuleExecutions(context.Background(), "missing")
 	require.Error(t, err)
 
-	_, err = b.CreatePipeline(samplePipeline("re-pipeline"), nil)
+	_, err = b.CreatePipeline(context.Background(), samplePipeline("re-pipeline"), nil)
 	require.NoError(t, err)
 
-	items, err := b.ListRuleExecutions("re-pipeline")
+	items, err := b.ListRuleExecutions(context.Background(), "re-pipeline")
 	require.NoError(t, err)
 	assert.Empty(t, items)
 }
@@ -122,13 +127,13 @@ func TestListDeployActionExecutionTargets_KnownAndUnknown(t *testing.T) {
 
 	b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.ListDeployActionExecutionTargets("missing", "exec-1")
+	_, err := b.ListDeployActionExecutionTargets(context.Background(), "missing", "exec-1")
 	require.Error(t, err)
 
-	_, err = b.CreatePipeline(samplePipeline("dt-pipeline"), nil)
+	_, err = b.CreatePipeline(context.Background(), samplePipeline("dt-pipeline"), nil)
 	require.NoError(t, err)
 
-	items, err := b.ListDeployActionExecutionTargets("dt-pipeline", "exec-1")
+	items, err := b.ListDeployActionExecutionTargets(context.Background(), "dt-pipeline", "exec-1")
 	require.NoError(t, err)
 	assert.Empty(t, items)
 }

--- a/services/codepipeline/audit_test.go
+++ b/services/codepipeline/audit_test.go
@@ -4,6 +4,7 @@ package codepipeline_test
 // All tests use table-driven format.
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -1001,7 +1002,11 @@ func TestHandler_ListTagsForResource_WebhookARN(t *testing.T) {
 		{
 			name: "pipeline ARN returns tags",
 			setup: func(h *codepipeline.Handler) string {
-				p, err := h.Backend.CreatePipeline(samplePipeline("tags-pl"), map[string]string{"Env": "prod"})
+				p, err := h.Backend.CreatePipeline(
+					context.Background(),
+					samplePipeline("tags-pl"),
+					map[string]string{"Env": "prod"},
+				)
 				require.NoError(t, err)
 
 				return p.Metadata.PipelineArn
@@ -1054,7 +1059,7 @@ func TestHandler_DisableStageTransition_StageValidation(t *testing.T) {
 		{
 			name: "existing stage disabled ok",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("stage-exists"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("stage-exists"), nil)
 				require.NoError(t, err)
 			},
 			input: map[string]any{
@@ -1068,7 +1073,7 @@ func TestHandler_DisableStageTransition_StageValidation(t *testing.T) {
 		{
 			name: "non-existent stage rejected",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("stage-missing"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("stage-missing"), nil)
 				require.NoError(t, err)
 			},
 			input: map[string]any{
@@ -1132,7 +1137,7 @@ func TestInMemoryBackend_Restore_DefensiveCopy(t *testing.T) {
 				t.Helper()
 
 				b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
-				_, err := b.CreatePipeline(samplePipeline("snap-pl"), nil)
+				_, err := b.CreatePipeline(context.Background(), samplePipeline("snap-pl"), nil)
 				require.NoError(t, err)
 
 				snap := b.Snapshot()
@@ -1147,7 +1152,7 @@ func TestInMemoryBackend_Restore_DefensiveCopy(t *testing.T) {
 				}
 
 				// b2 should still have the pipeline.
-				p, err := b2.GetPipeline("snap-pl")
+				p, err := b2.GetPipeline(context.Background(), "snap-pl")
 				require.NoError(t, err)
 				assert.Equal(t, "snap-pl", p.Declaration.Name)
 			},
@@ -1158,7 +1163,7 @@ func TestInMemoryBackend_Restore_DefensiveCopy(t *testing.T) {
 				t.Helper()
 
 				b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
-				_, err := b.CreatePipeline(samplePipeline("old-pl"), nil)
+				_, err := b.CreatePipeline(context.Background(), samplePipeline("old-pl"), nil)
 				require.NoError(t, err)
 
 				// Take snapshot of empty state.
@@ -1177,10 +1182,10 @@ func TestInMemoryBackend_Restore_DefensiveCopy(t *testing.T) {
 				t.Helper()
 
 				b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
-				_, err := b.CreatePipeline(samplePipeline("exec-snap"), nil)
+				_, err := b.CreatePipeline(context.Background(), samplePipeline("exec-snap"), nil)
 				require.NoError(t, err)
 
-				exec, err := b.StartPipelineExecution("exec-snap")
+				exec, err := b.StartPipelineExecution(context.Background(), "exec-snap")
 				require.NoError(t, err)
 
 				snap := b.Snapshot()
@@ -1188,7 +1193,7 @@ func TestInMemoryBackend_Restore_DefensiveCopy(t *testing.T) {
 				b2 := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 				require.NoError(t, b2.Restore(snap))
 
-				execs, err := b2.ListPipelineExecutions("exec-snap")
+				execs, err := b2.ListPipelineExecutions(context.Background(), "exec-snap")
 				require.NoError(t, err)
 				require.Len(t, execs, 1)
 				assert.Equal(t, exec.PipelineExecutionID, execs[0].PipelineExecutionID)
@@ -1241,7 +1246,7 @@ func TestHandler_UpdatePipeline_VersionConflict(t *testing.T) {
 			t.Parallel()
 
 			h := newTestHandler(t)
-			_, err := h.Backend.CreatePipeline(samplePipeline("ver-conflict"), nil)
+			_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("ver-conflict"), nil)
 			require.NoError(t, err)
 
 			p := samplePipeline("ver-conflict")
@@ -1287,7 +1292,7 @@ func TestHandler_DeleteCustomActionType_InUse(t *testing.T) {
 				p.Stages[0].Actions[0].ActionTypeID = codepipeline.ActionTypeID{
 					Category: "Build", Owner: "Custom", Provider: "InUseBuilder", Version: "1",
 				}
-				_, err := h.Backend.CreatePipeline(p, nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), p, nil)
 				require.NoError(t, err)
 			},
 			input: map[string]any{
@@ -1348,7 +1353,7 @@ func TestHandler_GetPipelineState_ActionStates(t *testing.T) {
 		{
 			name: "actionStates included per stage",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("state-pl"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("state-pl"), nil)
 				require.NoError(t, err)
 			},
 			wantStatus: http.StatusOK,
@@ -1403,7 +1408,7 @@ func TestHandler_ListPipelineExecutions_StoresAndReturns(t *testing.T) {
 		{
 			name: "two starts gives two entries in reverse order",
 			setup: func(h *codepipeline.Handler) string {
-				_, err := h.Backend.CreatePipeline(samplePipeline("list-execs"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("list-execs"), nil)
 				require.NoError(t, err)
 
 				rec := doRequest(t, h, "StartPipelineExecution", map[string]any{"name": "list-execs"})
@@ -1420,7 +1425,7 @@ func TestHandler_ListPipelineExecutions_StoresAndReturns(t *testing.T) {
 		{
 			name: "empty pipeline returns empty list",
 			setup: func(h *codepipeline.Handler) string {
-				_, err := h.Backend.CreatePipeline(samplePipeline("empty-execs"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("empty-execs"), nil)
 				require.NoError(t, err)
 
 				return "empty-execs"
@@ -1478,7 +1483,7 @@ func TestHandler_ListPipelines_IncludesPipelineType(t *testing.T) {
 				p := samplePipeline("v2-list-pl")
 				p.PipelineType = codepipeline.PipelineTypeV2
 				p.ExecutionMode = codepipeline.ExecutionModeParallel
-				_, err := h.Backend.CreatePipeline(p, nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), p, nil)
 				require.NoError(t, err)
 			},
 			wantType:   "V2",
@@ -1639,15 +1644,15 @@ func TestInMemoryBackend_DeletePipeline_ClearsExecutions(t *testing.T) {
 				t.Helper()
 
 				b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
-				_, err := b.CreatePipeline(samplePipeline("del-exec-pl"), nil)
+				_, err := b.CreatePipeline(context.Background(), samplePipeline("del-exec-pl"), nil)
 				require.NoError(t, err)
 
-				_, err = b.StartPipelineExecution("del-exec-pl")
+				_, err = b.StartPipelineExecution(context.Background(), "del-exec-pl")
 				require.NoError(t, err)
 
-				require.NoError(t, b.DeletePipeline("del-exec-pl"))
+				require.NoError(t, b.DeletePipeline(context.Background(), "del-exec-pl"))
 
-				_, err = b.ListPipelineExecutions("del-exec-pl")
+				_, err = b.ListPipelineExecutions(context.Background(), "del-exec-pl")
 				assert.Error(t, err, "should not find executions for deleted pipeline")
 			},
 		},

--- a/services/codepipeline/backend.go
+++ b/services/codepipeline/backend.go
@@ -2,6 +2,7 @@
 package codepipeline
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -14,6 +15,23 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+// CodePipeline resources are isolated per region: every backend operation resolves
+// the caller's region from the request context and operates only on that region's
+// nested store. Pipelines, action types, jobs, webhooks, executions, and stage
+// transitions are all region-scoped in AWS, so cross-region references never occur
+// and isolation is always safe.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 const (
 	// statusInProgress is the status for an in-progress job or execution.
@@ -339,16 +357,21 @@ type Tag struct {
 }
 
 // InMemoryBackend is a thread-safe in-memory store for CodePipeline resources.
+//
+// All resource maps are nested by region (outer key = region) so that same-named
+// resources are isolated across regions. The per-region inner maps are created
+// lazily via the *Store helpers. Callers must hold b.mu while accessing the inner
+// maps.
 type InMemoryBackend struct {
-	pipelines         map[string]*Pipeline
-	pipelineARNIndex  map[string]string // ARN → pipeline name
-	customActionTypes map[customActionTypeKey]*CustomActionType
-	jobs              map[string]*Job     // jobID → Job
-	webhooks          map[string]*Webhook // name → Webhook
-	webhookARNIndex   map[string]string   // ARN → webhook name
-	stageTransitions  map[stageTransitionKey]*StageTransitionState
-	executions        map[string][]*PipelineExecution // pipelineName → executions
-	actionExecutions  map[string][]*ActionExecution   // pipelineName → action executions
+	pipelines         map[string]map[string]*Pipeline
+	pipelineARNIndex  map[string]map[string]string // region → ARN → pipeline name
+	customActionTypes map[string]map[customActionTypeKey]*CustomActionType
+	jobs              map[string]map[string]*Job     // region → jobID → Job
+	webhooks          map[string]map[string]*Webhook // region → name → Webhook
+	webhookARNIndex   map[string]map[string]string   // region → ARN → webhook name
+	stageTransitions  map[string]map[stageTransitionKey]*StageTransitionState
+	executions        map[string]map[string][]*PipelineExecution // region → pipelineName → executions
+	actionExecutions  map[string]map[string][]*ActionExecution   // region → pipelineName → action executions
 	mu                *lockmetrics.RWMutex
 	accountID         string
 	region            string
@@ -357,22 +380,97 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new backend for the given account and region.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		pipelines:         make(map[string]*Pipeline),
-		pipelineARNIndex:  make(map[string]string),
-		customActionTypes: make(map[customActionTypeKey]*CustomActionType),
-		jobs:              make(map[string]*Job),
-		webhooks:          make(map[string]*Webhook),
-		webhookARNIndex:   make(map[string]string),
-		stageTransitions:  make(map[stageTransitionKey]*StageTransitionState),
-		executions:        make(map[string][]*PipelineExecution),
-		actionExecutions:  make(map[string][]*ActionExecution),
+		pipelines:         make(map[string]map[string]*Pipeline),
+		pipelineARNIndex:  make(map[string]map[string]string),
+		customActionTypes: make(map[string]map[customActionTypeKey]*CustomActionType),
+		jobs:              make(map[string]map[string]*Job),
+		webhooks:          make(map[string]map[string]*Webhook),
+		webhookARNIndex:   make(map[string]map[string]string),
+		stageTransitions:  make(map[string]map[stageTransitionKey]*StageTransitionState),
+		executions:        make(map[string]map[string][]*PipelineExecution),
+		actionExecutions:  make(map[string]map[string][]*ActionExecution),
 		accountID:         accountID,
 		region:            region,
 		mu:                lockmetrics.New("codepipeline-" + region),
 	}
 }
 
-// Region returns the region for this backend instance.
+// The *Store helpers return the per-region inner map, lazily creating it.
+// Callers must hold b.mu.
+
+func (b *InMemoryBackend) pipelinesStore(region string) map[string]*Pipeline {
+	if b.pipelines[region] == nil {
+		b.pipelines[region] = make(map[string]*Pipeline)
+	}
+
+	return b.pipelines[region]
+}
+
+func (b *InMemoryBackend) pipelineARNIndexStore(region string) map[string]string {
+	if b.pipelineARNIndex[region] == nil {
+		b.pipelineARNIndex[region] = make(map[string]string)
+	}
+
+	return b.pipelineARNIndex[region]
+}
+
+func (b *InMemoryBackend) customActionTypesStore(region string) map[customActionTypeKey]*CustomActionType {
+	if b.customActionTypes[region] == nil {
+		b.customActionTypes[region] = make(map[customActionTypeKey]*CustomActionType)
+	}
+
+	return b.customActionTypes[region]
+}
+
+func (b *InMemoryBackend) jobsStore(region string) map[string]*Job {
+	if b.jobs[region] == nil {
+		b.jobs[region] = make(map[string]*Job)
+	}
+
+	return b.jobs[region]
+}
+
+func (b *InMemoryBackend) webhooksStore(region string) map[string]*Webhook {
+	if b.webhooks[region] == nil {
+		b.webhooks[region] = make(map[string]*Webhook)
+	}
+
+	return b.webhooks[region]
+}
+
+func (b *InMemoryBackend) webhookARNIndexStore(region string) map[string]string {
+	if b.webhookARNIndex[region] == nil {
+		b.webhookARNIndex[region] = make(map[string]string)
+	}
+
+	return b.webhookARNIndex[region]
+}
+
+func (b *InMemoryBackend) stageTransitionsStore(region string) map[stageTransitionKey]*StageTransitionState {
+	if b.stageTransitions[region] == nil {
+		b.stageTransitions[region] = make(map[stageTransitionKey]*StageTransitionState)
+	}
+
+	return b.stageTransitions[region]
+}
+
+func (b *InMemoryBackend) executionsStore(region string) map[string][]*PipelineExecution {
+	if b.executions[region] == nil {
+		b.executions[region] = make(map[string][]*PipelineExecution)
+	}
+
+	return b.executions[region]
+}
+
+func (b *InMemoryBackend) actionExecutionsStore(region string) map[string][]*ActionExecution {
+	if b.actionExecutions[region] == nil {
+		b.actionExecutions[region] = make(map[string][]*ActionExecution)
+	}
+
+	return b.actionExecutions[region]
+}
+
+// Region returns the default region for this backend instance.
 func (b *InMemoryBackend) Region() string { return b.region }
 
 // Reset clears all state in the backend, resetting it to a pristine empty state.
@@ -380,31 +478,39 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.pipelines = make(map[string]*Pipeline)
-	b.pipelineARNIndex = make(map[string]string)
-	b.customActionTypes = make(map[customActionTypeKey]*CustomActionType)
-	b.jobs = make(map[string]*Job)
-	b.webhooks = make(map[string]*Webhook)
-	b.webhookARNIndex = make(map[string]string)
-	b.stageTransitions = make(map[stageTransitionKey]*StageTransitionState)
-	b.executions = make(map[string][]*PipelineExecution)
-	b.actionExecutions = make(map[string][]*ActionExecution)
+	b.pipelines = make(map[string]map[string]*Pipeline)
+	b.pipelineARNIndex = make(map[string]map[string]string)
+	b.customActionTypes = make(map[string]map[customActionTypeKey]*CustomActionType)
+	b.jobs = make(map[string]map[string]*Job)
+	b.webhooks = make(map[string]map[string]*Webhook)
+	b.webhookARNIndex = make(map[string]map[string]string)
+	b.stageTransitions = make(map[string]map[stageTransitionKey]*StageTransitionState)
+	b.executions = make(map[string]map[string][]*PipelineExecution)
+	b.actionExecutions = make(map[string]map[string][]*ActionExecution)
 }
 
-func (b *InMemoryBackend) buildPipelineARN(name string) string {
-	return arn.Build("codepipeline", b.region, b.accountID, name)
+func (b *InMemoryBackend) buildPipelineARN(region, name string) string {
+	return arn.Build("codepipeline", region, b.accountID, name)
 }
 
-func (b *InMemoryBackend) buildWebhookARN(name string) string {
-	return arn.Build("codepipeline", b.region, b.accountID, "webhook:"+name)
+func (b *InMemoryBackend) buildWebhookARN(region, name string) string {
+	return arn.Build("codepipeline", region, b.accountID, "webhook:"+name)
 }
 
 // CreatePipeline creates a new CodePipeline pipeline.
-func (b *InMemoryBackend) CreatePipeline(decl PipelineDeclaration, tags map[string]string) (*Pipeline, error) {
+func (b *InMemoryBackend) CreatePipeline(
+	ctx context.Context,
+	decl PipelineDeclaration,
+	tags map[string]string,
+) (*Pipeline, error) {
 	b.mu.Lock("CreatePipeline")
 	defer b.mu.Unlock()
 
-	if _, exists := b.pipelines[decl.Name]; exists {
+	region := getRegion(ctx, b.region)
+	store := b.pipelinesStore(region)
+	arnIndex := b.pipelineARNIndexStore(region)
+
+	if _, exists := store[decl.Name]; exists {
 		return nil, fmt.Errorf("%w: pipeline %q already exists", ErrPipelineNameInUse, decl.Name)
 	}
 
@@ -427,24 +533,24 @@ func (b *InMemoryBackend) CreatePipeline(decl PipelineDeclaration, tags map[stri
 	p := &Pipeline{
 		Declaration: decl,
 		Metadata: PipelineMetadata{
-			PipelineArn: b.buildPipelineARN(decl.Name),
+			PipelineArn: b.buildPipelineARN(region, decl.Name),
 			Created:     now,
 			Updated:     now,
 		},
 		Tags: tagsCopy,
 	}
-	b.pipelines[decl.Name] = p
-	b.pipelineARNIndex[p.Metadata.PipelineArn] = decl.Name
+	store[decl.Name] = p
+	arnIndex[p.Metadata.PipelineArn] = decl.Name
 
 	return copyPipeline(p), nil
 }
 
 // GetPipeline returns the pipeline with the given name.
-func (b *InMemoryBackend) GetPipeline(name string) (*Pipeline, error) {
+func (b *InMemoryBackend) GetPipeline(ctx context.Context, name string) (*Pipeline, error) {
 	b.mu.RLock("GetPipeline")
 	defer b.mu.RUnlock()
 
-	p, ok := b.pipelines[name]
+	p, ok := b.pipelinesStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: pipeline %q", ErrNotFound, name)
 	}
@@ -454,11 +560,11 @@ func (b *InMemoryBackend) GetPipeline(name string) (*Pipeline, error) {
 
 // UpdatePipeline replaces the pipeline declaration.
 // If decl.Version is non-zero it must match the current version (optimistic concurrency).
-func (b *InMemoryBackend) UpdatePipeline(decl PipelineDeclaration) (*Pipeline, error) {
+func (b *InMemoryBackend) UpdatePipeline(ctx context.Context, decl PipelineDeclaration) (*Pipeline, error) {
 	b.mu.Lock("UpdatePipeline")
 	defer b.mu.Unlock()
 
-	p, ok := b.pipelines[decl.Name]
+	p, ok := b.pipelinesStore(getRegion(ctx, b.region))[decl.Name]
 	if !ok {
 		return nil, fmt.Errorf("%w: pipeline %q", ErrNotFound, decl.Name)
 	}
@@ -477,44 +583,50 @@ func (b *InMemoryBackend) UpdatePipeline(decl PipelineDeclaration) (*Pipeline, e
 }
 
 // DeletePipeline removes the pipeline with the given name and cleans up associated state.
-func (b *InMemoryBackend) DeletePipeline(name string) error {
+func (b *InMemoryBackend) DeletePipeline(ctx context.Context, name string) error {
 	b.mu.Lock("DeletePipeline")
 	defer b.mu.Unlock()
 
-	p, ok := b.pipelines[name]
+	region := getRegion(ctx, b.region)
+	store := b.pipelinesStore(region)
+
+	p, ok := store[name]
 	if !ok {
 		return fmt.Errorf("%w: pipeline %q", ErrNotFound, name)
 	}
 
-	delete(b.pipelineARNIndex, p.Metadata.PipelineArn)
-	delete(b.pipelines, name)
-	delete(b.executions, name)
+	delete(b.pipelineARNIndexStore(region), p.Metadata.PipelineArn)
+	delete(store, name)
+	delete(b.executionsStore(region), name)
 
 	// Cascade: remove disabled stage transitions for this pipeline.
-	for key := range b.stageTransitions {
+	transitions := b.stageTransitionsStore(region)
+	for key := range transitions {
 		if key.PipelineName == name {
-			delete(b.stageTransitions, key)
+			delete(transitions, key)
 		}
 	}
 
 	return nil
 }
 
-// ListPipelines returns a sorted summary of all pipelines.
-func (b *InMemoryBackend) ListPipelines() []PipelineSummary {
+// ListPipelines returns a sorted summary of all pipelines in the request region.
+func (b *InMemoryBackend) ListPipelines(ctx context.Context) []PipelineSummary {
 	b.mu.RLock("ListPipelines")
 	defer b.mu.RUnlock()
 
-	names := make([]string, 0, len(b.pipelines))
-	for name := range b.pipelines {
+	store := b.pipelinesStore(getRegion(ctx, b.region))
+
+	names := make([]string, 0, len(store))
+	for name := range store {
 		names = append(names, name)
 	}
 
 	sort.Strings(names)
 
-	summaries := make([]PipelineSummary, 0, len(b.pipelines))
+	summaries := make([]PipelineSummary, 0, len(store))
 	for _, name := range names {
-		p := b.pipelines[name]
+		p := store[name]
 		summaries = append(summaries, PipelineSummary{
 			Name:          p.Declaration.Name,
 			Version:       p.Declaration.Version,
@@ -529,14 +641,16 @@ func (b *InMemoryBackend) ListPipelines() []PipelineSummary {
 	return summaries
 }
 
-// resolveResourceARN looks up a resource by ARN, returning its type ("pipeline" or "webhook")
-// and name. Returns ErrResourceNotFound if ARN refers to a webhook, ErrNotFound if unknown.
-func (b *InMemoryBackend) resolveResourceARN(resourceARN string) (string, string, error) {
-	if n, ok := b.pipelineARNIndex[resourceARN]; ok {
+// resolveResourceARN looks up a resource by ARN within the given region, returning
+// its type ("pipeline" or "webhook") and name. The ARN's region segment is used
+// when present so callers cannot resolve resources outside their region. Returns
+// ErrNotFound if unknown. Callers must hold b.mu.
+func (b *InMemoryBackend) resolveResourceARN(region, resourceARN string) (string, string, error) {
+	if n, ok := b.pipelineARNIndexStore(region)[resourceARN]; ok {
 		return kindPipeline, n, nil
 	}
 
-	if n, ok := b.webhookARNIndex[resourceARN]; ok {
+	if n, ok := b.webhookARNIndexStore(region)[resourceARN]; ok {
 		return "webhook", n, nil
 	}
 
@@ -545,18 +659,20 @@ func (b *InMemoryBackend) resolveResourceARN(resourceARN string) (string, string
 
 // ListTagsForResource returns the sorted tags for a pipeline by ARN.
 // Returns ResourceNotFoundException when the ARN refers to a non-pipeline resource.
-func (b *InMemoryBackend) ListTagsForResource(resourceARN string) ([]Tag, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceARN string) ([]Tag, error) {
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	kind, name, err := b.resolveResourceARN(resourceARN)
+	region := getRegion(ctx, b.region)
+
+	kind, name, err := b.resolveResourceARN(region, resourceARN)
 	if err != nil {
 		return nil, err
 	}
 
 	switch kind {
 	case kindPipeline:
-		return tagsToSortedSlice(b.pipelines[name].Tags), nil
+		return tagsToSortedSlice(b.pipelinesStore(region)[name].Tags), nil
 	case "webhook":
 		// Webhooks support tagging but we don't store tags on them yet;
 		// return empty slice for now.
@@ -567,11 +683,13 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) ([]Tag, error)
 }
 
 // TagResource adds or updates tags on a pipeline by ARN.
-func (b *InMemoryBackend) TagResource(resourceARN string, tags []Tag) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceARN string, tags []Tag) error {
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	kind, name, err := b.resolveResourceARN(resourceARN)
+	region := getRegion(ctx, b.region)
+
+	kind, name, err := b.resolveResourceARN(region, resourceARN)
 	if err != nil {
 		return err
 	}
@@ -580,7 +698,7 @@ func (b *InMemoryBackend) TagResource(resourceARN string, tags []Tag) error {
 		return fmt.Errorf("%w: ARN %q is not a pipeline", ErrResourceNotFound, resourceARN)
 	}
 
-	p := b.pipelines[name]
+	p := b.pipelinesStore(region)[name]
 	if p.Tags == nil {
 		p.Tags = make(map[string]string)
 	}
@@ -593,11 +711,13 @@ func (b *InMemoryBackend) TagResource(resourceARN string, tags []Tag) error {
 }
 
 // UntagResource removes tags from a pipeline by ARN.
-func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error {
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	kind, name, err := b.resolveResourceARN(resourceARN)
+	region := getRegion(ctx, b.region)
+
+	kind, name, err := b.resolveResourceARN(region, resourceARN)
 	if err != nil {
 		return err
 	}
@@ -606,7 +726,7 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) er
 		return fmt.Errorf("%w: ARN %q is not a pipeline", ErrResourceNotFound, resourceARN)
 	}
 
-	p := b.pipelines[name]
+	p := b.pipelinesStore(region)[name]
 
 	for _, k := range tagKeys {
 		delete(p.Tags, k)
@@ -643,10 +763,13 @@ func tagsToSortedSlice(kv map[string]string) []Tag {
 	return tags
 }
 
-// AddPipelineInternal seeds a pipeline directly into the backend (for testing).
+// AddPipelineInternal seeds a pipeline directly into the backend's default region (for testing).
 func (b *InMemoryBackend) AddPipelineInternal(decl PipelineDeclaration, tags map[string]string) *Pipeline {
 	b.mu.Lock("AddPipelineInternal")
 	defer b.mu.Unlock()
+
+	store := b.pipelinesStore(b.region)
+	arnIndex := b.pipelineARNIndexStore(b.region)
 
 	tagsCopy := make(map[string]string, len(tags))
 	maps.Copy(tagsCopy, tags)
@@ -659,29 +782,30 @@ func (b *InMemoryBackend) AddPipelineInternal(decl PipelineDeclaration, tags map
 	p := &Pipeline{
 		Declaration: decl,
 		Metadata: PipelineMetadata{
-			PipelineArn: b.buildPipelineARN(decl.Name),
+			PipelineArn: b.buildPipelineARN(b.region, decl.Name),
 			Created:     now,
 			Updated:     now,
 		},
 		Tags: tagsCopy,
 	}
-	b.pipelines[decl.Name] = p
-	b.pipelineARNIndex[p.Metadata.PipelineArn] = decl.Name
+	store[decl.Name] = p
+	arnIndex[p.Metadata.PipelineArn] = decl.Name
 
 	return copyPipeline(p)
 }
 
-// AddCustomActionTypeInternal seeds a custom action type directly into the backend (for testing).
+// AddCustomActionTypeInternal seeds a custom action type into the backend's default region (for testing).
 func (b *InMemoryBackend) AddCustomActionTypeInternal(cat *CustomActionType) {
 	b.mu.Lock("AddCustomActionTypeInternal")
 	defer b.mu.Unlock()
 
 	key := customActionTypeKey{Category: cat.Category, Provider: cat.Provider, Version: cat.Version}
-	b.customActionTypes[key] = copyCustomActionType(cat)
+	b.customActionTypesStore(b.region)[key] = copyCustomActionType(cat)
 }
 
 // GetStageTransitionState returns the disabled state for a stage transition, or nil if enabled.
 func (b *InMemoryBackend) GetStageTransitionState(
+	ctx context.Context,
 	pipelineName, stageName, transitionType string,
 ) *StageTransitionState {
 	b.mu.RLock("GetStageTransitionState")
@@ -693,7 +817,7 @@ func (b *InMemoryBackend) GetStageTransitionState(
 		TransitionType: transitionType,
 	}
 
-	state, ok := b.stageTransitions[key]
+	state, ok := b.stageTransitionsStore(getRegion(ctx, b.region))[key]
 	if !ok {
 		return nil
 	}
@@ -706,41 +830,47 @@ func (b *InMemoryBackend) GetStageTransitionState(
 // --- Custom Action Type operations ---
 
 // CreateCustomActionType stores a new custom action type.
-func (b *InMemoryBackend) CreateCustomActionType(cat *CustomActionType) (*CustomActionType, error) {
+func (b *InMemoryBackend) CreateCustomActionType(
+	ctx context.Context,
+	cat *CustomActionType,
+) (*CustomActionType, error) {
 	b.mu.Lock("CreateCustomActionType")
 	defer b.mu.Unlock()
 
+	store := b.customActionTypesStore(getRegion(ctx, b.region))
 	key := customActionTypeKey{Category: cat.Category, Provider: cat.Provider, Version: cat.Version}
 
-	if _, exists := b.customActionTypes[key]; exists {
+	if _, exists := store[key]; exists {
 		return nil, fmt.Errorf("%w: custom action type %q/%q/%q already exists",
 			ErrAlreadyExists, cat.Category, cat.Provider, cat.Version)
 	}
 
 	if cat.Owner == "" {
-		cat.Owner = "Custom"
+		cat.Owner = keyOwnerCustom
 	}
 
 	cp := copyCustomActionType(cat)
-	b.customActionTypes[key] = cp
+	store[key] = cp
 
 	return copyCustomActionType(cp), nil
 }
 
 // DeleteCustomActionType removes a custom action type.
 // Returns ResourceInUseException if any pipeline references the type.
-func (b *InMemoryBackend) DeleteCustomActionType(category, provider, version string) error {
+func (b *InMemoryBackend) DeleteCustomActionType(ctx context.Context, category, provider, version string) error {
 	b.mu.Lock("DeleteCustomActionType")
 	defer b.mu.Unlock()
 
+	region := getRegion(ctx, b.region)
+	store := b.customActionTypesStore(region)
 	key := customActionTypeKey{Category: category, Provider: provider, Version: version}
 
-	if _, ok := b.customActionTypes[key]; !ok {
+	if _, ok := store[key]; !ok {
 		return fmt.Errorf("%w: custom action type %q/%q/%q", ErrActionTypeNotFound, category, provider, version)
 	}
 
 	// Check that no pipeline references this action type.
-	for pName, p := range b.pipelines {
+	for pName, p := range b.pipelinesStore(region) {
 		for _, stage := range p.Declaration.Stages {
 			for _, action := range stage.Actions {
 				at := action.ActionTypeID
@@ -752,19 +882,22 @@ func (b *InMemoryBackend) DeleteCustomActionType(category, provider, version str
 		}
 	}
 
-	delete(b.customActionTypes, key)
+	delete(store, key)
 
 	return nil
 }
 
 // GetActionType retrieves a custom action type.
-func (b *InMemoryBackend) GetActionType(category, owner, provider, version string) (*CustomActionType, error) {
+func (b *InMemoryBackend) GetActionType(
+	ctx context.Context,
+	category, owner, provider, version string,
+) (*CustomActionType, error) {
 	b.mu.RLock("GetActionType")
 	defer b.mu.RUnlock()
 
 	key := customActionTypeKey{Category: category, Provider: provider, Version: version}
 
-	cat, ok := b.customActionTypes[key]
+	cat, ok := b.customActionTypesStore(getRegion(ctx, b.region))[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: action type %q/%q/%q/%q", ErrActionTypeNotFound, category, owner, provider, version)
 	}
@@ -776,11 +909,11 @@ func (b *InMemoryBackend) GetActionType(category, owner, provider, version strin
 
 // AcknowledgeJob acknowledges that a job worker has received a job.
 // Returns InProgress if Nonce matches; otherwise returns current status unchanged.
-func (b *InMemoryBackend) AcknowledgeJob(jobID, nonce string) (string, error) {
+func (b *InMemoryBackend) AcknowledgeJob(ctx context.Context, jobID, nonce string) (string, error) {
 	b.mu.Lock("AcknowledgeJob")
 	defer b.mu.Unlock()
 
-	job, ok := b.jobs[jobID]
+	job, ok := b.jobsStore(getRegion(ctx, b.region))[jobID]
 	if !ok {
 		return "", fmt.Errorf("%w: job %q", ErrJobNotFound, jobID)
 	}
@@ -793,11 +926,14 @@ func (b *InMemoryBackend) AcknowledgeJob(jobID, nonce string) (string, error) {
 }
 
 // AcknowledgeThirdPartyJob acknowledges that a third-party job worker has received a job.
-func (b *InMemoryBackend) AcknowledgeThirdPartyJob(jobID, nonce, clientToken string) (string, error) {
+func (b *InMemoryBackend) AcknowledgeThirdPartyJob(
+	ctx context.Context,
+	jobID, nonce, clientToken string,
+) (string, error) {
 	b.mu.Lock("AcknowledgeThirdPartyJob")
 	defer b.mu.Unlock()
 
-	job, ok := b.jobs[jobID]
+	job, ok := b.jobsStore(getRegion(ctx, b.region))[jobID]
 	if !ok {
 		return "", fmt.Errorf("%w: third-party job %q with client token %q", ErrJobNotFound, jobID, clientToken)
 	}
@@ -810,11 +946,11 @@ func (b *InMemoryBackend) AcknowledgeThirdPartyJob(jobID, nonce, clientToken str
 }
 
 // GetJobDetails returns details for a job by ID.
-func (b *InMemoryBackend) GetJobDetails(jobID string) (*Job, error) {
+func (b *InMemoryBackend) GetJobDetails(ctx context.Context, jobID string) (*Job, error) {
 	b.mu.RLock("GetJobDetails")
 	defer b.mu.RUnlock()
 
-	job, ok := b.jobs[jobID]
+	job, ok := b.jobsStore(getRegion(ctx, b.region))[jobID]
 	if !ok {
 		return nil, fmt.Errorf("%w: job %q", ErrJobNotFound, jobID)
 	}
@@ -824,66 +960,74 @@ func (b *InMemoryBackend) GetJobDetails(jobID string) (*Job, error) {
 	return &cp, nil
 }
 
-// AddJobInternal seeds a job directly into the backend (for testing).
+// AddJobInternal seeds a job into the backend's default region (for testing).
 func (b *InMemoryBackend) AddJobInternal(job *Job) {
 	b.mu.Lock("AddJobInternal")
 	defer b.mu.Unlock()
 
 	cp := *job
-	b.jobs[cp.ID] = &cp
+	b.jobsStore(b.region)[cp.ID] = &cp
 }
 
 // --- Webhook operations ---
 
 // DeleteWebhook removes a webhook by name (idempotent).
-func (b *InMemoryBackend) DeleteWebhook(name string) error {
+func (b *InMemoryBackend) DeleteWebhook(ctx context.Context, name string) error {
 	b.mu.Lock("DeleteWebhook")
 	defer b.mu.Unlock()
 
-	if wh, ok := b.webhooks[name]; ok {
-		delete(b.webhookARNIndex, wh.ARN)
+	region := getRegion(ctx, b.region)
+	store := b.webhooksStore(region)
+
+	if wh, ok := store[name]; ok {
+		delete(b.webhookARNIndexStore(region), wh.ARN)
 	}
 
-	delete(b.webhooks, name)
+	delete(store, name)
 
 	return nil
 }
 
 // DeregisterWebhookWithThirdParty clears the third-party registration flag on a webhook.
-func (b *InMemoryBackend) DeregisterWebhookWithThirdParty(name string) error {
+func (b *InMemoryBackend) DeregisterWebhookWithThirdParty(ctx context.Context, name string) error {
 	b.mu.Lock("DeregisterWebhookWithThirdParty")
 	defer b.mu.Unlock()
 
-	if wh, ok := b.webhooks[name]; ok {
+	if wh, ok := b.webhooksStore(getRegion(ctx, b.region))[name]; ok {
 		wh.RegisteredWithThirdParty = false
 	}
 
 	return nil
 }
 
-// AddWebhookInternal seeds a webhook directly into the backend (for testing).
+// AddWebhookInternal seeds a webhook into the backend's default region (for testing).
 func (b *InMemoryBackend) AddWebhookInternal(wh *Webhook) {
 	b.mu.Lock("AddWebhookInternal")
 	defer b.mu.Unlock()
 
 	cp := *wh
 	if cp.ARN == "" {
-		cp.ARN = b.buildWebhookARN(cp.Name)
+		cp.ARN = b.buildWebhookARN(b.region, cp.Name)
 	}
 
-	b.webhooks[cp.Name] = &cp
-	b.webhookARNIndex[cp.ARN] = cp.Name
+	b.webhooksStore(b.region)[cp.Name] = &cp
+	b.webhookARNIndexStore(b.region)[cp.ARN] = cp.Name
 }
 
 // --- Stage transition operations ---
 
 // DisableStageTransition disables a stage transition and records the reason.
 // Returns StageNotFoundException if stageName does not exist in the pipeline.
-func (b *InMemoryBackend) DisableStageTransition(pipelineName, stageName, transitionType, reason string) error {
+func (b *InMemoryBackend) DisableStageTransition(
+	ctx context.Context,
+	pipelineName, stageName, transitionType, reason string,
+) error {
 	b.mu.Lock("DisableStageTransition")
 	defer b.mu.Unlock()
 
-	p, ok := b.pipelines[pipelineName]
+	region := getRegion(ctx, b.region)
+
+	p, ok := b.pipelinesStore(region)[pipelineName]
 	if !ok {
 		return fmt.Errorf("%w: pipeline %q", ErrNotFound, pipelineName)
 	}
@@ -893,7 +1037,7 @@ func (b *InMemoryBackend) DisableStageTransition(pipelineName, stageName, transi
 	}
 
 	key := stageTransitionKey{PipelineName: pipelineName, StageName: stageName, TransitionType: transitionType}
-	b.stageTransitions[key] = &StageTransitionState{
+	b.stageTransitionsStore(region)[key] = &StageTransitionState{
 		PipelineName:   pipelineName,
 		StageName:      stageName,
 		TransitionType: transitionType,
@@ -905,16 +1049,21 @@ func (b *InMemoryBackend) DisableStageTransition(pipelineName, stageName, transi
 }
 
 // EnableStageTransition re-enables a stage transition.
-func (b *InMemoryBackend) EnableStageTransition(pipelineName, stageName, transitionType string) error {
+func (b *InMemoryBackend) EnableStageTransition(
+	ctx context.Context,
+	pipelineName, stageName, transitionType string,
+) error {
 	b.mu.Lock("EnableStageTransition")
 	defer b.mu.Unlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	region := getRegion(ctx, b.region)
+
+	if _, ok := b.pipelinesStore(region)[pipelineName]; !ok {
 		return fmt.Errorf("%w: pipeline %q", ErrNotFound, pipelineName)
 	}
 
 	key := stageTransitionKey{PipelineName: pipelineName, StageName: stageName, TransitionType: transitionType}
-	delete(b.stageTransitions, key)
+	delete(b.stageTransitionsStore(region), key)
 
 	return nil
 }
@@ -1074,11 +1223,13 @@ type PipelineExecution struct {
 }
 
 // StartPipelineExecution starts and stores a new execution of a pipeline.
-func (b *InMemoryBackend) StartPipelineExecution(pipelineName string) (*PipelineExecution, error) {
+func (b *InMemoryBackend) StartPipelineExecution(ctx context.Context, pipelineName string) (*PipelineExecution, error) {
 	b.mu.Lock("StartPipelineExecution")
 	defer b.mu.Unlock()
 
-	p, ok := b.pipelines[pipelineName]
+	region := getRegion(ctx, b.region)
+
+	p, ok := b.pipelinesStore(region)[pipelineName]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1090,11 +1241,14 @@ func (b *InMemoryBackend) StartPipelineExecution(pipelineName string) (*Pipeline
 		PipelineVersion:     p.Declaration.Version,
 	}
 
-	b.executions[pipelineName] = append(b.executions[pipelineName], exec)
+	execs := b.executionsStore(region)
+	execs[pipelineName] = append(execs[pipelineName], exec)
 
 	// Record an action execution for every action in the pipeline so that
 	// ListActionExecutions reflects the work performed by this execution.
 	now := time.Now().UTC()
+
+	actionExecs := b.actionExecutionsStore(region)
 
 	for _, stage := range p.Declaration.Stages {
 		for _, action := range stage.Actions {
@@ -1107,7 +1261,7 @@ func (b *InMemoryBackend) StartPipelineExecution(pipelineName string) (*Pipeline
 				StartTime:           now,
 				LastUpdateTime:      now,
 			}
-			b.actionExecutions[pipelineName] = append(b.actionExecutions[pipelineName], ae)
+			actionExecs[pipelineName] = append(actionExecs[pipelineName], ae)
 		}
 	}
 
@@ -1117,15 +1271,20 @@ func (b *InMemoryBackend) StartPipelineExecution(pipelineName string) (*Pipeline
 }
 
 // GetPipelineExecution returns the stored execution by pipeline name and execution ID.
-func (b *InMemoryBackend) GetPipelineExecution(pipelineName, executionID string) (*PipelineExecution, error) {
+func (b *InMemoryBackend) GetPipelineExecution(
+	ctx context.Context,
+	pipelineName, executionID string,
+) (*PipelineExecution, error) {
 	b.mu.RLock("GetPipelineExecution")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	region := getRegion(ctx, b.region)
+
+	if _, ok := b.pipelinesStore(region)[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
-	for _, exec := range b.executions[pipelineName] {
+	for _, exec := range b.executionsStore(region)[pipelineName] {
 		if exec.PipelineExecutionID == executionID {
 			cp := *exec
 
@@ -1142,17 +1301,22 @@ func (b *InMemoryBackend) GetPipelineExecution(pipelineName, executionID string)
 }
 
 // StopPipelineExecution stops an in-progress pipeline execution.
-func (b *InMemoryBackend) StopPipelineExecution(pipelineName, executionID, reason string) (*PipelineExecution, error) {
+func (b *InMemoryBackend) StopPipelineExecution(
+	ctx context.Context,
+	pipelineName, executionID, reason string,
+) (*PipelineExecution, error) {
 	b.mu.Lock("StopPipelineExecution")
 	defer b.mu.Unlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	region := getRegion(ctx, b.region)
+
+	if _, ok := b.pipelinesStore(region)[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
 	_ = reason
 
-	for _, exec := range b.executions[pipelineName] {
+	for _, exec := range b.executionsStore(region)[pipelineName] {
 		if exec.PipelineExecutionID == executionID {
 			exec.Status = "Stopping"
 			cp := *exec
@@ -1169,15 +1333,20 @@ func (b *InMemoryBackend) StopPipelineExecution(pipelineName, executionID, reaso
 }
 
 // ListPipelineExecutions returns stored executions for a pipeline, most recent first.
-func (b *InMemoryBackend) ListPipelineExecutions(pipelineName string) ([]PipelineExecution, error) {
+func (b *InMemoryBackend) ListPipelineExecutions(
+	ctx context.Context,
+	pipelineName string,
+) ([]PipelineExecution, error) {
 	b.mu.RLock("ListPipelineExecutions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	region := getRegion(ctx, b.region)
+
+	if _, ok := b.pipelinesStore(region)[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
-	stored := b.executions[pipelineName]
+	stored := b.executionsStore(region)[pipelineName]
 	out := make([]PipelineExecution, len(stored))
 
 	// Return in reverse order (most recent first).
@@ -1197,14 +1366,18 @@ type StageState struct {
 }
 
 // GetPipelineState returns the current state of each stage in a pipeline.
-func (b *InMemoryBackend) GetPipelineState(pipelineName string) ([]StageState, error) {
+func (b *InMemoryBackend) GetPipelineState(ctx context.Context, pipelineName string) ([]StageState, error) {
 	b.mu.RLock("GetPipelineState")
 	defer b.mu.RUnlock()
 
-	p, ok := b.pipelines[pipelineName]
+	region := getRegion(ctx, b.region)
+
+	p, ok := b.pipelinesStore(region)[pipelineName]
 	if !ok {
 		return nil, ErrNotFound
 	}
+
+	transitions := b.stageTransitionsStore(region)
 
 	states := make([]StageState, len(p.Declaration.Stages))
 	for i, stage := range p.Declaration.Stages {
@@ -1216,12 +1389,12 @@ func (b *InMemoryBackend) GetPipelineState(pipelineName string) ([]StageState, e
 		}
 
 		var inState, outState *StageTransitionState
-		if ts, found := b.stageTransitions[inKey]; found {
+		if ts, found := transitions[inKey]; found {
 			tsCopy := *ts
 			inState = &tsCopy
 		}
 
-		if ts, found := b.stageTransitions[outKey]; found {
+		if ts, found := transitions[outKey]; found {
 			tsCopy := *ts
 			outState = &tsCopy
 		}
@@ -1245,11 +1418,14 @@ func (b *InMemoryBackend) GetPipelineState(pipelineName string) ([]StageState, e
 }
 
 // RetryStageExecution retries a failed stage in a pipeline.
-func (b *InMemoryBackend) RetryStageExecution(pipelineName, stageName, executionID string) (*PipelineExecution, error) {
+func (b *InMemoryBackend) RetryStageExecution(
+	ctx context.Context,
+	pipelineName, stageName, executionID string,
+) (*PipelineExecution, error) {
 	b.mu.RLock("RetryStageExecution")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
@@ -1263,11 +1439,14 @@ func (b *InMemoryBackend) RetryStageExecution(pipelineName, stageName, execution
 }
 
 // RollbackStage rolls back a stage to a previous successful execution.
-func (b *InMemoryBackend) RollbackStage(pipelineName, stageName, targetExecutionID string) (*PipelineExecution, error) {
+func (b *InMemoryBackend) RollbackStage(
+	ctx context.Context,
+	pipelineName, stageName, targetExecutionID string,
+) (*PipelineExecution, error) {
 	b.mu.RLock("RollbackStage")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
@@ -1282,11 +1461,14 @@ func (b *InMemoryBackend) RollbackStage(pipelineName, stageName, targetExecution
 }
 
 // OverrideStageCondition overrides a stage condition.
-func (b *InMemoryBackend) OverrideStageCondition(pipelineName, stageName, executionID string) error {
+func (b *InMemoryBackend) OverrideStageCondition(
+	ctx context.Context,
+	pipelineName, stageName, executionID string,
+) error {
 	b.mu.RLock("OverrideStageCondition")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return ErrNotFound
 	}
 
@@ -1296,13 +1478,15 @@ func (b *InMemoryBackend) OverrideStageCondition(pipelineName, stageName, execut
 	return nil
 }
 
-// ListWebhooks returns all webhooks in the backend, sorted by name.
-func (b *InMemoryBackend) ListWebhooks() []*Webhook {
+// ListWebhooks returns all webhooks in the request region, sorted by name.
+func (b *InMemoryBackend) ListWebhooks(ctx context.Context) []*Webhook {
 	b.mu.RLock("ListWebhooks")
 	defer b.mu.RUnlock()
 
-	result := make([]*Webhook, 0, len(b.webhooks))
-	for _, wh := range b.webhooks {
+	store := b.webhooksStore(getRegion(ctx, b.region))
+
+	result := make([]*Webhook, 0, len(store))
+	for _, wh := range store {
 		cp := *wh
 		result = append(result, &cp)
 	}
@@ -1315,22 +1499,25 @@ func (b *InMemoryBackend) ListWebhooks() []*Webhook {
 }
 
 // PutWebhook creates or updates a webhook with full definition fields.
-func (b *InMemoryBackend) PutWebhook(wh *Webhook) (*Webhook, error) {
+func (b *InMemoryBackend) PutWebhook(ctx context.Context, wh *Webhook) (*Webhook, error) {
 	b.mu.Lock("PutWebhook")
 	defer b.mu.Unlock()
 
-	cp := *wh
-	cp.ARN = b.buildWebhookARN(wh.Name)
-	cp.URL = fmt.Sprintf("https://webhooks.%s.codepipeline.aws.a2z.com/trigger?t=%s",
-		b.region, uuid.NewString())
+	region := getRegion(ctx, b.region)
+	store := b.webhooksStore(region)
 
-	if existing, ok := b.webhooks[wh.Name]; ok {
+	cp := *wh
+	cp.ARN = b.buildWebhookARN(region, wh.Name)
+	cp.URL = fmt.Sprintf("https://webhooks.%s.codepipeline.aws.a2z.com/trigger?t=%s",
+		region, uuid.NewString())
+
+	if existing, ok := store[wh.Name]; ok {
 		// Preserve URL on update.
 		cp.URL = existing.URL
 	}
 
-	b.webhooks[cp.Name] = &cp
-	b.webhookARNIndex[cp.ARN] = cp.Name
+	store[cp.Name] = &cp
+	b.webhookARNIndexStore(region)[cp.ARN] = cp.Name
 
 	result := cp
 
@@ -1338,11 +1525,11 @@ func (b *InMemoryBackend) PutWebhook(wh *Webhook) (*Webhook, error) {
 }
 
 // RegisterWebhookWithThirdParty registers a webhook with a third-party provider.
-func (b *InMemoryBackend) RegisterWebhookWithThirdParty(name string) error {
+func (b *InMemoryBackend) RegisterWebhookWithThirdParty(ctx context.Context, name string) error {
 	b.mu.Lock("RegisterWebhookWithThirdParty")
 	defer b.mu.Unlock()
 
-	wh, ok := b.webhooks[name]
+	wh, ok := b.webhooksStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return ErrWebhookNotFound
 	}
@@ -1353,13 +1540,15 @@ func (b *InMemoryBackend) RegisterWebhookWithThirdParty(name string) error {
 }
 
 // PollForJobs returns available queued jobs matching the given ActionTypeID.
-func (b *InMemoryBackend) PollForJobs(category, owner, provider, version string) ([]*Job, error) {
+func (b *InMemoryBackend) PollForJobs(ctx context.Context, category, owner, provider, version string) ([]*Job, error) {
 	b.mu.RLock("PollForJobs")
 	defer b.mu.RUnlock()
 
-	result := make([]*Job, 0, len(b.jobs))
+	store := b.jobsStore(getRegion(ctx, b.region))
 
-	for _, job := range b.jobs {
+	result := make([]*Job, 0, len(store))
+
+	for _, job := range store {
 		if job.Status != "Queued" {
 			continue
 		}
@@ -1385,16 +1574,19 @@ func (b *InMemoryBackend) PollForJobs(category, owner, provider, version string)
 }
 
 // PollForThirdPartyJobs returns available third-party jobs.
-func (b *InMemoryBackend) PollForThirdPartyJobs(category, provider, version string) ([]*Job, error) {
-	return b.PollForJobs(category, "ThirdParty", provider, version)
+func (b *InMemoryBackend) PollForThirdPartyJobs(
+	ctx context.Context,
+	category, provider, version string,
+) ([]*Job, error) {
+	return b.PollForJobs(ctx, category, "ThirdParty", provider, version)
 }
 
 // GetThirdPartyJobDetails returns details for a third-party job.
-func (b *InMemoryBackend) GetThirdPartyJobDetails(jobID, clientToken string) (*Job, error) {
+func (b *InMemoryBackend) GetThirdPartyJobDetails(ctx context.Context, jobID, clientToken string) (*Job, error) {
 	b.mu.RLock("GetThirdPartyJobDetails")
 	defer b.mu.RUnlock()
 
-	job, ok := b.jobs[jobID]
+	job, ok := b.jobsStore(getRegion(ctx, b.region))[jobID]
 	if !ok {
 		return nil, ErrJobNotFound
 	}
@@ -1407,11 +1599,11 @@ func (b *InMemoryBackend) GetThirdPartyJobDetails(jobID, clientToken string) (*J
 }
 
 // PutJobSuccessResult acknowledges job success.
-func (b *InMemoryBackend) PutJobSuccessResult(jobID string) error {
+func (b *InMemoryBackend) PutJobSuccessResult(ctx context.Context, jobID string) error {
 	b.mu.Lock("PutJobSuccessResult")
 	defer b.mu.Unlock()
 
-	job, ok := b.jobs[jobID]
+	job, ok := b.jobsStore(getRegion(ctx, b.region))[jobID]
 	if !ok {
 		return ErrJobNotFound
 	}
@@ -1422,11 +1614,11 @@ func (b *InMemoryBackend) PutJobSuccessResult(jobID string) error {
 }
 
 // PutJobFailureResult acknowledges job failure.
-func (b *InMemoryBackend) PutJobFailureResult(jobID, message string) error {
+func (b *InMemoryBackend) PutJobFailureResult(ctx context.Context, jobID, message string) error {
 	b.mu.Lock("PutJobFailureResult")
 	defer b.mu.Unlock()
 
-	job, ok := b.jobs[jobID]
+	job, ok := b.jobsStore(getRegion(ctx, b.region))[jobID]
 	if !ok {
 		return ErrJobNotFound
 	}
@@ -1438,21 +1630,21 @@ func (b *InMemoryBackend) PutJobFailureResult(jobID, message string) error {
 }
 
 // PutThirdPartyJobSuccessResult acknowledges third-party job success.
-func (b *InMemoryBackend) PutThirdPartyJobSuccessResult(jobID, _ string) error {
-	return b.PutJobSuccessResult(jobID)
+func (b *InMemoryBackend) PutThirdPartyJobSuccessResult(ctx context.Context, jobID, _ string) error {
+	return b.PutJobSuccessResult(ctx, jobID)
 }
 
 // PutThirdPartyJobFailureResult acknowledges third-party job failure.
-func (b *InMemoryBackend) PutThirdPartyJobFailureResult(jobID, _, message string) error {
-	return b.PutJobFailureResult(jobID, message)
+func (b *InMemoryBackend) PutThirdPartyJobFailureResult(ctx context.Context, jobID, _, message string) error {
+	return b.PutJobFailureResult(ctx, jobID, message)
 }
 
 // PutActionRevision puts an action revision for a pipeline source action.
-func (b *InMemoryBackend) PutActionRevision(pipelineName, stageName, actionName string) error {
+func (b *InMemoryBackend) PutActionRevision(ctx context.Context, pipelineName, stageName, actionName string) error {
 	b.mu.RLock("PutActionRevision")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return ErrNotFound
 	}
 
@@ -1463,11 +1655,14 @@ func (b *InMemoryBackend) PutActionRevision(pipelineName, stageName, actionName 
 }
 
 // PutApprovalResult submits a manual approval for a pipeline action.
-func (b *InMemoryBackend) PutApprovalResult(pipelineName, stageName, actionName, status, summary string) error {
+func (b *InMemoryBackend) PutApprovalResult(
+	ctx context.Context,
+	pipelineName, stageName, actionName, status, summary string,
+) error {
 	b.mu.RLock("PutApprovalResult")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return ErrNotFound
 	}
 
@@ -1480,34 +1675,37 @@ func (b *InMemoryBackend) PutApprovalResult(pipelineName, stageName, actionName,
 }
 
 // UpdateActionType updates an action type definition with full fields.
-func (b *InMemoryBackend) UpdateActionType(cat *CustomActionType) error {
+func (b *InMemoryBackend) UpdateActionType(ctx context.Context, cat *CustomActionType) error {
 	b.mu.Lock("UpdateActionType")
 	defer b.mu.Unlock()
 
+	store := b.customActionTypesStore(getRegion(ctx, b.region))
 	key := customActionTypeKey{
 		Category: cat.Category,
 		Provider: cat.Provider,
 		Version:  cat.Version,
 	}
 
-	if _, ok := b.customActionTypes[key]; !ok {
+	if _, ok := store[key]; !ok {
 		return ErrActionTypeNotFound
 	}
 
 	cp := copyCustomActionType(cat)
-	b.customActionTypes[key] = cp
+	store[key] = cp
 
 	return nil
 }
 
-// ListActionTypes returns all registered action types.
-func (b *InMemoryBackend) ListActionTypes() []*CustomActionType {
+// ListActionTypes returns all registered action types in the request region.
+func (b *InMemoryBackend) ListActionTypes(ctx context.Context) []*CustomActionType {
 	b.mu.RLock("ListActionTypes")
 	defer b.mu.RUnlock()
 
-	result := make([]*CustomActionType, 0, len(b.customActionTypes))
+	store := b.customActionTypesStore(getRegion(ctx, b.region))
 
-	for _, cat := range b.customActionTypes {
+	result := make([]*CustomActionType, 0, len(store))
+
+	for _, cat := range store {
 		result = append(result, copyCustomActionType(cat))
 	}
 
@@ -1532,16 +1730,19 @@ type ActionExecution struct {
 // ListActionExecutions returns the recorded action executions for a pipeline,
 // most recent first. An optional pipelineExecutionId filters to a single run.
 func (b *InMemoryBackend) ListActionExecutions(
+	ctx context.Context,
 	pipelineName, pipelineExecutionID string,
 ) ([]map[string]any, error) {
 	b.mu.RLock("ListActionExecutions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	region := getRegion(ctx, b.region)
+
+	if _, ok := b.pipelinesStore(region)[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
-	stored := b.actionExecutions[pipelineName]
+	stored := b.actionExecutionsStore(region)[pipelineName]
 	out := make([]map[string]any, 0, len(stored))
 
 	// Iterate in reverse so the most recent execution appears first.
@@ -1567,11 +1768,11 @@ func (b *InMemoryBackend) ListActionExecutions(
 // ListRuleExecutions returns rule executions for a pipeline. The emulator does
 // not run condition rules, so this returns an empty (but valid) list for a known
 // pipeline and ErrNotFound otherwise.
-func (b *InMemoryBackend) ListRuleExecutions(pipelineName string) ([]map[string]any, error) {
+func (b *InMemoryBackend) ListRuleExecutions(ctx context.Context, pipelineName string) ([]map[string]any, error) {
 	b.mu.RLock("ListRuleExecutions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 
@@ -1603,12 +1804,13 @@ func (b *InMemoryBackend) ListRuleTypes() []map[string]any {
 // execution. The emulator does not model deployment targets, so it returns an
 // empty (but valid) list for a known pipeline and ErrNotFound otherwise.
 func (b *InMemoryBackend) ListDeployActionExecutionTargets(
+	ctx context.Context,
 	pipelineName, executionID string,
 ) ([]map[string]any, error) {
 	b.mu.RLock("ListDeployActionExecutionTargets")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.pipelines[pipelineName]; !ok {
+	if _, ok := b.pipelinesStore(getRegion(ctx, b.region))[pipelineName]; !ok {
 		return nil, ErrNotFound
 	}
 

--- a/services/codepipeline/codepipeline_coverage_test.go
+++ b/services/codepipeline/codepipeline_coverage_test.go
@@ -1,6 +1,7 @@
 package codepipeline_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -257,7 +258,7 @@ func TestHandler_JobOperations(t *testing.T) {
 		Version:  "1",
 	}
 
-	_, err := h.Backend.CreateCustomActionType(cat)
+	_, err := h.Backend.CreateCustomActionType(context.Background(), cat)
 	require.NoError(t, err)
 
 	job := &codepipeline.Job{
@@ -462,7 +463,7 @@ func TestHandler_ActionTypeOperations(t *testing.T) {
 		Provider: "MyCIProvider",
 		Version:  "1",
 	}
-	_, err := h.Backend.CreateCustomActionType(cat)
+	_, err := h.Backend.CreateCustomActionType(context.Background(), cat)
 	require.NoError(t, err)
 
 	// List action types
@@ -562,7 +563,7 @@ func TestCPBackend_PersistenceString(t *testing.T) {
 	t.Parallel()
 
 	b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreatePipeline(samplePipeline("snap-pipe"), nil)
+	_, err := b.CreatePipeline(context.Background(), samplePipeline("snap-pipe"), nil)
 	require.NoError(t, err)
 
 	snap := b.Snapshot()

--- a/services/codepipeline/export_test.go
+++ b/services/codepipeline/export_test.go
@@ -1,46 +1,71 @@
 package codepipeline
 
-// PipelineCount returns the number of pipelines stored in the backend.
+// PipelineCount returns the total number of pipelines stored across all regions.
 // Used only in tests.
 func (b *InMemoryBackend) PipelineCount() int {
 	b.mu.RLock("PipelineCount")
 	defer b.mu.RUnlock()
 
-	return len(b.pipelines)
+	total := 0
+	for _, regionMap := range b.pipelines {
+		total += len(regionMap)
+	}
+
+	return total
 }
 
-// CustomActionTypeCount returns the number of custom action types stored in the backend.
+// CustomActionTypeCount returns the total number of custom action types stored across all regions.
 // Used only in tests.
 func (b *InMemoryBackend) CustomActionTypeCount() int {
 	b.mu.RLock("CustomActionTypeCount")
 	defer b.mu.RUnlock()
 
-	return len(b.customActionTypes)
+	total := 0
+	for _, regionMap := range b.customActionTypes {
+		total += len(regionMap)
+	}
+
+	return total
 }
 
-// JobCount returns the number of jobs stored in the backend.
+// JobCount returns the total number of jobs stored across all regions.
 // Used only in tests.
 func (b *InMemoryBackend) JobCount() int {
 	b.mu.RLock("JobCount")
 	defer b.mu.RUnlock()
 
-	return len(b.jobs)
+	total := 0
+	for _, regionMap := range b.jobs {
+		total += len(regionMap)
+	}
+
+	return total
 }
 
-// WebhookCount returns the number of webhooks stored in the backend.
+// WebhookCount returns the total number of webhooks stored across all regions.
 // Used only in tests.
 func (b *InMemoryBackend) WebhookCount() int {
 	b.mu.RLock("WebhookCount")
 	defer b.mu.RUnlock()
 
-	return len(b.webhooks)
+	total := 0
+	for _, regionMap := range b.webhooks {
+		total += len(regionMap)
+	}
+
+	return total
 }
 
-// StageTransitionCount returns the number of disabled stage transitions stored in the backend.
+// StageTransitionCount returns the total number of disabled stage transitions stored across all regions.
 // Used only in tests.
 func (b *InMemoryBackend) StageTransitionCount() int {
 	b.mu.RLock("StageTransitionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.stageTransitions)
+	total := 0
+	for _, regionMap := range b.stageTransitions {
+		total += len(regionMap)
+	}
+
+	return total
 }

--- a/services/codepipeline/handler.go
+++ b/services/codepipeline/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
 	"github.com/blackbirdworks/gopherstack/pkgs/service"
 )
@@ -158,11 +159,17 @@ func (h *Handler) ExtractResource(_ *echo.Context) string {
 // Handler returns the Echo handler function for CodePipeline requests.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		// Resolve the per-request region (from SigV4 / X-Amz-Region) and attach
+		// it to the context so backend operations are region-scoped.
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
 		return service.HandleTarget(
 			c, logger.Load(c.Request().Context()),
 			"CodePipeline", "application/x-amz-json-1.1",
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(ctx context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(context.WithValue(ctx, regionContextKey{}, region), action, body)
+			},
 			h.handleError,
 		)
 	}
@@ -293,7 +300,7 @@ type createPipelineOutput struct {
 }
 
 func (h *Handler) handleCreatePipeline(
-	_ context.Context,
+	ctx context.Context,
 	in *createPipelineInput,
 ) (*createPipelineOutput, error) {
 	if in.Pipeline == nil {
@@ -326,7 +333,7 @@ func (h *Handler) handleCreatePipeline(
 
 	tagMap := tagsToMap(in.Tags)
 
-	p, err := h.Backend.CreatePipeline(*in.Pipeline, tagMap)
+	p, err := h.Backend.CreatePipeline(ctx, *in.Pipeline, tagMap)
 	if err != nil {
 		return nil, err
 	}
@@ -348,14 +355,14 @@ type getPipelineOutput struct {
 }
 
 func (h *Handler) handleGetPipeline(
-	_ context.Context,
+	ctx context.Context,
 	in *getPipelineInput,
 ) (*getPipelineOutput, error) {
 	if in.Name == "" {
 		return nil, fmt.Errorf("%w: name is required", errInvalidRequest)
 	}
 
-	p, err := h.Backend.GetPipeline(in.Name)
+	p, err := h.Backend.GetPipeline(ctx, in.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +387,7 @@ type updatePipelineOutput struct {
 }
 
 func (h *Handler) handleUpdatePipeline(
-	_ context.Context,
+	ctx context.Context,
 	in *updatePipelineInput,
 ) (*updatePipelineOutput, error) {
 	if in.Pipeline == nil {
@@ -391,7 +398,7 @@ func (h *Handler) handleUpdatePipeline(
 		return nil, fmt.Errorf("%w: pipeline name is required", errInvalidRequest)
 	}
 
-	p, err := h.Backend.UpdatePipeline(*in.Pipeline)
+	p, err := h.Backend.UpdatePipeline(ctx, *in.Pipeline)
 	if err != nil {
 		return nil, err
 	}
@@ -406,14 +413,14 @@ type deletePipelineInput struct {
 type deletePipelineOutput struct{}
 
 func (h *Handler) handleDeletePipeline(
-	_ context.Context,
+	ctx context.Context,
 	in *deletePipelineInput,
 ) (*deletePipelineOutput, error) {
 	if in.Name == "" {
 		return nil, fmt.Errorf("%w: name is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeletePipeline(in.Name); err != nil {
+	if err := h.Backend.DeletePipeline(ctx, in.Name); err != nil {
 		return nil, err
 	}
 
@@ -431,10 +438,10 @@ type listPipelinesOutput struct {
 }
 
 func (h *Handler) handleListPipelines(
-	_ context.Context,
+	ctx context.Context,
 	_ *listPipelinesInput,
 ) (*listPipelinesOutput, error) {
-	summaries := h.Backend.ListPipelines()
+	summaries := h.Backend.ListPipelines(ctx)
 	if summaries == nil {
 		summaries = []PipelineSummary{}
 	}
@@ -453,14 +460,14 @@ type listTagsForResourceOutput struct {
 }
 
 func (h *Handler) handleListTagsForResource(
-	_ context.Context,
+	ctx context.Context,
 	in *listTagsForResourceInput,
 ) (*listTagsForResourceOutput, error) {
 	if in.ResourceArn == "" {
 		return nil, fmt.Errorf("%w: resourceArn is required", errInvalidRequest)
 	}
 
-	tags, err := h.Backend.ListTagsForResource(in.ResourceArn)
+	tags, err := h.Backend.ListTagsForResource(ctx, in.ResourceArn)
 	if err != nil {
 		return nil, err
 	}
@@ -480,14 +487,14 @@ type tagResourceInput struct {
 type tagResourceOutput struct{}
 
 func (h *Handler) handleTagResource(
-	_ context.Context,
+	ctx context.Context,
 	in *tagResourceInput,
 ) (*tagResourceOutput, error) {
 	if in.ResourceArn == "" {
 		return nil, fmt.Errorf("%w: resourceArn is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.TagResource(in.ResourceArn, in.Tags); err != nil {
+	if err := h.Backend.TagResource(ctx, in.ResourceArn, in.Tags); err != nil {
 		return nil, err
 	}
 
@@ -502,14 +509,14 @@ type untagResourceInput struct {
 type untagResourceOutput struct{}
 
 func (h *Handler) handleUntagResource(
-	_ context.Context,
+	ctx context.Context,
 	in *untagResourceInput,
 ) (*untagResourceOutput, error) {
 	if in.ResourceArn == "" {
 		return nil, fmt.Errorf("%w: resourceArn is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.UntagResource(in.ResourceArn, in.TagKeys); err != nil {
+	if err := h.Backend.UntagResource(ctx, in.ResourceArn, in.TagKeys); err != nil {
 		return nil, err
 	}
 
@@ -552,7 +559,7 @@ type acknowledgeJobOutput struct {
 }
 
 func (h *Handler) handleAcknowledgeJob(
-	_ context.Context,
+	ctx context.Context,
 	in *acknowledgeJobInput,
 ) (*acknowledgeJobOutput, error) {
 	if in.JobID == "" {
@@ -563,7 +570,7 @@ func (h *Handler) handleAcknowledgeJob(
 		return nil, fmt.Errorf("%w: nonce is required", errInvalidRequest)
 	}
 
-	status, err := h.Backend.AcknowledgeJob(in.JobID, in.Nonce)
+	status, err := h.Backend.AcknowledgeJob(ctx, in.JobID, in.Nonce)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +591,7 @@ type acknowledgeThirdPartyJobOutput struct {
 }
 
 func (h *Handler) handleAcknowledgeThirdPartyJob(
-	_ context.Context,
+	ctx context.Context,
 	in *acknowledgeThirdPartyJobInput,
 ) (*acknowledgeThirdPartyJobOutput, error) {
 	if in.JobID == "" {
@@ -599,7 +606,7 @@ func (h *Handler) handleAcknowledgeThirdPartyJob(
 		return nil, fmt.Errorf("%w: clientToken is required", errInvalidRequest)
 	}
 
-	status, err := h.Backend.AcknowledgeThirdPartyJob(in.JobID, in.Nonce, in.ClientToken)
+	status, err := h.Backend.AcknowledgeThirdPartyJob(ctx, in.JobID, in.Nonce, in.ClientToken)
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +641,7 @@ type createCustomActionTypeOutput struct {
 }
 
 func (h *Handler) handleCreateCustomActionType(
-	_ context.Context,
+	ctx context.Context,
 	in *createCustomActionTypeInput,
 ) (*createCustomActionTypeOutput, error) {
 	if in.Category == "" {
@@ -664,7 +671,7 @@ func (h *Handler) handleCreateCustomActionType(
 		Tags:                    tagsToMap(in.Tags),
 	}
 
-	created, err := h.Backend.CreateCustomActionType(cat)
+	created, err := h.Backend.CreateCustomActionType(ctx, cat)
 	if err != nil {
 		return nil, err
 	}
@@ -702,7 +709,7 @@ type deleteCustomActionTypeInput struct {
 type deleteCustomActionTypeOutput struct{}
 
 func (h *Handler) handleDeleteCustomActionType(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteCustomActionTypeInput,
 ) (*deleteCustomActionTypeOutput, error) {
 	if in.Category == "" {
@@ -721,7 +728,7 @@ func (h *Handler) handleDeleteCustomActionType(
 		return nil, fmt.Errorf("%w: version is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteCustomActionType(in.Category, in.Provider, in.Version); err != nil {
+	if err := h.Backend.DeleteCustomActionType(ctx, in.Category, in.Provider, in.Version); err != nil {
 		return nil, err
 	}
 
@@ -742,7 +749,7 @@ type getActionTypeOutput struct {
 }
 
 func (h *Handler) handleGetActionType(
-	_ context.Context,
+	ctx context.Context,
 	in *getActionTypeInput,
 ) (*getActionTypeOutput, error) {
 	if in.Category == "" {
@@ -761,7 +768,7 @@ func (h *Handler) handleGetActionType(
 		return nil, fmt.Errorf("%w: version is required", errInvalidRequest)
 	}
 
-	cat, err := h.Backend.GetActionType(in.Category, in.Owner, in.Provider, in.Version)
+	cat, err := h.Backend.GetActionType(ctx, in.Category, in.Owner, in.Provider, in.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -808,14 +815,14 @@ type getJobDetailsOutput struct {
 }
 
 func (h *Handler) handleGetJobDetails(
-	_ context.Context,
+	ctx context.Context,
 	in *getJobDetailsInput,
 ) (*getJobDetailsOutput, error) {
 	if in.JobID == "" {
 		return nil, fmt.Errorf("%w: jobId is required", errInvalidRequest)
 	}
 
-	job, err := h.Backend.GetJobDetails(in.JobID)
+	job, err := h.Backend.GetJobDetails(ctx, in.JobID)
 	if err != nil {
 		return nil, err
 	}
@@ -838,14 +845,14 @@ type deleteWebhookInput struct {
 type deleteWebhookOutput struct{}
 
 func (h *Handler) handleDeleteWebhook(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteWebhookInput,
 ) (*deleteWebhookOutput, error) {
 	if in.Name == "" {
 		return nil, fmt.Errorf("%w: name is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.DeleteWebhook(in.Name); err != nil {
+	if err := h.Backend.DeleteWebhook(ctx, in.Name); err != nil {
 		return nil, err
 	}
 
@@ -861,10 +868,10 @@ type deregisterWebhookWithThirdPartyInput struct {
 type deregisterWebhookWithThirdPartyOutput struct{}
 
 func (h *Handler) handleDeregisterWebhookWithThirdParty(
-	_ context.Context,
+	ctx context.Context,
 	in *deregisterWebhookWithThirdPartyInput,
 ) (*deregisterWebhookWithThirdPartyOutput, error) {
-	if err := h.Backend.DeregisterWebhookWithThirdParty(in.WebhookName); err != nil {
+	if err := h.Backend.DeregisterWebhookWithThirdParty(ctx, in.WebhookName); err != nil {
 		return nil, err
 	}
 
@@ -883,7 +890,7 @@ type disableStageTransitionInput struct {
 type disableStageTransitionOutput struct{}
 
 func (h *Handler) handleDisableStageTransition(
-	_ context.Context,
+	ctx context.Context,
 	in *disableStageTransitionInput,
 ) (*disableStageTransitionOutput, error) {
 	if in.PipelineName == "" {
@@ -908,7 +915,7 @@ func (h *Handler) handleDisableStageTransition(
 	}
 
 	if err := h.Backend.DisableStageTransition(
-		in.PipelineName, in.StageName, in.TransitionType, in.Reason,
+		ctx, in.PipelineName, in.StageName, in.TransitionType, in.Reason,
 	); err != nil {
 		return nil, err
 	}
@@ -927,7 +934,7 @@ type enableStageTransitionInput struct {
 type enableStageTransitionOutput struct{}
 
 func (h *Handler) handleEnableStageTransition(
-	_ context.Context,
+	ctx context.Context,
 	in *enableStageTransitionInput,
 ) (*enableStageTransitionOutput, error) {
 	if in.PipelineName == "" {
@@ -947,7 +954,7 @@ func (h *Handler) handleEnableStageTransition(
 			ErrValidation, in.TransitionType, transitionTypeInbound, transitionTypeOutbound)
 	}
 
-	if err := h.Backend.EnableStageTransition(in.PipelineName, in.StageName, in.TransitionType); err != nil {
+	if err := h.Backend.EnableStageTransition(ctx, in.PipelineName, in.StageName, in.TransitionType); err != nil {
 		return nil, err
 	}
 
@@ -965,14 +972,14 @@ type pipelineExecutionOutput struct {
 }
 
 func (h *Handler) handleStartPipelineExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *startPipelineExecutionInput,
 ) (*pipelineExecutionOutput, error) {
 	if in.Name == "" {
 		return nil, fmt.Errorf("%w: name is required", errInvalidRequest)
 	}
 
-	exec, err := h.Backend.StartPipelineExecution(in.Name)
+	exec, err := h.Backend.StartPipelineExecution(ctx, in.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -990,14 +997,14 @@ type getPipelineExecutionOutput struct {
 }
 
 func (h *Handler) handleGetPipelineExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *getPipelineExecutionInput,
 ) (*getPipelineExecutionOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	exec, err := h.Backend.GetPipelineExecution(in.PipelineName, in.PipelineExecutionID)
+	exec, err := h.Backend.GetPipelineExecution(ctx, in.PipelineName, in.PipelineExecutionID)
 	if err != nil {
 		return nil, err
 	}
@@ -1020,14 +1027,14 @@ type stopPipelineExecutionInput struct {
 }
 
 func (h *Handler) handleStopPipelineExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *stopPipelineExecutionInput,
 ) (*pipelineExecutionOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	exec, err := h.Backend.StopPipelineExecution(in.PipelineName, in.PipelineExecutionID, in.Reason)
+	exec, err := h.Backend.StopPipelineExecution(ctx, in.PipelineName, in.PipelineExecutionID, in.Reason)
 	if err != nil {
 		return nil, err
 	}
@@ -1046,14 +1053,14 @@ type listPipelineExecutionsOutput struct {
 }
 
 func (h *Handler) handleListPipelineExecutions(
-	_ context.Context,
+	ctx context.Context,
 	in *listPipelineExecutionsInput,
 ) (*listPipelineExecutionsOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	execs, err := h.Backend.ListPipelineExecutions(in.PipelineName)
+	execs, err := h.Backend.ListPipelineExecutions(ctx, in.PipelineName)
 	if err != nil {
 		return nil, err
 	}
@@ -1084,14 +1091,14 @@ type getPipelineStateOutput struct {
 }
 
 func (h *Handler) handleGetPipelineState(
-	_ context.Context,
+	ctx context.Context,
 	in *getPipelineStateInput,
 ) (*getPipelineStateOutput, error) {
 	if in.Name == "" {
 		return nil, fmt.Errorf("%w: name is required", errInvalidRequest)
 	}
 
-	states, err := h.Backend.GetPipelineState(in.Name)
+	states, err := h.Backend.GetPipelineState(ctx, in.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -1135,14 +1142,14 @@ type retryStageExecutionInput struct {
 }
 
 func (h *Handler) handleRetryStageExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *retryStageExecutionInput,
 ) (*pipelineExecutionOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	exec, err := h.Backend.RetryStageExecution(in.PipelineName, in.StageName, in.PipelineExecutionID)
+	exec, err := h.Backend.RetryStageExecution(ctx, in.PipelineName, in.StageName, in.PipelineExecutionID)
 	if err != nil {
 		return nil, err
 	}
@@ -1157,14 +1164,14 @@ type rollbackStageInput struct {
 }
 
 func (h *Handler) handleRollbackStage(
-	_ context.Context,
+	ctx context.Context,
 	in *rollbackStageInput,
 ) (*pipelineExecutionOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	exec, err := h.Backend.RollbackStage(in.PipelineName, in.StageName, in.TargetPipelineExecutionID)
+	exec, err := h.Backend.RollbackStage(ctx, in.PipelineName, in.StageName, in.TargetPipelineExecutionID)
 	if err != nil {
 		return nil, err
 	}
@@ -1182,14 +1189,14 @@ type overrideStageConditionInput struct {
 type emptyOut struct{}
 
 func (h *Handler) handleOverrideStageCondition(
-	_ context.Context,
+	ctx context.Context,
 	in *overrideStageConditionInput,
 ) (*emptyOut, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.OverrideStageCondition(in.PipelineName, in.StageName, in.PipelineExecutionID); err != nil {
+	if err := h.Backend.OverrideStageCondition(ctx, in.PipelineName, in.StageName, in.PipelineExecutionID); err != nil {
 		return nil, err
 	}
 
@@ -1227,10 +1234,10 @@ type listWebhooksOutput struct {
 }
 
 func (h *Handler) handleListWebhooks(
-	_ context.Context,
+	ctx context.Context,
 	_ *listWebhooksInput,
 ) (*listWebhooksOutput, error) {
-	webhooks := h.Backend.ListWebhooks()
+	webhooks := h.Backend.ListWebhooks(ctx)
 	entries := make([]webhookListEntry, len(webhooks))
 
 	for i, wh := range webhooks {
@@ -1275,7 +1282,7 @@ type putWebhookOutput struct {
 }
 
 func (h *Handler) handlePutWebhook(
-	_ context.Context,
+	ctx context.Context,
 	in *putWebhookInput,
 ) (*putWebhookOutput, error) {
 	if in.Webhook.Name == "" {
@@ -1288,7 +1295,7 @@ func (h *Handler) handlePutWebhook(
 			WebhookAuthGitHubHMAC, WebhookAuthIP, WebhookAuthUnauthenticated)
 	}
 
-	wh, err := h.Backend.PutWebhook(&Webhook{
+	wh, err := h.Backend.PutWebhook(ctx, &Webhook{
 		Name:                        in.Webhook.Name,
 		TargetPipeline:              in.Webhook.TargetPipeline,
 		TargetAction:                in.Webhook.TargetAction,
@@ -1327,10 +1334,10 @@ type registerWebhookInput struct {
 }
 
 func (h *Handler) handleRegisterWebhookWithThirdParty(
-	_ context.Context,
+	ctx context.Context,
 	in *registerWebhookInput,
 ) (*emptyOut, error) {
-	if err := h.Backend.RegisterWebhookWithThirdParty(in.WebhookName); err != nil {
+	if err := h.Backend.RegisterWebhookWithThirdParty(ctx, in.WebhookName); err != nil {
 		return nil, err
 	}
 
@@ -1354,11 +1361,11 @@ type pollForJobsOutput struct {
 }
 
 func (h *Handler) handlePollForJobs(
-	_ context.Context,
+	ctx context.Context,
 	in *pollForJobsInput,
 ) (*pollForJobsOutput, error) {
 	jobs, err := h.Backend.PollForJobs(
-		in.ActionTypeID.Category, in.ActionTypeID.Owner,
+		ctx, in.ActionTypeID.Category, in.ActionTypeID.Owner,
 		in.ActionTypeID.Provider, in.ActionTypeID.Version,
 	)
 	if err != nil {
@@ -1388,11 +1395,11 @@ type pollForThirdPartyJobsOutput struct {
 }
 
 func (h *Handler) handlePollForThirdPartyJobs(
-	_ context.Context,
+	ctx context.Context,
 	in *pollForThirdPartyJobsInput,
 ) (*pollForThirdPartyJobsOutput, error) {
 	jobs, err := h.Backend.PollForThirdPartyJobs(
-		in.ActionTypeID.Category, in.ActionTypeID.Provider, in.ActionTypeID.Version,
+		ctx, in.ActionTypeID.Category, in.ActionTypeID.Provider, in.ActionTypeID.Version,
 	)
 	if err != nil {
 		return nil, err
@@ -1416,14 +1423,14 @@ type getThirdPartyJobDetailsOutput struct {
 }
 
 func (h *Handler) handleGetThirdPartyJobDetails(
-	_ context.Context,
+	ctx context.Context,
 	in *getThirdPartyJobDetailsInput,
 ) (*getThirdPartyJobDetailsOutput, error) {
 	if in.JobID == "" {
 		return nil, fmt.Errorf("%w: jobId is required", errInvalidRequest)
 	}
 
-	job, err := h.Backend.GetThirdPartyJobDetails(in.JobID, in.ClientToken)
+	job, err := h.Backend.GetThirdPartyJobDetails(ctx, in.JobID, in.ClientToken)
 	if err != nil {
 		return nil, err
 	}
@@ -1438,14 +1445,14 @@ type putJobSuccessResultInput struct {
 }
 
 func (h *Handler) handlePutJobSuccessResult(
-	_ context.Context,
+	ctx context.Context,
 	in *putJobSuccessResultInput,
 ) (*emptyOut, error) {
 	if in.JobID == "" {
 		return nil, fmt.Errorf("%w: jobId is required", errInvalidRequest)
 	}
 
-	return &emptyOut{}, h.Backend.PutJobSuccessResult(in.JobID)
+	return &emptyOut{}, h.Backend.PutJobSuccessResult(ctx, in.JobID)
 }
 
 type putJobFailureResultInput struct {
@@ -1456,14 +1463,14 @@ type putJobFailureResultInput struct {
 }
 
 func (h *Handler) handlePutJobFailureResult(
-	_ context.Context,
+	ctx context.Context,
 	in *putJobFailureResultInput,
 ) (*emptyOut, error) {
 	if in.JobID == "" {
 		return nil, fmt.Errorf("%w: jobId is required", errInvalidRequest)
 	}
 
-	return &emptyOut{}, h.Backend.PutJobFailureResult(in.JobID, in.FailureDetails.Message)
+	return &emptyOut{}, h.Backend.PutJobFailureResult(ctx, in.JobID, in.FailureDetails.Message)
 }
 
 type putThirdPartyJobSuccessResultInput struct {
@@ -1472,10 +1479,10 @@ type putThirdPartyJobSuccessResultInput struct {
 }
 
 func (h *Handler) handlePutThirdPartyJobSuccessResult(
-	_ context.Context,
+	ctx context.Context,
 	in *putThirdPartyJobSuccessResultInput,
 ) (*emptyOut, error) {
-	return &emptyOut{}, h.Backend.PutThirdPartyJobSuccessResult(in.JobID, in.ClientToken)
+	return &emptyOut{}, h.Backend.PutThirdPartyJobSuccessResult(ctx, in.JobID, in.ClientToken)
 }
 
 type putThirdPartyJobFailureResultInput struct {
@@ -1487,10 +1494,15 @@ type putThirdPartyJobFailureResultInput struct {
 }
 
 func (h *Handler) handlePutThirdPartyJobFailureResult(
-	_ context.Context,
+	ctx context.Context,
 	in *putThirdPartyJobFailureResultInput,
 ) (*emptyOut, error) {
-	return &emptyOut{}, h.Backend.PutThirdPartyJobFailureResult(in.JobID, in.ClientToken, in.FailureDetails.Message)
+	return &emptyOut{}, h.Backend.PutThirdPartyJobFailureResult(
+		ctx,
+		in.JobID,
+		in.ClientToken,
+		in.FailureDetails.Message,
+	)
 }
 
 // --- Action operations ---
@@ -1511,14 +1523,14 @@ type putActionRevisionOutput struct {
 }
 
 func (h *Handler) handlePutActionRevision(
-	_ context.Context,
+	ctx context.Context,
 	in *putActionRevisionInput,
 ) (*putActionRevisionOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.PutActionRevision(in.PipelineName, in.StageName, in.ActionName); err != nil {
+	if err := h.Backend.PutActionRevision(ctx, in.PipelineName, in.StageName, in.ActionName); err != nil {
 		return nil, err
 	}
 
@@ -1540,7 +1552,7 @@ type putApprovalResultOutput struct {
 }
 
 func (h *Handler) handlePutApprovalResult(
-	_ context.Context,
+	ctx context.Context,
 	in *putApprovalResultInput,
 ) (*putApprovalResultOutput, error) {
 	if in.PipelineName == "" {
@@ -1548,7 +1560,7 @@ func (h *Handler) handlePutApprovalResult(
 	}
 
 	if err := h.Backend.PutApprovalResult(
-		in.PipelineName, in.StageName, in.ActionName,
+		ctx, in.PipelineName, in.StageName, in.ActionName,
 		in.ApprovalResult.Status, in.ApprovalResult.Summary,
 	); err != nil {
 		return nil, err
@@ -1573,7 +1585,7 @@ type listActionExecutionsOutput struct {
 }
 
 func (h *Handler) handleListActionExecutions(
-	_ context.Context,
+	ctx context.Context,
 	in *listActionExecutionsInput,
 ) (*listActionExecutionsOutput, error) {
 	if in.PipelineName == "" {
@@ -1585,7 +1597,7 @@ func (h *Handler) handleListActionExecutions(
 		execFilter = in.Filter.PipelineExecutionID
 	}
 
-	items, err := h.Backend.ListActionExecutions(in.PipelineName, execFilter)
+	items, err := h.Backend.ListActionExecutions(ctx, in.PipelineName, execFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -1604,10 +1616,10 @@ type listActionTypesOutput struct {
 }
 
 func (h *Handler) handleListActionTypes(
-	_ context.Context,
+	ctx context.Context,
 	in *listActionTypesInput,
 ) (*listActionTypesOutput, error) {
-	types := h.Backend.ListActionTypes()
+	types := h.Backend.ListActionTypes(ctx)
 	items := make([]map[string]any, 0, len(types))
 
 	for _, at := range types {
@@ -1664,7 +1676,7 @@ type updateActionTypeInput struct {
 }
 
 func (h *Handler) handleUpdateActionType(
-	_ context.Context,
+	ctx context.Context,
 	in *updateActionTypeInput,
 ) (*emptyOut, error) {
 	id := in.ActionType.ID
@@ -1697,7 +1709,7 @@ func (h *Handler) handleUpdateActionType(
 		OutputArtifactDetails:   in.ActionType.OutputArtifactDetails,
 	}
 
-	if err := h.Backend.UpdateActionType(cat); err != nil {
+	if err := h.Backend.UpdateActionType(ctx, cat); err != nil {
 		return nil, err
 	}
 
@@ -1717,14 +1729,14 @@ type listRuleExecutionsOutput struct {
 }
 
 func (h *Handler) handleListRuleExecutions(
-	_ context.Context,
+	ctx context.Context,
 	in *listRuleExecutionsInput,
 ) (*listRuleExecutionsOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	items, err := h.Backend.ListRuleExecutions(in.PipelineName)
+	items, err := h.Backend.ListRuleExecutions(ctx, in.PipelineName)
 	if err != nil {
 		return nil, err
 	}
@@ -1759,14 +1771,14 @@ type listDeployActionExecutionTargetsOutput struct {
 }
 
 func (h *Handler) handleListDeployActionExecutionTargets(
-	_ context.Context,
+	ctx context.Context,
 	in *listDeployActionExecutionTargetsInput,
 ) (*listDeployActionExecutionTargetsOutput, error) {
 	if in.PipelineName == "" {
 		return nil, fmt.Errorf("%w: pipelineName is required", errInvalidRequest)
 	}
 
-	items, err := h.Backend.ListDeployActionExecutionTargets(in.PipelineName, in.ActionExecutionID)
+	items, err := h.Backend.ListDeployActionExecutionTargets(ctx, in.PipelineName, in.ActionExecutionID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/codepipeline/handler_test.go
+++ b/services/codepipeline/handler_test.go
@@ -2,6 +2,7 @@ package codepipeline_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -273,7 +274,7 @@ func TestHandler_GetPipeline(t *testing.T) {
 		{
 			name: "success",
 			pipelineFn: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("get-pipeline"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("get-pipeline"), nil)
 				require.NoError(t, err)
 			},
 			input:      map[string]any{"name": "get-pipeline"},
@@ -323,7 +324,7 @@ func TestHandler_UpdatePipeline(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("update-pipeline"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("update-pipeline"), nil)
 				require.NoError(t, err)
 			},
 			input: map[string]any{
@@ -377,7 +378,7 @@ func TestHandler_DeletePipeline(t *testing.T) {
 		{
 			name: "success",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("delete-pipeline"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("delete-pipeline"), nil)
 				require.NoError(t, err)
 			},
 			input:      map[string]any{"name": "delete-pipeline"},
@@ -426,9 +427,9 @@ func TestHandler_ListPipelines(t *testing.T) {
 		{
 			name: "with pipelines",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("pipeline-1"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("pipeline-1"), nil)
 				require.NoError(t, err)
-				_, err = h.Backend.CreatePipeline(samplePipeline("pipeline-2"), nil)
+				_, err = h.Backend.CreatePipeline(context.Background(), samplePipeline("pipeline-2"), nil)
 				require.NoError(t, err)
 			},
 			wantStatus: http.StatusOK,
@@ -476,7 +477,7 @@ func TestHandler_TaggingOperations(t *testing.T) {
 			name:   "list tags - empty",
 			action: "ListTagsForResource",
 			setup: func(h *codepipeline.Handler) string {
-				p, err := h.Backend.CreatePipeline(samplePipeline("list-empty-pipeline"), nil)
+				p, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("list-empty-pipeline"), nil)
 				require.NoError(t, err)
 
 				return p.Metadata.PipelineArn
@@ -490,7 +491,7 @@ func TestHandler_TaggingOperations(t *testing.T) {
 			name:   "tag resource",
 			action: "TagResource",
 			setup: func(h *codepipeline.Handler) string {
-				p, err := h.Backend.CreatePipeline(samplePipeline("tag-resource-pipeline"), nil)
+				p, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("tag-resource-pipeline"), nil)
 				require.NoError(t, err)
 
 				return p.Metadata.PipelineArn
@@ -507,7 +508,7 @@ func TestHandler_TaggingOperations(t *testing.T) {
 			name:   "untag resource",
 			action: "UntagResource",
 			setup: func(h *codepipeline.Handler) string {
-				p, err := h.Backend.CreatePipeline(
+				p, err := h.Backend.CreatePipeline(context.Background(),
 					samplePipeline("untag-resource-pipeline"),
 					map[string]string{"Env": "test"},
 				)
@@ -623,10 +624,14 @@ func TestInMemoryBackend_CreatePipeline_WithTags(t *testing.T) {
 
 	backend := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 
-	p, err := backend.CreatePipeline(samplePipeline("tagged-pipeline"), map[string]string{"Env": "prod"})
+	p, err := backend.CreatePipeline(
+		context.Background(),
+		samplePipeline("tagged-pipeline"),
+		map[string]string{"Env": "prod"},
+	)
 	require.NoError(t, err)
 
-	tags, err := backend.ListTagsForResource(p.Metadata.PipelineArn)
+	tags, err := backend.ListTagsForResource(context.Background(), p.Metadata.PipelineArn)
 	require.NoError(t, err)
 
 	tagMap := make(map[string]string, len(tags))
@@ -642,10 +647,10 @@ func TestInMemoryBackend_UpdatePipeline_IncrementsVersion(t *testing.T) {
 
 	backend := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := backend.CreatePipeline(samplePipeline("versioned-pipeline"), nil)
+	_, err := backend.CreatePipeline(context.Background(), samplePipeline("versioned-pipeline"), nil)
 	require.NoError(t, err)
 
-	updated, err := backend.UpdatePipeline(samplePipeline("versioned-pipeline"))
+	updated, err := backend.UpdatePipeline(context.Background(), samplePipeline("versioned-pipeline"))
 	require.NoError(t, err)
 	assert.Equal(t, 2, updated.Declaration.Version)
 }
@@ -671,7 +676,7 @@ func TestHandler_ErrorEnvelopes(t *testing.T) {
 		{
 			name: "duplicate create returns PipelineNameInUseException",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("duplicate-pipeline"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("duplicate-pipeline"), nil)
 				require.NoError(t, err)
 			},
 			action:     "CreatePipeline",
@@ -744,7 +749,7 @@ func TestHandler_GetPipeline_VersionHandling(t *testing.T) {
 			t.Parallel()
 
 			h := newTestHandler(t)
-			_, err := h.Backend.CreatePipeline(samplePipeline("ver-pipeline"), nil)
+			_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("ver-pipeline"), nil)
 			require.NoError(t, err)
 
 			rec := doRequest(t, h, "GetPipeline", map[string]any{
@@ -764,14 +769,14 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 	decl := samplePipeline("deep-copy-pipeline")
 	decl.Stages[0].Actions[0].Configuration = map[string]string{"key": "original"}
 
-	p, err := backend.CreatePipeline(decl, nil)
+	p, err := backend.CreatePipeline(context.Background(), decl, nil)
 	require.NoError(t, err)
 
 	// Mutate the returned pipeline's nested data.
 	p.Declaration.Stages[0].Actions[0].Configuration["key"] = "mutated"
 
 	// The backend should still have the original value.
-	stored, err := backend.GetPipeline("deep-copy-pipeline")
+	stored, err := backend.GetPipeline(context.Background(), "deep-copy-pipeline")
 	require.NoError(t, err)
 	assert.Equal(t, "original", stored.Declaration.Stages[0].Actions[0].Configuration["key"])
 }
@@ -1283,7 +1288,7 @@ func TestHandler_DisableEnableStageTransition(t *testing.T) {
 			name:   "disable_success",
 			action: "DisableStageTransition",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("trans-pipeline"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("trans-pipeline"), nil)
 				require.NoError(t, err)
 			},
 			input: map[string]any{
@@ -1323,7 +1328,7 @@ func TestHandler_DisableEnableStageTransition(t *testing.T) {
 			name:   "enable_success",
 			action: "EnableStageTransition",
 			setup: func(h *codepipeline.Handler) {
-				_, err := h.Backend.CreatePipeline(samplePipeline("enable-pipeline"), nil)
+				_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("enable-pipeline"), nil)
 				require.NoError(t, err)
 			},
 			input: map[string]any{
@@ -1378,7 +1383,7 @@ func TestHandler_DisableEnableStageTransition_RoundTrip(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	_, err := h.Backend.CreatePipeline(samplePipeline("rt-pipeline"), nil)
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("rt-pipeline"), nil)
 	require.NoError(t, err)
 
 	// Disable the transition.
@@ -1431,7 +1436,7 @@ func TestRefinement1_Reset(t *testing.T) {
 	h := newTestHandler(t)
 
 	// Create a pipeline so there is state to reset.
-	_, err := h.Backend.CreatePipeline(samplePipeline("reset-pl"), nil)
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("reset-pl"), nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, h.Backend.PipelineCount())
@@ -1461,7 +1466,7 @@ func TestRefinement1_SortedListPipelines(t *testing.T) {
 	h := newTestHandler(t)
 
 	for _, name := range []string{"zebra-pl", "apple-pl", "mango-pl"} {
-		_, err := h.Backend.CreatePipeline(samplePipeline(name), nil)
+		_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline(name), nil)
 		require.NoError(t, err)
 	}
 
@@ -1506,7 +1511,7 @@ func TestRefinement1_ListPipelines_IncludesARN(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	_, err := h.Backend.CreatePipeline(samplePipeline("arn-pl"), nil)
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("arn-pl"), nil)
 	require.NoError(t, err)
 
 	rec := doRequest(t, h, "ListPipelines", map[string]any{})
@@ -1528,13 +1533,13 @@ func TestRefinement1_SortedListTagsForResource(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	_, err := h.Backend.CreatePipeline(samplePipeline("tag-pl"), map[string]string{
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("tag-pl"), map[string]string{
 		"zzz": "last", "aaa": "first", "mmm": "mid",
 	})
 	require.NoError(t, err)
 
 	// Get the ARN by listing pipelines.
-	summaries := h.Backend.ListPipelines()
+	summaries := h.Backend.ListPipelines(context.Background())
 	require.Len(t, summaries, 1)
 	pipelineARN := summaries[0].PipelineArn
 	require.NotEmpty(t, pipelineARN)
@@ -1561,10 +1566,10 @@ func TestRefinement1_ListTagsForResource_EmptySlice(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	_, err := h.Backend.CreatePipeline(samplePipeline("notag-pl"), nil)
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("notag-pl"), nil)
 	require.NoError(t, err)
 
-	summaries := h.Backend.ListPipelines()
+	summaries := h.Backend.ListPipelines(context.Background())
 	pipelineARN := summaries[0].PipelineArn
 
 	rec := doRequest(t, h, "ListTagsForResource", map[string]any{"resourceArn": pipelineARN})
@@ -1582,7 +1587,7 @@ func TestRefinement1_DeletePipeline_CascadeStageTransitions(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	_, err := h.Backend.CreatePipeline(samplePipeline("cascade-pl"), nil)
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("cascade-pl"), nil)
 	require.NoError(t, err)
 
 	// Disable a stage transition.
@@ -1650,7 +1655,7 @@ func TestRefinement1_TransitionTypeValidation(t *testing.T) {
 			t.Parallel()
 
 			h := newTestHandler(t)
-			_, err := h.Backend.CreatePipeline(samplePipeline("enum-pl"), nil)
+			_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("enum-pl"), nil)
 			require.NoError(t, err)
 
 			var input map[string]any
@@ -1791,17 +1796,17 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 	require.NoError(t, b2.Restore(snap))
 
 	// Verify pipeline.
-	p, err := b2.GetPipeline("persist-pl")
+	p, err := b2.GetPipeline(context.Background(), "persist-pl")
 	require.NoError(t, err)
 	assert.Equal(t, "persist-pl", p.Declaration.Name)
 
 	// Verify custom action type.
-	cat, err := b2.GetActionType("Deploy", "Custom", "MyDeploy", "2")
+	cat, err := b2.GetActionType(context.Background(), "Deploy", "Custom", "MyDeploy", "2")
 	require.NoError(t, err)
 	assert.Equal(t, "Deploy", cat.Category)
 
 	// Verify job.
-	job, err := b2.GetJobDetails("persist-job")
+	job, err := b2.GetJobDetails(context.Background(), "persist-job")
 	require.NoError(t, err)
 	assert.Equal(t, "persist-job", job.ID)
 
@@ -1815,7 +1820,7 @@ func TestRefinement1_PersistenceWithStageTransitions(t *testing.T) {
 	b := codepipeline.NewInMemoryBackend("000000000000", "us-east-1")
 	b.AddPipelineInternal(samplePipeline("trans-pl"), nil)
 
-	err := b.DisableStageTransition("trans-pl", "Source", "Inbound", "test reason")
+	err := b.DisableStageTransition(context.Background(), "trans-pl", "Source", "Inbound", "test reason")
 	require.NoError(t, err)
 	assert.Equal(t, 1, b.StageTransitionCount())
 
@@ -1827,7 +1832,7 @@ func TestRefinement1_PersistenceWithStageTransitions(t *testing.T) {
 
 	// Verify stage transition was restored.
 	assert.Equal(t, 1, b2.StageTransitionCount())
-	state := b2.GetStageTransitionState("trans-pl", "Source", "Inbound")
+	state := b2.GetStageTransitionState(context.Background(), "trans-pl", "Source", "Inbound")
 	require.NotNil(t, state)
 	assert.Equal(t, "test reason", state.Reason)
 	assert.True(t, state.Disabled)
@@ -1838,11 +1843,11 @@ func TestRefinement1_GetStageTransitionState(t *testing.T) {
 
 	h := newTestHandler(t)
 
-	_, err := h.Backend.CreatePipeline(samplePipeline("state-pl"), nil)
+	_, err := h.Backend.CreatePipeline(context.Background(), samplePipeline("state-pl"), nil)
 	require.NoError(t, err)
 
 	// Initially enabled (nil).
-	state := h.Backend.GetStageTransitionState("state-pl", "Source", "Inbound")
+	state := h.Backend.GetStageTransitionState(context.Background(), "state-pl", "Source", "Inbound")
 	assert.Nil(t, state)
 
 	// Disable it.
@@ -1854,7 +1859,7 @@ func TestRefinement1_GetStageTransitionState(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	state = h.Backend.GetStageTransitionState("state-pl", "Source", "Inbound")
+	state = h.Backend.GetStageTransitionState(context.Background(), "state-pl", "Source", "Inbound")
 	require.NotNil(t, state)
 	assert.Equal(t, "blocked", state.Reason)
 	assert.True(t, state.Disabled)
@@ -1867,7 +1872,7 @@ func TestRefinement1_GetStageTransitionState(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	state = h.Backend.GetStageTransitionState("state-pl", "Source", "Inbound")
+	state = h.Backend.GetStageTransitionState(context.Background(), "state-pl", "Source", "Inbound")
 	assert.Nil(t, state)
 }
 
@@ -1904,7 +1909,7 @@ func TestRefinement1_AddCustomActionTypeInternal_DeepCopy(t *testing.T) {
 	// Mutate original - backend should not be affected.
 	cat.Tags["original"] = "mutated"
 
-	retrieved, err := b.GetActionType("Build", "Custom", "CopyTest", "1")
+	retrieved, err := b.GetActionType(context.Background(), "Build", "Custom", "CopyTest", "1")
 	require.NoError(t, err)
 	assert.Equal(t, "value", retrieved.Tags["original"])
 }

--- a/services/codepipeline/isolation_test.go
+++ b/services/codepipeline/isolation_test.go
@@ -1,0 +1,203 @@
+package codepipeline //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stageNameSource is the shared "Source" literal used across the isolation tests.
+const stageNameSource = "Source"
+
+func cpCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func samplePipelineDecl(name string) PipelineDeclaration {
+	return PipelineDeclaration{
+		Name:    name,
+		RoleArn: "arn:aws:iam::000000000000:role/pipeline",
+		Stages: []Stage{
+			{
+				Name: stageNameSource,
+				Actions: []Action{
+					{
+						Name: "SourceAction",
+						ActionTypeID: ActionTypeID{
+							Category: stageNameSource, Owner: "AWS", Provider: "S3", Version: "1",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestCodePipelineRegionIsolation proves that same-named pipelines created in two
+// different regions are fully isolated: each region sees only its own pipelines,
+// ARNs embed the correct region, tags resolve only within the owning region, and
+// deleting in one region leaves the other untouched.
+func TestCodePipelineRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := cpCtxRegion("us-east-1")
+	ctxWest := cpCtxRegion("us-west-2")
+
+	// 1. Create a pipeline with the SAME name in both regions.
+	eastDecl := samplePipelineDecl("shared-pipeline")
+	eastDecl.PipelineType = PipelineTypeV1
+
+	eastP, err := backend.CreatePipeline(ctxEast, eastDecl, map[string]string{"env": "east"})
+	require.NoError(t, err)
+	assert.Contains(t, eastP.Metadata.PipelineArn, "us-east-1")
+
+	westDecl := samplePipelineDecl("shared-pipeline")
+	westDecl.PipelineType = PipelineTypeV2
+
+	westP, err := backend.CreatePipeline(ctxWest, westDecl, map[string]string{"env": "west"})
+	require.NoError(t, err)
+	assert.Contains(t, westP.Metadata.PipelineArn, "us-west-2")
+
+	// ARNs must differ (region-qualified) even though names match.
+	assert.NotEqual(t, eastP.Metadata.PipelineArn, westP.Metadata.PipelineArn)
+
+	// 2. Each region reads back its own pipeline type.
+	eastGet, err := backend.GetPipeline(ctxEast, "shared-pipeline")
+	require.NoError(t, err)
+	assert.Equal(t, PipelineTypeV1, eastGet.Declaration.PipelineType)
+
+	westGet, err := backend.GetPipeline(ctxWest, "shared-pipeline")
+	require.NoError(t, err)
+	assert.Equal(t, PipelineTypeV2, westGet.Declaration.PipelineType)
+
+	// 3. Listing returns exactly one pipeline per region.
+	eastList := backend.ListPipelines(ctxEast)
+	require.Len(t, eastList, 1)
+	assert.Contains(t, eastList[0].PipelineArn, "us-east-1")
+
+	westList := backend.ListPipelines(ctxWest)
+	require.Len(t, westList, 1)
+	assert.Contains(t, westList[0].PipelineArn, "us-west-2")
+
+	// 4. Tags resolve only within the owning region. The east ARN must not be
+	//    tag-resolvable from the west region.
+	eastTags, err := backend.ListTagsForResource(ctxEast, eastP.Metadata.PipelineArn)
+	require.NoError(t, err)
+	require.Len(t, eastTags, 1)
+	assert.Equal(t, "east", eastTags[0].Value)
+
+	_, err = backend.ListTagsForResource(ctxWest, eastP.Metadata.PipelineArn)
+	require.Error(t, err, "east ARN must not be tag-resolvable from the west region")
+
+	// 5. Deleting the pipeline in us-east-1 must not affect us-west-2.
+	require.NoError(t, backend.DeletePipeline(ctxEast, "shared-pipeline"))
+
+	_, err = backend.GetPipeline(ctxEast, "shared-pipeline")
+	require.Error(t, err)
+
+	westStill, err := backend.GetPipeline(ctxWest, "shared-pipeline")
+	require.NoError(t, err)
+	assert.Equal(t, PipelineTypeV2, westStill.Declaration.PipelineType)
+}
+
+// TestCodePipelineExecutionAndWebhookRegionIsolation proves that executions,
+// custom action types, jobs, and webhooks are scoped to the request region.
+func TestCodePipelineExecutionAndWebhookRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := cpCtxRegion("us-east-1")
+	ctxWest := cpCtxRegion("us-west-2")
+
+	// Create a same-named pipeline in both regions.
+	_, err := backend.CreatePipeline(ctxEast, samplePipelineDecl("p"), nil)
+	require.NoError(t, err)
+	_, err = backend.CreatePipeline(ctxWest, samplePipelineDecl("p"), nil)
+	require.NoError(t, err)
+
+	// Start an execution only in us-east-1.
+	exec, err := backend.StartPipelineExecution(ctxEast, "p")
+	require.NoError(t, err)
+	require.NotEmpty(t, exec.PipelineExecutionID)
+
+	eastExecs, err := backend.ListPipelineExecutions(ctxEast, "p")
+	require.NoError(t, err)
+	require.Len(t, eastExecs, 1)
+
+	// us-west-2 sees no executions for the same-named pipeline.
+	westExecs, err := backend.ListPipelineExecutions(ctxWest, "p")
+	require.NoError(t, err)
+	assert.Empty(t, westExecs)
+
+	// Action executions recorded by the east run are not visible from the west.
+	eastActions, err := backend.ListActionExecutions(ctxEast, "p", "")
+	require.NoError(t, err)
+	require.Len(t, eastActions, 1)
+
+	westActions, err := backend.ListActionExecutions(ctxWest, "p", "")
+	require.NoError(t, err)
+	assert.Empty(t, westActions)
+
+	// Webhooks with the same name are isolated; ARNs are region-qualified.
+	eastWH, err := backend.PutWebhook(ctxEast, &Webhook{Name: "wh", TargetPipeline: "p", TargetAction: stageNameSource})
+	require.NoError(t, err)
+	assert.Contains(t, eastWH.ARN, "us-east-1")
+
+	westWH, err := backend.PutWebhook(ctxWest, &Webhook{Name: "wh", TargetPipeline: "p", TargetAction: stageNameSource})
+	require.NoError(t, err)
+	assert.Contains(t, westWH.ARN, "us-west-2")
+	assert.NotEqual(t, eastWH.ARN, westWH.ARN)
+
+	require.Len(t, backend.ListWebhooks(ctxEast), 1)
+	require.Len(t, backend.ListWebhooks(ctxWest), 1)
+
+	// Custom action types are region-scoped: deleting the east copy leaves west.
+	const (
+		catCategory = "Build"
+		catProvider = keyOwnerCustom
+		catVersion  = "1"
+	)
+
+	_, err = backend.CreateCustomActionType(
+		ctxEast, &CustomActionType{Category: catCategory, Provider: catProvider, Version: catVersion},
+	)
+	require.NoError(t, err)
+	_, err = backend.CreateCustomActionType(
+		ctxWest, &CustomActionType{Category: catCategory, Provider: catProvider, Version: catVersion},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, backend.DeleteCustomActionType(ctxEast, catCategory, catProvider, catVersion))
+
+	_, err = backend.GetActionType(ctxEast, catCategory, keyOwnerCustom, catProvider, catVersion)
+	require.Error(t, err)
+
+	_, err = backend.GetActionType(ctxWest, catCategory, keyOwnerCustom, catProvider, catVersion)
+	require.NoError(t, err, "west custom action type must survive deletion in east")
+}
+
+// TestCodePipelineDefaultRegionFallback verifies that a context without a region
+// falls back to the backend's configured default region.
+func TestCodePipelineDefaultRegionFallback(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "eu-central-1")
+
+	// No region in context -> default region store.
+	_, err := backend.CreatePipeline(context.Background(), samplePipelineDecl("def-pipeline"), nil)
+	require.NoError(t, err)
+
+	// Reading via the explicit default region sees it.
+	got, err := backend.GetPipeline(cpCtxRegion("eu-central-1"), "def-pipeline")
+	require.NoError(t, err)
+	assert.Contains(t, got.Metadata.PipelineArn, "eu-central-1")
+
+	// A different region sees nothing.
+	_, err = backend.GetPipeline(cpCtxRegion("ap-south-1"), "def-pipeline")
+	require.Error(t, err)
+}

--- a/services/codepipeline/persistence.go
+++ b/services/codepipeline/persistence.go
@@ -8,6 +8,7 @@ import (
 // customActionTypeEntry is the JSON-serialisable representation of a custom action type entry.
 type customActionTypeEntry struct {
 	Value    *CustomActionType `json:"value"`
+	Region   string            `json:"region"`
 	Category string            `json:"category"`
 	Provider string            `json:"provider"`
 	Version  string            `json:"version"`
@@ -16,6 +17,7 @@ type customActionTypeEntry struct {
 // stageTransitionEntry is the JSON-serialisable representation of a stage transition entry.
 type stageTransitionEntry struct {
 	Value          *StageTransitionState `json:"value"`
+	Region         string                `json:"region"`
 	PipelineName   string                `json:"pipelineName"`
 	StageName      string                `json:"stageName"`
 	TransitionType string                `json:"transitionType"`
@@ -23,45 +25,74 @@ type stageTransitionEntry struct {
 
 // executionEntry is the JSON-serialisable list of executions per pipeline.
 type executionEntry struct {
+	Region       string               `json:"region"`
 	PipelineName string               `json:"pipelineName"`
 	Executions   []*PipelineExecution `json:"executions"`
 }
 
 // backendSnapshot is the JSON-serialisable snapshot of InMemoryBackend state.
+//
+// Region-scoped resource maps are nested by region (outer key = region) so that
+// same-named resources in different regions round-trip without collision.
 type backendSnapshot struct {
-	Pipelines         map[string]*Pipeline    `json:"pipelines"`
-	PipelineARNIndex  map[string]string       `json:"pipelineARNIndex"`
-	Jobs              map[string]*Job         `json:"jobs"`
-	Webhooks          map[string]*Webhook     `json:"webhooks"`
-	WebhookARNIndex   map[string]string       `json:"webhookARNIndex"`
-	AccountID         string                  `json:"accountID"`
-	Region            string                  `json:"region"`
-	CustomActionTypes []customActionTypeEntry `json:"customActionTypes"`
-	StageTransitions  []stageTransitionEntry  `json:"stageTransitions"`
-	Executions        []executionEntry        `json:"executions"`
+	Pipelines         map[string]map[string]*Pipeline `json:"pipelines"`
+	PipelineARNIndex  map[string]map[string]string    `json:"pipelineARNIndex"`
+	Jobs              map[string]map[string]*Job      `json:"jobs"`
+	Webhooks          map[string]map[string]*Webhook  `json:"webhooks"`
+	WebhookARNIndex   map[string]map[string]string    `json:"webhookARNIndex"`
+	AccountID         string                          `json:"accountID"`
+	Region            string                          `json:"region"`
+	CustomActionTypes []customActionTypeEntry         `json:"customActionTypes"`
+	StageTransitions  []stageTransitionEntry          `json:"stageTransitions"`
+	Executions        []executionEntry                `json:"executions"`
 }
 
 // ensureNonNil initialises any nil maps so callers do not need to guard after Restore.
 func (s *backendSnapshot) ensureNonNil() {
 	if s.Pipelines == nil {
-		s.Pipelines = make(map[string]*Pipeline)
+		s.Pipelines = make(map[string]map[string]*Pipeline)
 	}
 
 	if s.PipelineARNIndex == nil {
-		s.PipelineARNIndex = make(map[string]string)
+		s.PipelineARNIndex = make(map[string]map[string]string)
 	}
 
 	if s.Jobs == nil {
-		s.Jobs = make(map[string]*Job)
+		s.Jobs = make(map[string]map[string]*Job)
 	}
 
 	if s.Webhooks == nil {
-		s.Webhooks = make(map[string]*Webhook)
+		s.Webhooks = make(map[string]map[string]*Webhook)
 	}
 
 	if s.WebhookARNIndex == nil {
-		s.WebhookARNIndex = make(map[string]string)
+		s.WebhookARNIndex = make(map[string]map[string]string)
 	}
+}
+
+// copyNestedPtr deep-copies the outer region map of a region-nested pointer map,
+// cloning each inner map so the snapshot owns its data independently of the backend.
+func copyNestedPtr[T any](src map[string]map[string]*T) map[string]map[string]*T {
+	out := make(map[string]map[string]*T, len(src))
+	for region, inner := range src {
+		cp := make(map[string]*T, len(inner))
+		maps.Copy(cp, inner)
+		out[region] = cp
+	}
+
+	return out
+}
+
+// copyNestedStr deep-copies the outer region map of a region-nested string map.
+func copyNestedStr(src map[string]map[string]string) map[string]map[string]string {
+	out := make(map[string]map[string]string, len(src))
+	for region, inner := range src {
+		cp := make(map[string]string, len(inner))
+		maps.Copy(cp, inner)
+		out[region] = cp
+	}
+
+	return out
 }
 
 // customActionTypeKey.String returns a unique string for use in sorted output.
@@ -74,57 +105,49 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	// Flatten struct-keyed maps into slices for JSON serialization.
-	cats := make([]customActionTypeEntry, 0, len(b.customActionTypes))
-	for k, v := range b.customActionTypes {
-		cats = append(cats, customActionTypeEntry{
-			Category: k.Category, Provider: k.Provider, Version: k.Version, Value: v,
-		})
-	}
-
-	transitions := make([]stageTransitionEntry, 0, len(b.stageTransitions))
-	for k, v := range b.stageTransitions {
-		transitions = append(transitions, stageTransitionEntry{
-			PipelineName:   k.PipelineName,
-			StageName:      k.StageName,
-			TransitionType: k.TransitionType,
-			Value:          v,
-		})
-	}
-
-	execs := make([]executionEntry, 0, len(b.executions))
-	for pName, list := range b.executions {
-		if len(list) == 0 {
-			continue
+	// Flatten struct-keyed maps into region-tagged slices for JSON serialization.
+	cats := make([]customActionTypeEntry, 0)
+	for region, inner := range b.customActionTypes {
+		for k, v := range inner {
+			cats = append(cats, customActionTypeEntry{
+				Region: region, Category: k.Category, Provider: k.Provider, Version: k.Version, Value: v,
+			})
 		}
+	}
 
-		execs = append(execs, executionEntry{PipelineName: pName, Executions: list})
+	transitions := make([]stageTransitionEntry, 0)
+	for region, inner := range b.stageTransitions {
+		for k, v := range inner {
+			transitions = append(transitions, stageTransitionEntry{
+				Region:         region,
+				PipelineName:   k.PipelineName,
+				StageName:      k.StageName,
+				TransitionType: k.TransitionType,
+				Value:          v,
+			})
+		}
+	}
+
+	execs := make([]executionEntry, 0)
+	for region, inner := range b.executions {
+		for pName, list := range inner {
+			if len(list) == 0 {
+				continue
+			}
+
+			execs = append(execs, executionEntry{Region: region, PipelineName: pName, Executions: list})
+		}
 	}
 
 	// Defensive copies for snapshot: the snapshot owns the data, not the backend.
-	pipelinesCopy := make(map[string]*Pipeline, len(b.pipelines))
-	maps.Copy(pipelinesCopy, b.pipelines)
-
-	arnIndexCopy := make(map[string]string, len(b.pipelineARNIndex))
-	maps.Copy(arnIndexCopy, b.pipelineARNIndex)
-
-	webhooksCopy := make(map[string]*Webhook, len(b.webhooks))
-	maps.Copy(webhooksCopy, b.webhooks)
-
-	webhookARNCopy := make(map[string]string, len(b.webhookARNIndex))
-	maps.Copy(webhookARNCopy, b.webhookARNIndex)
-
-	jobsCopy := make(map[string]*Job, len(b.jobs))
-	maps.Copy(jobsCopy, b.jobs)
-
 	snap := backendSnapshot{
-		Pipelines:         pipelinesCopy,
-		PipelineARNIndex:  arnIndexCopy,
+		Pipelines:         copyNestedPtr(b.pipelines),
+		PipelineARNIndex:  copyNestedStr(b.pipelineARNIndex),
 		CustomActionTypes: cats,
 		StageTransitions:  transitions,
-		Jobs:              jobsCopy,
-		Webhooks:          webhooksCopy,
-		WebhookARNIndex:   webhookARNCopy,
+		Jobs:              copyNestedPtr(b.jobs),
+		Webhooks:          copyNestedPtr(b.webhooks),
+		WebhookARNIndex:   copyNestedStr(b.webhookARNIndex),
 		Executions:        execs,
 		AccountID:         b.accountID,
 		Region:            b.region,
@@ -147,43 +170,46 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 
 	snap.ensureNonNil()
 
-	// Rebuild struct-keyed maps from slices.
-	cats := make(map[customActionTypeKey]*CustomActionType, len(snap.CustomActionTypes))
+	// Rebuild region-nested struct-keyed maps from region-tagged slices.
+	cats := make(map[string]map[customActionTypeKey]*CustomActionType)
 	for _, entry := range snap.CustomActionTypes {
+		if cats[entry.Region] == nil {
+			cats[entry.Region] = make(map[customActionTypeKey]*CustomActionType)
+		}
+
 		key := customActionTypeKey{Category: entry.Category, Provider: entry.Provider, Version: entry.Version}
-		cats[key] = entry.Value
+		cats[entry.Region][key] = entry.Value
 	}
 
-	transitions := make(map[stageTransitionKey]*StageTransitionState, len(snap.StageTransitions))
+	transitions := make(map[string]map[stageTransitionKey]*StageTransitionState)
 	for _, entry := range snap.StageTransitions {
+		if transitions[entry.Region] == nil {
+			transitions[entry.Region] = make(map[stageTransitionKey]*StageTransitionState)
+		}
+
 		key := stageTransitionKey{
 			PipelineName:   entry.PipelineName,
 			StageName:      entry.StageName,
 			TransitionType: entry.TransitionType,
 		}
-		transitions[key] = entry.Value
+		transitions[entry.Region][key] = entry.Value
 	}
 
-	executions := make(map[string][]*PipelineExecution, len(snap.Executions))
+	executions := make(map[string]map[string][]*PipelineExecution)
 	for _, entry := range snap.Executions {
-		executions[entry.PipelineName] = entry.Executions
+		if executions[entry.Region] == nil {
+			executions[entry.Region] = make(map[string][]*PipelineExecution)
+		}
+
+		executions[entry.Region][entry.PipelineName] = entry.Executions
 	}
 
 	// Defensive copies: the backend owns these maps independently of the snapshot.
-	pipelinesCopy := make(map[string]*Pipeline, len(snap.Pipelines))
-	maps.Copy(pipelinesCopy, snap.Pipelines)
-
-	arnIndexCopy := make(map[string]string, len(snap.PipelineARNIndex))
-	maps.Copy(arnIndexCopy, snap.PipelineARNIndex)
-
-	webhooksCopy := make(map[string]*Webhook, len(snap.Webhooks))
-	maps.Copy(webhooksCopy, snap.Webhooks)
-
-	webhookARNCopy := make(map[string]string, len(snap.WebhookARNIndex))
-	maps.Copy(webhookARNCopy, snap.WebhookARNIndex)
-
-	jobsCopy := make(map[string]*Job, len(snap.Jobs))
-	maps.Copy(jobsCopy, snap.Jobs)
+	pipelinesCopy := copyNestedPtr(snap.Pipelines)
+	arnIndexCopy := copyNestedStr(snap.PipelineARNIndex)
+	webhooksCopy := copyNestedPtr(snap.Webhooks)
+	webhookARNCopy := copyNestedStr(snap.WebhookARNIndex)
+	jobsCopy := copyNestedPtr(snap.Jobs)
 
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
@@ -198,6 +224,10 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.executions = executions
 	b.accountID = snap.AccountID
 	b.region = snap.Region
+
+	// actionExecutions are derived state (rebuilt on StartPipelineExecution) and
+	// are not persisted; ensure the map is initialised after a restore.
+	b.actionExecutions = make(map[string]map[string][]*ActionExecution)
 
 	return nil
 }

--- a/services/directoryservice/backend.go
+++ b/services/directoryservice/backend.go
@@ -1,6 +1,7 @@
 package directoryservice
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -11,6 +12,26 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+//
+// Directory Service resources are isolated per region: every backend operation
+// resolves the caller's region from the request context and operates only on that
+// region's nested store. Directories and all of their dependent resources (snapshots,
+// trusts, certificates, conditional forwarders, etc.) are inherently single-region —
+// their identifiers (d-..., s-..., t-..., c-...) carry no region component, so the
+// region is always taken from the request context (falling back to the backend
+// default). Cross-region references never occur and isolation is always safe.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 const (
 	errEntityNotExistsException     = "EntityDoesNotExistException"
@@ -88,48 +109,34 @@ func (s *storedSnapshot) toSnapshot() Snapshot {
 	}
 }
 
-// backendSnapshot is the serializable backend state.
-type backendSnapshot struct {
-	Directories map[string]*storedDirectory `json:"directories"`
-	Snapshots   map[string]*storedSnapshot  `json:"snapshots"`
-	Aliases     map[string]string           `json:"aliases"` // alias → directoryID
-}
-
-// InMemoryBackend implements StorageBackend using in-memory maps.
-type InMemoryBackend struct {
-	domainControllers     map[string]*storedDomainController
-	adAssessments         map[string]*storedADAssessment
+// regionState holds all resources for a single AWS region.
+type regionState struct {
+	directories           map[string]*storedDirectory
 	snapshots             map[string]*storedSnapshot
-	aliases               map[string]string
-	hybridADUpdates       map[string]*storedHybridADUpdate
-	updateInfoEntries     map[string][]*storedUpdateInfo
+	aliases               map[string]string // alias → directoryID
 	ipRoutes              map[string][]storedIpRoute
 	regions               map[string]*storedRegion
 	schemaExtensions      map[string]*storedSchemaExtension
 	conditionalForwarders map[string]*storedConditionalForwarder
 	logSubscriptions      map[string]*storedLogSubscription
 	eventTopics           map[string]*storedEventTopic
-	directories           map[string]*storedDirectory
+	domainControllers     map[string]*storedDomainController
+	trusts                map[string]*storedTrust
 	sharedDirectories     map[string]*storedSharedDirectory
-	mu                    *lockmetrics.RWMutex
 	certificates          map[string]*storedCertificate
 	ldapsSettings         map[string]*storedLDAPSSetting
 	clientAuthSettings    map[string]*storedClientAuthSetting
 	radiusSettings        map[string]*storedRadiusSettings
 	dirDataAccess         map[string]bool
 	caEnrollment          map[string]bool
-	trusts                map[string]*storedTrust
+	adAssessments         map[string]*storedADAssessment
 	dirSettings           map[string][]*storedDirectorySetting
-	region                string
-	accountID             string
+	updateInfoEntries     map[string][]*storedUpdateInfo
+	hybridADUpdates       map[string]*storedHybridADUpdate
 }
 
-// NewInMemoryBackend constructs a new InMemoryBackend.
-func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
-	return &InMemoryBackend{
-		mu:                    lockmetrics.New("directoryservice"),
-		accountID:             accountID,
-		region:                region,
+func newRegionState() *regionState {
+	return &regionState{
 		directories:           make(map[string]*storedDirectory),
 		snapshots:             make(map[string]*storedSnapshot),
 		aliases:               make(map[string]string),
@@ -153,6 +160,48 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 		updateInfoEntries:     make(map[string][]*storedUpdateInfo),
 		hybridADUpdates:       make(map[string]*storedHybridADUpdate),
 	}
+}
+
+// regionSnapshot is the serializable per-region backend state.
+type regionSnapshot struct {
+	Directories map[string]*storedDirectory `json:"directories"`
+	Snapshots   map[string]*storedSnapshot  `json:"snapshots"`
+	Aliases     map[string]string           `json:"aliases"` // alias → directoryID
+}
+
+// backendSnapshot is the serializable backend state, nested by region.
+type backendSnapshot struct {
+	Regions map[string]regionSnapshot `json:"regions"`
+}
+
+// InMemoryBackend implements StorageBackend using in-memory maps, nested per region.
+type InMemoryBackend struct {
+	states    map[string]*regionState // region → state
+	mu        *lockmetrics.RWMutex
+	region    string
+	accountID string
+}
+
+// NewInMemoryBackend constructs a new InMemoryBackend.
+func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
+	return &InMemoryBackend{
+		mu:        lockmetrics.New("directoryservice"),
+		accountID: accountID,
+		region:    region,
+		states:    make(map[string]*regionState),
+	}
+}
+
+// state returns the per-region state for region, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) state(region string) *regionState {
+	st, ok := b.states[region]
+	if !ok {
+		st = newRegionState()
+		b.states[region] = st
+	}
+
+	return st
 }
 
 func (b *InMemoryBackend) newDirectoryID() string {
@@ -199,9 +248,12 @@ func (b *InMemoryBackend) newStoredDirectory(
 
 // CreateDirectory creates a new Simple AD directory.
 func (b *InMemoryBackend) CreateDirectory(
+	ctx context.Context,
 	name, shortName, description, _ string,
 	size DirectorySize, tags []Tag,
 ) (*Directory, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateDirectory")
 	defer b.mu.Unlock()
 
@@ -209,9 +261,10 @@ func (b *InMemoryBackend) CreateDirectory(
 		return nil, ErrInvalidParameter
 	}
 
+	st := b.state(region)
 	d := b.newStoredDirectory(name, shortName, description, DirectoryTypeSimpleAD, size, "", tags)
-	b.directories[d.DirectoryID] = d
-	b.aliases[d.Alias] = d.DirectoryID
+	st.directories[d.DirectoryID] = d
+	st.aliases[d.Alias] = d.DirectoryID
 
 	cp := d.toDirectory()
 
@@ -220,9 +273,12 @@ func (b *InMemoryBackend) CreateDirectory(
 
 // CreateMicrosoftAD creates a new Managed Microsoft AD directory.
 func (b *InMemoryBackend) CreateMicrosoftAD(
+	ctx context.Context,
 	name, shortName, description, _ string,
 	edition DirectoryEdition, tags []Tag,
 ) (*Directory, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateMicrosoftAD")
 	defer b.mu.Unlock()
 
@@ -230,9 +286,10 @@ func (b *InMemoryBackend) CreateMicrosoftAD(
 		return nil, ErrInvalidParameter
 	}
 
+	st := b.state(region)
 	d := b.newStoredDirectory(name, shortName, description, DirectoryTypeMicrosoftAD, "", edition, tags)
-	b.directories[d.DirectoryID] = d
-	b.aliases[d.Alias] = d.DirectoryID
+	st.directories[d.DirectoryID] = d
+	st.aliases[d.Alias] = d.DirectoryID
 
 	cp := d.toDirectory()
 
@@ -240,22 +297,26 @@ func (b *InMemoryBackend) CreateMicrosoftAD(
 }
 
 // DeleteDirectory deletes a directory.
-func (b *InMemoryBackend) DeleteDirectory(directoryID string) error {
+func (b *InMemoryBackend) DeleteDirectory(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteDirectory")
 	defer b.mu.Unlock()
 
-	d, ok := b.directories[directoryID]
+	st := b.state(region)
+
+	d, ok := st.directories[directoryID]
 	if !ok {
 		return ErrDirectoryNotFound
 	}
 
-	delete(b.aliases, d.Alias)
-	delete(b.directories, directoryID)
+	delete(st.aliases, d.Alias)
+	delete(st.directories, directoryID)
 
 	// Delete associated snapshots.
-	for id, snap := range b.snapshots {
+	for id, snap := range st.snapshots {
 		if snap.DirectoryID == directoryID {
-			delete(b.snapshots, id)
+			delete(st.snapshots, id)
 		}
 	}
 
@@ -264,26 +325,31 @@ func (b *InMemoryBackend) DeleteDirectory(directoryID string) error {
 
 // DescribeDirectories returns directories, optionally filtered by IDs.
 func (b *InMemoryBackend) DescribeDirectories(
+	ctx context.Context,
 	directoryIDs []string,
 	limit int32,
 	nextToken string,
 ) ([]*Directory, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeDirectories")
 	defer b.mu.RUnlock()
+
+	st := b.state(region)
 
 	var ids []string
 
 	if len(directoryIDs) > 0 {
 		for _, id := range directoryIDs {
-			if _, ok := b.directories[id]; !ok {
+			if _, ok := st.directories[id]; !ok {
 				return nil, "", ErrDirectoryNotFound
 			}
 		}
 		ids = append([]string(nil), directoryIDs...)
 		sort.Strings(ids)
 	} else {
-		ids = make([]string, 0, len(b.directories))
-		for id := range b.directories {
+		ids = make([]string, 0, len(st.directories))
+		for id := range st.directories {
 			ids = append(ids, id)
 		}
 		sort.Strings(ids)
@@ -309,7 +375,7 @@ func (b *InMemoryBackend) DescribeDirectories(
 
 	result := make([]*Directory, 0, end-start)
 	for _, id := range ids[start:end] {
-		d := b.directories[id]
+		d := st.directories[id]
 		cp := d.toDirectory()
 		result = append(result, &cp)
 	}
@@ -323,33 +389,39 @@ func (b *InMemoryBackend) DescribeDirectories(
 }
 
 // CreateAlias creates an alias for a directory.
-func (b *InMemoryBackend) CreateAlias(directoryID, alias string) error {
+func (b *InMemoryBackend) CreateAlias(ctx context.Context, directoryID, alias string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateAlias")
 	defer b.mu.Unlock()
 
-	d, ok := b.directories[directoryID]
+	st := b.state(region)
+
+	d, ok := st.directories[directoryID]
 	if !ok {
 		return ErrDirectoryNotFound
 	}
 
-	if _, taken := b.aliases[alias]; taken {
+	if _, taken := st.aliases[alias]; taken {
 		return ErrAliasAlreadyExists
 	}
 
-	delete(b.aliases, d.Alias)
+	delete(st.aliases, d.Alias)
 	d.Alias = alias
 	d.AccessURL = b.defaultAccessURL(alias)
-	b.aliases[alias] = directoryID
+	st.aliases[alias] = directoryID
 
 	return nil
 }
 
 // EnableSso enables single sign-on for a directory.
-func (b *InMemoryBackend) EnableSso(directoryID string) error {
+func (b *InMemoryBackend) EnableSso(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableSso")
 	defer b.mu.Unlock()
 
-	d, ok := b.directories[directoryID]
+	d, ok := b.state(region).directories[directoryID]
 	if !ok {
 		return ErrDirectoryNotFound
 	}
@@ -360,11 +432,13 @@ func (b *InMemoryBackend) EnableSso(directoryID string) error {
 }
 
 // DisableSso disables single sign-on for a directory.
-func (b *InMemoryBackend) DisableSso(directoryID string) error {
+func (b *InMemoryBackend) DisableSso(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableSso")
 	defer b.mu.Unlock()
 
-	d, ok := b.directories[directoryID]
+	d, ok := b.state(region).directories[directoryID]
 	if !ok {
 		return ErrDirectoryNotFound
 	}
@@ -375,13 +449,15 @@ func (b *InMemoryBackend) DisableSso(directoryID string) error {
 }
 
 // GetDirectoryLimits returns directory limits for the region.
-func (b *InMemoryBackend) GetDirectoryLimits() *DirectoryLimits {
+func (b *InMemoryBackend) GetDirectoryLimits(ctx context.Context) *DirectoryLimits {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetDirectoryLimits")
 	defer b.mu.RUnlock()
 
 	var simpleADCount, msADCount, connectedCount int32
 
-	for _, d := range b.directories {
+	for _, d := range b.state(region).directories {
 		switch DirectoryType(d.DirType) { //nolint:exhaustive // existing issue.
 		case DirectoryTypeSimpleAD:
 			simpleADCount++
@@ -406,11 +482,15 @@ func (b *InMemoryBackend) GetDirectoryLimits() *DirectoryLimits {
 }
 
 // CreateSnapshot creates a manual snapshot for a directory.
-func (b *InMemoryBackend) CreateSnapshot(directoryID, name string) (*Snapshot, error) {
+func (b *InMemoryBackend) CreateSnapshot(ctx context.Context, directoryID, name string) (*Snapshot, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateSnapshot")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
@@ -425,7 +505,7 @@ func (b *InMemoryBackend) CreateSnapshot(directoryID, name string) (*Snapshot, e
 		Status:      string(SnapshotStatusCompleted),
 		SnapType:    string(SnapshotTypeManual),
 	}
-	b.snapshots[id] = s
+	st.snapshots[id] = s
 
 	cp := s.toSnapshot()
 
@@ -433,28 +513,37 @@ func (b *InMemoryBackend) CreateSnapshot(directoryID, name string) (*Snapshot, e
 }
 
 // DeleteSnapshot deletes a snapshot.
-func (b *InMemoryBackend) DeleteSnapshot(snapshotID string) error {
+func (b *InMemoryBackend) DeleteSnapshot(ctx context.Context, snapshotID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteSnapshot")
 	defer b.mu.Unlock()
 
-	if _, ok := b.snapshots[snapshotID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.snapshots[snapshotID]; !ok {
 		return ErrSnapshotNotFound
 	}
 
-	delete(b.snapshots, snapshotID)
+	delete(st.snapshots, snapshotID)
 
 	return nil
 }
 
 // DescribeSnapshots returns snapshots filtered by directory and/or snapshot IDs.
 func (b *InMemoryBackend) DescribeSnapshots(
+	ctx context.Context,
 	directoryID string,
 	snapshotIDs []string,
 	limit int32,
 	nextToken string,
 ) ([]*Snapshot, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeSnapshots")
 	defer b.mu.RUnlock()
+
+	st := b.state(region)
 
 	// Build filter set for snapshot IDs.
 	filterIDs := make(map[string]bool, len(snapshotIDs))
@@ -462,8 +551,8 @@ func (b *InMemoryBackend) DescribeSnapshots(
 		filterIDs[id] = true
 	}
 
-	ids := make([]string, 0, len(b.snapshots))
-	for id, snap := range b.snapshots {
+	ids := make([]string, 0, len(st.snapshots))
+	for id, snap := range st.snapshots {
 		if directoryID != "" && snap.DirectoryID != directoryID {
 			continue
 		}
@@ -494,7 +583,7 @@ func (b *InMemoryBackend) DescribeSnapshots(
 
 	result := make([]*Snapshot, 0, end-start)
 	for _, id := range ids[start:end] {
-		s := b.snapshots[id]
+		s := st.snapshots[id]
 		cp := s.toSnapshot()
 		result = append(result, &cp)
 	}
@@ -508,16 +597,20 @@ func (b *InMemoryBackend) DescribeSnapshots(
 }
 
 // GetSnapshotLimits returns snapshot limits for a directory.
-func (b *InMemoryBackend) GetSnapshotLimits(directoryID string) (*SnapshotLimits, error) {
+func (b *InMemoryBackend) GetSnapshotLimits(ctx context.Context, directoryID string) (*SnapshotLimits, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetSnapshotLimits")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
 	var count int32
-	for _, snap := range b.snapshots {
+	for _, snap := range st.snapshots {
 		if snap.DirectoryID == directoryID && snap.SnapType == string(SnapshotTypeManual) {
 			count++
 		}
@@ -531,11 +624,13 @@ func (b *InMemoryBackend) GetSnapshotLimits(directoryID string) (*SnapshotLimits
 }
 
 // RestoreFromSnapshot simulates restoring a directory from a snapshot.
-func (b *InMemoryBackend) RestoreFromSnapshot(snapshotID string) error {
+func (b *InMemoryBackend) RestoreFromSnapshot(ctx context.Context, snapshotID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("RestoreFromSnapshot")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.snapshots[snapshotID]; !ok {
+	if _, ok := b.state(region).snapshots[snapshotID]; !ok {
 		return ErrSnapshotNotFound
 	}
 
@@ -543,11 +638,13 @@ func (b *InMemoryBackend) RestoreFromSnapshot(snapshotID string) error {
 }
 
 // AddTagsToResource adds or updates tags on a directory.
-func (b *InMemoryBackend) AddTagsToResource(resourceID string, tags []Tag) error {
+func (b *InMemoryBackend) AddTagsToResource(ctx context.Context, resourceID string, tags []Tag) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddTagsToResource")
 	defer b.mu.Unlock()
 
-	d, ok := b.directories[resourceID]
+	d, ok := b.state(region).directories[resourceID]
 	if !ok {
 		return ErrDirectoryNotFound
 	}
@@ -564,11 +661,13 @@ func (b *InMemoryBackend) AddTagsToResource(resourceID string, tags []Tag) error
 }
 
 // RemoveTagsFromResource removes tags from a directory.
-func (b *InMemoryBackend) RemoveTagsFromResource(resourceID string, tagKeys []string) error {
+func (b *InMemoryBackend) RemoveTagsFromResource(ctx context.Context, resourceID string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveTagsFromResource")
 	defer b.mu.Unlock()
 
-	d, ok := b.directories[resourceID]
+	d, ok := b.state(region).directories[resourceID]
 	if !ok {
 		return ErrDirectoryNotFound
 	}
@@ -582,14 +681,17 @@ func (b *InMemoryBackend) RemoveTagsFromResource(resourceID string, tagKeys []st
 
 // ListTagsForResource returns tags for a directory.
 func (b *InMemoryBackend) ListTagsForResource(
+	ctx context.Context,
 	resourceID string,
 	_ int32,
 	_ string,
 ) ([]Tag, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	d, ok := b.directories[resourceID]
+	d, ok := b.state(region).directories[resourceID]
 	if !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
@@ -614,40 +716,24 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.directories = make(map[string]*storedDirectory)
-	b.snapshots = make(map[string]*storedSnapshot)
-	b.aliases = make(map[string]string)
-	b.ipRoutes = make(map[string][]storedIpRoute)
-	b.regions = make(map[string]*storedRegion)
-	b.schemaExtensions = make(map[string]*storedSchemaExtension)
-	b.conditionalForwarders = make(map[string]*storedConditionalForwarder)
-	b.logSubscriptions = make(map[string]*storedLogSubscription)
-	b.eventTopics = make(map[string]*storedEventTopic)
-	b.domainControllers = make(map[string]*storedDomainController)
-	b.trusts = make(map[string]*storedTrust)
-	b.sharedDirectories = make(map[string]*storedSharedDirectory)
-	b.certificates = make(map[string]*storedCertificate)
-	b.ldapsSettings = make(map[string]*storedLDAPSSetting)
-	b.clientAuthSettings = make(map[string]*storedClientAuthSetting)
-	b.radiusSettings = make(map[string]*storedRadiusSettings)
-	b.dirDataAccess = make(map[string]bool)
-	b.caEnrollment = make(map[string]bool)
-	b.adAssessments = make(map[string]*storedADAssessment)
-	b.dirSettings = make(map[string][]*storedDirectorySetting)
-	b.updateInfoEntries = make(map[string][]*storedUpdateInfo)
-	b.hybridADUpdates = make(map[string]*storedHybridADUpdate)
+	b.states = make(map[string]*regionState)
 }
 
-// BackendSnapshot serializes the backend state to JSON.
+// BackendSnapshot serializes the backend state to JSON, nested by region.
 func (b *InMemoryBackend) BackendSnapshot() []byte {
 	b.mu.RLock("BackendSnapshot")
 	defer b.mu.RUnlock()
 
-	data, _ := json.Marshal(backendSnapshot{
-		Directories: b.directories,
-		Snapshots:   b.snapshots,
-		Aliases:     b.aliases,
-	})
+	regions := make(map[string]regionSnapshot, len(b.states))
+	for region, st := range b.states {
+		regions[region] = regionSnapshot{
+			Directories: st.directories,
+			Snapshots:   st.snapshots,
+			Aliases:     st.aliases,
+		}
+	}
+
+	data, _ := json.Marshal(backendSnapshot{Regions: regions})
 
 	return data
 }
@@ -662,22 +748,19 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 		return err
 	}
 
-	if snap.Directories != nil {
-		b.directories = snap.Directories
-	} else {
-		b.directories = make(map[string]*storedDirectory)
-	}
-
-	if snap.Snapshots != nil {
-		b.snapshots = snap.Snapshots
-	} else {
-		b.snapshots = make(map[string]*storedSnapshot)
-	}
-
-	if snap.Aliases != nil {
-		b.aliases = snap.Aliases
-	} else {
-		b.aliases = make(map[string]string)
+	b.states = make(map[string]*regionState)
+	for region, rs := range snap.Regions {
+		st := newRegionState()
+		if rs.Directories != nil {
+			st.directories = rs.Directories
+		}
+		if rs.Snapshots != nil {
+			st.snapshots = rs.Snapshots
+		}
+		if rs.Aliases != nil {
+			st.aliases = rs.Aliases
+		}
+		b.states[region] = st
 	}
 
 	return nil

--- a/services/directoryservice/backend_appendixa.go
+++ b/services/directoryservice/backend_appendixa.go
@@ -1,6 +1,7 @@
 package directoryservice
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -406,18 +407,23 @@ type HybridADUpdateEntry struct {
 
 // AddIpRoutes adds CIDR IP routes to a directory.
 func (b *InMemoryBackend) AddIpRoutes( //nolint:revive,staticcheck // existing issue.
+	ctx context.Context,
 	directoryID string,
 	routes []IpRoute,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddIpRoutes")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	now := time.Now().UTC()
-	existing := b.ipRoutes[directoryID]
+	existing := st.ipRoutes[directoryID]
 	existingSet := make(map[string]bool, len(existing))
 	for _, r := range existing {
 		existingSet[r.CidrIP] = true
@@ -425,7 +431,7 @@ func (b *InMemoryBackend) AddIpRoutes( //nolint:revive,staticcheck // existing i
 
 	for _, r := range routes {
 		if !existingSet[r.CidrIP] {
-			b.ipRoutes[directoryID] = append(b.ipRoutes[directoryID], storedIpRoute{
+			st.ipRoutes[directoryID] = append(st.ipRoutes[directoryID], storedIpRoute{
 				DirectoryID:   directoryID,
 				CidrIP:        r.CidrIP,
 				Description:   r.Description,
@@ -440,13 +446,18 @@ func (b *InMemoryBackend) AddIpRoutes( //nolint:revive,staticcheck // existing i
 
 // RemoveIpRoutes removes CIDR IP routes from a directory.
 func (b *InMemoryBackend) RemoveIpRoutes( //nolint:revive,staticcheck // existing issue.
+	ctx context.Context,
 	directoryID string,
 	cidrIPs []string,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveIpRoutes")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
@@ -455,31 +466,36 @@ func (b *InMemoryBackend) RemoveIpRoutes( //nolint:revive,staticcheck // existin
 		remove[c] = true
 	}
 
-	filtered := b.ipRoutes[directoryID][:0]
-	for _, r := range b.ipRoutes[directoryID] {
+	filtered := st.ipRoutes[directoryID][:0]
+	for _, r := range st.ipRoutes[directoryID] {
 		if !remove[r.CidrIP] {
 			filtered = append(filtered, r)
 		}
 	}
-	b.ipRoutes[directoryID] = filtered
+	st.ipRoutes[directoryID] = filtered
 
 	return nil
 }
 
 // ListIpRoutes returns IP routes for a directory.
 func (b *InMemoryBackend) ListIpRoutes( //nolint:revive,staticcheck // existing issue.
+	ctx context.Context,
 	directoryID string,
 	limit int32,
 	nextToken string,
 ) ([]IpRoute, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListIpRoutes")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
-	stored := b.ipRoutes[directoryID]
+	stored := st.ipRoutes[directoryID]
 	sorted := make([]storedIpRoute, len(stored))
 	copy(sorted, stored)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].CidrIP < sorted[j].CidrIP })
@@ -523,20 +539,24 @@ func (b *InMemoryBackend) ListIpRoutes( //nolint:revive,staticcheck // existing 
 // --- Regions ---
 
 // AddRegion adds a region to a directory.
-func (b *InMemoryBackend) AddRegion(directoryID, regionName string) error {
+func (b *InMemoryBackend) AddRegion(ctx context.Context, directoryID, regionName string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddRegion")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + regionName
-	if _, exists := b.regions[key]; exists {
+	if _, exists := st.regions[key]; exists {
 		return ErrAliasAlreadyExists
 	}
 
-	b.regions[key] = &storedRegion{
+	st.regions[key] = &storedRegion{
 		DirectoryID: directoryID,
 		RegionName:  regionName,
 		RegionType:  "Additional",
@@ -548,17 +568,21 @@ func (b *InMemoryBackend) AddRegion(directoryID, regionName string) error {
 }
 
 // RemoveRegion removes a region from a directory.
-func (b *InMemoryBackend) RemoveRegion(directoryID string) error {
+func (b *InMemoryBackend) RemoveRegion(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveRegion")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	for key, r := range b.regions {
+	for key, r := range st.regions {
 		if r.DirectoryID == directoryID {
-			delete(b.regions, key)
+			delete(st.regions, key)
 		}
 	}
 
@@ -567,17 +591,22 @@ func (b *InMemoryBackend) RemoveRegion(directoryID string) error {
 
 // DescribeRegions returns regions for a directory.
 func (b *InMemoryBackend) DescribeRegions(
+	ctx context.Context,
 	directoryID, regionName, nextToken string, //nolint:revive // existing issue.
 ) ([]RegionDescription, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeRegions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
 	var all []storedRegion
-	for _, r := range b.regions {
+	for _, r := range st.regions {
 		if r.DirectoryID != directoryID {
 			continue
 		}
@@ -599,17 +628,24 @@ func (b *InMemoryBackend) DescribeRegions(
 // --- Schema Extensions ---
 
 // StartSchemaExtension starts a schema extension.
-func (b *InMemoryBackend) StartSchemaExtension(directoryID, description, _ string) (string, error) {
+func (b *InMemoryBackend) StartSchemaExtension(
+	ctx context.Context,
+	directoryID, description, _ string,
+) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("StartSchemaExtension")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	id := fmt.Sprintf("e-%s", uuid.NewString()[:10])
 	now := time.Now().UTC()
-	b.schemaExtensions[id] = &storedSchemaExtension{
+	st.schemaExtensions[id] = &storedSchemaExtension{
 		ExtensionID: id,
 		DirectoryID: directoryID,
 		Description: description,
@@ -622,11 +658,13 @@ func (b *InMemoryBackend) StartSchemaExtension(directoryID, description, _ strin
 }
 
 // CancelSchemaExtension cancels a schema extension.
-func (b *InMemoryBackend) CancelSchemaExtension(directoryID, schemaExtensionID string) error {
+func (b *InMemoryBackend) CancelSchemaExtension(ctx context.Context, directoryID, schemaExtensionID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CancelSchemaExtension")
 	defer b.mu.Unlock()
 
-	ext, ok := b.schemaExtensions[schemaExtensionID]
+	ext, ok := b.state(region).schemaExtensions[schemaExtensionID]
 	if !ok || ext.DirectoryID != directoryID {
 		return ErrSchemaExtensionNotFound
 	}
@@ -638,19 +676,24 @@ func (b *InMemoryBackend) CancelSchemaExtension(directoryID, schemaExtensionID s
 
 // ListSchemaExtensions returns schema extensions for a directory.
 func (b *InMemoryBackend) ListSchemaExtensions(
+	ctx context.Context,
 	directoryID string,
 	limit int32,
 	nextToken string,
 ) ([]SchemaExtension, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSchemaExtensions")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
 	var all []storedSchemaExtension
-	for _, e := range b.schemaExtensions {
+	for _, e := range st.schemaExtensions {
 		if e.DirectoryID == directoryID {
 			all = append(all, *e)
 		}
@@ -690,20 +733,28 @@ func (b *InMemoryBackend) ListSchemaExtensions(
 // --- Conditional Forwarders ---
 
 // CreateConditionalForwarder creates a conditional forwarder.
-func (b *InMemoryBackend) CreateConditionalForwarder(directoryID, remoteDomainName string, dnsIPAddrs []string) error {
+func (b *InMemoryBackend) CreateConditionalForwarder(
+	ctx context.Context,
+	directoryID, remoteDomainName string,
+	dnsIPAddrs []string,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateConditionalForwarder")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + remoteDomainName
-	if _, exists := b.conditionalForwarders[key]; exists {
+	if _, exists := st.conditionalForwarders[key]; exists {
 		return ErrAliasAlreadyExists
 	}
 
-	b.conditionalForwarders[key] = &storedConditionalForwarder{
+	st.conditionalForwarders[key] = &storedConditionalForwarder{
 		DirectoryID:      directoryID,
 		RemoteDomainName: remoteDomainName,
 		DNSIPAddrs:       dnsIPAddrs,
@@ -714,12 +765,18 @@ func (b *InMemoryBackend) CreateConditionalForwarder(directoryID, remoteDomainNa
 }
 
 // UpdateConditionalForwarder updates a conditional forwarder.
-func (b *InMemoryBackend) UpdateConditionalForwarder(directoryID, remoteDomainName string, dnsIPAddrs []string) error {
+func (b *InMemoryBackend) UpdateConditionalForwarder(
+	ctx context.Context,
+	directoryID, remoteDomainName string,
+	dnsIPAddrs []string,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateConditionalForwarder")
 	defer b.mu.Unlock()
 
 	key := directoryID + ":" + remoteDomainName
-	fwd, ok := b.conditionalForwarders[key]
+	fwd, ok := b.state(region).conditionalForwarders[key]
 	if !ok {
 		return ErrConditionalForwarderNotFound
 	}
@@ -730,29 +787,37 @@ func (b *InMemoryBackend) UpdateConditionalForwarder(directoryID, remoteDomainNa
 }
 
 // DeleteConditionalForwarder deletes a conditional forwarder.
-func (b *InMemoryBackend) DeleteConditionalForwarder(directoryID, remoteDomainName string) error {
+func (b *InMemoryBackend) DeleteConditionalForwarder(ctx context.Context, directoryID, remoteDomainName string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteConditionalForwarder")
 	defer b.mu.Unlock()
 
+	st := b.state(region)
 	key := directoryID + ":" + remoteDomainName
-	if _, ok := b.conditionalForwarders[key]; !ok {
+	if _, ok := st.conditionalForwarders[key]; !ok {
 		return ErrConditionalForwarderNotFound
 	}
 
-	delete(b.conditionalForwarders, key)
+	delete(st.conditionalForwarders, key)
 
 	return nil
 }
 
 // DescribeConditionalForwarders returns conditional forwarders for a directory.
 func (b *InMemoryBackend) DescribeConditionalForwarders(
+	ctx context.Context,
 	directoryID string,
 	remoteDomainNames []string,
 ) ([]ConditionalForwarder, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeConditionalForwarders")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
@@ -762,7 +827,7 @@ func (b *InMemoryBackend) DescribeConditionalForwarders(
 	}
 
 	var result []ConditionalForwarder
-	for _, fwd := range b.conditionalForwarders {
+	for _, fwd := range st.conditionalForwarders {
 		if fwd.DirectoryID != directoryID {
 			continue
 		}
@@ -786,20 +851,24 @@ func (b *InMemoryBackend) DescribeConditionalForwarders(
 // --- Log Subscriptions ---
 
 // CreateLogSubscription creates a log subscription.
-func (b *InMemoryBackend) CreateLogSubscription(directoryID, logGroupName string) error {
+func (b *InMemoryBackend) CreateLogSubscription(ctx context.Context, directoryID, logGroupName string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateLogSubscription")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + logGroupName
-	if _, exists := b.logSubscriptions[key]; exists {
+	if _, exists := st.logSubscriptions[key]; exists {
 		return ErrAliasAlreadyExists
 	}
 
-	b.logSubscriptions[key] = &storedLogSubscription{
+	st.logSubscriptions[key] = &storedLogSubscription{
 		DirectoryID:                 directoryID,
 		LogGroupName:                logGroupName,
 		SubscriptionCreatedDateTime: time.Now().UTC(),
@@ -809,17 +878,21 @@ func (b *InMemoryBackend) CreateLogSubscription(directoryID, logGroupName string
 }
 
 // DeleteLogSubscription deletes a log subscription.
-func (b *InMemoryBackend) DeleteLogSubscription(directoryID string) error {
+func (b *InMemoryBackend) DeleteLogSubscription(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteLogSubscription")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	for key, sub := range b.logSubscriptions {
+	for key, sub := range st.logSubscriptions {
 		if sub.DirectoryID == directoryID {
-			delete(b.logSubscriptions, key)
+			delete(st.logSubscriptions, key)
 		}
 	}
 
@@ -828,15 +901,18 @@ func (b *InMemoryBackend) DeleteLogSubscription(directoryID string) error {
 
 // ListLogSubscriptions returns log subscriptions.
 func (b *InMemoryBackend) ListLogSubscriptions(
+	ctx context.Context,
 	directoryID string,
 	limit int32,
 	nextToken string, //nolint:revive // existing issue.
 ) ([]LogSubscription, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListLogSubscriptions")
 	defer b.mu.RUnlock()
 
 	var all []storedLogSubscription
-	for _, sub := range b.logSubscriptions {
+	for _, sub := range b.state(region).logSubscriptions {
 		if directoryID != "" && sub.DirectoryID != directoryID {
 			continue
 		}
@@ -877,23 +953,27 @@ func (b *InMemoryBackend) ListLogSubscriptions(
 // --- Event Topics ---
 
 // RegisterEventTopic registers an event topic.
-func (b *InMemoryBackend) RegisterEventTopic(directoryID, topicName string) error {
+func (b *InMemoryBackend) RegisterEventTopic(ctx context.Context, directoryID, topicName string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RegisterEventTopic")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + topicName
-	if _, exists := b.eventTopics[key]; exists {
+	if _, exists := st.eventTopics[key]; exists {
 		return ErrAliasAlreadyExists
 	}
 
-	b.eventTopics[key] = &storedEventTopic{
+	st.eventTopics[key] = &storedEventTopic{
 		DirectoryID:     directoryID,
 		TopicName:       topicName,
-		TopicARN:        fmt.Sprintf("arn:aws:sns:%s:%s:%s", b.region, b.accountID, topicName),
+		TopicARN:        fmt.Sprintf("arn:aws:sns:%s:%s:%s", region, b.accountID, topicName),
 		Status:          "Registered",
 		CreatedDateTime: time.Now().UTC(),
 	}
@@ -902,22 +982,31 @@ func (b *InMemoryBackend) RegisterEventTopic(directoryID, topicName string) erro
 }
 
 // DeregisterEventTopic deregisters an event topic.
-func (b *InMemoryBackend) DeregisterEventTopic(directoryID, topicName string) error {
+func (b *InMemoryBackend) DeregisterEventTopic(ctx context.Context, directoryID, topicName string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeregisterEventTopic")
 	defer b.mu.Unlock()
 
+	st := b.state(region)
 	key := directoryID + ":" + topicName
-	if _, ok := b.eventTopics[key]; !ok {
+	if _, ok := st.eventTopics[key]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	delete(b.eventTopics, key)
+	delete(st.eventTopics, key)
 
 	return nil
 }
 
 // DescribeEventTopics returns event topics for a directory.
-func (b *InMemoryBackend) DescribeEventTopics(directoryID string, topicNames []string) ([]EventTopic, error) {
+func (b *InMemoryBackend) DescribeEventTopics(
+	ctx context.Context,
+	directoryID string,
+	topicNames []string,
+) ([]EventTopic, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeEventTopics")
 	defer b.mu.RUnlock()
 
@@ -927,7 +1016,7 @@ func (b *InMemoryBackend) DescribeEventTopics(directoryID string, topicNames []s
 	}
 
 	var result []EventTopic
-	for _, topic := range b.eventTopics {
+	for _, topic := range b.state(region).eventTopics {
 		if directoryID != "" && topic.DirectoryID != directoryID {
 			continue
 		}
@@ -951,15 +1040,20 @@ func (b *InMemoryBackend) DescribeEventTopics(directoryID string, topicNames []s
 
 // DescribeDomainControllers returns domain controllers for a directory.
 func (b *InMemoryBackend) DescribeDomainControllers(
+	ctx context.Context,
 	directoryID string,
 	domainControllerIDs []string,
 	limit int32,
 	nextToken string,
 ) ([]DomainController, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeDomainControllers")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
@@ -969,7 +1063,7 @@ func (b *InMemoryBackend) DescribeDomainControllers(
 	}
 
 	var ids []string
-	for id, dc := range b.domainControllers {
+	for id, dc := range st.domainControllers {
 		if dc.DirectoryID != directoryID {
 			continue
 		}
@@ -999,7 +1093,7 @@ func (b *InMemoryBackend) DescribeDomainControllers(
 	end := min(start+pageSize, len(ids))
 	result := make([]DomainController, 0, end-start)
 	for _, id := range ids[start:end] {
-		dc := b.domainControllers[id]
+		dc := st.domainControllers[id]
 		result = append(result, DomainController{
 			ControllerID:     dc.ControllerID,
 			DirectoryID:      dc.DirectoryID,
@@ -1018,17 +1112,25 @@ func (b *InMemoryBackend) DescribeDomainControllers(
 }
 
 // UpdateNumberOfDomainControllers sets the desired domain controller count.
-func (b *InMemoryBackend) UpdateNumberOfDomainControllers(directoryID string, desiredNumber int32) error {
+func (b *InMemoryBackend) UpdateNumberOfDomainControllers(
+	ctx context.Context,
+	directoryID string,
+	desiredNumber int32,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateNumberOfDomainControllers")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	// Count current controllers.
 	var current int32
-	for _, dc := range b.domainControllers {
+	for _, dc := range st.domainControllers {
 		if dc.DirectoryID == directoryID {
 			current++
 		}
@@ -1037,7 +1139,7 @@ func (b *InMemoryBackend) UpdateNumberOfDomainControllers(directoryID string, de
 	// Add controllers if desired > current.
 	for i := current; i < desiredNumber; i++ {
 		id := fmt.Sprintf("dc-%s", uuid.NewString()[:10])
-		b.domainControllers[id] = &storedDomainController{
+		st.domainControllers[id] = &storedDomainController{
 			ControllerID:     id,
 			DirectoryID:      directoryID,
 			Status:           "Active",
@@ -1049,14 +1151,14 @@ func (b *InMemoryBackend) UpdateNumberOfDomainControllers(directoryID string, de
 	// Remove controllers if desired < current.
 	if desiredNumber < current {
 		var toRemove []string
-		for id, dc := range b.domainControllers {
+		for id, dc := range st.domainControllers {
 			if dc.DirectoryID == directoryID {
 				toRemove = append(toRemove, id)
 			}
 		}
 		sort.Strings(toRemove)
 		for i := int32(len(toRemove)) - 1; i >= desiredNumber; i-- { //nolint:gosec // existing issue.
-			delete(b.domainControllers, toRemove[i])
+			delete(st.domainControllers, toRemove[i])
 		}
 	}
 
@@ -1067,18 +1169,23 @@ func (b *InMemoryBackend) UpdateNumberOfDomainControllers(directoryID string, de
 
 // CreateTrust creates a trust relationship.
 func (b *InMemoryBackend) CreateTrust(
+	ctx context.Context,
 	directoryID, remoteDomainName, _, trustDirection, trustType string,
 ) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateTrust")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	id := fmt.Sprintf("t-%s", uuid.NewString()[:10])
 	now := time.Now().UTC()
-	b.trusts[id] = &storedTrust{
+	st.trusts[id] = &storedTrust{
 		TrustID:              id,
 		DirectoryID:          directoryID,
 		RemoteDomainName:     remoteDomainName,
@@ -1095,26 +1202,33 @@ func (b *InMemoryBackend) CreateTrust(
 }
 
 // DeleteTrust deletes a trust relationship.
-func (b *InMemoryBackend) DeleteTrust(trustID string) (string, error) {
+func (b *InMemoryBackend) DeleteTrust(ctx context.Context, trustID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteTrust")
 	defer b.mu.Unlock()
 
-	if _, ok := b.trusts[trustID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.trusts[trustID]; !ok {
 		return "", ErrTrustNotFound
 	}
 
-	delete(b.trusts, trustID)
+	delete(st.trusts, trustID)
 
 	return trustID, nil
 }
 
 // DescribeTrusts returns trusts for a directory.
 func (b *InMemoryBackend) DescribeTrusts(
+	ctx context.Context,
 	directoryID string,
 	trustIDs []string,
 	limit int32,
 	nextToken string,
 ) ([]TrustInfo, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeTrusts")
 	defer b.mu.RUnlock()
 
@@ -1123,8 +1237,9 @@ func (b *InMemoryBackend) DescribeTrusts(
 		filterSet[id] = true
 	}
 
+	st := b.state(region)
 	var ids []string
-	for id, t := range b.trusts {
+	for id, t := range st.trusts {
 		if directoryID != "" && t.DirectoryID != directoryID {
 			continue
 		}
@@ -1154,7 +1269,7 @@ func (b *InMemoryBackend) DescribeTrusts(
 	end := min(start+pageSize, len(ids))
 	result := make([]TrustInfo, 0, end-start)
 	for _, id := range ids[start:end] {
-		t := b.trusts[id]
+		t := st.trusts[id]
 		result = append(result, TrustInfo{
 			TrustID:              t.TrustID,
 			DirectoryID:          t.DirectoryID,
@@ -1179,11 +1294,13 @@ func (b *InMemoryBackend) DescribeTrusts(
 }
 
 // UpdateTrust updates a trust relationship.
-func (b *InMemoryBackend) UpdateTrust(trustID, selectiveAuth string) (string, error) {
+func (b *InMemoryBackend) UpdateTrust(ctx context.Context, trustID, selectiveAuth string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateTrust")
 	defer b.mu.Unlock()
 
-	t, ok := b.trusts[trustID]
+	t, ok := b.state(region).trusts[trustID]
 	if !ok {
 		return "", ErrTrustNotFound
 	}
@@ -1197,11 +1314,13 @@ func (b *InMemoryBackend) UpdateTrust(trustID, selectiveAuth string) (string, er
 }
 
 // VerifyTrust verifies a trust relationship.
-func (b *InMemoryBackend) VerifyTrust(trustID string) (string, error) {
+func (b *InMemoryBackend) VerifyTrust(ctx context.Context, trustID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("VerifyTrust")
 	defer b.mu.Unlock()
 
-	t, ok := b.trusts[trustID]
+	t, ok := b.state(region).trusts[trustID]
 	if !ok {
 		return "", ErrTrustNotFound
 	}
@@ -1216,17 +1335,24 @@ func (b *InMemoryBackend) VerifyTrust(trustID string) (string, error) {
 // --- Shared Directories ---
 
 // ShareDirectory shares a directory.
-func (b *InMemoryBackend) ShareDirectory(directoryID, shareMethod, shareNotes, targetID string) (string, error) {
+func (b *InMemoryBackend) ShareDirectory(
+	ctx context.Context,
+	directoryID, shareMethod, shareNotes, targetID string,
+) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ShareDirectory")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	id := fmt.Sprintf("d-%s", uuid.NewString()[:10])
 	now := time.Now().UTC()
-	b.sharedDirectories[id] = &storedSharedDirectory{
+	st.sharedDirectories[id] = &storedSharedDirectory{
 		SharedDirectoryID:   id,
 		OwnerDirectoryID:    directoryID,
 		OwnerAccountID:      b.accountID,
@@ -1242,11 +1368,13 @@ func (b *InMemoryBackend) ShareDirectory(directoryID, shareMethod, shareNotes, t
 }
 
 // UnshareDirectory unshares a directory.
-func (b *InMemoryBackend) UnshareDirectory(directoryID, targetID string) (string, error) {
+func (b *InMemoryBackend) UnshareDirectory(ctx context.Context, directoryID, targetID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UnshareDirectory")
 	defer b.mu.Unlock()
 
-	for id, sd := range b.sharedDirectories {
+	for id, sd := range b.state(region).sharedDirectories {
 		if sd.OwnerDirectoryID == directoryID && sd.SharedAccountID == targetID {
 			sd.ShareStatus = "Deleted"
 			sd.LastUpdatedDateTime = time.Now().UTC()
@@ -1259,11 +1387,13 @@ func (b *InMemoryBackend) UnshareDirectory(directoryID, targetID string) (string
 }
 
 // AcceptSharedDirectory accepts a shared directory.
-func (b *InMemoryBackend) AcceptSharedDirectory(sharedDirectoryID string) (string, error) {
+func (b *InMemoryBackend) AcceptSharedDirectory(ctx context.Context, sharedDirectoryID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AcceptSharedDirectory")
 	defer b.mu.Unlock()
 
-	sd, ok := b.sharedDirectories[sharedDirectoryID]
+	sd, ok := b.state(region).sharedDirectories[sharedDirectoryID]
 	if !ok {
 		return "", ErrSharedDirectoryNotFound
 	}
@@ -1275,11 +1405,13 @@ func (b *InMemoryBackend) AcceptSharedDirectory(sharedDirectoryID string) (strin
 }
 
 // RejectSharedDirectory rejects a shared directory.
-func (b *InMemoryBackend) RejectSharedDirectory(sharedDirectoryID string) (string, error) {
+func (b *InMemoryBackend) RejectSharedDirectory(ctx context.Context, sharedDirectoryID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RejectSharedDirectory")
 	defer b.mu.Unlock()
 
-	sd, ok := b.sharedDirectories[sharedDirectoryID]
+	sd, ok := b.state(region).sharedDirectories[sharedDirectoryID]
 	if !ok {
 		return "", ErrSharedDirectoryNotFound
 	}
@@ -1292,11 +1424,14 @@ func (b *InMemoryBackend) RejectSharedDirectory(sharedDirectoryID string) (strin
 
 // DescribeSharedDirectories returns shared directories for an owner directory.
 func (b *InMemoryBackend) DescribeSharedDirectories(
+	ctx context.Context,
 	ownerDirID string,
 	sharedDirIDs []string,
 	limit int32,
 	nextToken string,
 ) ([]SharedDirInfo, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeSharedDirectories")
 	defer b.mu.RUnlock()
 
@@ -1305,8 +1440,9 @@ func (b *InMemoryBackend) DescribeSharedDirectories(
 		filterSet[id] = true
 	}
 
+	st := b.state(region)
 	var ids []string
-	for id, sd := range b.sharedDirectories {
+	for id, sd := range st.sharedDirectories {
 		if ownerDirID != "" && sd.OwnerDirectoryID != ownerDirID {
 			continue
 		}
@@ -1336,7 +1472,7 @@ func (b *InMemoryBackend) DescribeSharedDirectories(
 	end := min(start+pageSize, len(ids))
 	result := make([]SharedDirInfo, 0, end-start)
 	for _, id := range ids[start:end] {
-		sd := b.sharedDirectories[id]
+		sd := st.sharedDirectories[id]
 		result = append(result, SharedDirInfo{
 			SharedDirectoryID:   sd.SharedDirectoryID,
 			OwnerDirectoryID:    sd.OwnerDirectoryID,
@@ -1361,17 +1497,24 @@ func (b *InMemoryBackend) DescribeSharedDirectories(
 // --- Certificates ---
 
 // RegisterCertificate registers a certificate.
-func (b *InMemoryBackend) RegisterCertificate(directoryID, certData, certType string) (string, error) {
+func (b *InMemoryBackend) RegisterCertificate(
+	ctx context.Context,
+	directoryID, certData, certType string,
+) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RegisterCertificate")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	id := fmt.Sprintf("c-%s", uuid.NewString()[:10])
 	now := time.Now().UTC()
-	b.certificates[id] = &storedCertificate{
+	st.certificates[id] = &storedCertificate{
 		CertificateID:      id,
 		DirectoryID:        directoryID,
 		CertData:           certData,
@@ -1386,35 +1529,43 @@ func (b *InMemoryBackend) RegisterCertificate(directoryID, certData, certType st
 }
 
 // DeregisterCertificate deregisters a certificate.
-func (b *InMemoryBackend) DeregisterCertificate(directoryID, certID string) error {
+func (b *InMemoryBackend) DeregisterCertificate(ctx context.Context, directoryID, certID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeregisterCertificate")
 	defer b.mu.Unlock()
 
-	cert, ok := b.certificates[certID]
+	st := b.state(region)
+	cert, ok := st.certificates[certID]
 	if !ok || cert.DirectoryID != directoryID {
 		return ErrCertNotFound
 	}
 
-	delete(b.certificates, certID)
+	delete(st.certificates, certID)
 
 	return nil
 }
 
 // ListCertificates returns certificates for a directory.
 func (b *InMemoryBackend) ListCertificates(
+	ctx context.Context,
 	directoryID string,
 	limit int32,
 	nextToken string,
 ) ([]CertInfo, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListCertificates")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
 	var ids []string
-	for id, cert := range b.certificates {
+	for id, cert := range st.certificates {
 		if cert.DirectoryID == directoryID {
 			ids = append(ids, id)
 		}
@@ -1440,7 +1591,7 @@ func (b *InMemoryBackend) ListCertificates(
 	end := min(start+pageSize, len(ids))
 	result := make([]CertInfo, 0, end-start)
 	for _, id := range ids[start:end] {
-		cert := b.certificates[id]
+		cert := st.certificates[id]
 		result = append(result, CertInfo{
 			CertificateID:  cert.CertificateID,
 			CommonName:     cert.CommonName,
@@ -1459,11 +1610,13 @@ func (b *InMemoryBackend) ListCertificates(
 }
 
 // DescribeCertificate returns details of a certificate.
-func (b *InMemoryBackend) DescribeCertificate(directoryID, certID string) (*CertDetail, error) {
+func (b *InMemoryBackend) DescribeCertificate(ctx context.Context, directoryID, certID string) (*CertDetail, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeCertificate")
 	defer b.mu.RUnlock()
 
-	cert, ok := b.certificates[certID]
+	cert, ok := b.state(region).certificates[certID]
 	if !ok || cert.DirectoryID != directoryID {
 		return nil, ErrCertNotFound
 	}
@@ -1483,21 +1636,25 @@ func (b *InMemoryBackend) DescribeCertificate(directoryID, certID string) (*Cert
 // --- LDAPS ---
 
 // EnableLDAPS enables LDAPS for a directory.
-func (b *InMemoryBackend) EnableLDAPS(directoryID, ldapsType string) error {
+func (b *InMemoryBackend) EnableLDAPS(ctx context.Context, directoryID, ldapsType string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableLDAPS")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + ldapsType
 	now := time.Now().UTC()
-	if existing, ok := b.ldapsSettings[key]; ok {
+	if existing, ok := st.ldapsSettings[key]; ok {
 		existing.State = "Enabled" //nolint:goconst // existing issue.
 		existing.LastUpdatedDateTime = now
 	} else {
-		b.ldapsSettings[key] = &storedLDAPSSetting{
+		st.ldapsSettings[key] = &storedLDAPSSetting{
 			DirectoryID:               directoryID,
 			LDAPSType:                 ldapsType,
 			State:                     "Enabled",
@@ -1510,16 +1667,20 @@ func (b *InMemoryBackend) EnableLDAPS(directoryID, ldapsType string) error {
 }
 
 // DisableLDAPS disables LDAPS for a directory.
-func (b *InMemoryBackend) DisableLDAPS(directoryID, ldapsType string) error {
+func (b *InMemoryBackend) DisableLDAPS(ctx context.Context, directoryID, ldapsType string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableLDAPS")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + ldapsType
-	if setting, ok := b.ldapsSettings[key]; ok {
+	if setting, ok := st.ldapsSettings[key]; ok {
 		setting.State = "Disabled"
 		setting.LastUpdatedDateTime = time.Now().UTC()
 	}
@@ -1529,19 +1690,24 @@ func (b *InMemoryBackend) DisableLDAPS(directoryID, ldapsType string) error {
 
 // DescribeLDAPSSettings returns LDAPS settings for a directory.
 func (b *InMemoryBackend) DescribeLDAPSSettings(
+	ctx context.Context,
 	directoryID, ldapsType string,
 	limit int32, //nolint:revive // existing issue.
 	nextToken string, //nolint:revive // existing issue.
 ) ([]LDAPSSetting, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeLDAPSSettings")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
 	var result []LDAPSSetting
-	for _, s := range b.ldapsSettings {
+	for _, s := range st.ldapsSettings {
 		if s.DirectoryID != directoryID {
 			continue
 		}
@@ -1565,21 +1731,25 @@ func (b *InMemoryBackend) DescribeLDAPSSettings(
 // --- Client Authentication ---
 
 // EnableClientAuthentication enables client authentication.
-func (b *InMemoryBackend) EnableClientAuthentication(directoryID, authType string) error {
+func (b *InMemoryBackend) EnableClientAuthentication(ctx context.Context, directoryID, authType string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableClientAuthentication")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + authType
 	now := time.Now().UTC()
-	if existing, ok := b.clientAuthSettings[key]; ok {
+	if existing, ok := st.clientAuthSettings[key]; ok {
 		existing.Status = "Enabled"
 		existing.LastUpdatedDateTime = now
 	} else {
-		b.clientAuthSettings[key] = &storedClientAuthSetting{
+		st.clientAuthSettings[key] = &storedClientAuthSetting{
 			DirectoryID:         directoryID,
 			AuthType:            authType,
 			Status:              "Enabled",
@@ -1591,21 +1761,25 @@ func (b *InMemoryBackend) EnableClientAuthentication(directoryID, authType strin
 }
 
 // DisableClientAuthentication disables client authentication.
-func (b *InMemoryBackend) DisableClientAuthentication(directoryID, authType string) error {
+func (b *InMemoryBackend) DisableClientAuthentication(ctx context.Context, directoryID, authType string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableClientAuthentication")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	key := directoryID + ":" + authType
 	now := time.Now().UTC()
-	if existing, ok := b.clientAuthSettings[key]; ok {
+	if existing, ok := st.clientAuthSettings[key]; ok {
 		existing.Status = "Disabled"
 		existing.LastUpdatedDateTime = now
 	} else {
-		b.clientAuthSettings[key] = &storedClientAuthSetting{
+		st.clientAuthSettings[key] = &storedClientAuthSetting{
 			DirectoryID:         directoryID,
 			AuthType:            authType,
 			Status:              "Disabled",
@@ -1618,19 +1792,24 @@ func (b *InMemoryBackend) DisableClientAuthentication(directoryID, authType stri
 
 // DescribeClientAuthenticationSettings returns client auth settings.
 func (b *InMemoryBackend) DescribeClientAuthenticationSettings(
+	ctx context.Context,
 	directoryID, authType string,
 	limit int32, //nolint:revive // existing issue.
 	nextToken string, //nolint:revive // existing issue.
 ) ([]ClientAuthInfo, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeClientAuthenticationSettings")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
 	var result []ClientAuthInfo
-	for _, s := range b.clientAuthSettings {
+	for _, s := range st.clientAuthSettings {
 		if s.DirectoryID != directoryID {
 			continue
 		}
@@ -1652,17 +1831,21 @@ func (b *InMemoryBackend) DescribeClientAuthenticationSettings(
 // --- RADIUS ---
 
 // EnableRadius enables RADIUS for a directory.
-func (b *InMemoryBackend) EnableRadius(directoryID string, settings RadiusSettingsInput) error {
+func (b *InMemoryBackend) EnableRadius(ctx context.Context, directoryID string, settings RadiusSettingsInput) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableRadius")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	servers := make([]string, len(settings.RadiusServers))
 	copy(servers, settings.RadiusServers)
-	b.radiusSettings[directoryID] = &storedRadiusSettings{
+	st.radiusSettings[directoryID] = &storedRadiusSettings{
 		DirectoryID:            directoryID,
 		AuthenticationProtocol: settings.AuthenticationProtocol,
 		DisplayLabel:           settings.DisplayLabel,
@@ -1678,34 +1861,42 @@ func (b *InMemoryBackend) EnableRadius(directoryID string, settings RadiusSettin
 }
 
 // DisableRadius disables RADIUS for a directory.
-func (b *InMemoryBackend) DisableRadius(directoryID string) error {
+func (b *InMemoryBackend) DisableRadius(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableRadius")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	delete(b.radiusSettings, directoryID)
+	delete(st.radiusSettings, directoryID)
 
 	return nil
 }
 
 // UpdateRadius updates RADIUS settings for a directory.
-func (b *InMemoryBackend) UpdateRadius(directoryID string, settings RadiusSettingsInput) error {
+func (b *InMemoryBackend) UpdateRadius(ctx context.Context, directoryID string, settings RadiusSettingsInput) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateRadius")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	servers := make([]string, len(settings.RadiusServers))
 	copy(servers, settings.RadiusServers)
-	existing, ok := b.radiusSettings[directoryID]
+	existing, ok := st.radiusSettings[directoryID]
 	if !ok {
-		b.radiusSettings[directoryID] = &storedRadiusSettings{}
-		existing = b.radiusSettings[directoryID]
+		st.radiusSettings[directoryID] = &storedRadiusSettings{}
+		existing = st.radiusSettings[directoryID]
 	}
 	existing.DirectoryID = directoryID
 	existing.AuthenticationProtocol = settings.AuthenticationProtocol
@@ -1723,43 +1914,58 @@ func (b *InMemoryBackend) UpdateRadius(directoryID string, settings RadiusSettin
 // --- Directory Data Access ---
 
 // EnableDirectoryDataAccess enables directory data access.
-func (b *InMemoryBackend) EnableDirectoryDataAccess(directoryID string) error {
+func (b *InMemoryBackend) EnableDirectoryDataAccess(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableDirectoryDataAccess")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	b.dirDataAccess[directoryID] = true
+	st.dirDataAccess[directoryID] = true
 
 	return nil
 }
 
 // DisableDirectoryDataAccess disables directory data access.
-func (b *InMemoryBackend) DisableDirectoryDataAccess(directoryID string) error {
+func (b *InMemoryBackend) DisableDirectoryDataAccess(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableDirectoryDataAccess")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	b.dirDataAccess[directoryID] = false
+	st.dirDataAccess[directoryID] = false
 
 	return nil
 }
 
 // DescribeDirectoryDataAccess returns data access status for a directory.
-func (b *InMemoryBackend) DescribeDirectoryDataAccess(directoryID string) (*DirectoryDataAccessStatus, error) {
+func (b *InMemoryBackend) DescribeDirectoryDataAccess(
+	ctx context.Context,
+	directoryID string,
+) (*DirectoryDataAccessStatus, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeDirectoryDataAccess")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
-	enabled := b.dirDataAccess[directoryID]
+	enabled := st.dirDataAccess[directoryID]
 
 	return &DirectoryDataAccessStatus{DirectoryID: directoryID, Enabled: enabled}, nil
 }
@@ -1767,43 +1973,58 @@ func (b *InMemoryBackend) DescribeDirectoryDataAccess(directoryID string) (*Dire
 // --- CA Enrollment Policy ---
 
 // EnableCAEnrollmentPolicy enables CA enrollment policy.
-func (b *InMemoryBackend) EnableCAEnrollmentPolicy(directoryID string) error {
+func (b *InMemoryBackend) EnableCAEnrollmentPolicy(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableCAEnrollmentPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	b.caEnrollment[directoryID] = true
+	st.caEnrollment[directoryID] = true
 
 	return nil
 }
 
 // DisableCAEnrollmentPolicy disables CA enrollment policy.
-func (b *InMemoryBackend) DisableCAEnrollmentPolicy(directoryID string) error {
+func (b *InMemoryBackend) DisableCAEnrollmentPolicy(ctx context.Context, directoryID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableCAEnrollmentPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
-	b.caEnrollment[directoryID] = false
+	st.caEnrollment[directoryID] = false
 
 	return nil
 }
 
 // DescribeCAEnrollmentPolicy returns CA enrollment policy for a directory.
-func (b *InMemoryBackend) DescribeCAEnrollmentPolicy(directoryID string) (*CAEnrollmentPolicy, error) {
+func (b *InMemoryBackend) DescribeCAEnrollmentPolicy(
+	ctx context.Context,
+	directoryID string,
+) (*CAEnrollmentPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeCAEnrollmentPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
-	enabled := b.caEnrollment[directoryID]
+	enabled := st.caEnrollment[directoryID]
 
 	return &CAEnrollmentPolicy{DirectoryID: directoryID, Enabled: enabled}, nil
 }
@@ -1811,21 +2032,25 @@ func (b *InMemoryBackend) DescribeCAEnrollmentPolicy(directoryID string) (*CAEnr
 // --- AD Assessments ---
 
 // StartADAssessment starts an AD assessment.
-func (b *InMemoryBackend) StartADAssessment(directoryID string) (string, error) {
+func (b *InMemoryBackend) StartADAssessment(ctx context.Context, directoryID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("StartADAssessment")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	id := fmt.Sprintf("a-%s", uuid.NewString()[:10])
-	b.adAssessments[id] = &storedADAssessment{
+	st.adAssessments[id] = &storedADAssessment{
 		AssessmentID: id,
 		DirectoryID:  directoryID,
 		Status:       "Completed",
 		AssessType:   "Operational",
-		Region:       b.region,
+		Region:       region,
 		StartTime:    time.Now().UTC(),
 	}
 
@@ -1833,26 +2058,34 @@ func (b *InMemoryBackend) StartADAssessment(directoryID string) (string, error) 
 }
 
 // DeleteADAssessment deletes an AD assessment.
-func (b *InMemoryBackend) DeleteADAssessment(directoryID, assessmentID string) error {
+func (b *InMemoryBackend) DeleteADAssessment(ctx context.Context, directoryID, assessmentID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteADAssessment")
 	defer b.mu.Unlock()
 
-	a, ok := b.adAssessments[assessmentID]
+	st := b.state(region)
+	a, ok := st.adAssessments[assessmentID]
 	if !ok || a.DirectoryID != directoryID {
 		return ErrAssessmentNotFound
 	}
 
-	delete(b.adAssessments, assessmentID)
+	delete(st.adAssessments, assessmentID)
 
 	return nil
 }
 
 // DescribeADAssessment returns details of an AD assessment.
-func (b *InMemoryBackend) DescribeADAssessment(directoryID, assessmentID string) (*ADAssessmentInfo, error) {
+func (b *InMemoryBackend) DescribeADAssessment(
+	ctx context.Context,
+	directoryID, assessmentID string,
+) (*ADAssessmentInfo, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeADAssessment")
 	defer b.mu.RUnlock()
 
-	a, ok := b.adAssessments[assessmentID]
+	a, ok := b.state(region).adAssessments[assessmentID]
 	if !ok || a.DirectoryID != directoryID {
 		return nil, ErrAssessmentNotFound
 	}
@@ -1869,15 +2102,19 @@ func (b *InMemoryBackend) DescribeADAssessment(directoryID, assessmentID string)
 
 // ListADAssessments returns AD assessments for a directory.
 func (b *InMemoryBackend) ListADAssessments(
+	ctx context.Context,
 	directoryID string,
 	limit int32,
 	nextToken string,
 ) ([]ADAssessmentInfo, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListADAssessments")
 	defer b.mu.RUnlock()
 
+	st := b.state(region)
 	var ids []string
-	for id, a := range b.adAssessments {
+	for id, a := range st.adAssessments {
 		if directoryID != "" && a.DirectoryID != directoryID {
 			continue
 		}
@@ -1904,7 +2141,7 @@ func (b *InMemoryBackend) ListADAssessments(
 	end := min(start+pageSize, len(ids))
 	result := make([]ADAssessmentInfo, 0, end-start)
 	for _, id := range ids[start:end] {
-		a := b.adAssessments[id]
+		a := st.adAssessments[id]
 		result = append(result, ADAssessmentInfo{
 			AssessmentID: a.AssessmentID,
 			DirectoryID:  a.DirectoryID,
@@ -1927,10 +2164,13 @@ func (b *InMemoryBackend) ListADAssessments(
 
 // CreateHybridAD creates a Hybrid AD directory (stored as MicrosoftAD type).
 func (b *InMemoryBackend) CreateHybridAD(
+	ctx context.Context,
 	name, shortName, description, _ string,
 	edition DirectoryEdition,
 	tags []Tag,
 ) (*Directory, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateHybridAD")
 	defer b.mu.Unlock()
 
@@ -1938,12 +2178,13 @@ func (b *InMemoryBackend) CreateHybridAD(
 		return nil, "", ErrInvalidParameter
 	}
 
+	st := b.state(region)
 	d := b.newStoredDirectory(name, shortName, description, DirectoryTypeMicrosoftAD, "", edition, tags)
-	b.directories[d.DirectoryID] = d
-	b.aliases[d.Alias] = d.DirectoryID
+	st.directories[d.DirectoryID] = d
+	st.aliases[d.Alias] = d.DirectoryID
 
 	requestID := uuid.NewString()
-	b.hybridADUpdates[requestID] = &storedHybridADUpdate{
+	st.hybridADUpdates[requestID] = &storedHybridADUpdate{
 		RequestID:   requestID,
 		DirectoryID: d.DirectoryID,
 		Status:      "Updated", //nolint:goconst // existing issue.
@@ -1955,16 +2196,20 @@ func (b *InMemoryBackend) CreateHybridAD(
 }
 
 // UpdateHybridAD updates a Hybrid AD directory.
-func (b *InMemoryBackend) UpdateHybridAD(directoryID string) (string, error) {
+func (b *InMemoryBackend) UpdateHybridAD(ctx context.Context, directoryID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateHybridAD")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	requestID := uuid.NewString()
-	b.hybridADUpdates[requestID] = &storedHybridADUpdate{
+	st.hybridADUpdates[requestID] = &storedHybridADUpdate{
 		RequestID:   requestID,
 		DirectoryID: directoryID,
 		Status:      "Updated",
@@ -1974,16 +2219,23 @@ func (b *InMemoryBackend) UpdateHybridAD(directoryID string) (string, error) {
 }
 
 // DescribeHybridADUpdate returns hybrid AD update info for a directory.
-func (b *InMemoryBackend) DescribeHybridADUpdate(directoryID string) ([]HybridADUpdateEntry, error) {
+func (b *InMemoryBackend) DescribeHybridADUpdate(
+	ctx context.Context,
+	directoryID string,
+) ([]HybridADUpdateEntry, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeHybridADUpdate")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
 	var result []HybridADUpdateEntry
-	for _, u := range b.hybridADUpdates {
+	for _, u := range st.hybridADUpdates {
 		if u.DirectoryID == directoryID {
 			result = append(result, HybridADUpdateEntry{
 				RequestID:   u.RequestID,
@@ -2000,11 +2252,16 @@ func (b *InMemoryBackend) DescribeHybridADUpdate(directoryID string) ([]HybridAD
 // --- Computer ---
 
 // CreateComputer creates a computer account in a directory.
-func (b *InMemoryBackend) CreateComputer(directoryID, computerName, _ string) (*ComputerInfo, error) {
+func (b *InMemoryBackend) CreateComputer(
+	ctx context.Context,
+	directoryID, computerName, _ string,
+) (*ComputerInfo, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("CreateComputer")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	if _, ok := b.state(region).directories[directoryID]; !ok {
 		return nil, ErrDirectoryNotFound
 	}
 
@@ -2021,17 +2278,25 @@ func (b *InMemoryBackend) CreateComputer(directoryID, computerName, _ string) (*
 // --- Settings ---
 
 // UpdateSettings updates directory settings.
-func (b *InMemoryBackend) UpdateSettings(directoryID string, settings []DirectorySetting) (string, error) {
+func (b *InMemoryBackend) UpdateSettings(
+	ctx context.Context,
+	directoryID string,
+	settings []DirectorySetting,
+) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateSettings")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return "", ErrDirectoryNotFound
 	}
 
 	now := time.Now().UTC()
 	existing := make(map[string]*storedDirectorySetting)
-	for _, s := range b.dirSettings[directoryID] {
+	for _, s := range st.dirSettings[directoryID] {
 		existing[s.Name] = s
 	}
 
@@ -2050,7 +2315,7 @@ func (b *InMemoryBackend) UpdateSettings(directoryID string, settings []Director
 				Status:              "Updated",
 				LastUpdatedDateTime: now,
 			}
-			b.dirSettings[directoryID] = append(b.dirSettings[directoryID], ns)
+			st.dirSettings[directoryID] = append(st.dirSettings[directoryID], ns)
 		}
 	}
 
@@ -2059,16 +2324,21 @@ func (b *InMemoryBackend) UpdateSettings(directoryID string, settings []Director
 
 // DescribeSettings returns directory settings.
 func (b *InMemoryBackend) DescribeSettings(
+	ctx context.Context,
 	directoryID, status, nextToken string, //nolint:revive // existing issue.
 ) ([]SettingEntry, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeSettings")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
-	settings := b.dirSettings[directoryID]
+	settings := st.dirSettings[directoryID]
 	var filtered []storedDirectorySetting
 	for _, s := range settings {
 		if status != "" && s.Status != status {
@@ -2087,22 +2357,26 @@ func (b *InMemoryBackend) DescribeSettings(
 }
 
 // UpdateDirectorySetup initiates a directory setup update.
-func (b *InMemoryBackend) UpdateDirectorySetup(directoryID, updateType string, _ bool) error {
+func (b *InMemoryBackend) UpdateDirectorySetup(ctx context.Context, directoryID, updateType string, _ bool) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateDirectorySetup")
 	defer b.mu.Unlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
 	now := time.Now().UTC()
-	b.updateInfoEntries[directoryID] = append(b.updateInfoEntries[directoryID], &storedUpdateInfo{
+	st.updateInfoEntries[directoryID] = append(st.updateInfoEntries[directoryID], &storedUpdateInfo{
 		DirectoryID:         directoryID,
 		UpdateType:          updateType,
 		Status:              "Updated",
 		StartTime:           now,
 		LastUpdatedDateTime: now,
-		Region:              b.region,
+		Region:              region,
 		InitiatedBy:         b.accountID,
 	})
 
@@ -2111,17 +2385,22 @@ func (b *InMemoryBackend) UpdateDirectorySetup(directoryID, updateType string, _
 
 // DescribeUpdateDirectory returns update info entries for a directory.
 func (b *InMemoryBackend) DescribeUpdateDirectory(
+	ctx context.Context,
 	directoryID, updateType, nextToken string, //nolint:revive // existing issue.
 ) ([]UpdateInfoEntry, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeUpdateDirectory")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	st := b.state(region)
+
+	if _, ok := st.directories[directoryID]; !ok {
 		return nil, "", ErrDirectoryNotFound
 	}
 
 	var result []UpdateInfoEntry
-	for _, u := range b.updateInfoEntries[directoryID] {
+	for _, u := range st.updateInfoEntries[directoryID] {
 		if updateType != "" && u.UpdateType != updateType {
 			continue
 		}
@@ -2144,11 +2423,13 @@ func (b *InMemoryBackend) DescribeUpdateDirectory(
 // --- Password Reset ---
 
 // ResetUserPassword resets a user password.
-func (b *InMemoryBackend) ResetUserPassword(directoryID, _, _ string) error {
+func (b *InMemoryBackend) ResetUserPassword(ctx context.Context, directoryID, _, _ string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ResetUserPassword")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.directories[directoryID]; !ok {
+	if _, ok := b.state(region).directories[directoryID]; !ok {
 		return ErrDirectoryNotFound
 	}
 
@@ -2159,10 +2440,13 @@ func (b *InMemoryBackend) ResetUserPassword(directoryID, _, _ string) error {
 
 // ConnectDirectory creates an ADConnector directory.
 func (b *InMemoryBackend) ConnectDirectory(
+	ctx context.Context,
 	name, shortName, description, _ string,
 	size DirectorySize,
 	tags []Tag,
 ) (*Directory, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ConnectDirectory")
 	defer b.mu.Unlock()
 
@@ -2170,9 +2454,10 @@ func (b *InMemoryBackend) ConnectDirectory(
 		return nil, ErrInvalidParameter
 	}
 
+	st := b.state(region)
 	d := b.newStoredDirectory(name, shortName, description, DirectoryTypeADConnector, size, "", tags)
-	b.directories[d.DirectoryID] = d
-	b.aliases[d.Alias] = d.DirectoryID
+	st.directories[d.DirectoryID] = d
+	st.aliases[d.Alias] = d.DirectoryID
 
 	cp := d.toDirectory()
 

--- a/services/directoryservice/export_test.go
+++ b/services/directoryservice/export_test.go
@@ -1,19 +1,29 @@
 package directoryservice
 
-// DirectoryCount returns the number of stored directories.
+// DirectoryCount returns the number of stored directories across all regions.
 func DirectoryCount(b *InMemoryBackend) int {
 	b.mu.RLock("DirectoryCount")
 	defer b.mu.RUnlock()
 
-	return len(b.directories)
+	total := 0
+	for _, st := range b.states {
+		total += len(st.directories)
+	}
+
+	return total
 }
 
-// SnapshotCount returns the number of stored snapshots.
+// SnapshotCount returns the number of stored snapshots across all regions.
 func SnapshotCount(b *InMemoryBackend) int {
 	b.mu.RLock("SnapshotCount")
 	defer b.mu.RUnlock()
 
-	return len(b.snapshots)
+	total := 0
+	for _, st := range b.states {
+		total += len(st.snapshots)
+	}
+
+	return total
 }
 
 // HandlerOpsLen returns the count of GetSupportedOperations.

--- a/services/directoryservice/handler.go
+++ b/services/directoryservice/handler.go
@@ -1,6 +1,7 @@
 package directoryservice
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"maps"
@@ -167,6 +168,16 @@ func (h *Handler) doDispatch(c *echo.Context) error {
 	return c.JSON(http.StatusBadRequest, errResp("InvalidRequestException", "unrecognized operation: "+op))
 }
 
+// contextWithRegion returns the request context with the resolved AWS region attached
+// under regionContextKey so that backend operations are routed to the correct region.
+// The SigV4 credential-scope region in the Authorization header (extracted by
+// httputils.ExtractRegionFromRequest) takes precedence over the backend default.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
+}
+
 func (h *Handler) handleCreateDirectory(c *echo.Context) error { //nolint:dupl // existing issue.
 	body, err := httputils.ReadBody(c.Request())
 	if err != nil {
@@ -196,6 +207,7 @@ func (h *Handler) handleCreateDirectory(c *echo.Context) error { //nolint:dupl /
 	tags := reqTagsToTags(req.Tags)
 
 	d, createErr := h.Backend.CreateDirectory(
+		h.contextWithRegion(c),
 		req.Name,
 		req.ShortName,
 		req.Description,
@@ -245,7 +257,15 @@ func (h *Handler) handleCreateMicrosoftAD(c *echo.Context) error {
 
 	tags := reqTagsToTags(req.Tags)
 
-	d, createErr := h.Backend.CreateMicrosoftAD(req.Name, req.ShortName, req.Description, req.Password, edition, tags)
+	d, createErr := h.Backend.CreateMicrosoftAD(
+		h.contextWithRegion(c),
+		req.Name,
+		req.ShortName,
+		req.Description,
+		req.Password,
+		edition,
+		tags,
+	)
 	if createErr != nil {
 		return h.mapError(c, createErr)
 	}
@@ -273,7 +293,7 @@ func (h *Handler) handleDeleteDirectory(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if delErr := h.Backend.DeleteDirectory(req.DirectoryID); delErr != nil {
+	if delErr := h.Backend.DeleteDirectory(h.contextWithRegion(c), req.DirectoryID); delErr != nil {
 		return h.mapError(c, delErr)
 	}
 
@@ -300,7 +320,12 @@ func (h *Handler) handleDescribeDirectories(c *echo.Context) error {
 		}
 	}
 
-	dirs, nextToken, listErr := h.Backend.DescribeDirectories(req.DirectoryIDs, req.Limit, req.NextToken)
+	dirs, nextToken, listErr := h.Backend.DescribeDirectories(
+		h.contextWithRegion(c),
+		req.DirectoryIDs,
+		req.Limit,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -339,7 +364,7 @@ func (h *Handler) handleCreateAlias(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and Alias are required"))
 	}
 
-	if aliasErr := h.Backend.CreateAlias(req.DirectoryID, req.Alias); aliasErr != nil {
+	if aliasErr := h.Backend.CreateAlias(h.contextWithRegion(c), req.DirectoryID, req.Alias); aliasErr != nil {
 		return h.mapError(c, aliasErr)
 	}
 
@@ -367,7 +392,7 @@ func (h *Handler) handleEnableSso(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if ssoErr := h.Backend.EnableSso(req.DirectoryID); ssoErr != nil {
+	if ssoErr := h.Backend.EnableSso(h.contextWithRegion(c), req.DirectoryID); ssoErr != nil {
 		return h.mapError(c, ssoErr)
 	}
 
@@ -392,7 +417,7 @@ func (h *Handler) handleDisableSso(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if ssoErr := h.Backend.DisableSso(req.DirectoryID); ssoErr != nil {
+	if ssoErr := h.Backend.DisableSso(h.contextWithRegion(c), req.DirectoryID); ssoErr != nil {
 		return h.mapError(c, ssoErr)
 	}
 
@@ -400,7 +425,7 @@ func (h *Handler) handleDisableSso(c *echo.Context) error {
 }
 
 func (h *Handler) handleGetDirectoryLimits(c *echo.Context) error {
-	limits := h.Backend.GetDirectoryLimits()
+	limits := h.Backend.GetDirectoryLimits(h.contextWithRegion(c))
 
 	return c.JSON(http.StatusOK, map[string]any{
 		"DirectoryLimits": map[string]any{
@@ -436,7 +461,7 @@ func (h *Handler) handleCreateSnapshot(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	snap, snapErr := h.Backend.CreateSnapshot(req.DirectoryID, req.Name)
+	snap, snapErr := h.Backend.CreateSnapshot(h.contextWithRegion(c), req.DirectoryID, req.Name)
 	if snapErr != nil {
 		return h.mapError(c, snapErr)
 	}
@@ -464,7 +489,7 @@ func (h *Handler) handleDeleteSnapshot(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "SnapshotId is required"))
 	}
 
-	if delErr := h.Backend.DeleteSnapshot(req.SnapshotID); delErr != nil {
+	if delErr := h.Backend.DeleteSnapshot(h.contextWithRegion(c), req.SnapshotID); delErr != nil {
 		return h.mapError(c, delErr)
 	}
 
@@ -492,7 +517,13 @@ func (h *Handler) handleDescribeSnapshots(c *echo.Context) error {
 		}
 	}
 
-	snaps, nextToken, listErr := h.Backend.DescribeSnapshots(req.DirectoryID, req.SnapshotIDs, req.Limit, req.NextToken)
+	snaps, nextToken, listErr := h.Backend.DescribeSnapshots(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.SnapshotIDs,
+		req.Limit,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -530,7 +561,7 @@ func (h *Handler) handleGetSnapshotLimits(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	limits, limErr := h.Backend.GetSnapshotLimits(req.DirectoryID)
+	limits, limErr := h.Backend.GetSnapshotLimits(h.contextWithRegion(c), req.DirectoryID)
 	if limErr != nil {
 		return h.mapError(c, limErr)
 	}
@@ -562,7 +593,7 @@ func (h *Handler) handleRestoreFromSnapshot(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "SnapshotId is required"))
 	}
 
-	if restoreErr := h.Backend.RestoreFromSnapshot(req.SnapshotID); restoreErr != nil {
+	if restoreErr := h.Backend.RestoreFromSnapshot(h.contextWithRegion(c), req.SnapshotID); restoreErr != nil {
 		return h.mapError(c, restoreErr)
 	}
 
@@ -593,7 +624,7 @@ func (h *Handler) handleAddTagsToResource(c *echo.Context) error {
 
 	tags := reqTagsToTags(req.Tags)
 
-	if tagErr := h.Backend.AddTagsToResource(req.ResourceID, tags); tagErr != nil {
+	if tagErr := h.Backend.AddTagsToResource(h.contextWithRegion(c), req.ResourceID, tags); tagErr != nil {
 		return h.mapError(c, tagErr)
 	}
 
@@ -619,7 +650,8 @@ func (h *Handler) handleRemoveTagsFromResource(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "ResourceId is required"))
 	}
 
-	if untagErr := h.Backend.RemoveTagsFromResource(req.ResourceID, req.TagKeys); untagErr != nil {
+	untagErr := h.Backend.RemoveTagsFromResource(h.contextWithRegion(c), req.ResourceID, req.TagKeys)
+	if untagErr != nil {
 		return h.mapError(c, untagErr)
 	}
 
@@ -646,7 +678,12 @@ func (h *Handler) handleListTagsForResource(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "ResourceId is required"))
 	}
 
-	tags, nextToken, listErr := h.Backend.ListTagsForResource(req.ResourceID, req.Limit, req.NextToken)
+	tags, nextToken, listErr := h.Backend.ListTagsForResource(
+		h.contextWithRegion(c),
+		req.ResourceID,
+		req.Limit,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}

--- a/services/directoryservice/handler_appendixa.go
+++ b/services/directoryservice/handler_appendixa.go
@@ -1,6 +1,7 @@
 package directoryservice
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -10,6 +11,9 @@ import (
 )
 
 const (
+	keyRemoteDomainName = "RemoteDomainName"
+	keyTopicName        = "TopicName"
+
 	opAcceptSharedDirectory                = "AcceptSharedDirectory"
 	opAddIpRoutes                          = "AddIpRoutes" //nolint:revive,staticcheck // existing issue.
 	opAddRegion                            = "AddRegion"
@@ -216,6 +220,59 @@ func appendixAOpsNames() []string {
 	}
 }
 
+// twoFieldOp describes an operation that takes a directory ID plus one secondary
+// string field and returns only an error. It centralises the identical request
+// parsing, validation and error mapping shared by several Appendix A handlers.
+type twoFieldOp struct {
+	invoke    func(ctx context.Context, dirID, second string) error
+	secondKey string // JSON key (and human label) of the secondary field
+}
+
+// handleTwoFieldOp parses {DirectoryId, <secondKey>} from the request body,
+// validates both are present, resolves the request region and invokes op.
+func (h *Handler) handleTwoFieldOp(c *echo.Context, op twoFieldOp) error {
+	body, err := httputils.ReadBody(c.Request())
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
+	}
+
+	var raw map[string]json.RawMessage
+	if jsonErr := json.Unmarshal(body, &raw); jsonErr != nil {
+		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
+	}
+
+	dirID := jsonString(raw, keyDirectoryID)
+	second := jsonString(raw, op.secondKey)
+
+	if dirID == "" || second == "" {
+		msg := "DirectoryId and " + op.secondKey + " are required"
+
+		return c.JSON(http.StatusBadRequest, errResp("ClientException", msg))
+	}
+
+	if opErr := op.invoke(h.contextWithRegion(c), dirID, second); opErr != nil {
+		return h.mapError(c, opErr)
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{})
+}
+
+// jsonString returns the string value stored under key in raw, or "" if absent
+// or not a JSON string.
+func jsonString(raw map[string]json.RawMessage, key string) string {
+	v, ok := raw[key]
+	if !ok {
+		return ""
+	}
+
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return ""
+	}
+
+	return s
+}
+
 // --- IP Routes ---
 
 func (h *Handler) handleAddIpRoutes(c *echo.Context) error { //nolint:revive,staticcheck // existing issue.
@@ -245,7 +302,7 @@ func (h *Handler) handleAddIpRoutes(c *echo.Context) error { //nolint:revive,sta
 		routes = append(routes, IpRoute{CidrIP: r.CidrIp, Description: r.Description})
 	}
 
-	if addErr := h.Backend.AddIpRoutes(req.DirectoryID, routes); addErr != nil {
+	if addErr := h.Backend.AddIpRoutes(h.contextWithRegion(c), req.DirectoryID, routes); addErr != nil {
 		return h.mapError(c, addErr)
 	}
 
@@ -271,7 +328,7 @@ func (h *Handler) handleRemoveIpRoutes(c *echo.Context) error { //nolint:revive,
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if removeErr := h.Backend.RemoveIpRoutes(req.DirectoryID, req.CidrIPs); removeErr != nil {
+	if removeErr := h.Backend.RemoveIpRoutes(h.contextWithRegion(c), req.DirectoryID, req.CidrIPs); removeErr != nil {
 		return h.mapError(c, removeErr)
 	}
 
@@ -300,7 +357,12 @@ func (h *Handler) handleListIpRoutes(c *echo.Context) error { //nolint:revive,st
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	routes, nextToken, listErr := h.Backend.ListIpRoutes(req.DirectoryID, req.Limit, req.NextToken)
+	routes, nextToken, listErr := h.Backend.ListIpRoutes(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.Limit,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -327,29 +389,12 @@ func (h *Handler) handleListIpRoutes(c *echo.Context) error { //nolint:revive,st
 // --- Regions ---
 
 func (h *Handler) handleAddRegion(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID string `json:"DirectoryId"`
-		RegionName  string `json:"RegionName"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.RegionName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and RegionName are required"))
-	}
-
-	if addErr := h.Backend.AddRegion(req.DirectoryID, req.RegionName); addErr != nil {
-		return h.mapError(c, addErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: "RegionName",
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.AddRegion(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleRemoveRegion(c *echo.Context) error {
@@ -370,7 +415,7 @@ func (h *Handler) handleRemoveRegion(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if removeErr := h.Backend.RemoveRegion(req.DirectoryID); removeErr != nil {
+	if removeErr := h.Backend.RemoveRegion(h.contextWithRegion(c), req.DirectoryID); removeErr != nil {
 		return h.mapError(c, removeErr)
 	}
 
@@ -399,7 +444,12 @@ func (h *Handler) handleDescribeRegions(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	regions, nextToken, descErr := h.Backend.DescribeRegions(req.DirectoryID, req.RegionName, req.NextToken)
+	regions, nextToken, descErr := h.Backend.DescribeRegions(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.RegionName,
+		req.NextToken,
+	)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -446,7 +496,12 @@ func (h *Handler) handleStartSchemaExtension(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	id, startErr := h.Backend.StartSchemaExtension(req.DirectoryID, req.Description, req.LdifContent)
+	id, startErr := h.Backend.StartSchemaExtension(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.Description,
+		req.LdifContent,
+	)
 	if startErr != nil {
 		return h.mapError(c, startErr)
 	}
@@ -478,7 +533,8 @@ func (h *Handler) handleCancelSchemaExtension(c *echo.Context) error {
 		)
 	}
 
-	if cancelErr := h.Backend.CancelSchemaExtension(req.DirectoryID, req.SchemaExtensionID); cancelErr != nil {
+	cancelErr := h.Backend.CancelSchemaExtension(h.contextWithRegion(c), req.DirectoryID, req.SchemaExtensionID)
+	if cancelErr != nil {
 		return h.mapError(c, cancelErr)
 	}
 
@@ -507,7 +563,12 @@ func (h *Handler) handleListSchemaExtensions(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	exts, nextToken, listErr := h.Backend.ListSchemaExtensions(req.DirectoryID, req.Limit, req.NextToken)
+	exts, nextToken, listErr := h.Backend.ListSchemaExtensions(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.Limit,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -558,6 +619,7 @@ func (h *Handler) handleCreateConditionalForwarder(c *echo.Context) error { //no
 	}
 
 	if createErr := h.Backend.CreateConditionalForwarder(
+		h.contextWithRegion(c),
 		req.DirectoryID,
 		req.RemoteDomainName,
 		req.DNSIpAddrs,
@@ -592,6 +654,7 @@ func (h *Handler) handleUpdateConditionalForwarder(c *echo.Context) error { //no
 	}
 
 	if updateErr := h.Backend.UpdateConditionalForwarder(
+		h.contextWithRegion(c),
 		req.DirectoryID,
 		req.RemoteDomainName,
 		req.DNSIpAddrs,
@@ -603,32 +666,12 @@ func (h *Handler) handleUpdateConditionalForwarder(c *echo.Context) error { //no
 }
 
 func (h *Handler) handleDeleteConditionalForwarder(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID      string `json:"DirectoryId"`
-		RemoteDomainName string `json:"RemoteDomainName"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.RemoteDomainName == "" {
-		return c.JSON(
-			http.StatusBadRequest,
-			errResp("ClientException", "DirectoryId and RemoteDomainName are required"),
-		)
-	}
-
-	if delErr := h.Backend.DeleteConditionalForwarder(req.DirectoryID, req.RemoteDomainName); delErr != nil {
-		return h.mapError(c, delErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: keyRemoteDomainName,
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.DeleteConditionalForwarder(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleDescribeConditionalForwarders(c *echo.Context) error {
@@ -652,7 +695,11 @@ func (h *Handler) handleDescribeConditionalForwarders(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	fwds, descErr := h.Backend.DescribeConditionalForwarders(req.DirectoryID, req.RemoteDomainNames)
+	fwds, descErr := h.Backend.DescribeConditionalForwarders(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.RemoteDomainNames,
+	)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -672,29 +719,12 @@ func (h *Handler) handleDescribeConditionalForwarders(c *echo.Context) error {
 // --- Log Subscriptions ---
 
 func (h *Handler) handleCreateLogSubscription(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID  string `json:"DirectoryId"`
-		LogGroupName string `json:"LogGroupName"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.LogGroupName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and LogGroupName are required"))
-	}
-
-	if createErr := h.Backend.CreateLogSubscription(req.DirectoryID, req.LogGroupName); createErr != nil {
-		return h.mapError(c, createErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: "LogGroupName",
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.CreateLogSubscription(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleDeleteLogSubscription(c *echo.Context) error {
@@ -715,7 +745,7 @@ func (h *Handler) handleDeleteLogSubscription(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if delErr := h.Backend.DeleteLogSubscription(req.DirectoryID); delErr != nil {
+	if delErr := h.Backend.DeleteLogSubscription(h.contextWithRegion(c), req.DirectoryID); delErr != nil {
 		return h.mapError(c, delErr)
 	}
 
@@ -740,7 +770,12 @@ func (h *Handler) handleListLogSubscriptions(c *echo.Context) error {
 		}
 	}
 
-	subs, nextToken, listErr := h.Backend.ListLogSubscriptions(req.DirectoryID, req.Limit, req.NextToken)
+	subs, nextToken, listErr := h.Backend.ListLogSubscriptions(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.Limit,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -765,55 +800,21 @@ func (h *Handler) handleListLogSubscriptions(c *echo.Context) error {
 // --- Event Topics ---
 
 func (h *Handler) handleRegisterEventTopic(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID string `json:"DirectoryId"`
-		TopicName   string `json:"TopicName"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.TopicName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and TopicName are required"))
-	}
-
-	if regErr := h.Backend.RegisterEventTopic(req.DirectoryID, req.TopicName); regErr != nil {
-		return h.mapError(c, regErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: keyTopicName,
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.RegisterEventTopic(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleDeregisterEventTopic(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID string `json:"DirectoryId"`
-		TopicName   string `json:"TopicName"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.TopicName == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and TopicName are required"))
-	}
-
-	if deregErr := h.Backend.DeregisterEventTopic(req.DirectoryID, req.TopicName); deregErr != nil {
-		return h.mapError(c, deregErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: keyTopicName,
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.DeregisterEventTopic(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleDescribeEventTopics(c *echo.Context) error {
@@ -833,7 +834,7 @@ func (h *Handler) handleDescribeEventTopics(c *echo.Context) error {
 		}
 	}
 
-	topics, descErr := h.Backend.DescribeEventTopics(req.DirectoryID, req.TopicNames)
+	topics, descErr := h.Backend.DescribeEventTopics(h.contextWithRegion(c), req.DirectoryID, req.TopicNames)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -878,6 +879,7 @@ func (h *Handler) handleDescribeDomainControllers(c *echo.Context) error {
 	}
 
 	dcs, nextToken, descErr := h.Backend.DescribeDomainControllers(
+		h.contextWithRegion(c),
 		req.DirectoryID, req.DomainControllerIDs, req.Limit, req.NextToken,
 	)
 	if descErr != nil {
@@ -922,7 +924,8 @@ func (h *Handler) handleUpdateNumberOfDomainControllers(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if updateErr := h.Backend.UpdateNumberOfDomainControllers(req.DirectoryID, req.DesiredNumber); updateErr != nil {
+	updateErr := h.Backend.UpdateNumberOfDomainControllers(h.contextWithRegion(c), req.DirectoryID, req.DesiredNumber)
+	if updateErr != nil {
 		return h.mapError(c, updateErr)
 	}
 
@@ -962,6 +965,7 @@ func (h *Handler) handleCreateTrust(c *echo.Context) error {
 	}
 
 	trustID, createErr := h.Backend.CreateTrust(
+		h.contextWithRegion(c),
 		req.DirectoryID, req.RemoteDomainName, req.TrustPassword, req.TrustDirection, trustType,
 	)
 	if createErr != nil {
@@ -992,7 +996,7 @@ func (h *Handler) handleDeleteTrust(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "TrustId is required"))
 	}
 
-	trustID, delErr := h.Backend.DeleteTrust(req.TrustID)
+	trustID, delErr := h.Backend.DeleteTrust(h.contextWithRegion(c), req.TrustID)
 	if delErr != nil {
 		return h.mapError(c, delErr)
 	}
@@ -1019,7 +1023,13 @@ func (h *Handler) handleDescribeTrusts(c *echo.Context) error {
 		}
 	}
 
-	trusts, nextToken, descErr := h.Backend.DescribeTrusts(req.DirectoryID, req.TrustIDs, req.Limit, req.NextToken)
+	trusts, nextToken, descErr := h.Backend.DescribeTrusts(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.TrustIDs,
+		req.Limit,
+		req.NextToken,
+	)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -1068,7 +1078,7 @@ func (h *Handler) handleUpdateTrust(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "TrustId is required"))
 	}
 
-	trustID, updateErr := h.Backend.UpdateTrust(req.TrustID, req.SelectiveAuth)
+	trustID, updateErr := h.Backend.UpdateTrust(h.contextWithRegion(c), req.TrustID, req.SelectiveAuth)
 	if updateErr != nil {
 		return h.mapError(c, updateErr)
 	}
@@ -1097,7 +1107,7 @@ func (h *Handler) handleVerifyTrust(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "TrustId is required"))
 	}
 
-	trustID, verifyErr := h.Backend.VerifyTrust(req.TrustID)
+	trustID, verifyErr := h.Backend.VerifyTrust(h.contextWithRegion(c), req.TrustID)
 	if verifyErr != nil {
 		return h.mapError(c, verifyErr)
 	}
@@ -1136,7 +1146,13 @@ func (h *Handler) handleShareDirectory(c *echo.Context) error {
 		shareMethod = "HANDSHAKE"
 	}
 
-	sharedDirID, shareErr := h.Backend.ShareDirectory(req.DirectoryID, shareMethod, req.ShareNotes, req.ShareTarget.ID)
+	sharedDirID, shareErr := h.Backend.ShareDirectory(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		shareMethod,
+		req.ShareNotes,
+		req.ShareTarget.ID,
+	)
 	if shareErr != nil {
 		return h.mapError(c, shareErr)
 	}
@@ -1166,7 +1182,7 @@ func (h *Handler) handleUnshareDirectory(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	sharedDirID, unshareErr := h.Backend.UnshareDirectory(req.DirectoryID, req.UnshareTarget.ID)
+	sharedDirID, unshareErr := h.Backend.UnshareDirectory(h.contextWithRegion(c), req.DirectoryID, req.UnshareTarget.ID)
 	if unshareErr != nil {
 		return h.mapError(c, unshareErr)
 	}
@@ -1192,7 +1208,7 @@ func (h *Handler) handleAcceptSharedDirectory(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "SharedDirectoryId is required"))
 	}
 
-	id, acceptErr := h.Backend.AcceptSharedDirectory(req.SharedDirectoryID)
+	id, acceptErr := h.Backend.AcceptSharedDirectory(h.contextWithRegion(c), req.SharedDirectoryID)
 	if acceptErr != nil {
 		return h.mapError(c, acceptErr)
 	}
@@ -1220,7 +1236,7 @@ func (h *Handler) handleRejectSharedDirectory(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "SharedDirectoryId is required"))
 	}
 
-	id, rejectErr := h.Backend.RejectSharedDirectory(req.SharedDirectoryID)
+	id, rejectErr := h.Backend.RejectSharedDirectory(h.contextWithRegion(c), req.SharedDirectoryID)
 	if rejectErr != nil {
 		return h.mapError(c, rejectErr)
 	}
@@ -1252,6 +1268,7 @@ func (h *Handler) handleDescribeSharedDirectories(c *echo.Context) error {
 	}
 
 	dirs, nextToken, descErr := h.Backend.DescribeSharedDirectories(
+		h.contextWithRegion(c),
 		req.OwnerDirectoryID, req.SharedDirectoryIDs, req.Limit, req.NextToken,
 	)
 	if descErr != nil {
@@ -1308,7 +1325,12 @@ func (h *Handler) handleRegisterCertificate(c *echo.Context) error {
 		certType = "ClientLDAPS"
 	}
 
-	certID, regErr := h.Backend.RegisterCertificate(req.DirectoryID, req.CertificateData, certType)
+	certID, regErr := h.Backend.RegisterCertificate(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.CertificateData,
+		certType,
+	)
 	if regErr != nil {
 		return h.mapError(c, regErr)
 	}
@@ -1317,29 +1339,12 @@ func (h *Handler) handleRegisterCertificate(c *echo.Context) error {
 }
 
 func (h *Handler) handleDeregisterCertificate(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID   string `json:"DirectoryId"`
-		CertificateID string `json:"CertificateId"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.CertificateID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and CertificateId are required"))
-	}
-
-	if deregErr := h.Backend.DeregisterCertificate(req.DirectoryID, req.CertificateID); deregErr != nil {
-		return h.mapError(c, deregErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: "CertificateId",
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.DeregisterCertificate(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleListCertificates(c *echo.Context) error {
@@ -1364,7 +1369,12 @@ func (h *Handler) handleListCertificates(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	certs, nextToken, listErr := h.Backend.ListCertificates(req.DirectoryID, req.PageSize, req.NextToken)
+	certs, nextToken, listErr := h.Backend.ListCertificates(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.PageSize,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -1407,7 +1417,7 @@ func (h *Handler) handleDescribeCertificate(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and CertificateId are required"))
 	}
 
-	cert, descErr := h.Backend.DescribeCertificate(req.DirectoryID, req.CertificateID)
+	cert, descErr := h.Backend.DescribeCertificate(h.contextWithRegion(c), req.DirectoryID, req.CertificateID)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -1450,7 +1460,7 @@ func (h *Handler) handleEnableLDAPS(c *echo.Context) error { //nolint:dupl // ex
 		ldapsType = "Client"
 	}
 
-	if enableErr := h.Backend.EnableLDAPS(req.DirectoryID, ldapsType); enableErr != nil {
+	if enableErr := h.Backend.EnableLDAPS(h.contextWithRegion(c), req.DirectoryID, ldapsType); enableErr != nil {
 		return h.mapError(c, enableErr)
 	}
 
@@ -1481,7 +1491,7 @@ func (h *Handler) handleDisableLDAPS(c *echo.Context) error { //nolint:dupl // e
 		ldapsType = "Client"
 	}
 
-	if disableErr := h.Backend.DisableLDAPS(req.DirectoryID, ldapsType); disableErr != nil {
+	if disableErr := h.Backend.DisableLDAPS(h.contextWithRegion(c), req.DirectoryID, ldapsType); disableErr != nil {
 		return h.mapError(c, disableErr)
 	}
 
@@ -1511,7 +1521,13 @@ func (h *Handler) handleDescribeLDAPSSettings(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	settings, nextToken, descErr := h.Backend.DescribeLDAPSSettings(req.DirectoryID, req.Type, req.Limit, req.NextToken)
+	settings, nextToken, descErr := h.Backend.DescribeLDAPSSettings(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.Type,
+		req.Limit,
+		req.NextToken,
+	)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -1556,7 +1572,8 @@ func (h *Handler) handleEnableClientAuthentication(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if enableErr := h.Backend.EnableClientAuthentication(req.DirectoryID, req.Type); enableErr != nil {
+	enableErr := h.Backend.EnableClientAuthentication(h.contextWithRegion(c), req.DirectoryID, req.Type)
+	if enableErr != nil {
 		return h.mapError(c, enableErr)
 	}
 
@@ -1582,7 +1599,8 @@ func (h *Handler) handleDisableClientAuthentication(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if disableErr := h.Backend.DisableClientAuthentication(req.DirectoryID, req.Type); disableErr != nil {
+	disableErr := h.Backend.DisableClientAuthentication(h.contextWithRegion(c), req.DirectoryID, req.Type)
+	if disableErr != nil {
 		return h.mapError(c, disableErr)
 	}
 
@@ -1613,6 +1631,7 @@ func (h *Handler) handleDescribeClientAuthenticationSettings(c *echo.Context) er
 	}
 
 	settings, nextToken, descErr := h.Backend.DescribeClientAuthenticationSettings(
+		h.contextWithRegion(c),
 		req.DirectoryID, req.Type, req.PageSize, req.NextToken,
 	)
 	if descErr != nil {
@@ -1677,7 +1696,7 @@ func (h *Handler) handleEnableRadius(c *echo.Context) error { //nolint:dupl // e
 		UseSameUsername:        req.RadiusSettings.UseSameUsername,
 	}
 
-	if enableErr := h.Backend.EnableRadius(req.DirectoryID, settings); enableErr != nil {
+	if enableErr := h.Backend.EnableRadius(h.contextWithRegion(c), req.DirectoryID, settings); enableErr != nil {
 		return h.mapError(c, enableErr)
 	}
 
@@ -1702,7 +1721,7 @@ func (h *Handler) handleDisableRadius(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if disableErr := h.Backend.DisableRadius(req.DirectoryID); disableErr != nil {
+	if disableErr := h.Backend.DisableRadius(h.contextWithRegion(c), req.DirectoryID); disableErr != nil {
 		return h.mapError(c, disableErr)
 	}
 
@@ -1748,7 +1767,7 @@ func (h *Handler) handleUpdateRadius(c *echo.Context) error { //nolint:dupl // e
 		UseSameUsername:        req.RadiusSettings.UseSameUsername,
 	}
 
-	if updateErr := h.Backend.UpdateRadius(req.DirectoryID, settings); updateErr != nil {
+	if updateErr := h.Backend.UpdateRadius(h.contextWithRegion(c), req.DirectoryID, settings); updateErr != nil {
 		return h.mapError(c, updateErr)
 	}
 
@@ -1775,7 +1794,7 @@ func (h *Handler) handleEnableDirectoryDataAccess(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if enableErr := h.Backend.EnableDirectoryDataAccess(req.DirectoryID); enableErr != nil {
+	if enableErr := h.Backend.EnableDirectoryDataAccess(h.contextWithRegion(c), req.DirectoryID); enableErr != nil {
 		return h.mapError(c, enableErr)
 	}
 
@@ -1800,7 +1819,7 @@ func (h *Handler) handleDisableDirectoryDataAccess(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if disableErr := h.Backend.DisableDirectoryDataAccess(req.DirectoryID); disableErr != nil {
+	if disableErr := h.Backend.DisableDirectoryDataAccess(h.contextWithRegion(c), req.DirectoryID); disableErr != nil {
 		return h.mapError(c, disableErr)
 	}
 
@@ -1825,7 +1844,7 @@ func (h *Handler) handleDescribeDirectoryDataAccess(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	status, descErr := h.Backend.DescribeDirectoryDataAccess(req.DirectoryID)
+	status, descErr := h.Backend.DescribeDirectoryDataAccess(h.contextWithRegion(c), req.DirectoryID)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -1860,7 +1879,7 @@ func (h *Handler) handleEnableCAEnrollmentPolicy(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if enableErr := h.Backend.EnableCAEnrollmentPolicy(req.DirectoryID); enableErr != nil {
+	if enableErr := h.Backend.EnableCAEnrollmentPolicy(h.contextWithRegion(c), req.DirectoryID); enableErr != nil {
 		return h.mapError(c, enableErr)
 	}
 
@@ -1885,7 +1904,7 @@ func (h *Handler) handleDisableCAEnrollmentPolicy(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	if disableErr := h.Backend.DisableCAEnrollmentPolicy(req.DirectoryID); disableErr != nil {
+	if disableErr := h.Backend.DisableCAEnrollmentPolicy(h.contextWithRegion(c), req.DirectoryID); disableErr != nil {
 		return h.mapError(c, disableErr)
 	}
 
@@ -1910,7 +1929,7 @@ func (h *Handler) handleDescribeCAEnrollmentPolicy(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	policy, descErr := h.Backend.DescribeCAEnrollmentPolicy(req.DirectoryID)
+	policy, descErr := h.Backend.DescribeCAEnrollmentPolicy(h.contextWithRegion(c), req.DirectoryID)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -1947,7 +1966,7 @@ func (h *Handler) handleStartADAssessment(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	assessmentID, startErr := h.Backend.StartADAssessment(req.DirectoryID)
+	assessmentID, startErr := h.Backend.StartADAssessment(h.contextWithRegion(c), req.DirectoryID)
 	if startErr != nil {
 		return h.mapError(c, startErr)
 	}
@@ -1956,29 +1975,12 @@ func (h *Handler) handleStartADAssessment(c *echo.Context) error {
 }
 
 func (h *Handler) handleDeleteADAssessment(c *echo.Context) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
-	}
-
-	var req struct {
-		DirectoryID  string `json:"DirectoryId"`
-		AssessmentID string `json:"AssessmentId"`
-	}
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
-	}
-
-	if req.DirectoryID == "" || req.AssessmentID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and AssessmentId are required"))
-	}
-
-	if delErr := h.Backend.DeleteADAssessment(req.DirectoryID, req.AssessmentID); delErr != nil {
-		return h.mapError(c, delErr)
-	}
-
-	return c.JSON(http.StatusOK, map[string]any{})
+	return h.handleTwoFieldOp(c, twoFieldOp{
+		secondKey: "AssessmentId",
+		invoke: func(ctx context.Context, dirID, second string) error {
+			return h.Backend.DeleteADAssessment(ctx, dirID, second)
+		},
+	})
 }
 
 func (h *Handler) handleDescribeADAssessment(c *echo.Context) error {
@@ -2000,7 +2002,7 @@ func (h *Handler) handleDescribeADAssessment(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and AssessmentId are required"))
 	}
 
-	a, descErr := h.Backend.DescribeADAssessment(req.DirectoryID, req.AssessmentID)
+	a, descErr := h.Backend.DescribeADAssessment(h.contextWithRegion(c), req.DirectoryID, req.AssessmentID)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -2035,7 +2037,12 @@ func (h *Handler) handleListADAssessments(c *echo.Context) error {
 		}
 	}
 
-	assessments, nextToken, listErr := h.Backend.ListADAssessments(req.DirectoryID, req.PageSize, req.NextToken)
+	assessments, nextToken, listErr := h.Backend.ListADAssessments(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.PageSize,
+		req.NextToken,
+	)
 	if listErr != nil {
 		return h.mapError(c, listErr)
 	}
@@ -2095,6 +2102,7 @@ func (h *Handler) handleCreateHybridAD(c *echo.Context) error {
 
 	tags := reqTagsToTags(req.Tags)
 	d, requestID, createErr := h.Backend.CreateHybridAD(
+		h.contextWithRegion(c),
 		req.Name,
 		req.ShortName,
 		req.Description,
@@ -2130,7 +2138,7 @@ func (h *Handler) handleUpdateHybridAD(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	requestID, updateErr := h.Backend.UpdateHybridAD(req.DirectoryID)
+	requestID, updateErr := h.Backend.UpdateHybridAD(h.contextWithRegion(c), req.DirectoryID)
 	if updateErr != nil {
 		return h.mapError(c, updateErr)
 	}
@@ -2156,7 +2164,7 @@ func (h *Handler) handleDescribeHybridADUpdate(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	updates, descErr := h.Backend.DescribeHybridADUpdate(req.DirectoryID)
+	updates, descErr := h.Backend.DescribeHybridADUpdate(h.contextWithRegion(c), req.DirectoryID)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -2195,7 +2203,12 @@ func (h *Handler) handleCreateComputer(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and ComputerName are required"))
 	}
 
-	computer, createErr := h.Backend.CreateComputer(req.DirectoryID, req.ComputerName, req.Password)
+	computer, createErr := h.Backend.CreateComputer(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.ComputerName,
+		req.Password,
+	)
 	if createErr != nil {
 		return h.mapError(c, createErr)
 	}
@@ -2237,7 +2250,7 @@ func (h *Handler) handleUpdateSettings(c *echo.Context) error {
 		settings = append(settings, DirectorySetting{Name: s.Name, Value: s.Value})
 	}
 
-	directoryID, updateErr := h.Backend.UpdateSettings(req.DirectoryID, settings)
+	directoryID, updateErr := h.Backend.UpdateSettings(h.contextWithRegion(c), req.DirectoryID, settings)
 	if updateErr != nil {
 		return h.mapError(c, updateErr)
 	}
@@ -2267,7 +2280,12 @@ func (h *Handler) handleDescribeSettings(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	settings, nextToken, descErr := h.Backend.DescribeSettings(req.DirectoryID, req.Status, req.NextToken)
+	settings, nextToken, descErr := h.Backend.DescribeSettings(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.Status,
+		req.NextToken,
+	)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -2316,6 +2334,7 @@ func (h *Handler) handleUpdateDirectorySetup(c *echo.Context) error {
 	}
 
 	if updateErr := h.Backend.UpdateDirectorySetup(
+		h.contextWithRegion(c),
 		req.DirectoryID, req.UpdateType, req.CreateSnapshotBeforeUpdate,
 	); updateErr != nil {
 		return h.mapError(c, updateErr)
@@ -2346,7 +2365,12 @@ func (h *Handler) handleDescribeUpdateDirectory(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId is required"))
 	}
 
-	entries, nextToken, descErr := h.Backend.DescribeUpdateDirectory(req.DirectoryID, req.UpdateType, req.NextToken)
+	entries, nextToken, descErr := h.Backend.DescribeUpdateDirectory(
+		h.contextWithRegion(c),
+		req.DirectoryID,
+		req.UpdateType,
+		req.NextToken,
+	)
 	if descErr != nil {
 		return h.mapError(c, descErr)
 	}
@@ -2395,7 +2419,8 @@ func (h *Handler) handleResetUserPassword(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "DirectoryId and UserName are required"))
 	}
 
-	if resetErr := h.Backend.ResetUserPassword(req.DirectoryID, req.UserName, req.NewPassword); resetErr != nil {
+	resetErr := h.Backend.ResetUserPassword(h.contextWithRegion(c), req.DirectoryID, req.UserName, req.NewPassword)
+	if resetErr != nil {
 		return h.mapError(c, resetErr)
 	}
 
@@ -2432,6 +2457,7 @@ func (h *Handler) handleConnectDirectory(c *echo.Context) error { //nolint:dupl 
 
 	tags := reqTagsToTags(req.Tags)
 	d, createErr := h.Backend.ConnectDirectory(
+		h.contextWithRegion(c),
 		req.Name,
 		req.ShortName,
 		req.Description,

--- a/services/directoryservice/interfaces.go
+++ b/services/directoryservice/interfaces.go
@@ -1,147 +1,198 @@
 package directoryservice
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // StorageBackend is the interface for DirectoryService storage operations.
 type StorageBackend interface {
-	CreateDirectory(name, shortName, description, password string, size DirectorySize, tags []Tag) (*Directory, error)
+	CreateDirectory(
+		ctx context.Context,
+		name, shortName, description, password string,
+		size DirectorySize,
+		tags []Tag,
+	) (*Directory, error)
 	CreateMicrosoftAD(
+		ctx context.Context,
 		name, shortName, description, password string,
 		edition DirectoryEdition,
 		tags []Tag,
 	) (*Directory, error)
-	DeleteDirectory(directoryID string) error
-	DescribeDirectories(directoryIDs []string, limit int32, nextToken string) ([]*Directory, string, error)
-	CreateAlias(directoryID, alias string) error
-	EnableSso(directoryID string) error
-	DisableSso(directoryID string) error
-	GetDirectoryLimits() *DirectoryLimits
+	DeleteDirectory(ctx context.Context, directoryID string) error
+	DescribeDirectories(
+		ctx context.Context,
+		directoryIDs []string,
+		limit int32,
+		nextToken string,
+	) ([]*Directory, string, error)
+	CreateAlias(ctx context.Context, directoryID, alias string) error
+	EnableSso(ctx context.Context, directoryID string) error
+	DisableSso(ctx context.Context, directoryID string) error
+	GetDirectoryLimits(ctx context.Context) *DirectoryLimits
 
-	CreateSnapshot(directoryID, name string) (*Snapshot, error)
-	DeleteSnapshot(snapshotID string) error
+	CreateSnapshot(ctx context.Context, directoryID, name string) (*Snapshot, error)
+	DeleteSnapshot(ctx context.Context, snapshotID string) error
 	DescribeSnapshots(
+		ctx context.Context,
 		directoryID string,
 		snapshotIDs []string,
 		limit int32,
 		nextToken string,
 	) ([]*Snapshot, string, error)
-	GetSnapshotLimits(directoryID string) (*SnapshotLimits, error)
-	RestoreFromSnapshot(snapshotID string) error
+	GetSnapshotLimits(ctx context.Context, directoryID string) (*SnapshotLimits, error)
+	RestoreFromSnapshot(ctx context.Context, snapshotID string) error
 
-	AddTagsToResource(resourceID string, tags []Tag) error
-	RemoveTagsFromResource(resourceID string, tagKeys []string) error
-	ListTagsForResource(resourceID string, limit int32, nextToken string) ([]Tag, string, error)
+	AddTagsToResource(ctx context.Context, resourceID string, tags []Tag) error
+	RemoveTagsFromResource(ctx context.Context, resourceID string, tagKeys []string) error
+	ListTagsForResource(ctx context.Context, resourceID string, limit int32, nextToken string) ([]Tag, string, error)
 
-	AddIpRoutes(directoryID string, routes []IpRoute) error
-	RemoveIpRoutes(directoryID string, cidrIPs []string) error
-	ListIpRoutes(directoryID string, limit int32, nextToken string) ([]IpRoute, string, error)
+	AddIpRoutes(ctx context.Context, directoryID string, routes []IpRoute) error
+	RemoveIpRoutes(ctx context.Context, directoryID string, cidrIPs []string) error
+	ListIpRoutes(ctx context.Context, directoryID string, limit int32, nextToken string) ([]IpRoute, string, error)
 
-	AddRegion(directoryID, regionName string) error
-	RemoveRegion(directoryID string) error
-	DescribeRegions(directoryID, regionName, nextToken string) ([]RegionDescription, string, error)
+	AddRegion(ctx context.Context, directoryID, regionName string) error
+	RemoveRegion(ctx context.Context, directoryID string) error
+	DescribeRegions(ctx context.Context, directoryID, regionName, nextToken string) ([]RegionDescription, string, error)
 
-	StartSchemaExtension(directoryID, description, schemaExtensionBody string) (string, error)
-	CancelSchemaExtension(directoryID, schemaExtensionID string) error
-	ListSchemaExtensions(directoryID string, limit int32, nextToken string) ([]SchemaExtension, string, error)
+	StartSchemaExtension(ctx context.Context, directoryID, description, schemaExtensionBody string) (string, error)
+	CancelSchemaExtension(ctx context.Context, directoryID, schemaExtensionID string) error
+	ListSchemaExtensions(
+		ctx context.Context,
+		directoryID string,
+		limit int32,
+		nextToken string,
+	) ([]SchemaExtension, string, error)
 
-	CreateConditionalForwarder(directoryID, remoteDomainName string, dnsIPAddrs []string) error
-	UpdateConditionalForwarder(directoryID, remoteDomainName string, dnsIPAddrs []string) error
-	DeleteConditionalForwarder(directoryID, remoteDomainName string) error
-	DescribeConditionalForwarders(directoryID string, remoteDomainNames []string) ([]ConditionalForwarder, error)
+	CreateConditionalForwarder(ctx context.Context, directoryID, remoteDomainName string, dnsIPAddrs []string) error
+	UpdateConditionalForwarder(ctx context.Context, directoryID, remoteDomainName string, dnsIPAddrs []string) error
+	DeleteConditionalForwarder(ctx context.Context, directoryID, remoteDomainName string) error
+	DescribeConditionalForwarders(
+		ctx context.Context,
+		directoryID string,
+		remoteDomainNames []string,
+	) ([]ConditionalForwarder, error)
 
-	CreateLogSubscription(directoryID, logGroupName string) error
-	DeleteLogSubscription(directoryID string) error
-	ListLogSubscriptions(directoryID string, limit int32, nextToken string) ([]LogSubscription, string, error)
+	CreateLogSubscription(ctx context.Context, directoryID, logGroupName string) error
+	DeleteLogSubscription(ctx context.Context, directoryID string) error
+	ListLogSubscriptions(
+		ctx context.Context,
+		directoryID string,
+		limit int32,
+		nextToken string,
+	) ([]LogSubscription, string, error)
 
-	RegisterEventTopic(directoryID, topicName string) error
-	DeregisterEventTopic(directoryID, topicName string) error
-	DescribeEventTopics(directoryID string, topicNames []string) ([]EventTopic, error)
+	RegisterEventTopic(ctx context.Context, directoryID, topicName string) error
+	DeregisterEventTopic(ctx context.Context, directoryID, topicName string) error
+	DescribeEventTopics(ctx context.Context, directoryID string, topicNames []string) ([]EventTopic, error)
 
 	DescribeDomainControllers(
+		ctx context.Context,
 		directoryID string,
 		domainControllerIDs []string,
 		limit int32,
 		nextToken string,
 	) ([]DomainController, string, error)
-	UpdateNumberOfDomainControllers(directoryID string, desiredNumber int32) error
+	UpdateNumberOfDomainControllers(ctx context.Context, directoryID string, desiredNumber int32) error
 
-	CreateTrust(directoryID, remoteDomainName, trustPassword, trustDirection, trustType string) (string, error)
-	DeleteTrust(trustID string) (string, error)
+	CreateTrust(
+		ctx context.Context,
+		directoryID, remoteDomainName, trustPassword, trustDirection, trustType string,
+	) (string, error)
+	DeleteTrust(ctx context.Context, trustID string) (string, error)
 	DescribeTrusts(
+		ctx context.Context,
 		directoryID string,
 		trustIDs []string,
 		limit int32,
 		nextToken string,
 	) ([]TrustInfo, string, error)
-	UpdateTrust(trustID, selectiveAuth string) (string, error)
-	VerifyTrust(trustID string) (string, error)
+	UpdateTrust(ctx context.Context, trustID, selectiveAuth string) (string, error)
+	VerifyTrust(ctx context.Context, trustID string) (string, error)
 
-	ShareDirectory(directoryID, shareMethod, shareNotes, targetID string) (string, error)
-	UnshareDirectory(directoryID, targetID string) (string, error)
-	AcceptSharedDirectory(sharedDirectoryID string) (string, error)
-	RejectSharedDirectory(sharedDirectoryID string) (string, error)
+	ShareDirectory(ctx context.Context, directoryID, shareMethod, shareNotes, targetID string) (string, error)
+	UnshareDirectory(ctx context.Context, directoryID, targetID string) (string, error)
+	AcceptSharedDirectory(ctx context.Context, sharedDirectoryID string) (string, error)
+	RejectSharedDirectory(ctx context.Context, sharedDirectoryID string) (string, error)
 	DescribeSharedDirectories(
+		ctx context.Context,
 		ownerDirID string,
 		sharedDirIDs []string,
 		limit int32,
 		nextToken string,
 	) ([]SharedDirInfo, string, error)
 
-	RegisterCertificate(directoryID, certData, certType string) (string, error)
-	DeregisterCertificate(directoryID, certID string) error
-	ListCertificates(directoryID string, limit int32, nextToken string) ([]CertInfo, string, error)
-	DescribeCertificate(directoryID, certID string) (*CertDetail, error)
-	EnableLDAPS(directoryID, ldapsType string) error
-	DisableLDAPS(directoryID, ldapsType string) error
+	RegisterCertificate(ctx context.Context, directoryID, certData, certType string) (string, error)
+	DeregisterCertificate(ctx context.Context, directoryID, certID string) error
+	ListCertificates(ctx context.Context, directoryID string, limit int32, nextToken string) ([]CertInfo, string, error)
+	DescribeCertificate(ctx context.Context, directoryID, certID string) (*CertDetail, error)
+	EnableLDAPS(ctx context.Context, directoryID, ldapsType string) error
+	DisableLDAPS(ctx context.Context, directoryID, ldapsType string) error
 	DescribeLDAPSSettings(
+		ctx context.Context,
 		directoryID, ldapsType string,
 		limit int32,
 		nextToken string,
 	) ([]LDAPSSetting, string, error)
 
-	EnableClientAuthentication(directoryID, authType string) error
-	DisableClientAuthentication(directoryID, authType string) error
+	EnableClientAuthentication(ctx context.Context, directoryID, authType string) error
+	DisableClientAuthentication(ctx context.Context, directoryID, authType string) error
 	DescribeClientAuthenticationSettings(
+		ctx context.Context,
 		directoryID, authType string,
 		limit int32,
 		nextToken string,
 	) ([]ClientAuthInfo, string, error)
 
-	EnableRadius(directoryID string, settings RadiusSettingsInput) error
-	DisableRadius(directoryID string) error
-	UpdateRadius(directoryID string, settings RadiusSettingsInput) error
+	EnableRadius(ctx context.Context, directoryID string, settings RadiusSettingsInput) error
+	DisableRadius(ctx context.Context, directoryID string) error
+	UpdateRadius(ctx context.Context, directoryID string, settings RadiusSettingsInput) error
 
-	EnableDirectoryDataAccess(directoryID string) error
-	DisableDirectoryDataAccess(directoryID string) error
-	DescribeDirectoryDataAccess(directoryID string) (*DirectoryDataAccessStatus, error)
+	EnableDirectoryDataAccess(ctx context.Context, directoryID string) error
+	DisableDirectoryDataAccess(ctx context.Context, directoryID string) error
+	DescribeDirectoryDataAccess(ctx context.Context, directoryID string) (*DirectoryDataAccessStatus, error)
 
-	EnableCAEnrollmentPolicy(directoryID string) error
-	DisableCAEnrollmentPolicy(directoryID string) error
-	DescribeCAEnrollmentPolicy(directoryID string) (*CAEnrollmentPolicy, error)
+	EnableCAEnrollmentPolicy(ctx context.Context, directoryID string) error
+	DisableCAEnrollmentPolicy(ctx context.Context, directoryID string) error
+	DescribeCAEnrollmentPolicy(ctx context.Context, directoryID string) (*CAEnrollmentPolicy, error)
 
-	StartADAssessment(directoryID string) (string, error)
-	DeleteADAssessment(directoryID, assessmentID string) error
-	DescribeADAssessment(directoryID, assessmentID string) (*ADAssessmentInfo, error)
-	ListADAssessments(directoryID string, limit int32, nextToken string) ([]ADAssessmentInfo, string, error)
+	StartADAssessment(ctx context.Context, directoryID string) (string, error)
+	DeleteADAssessment(ctx context.Context, directoryID, assessmentID string) error
+	DescribeADAssessment(ctx context.Context, directoryID, assessmentID string) (*ADAssessmentInfo, error)
+	ListADAssessments(
+		ctx context.Context,
+		directoryID string,
+		limit int32,
+		nextToken string,
+	) ([]ADAssessmentInfo, string, error)
 
 	CreateHybridAD(
+		ctx context.Context,
 		name, shortName, description, password string,
 		edition DirectoryEdition,
 		tags []Tag,
 	) (*Directory, string, error)
-	UpdateHybridAD(directoryID string) (string, error)
-	DescribeHybridADUpdate(directoryID string) ([]HybridADUpdateEntry, error)
+	UpdateHybridAD(ctx context.Context, directoryID string) (string, error)
+	DescribeHybridADUpdate(ctx context.Context, directoryID string) ([]HybridADUpdateEntry, error)
 
-	CreateComputer(directoryID, computerName, password string) (*ComputerInfo, error)
+	CreateComputer(ctx context.Context, directoryID, computerName, password string) (*ComputerInfo, error)
 
-	UpdateSettings(directoryID string, settings []DirectorySetting) (string, error)
-	DescribeSettings(directoryID, status, nextToken string) ([]SettingEntry, string, error)
-	UpdateDirectorySetup(directoryID, updateType string, createSnapshotBeforeUpdate bool) error
-	DescribeUpdateDirectory(directoryID, updateType, nextToken string) ([]UpdateInfoEntry, string, error)
+	UpdateSettings(ctx context.Context, directoryID string, settings []DirectorySetting) (string, error)
+	DescribeSettings(ctx context.Context, directoryID, status, nextToken string) ([]SettingEntry, string, error)
+	UpdateDirectorySetup(ctx context.Context, directoryID, updateType string, createSnapshotBeforeUpdate bool) error
+	DescribeUpdateDirectory(
+		ctx context.Context,
+		directoryID, updateType, nextToken string,
+	) ([]UpdateInfoEntry, string, error)
 
-	ResetUserPassword(directoryID, userName, newPassword string) error
+	ResetUserPassword(ctx context.Context, directoryID, userName, newPassword string) error
 
-	ConnectDirectory(name, shortName, description, password string, size DirectorySize, tags []Tag) (*Directory, error)
+	ConnectDirectory(
+		ctx context.Context,
+		name, shortName, description, password string,
+		size DirectorySize,
+		tags []Tag,
+	) (*Directory, error)
 
 	AccountID() string
 	Region() string

--- a/services/directoryservice/isolation_test.go
+++ b/services/directoryservice/isolation_test.go
@@ -1,0 +1,230 @@
+package directoryservice //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region under regionContextKey,
+// mirroring what the HTTP handler injects from the SigV4 credential scope.
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestDirectoryRegionIsolation proves that directories created in two regions are
+// fully isolated: each region sees only its own directories, deleting in one region
+// leaves the other intact, and an ID created in one region is invisible from the other.
+func TestDirectoryRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// 1. Create a directory in each region (same name is allowed across regions).
+	eastDir, err := backend.CreateMicrosoftAD(
+		ctxEast, "corp.example.com", "corp", "east dir", "", DirectoryEditionEnterprise, nil,
+	)
+	require.NoError(t, err)
+
+	westDir, err := backend.CreateMicrosoftAD(
+		ctxWest, "corp.example.com", "corp", "west dir", "", DirectoryEditionStandard, nil,
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, eastDir.DirectoryID, westDir.DirectoryID)
+
+	// 2. Each region lists only its own directory with its own attributes.
+	eastList, _, err := backend.DescribeDirectories(ctxEast, nil, 0, "")
+	require.NoError(t, err)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, eastDir.DirectoryID, eastList[0].DirectoryID)
+	assert.Equal(t, "east dir", eastList[0].Description)
+
+	westList, _, err := backend.DescribeDirectories(ctxWest, nil, 0, "")
+	require.NoError(t, err)
+	require.Len(t, westList, 1)
+	assert.Equal(t, westDir.DirectoryID, westList[0].DirectoryID)
+	assert.Equal(t, "west dir", westList[0].Description)
+
+	// 3. The east directory ID is not resolvable from the west region.
+	_, _, err = backend.DescribeDirectories(ctxWest, []string{eastDir.DirectoryID}, 0, "")
+	require.ErrorIs(t, err, ErrDirectoryNotFound)
+
+	// 4. Deleting in us-east-1 leaves us-west-2 intact.
+	require.NoError(t, backend.DeleteDirectory(ctxEast, eastDir.DirectoryID))
+
+	eastList, _, err = backend.DescribeDirectories(ctxEast, nil, 0, "")
+	require.NoError(t, err)
+	assert.Empty(t, eastList)
+
+	westList, _, err = backend.DescribeDirectories(ctxWest, nil, 0, "")
+	require.NoError(t, err)
+	assert.Len(t, westList, 1)
+
+	// 5. Deleting an east directory ID from the west region fails (not found there).
+	require.ErrorIs(t, backend.DeleteDirectory(ctxWest, eastDir.DirectoryID), ErrDirectoryNotFound)
+}
+
+// TestDirectoryDefaultRegionFallback proves that a context without a region falls
+// back to the backend's default region.
+func TestDirectoryDefaultRegionFallback(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	// Created with no region in context -> backend default (us-east-1).
+	dir, err := backend.CreateDirectory(
+		context.Background(),
+		"fallback.example.com",
+		"fb",
+		"",
+		"",
+		DirectorySizeSmall,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Visible from the explicit default region.
+	list, _, err := backend.DescribeDirectories(ctxRegion("us-east-1"), nil, 0, "")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, dir.DirectoryID, list[0].DirectoryID)
+
+	// Not visible from a different region.
+	other, _, err := backend.DescribeDirectories(ctxRegion("eu-west-1"), nil, 0, "")
+	require.NoError(t, err)
+	assert.Empty(t, other)
+}
+
+// TestDependentResourceRegionIsolation proves that resources that hang off a
+// directory (snapshots, trusts, certificates, conditional forwarders, IP routes,
+// tags) are isolated per region along with their parent directory.
+func TestDependentResourceRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	eastDir, err := backend.CreateMicrosoftAD(
+		ctxEast,
+		"corp.example.com",
+		"corp",
+		"",
+		"",
+		DirectoryEditionEnterprise,
+		nil,
+	)
+	require.NoError(t, err)
+
+	westDir, err := backend.CreateMicrosoftAD(
+		ctxWest,
+		"corp.example.com",
+		"corp",
+		"",
+		"",
+		DirectoryEditionEnterprise,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Snapshot isolation: a snapshot of the east directory is invisible from west.
+	eastSnap, err := backend.CreateSnapshot(ctxEast, eastDir.DirectoryID, "east-snap")
+	require.NoError(t, err)
+
+	eastSnaps, _, err := backend.DescribeSnapshots(ctxEast, eastDir.DirectoryID, nil, 0, "")
+	require.NoError(t, err)
+	require.Len(t, eastSnaps, 1)
+	assert.Equal(t, eastSnap.SnapshotID, eastSnaps[0].SnapshotID)
+
+	westSnaps, _, err := backend.DescribeSnapshots(ctxWest, "", nil, 0, "")
+	require.NoError(t, err)
+	assert.Empty(t, westSnaps)
+
+	// The east snapshot cannot be deleted from the west region.
+	require.ErrorIs(t, backend.DeleteSnapshot(ctxWest, eastSnap.SnapshotID), ErrSnapshotNotFound)
+
+	// Trust isolation.
+	eastTrust, err := backend.CreateTrust(ctxEast, eastDir.DirectoryID, "remote.example.com", "pw", "Two-Way", "Forest")
+	require.NoError(t, err)
+
+	_, err = backend.UpdateTrust(ctxWest, eastTrust, "Enabled")
+	require.ErrorIs(t, err, ErrTrustNotFound)
+
+	eastTrusts, _, err := backend.DescribeTrusts(ctxEast, eastDir.DirectoryID, nil, 0, "")
+	require.NoError(t, err)
+	assert.Len(t, eastTrusts, 1)
+
+	westTrusts, _, err := backend.DescribeTrusts(ctxWest, westDir.DirectoryID, nil, 0, "")
+	require.NoError(t, err)
+	assert.Empty(t, westTrusts)
+
+	// Certificate isolation.
+	eastCert, err := backend.RegisterCertificate(ctxEast, eastDir.DirectoryID, "cert-data", "ClientLDAPS")
+	require.NoError(t, err)
+
+	_, err = backend.DescribeCertificate(ctxWest, westDir.DirectoryID, eastCert)
+	require.ErrorIs(t, err, ErrCertNotFound)
+
+	cert, err := backend.DescribeCertificate(ctxEast, eastDir.DirectoryID, eastCert)
+	require.NoError(t, err)
+	assert.Equal(t, eastCert, cert.CertificateID)
+
+	// Conditional forwarder isolation.
+	require.NoError(
+		t,
+		backend.CreateConditionalForwarder(ctxEast, eastDir.DirectoryID, "fwd.example.com", []string{"10.0.0.1"}),
+	)
+
+	westFwds, err := backend.DescribeConditionalForwarders(ctxWest, westDir.DirectoryID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, westFwds)
+
+	eastFwds, err := backend.DescribeConditionalForwarders(ctxEast, eastDir.DirectoryID, nil)
+	require.NoError(t, err)
+	assert.Len(t, eastFwds, 1)
+
+	// IP route isolation.
+	require.NoError(t, backend.AddIpRoutes(ctxEast, eastDir.DirectoryID, []IpRoute{{CidrIP: "10.0.0.0/16"}}))
+
+	eastRoutes, _, err := backend.ListIpRoutes(ctxEast, eastDir.DirectoryID, 0, "")
+	require.NoError(t, err)
+	assert.Len(t, eastRoutes, 1)
+
+	// Tag isolation: tagging the east directory does not leak to the same-named west directory.
+	require.NoError(t, backend.AddTagsToResource(ctxEast, eastDir.DirectoryID, []Tag{{Key: "env", Value: "east"}}))
+
+	westTags, _, err := backend.ListTagsForResource(ctxWest, westDir.DirectoryID, 0, "")
+	require.NoError(t, err)
+	assert.Empty(t, westTags)
+
+	eastTags, _, err := backend.ListTagsForResource(ctxEast, eastDir.DirectoryID, 0, "")
+	require.NoError(t, err)
+	require.Len(t, eastTags, 1)
+	assert.Equal(t, "east", eastTags[0].Value)
+}
+
+// TestADAssessmentRecordsContextRegion proves region-derived metadata reflects the
+// request-context region rather than the backend default.
+func TestADAssessmentRecordsContextRegion(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxWest := ctxRegion("us-west-2")
+
+	dir, err := backend.CreateMicrosoftAD(ctxWest, "corp.example.com", "corp", "", "", DirectoryEditionEnterprise, nil)
+	require.NoError(t, err)
+
+	assessID, err := backend.StartADAssessment(ctxWest, dir.DirectoryID)
+	require.NoError(t, err)
+
+	info, err := backend.DescribeADAssessment(ctxWest, dir.DirectoryID, assessID)
+	require.NoError(t, err)
+	assert.Equal(t, "us-west-2", info.Region)
+}

--- a/services/dms/backend.go
+++ b/services/dms/backend.go
@@ -2,6 +2,7 @@
 package dms
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -12,6 +13,23 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+// DMS resources are isolated per region: every backend operation resolves the
+// caller's region from the request context and operates only on that region's
+// nested store. DMS replication is inherently single-region (the source and
+// target endpoints and the replication instance all live in the same region),
+// so cross-region references never occur and isolation is always safe.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 const (
 	statusActive         = "active"
@@ -229,29 +247,34 @@ type Connection struct {
 }
 
 // InMemoryBackend is the in-memory store for AWS DMS resources.
+//
+// All resource maps are nested by region (outer key = region) so that
+// same-named resources are isolated across regions. The per-region inner maps
+// are created lazily via the *Store helpers. Callers must hold b.mu while
+// accessing the inner maps.
 type InMemoryBackend struct {
-	replicationInstances         map[string]*ReplicationInstance
-	endpoints                    map[string]*Endpoint
-	replicationTasks             map[string]*ReplicationTask
-	dataMigrations               map[string]*DataMigration
-	dataProviders                map[string]*DataProvider
-	eventSubscriptions           map[string]*EventSubscription
-	fleetAdvisorCollectors       map[string]*FleetAdvisorCollector
-	instanceProfiles             map[string]*InstanceProfile
-	replicationInstancesByARN    map[string]*ReplicationInstance
-	endpointsByARN               map[string]*Endpoint
-	replicationTasksByARN        map[string]*ReplicationTask
-	dataMigrationsByARN          map[string]*DataMigration
-	dataProvidersByARN           map[string]*DataProvider
-	instanceProfilesByARN        map[string]*InstanceProfile
-	certificates                 map[string]*Certificate
-	replicationSubnetGroups      map[string]*ReplicationSubnetGroup
-	replicationSubnetGroupsByARN map[string]*ReplicationSubnetGroup
-	migrationProjects            map[string]*MigrationProject
-	migrationProjectsByARN       map[string]*MigrationProject
-	replicationConfigs           map[string]*ReplicationConfig
-	replicationConfigsByARN      map[string]*ReplicationConfig
-	connections                  map[string]*Connection // key: "riArn:epArn"
+	replicationInstances         map[string]map[string]*ReplicationInstance
+	endpoints                    map[string]map[string]*Endpoint
+	replicationTasks             map[string]map[string]*ReplicationTask
+	dataMigrations               map[string]map[string]*DataMigration
+	dataProviders                map[string]map[string]*DataProvider
+	eventSubscriptions           map[string]map[string]*EventSubscription
+	fleetAdvisorCollectors       map[string]map[string]*FleetAdvisorCollector
+	instanceProfiles             map[string]map[string]*InstanceProfile
+	replicationInstancesByARN    map[string]map[string]*ReplicationInstance
+	endpointsByARN               map[string]map[string]*Endpoint
+	replicationTasksByARN        map[string]map[string]*ReplicationTask
+	dataMigrationsByARN          map[string]map[string]*DataMigration
+	dataProvidersByARN           map[string]map[string]*DataProvider
+	instanceProfilesByARN        map[string]map[string]*InstanceProfile
+	certificates                 map[string]map[string]*Certificate
+	replicationSubnetGroups      map[string]map[string]*ReplicationSubnetGroup
+	replicationSubnetGroupsByARN map[string]map[string]*ReplicationSubnetGroup
+	migrationProjects            map[string]map[string]*MigrationProject
+	migrationProjectsByARN       map[string]map[string]*MigrationProject
+	replicationConfigs           map[string]map[string]*ReplicationConfig
+	replicationConfigsByARN      map[string]map[string]*ReplicationConfig
+	connections                  map[string]map[string]*Connection // inner key: "riArn:epArn"
 	mu                           *lockmetrics.RWMutex
 	accountID                    string
 	region                       string
@@ -261,28 +284,28 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new in-memory DMS backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		replicationInstances:         make(map[string]*ReplicationInstance),
-		endpoints:                    make(map[string]*Endpoint),
-		replicationTasks:             make(map[string]*ReplicationTask),
-		dataMigrations:               make(map[string]*DataMigration),
-		dataProviders:                make(map[string]*DataProvider),
-		eventSubscriptions:           make(map[string]*EventSubscription),
-		fleetAdvisorCollectors:       make(map[string]*FleetAdvisorCollector),
-		instanceProfiles:             make(map[string]*InstanceProfile),
-		replicationInstancesByARN:    make(map[string]*ReplicationInstance),
-		endpointsByARN:               make(map[string]*Endpoint),
-		replicationTasksByARN:        make(map[string]*ReplicationTask),
-		dataMigrationsByARN:          make(map[string]*DataMigration),
-		dataProvidersByARN:           make(map[string]*DataProvider),
-		instanceProfilesByARN:        make(map[string]*InstanceProfile),
-		certificates:                 make(map[string]*Certificate),
-		replicationSubnetGroups:      make(map[string]*ReplicationSubnetGroup),
-		replicationSubnetGroupsByARN: make(map[string]*ReplicationSubnetGroup),
-		migrationProjects:            make(map[string]*MigrationProject),
-		migrationProjectsByARN:       make(map[string]*MigrationProject),
-		replicationConfigs:           make(map[string]*ReplicationConfig),
-		replicationConfigsByARN:      make(map[string]*ReplicationConfig),
-		connections:                  make(map[string]*Connection),
+		replicationInstances:         make(map[string]map[string]*ReplicationInstance),
+		endpoints:                    make(map[string]map[string]*Endpoint),
+		replicationTasks:             make(map[string]map[string]*ReplicationTask),
+		dataMigrations:               make(map[string]map[string]*DataMigration),
+		dataProviders:                make(map[string]map[string]*DataProvider),
+		eventSubscriptions:           make(map[string]map[string]*EventSubscription),
+		fleetAdvisorCollectors:       make(map[string]map[string]*FleetAdvisorCollector),
+		instanceProfiles:             make(map[string]map[string]*InstanceProfile),
+		replicationInstancesByARN:    make(map[string]map[string]*ReplicationInstance),
+		endpointsByARN:               make(map[string]map[string]*Endpoint),
+		replicationTasksByARN:        make(map[string]map[string]*ReplicationTask),
+		dataMigrationsByARN:          make(map[string]map[string]*DataMigration),
+		dataProvidersByARN:           make(map[string]map[string]*DataProvider),
+		instanceProfilesByARN:        make(map[string]map[string]*InstanceProfile),
+		certificates:                 make(map[string]map[string]*Certificate),
+		replicationSubnetGroups:      make(map[string]map[string]*ReplicationSubnetGroup),
+		replicationSubnetGroupsByARN: make(map[string]map[string]*ReplicationSubnetGroup),
+		migrationProjects:            make(map[string]map[string]*MigrationProject),
+		migrationProjectsByARN:       make(map[string]map[string]*MigrationProject),
+		replicationConfigs:           make(map[string]map[string]*ReplicationConfig),
+		replicationConfigsByARN:      make(map[string]map[string]*ReplicationConfig),
+		connections:                  make(map[string]map[string]*Connection),
 		accountID:                    accountID,
 		region:                       region,
 		paginationSecret:             uuid.NewString(),
@@ -290,26 +313,205 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	}
 }
 
+// The *Store helpers return the per-region inner map, lazily creating it.
+// Callers must hold b.mu.
+
+func (b *InMemoryBackend) replicationInstancesStore(region string) map[string]*ReplicationInstance {
+	if b.replicationInstances[region] == nil {
+		b.replicationInstances[region] = make(map[string]*ReplicationInstance)
+	}
+
+	return b.replicationInstances[region]
+}
+
+func (b *InMemoryBackend) replicationInstancesByARNStore(region string) map[string]*ReplicationInstance {
+	if b.replicationInstancesByARN[region] == nil {
+		b.replicationInstancesByARN[region] = make(map[string]*ReplicationInstance)
+	}
+
+	return b.replicationInstancesByARN[region]
+}
+
+func (b *InMemoryBackend) endpointsStore(region string) map[string]*Endpoint {
+	if b.endpoints[region] == nil {
+		b.endpoints[region] = make(map[string]*Endpoint)
+	}
+
+	return b.endpoints[region]
+}
+
+func (b *InMemoryBackend) endpointsByARNStore(region string) map[string]*Endpoint {
+	if b.endpointsByARN[region] == nil {
+		b.endpointsByARN[region] = make(map[string]*Endpoint)
+	}
+
+	return b.endpointsByARN[region]
+}
+
+func (b *InMemoryBackend) replicationTasksStore(region string) map[string]*ReplicationTask {
+	if b.replicationTasks[region] == nil {
+		b.replicationTasks[region] = make(map[string]*ReplicationTask)
+	}
+
+	return b.replicationTasks[region]
+}
+
+func (b *InMemoryBackend) replicationTasksByARNStore(region string) map[string]*ReplicationTask {
+	if b.replicationTasksByARN[region] == nil {
+		b.replicationTasksByARN[region] = make(map[string]*ReplicationTask)
+	}
+
+	return b.replicationTasksByARN[region]
+}
+
+func (b *InMemoryBackend) dataMigrationsStore(region string) map[string]*DataMigration {
+	if b.dataMigrations[region] == nil {
+		b.dataMigrations[region] = make(map[string]*DataMigration)
+	}
+
+	return b.dataMigrations[region]
+}
+
+func (b *InMemoryBackend) dataMigrationsByARNStore(region string) map[string]*DataMigration {
+	if b.dataMigrationsByARN[region] == nil {
+		b.dataMigrationsByARN[region] = make(map[string]*DataMigration)
+	}
+
+	return b.dataMigrationsByARN[region]
+}
+
+func (b *InMemoryBackend) dataProvidersStore(region string) map[string]*DataProvider {
+	if b.dataProviders[region] == nil {
+		b.dataProviders[region] = make(map[string]*DataProvider)
+	}
+
+	return b.dataProviders[region]
+}
+
+func (b *InMemoryBackend) dataProvidersByARNStore(region string) map[string]*DataProvider {
+	if b.dataProvidersByARN[region] == nil {
+		b.dataProvidersByARN[region] = make(map[string]*DataProvider)
+	}
+
+	return b.dataProvidersByARN[region]
+}
+
+func (b *InMemoryBackend) eventSubscriptionsStore(region string) map[string]*EventSubscription {
+	if b.eventSubscriptions[region] == nil {
+		b.eventSubscriptions[region] = make(map[string]*EventSubscription)
+	}
+
+	return b.eventSubscriptions[region]
+}
+
+func (b *InMemoryBackend) fleetAdvisorCollectorsStore(region string) map[string]*FleetAdvisorCollector {
+	if b.fleetAdvisorCollectors[region] == nil {
+		b.fleetAdvisorCollectors[region] = make(map[string]*FleetAdvisorCollector)
+	}
+
+	return b.fleetAdvisorCollectors[region]
+}
+
+func (b *InMemoryBackend) instanceProfilesStore(region string) map[string]*InstanceProfile {
+	if b.instanceProfiles[region] == nil {
+		b.instanceProfiles[region] = make(map[string]*InstanceProfile)
+	}
+
+	return b.instanceProfiles[region]
+}
+
+func (b *InMemoryBackend) instanceProfilesByARNStore(region string) map[string]*InstanceProfile {
+	if b.instanceProfilesByARN[region] == nil {
+		b.instanceProfilesByARN[region] = make(map[string]*InstanceProfile)
+	}
+
+	return b.instanceProfilesByARN[region]
+}
+
+func (b *InMemoryBackend) certificatesStore(region string) map[string]*Certificate {
+	if b.certificates[region] == nil {
+		b.certificates[region] = make(map[string]*Certificate)
+	}
+
+	return b.certificates[region]
+}
+
+func (b *InMemoryBackend) replicationSubnetGroupsStore(region string) map[string]*ReplicationSubnetGroup {
+	if b.replicationSubnetGroups[region] == nil {
+		b.replicationSubnetGroups[region] = make(map[string]*ReplicationSubnetGroup)
+	}
+
+	return b.replicationSubnetGroups[region]
+}
+
+func (b *InMemoryBackend) replicationSubnetGroupsByARNStore(region string) map[string]*ReplicationSubnetGroup {
+	if b.replicationSubnetGroupsByARN[region] == nil {
+		b.replicationSubnetGroupsByARN[region] = make(map[string]*ReplicationSubnetGroup)
+	}
+
+	return b.replicationSubnetGroupsByARN[region]
+}
+
+func (b *InMemoryBackend) migrationProjectsStore(region string) map[string]*MigrationProject {
+	if b.migrationProjects[region] == nil {
+		b.migrationProjects[region] = make(map[string]*MigrationProject)
+	}
+
+	return b.migrationProjects[region]
+}
+
+func (b *InMemoryBackend) migrationProjectsByARNStore(region string) map[string]*MigrationProject {
+	if b.migrationProjectsByARN[region] == nil {
+		b.migrationProjectsByARN[region] = make(map[string]*MigrationProject)
+	}
+
+	return b.migrationProjectsByARN[region]
+}
+
+func (b *InMemoryBackend) replicationConfigsStore(region string) map[string]*ReplicationConfig {
+	if b.replicationConfigs[region] == nil {
+		b.replicationConfigs[region] = make(map[string]*ReplicationConfig)
+	}
+
+	return b.replicationConfigs[region]
+}
+
+func (b *InMemoryBackend) replicationConfigsByARNStore(region string) map[string]*ReplicationConfig {
+	if b.replicationConfigsByARN[region] == nil {
+		b.replicationConfigsByARN[region] = make(map[string]*ReplicationConfig)
+	}
+
+	return b.replicationConfigsByARN[region]
+}
+
+func (b *InMemoryBackend) connectionsStore(region string) map[string]*Connection {
+	if b.connections[region] == nil {
+		b.connections[region] = make(map[string]*Connection)
+	}
+
+	return b.connections[region]
+}
+
 // AccountID returns the AWS account ID this backend is configured for.
 func (b *InMemoryBackend) AccountID() string { return b.accountID }
 
 // mustDescribeReplicationInstances returns all replication instances without error (for internal use).
-func (b *InMemoryBackend) mustDescribeReplicationInstances() []*ReplicationInstance {
-	list, _ := b.DescribeReplicationInstances("")
+func (b *InMemoryBackend) mustDescribeReplicationInstances(ctx context.Context) []*ReplicationInstance {
+	list, _ := b.DescribeReplicationInstances(ctx, "")
 
 	return list
 }
 
 // mustDescribeEndpoints returns all endpoints without error (for internal use).
-func (b *InMemoryBackend) mustDescribeEndpoints() []*Endpoint {
-	list, _ := b.DescribeEndpoints("")
+func (b *InMemoryBackend) mustDescribeEndpoints(ctx context.Context) []*Endpoint {
+	list, _ := b.DescribeEndpoints(ctx, "")
 
 	return list
 }
 
 // mustDescribeReplicationTasks returns all replication tasks without error (for internal use).
-func (b *InMemoryBackend) mustDescribeReplicationTasks() []*ReplicationTask {
-	list, _ := b.DescribeReplicationTasks("")
+func (b *InMemoryBackend) mustDescribeReplicationTasks(ctx context.Context) []*ReplicationTask {
+	list, _ := b.DescribeReplicationTasks(ctx, "")
 
 	return list
 }
@@ -319,6 +521,7 @@ func (b *InMemoryBackend) Region() string { return b.region }
 
 // CreateReplicationInstance creates a new DMS replication instance.
 func (b *InMemoryBackend) CreateReplicationInstance(
+	ctx context.Context,
 	identifier, class, engineVersion, availabilityZone string,
 	allocatedStorage int32,
 	multiAZ, autoMinorVersionUpgrade, publiclyAccessible bool,
@@ -327,7 +530,11 @@ func (b *InMemoryBackend) CreateReplicationInstance(
 	b.mu.Lock("CreateReplicationInstance")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicationInstances[identifier]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.replicationInstancesStore(region)
+	byARN := b.replicationInstancesByARNStore(region)
+
+	if _, ok := store[identifier]; ok {
 		return nil, fmt.Errorf(
 			"%w: replication instance %s already exists",
 			ErrAlreadyExists,
@@ -335,7 +542,7 @@ func (b *InMemoryBackend) CreateReplicationInstance(
 		)
 	}
 
-	instanceARN := arn.Build("dms", b.region, b.accountID, "rep:"+identifier)
+	instanceARN := arn.Build("dms", region, b.accountID, "rep:"+identifier)
 	t := tags.New("dms.replication-instance." + identifier + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -362,12 +569,12 @@ func (b *InMemoryBackend) CreateReplicationInstance(
 		ReplicationInstanceStatus:     statusAvailable,
 		PrivateIPAddress:              "10.0.0.1",
 		AccountID:                     b.accountID,
-		Region:                        b.region,
+		Region:                        region,
 		CreationTime:                  time.Now().UTC(),
 		Tags:                          t,
 	}
-	b.replicationInstances[identifier] = ri
-	b.replicationInstancesByARN[instanceARN] = ri
+	store[identifier] = ri
+	byARN[instanceARN] = ri
 	cp := *ri
 
 	return &cp, nil
@@ -375,20 +582,23 @@ func (b *InMemoryBackend) CreateReplicationInstance(
 
 // DescribeReplicationInstances returns replication instances, optionally filtered by identifier or ARN.
 func (b *InMemoryBackend) DescribeReplicationInstances(
+	ctx context.Context,
 	identifierOrArn string,
 ) ([]*ReplicationInstance, error) {
 	b.mu.RLock("DescribeReplicationInstances")
 	defer b.mu.RUnlock()
 
+	store := b.replicationInstancesStore(getRegion(ctx, b.region))
+
 	if identifierOrArn != "" {
 		// Try by identifier first.
-		if ri, ok := b.replicationInstances[identifierOrArn]; ok {
+		if ri, ok := store[identifierOrArn]; ok {
 			cp := *ri
 
 			return []*ReplicationInstance{&cp}, nil
 		}
 		// Try by ARN.
-		for _, ri := range b.replicationInstances {
+		for _, ri := range store {
 			if ri.ReplicationInstanceArn == identifierOrArn {
 				cp := *ri
 
@@ -399,8 +609,8 @@ func (b *InMemoryBackend) DescribeReplicationInstances(
 		return []*ReplicationInstance{}, nil
 	}
 
-	list := make([]*ReplicationInstance, 0, len(b.replicationInstances))
-	for _, ri := range b.replicationInstances {
+	list := make([]*ReplicationInstance, 0, len(store))
+	for _, ri := range store {
 		cp := *ri
 		list = append(list, &cp)
 	}
@@ -410,13 +620,18 @@ func (b *InMemoryBackend) DescribeReplicationInstances(
 
 // DeleteReplicationInstance deletes a replication instance by ARN or identifier.
 // AWS requires all replication tasks on the instance to be deleted first.
-func (b *InMemoryBackend) DeleteReplicationInstance(arnOrID string) error {
+func (b *InMemoryBackend) DeleteReplicationInstance(ctx context.Context, arnOrID string) error {
 	b.mu.Lock("DeleteReplicationInstance")
 	defer b.mu.Unlock()
 
+	region := getRegion(ctx, b.region)
+	store := b.replicationInstancesStore(region)
+	byARN := b.replicationInstancesByARNStore(region)
+	tasks := b.replicationTasksStore(region)
+
 	deleteInstance := func(ri *ReplicationInstance, id string) error {
 		// Check for tasks attached to this instance.
-		for _, rt := range b.replicationTasks {
+		for _, rt := range tasks {
 			if rt.ReplicationInstanceArn == ri.ReplicationInstanceArn {
 				return fmt.Errorf(
 					"%w: replication instance %s has tasks attached; delete all tasks first",
@@ -426,18 +641,18 @@ func (b *InMemoryBackend) DeleteReplicationInstance(arnOrID string) error {
 			}
 		}
 		ri.Tags.Close()
-		delete(b.replicationInstancesByARN, ri.ReplicationInstanceArn)
-		delete(b.replicationInstances, id)
+		delete(byARN, ri.ReplicationInstanceArn)
+		delete(store, id)
 
 		return nil
 	}
 
 	// Try by identifier first.
-	if ri, ok := b.replicationInstances[arnOrID]; ok {
+	if ri, ok := store[arnOrID]; ok {
 		return deleteInstance(ri, arnOrID)
 	}
 	// Try by ARN.
-	for id, ri := range b.replicationInstances {
+	for id, ri := range store {
 		if ri.ReplicationInstanceArn == arnOrID {
 			return deleteInstance(ri, id)
 		}
@@ -448,6 +663,7 @@ func (b *InMemoryBackend) DeleteReplicationInstance(arnOrID string) error {
 
 // CreateEndpoint creates a new DMS endpoint.
 func (b *InMemoryBackend) CreateEndpoint(
+	ctx context.Context,
 	identifier, endpointType, engineName, serverName, databaseName, username string,
 	port int32,
 	kv map[string]string,
@@ -455,12 +671,16 @@ func (b *InMemoryBackend) CreateEndpoint(
 	b.mu.Lock("CreateEndpoint")
 	defer b.mu.Unlock()
 
-	if _, ok := b.endpoints[identifier]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.endpointsStore(region)
+	byARN := b.endpointsByARNStore(region)
+
+	if _, ok := store[identifier]; ok {
 		return nil, fmt.Errorf("%w: endpoint %s already exists", ErrAlreadyExists, identifier)
 	}
 
 	endpointID := uuid.NewString()
-	endpointARN := arn.Build("dms", b.region, b.accountID, "endpoint:"+endpointID)
+	endpointARN := arn.Build("dms", region, b.accountID, "endpoint:"+endpointID)
 	t := tags.New("dms.endpoint." + identifier + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -477,31 +697,33 @@ func (b *InMemoryBackend) CreateEndpoint(
 		Port:               port,
 		Status:             statusActive,
 		AccountID:          b.accountID,
-		Region:             b.region,
+		Region:             region,
 		CreationTime:       time.Now().UTC(),
 		Tags:               t,
 	}
-	b.endpoints[identifier] = ep
-	b.endpointsByARN[endpointARN] = ep
+	store[identifier] = ep
+	byARN[endpointARN] = ep
 	cp := *ep
 
 	return &cp, nil
 }
 
 // DescribeEndpoints returns endpoints, optionally filtered by identifier or ARN.
-func (b *InMemoryBackend) DescribeEndpoints(identifierOrArn string) ([]*Endpoint, error) {
+func (b *InMemoryBackend) DescribeEndpoints(ctx context.Context, identifierOrArn string) ([]*Endpoint, error) {
 	b.mu.RLock("DescribeEndpoints")
 	defer b.mu.RUnlock()
 
+	store := b.endpointsStore(getRegion(ctx, b.region))
+
 	if identifierOrArn != "" {
 		// Try by identifier first.
-		if ep, ok := b.endpoints[identifierOrArn]; ok {
+		if ep, ok := store[identifierOrArn]; ok {
 			cp := *ep
 
 			return []*Endpoint{&cp}, nil
 		}
 		// Try by ARN.
-		for _, ep := range b.endpoints {
+		for _, ep := range store {
 			if ep.EndpointArn == identifierOrArn {
 				cp := *ep
 
@@ -512,8 +734,8 @@ func (b *InMemoryBackend) DescribeEndpoints(identifierOrArn string) ([]*Endpoint
 		return []*Endpoint{}, nil
 	}
 
-	list := make([]*Endpoint, 0, len(b.endpoints))
-	for _, ep := range b.endpoints {
+	list := make([]*Endpoint, 0, len(store))
+	for _, ep := range store {
 		cp := *ep
 		list = append(list, &cp)
 	}
@@ -522,26 +744,30 @@ func (b *InMemoryBackend) DescribeEndpoints(identifierOrArn string) ([]*Endpoint
 }
 
 // DeleteEndpoint deletes an endpoint by ARN or identifier.
-func (b *InMemoryBackend) DeleteEndpoint(arnOrID string) (*Endpoint, error) {
+func (b *InMemoryBackend) DeleteEndpoint(ctx context.Context, arnOrID string) (*Endpoint, error) {
 	b.mu.Lock("DeleteEndpoint")
 	defer b.mu.Unlock()
 
+	region := getRegion(ctx, b.region)
+	store := b.endpointsStore(region)
+	byARN := b.endpointsByARNStore(region)
+
 	// Try by identifier first.
-	if ep, ok := b.endpoints[arnOrID]; ok {
+	if ep, ok := store[arnOrID]; ok {
 		cp := *ep
 		ep.Tags.Close()
-		delete(b.endpointsByARN, ep.EndpointArn)
-		delete(b.endpoints, arnOrID)
+		delete(byARN, ep.EndpointArn)
+		delete(store, arnOrID)
 
 		return &cp, nil
 	}
 	// Try by ARN.
-	for id, ep := range b.endpoints {
+	for id, ep := range store {
 		if ep.EndpointArn == arnOrID {
 			cp := *ep
 			ep.Tags.Close()
-			delete(b.endpointsByARN, arnOrID)
-			delete(b.endpoints, id)
+			delete(byARN, arnOrID)
+			delete(store, id)
 
 			return &cp, nil
 		}
@@ -552,6 +778,7 @@ func (b *InMemoryBackend) DeleteEndpoint(arnOrID string) (*Endpoint, error) {
 
 // CreateReplicationTask creates a new DMS replication task.
 func (b *InMemoryBackend) CreateReplicationTask(
+	ctx context.Context,
 	identifier, sourceEndpointArn, targetEndpointArn, replicationInstanceArn,
 	migrationType, tableMappings, settings string,
 	kv map[string]string,
@@ -559,7 +786,11 @@ func (b *InMemoryBackend) CreateReplicationTask(
 	b.mu.Lock("CreateReplicationTask")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicationTasks[identifier]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.replicationTasksStore(region)
+	byARN := b.replicationTasksByARNStore(region)
+
+	if _, ok := store[identifier]; ok {
 		return nil, fmt.Errorf(
 			"%w: replication task %s already exists",
 			ErrAlreadyExists,
@@ -567,7 +798,7 @@ func (b *InMemoryBackend) CreateReplicationTask(
 		)
 	}
 
-	taskARN := arn.Build("dms", b.region, b.accountID, "task:"+uuid.NewString())
+	taskARN := arn.Build("dms", region, b.accountID, "task:"+uuid.NewString())
 	t := tags.New("dms.task." + identifier + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -584,31 +815,33 @@ func (b *InMemoryBackend) CreateReplicationTask(
 		ReplicationTaskSettings:   settings,
 		Status:                    statusReady,
 		AccountID:                 b.accountID,
-		Region:                    b.region,
+		Region:                    region,
 		CreationTime:              time.Now().UTC(),
 		Tags:                      t,
 	}
-	b.replicationTasks[identifier] = rt
-	b.replicationTasksByARN[taskARN] = rt
+	store[identifier] = rt
+	byARN[taskARN] = rt
 	cp := *rt
 
 	return &cp, nil
 }
 
 // DescribeReplicationTasks returns replication tasks, optionally filtered by ARN or identifier.
-func (b *InMemoryBackend) DescribeReplicationTasks(arnOrID string) ([]*ReplicationTask, error) {
+func (b *InMemoryBackend) DescribeReplicationTasks(ctx context.Context, arnOrID string) ([]*ReplicationTask, error) {
 	b.mu.RLock("DescribeReplicationTasks")
 	defer b.mu.RUnlock()
 
+	store := b.replicationTasksStore(getRegion(ctx, b.region))
+
 	if arnOrID != "" {
 		// Try by identifier first.
-		if rt, ok := b.replicationTasks[arnOrID]; ok {
+		if rt, ok := store[arnOrID]; ok {
 			cp := *rt
 
 			return []*ReplicationTask{&cp}, nil
 		}
 		// Try by ARN.
-		for _, rt := range b.replicationTasks {
+		for _, rt := range store {
 			if rt.ReplicationTaskArn == arnOrID {
 				cp := *rt
 
@@ -619,8 +852,8 @@ func (b *InMemoryBackend) DescribeReplicationTasks(arnOrID string) ([]*Replicati
 		return []*ReplicationTask{}, nil
 	}
 
-	list := make([]*ReplicationTask, 0, len(b.replicationTasks))
-	for _, rt := range b.replicationTasks {
+	list := make([]*ReplicationTask, 0, len(store))
+	for _, rt := range store {
 		cp := *rt
 		list = append(list, &cp)
 	}
@@ -629,11 +862,11 @@ func (b *InMemoryBackend) DescribeReplicationTasks(arnOrID string) ([]*Replicati
 }
 
 // StartReplicationTask transitions a replication task to running status.
-func (b *InMemoryBackend) StartReplicationTask(arnOrID string) (*ReplicationTask, error) {
+func (b *InMemoryBackend) StartReplicationTask(ctx context.Context, arnOrID string) (*ReplicationTask, error) {
 	b.mu.Lock("StartReplicationTask")
 	defer b.mu.Unlock()
 
-	rt := b.findTask(arnOrID)
+	rt := b.findTask(ctx, arnOrID)
 	if rt == nil {
 		return nil, fmt.Errorf("%w: replication task %s not found", ErrNotFound, arnOrID)
 	}
@@ -653,11 +886,11 @@ func (b *InMemoryBackend) StartReplicationTask(arnOrID string) (*ReplicationTask
 }
 
 // StopReplicationTask transitions a replication task to stopped status.
-func (b *InMemoryBackend) StopReplicationTask(arnOrID string) (*ReplicationTask, error) {
+func (b *InMemoryBackend) StopReplicationTask(ctx context.Context, arnOrID string) (*ReplicationTask, error) {
 	b.mu.Lock("StopReplicationTask")
 	defer b.mu.Unlock()
 
-	rt := b.findTask(arnOrID)
+	rt := b.findTask(ctx, arnOrID)
 	if rt == nil {
 		return nil, fmt.Errorf("%w: replication task %s not found", ErrNotFound, arnOrID)
 	}
@@ -670,9 +903,13 @@ func (b *InMemoryBackend) StopReplicationTask(arnOrID string) (*ReplicationTask,
 
 // DeleteReplicationTask deletes a replication task by ARN or identifier.
 // AWS does not allow deleting a task while it is running.
-func (b *InMemoryBackend) DeleteReplicationTask(arnOrID string) (*ReplicationTask, error) {
+func (b *InMemoryBackend) DeleteReplicationTask(ctx context.Context, arnOrID string) (*ReplicationTask, error) {
 	b.mu.Lock("DeleteReplicationTask")
 	defer b.mu.Unlock()
+
+	region := getRegion(ctx, b.region)
+	store := b.replicationTasksStore(region)
+	byARN := b.replicationTasksByARNStore(region)
 
 	deleteTask := func(rt *ReplicationTask, id string) (*ReplicationTask, error) {
 		if rt.Status == statusRunning {
@@ -684,18 +921,18 @@ func (b *InMemoryBackend) DeleteReplicationTask(arnOrID string) (*ReplicationTas
 		}
 		cp := *rt
 		rt.Tags.Close()
-		delete(b.replicationTasksByARN, rt.ReplicationTaskArn)
-		delete(b.replicationTasks, id)
+		delete(byARN, rt.ReplicationTaskArn)
+		delete(store, id)
 
 		return &cp, nil
 	}
 
 	// Try by identifier first.
-	if rt, ok := b.replicationTasks[arnOrID]; ok {
+	if rt, ok := store[arnOrID]; ok {
 		return deleteTask(rt, arnOrID)
 	}
 	// Try by ARN.
-	for id, rt := range b.replicationTasks {
+	for id, rt := range store {
 		if rt.ReplicationTaskArn == arnOrID {
 			return deleteTask(rt, id)
 		}
@@ -704,12 +941,14 @@ func (b *InMemoryBackend) DeleteReplicationTask(arnOrID string) (*ReplicationTas
 	return nil, fmt.Errorf("%w: replication task %s not found", ErrNotFound, arnOrID)
 }
 
-// findTask locates a replication task by identifier or ARN (must hold a lock).
-func (b *InMemoryBackend) findTask(arnOrID string) *ReplicationTask {
-	if rt, ok := b.replicationTasks[arnOrID]; ok {
+// findTask locates a replication task by identifier or ARN within the request
+// region (must hold a lock).
+func (b *InMemoryBackend) findTask(ctx context.Context, arnOrID string) *ReplicationTask {
+	store := b.replicationTasksStore(getRegion(ctx, b.region))
+	if rt, ok := store[arnOrID]; ok {
 		return rt
 	}
-	for _, rt := range b.replicationTasks {
+	for _, rt := range store {
 		if rt.ReplicationTaskArn == arnOrID {
 			return rt
 		}
@@ -719,11 +958,11 @@ func (b *InMemoryBackend) findTask(arnOrID string) *ReplicationTask {
 }
 
 // AddTagsToResource adds tags to a DMS resource by ARN.
-func (b *InMemoryBackend) AddTagsToResource(resourceArn string, kv map[string]string) error {
+func (b *InMemoryBackend) AddTagsToResource(ctx context.Context, resourceArn string, kv map[string]string) error {
 	b.mu.Lock("AddTagsToResource")
 	defer b.mu.Unlock()
 
-	t := b.findResourceTags(resourceArn)
+	t := b.findResourceTags(getRegion(ctx, b.region), resourceArn)
 	if t == nil {
 		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceArn)
 	}
@@ -734,11 +973,11 @@ func (b *InMemoryBackend) AddTagsToResource(resourceArn string, kv map[string]st
 }
 
 // ListTagsForResource returns tags for a DMS resource by ARN.
-func (b *InMemoryBackend) ListTagsForResource(resourceArn string) (map[string]string, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceArn string) (map[string]string, error) {
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	t := b.findResourceTags(resourceArn)
+	t := b.findResourceTags(getRegion(ctx, b.region), resourceArn)
 	if t == nil {
 		return nil, fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceArn)
 	}
@@ -748,12 +987,13 @@ func (b *InMemoryBackend) ListTagsForResource(resourceArn string) (map[string]st
 
 // ApplyPendingMaintenanceAction applies a pending maintenance action to a replication instance.
 func (b *InMemoryBackend) ApplyPendingMaintenanceAction(
+	ctx context.Context,
 	replicationInstanceArn, applyAction, optInType string,
 ) (*ReplicationInstance, error) {
 	b.mu.Lock("ApplyPendingMaintenanceAction")
 	defer b.mu.Unlock()
 
-	for _, ri := range b.replicationInstances {
+	for _, ri := range b.replicationInstancesStore(getRegion(ctx, b.region)) {
 		if ri.ReplicationInstanceArn == replicationInstanceArn {
 			// In-memory: mark the action as applied by updating the engine version
 			// for "os-upgrade" / "db-upgrade" or just acknowledge for others.
@@ -774,12 +1014,13 @@ func (b *InMemoryBackend) ApplyPendingMaintenanceAction(
 
 // BatchStartRecommendations starts the analysis to generate recommendations.
 // In-memory: always returns an empty error list (all successful).
-func (b *InMemoryBackend) BatchStartRecommendations() error {
+func (b *InMemoryBackend) BatchStartRecommendations(_ context.Context) error {
 	return nil
 }
 
 // CancelMetadataModelConversion cancels a pending metadata model conversion task.
 func (b *InMemoryBackend) CancelMetadataModelConversion(
+	_ context.Context,
 	migrationProjectIdentifier, requestIdentifier string,
 ) (string, error) {
 	if migrationProjectIdentifier == "" {
@@ -795,6 +1036,7 @@ func (b *InMemoryBackend) CancelMetadataModelConversion(
 
 // CancelMetadataModelCreation cancels a pending metadata model creation task.
 func (b *InMemoryBackend) CancelMetadataModelCreation(
+	_ context.Context,
 	migrationProjectIdentifier, requestIdentifier string,
 ) (string, error) {
 	if migrationProjectIdentifier == "" {
@@ -810,6 +1052,7 @@ func (b *InMemoryBackend) CancelMetadataModelCreation(
 
 // CancelReplicationTaskAssessmentRun cancels a single premigration assessment run.
 func (b *InMemoryBackend) CancelReplicationTaskAssessmentRun(
+	_ context.Context,
 	replicationTaskAssessmentRunArn string,
 ) error {
 	if replicationTaskAssessmentRunArn == "" {
@@ -838,6 +1081,7 @@ func copyStringsOrEmpty(src []string) []string {
 
 // CreateDataMigration creates a new data migration.
 func (b *InMemoryBackend) CreateDataMigration(
+	ctx context.Context,
 	name, migrationProjectArn, migrationType, serviceAccessRoleArn, selectionRules string,
 	numberOfJobs int32,
 	enableCloudwatchLogs bool,
@@ -846,7 +1090,11 @@ func (b *InMemoryBackend) CreateDataMigration(
 	b.mu.Lock("CreateDataMigration")
 	defer b.mu.Unlock()
 
-	if _, ok := b.dataMigrations[name]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.dataMigrationsStore(region)
+	byARN := b.dataMigrationsByARNStore(region)
+
+	if _, ok := store[name]; ok {
 		return nil, fmt.Errorf("%w: data migration %s already exists", ErrAlreadyExists, name)
 	}
 
@@ -858,7 +1106,7 @@ func (b *InMemoryBackend) CreateDataMigration(
 		)
 	}
 
-	migrationARN := arn.Build("dms", b.region, b.accountID, "data-migration:"+uuid.NewString())
+	migrationARN := arn.Build("dms", region, b.accountID, "data-migration:"+uuid.NewString())
 	t := tags.New("dms.data-migration." + name + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -879,12 +1127,12 @@ func (b *InMemoryBackend) CreateDataMigration(
 		EnableCloudwatchLogs: enableCloudwatchLogs,
 		DataMigrationStatus:  statusReady,
 		AccountID:            b.accountID,
-		Region:               b.region,
+		Region:               region,
 		CreationTime:         time.Now().UTC(),
 		Tags:                 t,
 	}
-	b.dataMigrations[name] = dm
-	b.dataMigrationsByARN[migrationARN] = dm
+	store[name] = dm
+	byARN[migrationARN] = dm
 	cp := *dm
 
 	return &cp, nil
@@ -892,17 +1140,22 @@ func (b *InMemoryBackend) CreateDataMigration(
 
 // CreateDataProvider creates a new data provider.
 func (b *InMemoryBackend) CreateDataProvider(
+	ctx context.Context,
 	name, engine, description string,
 	kv map[string]string,
 ) (*DataProvider, error) {
 	b.mu.Lock("CreateDataProvider")
 	defer b.mu.Unlock()
 
-	if _, ok := b.dataProviders[name]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.dataProvidersStore(region)
+	byARN := b.dataProvidersByARNStore(region)
+
+	if _, ok := store[name]; ok {
 		return nil, fmt.Errorf("%w: data provider %s already exists", ErrAlreadyExists, name)
 	}
 
-	providerARN := arn.Build("dms", b.region, b.accountID, "data-provider:"+uuid.NewString())
+	providerARN := arn.Build("dms", region, b.accountID, "data-provider:"+uuid.NewString())
 	t := tags.New("dms.data-provider." + name + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -915,12 +1168,12 @@ func (b *InMemoryBackend) CreateDataProvider(
 		Engine:           engine,
 		Description:      description,
 		AccountID:        b.accountID,
-		Region:           b.region,
+		Region:           region,
 		CreationTime:     now,
 		Tags:             t,
 	}
-	b.dataProviders[name] = dp
-	b.dataProvidersByARN[providerARN] = dp
+	store[name] = dp
+	byARN[providerARN] = dp
 	cp := *dp
 
 	return &cp, nil
@@ -928,6 +1181,7 @@ func (b *InMemoryBackend) CreateDataProvider(
 
 // CreateEventSubscription creates a new event subscription.
 func (b *InMemoryBackend) CreateEventSubscription(
+	ctx context.Context,
 	subscriptionName, snsTopicArn, sourceType string,
 	sourceIDs, eventCategories []string,
 	enabled bool,
@@ -936,7 +1190,10 @@ func (b *InMemoryBackend) CreateEventSubscription(
 	b.mu.Lock("CreateEventSubscription")
 	defer b.mu.Unlock()
 
-	if _, ok := b.eventSubscriptions[subscriptionName]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.eventSubscriptionsStore(region)
+
+	if _, ok := store[subscriptionName]; ok {
 		return nil, fmt.Errorf(
 			"%w: event subscription %s already exists",
 			ErrAlreadyExists,
@@ -961,11 +1218,11 @@ func (b *InMemoryBackend) CreateEventSubscription(
 		Enabled:          enabled,
 		Status:           statusActive,
 		AccountID:        b.accountID,
-		Region:           b.region,
+		Region:           region,
 		CreationTime:     time.Now().UTC(),
 		Tags:             t,
 	}
-	b.eventSubscriptions[subscriptionName] = es
+	store[subscriptionName] = es
 	cp := *es
 	cp.SourceIDsList = copyStringsOrEmpty(es.SourceIDsList)
 	cp.EventCategories = copyStringsOrEmpty(es.EventCategories)
@@ -975,12 +1232,16 @@ func (b *InMemoryBackend) CreateEventSubscription(
 
 // CreateFleetAdvisorCollector creates a new Fleet Advisor collector.
 func (b *InMemoryBackend) CreateFleetAdvisorCollector(
+	ctx context.Context,
 	collectorName, description, serviceAccessRoleArn, s3BucketName string,
 ) (*FleetAdvisorCollector, error) {
 	b.mu.Lock("CreateFleetAdvisorCollector")
 	defer b.mu.Unlock()
 
-	if _, ok := b.fleetAdvisorCollectors[collectorName]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.fleetAdvisorCollectorsStore(region)
+
+	if _, ok := store[collectorName]; ok {
 		return nil, fmt.Errorf(
 			"%w: Fleet Advisor collector %s already exists",
 			ErrAlreadyExists,
@@ -999,11 +1260,11 @@ func (b *InMemoryBackend) CreateFleetAdvisorCollector(
 		S3BucketName:          s3BucketName,
 		CollectorHealthCheck:  "HEALTHY",
 		AccountID:             b.accountID,
-		Region:                b.region,
+		Region:                region,
 		CreatedDate:           time.Now().UTC(),
 		Tags:                  t,
 	}
-	b.fleetAdvisorCollectors[collectorName] = col
+	store[collectorName] = col
 	cp := *col
 
 	return &cp, nil
@@ -1015,6 +1276,7 @@ func isValidNetworkType(s string) bool {
 
 // CreateInstanceProfile creates a new instance profile.
 func (b *InMemoryBackend) CreateInstanceProfile(
+	ctx context.Context,
 	instanceProfileName, availabilityZone, kmsKeyArn, networkType, description, subnetGroupIdentifier string,
 	publiclyAccessible bool,
 	kv map[string]string,
@@ -1022,12 +1284,16 @@ func (b *InMemoryBackend) CreateInstanceProfile(
 	b.mu.Lock("CreateInstanceProfile")
 	defer b.mu.Unlock()
 
+	region := getRegion(ctx, b.region)
+	store := b.instanceProfilesStore(region)
+	byARN := b.instanceProfilesByARNStore(region)
+
 	key := instanceProfileName
 	if key == "" {
 		key = uuid.NewString()
 	}
 
-	if _, ok := b.instanceProfiles[key]; ok {
+	if _, ok := store[key]; ok {
 		return nil, fmt.Errorf("%w: instance profile %s already exists", ErrAlreadyExists, key)
 	}
 
@@ -1039,7 +1305,7 @@ func (b *InMemoryBackend) CreateInstanceProfile(
 		)
 	}
 
-	profileARN := arn.Build("dms", b.region, b.accountID, "instance-profile:"+uuid.NewString())
+	profileARN := arn.Build("dms", region, b.accountID, "instance-profile:"+uuid.NewString())
 	t := tags.New("dms.instance-profile." + key + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -1059,85 +1325,76 @@ func (b *InMemoryBackend) CreateInstanceProfile(
 		SubnetGroupIdentifier: subnetGroupIdentifier,
 		PubliclyAccessible:    publiclyAccessible,
 		AccountID:             b.accountID,
-		Region:                b.region,
+		Region:                region,
 		CreationTime:          time.Now().UTC(),
 		Tags:                  t,
 	}
-	b.instanceProfiles[key] = ip
-	b.instanceProfilesByARN[profileARN] = ip
+	store[key] = ip
+	byARN[profileARN] = ip
 	cp := *ip
 
 	return &cp, nil
 }
 
-// Reset clears all backend state and closes all tag registries.
+// closeTagged closes the Tags registry on every value across all per-region
+// inner maps. The Tagged constraint matches resource structs that embed a
+// *tags.Tags accessible via a Close-able registry; closeTagged uses a closer
+// callback so it stays generic over the concrete resource type.
+func closeAllTags[T any](m map[string]map[string]*T, closer func(*T)) {
+	for _, regionMap := range m {
+		for _, v := range regionMap {
+			closer(v)
+		}
+	}
+}
+
+// Reset clears all backend state and closes all tag registries across all regions.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, ri := range b.replicationInstances {
-		ri.Tags.Close()
-	}
-	for _, ep := range b.endpoints {
-		ep.Tags.Close()
-	}
-	for _, rt := range b.replicationTasks {
-		rt.Tags.Close()
-	}
-	for _, dm := range b.dataMigrations {
-		dm.Tags.Close()
-	}
-	for _, dp := range b.dataProviders {
-		dp.Tags.Close()
-	}
-	for _, es := range b.eventSubscriptions {
-		es.Tags.Close()
-	}
-	for _, col := range b.fleetAdvisorCollectors {
-		col.Tags.Close()
-	}
-	for _, ip := range b.instanceProfiles {
-		ip.Tags.Close()
-	}
+	closeAllTags(b.replicationInstances, func(ri *ReplicationInstance) { ri.Tags.Close() })
+	closeAllTags(b.endpoints, func(ep *Endpoint) { ep.Tags.Close() })
+	closeAllTags(b.replicationTasks, func(rt *ReplicationTask) { rt.Tags.Close() })
+	closeAllTags(b.dataMigrations, func(dm *DataMigration) { dm.Tags.Close() })
+	closeAllTags(b.dataProviders, func(dp *DataProvider) { dp.Tags.Close() })
+	closeAllTags(b.eventSubscriptions, func(es *EventSubscription) { es.Tags.Close() })
+	closeAllTags(b.fleetAdvisorCollectors, func(col *FleetAdvisorCollector) { col.Tags.Close() })
+	closeAllTags(b.instanceProfiles, func(ip *InstanceProfile) { ip.Tags.Close() })
+	closeAllTags(b.migrationProjects, func(mp *MigrationProject) { mp.Tags.Close() })
+	closeAllTags(b.replicationSubnetGroups, func(sg *ReplicationSubnetGroup) { sg.Tags.Close() })
+	closeAllTags(b.replicationConfigs, func(rc *ReplicationConfig) { rc.Tags.Close() })
 
-	b.replicationInstances = make(map[string]*ReplicationInstance)
-	b.replicationInstancesByARN = make(map[string]*ReplicationInstance)
-	b.endpoints = make(map[string]*Endpoint)
-	b.endpointsByARN = make(map[string]*Endpoint)
-	for _, mp := range b.migrationProjects {
-		mp.Tags.Close()
-	}
-	for _, sg := range b.replicationSubnetGroups {
-		sg.Tags.Close()
-	}
-	for _, rc := range b.replicationConfigs {
-		rc.Tags.Close()
-	}
-
-	b.replicationTasks = make(map[string]*ReplicationTask)
-	b.replicationTasksByARN = make(map[string]*ReplicationTask)
-	b.dataMigrations = make(map[string]*DataMigration)
-	b.dataMigrationsByARN = make(map[string]*DataMigration)
-	b.dataProviders = make(map[string]*DataProvider)
-	b.dataProvidersByARN = make(map[string]*DataProvider)
-	b.eventSubscriptions = make(map[string]*EventSubscription)
-	b.fleetAdvisorCollectors = make(map[string]*FleetAdvisorCollector)
-	b.instanceProfiles = make(map[string]*InstanceProfile)
-	b.instanceProfilesByARN = make(map[string]*InstanceProfile)
-	b.certificates = make(map[string]*Certificate)
-	b.replicationSubnetGroups = make(map[string]*ReplicationSubnetGroup)
-	b.replicationSubnetGroupsByARN = make(map[string]*ReplicationSubnetGroup)
-	b.migrationProjects = make(map[string]*MigrationProject)
-	b.migrationProjectsByARN = make(map[string]*MigrationProject)
-	b.replicationConfigs = make(map[string]*ReplicationConfig)
-	b.replicationConfigsByARN = make(map[string]*ReplicationConfig)
-	b.connections = make(map[string]*Connection)
+	b.replicationInstances = make(map[string]map[string]*ReplicationInstance)
+	b.replicationInstancesByARN = make(map[string]map[string]*ReplicationInstance)
+	b.endpoints = make(map[string]map[string]*Endpoint)
+	b.endpointsByARN = make(map[string]map[string]*Endpoint)
+	b.replicationTasks = make(map[string]map[string]*ReplicationTask)
+	b.replicationTasksByARN = make(map[string]map[string]*ReplicationTask)
+	b.dataMigrations = make(map[string]map[string]*DataMigration)
+	b.dataMigrationsByARN = make(map[string]map[string]*DataMigration)
+	b.dataProviders = make(map[string]map[string]*DataProvider)
+	b.dataProvidersByARN = make(map[string]map[string]*DataProvider)
+	b.eventSubscriptions = make(map[string]map[string]*EventSubscription)
+	b.fleetAdvisorCollectors = make(map[string]map[string]*FleetAdvisorCollector)
+	b.instanceProfiles = make(map[string]map[string]*InstanceProfile)
+	b.instanceProfilesByARN = make(map[string]map[string]*InstanceProfile)
+	b.certificates = make(map[string]map[string]*Certificate)
+	b.replicationSubnetGroups = make(map[string]map[string]*ReplicationSubnetGroup)
+	b.replicationSubnetGroupsByARN = make(map[string]map[string]*ReplicationSubnetGroup)
+	b.migrationProjects = make(map[string]map[string]*MigrationProject)
+	b.migrationProjectsByARN = make(map[string]map[string]*MigrationProject)
+	b.replicationConfigs = make(map[string]map[string]*ReplicationConfig)
+	b.replicationConfigsByARN = make(map[string]map[string]*ReplicationConfig)
+	b.connections = make(map[string]map[string]*Connection)
 }
 
 // AddReplicationInstanceInternal seeds a replication instance directly without HTTP.
 func (b *InMemoryBackend) AddReplicationInstanceInternal(identifier, class string) {
 	b.mu.Lock("AddReplicationInstanceInternal")
 	defer b.mu.Unlock()
+	store := b.replicationInstancesStore(b.region)
+	byARN := b.replicationInstancesByARNStore(b.region)
 	instanceARN := arn.Build("dms", b.region, b.accountID, "rep:"+identifier)
 	t := tags.New("dms.replication-instance." + identifier + ".tags")
 	ri := &ReplicationInstance{
@@ -1153,14 +1410,16 @@ func (b *InMemoryBackend) AddReplicationInstanceInternal(identifier, class strin
 		CreationTime:                  time.Now().UTC(),
 		Tags:                          t,
 	}
-	b.replicationInstances[identifier] = ri
-	b.replicationInstancesByARN[instanceARN] = ri
+	store[identifier] = ri
+	byARN[instanceARN] = ri
 }
 
 // AddEndpointInternal seeds an endpoint directly without HTTP.
 func (b *InMemoryBackend) AddEndpointInternal(identifier, endpointType, engineName string) {
 	b.mu.Lock("AddEndpointInternal")
 	defer b.mu.Unlock()
+	store := b.endpointsStore(b.region)
+	byARN := b.endpointsByARNStore(b.region)
 	epID := uuid.NewString()
 	epARN := arn.Build("dms", b.region, b.accountID, "endpoint:"+epID)
 	t := tags.New("dms.endpoint." + identifier + ".tags")
@@ -1175,8 +1434,8 @@ func (b *InMemoryBackend) AddEndpointInternal(identifier, endpointType, engineNa
 		CreationTime:       time.Now().UTC(),
 		Tags:               t,
 	}
-	b.endpoints[identifier] = ep
-	b.endpointsByARN[epARN] = ep
+	store[identifier] = ep
+	byARN[epARN] = ep
 }
 
 // AddReplicationTaskInternal seeds a replication task directly without HTTP.
@@ -1185,6 +1444,8 @@ func (b *InMemoryBackend) AddReplicationTaskInternal(
 ) {
 	b.mu.Lock("AddReplicationTaskInternal")
 	defer b.mu.Unlock()
+	store := b.replicationTasksStore(b.region)
+	byARN := b.replicationTasksByARNStore(b.region)
 	taskARN := arn.Build("dms", b.region, b.accountID, "task:"+uuid.NewString())
 	t := tags.New("dms.task." + identifier + ".tags")
 	rt := &ReplicationTask{
@@ -1200,14 +1461,16 @@ func (b *InMemoryBackend) AddReplicationTaskInternal(
 		CreationTime:              time.Now().UTC(),
 		Tags:                      t,
 	}
-	b.replicationTasks[identifier] = rt
-	b.replicationTasksByARN[taskARN] = rt
+	store[identifier] = rt
+	byARN[taskARN] = rt
 }
 
 // AddDataMigrationInternal seeds a data migration directly without HTTP.
 func (b *InMemoryBackend) AddDataMigrationInternal(name, migrationType string) {
 	b.mu.Lock("AddDataMigrationInternal")
 	defer b.mu.Unlock()
+	store := b.dataMigrationsStore(b.region)
+	byARN := b.dataMigrationsByARNStore(b.region)
 	migrationARN := arn.Build("dms", b.region, b.accountID, "data-migration:"+uuid.NewString())
 	t := tags.New("dms.data-migration." + name + ".tags")
 	dm := &DataMigration{
@@ -1221,14 +1484,16 @@ func (b *InMemoryBackend) AddDataMigrationInternal(name, migrationType string) {
 		CreationTime:        time.Now().UTC(),
 		Tags:                t,
 	}
-	b.dataMigrations[name] = dm
-	b.dataMigrationsByARN[migrationARN] = dm
+	store[name] = dm
+	byARN[migrationARN] = dm
 }
 
 // AddDataProviderInternal seeds a data provider directly without HTTP.
 func (b *InMemoryBackend) AddDataProviderInternal(name, engine string) {
 	b.mu.Lock("AddDataProviderInternal")
 	defer b.mu.Unlock()
+	store := b.dataProvidersStore(b.region)
+	byARN := b.dataProvidersByARNStore(b.region)
 	providerARN := arn.Build("dms", b.region, b.accountID, "data-provider:"+uuid.NewString())
 	t := tags.New("dms.data-provider." + name + ".tags")
 	now := time.Now().UTC()
@@ -1241,14 +1506,15 @@ func (b *InMemoryBackend) AddDataProviderInternal(name, engine string) {
 		CreationTime:     now,
 		Tags:             t,
 	}
-	b.dataProviders[name] = dp
-	b.dataProvidersByARN[providerARN] = dp
+	store[name] = dp
+	byARN[providerARN] = dp
 }
 
 // AddEventSubscriptionInternal seeds an event subscription directly without HTTP.
 func (b *InMemoryBackend) AddEventSubscriptionInternal(name, snsTopicArn string) {
 	b.mu.Lock("AddEventSubscriptionInternal")
 	defer b.mu.Unlock()
+	store := b.eventSubscriptionsStore(b.region)
 	t := tags.New("dms.event-subscription." + name + ".tags")
 	es := &EventSubscription{
 		SubscriptionName: name,
@@ -1262,13 +1528,14 @@ func (b *InMemoryBackend) AddEventSubscriptionInternal(name, snsTopicArn string)
 		CreationTime:     time.Now().UTC(),
 		Tags:             t,
 	}
-	b.eventSubscriptions[name] = es
+	store[name] = es
 }
 
 // AddFleetAdvisorCollectorInternal seeds a Fleet Advisor collector directly without HTTP.
 func (b *InMemoryBackend) AddFleetAdvisorCollectorInternal(name string) {
 	b.mu.Lock("AddFleetAdvisorCollectorInternal")
 	defer b.mu.Unlock()
+	store := b.fleetAdvisorCollectorsStore(b.region)
 	t := tags.New("dms.fleet-advisor-collector." + name + ".tags")
 	col := &FleetAdvisorCollector{
 		CollectorName:         name,
@@ -1280,7 +1547,7 @@ func (b *InMemoryBackend) AddFleetAdvisorCollectorInternal(name string) {
 		CreatedDate:           time.Now().UTC(),
 		Tags:                  t,
 	}
-	b.fleetAdvisorCollectors[name] = col
+	store[name] = col
 }
 
 // AddInstanceProfileInternal seeds an instance profile directly without HTTP.
@@ -1290,6 +1557,8 @@ func (b *InMemoryBackend) AddInstanceProfileInternal(name string) {
 	if name == "" {
 		name = uuid.NewString()
 	}
+	store := b.instanceProfilesStore(b.region)
+	byARN := b.instanceProfilesByARNStore(b.region)
 	profileARN := arn.Build("dms", b.region, b.accountID, "instance-profile:"+uuid.NewString())
 	t := tags.New("dms.instance-profile." + name + ".tags")
 	ip := &InstanceProfile{
@@ -1300,8 +1569,8 @@ func (b *InMemoryBackend) AddInstanceProfileInternal(name string) {
 		CreationTime:        time.Now().UTC(),
 		Tags:                t,
 	}
-	b.instanceProfiles[name] = ip
-	b.instanceProfilesByARN[profileARN] = ip
+	store[name] = ip
+	byARN[profileARN] = ip
 }
 
 // PaginationSecret returns the HMAC secret for pagination tokens.
@@ -1309,13 +1578,14 @@ func (b *InMemoryBackend) PaginationSecret() string { return b.paginationSecret 
 
 // ModifyEndpoint updates endpoint settings.
 func (b *InMemoryBackend) ModifyEndpoint(
+	ctx context.Context,
 	arnOrID, serverName, databaseName, username string,
 	port int32,
 ) (*Endpoint, error) {
 	b.mu.Lock("ModifyEndpoint")
 	defer b.mu.Unlock()
 
-	ep := b.findEndpoint(arnOrID)
+	ep := b.findEndpoint(ctx, arnOrID)
 	if ep == nil {
 		return nil, fmt.Errorf("%w: endpoint %s not found", ErrNotFound, arnOrID)
 	}
@@ -1341,13 +1611,15 @@ func (b *InMemoryBackend) ModifyEndpoint(
 	return &cp, nil
 }
 
-// findEndpoint locates an endpoint by identifier or ARN (must hold a lock).
-func (b *InMemoryBackend) findEndpoint(arnOrID string) *Endpoint {
-	if ep, ok := b.endpoints[arnOrID]; ok {
+// findEndpoint locates an endpoint by identifier or ARN within the request
+// region (must hold a lock).
+func (b *InMemoryBackend) findEndpoint(ctx context.Context, arnOrID string) *Endpoint {
+	store := b.endpointsStore(getRegion(ctx, b.region))
+	if ep, ok := store[arnOrID]; ok {
 		return ep
 	}
 
-	for _, ep := range b.endpoints {
+	for _, ep := range store {
 		if ep.EndpointArn == arnOrID {
 			return ep
 		}
@@ -1358,6 +1630,7 @@ func (b *InMemoryBackend) findEndpoint(arnOrID string) *Endpoint {
 
 // ModifyReplicationInstance updates a replication instance's class and engineVersion.
 func (b *InMemoryBackend) ModifyReplicationInstance(
+	ctx context.Context,
 	arnOrID, class, engineVersion string,
 	multiAZ, autoMinorVersionUpgrade *bool,
 	allocatedStorage *int32,
@@ -1365,7 +1638,7 @@ func (b *InMemoryBackend) ModifyReplicationInstance(
 	b.mu.Lock("ModifyReplicationInstance")
 	defer b.mu.Unlock()
 
-	ri := b.findReplicationInstance(arnOrID)
+	ri := b.findReplicationInstance(ctx, arnOrID)
 	if ri == nil {
 		return nil, fmt.Errorf("%w: replication instance %s not found", ErrNotFound, arnOrID)
 	}
@@ -1395,13 +1668,15 @@ func (b *InMemoryBackend) ModifyReplicationInstance(
 	return &cp, nil
 }
 
-// findReplicationInstance locates a replication instance by identifier or ARN (must hold a lock).
-func (b *InMemoryBackend) findReplicationInstance(arnOrID string) *ReplicationInstance {
-	if ri, ok := b.replicationInstances[arnOrID]; ok {
+// findReplicationInstance locates a replication instance by identifier or ARN
+// within the request region (must hold a lock).
+func (b *InMemoryBackend) findReplicationInstance(ctx context.Context, arnOrID string) *ReplicationInstance {
+	store := b.replicationInstancesStore(getRegion(ctx, b.region))
+	if ri, ok := store[arnOrID]; ok {
 		return ri
 	}
 
-	for _, ri := range b.replicationInstances {
+	for _, ri := range store {
 		if ri.ReplicationInstanceArn == arnOrID {
 			return ri
 		}
@@ -1413,12 +1688,13 @@ func (b *InMemoryBackend) findReplicationInstance(arnOrID string) *ReplicationIn
 // ModifyReplicationTask updates task settings.
 // AWS does not allow modifying a running task.
 func (b *InMemoryBackend) ModifyReplicationTask(
+	ctx context.Context,
 	arnOrID, migrationType, tableMappings, replicationTaskSettings string,
 ) (*ReplicationTask, error) {
 	b.mu.Lock("ModifyReplicationTask")
 	defer b.mu.Unlock()
 
-	rt := b.findTask(arnOrID)
+	rt := b.findTask(ctx, arnOrID)
 	if rt == nil {
 		return nil, fmt.Errorf("%w: replication task %s not found", ErrNotFound, arnOrID)
 	}
@@ -1449,25 +1725,29 @@ func (b *InMemoryBackend) ModifyReplicationTask(
 }
 
 // DeleteDataMigration deletes a data migration by name or ARN.
-func (b *InMemoryBackend) DeleteDataMigration(nameOrArn string) (*DataMigration, error) {
+func (b *InMemoryBackend) DeleteDataMigration(ctx context.Context, nameOrArn string) (*DataMigration, error) {
 	b.mu.Lock("DeleteDataMigration")
 	defer b.mu.Unlock()
 
-	if dm, ok := b.dataMigrations[nameOrArn]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.dataMigrationsStore(region)
+	byARN := b.dataMigrationsByARNStore(region)
+
+	if dm, ok := store[nameOrArn]; ok {
 		cp := *dm
 		dm.Tags.Close()
-		delete(b.dataMigrationsByARN, dm.DataMigrationArn)
-		delete(b.dataMigrations, nameOrArn)
+		delete(byARN, dm.DataMigrationArn)
+		delete(store, nameOrArn)
 
 		return &cp, nil
 	}
 
-	for id, dm := range b.dataMigrations {
+	for id, dm := range store {
 		if dm.DataMigrationArn == nameOrArn {
 			cp := *dm
 			dm.Tags.Close()
-			delete(b.dataMigrationsByARN, nameOrArn)
-			delete(b.dataMigrations, id)
+			delete(byARN, nameOrArn)
+			delete(store, id)
 
 			return &cp, nil
 		}
@@ -1477,25 +1757,29 @@ func (b *InMemoryBackend) DeleteDataMigration(nameOrArn string) (*DataMigration,
 }
 
 // DeleteDataProvider deletes a data provider by name or ARN.
-func (b *InMemoryBackend) DeleteDataProvider(nameOrArn string) (*DataProvider, error) {
+func (b *InMemoryBackend) DeleteDataProvider(ctx context.Context, nameOrArn string) (*DataProvider, error) {
 	b.mu.Lock("DeleteDataProvider")
 	defer b.mu.Unlock()
 
-	if dp, ok := b.dataProviders[nameOrArn]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.dataProvidersStore(region)
+	byARN := b.dataProvidersByARNStore(region)
+
+	if dp, ok := store[nameOrArn]; ok {
 		cp := *dp
 		dp.Tags.Close()
-		delete(b.dataProvidersByARN, dp.DataProviderArn)
-		delete(b.dataProviders, nameOrArn)
+		delete(byARN, dp.DataProviderArn)
+		delete(store, nameOrArn)
 
 		return &cp, nil
 	}
 
-	for id, dp := range b.dataProviders {
+	for id, dp := range store {
 		if dp.DataProviderArn == nameOrArn {
 			cp := *dp
 			dp.Tags.Close()
-			delete(b.dataProvidersByARN, nameOrArn)
-			delete(b.dataProviders, id)
+			delete(byARN, nameOrArn)
+			delete(store, id)
 
 			return &cp, nil
 		}
@@ -1505,11 +1789,13 @@ func (b *InMemoryBackend) DeleteDataProvider(nameOrArn string) (*DataProvider, e
 }
 
 // DeleteEventSubscription deletes an event subscription by name.
-func (b *InMemoryBackend) DeleteEventSubscription(name string) (*EventSubscription, error) {
+func (b *InMemoryBackend) DeleteEventSubscription(ctx context.Context, name string) (*EventSubscription, error) {
 	b.mu.Lock("DeleteEventSubscription")
 	defer b.mu.Unlock()
 
-	es, ok := b.eventSubscriptions[name]
+	store := b.eventSubscriptionsStore(getRegion(ctx, b.region))
+
+	es, ok := store[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: event subscription %s not found", ErrNotFound, name)
 	}
@@ -1518,27 +1804,29 @@ func (b *InMemoryBackend) DeleteEventSubscription(name string) (*EventSubscripti
 	cp.SourceIDsList = copyStringsOrEmpty(es.SourceIDsList)
 	cp.EventCategories = copyStringsOrEmpty(es.EventCategories)
 	es.Tags.Close()
-	delete(b.eventSubscriptions, name)
+	delete(store, name)
 
 	return &cp, nil
 }
 
 // DeleteFleetAdvisorCollector deletes a fleet advisor collector by name or ID.
-func (b *InMemoryBackend) DeleteFleetAdvisorCollector(nameOrID string) error {
+func (b *InMemoryBackend) DeleteFleetAdvisorCollector(ctx context.Context, nameOrID string) error {
 	b.mu.Lock("DeleteFleetAdvisorCollector")
 	defer b.mu.Unlock()
 
-	if col, ok := b.fleetAdvisorCollectors[nameOrID]; ok {
+	store := b.fleetAdvisorCollectorsStore(getRegion(ctx, b.region))
+
+	if col, ok := store[nameOrID]; ok {
 		col.Tags.Close()
-		delete(b.fleetAdvisorCollectors, nameOrID)
+		delete(store, nameOrID)
 
 		return nil
 	}
 
-	for name, col := range b.fleetAdvisorCollectors {
+	for name, col := range store {
 		if col.CollectorReferencedID == nameOrID {
 			col.Tags.Close()
-			delete(b.fleetAdvisorCollectors, name)
+			delete(store, name)
 
 			return nil
 		}
@@ -1548,23 +1836,27 @@ func (b *InMemoryBackend) DeleteFleetAdvisorCollector(nameOrID string) error {
 }
 
 // DeleteInstanceProfile deletes an instance profile by name or ARN.
-func (b *InMemoryBackend) DeleteInstanceProfile(nameOrArn string) error {
+func (b *InMemoryBackend) DeleteInstanceProfile(ctx context.Context, nameOrArn string) error {
 	b.mu.Lock("DeleteInstanceProfile")
 	defer b.mu.Unlock()
 
-	if ip, ok := b.instanceProfiles[nameOrArn]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.instanceProfilesStore(region)
+	byARN := b.instanceProfilesByARNStore(region)
+
+	if ip, ok := store[nameOrArn]; ok {
 		ip.Tags.Close()
-		delete(b.instanceProfilesByARN, ip.InstanceProfileArn)
-		delete(b.instanceProfiles, nameOrArn)
+		delete(byARN, ip.InstanceProfileArn)
+		delete(store, nameOrArn)
 
 		return nil
 	}
 
-	for name, ip := range b.instanceProfiles {
+	for name, ip := range store {
 		if ip.InstanceProfileArn == nameOrArn {
 			ip.Tags.Close()
-			delete(b.instanceProfilesByARN, nameOrArn)
-			delete(b.instanceProfiles, name)
+			delete(byARN, nameOrArn)
+			delete(store, name)
 
 			return nil
 		}
@@ -1573,42 +1865,42 @@ func (b *InMemoryBackend) DeleteInstanceProfile(nameOrArn string) error {
 	return fmt.Errorf("%w: instance profile %s not found", ErrNotFound, nameOrArn)
 }
 
-// findResourceTags returns the Tags for a resource ARN (must hold a lock).
-// Returns nil if not found.
-func (b *InMemoryBackend) findResourceTags(resourceArn string) *tags.Tags {
-	if ri, ok := b.replicationInstancesByARN[resourceArn]; ok {
+// findResourceTags returns the Tags for a resource ARN within the given region
+// (must hold a lock). Returns nil if not found.
+func (b *InMemoryBackend) findResourceTags(region, resourceArn string) *tags.Tags {
+	if ri, ok := b.replicationInstancesByARNStore(region)[resourceArn]; ok {
 		return ri.Tags
 	}
 
-	if ep, ok := b.endpointsByARN[resourceArn]; ok {
+	if ep, ok := b.endpointsByARNStore(region)[resourceArn]; ok {
 		return ep.Tags
 	}
 
-	if rt, ok := b.replicationTasksByARN[resourceArn]; ok {
+	if rt, ok := b.replicationTasksByARNStore(region)[resourceArn]; ok {
 		return rt.Tags
 	}
 
-	if dm, ok := b.dataMigrationsByARN[resourceArn]; ok {
+	if dm, ok := b.dataMigrationsByARNStore(region)[resourceArn]; ok {
 		return dm.Tags
 	}
 
-	if dp, ok := b.dataProvidersByARN[resourceArn]; ok {
+	if dp, ok := b.dataProvidersByARNStore(region)[resourceArn]; ok {
 		return dp.Tags
 	}
 
-	if ip, ok := b.instanceProfilesByARN[resourceArn]; ok {
+	if ip, ok := b.instanceProfilesByARNStore(region)[resourceArn]; ok {
 		return ip.Tags
 	}
 
-	if mp, ok := b.migrationProjectsByARN[resourceArn]; ok {
+	if mp, ok := b.migrationProjectsByARNStore(region)[resourceArn]; ok {
 		return mp.Tags
 	}
 
-	if sg, ok := b.replicationSubnetGroupsByARN[resourceArn]; ok {
+	if sg, ok := b.replicationSubnetGroupsByARNStore(region)[resourceArn]; ok {
 		return sg.Tags
 	}
 
-	if rc, ok := b.replicationConfigsByARN[resourceArn]; ok {
+	if rc, ok := b.replicationConfigsByARNStore(region)[resourceArn]; ok {
 		return rc.Tags
 	}
 
@@ -1616,11 +1908,11 @@ func (b *InMemoryBackend) findResourceTags(resourceArn string) *tags.Tags {
 }
 
 // RemoveTagsFromResource removes tags from a DMS resource by ARN.
-func (b *InMemoryBackend) RemoveTagsFromResource(resourceArn string, tagKeys []string) error {
+func (b *InMemoryBackend) RemoveTagsFromResource(ctx context.Context, resourceArn string, tagKeys []string) error {
 	b.mu.Lock("RemoveTagsFromResource")
 	defer b.mu.Unlock()
 
-	t := b.findResourceTags(resourceArn)
+	t := b.findResourceTags(getRegion(ctx, b.region), resourceArn)
 	if t == nil {
 		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceArn)
 	}
@@ -1632,13 +1924,14 @@ func (b *InMemoryBackend) RemoveTagsFromResource(resourceArn string, tagKeys []s
 
 // ModifyDataMigration updates a data migration.
 func (b *InMemoryBackend) ModifyDataMigration(
+	ctx context.Context,
 	nameOrArn, migrationType, serviceAccessRoleArn string,
 	numberOfJobs *int32,
 ) (*DataMigration, error) {
 	b.mu.Lock("ModifyDataMigration")
 	defer b.mu.Unlock()
 
-	dm := b.findDataMigration(nameOrArn)
+	dm := b.findDataMigration(ctx, nameOrArn)
 	if dm == nil {
 		return nil, fmt.Errorf("%w: data migration %s not found", ErrNotFound, nameOrArn)
 	}
@@ -1660,13 +1953,15 @@ func (b *InMemoryBackend) ModifyDataMigration(
 	return &cp, nil
 }
 
-// findDataMigration locates a data migration by name or ARN (must hold a lock).
-func (b *InMemoryBackend) findDataMigration(nameOrArn string) *DataMigration {
-	if dm, ok := b.dataMigrations[nameOrArn]; ok {
+// findDataMigration locates a data migration by name or ARN within the request
+// region (must hold a lock).
+func (b *InMemoryBackend) findDataMigration(ctx context.Context, nameOrArn string) *DataMigration {
+	store := b.dataMigrationsStore(getRegion(ctx, b.region))
+	if dm, ok := store[nameOrArn]; ok {
 		return dm
 	}
 
-	for _, dm := range b.dataMigrations {
+	for _, dm := range store {
 		if dm.DataMigrationArn == nameOrArn {
 			return dm
 		}
@@ -1677,12 +1972,13 @@ func (b *InMemoryBackend) findDataMigration(nameOrArn string) *DataMigration {
 
 // ModifyDataProvider updates a data provider.
 func (b *InMemoryBackend) ModifyDataProvider(
+	ctx context.Context,
 	nameOrArn, engine, description string,
 ) (*DataProvider, error) {
 	b.mu.Lock("ModifyDataProvider")
 	defer b.mu.Unlock()
 
-	dp := b.findDataProvider(nameOrArn)
+	dp := b.findDataProvider(ctx, nameOrArn)
 	if dp == nil {
 		return nil, fmt.Errorf("%w: data provider %s not found", ErrNotFound, nameOrArn)
 	}
@@ -1700,13 +1996,15 @@ func (b *InMemoryBackend) ModifyDataProvider(
 	return &cp, nil
 }
 
-// findDataProvider locates a data provider by name or ARN (must hold a lock).
-func (b *InMemoryBackend) findDataProvider(nameOrArn string) *DataProvider {
-	if dp, ok := b.dataProviders[nameOrArn]; ok {
+// findDataProvider locates a data provider by name or ARN within the request
+// region (must hold a lock).
+func (b *InMemoryBackend) findDataProvider(ctx context.Context, nameOrArn string) *DataProvider {
+	store := b.dataProvidersStore(getRegion(ctx, b.region))
+	if dp, ok := store[nameOrArn]; ok {
 		return dp
 	}
 
-	for _, dp := range b.dataProviders {
+	for _, dp := range store {
 		if dp.DataProviderArn == nameOrArn {
 			return dp
 		}
@@ -1717,13 +2015,14 @@ func (b *InMemoryBackend) findDataProvider(nameOrArn string) *DataProvider {
 
 // ModifyEventSubscription updates an event subscription.
 func (b *InMemoryBackend) ModifyEventSubscription(
+	ctx context.Context,
 	name string,
 	enabled *bool,
 ) (*EventSubscription, error) {
 	b.mu.Lock("ModifyEventSubscription")
 	defer b.mu.Unlock()
 
-	es, ok := b.eventSubscriptions[name]
+	es, ok := b.eventSubscriptionsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: event subscription %s not found", ErrNotFound, name)
 	}
@@ -1741,12 +2040,13 @@ func (b *InMemoryBackend) ModifyEventSubscription(
 
 // ModifyInstanceProfile updates an instance profile.
 func (b *InMemoryBackend) ModifyInstanceProfile(
+	ctx context.Context,
 	nameOrArn, availabilityZone, description, networkType string,
 ) (*InstanceProfile, error) {
 	b.mu.Lock("ModifyInstanceProfile")
 	defer b.mu.Unlock()
 
-	ip := b.findInstanceProfile(nameOrArn)
+	ip := b.findInstanceProfile(ctx, nameOrArn)
 	if ip == nil {
 		return nil, fmt.Errorf("%w: instance profile %s not found", ErrNotFound, nameOrArn)
 	}
@@ -1768,13 +2068,15 @@ func (b *InMemoryBackend) ModifyInstanceProfile(
 	return &cp, nil
 }
 
-// findInstanceProfile locates an instance profile by name or ARN (must hold a lock).
-func (b *InMemoryBackend) findInstanceProfile(nameOrArn string) *InstanceProfile {
-	if ip, ok := b.instanceProfiles[nameOrArn]; ok {
+// findInstanceProfile locates an instance profile by name or ARN within the
+// request region (must hold a lock).
+func (b *InMemoryBackend) findInstanceProfile(ctx context.Context, nameOrArn string) *InstanceProfile {
+	store := b.instanceProfilesStore(getRegion(ctx, b.region))
+	if ip, ok := store[nameOrArn]; ok {
 		return ip
 	}
 
-	for _, ip := range b.instanceProfiles {
+	for _, ip := range store {
 		if ip.InstanceProfileArn == nameOrArn {
 			return ip
 		}
@@ -1784,11 +2086,11 @@ func (b *InMemoryBackend) findInstanceProfile(nameOrArn string) *InstanceProfile
 }
 
 // StartDataMigration transitions a data migration to running status.
-func (b *InMemoryBackend) StartDataMigration(nameOrArn string) (*DataMigration, error) {
+func (b *InMemoryBackend) StartDataMigration(ctx context.Context, nameOrArn string) (*DataMigration, error) {
 	b.mu.Lock("StartDataMigration")
 	defer b.mu.Unlock()
 
-	dm := b.findDataMigration(nameOrArn)
+	dm := b.findDataMigration(ctx, nameOrArn)
 	if dm == nil {
 		return nil, fmt.Errorf("%w: data migration %s not found", ErrNotFound, nameOrArn)
 	}
@@ -1800,11 +2102,11 @@ func (b *InMemoryBackend) StartDataMigration(nameOrArn string) (*DataMigration, 
 }
 
 // StopDataMigration transitions a data migration to stopped status.
-func (b *InMemoryBackend) StopDataMigration(nameOrArn string) (*DataMigration, error) {
+func (b *InMemoryBackend) StopDataMigration(ctx context.Context, nameOrArn string) (*DataMigration, error) {
 	b.mu.Lock("StopDataMigration")
 	defer b.mu.Unlock()
 
-	dm := b.findDataMigration(nameOrArn)
+	dm := b.findDataMigration(ctx, nameOrArn)
 	if dm == nil {
 		return nil, fmt.Errorf("%w: data migration %s not found", ErrNotFound, nameOrArn)
 	}
@@ -1816,11 +2118,11 @@ func (b *InMemoryBackend) StopDataMigration(nameOrArn string) (*DataMigration, e
 }
 
 // RebootReplicationInstance reboots a replication instance (no-op in memory).
-func (b *InMemoryBackend) RebootReplicationInstance(arnOrID string) (*ReplicationInstance, error) {
+func (b *InMemoryBackend) RebootReplicationInstance(ctx context.Context, arnOrID string) (*ReplicationInstance, error) {
 	b.mu.RLock("RebootReplicationInstance")
 	defer b.mu.RUnlock()
 
-	ri := b.findReplicationInstance(arnOrID)
+	ri := b.findReplicationInstance(ctx, arnOrID)
 	if ri == nil {
 		return nil, fmt.Errorf("%w: replication instance %s not found", ErrNotFound, arnOrID)
 	}
@@ -1832,12 +2134,13 @@ func (b *InMemoryBackend) RebootReplicationInstance(arnOrID string) (*Replicatio
 
 // MoveReplicationTask moves a replication task to a different instance.
 func (b *InMemoryBackend) MoveReplicationTask(
+	ctx context.Context,
 	taskArnOrID, targetInstanceArn string,
 ) (*ReplicationTask, error) {
 	b.mu.Lock("MoveReplicationTask")
 	defer b.mu.Unlock()
 
-	rt := b.findTask(taskArnOrID)
+	rt := b.findTask(ctx, taskArnOrID)
 	if rt == nil {
 		return nil, fmt.Errorf("%w: replication task %s not found", ErrNotFound, taskArnOrID)
 	}
@@ -1849,11 +2152,16 @@ func (b *InMemoryBackend) MoveReplicationTask(
 }
 
 // TestConnection tests a DMS connection and records the result.
-func (b *InMemoryBackend) TestConnection(replicationInstanceArn, endpointArn string) (*Connection, error) {
+func (b *InMemoryBackend) TestConnection(
+	ctx context.Context,
+	replicationInstanceArn, endpointArn string,
+) (*Connection, error) {
 	b.mu.Lock("TestConnection")
 	defer b.mu.Unlock()
 
-	ri, ok := b.replicationInstancesByARN[replicationInstanceArn]
+	region := getRegion(ctx, b.region)
+
+	ri, ok := b.replicationInstancesByARNStore(region)[replicationInstanceArn]
 	if !ok {
 		return nil, fmt.Errorf(
 			"%w: replication instance %s not found",
@@ -1862,7 +2170,7 @@ func (b *InMemoryBackend) TestConnection(replicationInstanceArn, endpointArn str
 		)
 	}
 
-	ep, ok := b.endpointsByARN[endpointArn]
+	ep, ok := b.endpointsByARNStore(region)[endpointArn]
 	if !ok {
 		return nil, fmt.Errorf("%w: endpoint %s not found", ErrNotFound, endpointArn)
 	}
@@ -1875,19 +2183,23 @@ func (b *InMemoryBackend) TestConnection(replicationInstanceArn, endpointArn str
 		EndpointIdentifier:            ep.EndpointIdentifier,
 		Status:                        "successful",
 	}
-	b.connections[key] = conn
+	b.connectionsStore(region)[key] = conn
 	cp := *conn
 
 	return &cp, nil
 }
 
 // DescribeConnections returns stored connections, optionally filtered by replication instance ARN or endpoint ARN.
-func (b *InMemoryBackend) DescribeConnections(replicationInstanceArn, endpointArn string) ([]*Connection, error) {
+func (b *InMemoryBackend) DescribeConnections(
+	ctx context.Context,
+	replicationInstanceArn, endpointArn string,
+) ([]*Connection, error) {
 	b.mu.RLock("DescribeConnections")
 	defer b.mu.RUnlock()
 
-	list := make([]*Connection, 0, len(b.connections))
-	for _, conn := range b.connections {
+	store := b.connectionsStore(getRegion(ctx, b.region))
+	list := make([]*Connection, 0, len(store))
+	for _, conn := range store {
 		if replicationInstanceArn != "" && conn.ReplicationInstanceArn != replicationInstanceArn {
 			continue
 		}
@@ -1902,44 +2214,49 @@ func (b *InMemoryBackend) DescribeConnections(replicationInstanceArn, endpointAr
 }
 
 // ImportCertificate creates a certificate record.
-func (b *InMemoryBackend) ImportCertificate(identifier, certPem string) (*Certificate, error) {
+func (b *InMemoryBackend) ImportCertificate(ctx context.Context, identifier, certPem string) (*Certificate, error) {
 	b.mu.Lock("ImportCertificate")
 	defer b.mu.Unlock()
 
-	if _, ok := b.certificates[identifier]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.certificatesStore(region)
+
+	if _, ok := store[identifier]; ok {
 		return nil, fmt.Errorf("%w: certificate %s already exists", ErrAlreadyExists, identifier)
 	}
 
-	certARN := arn.Build("dms", b.region, b.accountID, "certificate:"+identifier)
+	certARN := arn.Build("dms", region, b.accountID, "certificate:"+identifier)
 	cert := &Certificate{
 		CertificateIdentifier: identifier,
 		CertificateArn:        certARN,
 		CertificatePem:        certPem,
 		AccountID:             b.accountID,
-		Region:                b.region,
+		Region:                region,
 	}
-	b.certificates[identifier] = cert
+	store[identifier] = cert
 	cp := *cert
 
 	return &cp, nil
 }
 
 // DeleteCertificate deletes a certificate by identifier or ARN.
-func (b *InMemoryBackend) DeleteCertificate(identifierOrArn string) (*Certificate, error) {
+func (b *InMemoryBackend) DeleteCertificate(ctx context.Context, identifierOrArn string) (*Certificate, error) {
 	b.mu.Lock("DeleteCertificate")
 	defer b.mu.Unlock()
 
-	if cert, ok := b.certificates[identifierOrArn]; ok {
+	store := b.certificatesStore(getRegion(ctx, b.region))
+
+	if cert, ok := store[identifierOrArn]; ok {
 		cp := *cert
-		delete(b.certificates, identifierOrArn)
+		delete(store, identifierOrArn)
 
 		return &cp, nil
 	}
 
-	for id, cert := range b.certificates {
+	for id, cert := range store {
 		if cert.CertificateArn == identifierOrArn {
 			cp := *cert
-			delete(b.certificates, id)
+			delete(store, id)
 
 			return &cp, nil
 		}
@@ -1950,17 +2267,22 @@ func (b *InMemoryBackend) DeleteCertificate(identifierOrArn string) (*Certificat
 
 // CreateMigrationProject creates a migration project.
 func (b *InMemoryBackend) CreateMigrationProject(
+	ctx context.Context,
 	name, description string,
 	kv map[string]string,
 ) (*MigrationProject, error) {
 	b.mu.Lock("CreateMigrationProject")
 	defer b.mu.Unlock()
 
-	if _, ok := b.migrationProjects[name]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.migrationProjectsStore(region)
+	byARN := b.migrationProjectsByARNStore(region)
+
+	if _, ok := store[name]; ok {
 		return nil, fmt.Errorf("%w: migration project %s already exists", ErrAlreadyExists, name)
 	}
 
-	projectARN := arn.Build("dms", b.region, b.accountID, "migration-project:"+uuid.NewString())
+	projectARN := arn.Build("dms", region, b.accountID, "migration-project:"+uuid.NewString())
 	t := tags.New("dms.migration-project." + name + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -1971,34 +2293,38 @@ func (b *InMemoryBackend) CreateMigrationProject(
 		MigrationProjectIdentifier: name,
 		Description:                description,
 		AccountID:                  b.accountID,
-		Region:                     b.region,
+		Region:                     region,
 		Tags:                       t,
 	}
-	b.migrationProjects[name] = mp
-	b.migrationProjectsByARN[projectARN] = mp
+	store[name] = mp
+	byARN[projectARN] = mp
 	cp := *mp
 
 	return &cp, nil
 }
 
 // DeleteMigrationProject deletes a migration project by name or ARN.
-func (b *InMemoryBackend) DeleteMigrationProject(nameOrArn string) error {
+func (b *InMemoryBackend) DeleteMigrationProject(ctx context.Context, nameOrArn string) error {
 	b.mu.Lock("DeleteMigrationProject")
 	defer b.mu.Unlock()
 
-	if mp, ok := b.migrationProjects[nameOrArn]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.migrationProjectsStore(region)
+	byARN := b.migrationProjectsByARNStore(region)
+
+	if mp, ok := store[nameOrArn]; ok {
 		mp.Tags.Close()
-		delete(b.migrationProjectsByARN, mp.MigrationProjectArn)
-		delete(b.migrationProjects, nameOrArn)
+		delete(byARN, mp.MigrationProjectArn)
+		delete(store, nameOrArn)
 
 		return nil
 	}
 
-	for name, mp := range b.migrationProjects {
+	for name, mp := range store {
 		if mp.MigrationProjectArn == nameOrArn {
 			mp.Tags.Close()
-			delete(b.migrationProjectsByARN, nameOrArn)
-			delete(b.migrationProjects, name)
+			delete(byARN, nameOrArn)
+			delete(store, name)
 
 			return nil
 		}
@@ -2009,13 +2335,18 @@ func (b *InMemoryBackend) DeleteMigrationProject(nameOrArn string) error {
 
 // CreateReplicationSubnetGroup creates a subnet group.
 func (b *InMemoryBackend) CreateReplicationSubnetGroup(
+	ctx context.Context,
 	identifier, description, vpcID string,
 	kv map[string]string,
 ) (*ReplicationSubnetGroup, error) {
 	b.mu.Lock("CreateReplicationSubnetGroup")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicationSubnetGroups[identifier]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.replicationSubnetGroupsStore(region)
+	byARN := b.replicationSubnetGroupsByARNStore(region)
+
+	if _, ok := store[identifier]; ok {
 		return nil, fmt.Errorf(
 			"%w: replication subnet group %s already exists",
 			ErrAlreadyExists,
@@ -2023,7 +2354,7 @@ func (b *InMemoryBackend) CreateReplicationSubnetGroup(
 		)
 	}
 
-	sgARN := arn.Build("dms", b.region, b.accountID, "subgrp:"+identifier)
+	sgARN := arn.Build("dms", region, b.accountID, "subgrp:"+identifier)
 	t := tags.New("dms.replication-subnet-group." + identifier + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -2034,34 +2365,38 @@ func (b *InMemoryBackend) CreateReplicationSubnetGroup(
 		ReplicationSubnetGroupDescription: description,
 		VpcID:                             vpcID,
 		AccountID:                         b.accountID,
-		Region:                            b.region,
+		Region:                            region,
 		Tags:                              t,
 	}
-	b.replicationSubnetGroups[identifier] = sg
-	b.replicationSubnetGroupsByARN[sgARN] = sg
+	store[identifier] = sg
+	byARN[sgARN] = sg
 	cp := *sg
 
 	return &cp, nil
 }
 
 // DeleteReplicationSubnetGroup deletes a subnet group by identifier or ARN.
-func (b *InMemoryBackend) DeleteReplicationSubnetGroup(identifierOrArn string) error {
+func (b *InMemoryBackend) DeleteReplicationSubnetGroup(ctx context.Context, identifierOrArn string) error {
 	b.mu.Lock("DeleteReplicationSubnetGroup")
 	defer b.mu.Unlock()
 
-	if sg, ok := b.replicationSubnetGroups[identifierOrArn]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.replicationSubnetGroupsStore(region)
+	byARN := b.replicationSubnetGroupsByARNStore(region)
+
+	if sg, ok := store[identifierOrArn]; ok {
 		sg.Tags.Close()
-		delete(b.replicationSubnetGroupsByARN, sg.ReplicationSubnetGroupArn)
-		delete(b.replicationSubnetGroups, identifierOrArn)
+		delete(byARN, sg.ReplicationSubnetGroupArn)
+		delete(store, identifierOrArn)
 
 		return nil
 	}
 
-	for id, sg := range b.replicationSubnetGroups {
+	for id, sg := range store {
 		if sg.ReplicationSubnetGroupArn == identifierOrArn {
 			sg.Tags.Close()
-			delete(b.replicationSubnetGroupsByARN, identifierOrArn)
-			delete(b.replicationSubnetGroups, id)
+			delete(byARN, identifierOrArn)
+			delete(store, id)
 
 			return nil
 		}
@@ -2072,13 +2407,18 @@ func (b *InMemoryBackend) DeleteReplicationSubnetGroup(identifierOrArn string) e
 
 // CreateReplicationConfig creates a replication config.
 func (b *InMemoryBackend) CreateReplicationConfig(
+	ctx context.Context,
 	identifier, replicationType, sourceEndpointArn, targetEndpointArn string,
 	kv map[string]string,
 ) (*ReplicationConfig, error) {
 	b.mu.Lock("CreateReplicationConfig")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicationConfigs[identifier]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.replicationConfigsStore(region)
+	byARN := b.replicationConfigsByARNStore(region)
+
+	if _, ok := store[identifier]; ok {
 		return nil, fmt.Errorf(
 			"%w: replication config %s already exists",
 			ErrAlreadyExists,
@@ -2086,7 +2426,7 @@ func (b *InMemoryBackend) CreateReplicationConfig(
 		)
 	}
 
-	configARN := arn.Build("dms", b.region, b.accountID, "replication-config:"+uuid.NewString())
+	configARN := arn.Build("dms", region, b.accountID, "replication-config:"+uuid.NewString())
 	t := tags.New("dms.replication-config." + identifier + ".tags")
 	if len(kv) > 0 {
 		t.Merge(kv)
@@ -2098,34 +2438,38 @@ func (b *InMemoryBackend) CreateReplicationConfig(
 		SourceEndpointArn:           sourceEndpointArn,
 		TargetEndpointArn:           targetEndpointArn,
 		AccountID:                   b.accountID,
-		Region:                      b.region,
+		Region:                      region,
 		Tags:                        t,
 	}
-	b.replicationConfigs[identifier] = rc
-	b.replicationConfigsByARN[configARN] = rc
+	store[identifier] = rc
+	byARN[configARN] = rc
 	cp := *rc
 
 	return &cp, nil
 }
 
 // DeleteReplicationConfig deletes a replication config by identifier or ARN.
-func (b *InMemoryBackend) DeleteReplicationConfig(identifierOrArn string) error {
+func (b *InMemoryBackend) DeleteReplicationConfig(ctx context.Context, identifierOrArn string) error {
 	b.mu.Lock("DeleteReplicationConfig")
 	defer b.mu.Unlock()
 
-	if rc, ok := b.replicationConfigs[identifierOrArn]; ok {
+	region := getRegion(ctx, b.region)
+	store := b.replicationConfigsStore(region)
+	byARN := b.replicationConfigsByARNStore(region)
+
+	if rc, ok := store[identifierOrArn]; ok {
 		rc.Tags.Close()
-		delete(b.replicationConfigsByARN, rc.ReplicationConfigArn)
-		delete(b.replicationConfigs, identifierOrArn)
+		delete(byARN, rc.ReplicationConfigArn)
+		delete(store, identifierOrArn)
 
 		return nil
 	}
 
-	for id, rc := range b.replicationConfigs {
+	for id, rc := range store {
 		if rc.ReplicationConfigArn == identifierOrArn {
 			rc.Tags.Close()
-			delete(b.replicationConfigsByARN, identifierOrArn)
-			delete(b.replicationConfigs, id)
+			delete(byARN, identifierOrArn)
+			delete(store, id)
 
 			return nil
 		}
@@ -2135,12 +2479,12 @@ func (b *InMemoryBackend) DeleteReplicationConfig(identifierOrArn string) error 
 }
 
 // DescribeDataMigrations returns all data migrations (optionally filtered by name/arn).
-func (b *InMemoryBackend) DescribeDataMigrations(nameOrArn string) ([]*DataMigration, error) {
+func (b *InMemoryBackend) DescribeDataMigrations(ctx context.Context, nameOrArn string) ([]*DataMigration, error) {
 	b.mu.RLock("DescribeDataMigrations")
 	defer b.mu.RUnlock()
 
 	if nameOrArn != "" {
-		dm := b.findDataMigration(nameOrArn)
+		dm := b.findDataMigration(ctx, nameOrArn)
 		if dm == nil {
 			return []*DataMigration{}, nil
 		}
@@ -2150,8 +2494,9 @@ func (b *InMemoryBackend) DescribeDataMigrations(nameOrArn string) ([]*DataMigra
 		return []*DataMigration{&cp}, nil
 	}
 
-	list := make([]*DataMigration, 0, len(b.dataMigrations))
-	for _, dm := range b.dataMigrations {
+	store := b.dataMigrationsStore(getRegion(ctx, b.region))
+	list := make([]*DataMigration, 0, len(store))
+	for _, dm := range store {
 		cp := *dm
 		list = append(list, &cp)
 	}
@@ -2160,12 +2505,12 @@ func (b *InMemoryBackend) DescribeDataMigrations(nameOrArn string) ([]*DataMigra
 }
 
 // DescribeDataProviders returns all data providers (optionally filtered by name/arn).
-func (b *InMemoryBackend) DescribeDataProviders(nameOrArn string) ([]*DataProvider, error) {
+func (b *InMemoryBackend) DescribeDataProviders(ctx context.Context, nameOrArn string) ([]*DataProvider, error) {
 	b.mu.RLock("DescribeDataProviders")
 	defer b.mu.RUnlock()
 
 	if nameOrArn != "" {
-		dp := b.findDataProvider(nameOrArn)
+		dp := b.findDataProvider(ctx, nameOrArn)
 		if dp == nil {
 			return []*DataProvider{}, nil
 		}
@@ -2175,8 +2520,9 @@ func (b *InMemoryBackend) DescribeDataProviders(nameOrArn string) ([]*DataProvid
 		return []*DataProvider{&cp}, nil
 	}
 
-	list := make([]*DataProvider, 0, len(b.dataProviders))
-	for _, dp := range b.dataProviders {
+	store := b.dataProvidersStore(getRegion(ctx, b.region))
+	list := make([]*DataProvider, 0, len(store))
+	for _, dp := range store {
 		cp := *dp
 		list = append(list, &cp)
 	}
@@ -2185,12 +2531,14 @@ func (b *InMemoryBackend) DescribeDataProviders(nameOrArn string) ([]*DataProvid
 }
 
 // DescribeEventSubscriptions returns all event subscriptions (optionally filtered by name).
-func (b *InMemoryBackend) DescribeEventSubscriptions(name string) ([]*EventSubscription, error) {
+func (b *InMemoryBackend) DescribeEventSubscriptions(ctx context.Context, name string) ([]*EventSubscription, error) {
 	b.mu.RLock("DescribeEventSubscriptions")
 	defer b.mu.RUnlock()
 
+	store := b.eventSubscriptionsStore(getRegion(ctx, b.region))
+
 	if name != "" {
-		es, ok := b.eventSubscriptions[name]
+		es, ok := store[name]
 		if !ok {
 			return []*EventSubscription{}, nil
 		}
@@ -2202,8 +2550,8 @@ func (b *InMemoryBackend) DescribeEventSubscriptions(name string) ([]*EventSubsc
 		return []*EventSubscription{&cp}, nil
 	}
 
-	list := make([]*EventSubscription, 0, len(b.eventSubscriptions))
-	for _, es := range b.eventSubscriptions {
+	list := make([]*EventSubscription, 0, len(store))
+	for _, es := range store {
 		cp := *es
 		cp.SourceIDsList = copyStringsOrEmpty(es.SourceIDsList)
 		cp.EventCategories = copyStringsOrEmpty(es.EventCategories)
@@ -2214,12 +2562,13 @@ func (b *InMemoryBackend) DescribeEventSubscriptions(name string) ([]*EventSubsc
 }
 
 // DescribeFleetAdvisorCollectors returns all fleet advisor collectors.
-func (b *InMemoryBackend) DescribeFleetAdvisorCollectors() ([]*FleetAdvisorCollector, error) {
+func (b *InMemoryBackend) DescribeFleetAdvisorCollectors(ctx context.Context) ([]*FleetAdvisorCollector, error) {
 	b.mu.RLock("DescribeFleetAdvisorCollectors")
 	defer b.mu.RUnlock()
 
-	list := make([]*FleetAdvisorCollector, 0, len(b.fleetAdvisorCollectors))
-	for _, col := range b.fleetAdvisorCollectors {
+	store := b.fleetAdvisorCollectorsStore(getRegion(ctx, b.region))
+	list := make([]*FleetAdvisorCollector, 0, len(store))
+	for _, col := range store {
 		cp := *col
 		list = append(list, &cp)
 	}
@@ -2228,12 +2577,13 @@ func (b *InMemoryBackend) DescribeFleetAdvisorCollectors() ([]*FleetAdvisorColle
 }
 
 // DescribeInstanceProfiles returns all instance profiles.
-func (b *InMemoryBackend) DescribeInstanceProfiles() ([]*InstanceProfile, error) {
+func (b *InMemoryBackend) DescribeInstanceProfiles(ctx context.Context) ([]*InstanceProfile, error) {
 	b.mu.RLock("DescribeInstanceProfiles")
 	defer b.mu.RUnlock()
 
-	list := make([]*InstanceProfile, 0, len(b.instanceProfiles))
-	for _, ip := range b.instanceProfiles {
+	store := b.instanceProfilesStore(getRegion(ctx, b.region))
+	list := make([]*InstanceProfile, 0, len(store))
+	for _, ip := range store {
 		cp := *ip
 		list = append(list, &cp)
 	}
@@ -2242,12 +2592,13 @@ func (b *InMemoryBackend) DescribeInstanceProfiles() ([]*InstanceProfile, error)
 }
 
 // DescribeMigrationProjects returns all migration projects.
-func (b *InMemoryBackend) DescribeMigrationProjects() ([]*MigrationProject, error) {
+func (b *InMemoryBackend) DescribeMigrationProjects(ctx context.Context) ([]*MigrationProject, error) {
 	b.mu.RLock("DescribeMigrationProjects")
 	defer b.mu.RUnlock()
 
-	list := make([]*MigrationProject, 0, len(b.migrationProjects))
-	for _, mp := range b.migrationProjects {
+	store := b.migrationProjectsStore(getRegion(ctx, b.region))
+	list := make([]*MigrationProject, 0, len(store))
+	for _, mp := range store {
 		cp := *mp
 		list = append(list, &cp)
 	}
@@ -2256,12 +2607,13 @@ func (b *InMemoryBackend) DescribeMigrationProjects() ([]*MigrationProject, erro
 }
 
 // DescribeReplicationSubnetGroups returns all subnet groups.
-func (b *InMemoryBackend) DescribeReplicationSubnetGroups() ([]*ReplicationSubnetGroup, error) {
+func (b *InMemoryBackend) DescribeReplicationSubnetGroups(ctx context.Context) ([]*ReplicationSubnetGroup, error) {
 	b.mu.RLock("DescribeReplicationSubnetGroups")
 	defer b.mu.RUnlock()
 
-	list := make([]*ReplicationSubnetGroup, 0, len(b.replicationSubnetGroups))
-	for _, sg := range b.replicationSubnetGroups {
+	store := b.replicationSubnetGroupsStore(getRegion(ctx, b.region))
+	list := make([]*ReplicationSubnetGroup, 0, len(store))
+	for _, sg := range store {
 		cp := *sg
 		list = append(list, &cp)
 	}
@@ -2270,12 +2622,13 @@ func (b *InMemoryBackend) DescribeReplicationSubnetGroups() ([]*ReplicationSubne
 }
 
 // DescribeReplicationConfigs returns all replication configs.
-func (b *InMemoryBackend) DescribeReplicationConfigs() ([]*ReplicationConfig, error) {
+func (b *InMemoryBackend) DescribeReplicationConfigs(ctx context.Context) ([]*ReplicationConfig, error) {
 	b.mu.RLock("DescribeReplicationConfigs")
 	defer b.mu.RUnlock()
 
-	list := make([]*ReplicationConfig, 0, len(b.replicationConfigs))
-	for _, rc := range b.replicationConfigs {
+	store := b.replicationConfigsStore(getRegion(ctx, b.region))
+	list := make([]*ReplicationConfig, 0, len(store))
+	for _, rc := range store {
 		cp := *rc
 		list = append(list, &cp)
 	}
@@ -2284,12 +2637,13 @@ func (b *InMemoryBackend) DescribeReplicationConfigs() ([]*ReplicationConfig, er
 }
 
 // DescribeCertificates returns all certificates.
-func (b *InMemoryBackend) DescribeCertificates() ([]*Certificate, error) {
+func (b *InMemoryBackend) DescribeCertificates(ctx context.Context) ([]*Certificate, error) {
 	b.mu.RLock("DescribeCertificates")
 	defer b.mu.RUnlock()
 
-	list := make([]*Certificate, 0, len(b.certificates))
-	for _, cert := range b.certificates {
+	store := b.certificatesStore(getRegion(ctx, b.region))
+	list := make([]*Certificate, 0, len(store))
+	for _, cert := range store {
 		cp := *cert
 		list = append(list, &cp)
 	}

--- a/services/dms/export_test.go
+++ b/services/dms/export_test.go
@@ -1,11 +1,21 @@
 package dms
 
+// sumRegions returns the total number of entries across all per-region inner maps.
+func sumRegions[T any](m map[string]map[string]*T) int {
+	total := 0
+	for _, regionMap := range m {
+		total += len(regionMap)
+	}
+
+	return total
+}
+
 // ReplicationInstanceCount returns the number of replication instances. Used only in tests.
 func (b *InMemoryBackend) ReplicationInstanceCount() int {
 	b.mu.RLock("ReplicationInstanceCount")
 	defer b.mu.RUnlock()
 
-	return len(b.replicationInstances)
+	return sumRegions(b.replicationInstances)
 }
 
 // EndpointCount returns the number of endpoints. Used only in tests.
@@ -13,7 +23,7 @@ func (b *InMemoryBackend) EndpointCount() int {
 	b.mu.RLock("EndpointCount")
 	defer b.mu.RUnlock()
 
-	return len(b.endpoints)
+	return sumRegions(b.endpoints)
 }
 
 // ReplicationTaskCount returns the number of replication tasks. Used only in tests.
@@ -21,7 +31,7 @@ func (b *InMemoryBackend) ReplicationTaskCount() int {
 	b.mu.RLock("ReplicationTaskCount")
 	defer b.mu.RUnlock()
 
-	return len(b.replicationTasks)
+	return sumRegions(b.replicationTasks)
 }
 
 // DataMigrationCount returns the number of data migrations. Used only in tests.
@@ -29,7 +39,7 @@ func (b *InMemoryBackend) DataMigrationCount() int {
 	b.mu.RLock("DataMigrationCount")
 	defer b.mu.RUnlock()
 
-	return len(b.dataMigrations)
+	return sumRegions(b.dataMigrations)
 }
 
 // DataProviderCount returns the number of data providers. Used only in tests.
@@ -37,7 +47,7 @@ func (b *InMemoryBackend) DataProviderCount() int {
 	b.mu.RLock("DataProviderCount")
 	defer b.mu.RUnlock()
 
-	return len(b.dataProviders)
+	return sumRegions(b.dataProviders)
 }
 
 // EventSubscriptionCount returns the number of event subscriptions. Used only in tests.
@@ -45,7 +55,7 @@ func (b *InMemoryBackend) EventSubscriptionCount() int {
 	b.mu.RLock("EventSubscriptionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.eventSubscriptions)
+	return sumRegions(b.eventSubscriptions)
 }
 
 // FleetAdvisorCollectorCount returns the number of Fleet Advisor collectors. Used only in tests.
@@ -53,7 +63,7 @@ func (b *InMemoryBackend) FleetAdvisorCollectorCount() int {
 	b.mu.RLock("FleetAdvisorCollectorCount")
 	defer b.mu.RUnlock()
 
-	return len(b.fleetAdvisorCollectors)
+	return sumRegions(b.fleetAdvisorCollectors)
 }
 
 // InstanceProfileCount returns the number of instance profiles. Used only in tests.
@@ -61,7 +71,7 @@ func (b *InMemoryBackend) InstanceProfileCount() int {
 	b.mu.RLock("InstanceProfileCount")
 	defer b.mu.RUnlock()
 
-	return len(b.instanceProfiles)
+	return sumRegions(b.instanceProfiles)
 }
 
 // ConnectionCount returns the number of stored connections. Used only in tests.
@@ -69,5 +79,5 @@ func (b *InMemoryBackend) ConnectionCount() int {
 	b.mu.RLock("ConnectionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.connections)
+	return sumRegions(b.connections)
 }

--- a/services/dms/handler.go
+++ b/services/dms/handler.go
@@ -735,12 +735,18 @@ func extractField(c *echo.Context, keys ...string) string {
 // Handler returns the Echo handler function for DMS requests.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		// Resolve the per-request region (from SigV4 / X-Amz-Region) and attach
+		// it to the context so backend operations are region-scoped.
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
 		return service.HandleTarget(
 			c,
 			logger.Load(c.Request().Context()),
 			"AmazonDMSv20160101", contentType,
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(ctx context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(context.WithValue(ctx, regionContextKey{}, region), action, body)
+			},
 			h.handleError,
 		)
 	}
@@ -820,7 +826,7 @@ type createReplicationInstanceOutput struct {
 }
 
 func (h *Handler) handleCreateReplicationInstance(
-	_ context.Context, in *createReplicationInstanceInput,
+	ctx context.Context, in *createReplicationInstanceInput,
 ) (*createReplicationInstanceOutput, error) {
 	identifier := ptrStr(in.ReplicationInstanceIdentifier)
 	class := ptrStr(in.ReplicationInstanceClass)
@@ -835,6 +841,7 @@ func (h *Handler) handleCreateReplicationInstance(
 
 	kv := tagsToMap(in.Tags)
 	ri, err := h.Backend.CreateReplicationInstance(
+		ctx,
 		identifier, class,
 		ptrStr(in.EngineVersion),
 		ptrStr(in.AvailabilityZone),
@@ -865,7 +872,7 @@ type describeReplicationInstancesOutput struct {
 }
 
 func (h *Handler) handleDescribeReplicationInstances(
-	_ context.Context,
+	ctx context.Context,
 	in *describeReplicationInstancesInput,
 ) (*describeReplicationInstancesOutput, error) {
 	identifier := extractFilterValue(in.Filters, "replication-instance-id")
@@ -877,7 +884,7 @@ func (h *Handler) handleDescribeReplicationInstances(
 		lookup = arnFilter
 	}
 
-	list, err := h.Backend.DescribeReplicationInstances(lookup)
+	list, err := h.Backend.DescribeReplicationInstances(ctx, lookup)
 	if err != nil {
 		return nil, err
 	}
@@ -906,21 +913,21 @@ type deleteReplicationInstanceOutput struct {
 }
 
 func (h *Handler) handleDeleteReplicationInstance(
-	_ context.Context, in *deleteReplicationInstanceInput,
+	ctx context.Context, in *deleteReplicationInstanceInput,
 ) (*deleteReplicationInstanceOutput, error) {
 	arnOrID := ptrStr(in.ReplicationInstanceArn)
 	// Retrieve before deletion to return it in the response.
-	instances, err := h.Backend.DescribeReplicationInstances(arnOrID)
+	instances, err := h.Backend.DescribeReplicationInstances(ctx, arnOrID)
 	if err != nil {
 		// Try ARN lookup via delete directly.
-		if delErr := h.Backend.DeleteReplicationInstance(arnOrID); delErr != nil {
+		if delErr := h.Backend.DeleteReplicationInstance(ctx, arnOrID); delErr != nil {
 			return nil, delErr
 		}
 
 		return &deleteReplicationInstanceOutput{}, nil
 	}
 
-	if delErr := h.Backend.DeleteReplicationInstance(arnOrID); delErr != nil {
+	if delErr := h.Backend.DeleteReplicationInstance(ctx, arnOrID); delErr != nil {
 		return nil, delErr
 	}
 
@@ -949,7 +956,7 @@ type createEndpointOutput struct {
 }
 
 func (h *Handler) handleCreateEndpoint(
-	_ context.Context, in *createEndpointInput,
+	ctx context.Context, in *createEndpointInput,
 ) (*createEndpointOutput, error) {
 	identifier := ptrStr(in.EndpointIdentifier)
 	endpointType := ptrStr(in.EndpointType)
@@ -969,6 +976,7 @@ func (h *Handler) handleCreateEndpoint(
 
 	kv := tagsToMap(in.Tags)
 	ep, err := h.Backend.CreateEndpoint(
+		ctx,
 		identifier,
 		endpointType,
 		engineName,
@@ -997,7 +1005,7 @@ type describeEndpointsOutput struct {
 }
 
 func (h *Handler) handleDescribeEndpoints(
-	_ context.Context,
+	ctx context.Context,
 	in *describeEndpointsInput,
 ) (*describeEndpointsOutput, error) {
 	identifier := extractFilterValue(in.Filters, "endpoint-id")
@@ -1008,7 +1016,7 @@ func (h *Handler) handleDescribeEndpoints(
 		lookup = arnFilter
 	}
 
-	list, err := h.Backend.DescribeEndpoints(lookup)
+	list, err := h.Backend.DescribeEndpoints(ctx, lookup)
 	if err != nil {
 		return nil, err
 	}
@@ -1037,9 +1045,9 @@ type deleteEndpointOutput struct {
 }
 
 func (h *Handler) handleDeleteEndpoint(
-	_ context.Context, in *deleteEndpointInput,
+	ctx context.Context, in *deleteEndpointInput,
 ) (*deleteEndpointOutput, error) {
-	ep, err := h.Backend.DeleteEndpoint(ptrStr(in.EndpointArn))
+	ep, err := h.Backend.DeleteEndpoint(ctx, ptrStr(in.EndpointArn))
 	if err != nil {
 		return nil, err
 	}
@@ -1065,7 +1073,7 @@ type createReplicationTaskOutput struct {
 }
 
 func (h *Handler) handleCreateReplicationTask(
-	_ context.Context, in *createReplicationTaskInput,
+	ctx context.Context, in *createReplicationTaskInput,
 ) (*createReplicationTaskOutput, error) {
 	identifier := ptrStr(in.ReplicationTaskIdentifier)
 	sourceEndpointArn := ptrStr(in.SourceEndpointArn)
@@ -1095,6 +1103,7 @@ func (h *Handler) handleCreateReplicationTask(
 
 	kv := tagsToMap(in.Tags)
 	rt, err := h.Backend.CreateReplicationTask(
+		ctx,
 		identifier,
 		sourceEndpointArn,
 		targetEndpointArn,
@@ -1123,10 +1132,10 @@ type describeReplicationTasksOutput struct {
 }
 
 func (h *Handler) handleDescribeReplicationTasks(
-	_ context.Context, in *describeReplicationTasksInput,
+	ctx context.Context, in *describeReplicationTasksInput,
 ) (*describeReplicationTasksOutput, error) {
 	arnOrID := extractFilterValue(in.Filters, "replication-task-id", "replication-task-arn")
-	list, err := h.Backend.DescribeReplicationTasks(arnOrID)
+	list, err := h.Backend.DescribeReplicationTasks(ctx, arnOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -1160,7 +1169,7 @@ func isValidStartReplicationTaskType(s string) bool {
 }
 
 func (h *Handler) handleStartReplicationTask(
-	_ context.Context, in *startReplicationTaskInput,
+	ctx context.Context, in *startReplicationTaskInput,
 ) (*startReplicationTaskOutput, error) {
 	taskType := ptrStr(in.StartReplicationTaskType)
 	if taskType == "" {
@@ -1175,7 +1184,7 @@ func (h *Handler) handleStartReplicationTask(
 		)
 	}
 
-	rt, err := h.Backend.StartReplicationTask(ptrStr(in.ReplicationTaskArn))
+	rt, err := h.Backend.StartReplicationTask(ctx, ptrStr(in.ReplicationTaskArn))
 	if err != nil {
 		return nil, err
 	}
@@ -1192,9 +1201,9 @@ type stopReplicationTaskOutput struct {
 }
 
 func (h *Handler) handleStopReplicationTask(
-	_ context.Context, in *stopReplicationTaskInput,
+	ctx context.Context, in *stopReplicationTaskInput,
 ) (*stopReplicationTaskOutput, error) {
-	rt, err := h.Backend.StopReplicationTask(ptrStr(in.ReplicationTaskArn))
+	rt, err := h.Backend.StopReplicationTask(ctx, ptrStr(in.ReplicationTaskArn))
 	if err != nil {
 		return nil, err
 	}
@@ -1211,9 +1220,9 @@ type deleteReplicationTaskOutput struct {
 }
 
 func (h *Handler) handleDeleteReplicationTask(
-	_ context.Context, in *deleteReplicationTaskInput,
+	ctx context.Context, in *deleteReplicationTaskInput,
 ) (*deleteReplicationTaskOutput, error) {
-	rt, err := h.Backend.DeleteReplicationTask(ptrStr(in.ReplicationTaskArn))
+	rt, err := h.Backend.DeleteReplicationTask(ctx, ptrStr(in.ReplicationTaskArn))
 	if err != nil {
 		return nil, err
 	}
@@ -1236,10 +1245,10 @@ type addTagsToResourceInput struct {
 type addTagsToResourceOutput struct{}
 
 func (h *Handler) handleAddTagsToResource(
-	_ context.Context, in *addTagsToResourceInput,
+	ctx context.Context, in *addTagsToResourceInput,
 ) (*addTagsToResourceOutput, error) {
 	kv := tagsToMap(in.Tags)
-	if err := h.Backend.AddTagsToResource(ptrStr(in.ResourceArn), kv); err != nil {
+	if err := h.Backend.AddTagsToResource(ctx, ptrStr(in.ResourceArn), kv); err != nil {
 		return nil, err
 	}
 
@@ -1255,9 +1264,9 @@ type listTagsForResourceOutput struct {
 }
 
 func (h *Handler) handleListTagsForResource(
-	_ context.Context, in *listTagsForResourceInput,
+	ctx context.Context, in *listTagsForResourceInput,
 ) (*listTagsForResourceOutput, error) {
-	kv, err := h.Backend.ListTagsForResource(ptrStr(in.ResourceArn))
+	kv, err := h.Backend.ListTagsForResource(ctx, ptrStr(in.ResourceArn))
 	if err != nil {
 		return nil, err
 	}
@@ -1496,7 +1505,7 @@ type applyPendingMaintenanceActionOutput struct {
 }
 
 func (h *Handler) handleApplyPendingMaintenanceAction(
-	_ context.Context, in *applyPendingMaintenanceActionInput,
+	ctx context.Context, in *applyPendingMaintenanceActionInput,
 ) (*applyPendingMaintenanceActionOutput, error) {
 	instanceArn := ptrStr(in.ReplicationInstanceArn)
 	if instanceArn == "" {
@@ -1504,6 +1513,7 @@ func (h *Handler) handleApplyPendingMaintenanceAction(
 	}
 
 	ri, err := h.Backend.ApplyPendingMaintenanceAction(
+		ctx,
 		instanceArn,
 		ptrStr(in.ApplyAction),
 		ptrStr(in.OptInType),
@@ -1537,9 +1547,9 @@ type batchStartRecommendationsOutput struct {
 }
 
 func (h *Handler) handleBatchStartRecommendations(
-	_ context.Context, _ *batchStartRecommendationsInput,
+	ctx context.Context, _ *batchStartRecommendationsInput,
 ) (*batchStartRecommendationsOutput, error) {
-	if err := h.Backend.BatchStartRecommendations(); err != nil {
+	if err := h.Backend.BatchStartRecommendations(ctx); err != nil {
 		return nil, err
 	}
 
@@ -1560,9 +1570,10 @@ type cancelMetadataModelConversionOutput struct {
 }
 
 func (h *Handler) handleCancelMetadataModelConversion(
-	_ context.Context, in *cancelMetadataModelConversionInput,
+	ctx context.Context, in *cancelMetadataModelConversionInput,
 ) (*cancelMetadataModelConversionOutput, error) {
 	reqID, err := h.Backend.CancelMetadataModelConversion(
+		ctx,
 		ptrStr(in.MigrationProjectIdentifier),
 		ptrStr(in.RequestIdentifier),
 	)
@@ -1585,9 +1596,10 @@ type cancelMetadataModelCreationOutput struct {
 }
 
 func (h *Handler) handleCancelMetadataModelCreation(
-	_ context.Context, in *cancelMetadataModelCreationInput,
+	ctx context.Context, in *cancelMetadataModelCreationInput,
 ) (*cancelMetadataModelCreationOutput, error) {
 	reqID, err := h.Backend.CancelMetadataModelCreation(
+		ctx,
 		ptrStr(in.MigrationProjectIdentifier),
 		ptrStr(in.RequestIdentifier),
 	)
@@ -1609,9 +1621,10 @@ type cancelReplicationTaskAssessmentRunOutput struct {
 }
 
 func (h *Handler) handleCancelReplicationTaskAssessmentRun(
-	_ context.Context, in *cancelReplicationTaskAssessmentRunInput,
+	ctx context.Context, in *cancelReplicationTaskAssessmentRunInput,
 ) (*cancelReplicationTaskAssessmentRunOutput, error) {
 	if err := h.Backend.CancelReplicationTaskAssessmentRun(
+		ctx,
 		ptrStr(in.ReplicationTaskAssessmentRunArn),
 	); err != nil {
 		return nil, err
@@ -1654,7 +1667,7 @@ type createDataMigrationOutput struct {
 }
 
 func (h *Handler) handleCreateDataMigration(
-	_ context.Context, in *createDataMigrationInput,
+	ctx context.Context, in *createDataMigrationInput,
 ) (*createDataMigrationOutput, error) {
 	name := ptrStr(in.DataMigrationName)
 	if name == "" {
@@ -1668,6 +1681,7 @@ func (h *Handler) handleCreateDataMigration(
 
 	kv := tagsToMap(in.Tags)
 	dm, err := h.Backend.CreateDataMigration(
+		ctx,
 		name,
 		ptrStr(in.MigrationProjectIdentifier),
 		migrationType,
@@ -1718,7 +1732,7 @@ type createDataProviderOutput struct {
 }
 
 func (h *Handler) handleCreateDataProvider(
-	_ context.Context, in *createDataProviderInput,
+	ctx context.Context, in *createDataProviderInput,
 ) (*createDataProviderOutput, error) {
 	name := ptrStr(in.DataProviderName)
 	if name == "" {
@@ -1731,7 +1745,7 @@ func (h *Handler) handleCreateDataProvider(
 	}
 
 	kv := tagsToMap(in.Tags)
-	dp, err := h.Backend.CreateDataProvider(name, engine, ptrStr(in.Description), kv)
+	dp, err := h.Backend.CreateDataProvider(ctx, name, engine, ptrStr(in.Description), kv)
 	if err != nil {
 		return nil, err
 	}
@@ -1775,7 +1789,7 @@ type createEventSubscriptionOutput struct {
 }
 
 func (h *Handler) handleCreateEventSubscription(
-	_ context.Context, in *createEventSubscriptionInput,
+	ctx context.Context, in *createEventSubscriptionInput,
 ) (*createEventSubscriptionOutput, error) {
 	name := ptrStr(in.SubscriptionName)
 	if name == "" {
@@ -1794,6 +1808,7 @@ func (h *Handler) handleCreateEventSubscription(
 
 	kv := tagsToMap(in.Tags)
 	es, err := h.Backend.CreateEventSubscription(
+		ctx,
 		name,
 		snsTopicArn,
 		ptrStr(in.SourceType),
@@ -1848,7 +1863,7 @@ type createFleetAdvisorCollectorOutput struct {
 }
 
 func (h *Handler) handleCreateFleetAdvisorCollector(
-	_ context.Context, in *createFleetAdvisorCollectorInput,
+	ctx context.Context, in *createFleetAdvisorCollectorInput,
 ) (*createFleetAdvisorCollectorOutput, error) {
 	name := ptrStr(in.CollectorName)
 	if name == "" {
@@ -1856,6 +1871,7 @@ func (h *Handler) handleCreateFleetAdvisorCollector(
 	}
 
 	col, err := h.Backend.CreateFleetAdvisorCollector(
+		ctx,
 		name,
 		ptrStr(in.Description),
 		ptrStr(in.ServiceAccessRoleArn),
@@ -1903,10 +1919,11 @@ type createInstanceProfileOutput struct {
 }
 
 func (h *Handler) handleCreateInstanceProfile(
-	_ context.Context, in *createInstanceProfileInput,
+	ctx context.Context, in *createInstanceProfileInput,
 ) (*createInstanceProfileOutput, error) {
 	kv := tagsToMap(in.Tags)
 	ip, err := h.Backend.CreateInstanceProfile(
+		ctx,
 		ptrStr(in.InstanceProfileName),
 		ptrStr(in.AvailabilityZone),
 		ptrStr(in.KmsKeyArn),
@@ -1965,7 +1982,7 @@ func mpToJSON(mp *MigrationProject) migrationProjectJSON {
 }
 
 func (h *Handler) handleCreateMigrationProject(
-	_ context.Context, in *createMigrationProjectInput,
+	ctx context.Context, in *createMigrationProjectInput,
 ) (*createMigrationProjectOutput, error) {
 	name := ptrStr(in.MigrationProjectName)
 	if name == "" {
@@ -1973,7 +1990,7 @@ func (h *Handler) handleCreateMigrationProject(
 	}
 
 	kv := tagsToMap(in.Tags)
-	mp, err := h.Backend.CreateMigrationProject(name, ptrStr(in.Description), kv)
+	mp, err := h.Backend.CreateMigrationProject(ctx, name, ptrStr(in.Description), kv)
 	if err != nil {
 		return nil, err
 	}
@@ -2014,7 +2031,7 @@ func rcToJSON(rc *ReplicationConfig) replicationConfigJSON {
 }
 
 func (h *Handler) handleCreateReplicationConfig(
-	_ context.Context, in *createReplicationConfigInput,
+	ctx context.Context, in *createReplicationConfigInput,
 ) (*createReplicationConfigOutput, error) {
 	identifier := ptrStr(in.ReplicationConfigIdentifier)
 	if identifier == "" {
@@ -2023,6 +2040,7 @@ func (h *Handler) handleCreateReplicationConfig(
 
 	kv := tagsToMap(in.Tags)
 	rc, err := h.Backend.CreateReplicationConfig(
+		ctx,
 		identifier,
 		ptrStr(in.ReplicationType),
 		ptrStr(in.SourceEndpointArn),
@@ -2066,7 +2084,7 @@ func rsgToJSON(sg *ReplicationSubnetGroup) replicationSubnetGroupFullJSON {
 }
 
 func (h *Handler) handleCreateReplicationSubnetGroup(
-	_ context.Context, in *createReplicationSubnetGroupInput,
+	ctx context.Context, in *createReplicationSubnetGroupInput,
 ) (*createReplicationSubnetGroupOutput, error) {
 	identifier := ptrStr(in.ReplicationSubnetGroupIdentifier)
 	if identifier == "" {
@@ -2075,6 +2093,7 @@ func (h *Handler) handleCreateReplicationSubnetGroup(
 
 	kv := tagsToMap(in.Tags)
 	sg, err := h.Backend.CreateReplicationSubnetGroup(
+		ctx,
 		identifier,
 		ptrStr(in.ReplicationSubnetGroupDescription),
 		"",
@@ -2110,9 +2129,9 @@ func certToJSON(c *Certificate) certificateJSON {
 }
 
 func (h *Handler) handleDeleteCertificate(
-	_ context.Context, in *deleteCertificateInput,
+	ctx context.Context, in *deleteCertificateInput,
 ) (*deleteCertificateOutput, error) {
-	cert, err := h.Backend.DeleteCertificate(ptrStr(in.CertificateArn))
+	cert, err := h.Backend.DeleteCertificate(ctx, ptrStr(in.CertificateArn))
 	if err != nil {
 		return nil, err
 	}
@@ -2148,9 +2167,9 @@ type deleteDataMigrationOutput struct {
 }
 
 func (h *Handler) handleDeleteDataMigration(
-	_ context.Context, in *deleteDataMigrationInput,
+	ctx context.Context, in *deleteDataMigrationInput,
 ) (*deleteDataMigrationOutput, error) {
-	dm, err := h.Backend.DeleteDataMigration(ptrStr(in.DataMigrationIdentifier))
+	dm, err := h.Backend.DeleteDataMigration(ctx, ptrStr(in.DataMigrationIdentifier))
 	if err != nil {
 		return nil, err
 	}
@@ -2169,9 +2188,9 @@ type deleteDataProviderOutput struct {
 }
 
 func (h *Handler) handleDeleteDataProvider(
-	_ context.Context, in *deleteDataProviderInput,
+	ctx context.Context, in *deleteDataProviderInput,
 ) (*deleteDataProviderOutput, error) {
-	dp, err := h.Backend.DeleteDataProvider(ptrStr(in.DataProviderArn))
+	dp, err := h.Backend.DeleteDataProvider(ctx, ptrStr(in.DataProviderArn))
 	if err != nil {
 		return nil, err
 	}
@@ -2190,9 +2209,9 @@ type deleteEventSubscriptionOutput struct {
 }
 
 func (h *Handler) handleDeleteEventSubscription(
-	_ context.Context, in *deleteEventSubscriptionInput,
+	ctx context.Context, in *deleteEventSubscriptionInput,
 ) (*deleteEventSubscriptionOutput, error) {
-	es, err := h.Backend.DeleteEventSubscription(ptrStr(in.SubscriptionName))
+	es, err := h.Backend.DeleteEventSubscription(ctx, ptrStr(in.SubscriptionName))
 	if err != nil {
 		return nil, err
 	}
@@ -2209,9 +2228,9 @@ type deleteFleetAdvisorCollectorInput struct {
 type deleteFleetAdvisorCollectorOutput struct{}
 
 func (h *Handler) handleDeleteFleetAdvisorCollector(
-	_ context.Context, in *deleteFleetAdvisorCollectorInput,
+	ctx context.Context, in *deleteFleetAdvisorCollectorInput,
 ) (*deleteFleetAdvisorCollectorOutput, error) {
-	if err := h.Backend.DeleteFleetAdvisorCollector(ptrStr(in.CollectorReferencedID)); err != nil {
+	if err := h.Backend.DeleteFleetAdvisorCollector(ctx, ptrStr(in.CollectorReferencedID)); err != nil {
 		return nil, err
 	}
 
@@ -2245,12 +2264,12 @@ type deleteInstanceProfileOutput struct {
 }
 
 func (h *Handler) handleDeleteInstanceProfile(
-	_ context.Context, in *deleteInstanceProfileInput,
+	ctx context.Context, in *deleteInstanceProfileInput,
 ) (*deleteInstanceProfileOutput, error) {
 	// We need to get the profile before deleting it for the response.
 	arnOrName := ptrStr(in.InstanceProfileArn)
 
-	profiles, _ := h.Backend.DescribeInstanceProfiles()
+	profiles, _ := h.Backend.DescribeInstanceProfiles(ctx)
 	var found *InstanceProfile
 	for _, p := range profiles {
 		if p.InstanceProfileArn == arnOrName || p.InstanceProfileName == arnOrName {
@@ -2260,7 +2279,7 @@ func (h *Handler) handleDeleteInstanceProfile(
 		}
 	}
 
-	if err := h.Backend.DeleteInstanceProfile(arnOrName); err != nil {
+	if err := h.Backend.DeleteInstanceProfile(ctx, arnOrName); err != nil {
 		return nil, err
 	}
 
@@ -2282,11 +2301,11 @@ type deleteMigrationProjectOutput struct {
 }
 
 func (h *Handler) handleDeleteMigrationProject(
-	_ context.Context, in *deleteMigrationProjectInput,
+	ctx context.Context, in *deleteMigrationProjectInput,
 ) (*deleteMigrationProjectOutput, error) {
 	nameOrArn := ptrStr(in.MigrationProjectArn)
 
-	projects, _ := h.Backend.DescribeMigrationProjects()
+	projects, _ := h.Backend.DescribeMigrationProjects(ctx)
 	var found *MigrationProject
 	for _, p := range projects {
 		if p.MigrationProjectArn == nameOrArn || p.MigrationProjectName == nameOrArn {
@@ -2296,7 +2315,7 @@ func (h *Handler) handleDeleteMigrationProject(
 		}
 	}
 
-	if err := h.Backend.DeleteMigrationProject(nameOrArn); err != nil {
+	if err := h.Backend.DeleteMigrationProject(ctx, nameOrArn); err != nil {
 		return nil, err
 	}
 
@@ -2318,11 +2337,11 @@ type deleteReplicationConfigOutput struct {
 }
 
 func (h *Handler) handleDeleteReplicationConfig(
-	_ context.Context, in *deleteReplicationConfigInput,
+	ctx context.Context, in *deleteReplicationConfigInput,
 ) (*deleteReplicationConfigOutput, error) {
 	identifierOrArn := ptrStr(in.ReplicationConfigArn)
 
-	configs, _ := h.Backend.DescribeReplicationConfigs()
+	configs, _ := h.Backend.DescribeReplicationConfigs(ctx)
 	var found *ReplicationConfig
 	for _, rc := range configs {
 		if rc.ReplicationConfigArn == identifierOrArn ||
@@ -2333,7 +2352,7 @@ func (h *Handler) handleDeleteReplicationConfig(
 		}
 	}
 
-	if err := h.Backend.DeleteReplicationConfig(identifierOrArn); err != nil {
+	if err := h.Backend.DeleteReplicationConfig(ctx, identifierOrArn); err != nil {
 		return nil, err
 	}
 
@@ -2353,9 +2372,9 @@ type deleteReplicationSubnetGroupInput struct {
 type deleteReplicationSubnetGroupOutput struct{}
 
 func (h *Handler) handleDeleteReplicationSubnetGroup(
-	_ context.Context, in *deleteReplicationSubnetGroupInput,
+	ctx context.Context, in *deleteReplicationSubnetGroupInput,
 ) (*deleteReplicationSubnetGroupOutput, error) {
-	if err := h.Backend.DeleteReplicationSubnetGroup(ptrStr(in.ReplicationSubnetGroupIdentifier)); err != nil {
+	if err := h.Backend.DeleteReplicationSubnetGroup(ctx, ptrStr(in.ReplicationSubnetGroupIdentifier)); err != nil {
 		return nil, err
 	}
 
@@ -2406,11 +2425,11 @@ const (
 )
 
 func (h *Handler) handleDescribeAccountAttributes(
-	_ context.Context, _ *describeAccountAttributesInput,
+	ctx context.Context, _ *describeAccountAttributesInput,
 ) (*describeAccountAttributesOutput, error) {
-	riCount := int64(len(h.Backend.mustDescribeReplicationInstances()))
-	epCount := int64(len(h.Backend.mustDescribeEndpoints()))
-	taskCount := int64(len(h.Backend.mustDescribeReplicationTasks()))
+	riCount := int64(len(h.Backend.mustDescribeReplicationInstances(ctx)))
+	epCount := int64(len(h.Backend.mustDescribeEndpoints(ctx)))
+	taskCount := int64(len(h.Backend.mustDescribeReplicationTasks(ctx)))
 
 	return &describeAccountAttributesOutput{
 		UniqueAccountIdentifier: h.Backend.AccountID(),
@@ -2460,9 +2479,9 @@ type describeCertificatesOutput struct {
 }
 
 func (h *Handler) handleDescribeCertificates(
-	_ context.Context, in *describeCertificatesInput,
+	ctx context.Context, in *describeCertificatesInput,
 ) (*describeCertificatesOutput, error) {
-	list, err := h.Backend.DescribeCertificates()
+	list, err := h.Backend.DescribeCertificates(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2495,12 +2514,12 @@ type describeConnectionsOutput struct {
 }
 
 func (h *Handler) handleDescribeConnections(
-	_ context.Context, in *describeConnectionsInput,
+	ctx context.Context, in *describeConnectionsInput,
 ) (*describeConnectionsOutput, error) {
 	riArn := extractFilterValue(in.Filters, "replication-instance-id")
 	epArn := extractFilterValue(in.Filters, "endpoint-id")
 
-	list, err := h.Backend.DescribeConnections(riArn, epArn)
+	list, err := h.Backend.DescribeConnections(ctx, riArn, epArn)
 	if err != nil {
 		return nil, err
 	}
@@ -2551,9 +2570,9 @@ type describeDataMigrationsOutput struct {
 }
 
 func (h *Handler) handleDescribeDataMigrations(
-	_ context.Context, in *describeDataMigrationsInput,
+	ctx context.Context, in *describeDataMigrationsInput,
 ) (*describeDataMigrationsOutput, error) {
-	list, err := h.Backend.DescribeDataMigrations(ptrStr(in.DataMigrationIdentifier))
+	list, err := h.Backend.DescribeDataMigrations(ctx, ptrStr(in.DataMigrationIdentifier))
 	if err != nil {
 		return nil, err
 	}
@@ -2586,9 +2605,9 @@ type describeDataProvidersOutput struct {
 }
 
 func (h *Handler) handleDescribeDataProviders(
-	_ context.Context, in *describeDataProvidersInput,
+	ctx context.Context, in *describeDataProvidersInput,
 ) (*describeDataProvidersOutput, error) {
-	list, err := h.Backend.DescribeDataProviders(ptrStr(in.DataProviderIdentifier))
+	list, err := h.Backend.DescribeDataProviders(ctx, ptrStr(in.DataProviderIdentifier))
 	if err != nil {
 		return nil, err
 	}
@@ -2809,9 +2828,9 @@ type describeEventSubscriptionsOutput struct {
 }
 
 func (h *Handler) handleDescribeEventSubscriptions(
-	_ context.Context, in *describeEventSubscriptionsInput,
+	ctx context.Context, in *describeEventSubscriptionsInput,
 ) (*describeEventSubscriptionsOutput, error) {
-	list, err := h.Backend.DescribeEventSubscriptions(ptrStr(in.SubscriptionName))
+	list, err := h.Backend.DescribeEventSubscriptions(ctx, ptrStr(in.SubscriptionName))
 	if err != nil {
 		return nil, err
 	}
@@ -2890,9 +2909,9 @@ type describeFleetAdvisorCollectorsOutput struct {
 }
 
 func (h *Handler) handleDescribeFleetAdvisorCollectors(
-	_ context.Context, _ *describeFleetAdvisorCollectorsInput,
+	ctx context.Context, _ *describeFleetAdvisorCollectorsInput,
 ) (*describeFleetAdvisorCollectorsOutput, error) {
-	list, err := h.Backend.DescribeFleetAdvisorCollectors()
+	list, err := h.Backend.DescribeFleetAdvisorCollectors(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3004,9 +3023,9 @@ type describeInstanceProfilesOutput struct {
 }
 
 func (h *Handler) handleDescribeInstanceProfiles(
-	_ context.Context, in *describeInstanceProfilesInput,
+	ctx context.Context, in *describeInstanceProfilesInput,
 ) (*describeInstanceProfilesOutput, error) {
-	list, err := h.Backend.DescribeInstanceProfiles()
+	list, err := h.Backend.DescribeInstanceProfiles(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3187,9 +3206,9 @@ type describeMigrationProjectsOutput struct {
 }
 
 func (h *Handler) handleDescribeMigrationProjects(
-	_ context.Context, in *describeMigrationProjectsInput,
+	ctx context.Context, in *describeMigrationProjectsInput,
 ) (*describeMigrationProjectsOutput, error) {
-	list, err := h.Backend.DescribeMigrationProjects()
+	list, err := h.Backend.DescribeMigrationProjects(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3434,9 +3453,9 @@ type describeReplicationConfigsOutput struct {
 }
 
 func (h *Handler) handleDescribeReplicationConfigs(
-	_ context.Context, in *describeReplicationConfigsInput,
+	ctx context.Context, in *describeReplicationConfigsInput,
 ) (*describeReplicationConfigsOutput, error) {
-	list, err := h.Backend.DescribeReplicationConfigs()
+	list, err := h.Backend.DescribeReplicationConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3492,9 +3511,9 @@ type describeReplicationSubnetGroupsOutput struct {
 }
 
 func (h *Handler) handleDescribeReplicationSubnetGroups(
-	_ context.Context, in *describeReplicationSubnetGroupsInput,
+	ctx context.Context, in *describeReplicationSubnetGroupsInput,
 ) (*describeReplicationSubnetGroupsOutput, error) {
-	list, err := h.Backend.DescribeReplicationSubnetGroups()
+	list, err := h.Backend.DescribeReplicationSubnetGroups(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3583,11 +3602,11 @@ type describeReplicationTableStatisticsOutput struct {
 }
 
 func (h *Handler) handleDescribeReplicationTableStatistics(
-	_ context.Context, in *describeReplicationTableStatisticsInput,
+	ctx context.Context, in *describeReplicationTableStatisticsInput,
 ) (*describeReplicationTableStatisticsOutput, error) {
 	taskArn := ptrStr(in.ReplicationTaskArn)
 
-	tasks, err := h.Backend.DescribeReplicationTasks(taskArn)
+	tasks, err := h.Backend.DescribeReplicationTasks(ctx, taskArn)
 	if err != nil {
 		return nil, err
 	}
@@ -3725,11 +3744,11 @@ type describeTableStatisticsOutput struct {
 }
 
 func (h *Handler) handleDescribeTableStatistics(
-	_ context.Context, in *describeTableStatisticsInput,
+	ctx context.Context, in *describeTableStatisticsInput,
 ) (*describeTableStatisticsOutput, error) {
 	taskArn := ptrStr(in.ReplicationTaskArn)
 
-	tasks, err := h.Backend.DescribeReplicationTasks(taskArn)
+	tasks, err := h.Backend.DescribeReplicationTasks(ctx, taskArn)
 	if err != nil {
 		return nil, err
 	}
@@ -3806,14 +3825,14 @@ type importCertificateOutput struct {
 }
 
 func (h *Handler) handleImportCertificate(
-	_ context.Context, in *importCertificateInput,
+	ctx context.Context, in *importCertificateInput,
 ) (*importCertificateOutput, error) {
 	identifier := ptrStr(in.CertificateIdentifier)
 	if identifier == "" {
 		return nil, fmt.Errorf("%w: CertificateIdentifier is required", ErrValidation)
 	}
 
-	cert, err := h.Backend.ImportCertificate(identifier, ptrStr(in.CertificatePem))
+	cert, err := h.Backend.ImportCertificate(ctx, identifier, ptrStr(in.CertificatePem))
 	if err != nil {
 		return nil, err
 	}
@@ -3856,9 +3875,10 @@ type modifyDataMigrationOutput struct {
 }
 
 func (h *Handler) handleModifyDataMigration(
-	_ context.Context, in *modifyDataMigrationInput,
+	ctx context.Context, in *modifyDataMigrationInput,
 ) (*modifyDataMigrationOutput, error) {
 	dm, err := h.Backend.ModifyDataMigration(
+		ctx,
 		ptrStr(in.DataMigrationIdentifier),
 		ptrStr(in.DataMigrationType),
 		ptrStr(in.ServiceAccessRoleArn),
@@ -3884,9 +3904,10 @@ type modifyDataProviderOutput struct {
 }
 
 func (h *Handler) handleModifyDataProvider(
-	_ context.Context, in *modifyDataProviderInput,
+	ctx context.Context, in *modifyDataProviderInput,
 ) (*modifyDataProviderOutput, error) {
 	dp, err := h.Backend.ModifyDataProvider(
+		ctx,
 		ptrStr(in.DataProviderArn),
 		ptrStr(in.Engine),
 		ptrStr(in.Description),
@@ -3913,9 +3934,10 @@ type modifyEndpointOutput struct {
 }
 
 func (h *Handler) handleModifyEndpoint(
-	_ context.Context, in *modifyEndpointInput,
+	ctx context.Context, in *modifyEndpointInput,
 ) (*modifyEndpointOutput, error) {
 	ep, err := h.Backend.ModifyEndpoint(
+		ctx,
 		ptrStr(in.EndpointArn),
 		ptrStr(in.ServerName),
 		ptrStr(in.DatabaseName),
@@ -3941,9 +3963,9 @@ type modifyEventSubscriptionOutput struct {
 }
 
 func (h *Handler) handleModifyEventSubscription(
-	_ context.Context, in *modifyEventSubscriptionInput,
+	ctx context.Context, in *modifyEventSubscriptionInput,
 ) (*modifyEventSubscriptionOutput, error) {
-	es, err := h.Backend.ModifyEventSubscription(ptrStr(in.SubscriptionName), in.Enabled)
+	es, err := h.Backend.ModifyEventSubscription(ctx, ptrStr(in.SubscriptionName), in.Enabled)
 	if err != nil {
 		return nil, err
 	}
@@ -3965,9 +3987,10 @@ type modifyInstanceProfileOutput struct {
 }
 
 func (h *Handler) handleModifyInstanceProfile(
-	_ context.Context, in *modifyInstanceProfileInput,
+	ctx context.Context, in *modifyInstanceProfileInput,
 ) (*modifyInstanceProfileOutput, error) {
 	ip, err := h.Backend.ModifyInstanceProfile(
+		ctx,
 		ptrStr(in.InstanceProfileArn),
 		ptrStr(in.AvailabilityZone),
 		ptrStr(in.Description),
@@ -3992,11 +4015,11 @@ type modifyMigrationProjectOutput struct {
 }
 
 func (h *Handler) handleModifyMigrationProject(
-	_ context.Context, in *modifyMigrationProjectInput,
+	ctx context.Context, in *modifyMigrationProjectInput,
 ) (*modifyMigrationProjectOutput, error) {
 	nameOrArn := ptrStr(in.MigrationProjectArn)
 
-	projects, _ := h.Backend.DescribeMigrationProjects()
+	projects, _ := h.Backend.DescribeMigrationProjects(ctx)
 	for _, mp := range projects {
 		if mp.MigrationProjectArn == nameOrArn || mp.MigrationProjectName == nameOrArn {
 			return &modifyMigrationProjectOutput{MigrationProject: mpToJSON(mp)}, nil
@@ -4018,11 +4041,11 @@ type modifyReplicationConfigOutput struct {
 }
 
 func (h *Handler) handleModifyReplicationConfig(
-	_ context.Context, in *modifyReplicationConfigInput,
+	ctx context.Context, in *modifyReplicationConfigInput,
 ) (*modifyReplicationConfigOutput, error) {
 	identifierOrArn := ptrStr(in.ReplicationConfigArn)
 
-	configs, _ := h.Backend.DescribeReplicationConfigs()
+	configs, _ := h.Backend.DescribeReplicationConfigs(ctx)
 	for _, rc := range configs {
 		if rc.ReplicationConfigArn == identifierOrArn ||
 			rc.ReplicationConfigIdentifier == identifierOrArn {
@@ -4049,9 +4072,10 @@ type modifyReplicationInstanceOutput struct {
 }
 
 func (h *Handler) handleModifyReplicationInstance(
-	_ context.Context, in *modifyReplicationInstanceInput,
+	ctx context.Context, in *modifyReplicationInstanceInput,
 ) (*modifyReplicationInstanceOutput, error) {
 	ri, err := h.Backend.ModifyReplicationInstance(
+		ctx,
 		ptrStr(in.ReplicationInstanceArn),
 		ptrStr(in.ReplicationInstanceClass),
 		ptrStr(in.EngineVersion),
@@ -4079,11 +4103,11 @@ type modifyReplicationSubnetGroupOutput struct {
 }
 
 func (h *Handler) handleModifyReplicationSubnetGroup(
-	_ context.Context, in *modifyReplicationSubnetGroupInput,
+	ctx context.Context, in *modifyReplicationSubnetGroupInput,
 ) (*modifyReplicationSubnetGroupOutput, error) {
 	identifier := ptrStr(in.ReplicationSubnetGroupIdentifier)
 
-	groups, _ := h.Backend.DescribeReplicationSubnetGroups()
+	groups, _ := h.Backend.DescribeReplicationSubnetGroups(ctx)
 	for _, sg := range groups {
 		if sg.ReplicationSubnetGroupIdentifier == identifier ||
 			sg.ReplicationSubnetGroupArn == identifier {
@@ -4108,9 +4132,10 @@ type modifyReplicationTaskOutput struct {
 }
 
 func (h *Handler) handleModifyReplicationTask(
-	_ context.Context, in *modifyReplicationTaskInput,
+	ctx context.Context, in *modifyReplicationTaskInput,
 ) (*modifyReplicationTaskOutput, error) {
 	rt, err := h.Backend.ModifyReplicationTask(
+		ctx,
 		ptrStr(in.ReplicationTaskArn),
 		ptrStr(in.MigrationType),
 		ptrStr(in.TableMappings),
@@ -4135,9 +4160,10 @@ type moveReplicationTaskOutput struct {
 }
 
 func (h *Handler) handleMoveReplicationTask(
-	_ context.Context, in *moveReplicationTaskInput,
+	ctx context.Context, in *moveReplicationTaskInput,
 ) (*moveReplicationTaskOutput, error) {
 	rt, err := h.Backend.MoveReplicationTask(
+		ctx,
 		ptrStr(in.ReplicationTaskArn),
 		ptrStr(in.TargetReplicationInstanceArn),
 	)
@@ -4161,9 +4187,9 @@ type rebootReplicationInstanceOutput struct {
 }
 
 func (h *Handler) handleRebootReplicationInstance(
-	_ context.Context, in *rebootReplicationInstanceInput,
+	ctx context.Context, in *rebootReplicationInstanceInput,
 ) (*rebootReplicationInstanceOutput, error) {
-	ri, err := h.Backend.RebootReplicationInstance(ptrStr(in.ReplicationInstanceArn))
+	ri, err := h.Backend.RebootReplicationInstance(ctx, ptrStr(in.ReplicationInstanceArn))
 	if err != nil {
 		return nil, err
 	}
@@ -4236,9 +4262,9 @@ type removeTagsFromResourceInput struct {
 type removeTagsFromResourceOutput struct{}
 
 func (h *Handler) handleRemoveTagsFromResource(
-	_ context.Context, in *removeTagsFromResourceInput,
+	ctx context.Context, in *removeTagsFromResourceInput,
 ) (*removeTagsFromResourceOutput, error) {
-	if err := h.Backend.RemoveTagsFromResource(ptrStr(in.ResourceArn), in.TagKeys); err != nil {
+	if err := h.Backend.RemoveTagsFromResource(ctx, ptrStr(in.ResourceArn), in.TagKeys); err != nil {
 		return nil, err
 	}
 
@@ -4275,9 +4301,9 @@ type startDataMigrationOutput struct {
 }
 
 func (h *Handler) handleStartDataMigration(
-	_ context.Context, in *startDataMigrationInput,
+	ctx context.Context, in *startDataMigrationInput,
 ) (*startDataMigrationOutput, error) {
-	dm, err := h.Backend.StartDataMigration(ptrStr(in.DataMigrationIdentifier))
+	dm, err := h.Backend.StartDataMigration(ctx, ptrStr(in.DataMigrationIdentifier))
 	if err != nil {
 		return nil, err
 	}
@@ -4498,9 +4524,9 @@ type stopDataMigrationOutput struct {
 }
 
 func (h *Handler) handleStopDataMigration(
-	_ context.Context, in *stopDataMigrationInput,
+	ctx context.Context, in *stopDataMigrationInput,
 ) (*stopDataMigrationOutput, error) {
-	dm, err := h.Backend.StopDataMigration(ptrStr(in.DataMigrationIdentifier))
+	dm, err := h.Backend.StopDataMigration(ctx, ptrStr(in.DataMigrationIdentifier))
 	if err != nil {
 		return nil, err
 	}
@@ -4554,9 +4580,10 @@ func connToJSON(c *Connection) connectionJSON {
 }
 
 func (h *Handler) handleTestConnection(
-	_ context.Context, in *testConnectionInput,
+	ctx context.Context, in *testConnectionInput,
 ) (*testConnectionOutput, error) {
 	conn, err := h.Backend.TestConnection(
+		ctx,
 		ptrStr(in.ReplicationInstanceArn),
 		ptrStr(in.EndpointArn),
 	)

--- a/services/dms/isolation_test.go
+++ b/services/dms/isolation_test.go
@@ -1,0 +1,164 @@
+package dms //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dmsCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestDMSRegionIsolation proves that same-named DMS resources created in two
+// different regions are fully isolated: each region sees only its own
+// resources, ARNs embed the correct region, and deleting in one region leaves
+// the other untouched.
+func TestDMSRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := dmsCtxRegion("us-east-1")
+	ctxWest := dmsCtxRegion("us-west-2")
+
+	// 1. Create a replication instance with the SAME identifier in both regions.
+	eastRI, err := backend.CreateReplicationInstance(
+		ctxEast, "shared-ri", "dms.t3.medium", "", "", 0, false, false, false, nil,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, eastRI.ReplicationInstanceArn, "us-east-1")
+
+	westRI, err := backend.CreateReplicationInstance(
+		ctxWest, "shared-ri", "dms.r5.large", "", "", 0, false, false, false, nil,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, westRI.ReplicationInstanceArn, "us-west-2")
+
+	// ARNs must differ (region-qualified) even though identifiers match.
+	assert.NotEqual(t, eastRI.ReplicationInstanceArn, westRI.ReplicationInstanceArn)
+
+	// 2. Each region reads back its own instance class.
+	eastList, err := backend.DescribeReplicationInstances(ctxEast, "shared-ri")
+	require.NoError(t, err)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, "dms.t3.medium", eastList[0].ReplicationInstanceClass)
+	assert.Equal(t, "us-east-1", eastList[0].Region)
+
+	westList, err := backend.DescribeReplicationInstances(ctxWest, "shared-ri")
+	require.NoError(t, err)
+	require.Len(t, westList, 1)
+	assert.Equal(t, "dms.r5.large", westList[0].ReplicationInstanceClass)
+	assert.Equal(t, "us-west-2", westList[0].Region)
+
+	// 3. Listing without a filter returns exactly one instance per region.
+	eastAll, err := backend.DescribeReplicationInstances(ctxEast, "")
+	require.NoError(t, err)
+	require.Len(t, eastAll, 1)
+
+	westAll, err := backend.DescribeReplicationInstances(ctxWest, "")
+	require.NoError(t, err)
+	require.Len(t, westAll, 1)
+
+	// 4. Endpoints with the same identifier are isolated too.
+	_, err = backend.CreateEndpoint(ctxEast, "shared-ep", "source", "mysql", "", "", "", 0, nil)
+	require.NoError(t, err)
+	_, err = backend.CreateEndpoint(ctxWest, "shared-ep", "target", "postgres", "", "", "", 0, nil)
+	require.NoError(t, err)
+
+	eastEP, err := backend.DescribeEndpoints(ctxEast, "shared-ep")
+	require.NoError(t, err)
+	require.Len(t, eastEP, 1)
+	assert.Equal(t, "source", eastEP[0].EndpointType)
+	assert.Equal(t, "mysql", eastEP[0].EngineName)
+
+	westEP, err := backend.DescribeEndpoints(ctxWest, "shared-ep")
+	require.NoError(t, err)
+	require.Len(t, westEP, 1)
+	assert.Equal(t, "target", westEP[0].EndpointType)
+	assert.Equal(t, "postgres", westEP[0].EngineName)
+
+	// 5. Deleting the replication instance in us-east-1 must not affect us-west-2.
+	require.NoError(t, backend.DeleteReplicationInstance(ctxEast, "shared-ri"))
+
+	eastGone, err := backend.DescribeReplicationInstances(ctxEast, "shared-ri")
+	require.NoError(t, err)
+	assert.Empty(t, eastGone)
+
+	westStill, err := backend.DescribeReplicationInstances(ctxWest, "shared-ri")
+	require.NoError(t, err)
+	require.Len(t, westStill, 1)
+	assert.Equal(t, "dms.r5.large", westStill[0].ReplicationInstanceClass)
+}
+
+// TestDMSTagAndConnectionRegionIsolation proves tag and connection operations
+// are scoped to the request region: a connection tested in one region is not
+// visible in another, and tags resolved by ARN only match within the region.
+func TestDMSTagAndConnectionRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := dmsCtxRegion("us-east-1")
+	ctxWest := dmsCtxRegion("us-west-2")
+
+	eastRI, err := backend.CreateReplicationInstance(
+		ctxEast, "conn-ri", "dms.t3.medium", "", "", 0, false, false, false, nil,
+	)
+	require.NoError(t, err)
+	eastEP, err := backend.CreateEndpoint(ctxEast, "conn-ep", "source", "mysql", "", "", "", 0, nil)
+	require.NoError(t, err)
+
+	// TestConnection in us-east-1 succeeds.
+	_, err = backend.TestConnection(ctxEast, eastRI.ReplicationInstanceArn, eastEP.EndpointArn)
+	require.NoError(t, err)
+
+	eastConns, err := backend.DescribeConnections(ctxEast, "", "")
+	require.NoError(t, err)
+	require.Len(t, eastConns, 1)
+
+	// us-west-2 sees no connections.
+	westConns, err := backend.DescribeConnections(ctxWest, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, westConns)
+
+	// The east instance ARN does not resolve for tags in the west region.
+	require.NoError(
+		t,
+		backend.AddTagsToResource(ctxEast, eastRI.ReplicationInstanceArn, map[string]string{"env": "prod"}),
+	)
+
+	eastTags, err := backend.ListTagsForResource(ctxEast, eastRI.ReplicationInstanceArn)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", eastTags["env"])
+
+	_, err = backend.ListTagsForResource(ctxWest, eastRI.ReplicationInstanceArn)
+	require.Error(t, err, "east ARN must not be tag-resolvable from the west region")
+}
+
+// TestDMSDefaultRegionFallback verifies that a context without a region falls
+// back to the backend's configured default region.
+func TestDMSDefaultRegionFallback(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "eu-central-1")
+
+	// No region in context -> default region store.
+	_, err := backend.CreateReplicationInstance(
+		context.Background(), "def-ri", "dms.t3.medium", "", "", 0, false, false, false, nil,
+	)
+	require.NoError(t, err)
+
+	// Reading via the explicit default region sees it.
+	list, err := backend.DescribeReplicationInstances(dmsCtxRegion("eu-central-1"), "def-ri")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "eu-central-1", list[0].Region)
+
+	// A different region sees nothing.
+	other, err := backend.DescribeReplicationInstances(dmsCtxRegion("ap-south-1"), "def-ri")
+	require.NoError(t, err)
+	assert.Empty(t, other)
+}

--- a/services/dms/persistence.go
+++ b/services/dms/persistence.go
@@ -7,43 +7,44 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
+// backendSnapshot mirrors the region-nested backend maps (outer key = region).
 type backendSnapshot struct {
-	ReplicationInstances   map[string]*ReplicationInstance   `json:"replicationInstances"`
-	Endpoints              map[string]*Endpoint              `json:"endpoints"`
-	ReplicationTasks       map[string]*ReplicationTask       `json:"replicationTasks"`
-	DataMigrations         map[string]*DataMigration         `json:"dataMigrations"`
-	DataProviders          map[string]*DataProvider          `json:"dataProviders"`
-	EventSubscriptions     map[string]*EventSubscription     `json:"eventSubscriptions"`
-	FleetAdvisorCollectors map[string]*FleetAdvisorCollector `json:"fleetAdvisorCollectors"`
-	InstanceProfiles       map[string]*InstanceProfile       `json:"instanceProfiles"`
-	AccountID              string                            `json:"accountID"`
-	Region                 string                            `json:"region"`
+	ReplicationInstances   map[string]map[string]*ReplicationInstance   `json:"replicationInstances"`
+	Endpoints              map[string]map[string]*Endpoint              `json:"endpoints"`
+	ReplicationTasks       map[string]map[string]*ReplicationTask       `json:"replicationTasks"`
+	DataMigrations         map[string]map[string]*DataMigration         `json:"dataMigrations"`
+	DataProviders          map[string]map[string]*DataProvider          `json:"dataProviders"`
+	EventSubscriptions     map[string]map[string]*EventSubscription     `json:"eventSubscriptions"`
+	FleetAdvisorCollectors map[string]map[string]*FleetAdvisorCollector `json:"fleetAdvisorCollectors"`
+	InstanceProfiles       map[string]map[string]*InstanceProfile       `json:"instanceProfiles"`
+	AccountID              string                                       `json:"accountID"`
+	Region                 string                                       `json:"region"`
 }
 
 func (s *backendSnapshot) ensureNonNil() {
 	if s.ReplicationInstances == nil {
-		s.ReplicationInstances = make(map[string]*ReplicationInstance)
+		s.ReplicationInstances = make(map[string]map[string]*ReplicationInstance)
 	}
 	if s.Endpoints == nil {
-		s.Endpoints = make(map[string]*Endpoint)
+		s.Endpoints = make(map[string]map[string]*Endpoint)
 	}
 	if s.ReplicationTasks == nil {
-		s.ReplicationTasks = make(map[string]*ReplicationTask)
+		s.ReplicationTasks = make(map[string]map[string]*ReplicationTask)
 	}
 	if s.DataMigrations == nil {
-		s.DataMigrations = make(map[string]*DataMigration)
+		s.DataMigrations = make(map[string]map[string]*DataMigration)
 	}
 	if s.DataProviders == nil {
-		s.DataProviders = make(map[string]*DataProvider)
+		s.DataProviders = make(map[string]map[string]*DataProvider)
 	}
 	if s.EventSubscriptions == nil {
-		s.EventSubscriptions = make(map[string]*EventSubscription)
+		s.EventSubscriptions = make(map[string]map[string]*EventSubscription)
 	}
 	if s.FleetAdvisorCollectors == nil {
-		s.FleetAdvisorCollectors = make(map[string]*FleetAdvisorCollector)
+		s.FleetAdvisorCollectors = make(map[string]map[string]*FleetAdvisorCollector)
 	}
 	if s.InstanceProfiles == nil {
-		s.InstanceProfiles = make(map[string]*InstanceProfile)
+		s.InstanceProfiles = make(map[string]map[string]*InstanceProfile)
 	}
 }
 
@@ -104,16 +105,45 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	return nil
 }
 
-// rebuildARNIndexes reconstructs all ARN-keyed maps and reinitialises nil tag registries.
+// rebuildARNIndexes reconstructs all ARN-keyed maps (region-nested) and
+// reinitialises nil tag registries.
 func (b *InMemoryBackend) rebuildARNIndexes(snap *backendSnapshot) {
-	b.replicationInstancesByARN = rebuildRI(snap.ReplicationInstances)
-	b.endpointsByARN = rebuildEP(snap.Endpoints)
-	b.replicationTasksByARN = rebuildRT(snap.ReplicationTasks)
-	b.dataMigrationsByARN = rebuildDM(snap.DataMigrations)
-	b.dataProvidersByARN = rebuildDP(snap.DataProviders)
-	initEventSubscriptionTags(snap.EventSubscriptions)
-	initCollectorTags(snap.FleetAdvisorCollectors)
-	b.instanceProfilesByARN = rebuildIP(snap.InstanceProfiles)
+	b.replicationInstancesByARN = make(map[string]map[string]*ReplicationInstance, len(snap.ReplicationInstances))
+	for region, m := range snap.ReplicationInstances {
+		b.replicationInstancesByARN[region] = rebuildRI(m)
+	}
+
+	b.endpointsByARN = make(map[string]map[string]*Endpoint, len(snap.Endpoints))
+	for region, m := range snap.Endpoints {
+		b.endpointsByARN[region] = rebuildEP(m)
+	}
+
+	b.replicationTasksByARN = make(map[string]map[string]*ReplicationTask, len(snap.ReplicationTasks))
+	for region, m := range snap.ReplicationTasks {
+		b.replicationTasksByARN[region] = rebuildRT(m)
+	}
+
+	b.dataMigrationsByARN = make(map[string]map[string]*DataMigration, len(snap.DataMigrations))
+	for region, m := range snap.DataMigrations {
+		b.dataMigrationsByARN[region] = rebuildDM(m)
+	}
+
+	b.dataProvidersByARN = make(map[string]map[string]*DataProvider, len(snap.DataProviders))
+	for region, m := range snap.DataProviders {
+		b.dataProvidersByARN[region] = rebuildDP(m)
+	}
+
+	for _, m := range snap.EventSubscriptions {
+		initEventSubscriptionTags(m)
+	}
+	for _, m := range snap.FleetAdvisorCollectors {
+		initCollectorTags(m)
+	}
+
+	b.instanceProfilesByARN = make(map[string]map[string]*InstanceProfile, len(snap.InstanceProfiles))
+	for region, m := range snap.InstanceProfiles {
+		b.instanceProfilesByARN[region] = rebuildIP(m)
+	}
 }
 
 func rebuildRI(m map[string]*ReplicationInstance) map[string]*ReplicationInstance {

--- a/services/efs/backend.go
+++ b/services/efs/backend.go
@@ -1,6 +1,7 @@
 package efs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,18 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 // Package-local sentinels used as the inner error for wrapped error types.
 // They are not exported; callers should match via the exported Err* vars.
@@ -261,18 +274,23 @@ type CreateAccessPointRequest struct {
 }
 
 // InMemoryBackend is the in-memory store for EFS resources.
+//
+// All resource maps are nested by region (outer key = region) so that
+// same-named resources in different regions are fully isolated. The
+// cross-index maps (by ARN, by client token) are likewise region-scoped.
+// accountPreferences is account-level state in AWS and so is not region-nested.
 type InMemoryBackend struct {
-	fileSystems               map[string]*FileSystem
-	mountTargets              map[string]*MountTarget
-	accessPoints              map[string]*AccessPoint
-	lifecyclePolicies         map[string][]LifecyclePolicy
-	replicationConfigs        map[string]*ReplicationConfiguration
-	backupPolicies            map[string]string
-	fileSystemPolicies        map[string]string
-	fileSystemsByARN          map[string]*FileSystem
-	mountTargetsByARN         map[string]*MountTarget
-	accessPointsByARN         map[string]*AccessPoint
-	accessPointsByClientToken map[string]*AccessPoint
+	fileSystems               map[string]map[string]*FileSystem
+	mountTargets              map[string]map[string]*MountTarget
+	accessPoints              map[string]map[string]*AccessPoint
+	lifecyclePolicies         map[string]map[string][]LifecyclePolicy
+	replicationConfigs        map[string]map[string]*ReplicationConfiguration
+	backupPolicies            map[string]map[string]string
+	fileSystemPolicies        map[string]map[string]string
+	fileSystemsByARN          map[string]map[string]*FileSystem
+	mountTargetsByARN         map[string]map[string]*MountTarget
+	accessPointsByARN         map[string]map[string]*AccessPoint
+	accessPointsByClientToken map[string]map[string]*AccessPoint
 	accountPreferences        AccountPreferences
 	mu                        *lockmetrics.RWMutex
 	accountID                 string
@@ -288,23 +306,121 @@ type LifecyclePolicy struct {
 
 // NewInMemoryBackend creates a new in-memory EFS backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
-	return &InMemoryBackend{
-		fileSystems:               make(map[string]*FileSystem),
-		mountTargets:              make(map[string]*MountTarget),
-		accessPoints:              make(map[string]*AccessPoint),
-		lifecyclePolicies:         make(map[string][]LifecyclePolicy),
-		replicationConfigs:        make(map[string]*ReplicationConfiguration),
-		backupPolicies:            make(map[string]string),
-		fileSystemPolicies:        make(map[string]string),
-		fileSystemsByARN:          make(map[string]*FileSystem),
-		mountTargetsByARN:         make(map[string]*MountTarget),
-		accessPointsByARN:         make(map[string]*AccessPoint),
-		accessPointsByClientToken: make(map[string]*AccessPoint),
-		accountPreferences:        AccountPreferences{ResourceIDType: "LONG_ID"},
-		accountID:                 accountID,
-		region:                    region,
-		mu:                        lockmetrics.New("efs"),
+	b := &InMemoryBackend{
+		accountPreferences: AccountPreferences{ResourceIDType: "LONG_ID"},
+		accountID:          accountID,
+		region:             region,
+		mu:                 lockmetrics.New("efs"),
 	}
+	b.initRegionMaps()
+
+	return b
+}
+
+// initRegionMaps allocates the (empty) outer per-region map for every resource kind.
+func (b *InMemoryBackend) initRegionMaps() {
+	b.fileSystems = make(map[string]map[string]*FileSystem)
+	b.mountTargets = make(map[string]map[string]*MountTarget)
+	b.accessPoints = make(map[string]map[string]*AccessPoint)
+	b.lifecyclePolicies = make(map[string]map[string][]LifecyclePolicy)
+	b.replicationConfigs = make(map[string]map[string]*ReplicationConfiguration)
+	b.backupPolicies = make(map[string]map[string]string)
+	b.fileSystemPolicies = make(map[string]map[string]string)
+	b.fileSystemsByARN = make(map[string]map[string]*FileSystem)
+	b.mountTargetsByARN = make(map[string]map[string]*MountTarget)
+	b.accessPointsByARN = make(map[string]map[string]*AccessPoint)
+	b.accessPointsByClientToken = make(map[string]map[string]*AccessPoint)
+}
+
+// The following per-region store helpers return the inner map for region,
+// lazily creating it on first access. Callers must hold b.mu.
+
+func (b *InMemoryBackend) fsStore(region string) map[string]*FileSystem {
+	if b.fileSystems[region] == nil {
+		b.fileSystems[region] = make(map[string]*FileSystem)
+	}
+
+	return b.fileSystems[region]
+}
+
+func (b *InMemoryBackend) mtStore(region string) map[string]*MountTarget {
+	if b.mountTargets[region] == nil {
+		b.mountTargets[region] = make(map[string]*MountTarget)
+	}
+
+	return b.mountTargets[region]
+}
+
+func (b *InMemoryBackend) apStore(region string) map[string]*AccessPoint {
+	if b.accessPoints[region] == nil {
+		b.accessPoints[region] = make(map[string]*AccessPoint)
+	}
+
+	return b.accessPoints[region]
+}
+
+func (b *InMemoryBackend) lifecycleStore(region string) map[string][]LifecyclePolicy {
+	if b.lifecyclePolicies[region] == nil {
+		b.lifecyclePolicies[region] = make(map[string][]LifecyclePolicy)
+	}
+
+	return b.lifecyclePolicies[region]
+}
+
+func (b *InMemoryBackend) replicationStore(region string) map[string]*ReplicationConfiguration {
+	if b.replicationConfigs[region] == nil {
+		b.replicationConfigs[region] = make(map[string]*ReplicationConfiguration)
+	}
+
+	return b.replicationConfigs[region]
+}
+
+func (b *InMemoryBackend) backupStore(region string) map[string]string {
+	if b.backupPolicies[region] == nil {
+		b.backupPolicies[region] = make(map[string]string)
+	}
+
+	return b.backupPolicies[region]
+}
+
+func (b *InMemoryBackend) fsPolicyStore(region string) map[string]string {
+	if b.fileSystemPolicies[region] == nil {
+		b.fileSystemPolicies[region] = make(map[string]string)
+	}
+
+	return b.fileSystemPolicies[region]
+}
+
+func (b *InMemoryBackend) fsARNStore(region string) map[string]*FileSystem {
+	if b.fileSystemsByARN[region] == nil {
+		b.fileSystemsByARN[region] = make(map[string]*FileSystem)
+	}
+
+	return b.fileSystemsByARN[region]
+}
+
+func (b *InMemoryBackend) mtARNStore(region string) map[string]*MountTarget {
+	if b.mountTargetsByARN[region] == nil {
+		b.mountTargetsByARN[region] = make(map[string]*MountTarget)
+	}
+
+	return b.mountTargetsByARN[region]
+}
+
+func (b *InMemoryBackend) apARNStore(region string) map[string]*AccessPoint {
+	if b.accessPointsByARN[region] == nil {
+		b.accessPointsByARN[region] = make(map[string]*AccessPoint)
+	}
+
+	return b.accessPointsByARN[region]
+}
+
+func (b *InMemoryBackend) apClientTokenStore(region string) map[string]*AccessPoint {
+	if b.accessPointsByClientToken[region] == nil {
+		b.accessPointsByClientToken[region] = make(map[string]*AccessPoint)
+	}
+
+	return b.accessPointsByClientToken[region]
 }
 
 // Reset clears all stored resources, returning the backend to its empty initial state.
@@ -312,24 +428,18 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, fs := range b.fileSystems {
-		fs.Tags.Close()
+	for _, regionFS := range b.fileSystems {
+		for _, fs := range regionFS {
+			fs.Tags.Close()
+		}
 	}
-	for _, ap := range b.accessPoints {
-		ap.Tags.Close()
+	for _, regionAP := range b.accessPoints {
+		for _, ap := range regionAP {
+			ap.Tags.Close()
+		}
 	}
 
-	b.fileSystems = make(map[string]*FileSystem)
-	b.mountTargets = make(map[string]*MountTarget)
-	b.accessPoints = make(map[string]*AccessPoint)
-	b.lifecyclePolicies = make(map[string][]LifecyclePolicy)
-	b.replicationConfigs = make(map[string]*ReplicationConfiguration)
-	b.backupPolicies = make(map[string]string)
-	b.fileSystemPolicies = make(map[string]string)
-	b.fileSystemsByARN = make(map[string]*FileSystem)
-	b.mountTargetsByARN = make(map[string]*MountTarget)
-	b.accessPointsByARN = make(map[string]*AccessPoint)
-	b.accessPointsByClientToken = make(map[string]*AccessPoint)
+	b.initRegionMaps()
 }
 
 // Region returns the AWS region this backend is configured for.
@@ -451,17 +561,24 @@ func validateCreateFSRequest(req *CreateFileSystemRequest) (string, error) {
 	return kmsKeyID, nil
 }
 
-func (b *InMemoryBackend) CreateFileSystem(req CreateFileSystemRequest) (*FileSystem, error) {
+func (b *InMemoryBackend) CreateFileSystem(
+	ctx context.Context,
+	req CreateFileSystemRequest,
+) (*FileSystem, error) {
 	kmsKeyID, err := validateCreateFSRequest(&req)
 	if err != nil {
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateFileSystem")
 	defer b.mu.Unlock()
 
+	fileSystems := b.fsStore(region)
+
 	// Idempotency: if creationToken already used, compare args.
-	for _, fs := range b.fileSystems {
+	for _, fs := range fileSystems {
 		if fs.CreationToken == req.CreationToken {
 			if fs.PerformanceMode == req.PerformanceMode &&
 				fs.ThroughputMode == req.ThroughputMode &&
@@ -489,7 +606,7 @@ func (b *InMemoryBackend) CreateFileSystem(req CreateFileSystemRequest) (*FileSy
 	}
 
 	id := "fs-" + uuid.NewString()[:8]
-	fsARN := arn.Build("elasticfilesystem", b.region, b.accountID, "file-system/"+id)
+	fsARN := arn.Build("elasticfilesystem", region, b.accountID, "file-system/"+id)
 	t := tags.New("efs.filesystem." + id + ".tags")
 
 	tagCopy := make(map[string]string, len(req.Tags))
@@ -515,12 +632,12 @@ func (b *InMemoryBackend) CreateFileSystem(req CreateFileSystemRequest) (*FileSy
 		ProvisionedThroughputMib:       req.ProvisionedThroughputMib,
 		ReplicationOverwriteProtection: protectionDisabled,
 		AccountID:                      b.accountID,
-		Region:                         b.region,
+		Region:                         region,
 		CreationTime:                   time.Now().UTC(),
 		Tags:                           t,
 	}
-	b.fileSystems[id] = fs
-	b.fileSystemsByARN[fsARN] = fs
+	fileSystems[id] = fs
+	b.fsARNStore(region)[fsARN] = fs
 	cp := *fs
 
 	return &cp, nil
@@ -528,14 +645,19 @@ func (b *InMemoryBackend) CreateFileSystem(req CreateFileSystemRequest) (*FileSy
 
 // DescribeFileSystems returns file systems, optionally filtered by ID or creation token, with pagination support.
 func (b *InMemoryBackend) DescribeFileSystems(
+	ctx context.Context,
 	fileSystemID, creationToken, marker string,
 	maxItems int,
 ) ([]*FileSystem, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeFileSystems")
 	defer b.mu.RUnlock()
 
+	fileSystems := b.fsStore(region)
+
 	if fileSystemID != "" {
-		fs, ok := b.fileSystems[fileSystemID]
+		fs, ok := fileSystems[fileSystemID]
 		if !ok {
 			return nil, "", fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 		}
@@ -545,7 +667,7 @@ func (b *InMemoryBackend) DescribeFileSystems(
 	}
 
 	if creationToken != "" {
-		for _, fs := range b.fileSystems {
+		for _, fs := range fileSystems {
 			if fs.CreationToken == creationToken {
 				cp := *fs
 
@@ -556,8 +678,8 @@ func (b *InMemoryBackend) DescribeFileSystems(
 		return []*FileSystem{}, "", nil
 	}
 
-	all := make([]*FileSystem, 0, len(b.fileSystems))
-	for _, fs := range b.fileSystems {
+	all := make([]*FileSystem, 0, len(fileSystems))
+	for _, fs := range fileSystems {
 		cp := *fs
 		all = append(all, &cp)
 	}
@@ -568,17 +690,20 @@ func (b *InMemoryBackend) DescribeFileSystems(
 
 // DeleteFileSystem deletes a file system by ID.
 // Returns ErrFileSystemInUse if any mount targets exist.
-func (b *InMemoryBackend) DeleteFileSystem(fileSystemID string) error {
+func (b *InMemoryBackend) DeleteFileSystem(ctx context.Context, fileSystemID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteFileSystem")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[fileSystemID]
+	fileSystems := b.fsStore(region)
+	fs, ok := fileSystems[fileSystemID]
 	if !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
 	// Reject delete if mount targets or access points exist (AWS: FileSystemInUse).
-	for _, mt := range b.mountTargets {
+	for _, mt := range b.mtStore(region) {
 		if mt.FileSystemID == fileSystemID {
 			return fmt.Errorf(
 				"%w: file system %s has existing mount targets",
@@ -587,7 +712,7 @@ func (b *InMemoryBackend) DeleteFileSystem(fileSystemID string) error {
 			)
 		}
 	}
-	for _, ap := range b.accessPoints {
+	for _, ap := range b.apStore(region) {
 		if ap.FileSystemID == fileSystemID {
 			return fmt.Errorf(
 				"%w: file system %s has existing access points",
@@ -597,43 +722,45 @@ func (b *InMemoryBackend) DeleteFileSystem(fileSystemID string) error {
 		}
 	}
 
-	delete(b.fileSystemsByARN, fs.FileSystemArn)
+	delete(b.fsARNStore(region), fs.FileSystemArn)
 	fs.Tags.Close()
-	delete(b.fileSystems, fileSystemID)
-	delete(b.lifecyclePolicies, fileSystemID)
-	delete(b.backupPolicies, fileSystemID)
-	delete(b.fileSystemPolicies, fileSystemID)
-	delete(b.replicationConfigs, fileSystemID)
+	delete(fileSystems, fileSystemID)
+	delete(b.lifecycleStore(region), fileSystemID)
+	delete(b.backupStore(region), fileSystemID)
+	delete(b.fsPolicyStore(region), fileSystemID)
+	delete(b.replicationStore(region), fileSystemID)
 
 	return nil
 }
 
 // TagResource adds or updates tags on a resource (file system or access point) by ARN or ID.
-func (b *InMemoryBackend) TagResource(resourceID string, kv map[string]string) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceID string, kv map[string]string) error {
 	if err := validateTags(kv); err != nil {
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	if fs, ok := b.fileSystems[resourceID]; ok {
+	if fs, ok := b.fsStore(region)[resourceID]; ok {
 		fs.Tags.Merge(kv)
 
 		return nil
 	}
-	if fs, ok := b.fileSystemsByARN[resourceID]; ok {
+	if fs, ok := b.fsARNStore(region)[resourceID]; ok {
 		fs.Tags.Merge(kv)
 
 		return nil
 	}
 
-	if ap, ok := b.accessPoints[resourceID]; ok {
+	if ap, ok := b.apStore(region)[resourceID]; ok {
 		ap.Tags.Merge(kv)
 
 		return nil
 	}
-	if ap, ok := b.accessPointsByARN[resourceID]; ok {
+	if ap, ok := b.apARNStore(region)[resourceID]; ok {
 		ap.Tags.Merge(kv)
 
 		return nil
@@ -643,27 +770,29 @@ func (b *InMemoryBackend) TagResource(resourceID string, kv map[string]string) e
 }
 
 // UntagResource removes tags from a resource (file system or access point) by ARN or ID.
-func (b *InMemoryBackend) UntagResource(resourceID string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceID string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	if fs, ok := b.fileSystems[resourceID]; ok {
+	if fs, ok := b.fsStore(region)[resourceID]; ok {
 		fs.Tags.DeleteKeys(tagKeys)
 
 		return nil
 	}
-	if fs, ok := b.fileSystemsByARN[resourceID]; ok {
+	if fs, ok := b.fsARNStore(region)[resourceID]; ok {
 		fs.Tags.DeleteKeys(tagKeys)
 
 		return nil
 	}
 
-	if ap, ok := b.accessPoints[resourceID]; ok {
+	if ap, ok := b.apStore(region)[resourceID]; ok {
 		ap.Tags.DeleteKeys(tagKeys)
 
 		return nil
 	}
-	if ap, ok := b.accessPointsByARN[resourceID]; ok {
+	if ap, ok := b.apARNStore(region)[resourceID]; ok {
 		ap.Tags.DeleteKeys(tagKeys)
 
 		return nil
@@ -673,21 +802,26 @@ func (b *InMemoryBackend) UntagResource(resourceID string, tagKeys []string) err
 }
 
 // ListTagsForResource lists tags for a resource by ID or ARN.
-func (b *InMemoryBackend) ListTagsForResource(resourceID string) (map[string]string, error) {
+func (b *InMemoryBackend) ListTagsForResource(
+	ctx context.Context,
+	resourceID string,
+) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	if fs, ok := b.fileSystems[resourceID]; ok {
+	if fs, ok := b.fsStore(region)[resourceID]; ok {
 		return fs.Tags.Clone(), nil
 	}
-	if fs, ok := b.fileSystemsByARN[resourceID]; ok {
+	if fs, ok := b.fsARNStore(region)[resourceID]; ok {
 		return fs.Tags.Clone(), nil
 	}
 
-	if ap, ok := b.accessPoints[resourceID]; ok {
+	if ap, ok := b.apStore(region)[resourceID]; ok {
 		return ap.Tags.Clone(), nil
 	}
-	if ap, ok := b.accessPointsByARN[resourceID]; ok {
+	if ap, ok := b.apARNStore(region)[resourceID]; ok {
 		return ap.Tags.Clone(), nil
 	}
 
@@ -696,18 +830,25 @@ func (b *InMemoryBackend) ListTagsForResource(resourceID string) (map[string]str
 
 // CreateMountTarget creates a mount target for a file system.
 // Returns ErrMountTargetConflict if a mount target already exists in the same subnet.
-func (b *InMemoryBackend) CreateMountTarget(req CreateMountTargetRequest) (*MountTarget, error) {
+func (b *InMemoryBackend) CreateMountTarget(
+	ctx context.Context,
+	req CreateMountTargetRequest,
+) (*MountTarget, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateMountTarget")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[req.FileSystemID]
+	mountTargets := b.mtStore(region)
+
+	fs, ok := b.fsStore(region)[req.FileSystemID]
 	if !ok {
 		return nil, fmt.Errorf("%w: file system %s not found", ErrNotFound, req.FileSystemID)
 	}
 
 	// One mount target per subnet per file system.
 	if req.SubnetID != "" {
-		for _, mt := range b.mountTargets {
+		for _, mt := range mountTargets {
 			if mt.FileSystemID == req.FileSystemID && mt.SubnetID == req.SubnetID {
 				return nil, fmt.Errorf(
 					"%w: mount target already exists for file system %s in subnet %s",
@@ -729,7 +870,7 @@ func (b *InMemoryBackend) CreateMountTarget(req CreateMountTargetRequest) (*Moun
 	}
 
 	id := "fsmt-" + uuid.NewString()[:8]
-	mtARN := arn.Build("elasticfilesystem", b.region, b.accountID, "mount-target/"+id)
+	mtARN := arn.Build("elasticfilesystem", region, b.accountID, "mount-target/"+id)
 	eniID := "eni-" + uuid.NewString()[:8]
 
 	sgs := make([]string, len(req.SecurityGroups))
@@ -746,8 +887,8 @@ func (b *InMemoryBackend) CreateMountTarget(req CreateMountTargetRequest) (*Moun
 		OwnerID:            b.accountID,
 		SecurityGroups:     sgs,
 	}
-	b.mountTargets[id] = mt
-	b.mountTargetsByARN[mtARN] = mt
+	mountTargets[id] = mt
+	b.mtARNStore(region)[mtARN] = mt
 	fs.NumberOfMountTargets++
 
 	cp := *mt
@@ -793,13 +934,16 @@ func describeByIDOrFilter[T any](
 
 // DescribeMountTargets returns mount targets, optionally filtered by file system ID or mount target ID.
 func (b *InMemoryBackend) DescribeMountTargets(
+	ctx context.Context,
 	fileSystemID, mountTargetID, marker string, maxItems int,
 ) ([]*MountTarget, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeMountTargets")
 	defer b.mu.RUnlock()
 
 	return describeByIDOrFilter(
-		b.mountTargets, mountTargetID, ErrMountTargetNotFound,
+		b.mtStore(region), mountTargetID, ErrMountTargetNotFound,
 		fileSystemID,
 		func(mt *MountTarget) string { return mt.FileSystemID },
 		copyMountTarget,
@@ -817,43 +961,51 @@ func copyMountTarget(mt *MountTarget) *MountTarget {
 }
 
 // DeleteMountTarget deletes a mount target by ID.
-func (b *InMemoryBackend) DeleteMountTarget(mountTargetID string) error {
+func (b *InMemoryBackend) DeleteMountTarget(ctx context.Context, mountTargetID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteMountTarget")
 	defer b.mu.Unlock()
 
-	mt, ok := b.mountTargets[mountTargetID]
+	mountTargets := b.mtStore(region)
+	mt, ok := mountTargets[mountTargetID]
 	if !ok {
 		return fmt.Errorf("%w: mount target %s not found", ErrMountTargetNotFound, mountTargetID)
 	}
-	if fs, found := b.fileSystems[mt.FileSystemID]; found {
+	if fs, found := b.fsStore(region)[mt.FileSystemID]; found {
 		fs.NumberOfMountTargets--
 	}
-	delete(b.mountTargetsByARN, mt.MountTargetArn)
-	delete(b.mountTargets, mountTargetID)
+	delete(b.mtARNStore(region), mt.MountTargetArn)
+	delete(mountTargets, mountTargetID)
 
 	return nil
 }
 
 // CreateAccessPoint creates an access point for a file system.
 // Supports ClientToken idempotency.
-func (b *InMemoryBackend) CreateAccessPoint(req CreateAccessPointRequest) (*AccessPoint, error) {
+func (b *InMemoryBackend) CreateAccessPoint(
+	ctx context.Context,
+	req CreateAccessPointRequest,
+) (*AccessPoint, error) {
 	if err := validateTags(req.Tags); err != nil {
 		return nil, err
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.Lock("CreateAccessPoint")
 	defer b.mu.Unlock()
 
 	// ClientToken idempotency.
 	if req.ClientToken != "" {
-		if existing, ok := b.accessPointsByClientToken[req.ClientToken]; ok {
+		if existing, ok := b.apClientTokenStore(region)[req.ClientToken]; ok {
 			cp := copyAccessPoint(existing)
 
 			return cp, nil
 		}
 	}
 
-	if _, ok := b.fileSystems[req.FileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[req.FileSystemID]; !ok {
 		return nil, fmt.Errorf("%w: file system %s not found", ErrNotFound, req.FileSystemID)
 	}
 
@@ -868,7 +1020,7 @@ func (b *InMemoryBackend) CreateAccessPoint(req CreateAccessPointRequest) (*Acce
 	}
 
 	id := "fsap-" + uuid.NewString()[:8]
-	apARN := arn.Build("elasticfilesystem", b.region, b.accountID, "access-point/"+id)
+	apARN := arn.Build("elasticfilesystem", region, b.accountID, "access-point/"+id)
 	t := tags.New("efs.accesspoint." + id + ".tags")
 
 	tagCopy := make(map[string]string, len(req.Tags))
@@ -891,10 +1043,10 @@ func (b *InMemoryBackend) CreateAccessPoint(req CreateAccessPointRequest) (*Acce
 		RootDirectory:  req.RootDirectory,
 		OwnerID:        b.accountID,
 	}
-	b.accessPoints[id] = ap
-	b.accessPointsByARN[apARN] = ap
+	b.apStore(region)[id] = ap
+	b.apARNStore(region)[apARN] = ap
 	if req.ClientToken != "" {
-		b.accessPointsByClientToken[req.ClientToken] = ap
+		b.apClientTokenStore(region)[req.ClientToken] = ap
 	}
 	cp := copyAccessPoint(ap)
 
@@ -927,13 +1079,16 @@ func copyAccessPoint(ap *AccessPoint) *AccessPoint {
 
 // DescribeAccessPoints returns access points, optionally filtered by file system ID or access point ID.
 func (b *InMemoryBackend) DescribeAccessPoints(
+	ctx context.Context,
 	fileSystemID, accessPointID, marker string, maxItems int,
 ) ([]*AccessPoint, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeAccessPoints")
 	defer b.mu.RUnlock()
 
 	return describeByIDOrFilter(
-		b.accessPoints, accessPointID, ErrAccessPointNotFound,
+		b.apStore(region), accessPointID, ErrAccessPointNotFound,
 		fileSystemID,
 		func(ap *AccessPoint) string { return ap.FileSystemID },
 		copyAccessPoint,
@@ -943,36 +1098,42 @@ func (b *InMemoryBackend) DescribeAccessPoints(
 }
 
 // DeleteAccessPoint deletes an access point by ID.
-func (b *InMemoryBackend) DeleteAccessPoint(accessPointID string) error {
+func (b *InMemoryBackend) DeleteAccessPoint(ctx context.Context, accessPointID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteAccessPoint")
 	defer b.mu.Unlock()
 
-	ap, ok := b.accessPoints[accessPointID]
+	accessPoints := b.apStore(region)
+	ap, ok := accessPoints[accessPointID]
 	if !ok {
 		return fmt.Errorf("%w: access point %s not found", ErrAccessPointNotFound, accessPointID)
 	}
-	delete(b.accessPointsByARN, ap.AccessPointArn)
+	delete(b.apARNStore(region), ap.AccessPointArn)
 	if ap.ClientToken != "" {
-		delete(b.accessPointsByClientToken, ap.ClientToken)
+		delete(b.apClientTokenStore(region), ap.ClientToken)
 	}
 	ap.Tags.Close()
-	delete(b.accessPoints, accessPointID)
+	delete(accessPoints, accessPointID)
 
 	return nil
 }
 
 // DescribeLifecycleConfiguration returns lifecycle policies for a file system.
 func (b *InMemoryBackend) DescribeLifecycleConfiguration(
+	ctx context.Context,
 	fileSystemID string,
 ) ([]LifecyclePolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeLifecycleConfiguration")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return nil, fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
-	policies := b.lifecyclePolicies[fileSystemID]
+	policies := b.lifecycleStore(region)[fileSystemID]
 	if policies == nil {
 		return []LifecyclePolicy{}, nil
 	}
@@ -1018,6 +1179,7 @@ func validateLifecyclePolicies(policies []LifecyclePolicy) error {
 
 // PutLifecycleConfiguration sets lifecycle policies for a file system.
 func (b *InMemoryBackend) PutLifecycleConfiguration(
+	ctx context.Context,
 	fileSystemID string,
 	policies []LifecyclePolicy,
 ) ([]LifecyclePolicy, error) {
@@ -1025,16 +1187,18 @@ func (b *InMemoryBackend) PutLifecycleConfiguration(
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutLifecycleConfiguration")
 	defer b.mu.Unlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return nil, fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
 	stored := make([]LifecyclePolicy, len(policies))
 	copy(stored, policies)
-	b.lifecyclePolicies[fileSystemID] = stored
+	b.lifecycleStore(region)[fileSystemID] = stored
 
 	result := make([]LifecyclePolicy, len(stored))
 	copy(result, stored)
@@ -1044,6 +1208,7 @@ func (b *InMemoryBackend) PutLifecycleConfiguration(
 
 // CreateReplicationConfiguration creates a replication configuration for a file system.
 func (b *InMemoryBackend) CreateReplicationConfiguration(
+	ctx context.Context,
 	sourceFileSystemID string,
 	destinations []ReplicationDestination,
 ) (*ReplicationConfiguration, error) {
@@ -1056,15 +1221,19 @@ func (b *InMemoryBackend) CreateReplicationConfiguration(
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateReplicationConfiguration")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[sourceFileSystemID]
+	replicationConfigs := b.replicationStore(region)
+
+	fs, ok := b.fsStore(region)[sourceFileSystemID]
 	if !ok {
 		return nil, fmt.Errorf("%w: file system %s not found", ErrNotFound, sourceFileSystemID)
 	}
 
-	if _, exists := b.replicationConfigs[sourceFileSystemID]; exists {
+	if _, exists := replicationConfigs[sourceFileSystemID]; exists {
 		return nil, fmt.Errorf(
 			"%w: replication configuration already exists for file system %s",
 			ErrAlreadyExists,
@@ -1084,11 +1253,11 @@ func (b *InMemoryBackend) CreateReplicationConfiguration(
 		OriginalSourceFileSystemARN: fs.FileSystemArn,
 		SourceFileSystemARN:         fs.FileSystemArn,
 		SourceFileSystemID:          sourceFileSystemID,
-		SourceFileSystemRegion:      b.region,
+		SourceFileSystemRegion:      region,
 		CreationTime:                time.Now().UTC().Unix(),
 		Destinations:                dests,
 	}
-	b.replicationConfigs[sourceFileSystemID] = rc
+	replicationConfigs[sourceFileSystemID] = rc
 
 	// Mark source file system as replicating.
 	fs.ReplicationOverwriteProtection = protectionReplicating
@@ -1103,15 +1272,22 @@ func (b *InMemoryBackend) CreateReplicationConfiguration(
 // DeleteReplicationConfiguration deletes the replication configuration for a file system.
 // The destination file system (if tracked) becomes a standalone writable file system
 // with ReplicationOverwriteProtection set to ENABLED.
-func (b *InMemoryBackend) DeleteReplicationConfiguration(sourceFileSystemID string) error {
+func (b *InMemoryBackend) DeleteReplicationConfiguration(
+	ctx context.Context,
+	sourceFileSystemID string,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteReplicationConfiguration")
 	defer b.mu.Unlock()
 
-	if _, ok := b.fileSystems[sourceFileSystemID]; !ok {
+	fileSystems := b.fsStore(region)
+	if _, ok := fileSystems[sourceFileSystemID]; !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, sourceFileSystemID)
 	}
 
-	if _, exists := b.replicationConfigs[sourceFileSystemID]; !exists {
+	replicationConfigs := b.replicationStore(region)
+	if _, exists := replicationConfigs[sourceFileSystemID]; !exists {
 		return fmt.Errorf(
 			"%w: replication configuration not found for file system %s",
 			ErrNotFound,
@@ -1119,10 +1295,10 @@ func (b *InMemoryBackend) DeleteReplicationConfiguration(sourceFileSystemID stri
 		)
 	}
 
-	delete(b.replicationConfigs, sourceFileSystemID)
+	delete(replicationConfigs, sourceFileSystemID)
 
 	// Reset source protection to DISABLED.
-	if fs, ok := b.fileSystems[sourceFileSystemID]; ok {
+	if fs, ok := fileSystems[sourceFileSystemID]; ok {
 		fs.ReplicationOverwriteProtection = protectionDisabled
 	}
 
@@ -1131,13 +1307,18 @@ func (b *InMemoryBackend) DeleteReplicationConfiguration(sourceFileSystemID stri
 
 // DescribeReplicationConfigurations returns replication configurations, optionally filtered by file system ID.
 func (b *InMemoryBackend) DescribeReplicationConfigurations(
+	ctx context.Context,
 	fileSystemID string,
 ) ([]*ReplicationConfiguration, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeReplicationConfigurations")
 	defer b.mu.RUnlock()
 
+	replicationConfigs := b.replicationStore(region)
+
 	if fileSystemID != "" {
-		rc, ok := b.replicationConfigs[fileSystemID]
+		rc, ok := replicationConfigs[fileSystemID]
 		if !ok {
 			return []*ReplicationConfiguration{}, nil
 		}
@@ -1149,8 +1330,8 @@ func (b *InMemoryBackend) DescribeReplicationConfigurations(
 		return []*ReplicationConfiguration{&cp}, nil
 	}
 
-	list := make([]*ReplicationConfiguration, 0, len(b.replicationConfigs))
-	for _, rc := range b.replicationConfigs {
+	list := make([]*ReplicationConfiguration, 0, len(replicationConfigs))
+	for _, rc := range replicationConfigs {
 		cp := *rc
 		cp.Destinations = make([]ReplicationDestination, len(rc.Destinations))
 		copy(cp.Destinations, rc.Destinations)
@@ -1165,15 +1346,17 @@ func (b *InMemoryBackend) DescribeReplicationConfigurations(
 }
 
 // CreateTags adds tags to a file system (legacy operation, delegates to TagResource).
-func (b *InMemoryBackend) CreateTags(fileSystemID string, kv map[string]string) error {
+func (b *InMemoryBackend) CreateTags(ctx context.Context, fileSystemID string, kv map[string]string) error {
 	if err := validateTags(kv); err != nil {
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateTags")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[fileSystemID]
+	fs, ok := b.fsStore(region)[fileSystemID]
 	if !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
@@ -1184,11 +1367,13 @@ func (b *InMemoryBackend) CreateTags(fileSystemID string, kv map[string]string) 
 }
 
 // DeleteTags removes tags from a file system by key (legacy operation).
-func (b *InMemoryBackend) DeleteTags(fileSystemID string, tagKeys []string) error {
+func (b *InMemoryBackend) DeleteTags(ctx context.Context, fileSystemID string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteTags")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[fileSystemID]
+	fs, ok := b.fsStore(region)[fileSystemID]
 	if !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
@@ -1199,15 +1384,17 @@ func (b *InMemoryBackend) DeleteTags(fileSystemID string, tagKeys []string) erro
 }
 
 // DescribeFileSystemPolicy returns the resource-based policy for a file system.
-func (b *InMemoryBackend) DescribeFileSystemPolicy(fileSystemID string) (string, error) {
+func (b *InMemoryBackend) DescribeFileSystemPolicy(ctx context.Context, fileSystemID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeFileSystemPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return "", fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
-	policy, ok := b.fileSystemPolicies[fileSystemID]
+	policy, ok := b.fsPolicyStore(region)[fileSystemID]
 	if !ok {
 		return "", fmt.Errorf("%w: no policy found for file system %s", ErrPolicyNotFound, fileSystemID)
 	}
@@ -1216,15 +1403,17 @@ func (b *InMemoryBackend) DescribeFileSystemPolicy(fileSystemID string) (string,
 }
 
 // DeleteFileSystemPolicy removes the resource-based policy from a file system.
-func (b *InMemoryBackend) DeleteFileSystemPolicy(fileSystemID string) error {
+func (b *InMemoryBackend) DeleteFileSystemPolicy(ctx context.Context, fileSystemID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteFileSystemPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
-	delete(b.fileSystemPolicies, fileSystemID)
+	delete(b.fsPolicyStore(region), fileSystemID)
 
 	return nil
 }
@@ -1238,15 +1427,17 @@ func (b *InMemoryBackend) DescribeAccountPreferences() AccountPreferences {
 }
 
 // DescribeBackupPolicy returns the backup policy for a file system.
-func (b *InMemoryBackend) DescribeBackupPolicy(fileSystemID string) (string, error) {
+func (b *InMemoryBackend) DescribeBackupPolicy(ctx context.Context, fileSystemID string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeBackupPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return "", fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
-	status, ok := b.backupPolicies[fileSystemID]
+	status, ok := b.backupStore(region)[fileSystemID]
 	if !ok {
 		return backupStatusDisabled, nil
 	}
@@ -1256,12 +1447,15 @@ func (b *InMemoryBackend) DescribeBackupPolicy(fileSystemID string) (string, err
 
 // DescribeMountTargetSecurityGroups returns the security groups for a mount target.
 func (b *InMemoryBackend) DescribeMountTargetSecurityGroups(
+	ctx context.Context,
 	mountTargetID string,
 ) ([]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeMountTargetSecurityGroups")
 	defer b.mu.RUnlock()
 
-	mt, ok := b.mountTargets[mountTargetID]
+	mt, ok := b.mtStore(region)[mountTargetID]
 	if !ok {
 		return nil, fmt.Errorf(
 			"%w: mount target %s not found",
@@ -1282,7 +1476,7 @@ func (b *InMemoryBackend) DescribeMountTargetSecurityGroups(
 
 // PutBackupPolicy sets the backup policy status for a file system.
 // Valid values: ENABLED, ENABLING, DISABLED, DISABLING.
-func (b *InMemoryBackend) PutBackupPolicy(fileSystemID, status string) error {
+func (b *InMemoryBackend) PutBackupPolicy(ctx context.Context, fileSystemID, status string) error {
 	switch status {
 	case backupStatusEnabled, backupStatusEnabling, backupStatusDisabled, "DISABLING":
 		// valid
@@ -1294,21 +1488,23 @@ func (b *InMemoryBackend) PutBackupPolicy(fileSystemID, status string) error {
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutBackupPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
-	b.backupPolicies[fileSystemID] = status
+	b.backupStore(region)[fileSystemID] = status
 
 	return nil
 }
 
 // PutFileSystemPolicy sets the resource-based policy for a file system.
 // The policy must be valid JSON and no larger than 20 KB.
-func (b *InMemoryBackend) PutFileSystemPolicy(fileSystemID, policy string) error {
+func (b *InMemoryBackend) PutFileSystemPolicy(ctx context.Context, fileSystemID, policy string) error {
 	if !json.Valid([]byte(policy)) {
 		return fmt.Errorf("%w: FileSystemPolicy is not valid JSON", ErrValidation)
 	}
@@ -1321,14 +1517,16 @@ func (b *InMemoryBackend) PutFileSystemPolicy(fileSystemID, policy string) error
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutFileSystemPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.fileSystems[fileSystemID]; !ok {
+	if _, ok := b.fsStore(region)[fileSystemID]; !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
 
-	b.fileSystemPolicies[fileSystemID] = policy
+	b.fsPolicyStore(region)[fileSystemID] = policy
 
 	return nil
 }
@@ -1377,13 +1575,16 @@ func (b *InMemoryBackend) applyThroughputModeChange(
 // UpdateFileSystem updates throughput settings for a file system.
 // Enforces a 24-hour cooldown between throughput mode changes.
 func (b *InMemoryBackend) UpdateFileSystem(
+	ctx context.Context,
 	fileSystemID string,
 	req UpdateFileSystemRequest,
 ) (*FileSystem, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateFileSystem")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[fileSystemID]
+	fs, ok := b.fsStore(region)[fileSystemID]
 	if !ok {
 		return nil, fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
@@ -1419,6 +1620,7 @@ func (b *InMemoryBackend) UpdateFileSystem(
 // ModifyMountTargetSecurityGroups replaces the security groups for a mount target.
 // Enforces a maximum of 5 security groups.
 func (b *InMemoryBackend) ModifyMountTargetSecurityGroups(
+	ctx context.Context,
 	mountTargetID string,
 	securityGroups []string,
 ) error {
@@ -1431,10 +1633,12 @@ func (b *InMemoryBackend) ModifyMountTargetSecurityGroups(
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ModifyMountTargetSecurityGroups")
 	defer b.mu.Unlock()
 
-	mt, ok := b.mountTargets[mountTargetID]
+	mt, ok := b.mtStore(region)[mountTargetID]
 	if !ok {
 		return fmt.Errorf("%w: mount target %s not found", ErrMountTargetNotFound, mountTargetID)
 	}
@@ -1466,6 +1670,7 @@ func (b *InMemoryBackend) PutAccountPreferences(resourceIDType string) (AccountP
 
 // UpdateFileSystemProtection sets the replication overwrite protection for a file system.
 func (b *InMemoryBackend) UpdateFileSystemProtection(
+	ctx context.Context,
 	fileSystemID, replicationOverwriteProtection string,
 ) error {
 	switch replicationOverwriteProtection {
@@ -1479,10 +1684,12 @@ func (b *InMemoryBackend) UpdateFileSystemProtection(
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateFileSystemProtection")
 	defer b.mu.Unlock()
 
-	fs, ok := b.fileSystems[fileSystemID]
+	fs, ok := b.fsStore(region)[fileSystemID]
 	if !ok {
 		return fmt.Errorf("%w: file system %s not found", ErrNotFound, fileSystemID)
 	}
@@ -1525,13 +1732,31 @@ func paginate[T any](
 	return page, next, nil
 }
 
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
+}
+
 // AddFileSystemInternal inserts a pre-built FileSystem directly into the backend (test seed helper).
 func (b *InMemoryBackend) AddFileSystemInternal(fs *FileSystem) {
 	b.mu.Lock("AddFileSystemInternal")
 	defer b.mu.Unlock()
 
-	b.fileSystems[fs.FileSystemID] = fs
-	b.fileSystemsByARN[fs.FileSystemArn] = fs
+	region := fs.Region
+	if region == "" {
+		region = regionFromARN(fs.FileSystemArn, b.region)
+		fs.Region = region
+	}
+
+	b.fsStore(region)[fs.FileSystemID] = fs
+	b.fsARNStore(region)[fs.FileSystemArn] = fs
 }
 
 // AddMountTargetInternal inserts a pre-built MountTarget directly into the backend (test seed helper).
@@ -1539,8 +1764,9 @@ func (b *InMemoryBackend) AddMountTargetInternal(mt *MountTarget) {
 	b.mu.Lock("AddMountTargetInternal")
 	defer b.mu.Unlock()
 
-	b.mountTargets[mt.MountTargetID] = mt
-	b.mountTargetsByARN[mt.MountTargetArn] = mt
+	region := regionFromARN(mt.MountTargetArn, b.region)
+	b.mtStore(region)[mt.MountTargetID] = mt
+	b.mtARNStore(region)[mt.MountTargetArn] = mt
 }
 
 // AddAccessPointInternal inserts a pre-built AccessPoint directly into the backend (test seed helper).
@@ -1548,6 +1774,7 @@ func (b *InMemoryBackend) AddAccessPointInternal(ap *AccessPoint) {
 	b.mu.Lock("AddAccessPointInternal")
 	defer b.mu.Unlock()
 
-	b.accessPoints[ap.AccessPointID] = ap
-	b.accessPointsByARN[ap.AccessPointArn] = ap
+	region := regionFromARN(ap.AccessPointArn, b.region)
+	b.apStore(region)[ap.AccessPointID] = ap
+	b.apARNStore(region)[ap.AccessPointArn] = ap
 }

--- a/services/efs/export_test.go
+++ b/services/efs/export_test.go
@@ -1,59 +1,107 @@
 package efs
 
-// FileSystemCount returns the number of file systems stored in the backend. Used only in tests.
+// FileSystemCount returns the number of file systems stored in the backend
+// across all regions. Used only in tests.
 func FileSystemCount(b *InMemoryBackend) int {
 	b.mu.RLock("FileSystemCount")
 	defer b.mu.RUnlock()
 
-	return len(b.fileSystems)
+	total := 0
+	for _, regionFS := range b.fileSystems {
+		total += len(regionFS)
+	}
+
+	return total
 }
 
-// MountTargetCount returns the number of mount targets stored in the backend. Used only in tests.
+// MountTargetCount returns the number of mount targets stored in the backend
+// across all regions. Used only in tests.
 func MountTargetCount(b *InMemoryBackend) int {
 	b.mu.RLock("MountTargetCount")
 	defer b.mu.RUnlock()
 
-	return len(b.mountTargets)
+	total := 0
+	for _, regionMT := range b.mountTargets {
+		total += len(regionMT)
+	}
+
+	return total
 }
 
-// AccessPointCount returns the number of access points stored in the backend. Used only in tests.
+// AccessPointCount returns the number of access points stored in the backend
+// across all regions. Used only in tests.
 func AccessPointCount(b *InMemoryBackend) int {
 	b.mu.RLock("AccessPointCount")
 	defer b.mu.RUnlock()
 
-	return len(b.accessPoints)
+	total := 0
+	for _, regionAP := range b.accessPoints {
+		total += len(regionAP)
+	}
+
+	return total
 }
 
-// ReplicationConfigCount returns the number of replication configurations stored in the backend. Used only in tests.
+// ReplicationConfigCount returns the number of replication configurations stored
+// in the backend across all regions. Used only in tests.
 func ReplicationConfigCount(b *InMemoryBackend) int {
 	b.mu.RLock("ReplicationConfigCount")
 	defer b.mu.RUnlock()
 
-	return len(b.replicationConfigs)
+	total := 0
+	for _, regionRC := range b.replicationConfigs {
+		total += len(regionRC)
+	}
+
+	return total
 }
 
-// BackupPolicyCount returns the number of backup policies stored in the backend. Used only in tests.
+// BackupPolicyCount returns the number of backup policies stored in the backend
+// across all regions. Used only in tests.
 func BackupPolicyCount(b *InMemoryBackend) int {
 	b.mu.RLock("BackupPolicyCount")
 	defer b.mu.RUnlock()
 
-	return len(b.backupPolicies)
+	total := 0
+	for _, regionBP := range b.backupPolicies {
+		total += len(regionBP)
+	}
+
+	return total
 }
 
-// FileSystemPolicyCount returns the number of file system policies stored in the backend. Used only in tests.
+// FileSystemPolicyCount returns the number of file system policies stored in the
+// backend across all regions. Used only in tests.
 func FileSystemPolicyCount(b *InMemoryBackend) int {
 	b.mu.RLock("FileSystemPolicyCount")
 	defer b.mu.RUnlock()
 
-	return len(b.fileSystemPolicies)
+	total := 0
+	for _, regionFSP := range b.fileSystemPolicies {
+		total += len(regionFSP)
+	}
+
+	return total
 }
 
-// ARNIndexSize returns the total number of entries in all ARN indexes. Used only in tests.
+// ARNIndexSize returns the total number of entries in all ARN indexes across all
+// regions. Used only in tests.
 func ARNIndexSize(b *InMemoryBackend) int {
 	b.mu.RLock("ARNIndexSize")
 	defer b.mu.RUnlock()
 
-	return len(b.fileSystemsByARN) + len(b.mountTargetsByARN) + len(b.accessPointsByARN)
+	total := 0
+	for _, m := range b.fileSystemsByARN {
+		total += len(m)
+	}
+	for _, m := range b.mountTargetsByARN {
+		total += len(m)
+	}
+	for _, m := range b.accessPointsByARN {
+		total += len(m)
+	}
+
+	return total
 }
 
 // OpsCount returns the number of pre-built operation entries in the handler. Used only in tests.

--- a/services/efs/handler.go
+++ b/services/efs/handler.go
@@ -1,6 +1,7 @@
 package efs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
 	"github.com/blackbirdworks/gopherstack/pkgs/service"
 )
@@ -438,6 +440,14 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	}
 }
 
+// contextWithRegion returns the request context with the resolved AWS region attached
+// under regionContextKey so that backend operations are routed to the correct region.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
+}
+
 func (h *Handler) dispatch(c *echo.Context, route efsRoute, body []byte) error {
 	if ok, err := h.dispatchFileSystemOps(c, route, body); ok {
 		return err
@@ -451,10 +461,17 @@ func (h *Handler) dispatch(c *echo.Context, route efsRoute, body []byte) error {
 		return err
 	}
 
-	return c.JSON(http.StatusNotFound, errResp("UnsupportedOperation", "unknown operation: "+route.operation))
+	return c.JSON(
+		http.StatusNotFound,
+		errResp("UnsupportedOperation", "unknown operation: "+route.operation),
+	)
 }
 
-func (h *Handler) dispatchFileSystemOps(c *echo.Context, route efsRoute, body []byte) (bool, error) {
+func (h *Handler) dispatchFileSystemOps(
+	c *echo.Context,
+	route efsRoute,
+	body []byte,
+) (bool, error) {
 	switch route.operation {
 	case opCreateFileSystem:
 		return true, h.handleCreateFileSystem(c, body)
@@ -489,7 +506,11 @@ func (h *Handler) dispatchFileSystemOps(c *echo.Context, route efsRoute, body []
 	return false, nil
 }
 
-func (h *Handler) dispatchMountTargetAndAccessPointOps(c *echo.Context, route efsRoute, body []byte) (bool, error) {
+func (h *Handler) dispatchMountTargetAndAccessPointOps(
+	c *echo.Context,
+	route efsRoute,
+	body []byte,
+) (bool, error) {
 	switch route.operation {
 	case opCreateMountTarget:
 		return true, h.handleCreateMountTarget(c, body)
@@ -512,7 +533,11 @@ func (h *Handler) dispatchMountTargetAndAccessPointOps(c *echo.Context, route ef
 	return false, nil
 }
 
-func (h *Handler) dispatchTagAndMiscOps(c *echo.Context, route efsRoute, body []byte) (bool, error) {
+func (h *Handler) dispatchTagAndMiscOps(
+	c *echo.Context,
+	route efsRoute,
+	body []byte,
+) (bool, error) {
 	switch route.operation {
 	case opTagResource:
 		return true, h.handleTagResource(c, route.resource, body)
@@ -647,7 +672,7 @@ func (h *Handler) handleCreateFileSystem(c *echo.Context, body []byte) error {
 		Tags:                     tagsFromEntries(in.Tags),
 	}
 
-	fs, err := h.Backend.CreateFileSystem(req)
+	fs, err := h.Backend.CreateFileSystem(h.contextWithRegion(c), req)
 	if err != nil {
 		if errors.Is(err, ErrCreationTokenExists) {
 			// Identical token with identical args: return existing fs with 200 OK.
@@ -681,7 +706,9 @@ func (h *Handler) handleDescribeFileSystems(c *echo.Context, fileSystemID string
 	marker := c.Request().URL.Query().Get("Marker")
 	maxItems := queryInt(c, "MaxItems", defaultMaxItems)
 
-	fsList, nextMarker, err := h.Backend.DescribeFileSystems(fileSystemID, creationToken, marker, maxItems)
+	fsList, nextMarker, err := h.Backend.DescribeFileSystems(
+		h.contextWithRegion(c), fileSystemID, creationToken, marker, maxItems,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -702,7 +729,7 @@ func (h *Handler) handleDescribeFileSystems(c *echo.Context, fileSystemID string
 }
 
 func (h *Handler) handleDeleteFileSystem(c *echo.Context, fileSystemID string) error {
-	if err := h.Backend.DeleteFileSystem(fileSystemID); err != nil {
+	if err := h.Backend.DeleteFileSystem(h.contextWithRegion(c), fileSystemID); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -772,7 +799,7 @@ func (h *Handler) handleCreateMountTarget(c *echo.Context, body []byte) error {
 
 	req := CreateMountTargetRequest(in)
 
-	mt, err := h.Backend.CreateMountTarget(req)
+	mt, err := h.Backend.CreateMountTarget(h.contextWithRegion(c), req)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -786,7 +813,7 @@ func (h *Handler) handleCreateMountTarget(c *echo.Context, body []byte) error {
 func describeListResponse[T any](
 	c *echo.Context,
 	h *Handler,
-	listFn func(fsID, itemID, marker string, maxItems int) ([]*T, string, error),
+	listFn func(ctx context.Context, fsID, itemID, marker string, maxItems int) ([]*T, string, error),
 	toResp func(*T) map[string]any,
 	itemID, idQueryKey, markerKey, maxKey, respListKey, nextKey string,
 ) error {
@@ -798,7 +825,7 @@ func describeListResponse[T any](
 	marker := c.Request().URL.Query().Get(markerKey)
 	maxItems := queryInt(c, maxKey, defaultMaxItems)
 
-	results, nextMarker, err := listFn(fsID, itemID, marker, maxItems)
+	results, nextMarker, err := listFn(h.contextWithRegion(c), fsID, itemID, marker, maxItems)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -827,7 +854,7 @@ func (h *Handler) handleDescribeMountTargets(c *echo.Context, mountTargetID stri
 }
 
 func (h *Handler) handleDeleteMountTarget(c *echo.Context, mountTargetID string) error {
-	if err := h.Backend.DeleteMountTarget(mountTargetID); err != nil {
+	if err := h.Backend.DeleteMountTarget(h.contextWithRegion(c), mountTargetID); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -882,7 +909,7 @@ func (h *Handler) handleCreateAccessPoint(c *echo.Context, body []byte) error {
 		RootDirectory: in.RootDirectory,
 	}
 
-	ap, err := h.Backend.CreateAccessPoint(req)
+	ap, err := h.Backend.CreateAccessPoint(h.contextWithRegion(c), req)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -899,7 +926,7 @@ func (h *Handler) handleDescribeAccessPoints(c *echo.Context, accessPointID stri
 }
 
 func (h *Handler) handleDeleteAccessPoint(c *echo.Context, accessPointID string) error {
-	if err := h.Backend.DeleteAccessPoint(accessPointID); err != nil {
+	if err := h.Backend.DeleteAccessPoint(h.contextWithRegion(c), accessPointID); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -944,7 +971,7 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceID string, body []b
 	}
 
 	kv := tagsFromEntries(in.Tags)
-	if err := h.Backend.TagResource(resourceID, kv); err != nil {
+	if err := h.Backend.TagResource(h.contextWithRegion(c), resourceID, kv); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -952,7 +979,7 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceID string, body []b
 }
 
 func (h *Handler) handleListTagsForResource(c *echo.Context, resourceID string) error {
-	t, err := h.Backend.ListTagsForResource(resourceID)
+	t, err := h.Backend.ListTagsForResource(h.contextWithRegion(c), resourceID)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -969,7 +996,7 @@ type putLifecycleConfigBody struct {
 }
 
 func (h *Handler) handleDescribeLifecycleConfiguration(c *echo.Context, fileSystemID string) error {
-	policies, err := h.Backend.DescribeLifecycleConfiguration(fileSystemID)
+	policies, err := h.Backend.DescribeLifecycleConfiguration(h.contextWithRegion(c), fileSystemID)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -979,13 +1006,21 @@ func (h *Handler) handleDescribeLifecycleConfiguration(c *echo.Context, fileSyst
 	})
 }
 
-func (h *Handler) handlePutLifecycleConfiguration(c *echo.Context, fileSystemID string, body []byte) error {
+func (h *Handler) handlePutLifecycleConfiguration(
+	c *echo.Context,
+	fileSystemID string,
+	body []byte,
+) error {
 	var in putLifecycleConfigBody
 	if err := json.Unmarshal(body, &in); err != nil {
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
 	}
 
-	stored, err := h.Backend.PutLifecycleConfiguration(fileSystemID, in.LifecyclePolicies)
+	stored, err := h.Backend.PutLifecycleConfiguration(
+		h.contextWithRegion(c),
+		fileSystemID,
+		in.LifecyclePolicies,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1001,7 +1036,11 @@ type createReplicationConfigBody struct {
 	Destinations []ReplicationDestination `json:"Destinations"`
 }
 
-func (h *Handler) handleCreateReplicationConfiguration(c *echo.Context, fileSystemID string, body []byte) error {
+func (h *Handler) handleCreateReplicationConfiguration(
+	c *echo.Context,
+	fileSystemID string,
+	body []byte,
+) error {
 	var in createReplicationConfigBody
 	if err := json.Unmarshal(body, &in); err != nil {
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
@@ -1011,7 +1050,11 @@ func (h *Handler) handleCreateReplicationConfiguration(c *echo.Context, fileSyst
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "FileSystemId is required"))
 	}
 
-	rc, err := h.Backend.CreateReplicationConfiguration(fileSystemID, in.Destinations)
+	rc, err := h.Backend.CreateReplicationConfiguration(
+		h.contextWithRegion(c),
+		fileSystemID,
+		in.Destinations,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1020,7 +1063,7 @@ func (h *Handler) handleCreateReplicationConfiguration(c *echo.Context, fileSyst
 }
 
 func (h *Handler) handleDeleteReplicationConfiguration(c *echo.Context, fileSystemID string) error {
-	if err := h.Backend.DeleteReplicationConfiguration(fileSystemID); err != nil {
+	if err := h.Backend.DeleteReplicationConfiguration(h.contextWithRegion(c), fileSystemID); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1030,7 +1073,7 @@ func (h *Handler) handleDeleteReplicationConfiguration(c *echo.Context, fileSyst
 func (h *Handler) handleDescribeReplicationConfigurations(c *echo.Context) error {
 	fsID := c.Request().URL.Query().Get(keyFileSystemID)
 
-	rcs, err := h.Backend.DescribeReplicationConfigurations(fsID)
+	rcs, err := h.Backend.DescribeReplicationConfigurations(h.contextWithRegion(c), fsID)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1069,7 +1112,7 @@ func (h *Handler) handleCreateTags(c *echo.Context, fileSystemID string, body []
 	}
 
 	kv := tagsFromEntries(in.Tags)
-	if err := h.Backend.CreateTags(fileSystemID, kv); err != nil {
+	if err := h.Backend.CreateTags(h.contextWithRegion(c), fileSystemID, kv); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1086,7 +1129,7 @@ func (h *Handler) handleDeleteTags(c *echo.Context, fileSystemID string, body []
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
 	}
 
-	if err := h.Backend.DeleteTags(fileSystemID, in.TagKeys); err != nil {
+	if err := h.Backend.DeleteTags(h.contextWithRegion(c), fileSystemID, in.TagKeys); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1096,7 +1139,7 @@ func (h *Handler) handleDeleteTags(c *echo.Context, fileSystemID string, body []
 // --- FileSystem Policy handlers ---
 
 func (h *Handler) handleDescribeFileSystemPolicy(c *echo.Context, fileSystemID string) error {
-	policy, err := h.Backend.DescribeFileSystemPolicy(fileSystemID)
+	policy, err := h.Backend.DescribeFileSystemPolicy(h.contextWithRegion(c), fileSystemID)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1108,7 +1151,7 @@ func (h *Handler) handleDescribeFileSystemPolicy(c *echo.Context, fileSystemID s
 }
 
 func (h *Handler) handleDeleteFileSystemPolicy(c *echo.Context, fileSystemID string) error {
-	if err := h.Backend.DeleteFileSystemPolicy(fileSystemID); err != nil {
+	if err := h.Backend.DeleteFileSystemPolicy(h.contextWithRegion(c), fileSystemID); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1131,7 +1174,7 @@ func (h *Handler) handleDescribeAccountPreferences(c *echo.Context) error {
 // --- Backup Policy handler ---
 
 func (h *Handler) handleDescribeBackupPolicy(c *echo.Context, fileSystemID string) error {
-	status, err := h.Backend.DescribeBackupPolicy(fileSystemID)
+	status, err := h.Backend.DescribeBackupPolicy(h.contextWithRegion(c), fileSystemID)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1145,8 +1188,14 @@ func (h *Handler) handleDescribeBackupPolicy(c *echo.Context, fileSystemID strin
 
 // --- Mount Target Security Groups handler ---
 
-func (h *Handler) handleDescribeMountTargetSecurityGroups(c *echo.Context, mountTargetID string) error {
-	groups, err := h.Backend.DescribeMountTargetSecurityGroups(mountTargetID)
+func (h *Handler) handleDescribeMountTargetSecurityGroups(
+	c *echo.Context,
+	mountTargetID string,
+) error {
+	groups, err := h.Backend.DescribeMountTargetSecurityGroups(
+		h.contextWithRegion(c),
+		mountTargetID,
+	)
 	if err != nil {
 		return h.handleError(c, err)
 	}
@@ -1170,7 +1219,7 @@ func (h *Handler) handlePutBackupPolicy(c *echo.Context, fileSystemID string, bo
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
 	}
 
-	if err := h.Backend.PutBackupPolicy(fileSystemID, in.BackupPolicy.Status); err != nil {
+	if err := h.Backend.PutBackupPolicy(h.contextWithRegion(c), fileSystemID, in.BackupPolicy.Status); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1188,13 +1237,17 @@ type putFileSystemPolicyBody struct {
 	BypassPolicyLockoutSafetyCheck bool   `json:"BypassPolicyLockoutSafetyCheck"`
 }
 
-func (h *Handler) handlePutFileSystemPolicy(c *echo.Context, fileSystemID string, body []byte) error {
+func (h *Handler) handlePutFileSystemPolicy(
+	c *echo.Context,
+	fileSystemID string,
+	body []byte,
+) error {
 	var in putFileSystemPolicyBody
 	if err := json.Unmarshal(body, &in); err != nil {
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
 	}
 
-	if err := h.Backend.PutFileSystemPolicy(fileSystemID, in.Policy); err != nil {
+	if err := h.Backend.PutFileSystemPolicy(h.contextWithRegion(c), fileSystemID, in.Policy); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1208,7 +1261,7 @@ func (h *Handler) handlePutFileSystemPolicy(c *echo.Context, fileSystemID string
 
 func (h *Handler) handleUntagResource(c *echo.Context, resourceID string) error {
 	tagKeys := c.Request().URL.Query()["tagKeys"]
-	if err := h.Backend.UntagResource(resourceID, tagKeys); err != nil {
+	if err := h.Backend.UntagResource(h.contextWithRegion(c), resourceID, tagKeys); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1221,13 +1274,18 @@ type modifyMountTargetSGBody struct {
 	SecurityGroups []string `json:"SecurityGroups"`
 }
 
-func (h *Handler) handleModifyMountTargetSecurityGroups(c *echo.Context, mountTargetID string, body []byte) error {
+func (h *Handler) handleModifyMountTargetSecurityGroups(
+	c *echo.Context,
+	mountTargetID string,
+	body []byte,
+) error {
 	var in modifyMountTargetSGBody
 	if err := json.Unmarshal(body, &in); err != nil {
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
 	}
 
-	if err := h.Backend.ModifyMountTargetSecurityGroups(mountTargetID, in.SecurityGroups); err != nil {
+	ctx := h.contextWithRegion(c)
+	if err := h.Backend.ModifyMountTargetSecurityGroups(ctx, mountTargetID, in.SecurityGroups); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1267,13 +1325,19 @@ type updateFileSystemProtectionBody struct {
 	ReplicationOverwriteProtection string `json:"ReplicationOverwriteProtection"`
 }
 
-func (h *Handler) handleUpdateFileSystemProtection(c *echo.Context, fileSystemID string, body []byte) error {
+func (h *Handler) handleUpdateFileSystemProtection(
+	c *echo.Context,
+	fileSystemID string,
+	body []byte,
+) error {
 	var in updateFileSystemProtectionBody
 	if err := json.Unmarshal(body, &in); err != nil {
 		return c.JSON(http.StatusBadRequest, errResp("BadRequest", "invalid request body"))
 	}
 
-	if err := h.Backend.UpdateFileSystemProtection(fileSystemID, in.ReplicationOverwriteProtection); err != nil {
+	if err := h.Backend.UpdateFileSystemProtection(
+		h.contextWithRegion(c), fileSystemID, in.ReplicationOverwriteProtection,
+	); err != nil {
 		return h.handleError(c, err)
 	}
 
@@ -1297,7 +1361,7 @@ func (h *Handler) handleUpdateFileSystem(c *echo.Context, fileSystemID string, b
 
 	req := UpdateFileSystemRequest(in)
 
-	fs, err := h.Backend.UpdateFileSystem(fileSystemID, req)
+	fs, err := h.Backend.UpdateFileSystem(h.contextWithRegion(c), fileSystemID, req)
 	if err != nil {
 		return h.handleError(c, err)
 	}

--- a/services/efs/handler_audit2_test.go
+++ b/services/efs/handler_audit2_test.go
@@ -1,6 +1,7 @@
 package efs_test
 
 import (
+	"context"
 	"maps"
 	"net/http"
 	"strings"
@@ -48,9 +49,15 @@ func TestAudit2_CreationTokenMaxLength(t *testing.T) {
 			t.Parallel()
 
 			h := newRefinementHandler()
-			rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/file-systems", map[string]any{
-				"CreationToken": tt.token,
-			})
+			rec := doRESTRefinement(
+				t,
+				h,
+				http.MethodPost,
+				"/2015-02-01/file-systems",
+				map[string]any{
+					"CreationToken": tt.token,
+				},
+			)
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusBadRequest {
@@ -118,7 +125,7 @@ func TestAudit2_DescribeFileSystems_NotFound_Backend(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			_, _, err := b.DescribeFileSystems(tt.id, "", "", 0)
+			_, _, err := b.DescribeFileSystems(context.Background(), tt.id, "", "", 0)
 			require.ErrorIs(t, err, efs.ErrNotFound)
 		})
 	}
@@ -172,10 +179,13 @@ func TestAudit2_CreateTags_Validates(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(efs.CreateFileSystemRequest{CreationToken: "tags-" + tt.name})
+			fs, err := b.CreateFileSystem(
+				context.Background(),
+				efs.CreateFileSystemRequest{CreationToken: "tags-" + tt.name},
+			)
 			require.NoError(t, err)
 
-			err = b.CreateTags(fs.FileSystemID, tt.tags)
+			err = b.CreateTags(context.Background(), fs.FileSystemID, tt.tags)
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
 			} else {

--- a/services/efs/handler_batch2_audit_test.go
+++ b/services/efs/handler_batch2_audit_test.go
@@ -1,6 +1,7 @@
 package efs_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -52,9 +53,15 @@ func TestBatch2_DescribeFileSystems_CreationTokenFilter(t *testing.T) {
 
 			h := newRefinementHandler()
 			for _, tok := range tt.setupTokens {
-				rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/file-systems", map[string]any{
-					"CreationToken": tok,
-				})
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodPost,
+					"/2015-02-01/file-systems",
+					map[string]any{
+						"CreationToken": tok,
+					},
+				)
 				require.Equal(t, http.StatusCreated, rec.Code)
 			}
 
@@ -109,11 +116,14 @@ func TestBatch2_DescribeFileSystems_CreationTokenFilter_Backend(t *testing.T) {
 
 			b := newRefinementBackend()
 			for _, tok := range tt.setupTokens {
-				_, err := b.CreateFileSystem(efs.CreateFileSystemRequest{CreationToken: tok})
+				_, err := b.CreateFileSystem(
+					context.Background(),
+					efs.CreateFileSystemRequest{CreationToken: tok},
+				)
 				require.NoError(t, err)
 			}
 
-			list, _, err := b.DescribeFileSystems("", tt.token, "", 0)
+			list, _, err := b.DescribeFileSystems(context.Background(), "", tt.token, "", 0)
 			require.NoError(t, err)
 			assert.Len(t, list, tt.wantCount)
 
@@ -178,10 +188,13 @@ func TestBatch2_DescribeFileSystemPolicy_PolicyNotFound_Backend(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(efs.CreateFileSystemRequest{CreationToken: "policy-backend-" + tt.name})
+			fs, err := b.CreateFileSystem(
+				context.Background(),
+				efs.CreateFileSystemRequest{CreationToken: "policy-backend-" + tt.name},
+			)
 			require.NoError(t, err)
 
-			_, err = b.DescribeFileSystemPolicy(fs.FileSystemID)
+			_, err = b.DescribeFileSystemPolicy(context.Background(), fs.FileSystemID)
 			require.ErrorIs(t, err, efs.ErrPolicyNotFound)
 			require.NotErrorIs(t, err, efs.ErrNotFound)
 		})

--- a/services/efs/handler_refinement1_test.go
+++ b/services/efs/handler_refinement1_test.go
@@ -2,6 +2,7 @@ package efs_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -109,18 +110,21 @@ func TestRefinement1_Reset(t *testing.T) {
 		{
 			name: "resets_file_systems",
 			setup: func(b *efs.InMemoryBackend) {
-				_, err := b.CreateFileSystem(fsReq("t1"))
+				_, err := b.CreateFileSystem(context.Background(), fsReq("t1"))
 				require.NoError(t, err)
-				_, err = b.CreateFileSystem(fsReq("t2"))
+				_, err = b.CreateFileSystem(context.Background(), fsReq("t2"))
 				require.NoError(t, err)
 			},
 		},
 		{
 			name: "resets_mount_targets",
 			setup: func(b *efs.InMemoryBackend) {
-				fs, err := b.CreateFileSystem(fsReq("t1"))
+				fs, err := b.CreateFileSystem(context.Background(), fsReq("t1"))
 				require.NoError(t, err)
-				_, err = b.CreateMountTarget(mtReq(fs.FileSystemID, "subnet-1"))
+				_, err = b.CreateMountTarget(
+					context.Background(),
+					mtReq(fs.FileSystemID, "subnet-1"),
+				)
 				require.NoError(t, err)
 			},
 		},
@@ -234,7 +238,7 @@ func TestRefinement1_ErrValidation(t *testing.T) {
 		{
 			name: "bad_performance_mode",
 			perform: func(b *efs.InMemoryBackend) error {
-				_, err := b.CreateFileSystem(efs.CreateFileSystemRequest{
+				_, err := b.CreateFileSystem(context.Background(), efs.CreateFileSystemRequest{
 					CreationToken:   "tok",
 					PerformanceMode: "badMode",
 				})
@@ -245,7 +249,7 @@ func TestRefinement1_ErrValidation(t *testing.T) {
 		{
 			name: "bad_throughput_mode",
 			perform: func(b *efs.InMemoryBackend) error {
-				_, err := b.CreateFileSystem(efs.CreateFileSystemRequest{
+				_, err := b.CreateFileSystem(context.Background(), efs.CreateFileSystemRequest{
 					CreationToken:  "tok",
 					ThroughputMode: "badMode",
 				})
@@ -289,7 +293,7 @@ func TestRefinement1_PerformanceModeValidation(t *testing.T) {
 
 			b := newRefinementBackend()
 			token := "token-perf-" + tt.name + "-" + string(rune('a'+i))
-			_, err := b.CreateFileSystem(efs.CreateFileSystemRequest{
+			_, err := b.CreateFileSystem(context.Background(), efs.CreateFileSystemRequest{
 				CreationToken:   token,
 				PerformanceMode: tt.mode,
 			})
@@ -326,7 +330,7 @@ func TestRefinement1_ThroughputModeValidation(t *testing.T) {
 
 			b := newRefinementBackend()
 			token := "token-thru-" + tt.name + "-" + string(rune('a'+i))
-			_, err := b.CreateFileSystem(efs.CreateFileSystemRequest{
+			_, err := b.CreateFileSystem(context.Background(), efs.CreateFileSystemRequest{
 				CreationToken:            token,
 				ThroughputMode:           tt.mode,
 				ProvisionedThroughputMib: tt.provisionedThroughputMib,
@@ -353,7 +357,7 @@ func TestRefinement1_ARNIndexes(t *testing.T) {
 		{
 			name: "file_system_arn_indexed",
 			perform: func(b *efs.InMemoryBackend) (string, error) {
-				fs, err := b.CreateFileSystem(fsReq("tok-arn"))
+				fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-arn"))
 				if err != nil {
 					return "", err
 				}
@@ -365,11 +369,11 @@ func TestRefinement1_ARNIndexes(t *testing.T) {
 		{
 			name: "mount_target_arn_indexed",
 			perform: func(b *efs.InMemoryBackend) (string, error) {
-				fs, err := b.CreateFileSystem(fsReq("tok-mt-arn"))
+				fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-mt-arn"))
 				if err != nil {
 					return "", err
 				}
-				mt, err := b.CreateMountTarget(mtReq(fs.FileSystemID, "sn-1"))
+				mt, err := b.CreateMountTarget(context.Background(), mtReq(fs.FileSystemID, "sn-1"))
 				if err != nil {
 					return "", err
 				}
@@ -381,11 +385,11 @@ func TestRefinement1_ARNIndexes(t *testing.T) {
 		{
 			name: "access_point_arn_indexed",
 			perform: func(b *efs.InMemoryBackend) (string, error) {
-				fs, err := b.CreateFileSystem(fsReq("tok-ap-arn"))
+				fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-ap-arn"))
 				if err != nil {
 					return "", err
 				}
-				ap, err := b.CreateAccessPoint(apReq(fs.FileSystemID))
+				ap, err := b.CreateAccessPoint(context.Background(), apReq(fs.FileSystemID))
 				if err != nil {
 					return "", err
 				}
@@ -467,10 +471,16 @@ func TestRefinement1_SortedDescribeMountTargets(t *testing.T) {
 			fsID := createFS(t, h, "tok-mt-sort-"+tt.name)
 
 			for i := range tt.count {
-				rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/mount-targets", map[string]any{
-					"FileSystemId": fsID,
-					"SubnetId":     "sn-" + string(rune('a'+i)),
-				})
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodPost,
+					"/2015-02-01/mount-targets",
+					map[string]any{
+						"FileSystemId": fsID,
+						"SubnetId":     "sn-" + string(rune('a'+i)),
+					},
+				)
 				require.Equal(t, http.StatusOK, rec.Code)
 			}
 
@@ -510,9 +520,15 @@ func TestRefinement1_SortedDescribeAccessPoints(t *testing.T) {
 			fsID := createFS(t, h, "tok-ap-sort-"+tt.name)
 
 			for range tt.count {
-				rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/access-points", map[string]any{
-					"FileSystemId": fsID,
-				})
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodPost,
+					"/2015-02-01/access-points",
+					map[string]any{
+						"FileSystemId": fsID,
+					},
+				)
 				require.Equal(t, http.StatusOK, rec.Code)
 			}
 
@@ -602,37 +618,40 @@ func TestRefinement1_DeleteFileSystem_RequiresEmptyState(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-del-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-del-"+tt.name))
 			require.NoError(t, err)
 
 			var mtIDs []string
 			for i := range tt.numMTs {
-				mt, mtErr := b.CreateMountTarget(mtReq(fs.FileSystemID, "sn-"+string(rune('a'+i))))
+				mt, mtErr := b.CreateMountTarget(
+					context.Background(),
+					mtReq(fs.FileSystemID, "sn-"+string(rune('a'+i))),
+				)
 				require.NoError(t, mtErr)
 				mtIDs = append(mtIDs, mt.MountTargetID)
 			}
 
 			var apIDs []string
 			for range tt.numAPs {
-				ap, apErr := b.CreateAccessPoint(apReq(fs.FileSystemID))
+				ap, apErr := b.CreateAccessPoint(context.Background(), apReq(fs.FileSystemID))
 				require.NoError(t, apErr)
 				apIDs = append(apIDs, ap.AccessPointID)
 			}
 
 			// First delete attempt.
-			err = b.DeleteFileSystem(fs.FileSystemID)
+			err = b.DeleteFileSystem(context.Background(), fs.FileSystemID)
 			if tt.wantErrOnFull {
 				require.ErrorIs(t, err, efs.ErrFileSystemInUse)
 
 				// Clean up dependents and retry.
 				for _, mtID := range mtIDs {
-					require.NoError(t, b.DeleteMountTarget(mtID))
+					require.NoError(t, b.DeleteMountTarget(context.Background(), mtID))
 				}
 				for _, apID := range apIDs {
-					require.NoError(t, b.DeleteAccessPoint(apID))
+					require.NoError(t, b.DeleteAccessPoint(context.Background(), apID))
 				}
 
-				err = b.DeleteFileSystem(fs.FileSystemID)
+				err = b.DeleteFileSystem(context.Background(), fs.FileSystemID)
 				require.NoError(t, err)
 			} else {
 				require.NoError(t, err)
@@ -660,7 +679,7 @@ func TestRefinement1_DescribeFileSystems_FilterMiss_EmptyList(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			_, _, err := b.DescribeFileSystems(tt.id, "", "", 0)
+			_, _, err := b.DescribeFileSystems(context.Background(), tt.id, "", "", 0)
 			require.ErrorIs(t, err, efs.ErrNotFound)
 		})
 	}
@@ -675,7 +694,10 @@ func TestRefinement1_PutFileSystemPolicy(t *testing.T) {
 		policy string
 	}{
 		{name: "set_policy", policy: `{"Version":"2012-10-17","Statement":[]}`},
-		{name: "overwrite_policy", policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]}`},
+		{
+			name:   "overwrite_policy",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -811,7 +833,7 @@ func TestRefinement1_TagResource_ARNIndex(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-tag-arn-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-tag-arn-"+tt.name))
 			require.NoError(t, err)
 
 			resourceID := fs.FileSystemID
@@ -819,10 +841,10 @@ func TestRefinement1_TagResource_ARNIndex(t *testing.T) {
 				resourceID = fs.FileSystemArn
 			}
 
-			err = b.TagResource(resourceID, map[string]string{"env": "test"})
+			err = b.TagResource(context.Background(), resourceID, map[string]string{"env": "test"})
 			require.NoError(t, err)
 
-			tags, err := b.ListTagsForResource(resourceID)
+			tags, err := b.ListTagsForResource(context.Background(), resourceID)
 			require.NoError(t, err)
 			assert.Equal(t, "test", tags["env"])
 		})
@@ -907,24 +929,32 @@ func TestRefinement1_ExportCountHelpers(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-counts-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-counts-"+tt.name))
 			require.NoError(t, err)
 
-			_, err = b.CreateMountTarget(mtReq(fs.FileSystemID, "sn-1"))
+			_, err = b.CreateMountTarget(context.Background(), mtReq(fs.FileSystemID, "sn-1"))
 			require.NoError(t, err)
 
-			_, err = b.CreateAccessPoint(apReq(fs.FileSystemID))
+			_, err = b.CreateAccessPoint(context.Background(), apReq(fs.FileSystemID))
 			require.NoError(t, err)
 
-			_, err = b.CreateReplicationConfiguration(fs.FileSystemID, []efs.ReplicationDestination{
-				{Region: "us-west-2"},
-			})
+			_, err = b.CreateReplicationConfiguration(
+				context.Background(),
+				fs.FileSystemID,
+				[]efs.ReplicationDestination{
+					{Region: "us-west-2"},
+				},
+			)
 			require.NoError(t, err)
 
-			err = b.PutBackupPolicy(fs.FileSystemID, "ENABLED")
+			err = b.PutBackupPolicy(context.Background(), fs.FileSystemID, "ENABLED")
 			require.NoError(t, err)
 
-			err = b.PutFileSystemPolicy(fs.FileSystemID, `{"Version":"2012-10-17"}`)
+			err = b.PutFileSystemPolicy(
+				context.Background(),
+				fs.FileSystemID,
+				`{"Version":"2012-10-17"}`,
+			)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantFS, efs.FileSystemCount(b))
@@ -955,13 +985,13 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-persist-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-persist-"+tt.name))
 			require.NoError(t, err)
 
-			_, err = b.CreateMountTarget(mtReq(fs.FileSystemID, "sn-1"))
+			_, err = b.CreateMountTarget(context.Background(), mtReq(fs.FileSystemID, "sn-1"))
 			require.NoError(t, err)
 
-			_, err = b.CreateAccessPoint(apReq(fs.FileSystemID))
+			_, err = b.CreateAccessPoint(context.Background(), apReq(fs.FileSystemID))
 			require.NoError(t, err)
 
 			snap := b.Snapshot()

--- a/services/efs/handler_refinement2_test.go
+++ b/services/efs/handler_refinement2_test.go
@@ -1,6 +1,7 @@
 package efs_test
 
 import (
+	"context"
 	"maps"
 	"net/http"
 	"testing"
@@ -26,15 +27,24 @@ func TestRefinement2_CreationTokenIdempotency(t *testing.T) {
 		wantSameFS bool
 	}{
 		{
-			name:       "identical_token_and_mode_returns_existing",
-			first:      efs.CreateFileSystemRequest{CreationToken: "tok", ThroughputMode: "bursting"},
-			second:     efs.CreateFileSystemRequest{CreationToken: "tok", ThroughputMode: "bursting"},
+			name: "identical_token_and_mode_returns_existing",
+			first: efs.CreateFileSystemRequest{
+				CreationToken:  "tok",
+				ThroughputMode: "bursting",
+			},
+			second: efs.CreateFileSystemRequest{
+				CreationToken:  "tok",
+				ThroughputMode: "bursting",
+			},
 			wantErrIs:  efs.ErrCreationTokenExists,
 			wantSameFS: true,
 		},
 		{
-			name:      "same_token_different_perf_mode_returns_conflict",
-			first:     efs.CreateFileSystemRequest{CreationToken: "tok2", PerformanceMode: "generalPurpose"},
+			name: "same_token_different_perf_mode_returns_conflict",
+			first: efs.CreateFileSystemRequest{
+				CreationToken:   "tok2",
+				PerformanceMode: "generalPurpose",
+			},
 			second:    efs.CreateFileSystemRequest{CreationToken: "tok2", PerformanceMode: "maxIO"},
 			wantErrIs: efs.ErrAlreadyExists,
 		},
@@ -57,10 +67,10 @@ func TestRefinement2_CreationTokenIdempotency(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs1, err := b.CreateFileSystem(tt.first)
+			fs1, err := b.CreateFileSystem(context.Background(), tt.first)
 			require.NoError(t, err)
 
-			fs2, err2 := b.CreateFileSystem(tt.second)
+			fs2, err2 := b.CreateFileSystem(context.Background(), tt.second)
 			require.ErrorIs(t, err2, tt.wantErrIs)
 
 			if tt.wantSameFS {
@@ -90,8 +100,11 @@ func TestRefinement2_CreationTokenIdempotency_HTTP(t *testing.T) {
 			wantSecond: http.StatusOK,
 		},
 		{
-			name:       "different_perf_mode_returns_409",
-			first:      map[string]any{"CreationToken": "http-tok2", "PerformanceMode": "generalPurpose"},
+			name: "different_perf_mode_returns_409",
+			first: map[string]any{
+				"CreationToken":   "http-tok2",
+				"PerformanceMode": "generalPurpose",
+			},
 			second:     map[string]any{"CreationToken": "http-tok2", "PerformanceMode": "maxIO"},
 			wantFirst:  http.StatusCreated,
 			wantSecond: http.StatusConflict,
@@ -187,7 +200,7 @@ func TestRefinement2_ProvisionedThroughput(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(tt.req)
+			fs, err := b.CreateFileSystem(context.Background(), tt.req)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -242,7 +255,12 @@ func TestRefinement2_ProvisionedThroughput_InResponse(t *testing.T) {
 			assert.Equal(t, tt.wantInResp, hasField)
 
 			if tt.wantInResp {
-				assert.InDelta(t, tt.wantMibps, resp["ProvisionedThroughputInMibps"].(float64), 0.001)
+				assert.InDelta(
+					t,
+					tt.wantMibps,
+					resp["ProvisionedThroughputInMibps"].(float64),
+					0.001,
+				)
 			}
 		})
 	}
@@ -303,7 +321,7 @@ func TestRefinement2_KmsKeyId(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(tt.req)
+			fs, err := b.CreateFileSystem(context.Background(), tt.req)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -407,11 +425,17 @@ func TestRefinement2_MountTargetFields(t *testing.T) {
 			h := newRefinementHandler()
 			fsID := createFS(t, h, "tok-mt-fields-"+tt.name)
 
-			rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/mount-targets", map[string]any{
-				"FileSystemId": fsID,
-				"SubnetId":     "subnet-12345",
-				"IpAddress":    "10.0.1.5",
-			})
+			rec := doRESTRefinement(
+				t,
+				h,
+				http.MethodPost,
+				"/2015-02-01/mount-targets",
+				map[string]any{
+					"FileSystemId": fsID,
+					"SubnetId":     "subnet-12345",
+					"IpAddress":    "10.0.1.5",
+				},
+			)
 			require.Equal(t, http.StatusOK, rec.Code)
 
 			resp := parseRefinementResp(t, rec)
@@ -522,10 +546,16 @@ func TestRefinement2_ModifyMountTargetSecurityGroups_MaxQuota(t *testing.T) {
 			h := newRefinementHandler()
 			fsID := createFS(t, h, "tok-mtsgs-"+tt.name)
 
-			mtRec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/mount-targets", map[string]any{
-				"FileSystemId": fsID,
-				"SubnetId":     "subnet-abc",
-			})
+			mtRec := doRESTRefinement(
+				t,
+				h,
+				http.MethodPost,
+				"/2015-02-01/mount-targets",
+				map[string]any{
+					"FileSystemId": fsID,
+					"SubnetId":     "subnet-abc",
+				},
+			)
 			require.Equal(t, http.StatusOK, mtRec.Code)
 			mtID := parseRefinementResp(t, mtRec)["MountTargetId"].(string)
 
@@ -569,10 +599,16 @@ func TestRefinement2_MountTargetConflict(t *testing.T) {
 
 			var lastCode int
 			for _, sn := range tt.subnets {
-				rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/mount-targets", map[string]any{
-					"FileSystemId": fsID,
-					"SubnetId":     sn,
-				})
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodPost,
+					"/2015-02-01/mount-targets",
+					map[string]any{
+						"FileSystemId": fsID,
+						"SubnetId":     sn,
+					},
+				)
 				lastCode = rec.Code
 			}
 			assert.Equal(t, tt.wantLast, lastCode)
@@ -609,10 +645,10 @@ func TestRefinement2_AccessPointPosixUser(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-ap-posix-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-ap-posix-"+tt.name))
 			require.NoError(t, err)
 
-			ap, err := b.CreateAccessPoint(efs.CreateAccessPointRequest{
+			ap, err := b.CreateAccessPoint(context.Background(), efs.CreateAccessPointRequest{
 				FileSystemID: fs.FileSystemID,
 				PosixUser:    tt.posixUser,
 			})
@@ -676,10 +712,10 @@ func TestRefinement2_AccessPointRootDirectory(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-ap-rd-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-ap-rd-"+tt.name))
 			require.NoError(t, err)
 
-			_, err = b.CreateAccessPoint(efs.CreateAccessPointRequest{
+			_, err = b.CreateAccessPoint(context.Background(), efs.CreateAccessPointRequest{
 				FileSystemID:  fs.FileSystemID,
 				RootDirectory: tt.rootDirectory,
 			})
@@ -719,16 +755,16 @@ func TestRefinement2_AccessPointClientTokenIdempotency(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-ap-ct-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-ap-ct-"+tt.name))
 			require.NoError(t, err)
 
-			ap1, err := b.CreateAccessPoint(efs.CreateAccessPointRequest{
+			ap1, err := b.CreateAccessPoint(context.Background(), efs.CreateAccessPointRequest{
 				FileSystemID: fs.FileSystemID,
 				ClientToken:  tt.clientToken,
 			})
 			require.NoError(t, err)
 
-			ap2, err := b.CreateAccessPoint(efs.CreateAccessPointRequest{
+			ap2, err := b.CreateAccessPoint(context.Background(), efs.CreateAccessPointRequest{
 				FileSystemID: fs.FileSystemID,
 				ClientToken:  tt.clientToken,
 			})
@@ -738,7 +774,13 @@ func TestRefinement2_AccessPointClientTokenIdempotency(t *testing.T) {
 				assert.Equal(t, ap1.AccessPointID, ap2.AccessPointID)
 				// Only one AP should exist.
 				var aps []*efs.AccessPoint
-				aps, _, err = b.DescribeAccessPoints(fs.FileSystemID, "", "", 0)
+				aps, _, err = b.DescribeAccessPoints(
+					context.Background(),
+					fs.FileSystemID,
+					"",
+					"",
+					0,
+				)
 				require.NoError(t, err)
 				assert.Len(t, aps, 1)
 			} else {
@@ -867,10 +909,14 @@ func TestRefinement2_LifecyclePolicyValidation(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-lp-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-lp-"+tt.name))
 			require.NoError(t, err)
 
-			_, err = b.PutLifecycleConfiguration(fs.FileSystemID, []efs.LifecyclePolicy{tt.policy})
+			_, err = b.PutLifecycleConfiguration(
+				context.Background(),
+				fs.FileSystemID,
+				[]efs.LifecyclePolicy{tt.policy},
+			)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -934,7 +980,12 @@ func TestRefinement2_BackupPolicyValidation(t *testing.T) {
 		{name: "enabling_valid", status: "ENABLING"},
 		{name: "disabling_valid", status: "DISABLING"},
 		{name: "empty_invalid", status: "", wantErr: true, wantErrIs: efs.ErrValidation},
-		{name: "unknown_status_invalid", status: "ACTIVE", wantErr: true, wantErrIs: efs.ErrValidation},
+		{
+			name:      "unknown_status_invalid",
+			status:    "ACTIVE",
+			wantErr:   true,
+			wantErrIs: efs.ErrValidation,
+		},
 	}
 
 	for _, tt := range tests {
@@ -942,10 +993,10 @@ func TestRefinement2_BackupPolicyValidation(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-bp-val-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-bp-val-"+tt.name))
 			require.NoError(t, err)
 
-			err = b.PutBackupPolicy(fs.FileSystemID, tt.status)
+			err = b.PutBackupPolicy(context.Background(), fs.FileSystemID, tt.status)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -991,10 +1042,10 @@ func TestRefinement2_FileSystemPolicyValidation(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-fsp-val-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-fsp-val-"+tt.name))
 			require.NoError(t, err)
 
-			err = b.PutFileSystemPolicy(fs.FileSystemID, tt.policy)
+			err = b.PutFileSystemPolicy(context.Background(), fs.FileSystemID, tt.policy)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -1044,16 +1095,28 @@ func TestRefinement2_DeleteFileSystem_FileSystemInUse(t *testing.T) {
 			fsID := createFS(t, h, "tok-del-inuse-"+tt.name)
 
 			if tt.createMT {
-				rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/mount-targets", map[string]any{
-					"FileSystemId": fsID,
-					"SubnetId":     "subnet-abc",
-				})
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodPost,
+					"/2015-02-01/mount-targets",
+					map[string]any{
+						"FileSystemId": fsID,
+						"SubnetId":     "subnet-abc",
+					},
+				)
 				require.Equal(t, http.StatusOK, rec.Code)
 			}
 			if tt.createAP {
-				rec := doRESTRefinement(t, h, http.MethodPost, "/2015-02-01/access-points", map[string]any{
-					"FileSystemId": fsID,
-				})
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodPost,
+					"/2015-02-01/access-points",
+					map[string]any{
+						"FileSystemId": fsID,
+					},
+				)
 				require.Equal(t, http.StatusOK, rec.Code)
 			}
 
@@ -1109,7 +1172,7 @@ func TestRefinement2_TagValidation(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			_, err := b.CreateFileSystem(efs.CreateFileSystemRequest{
+			_, err := b.CreateFileSystem(context.Background(), efs.CreateFileSystemRequest{
 				CreationToken: "tok-tagval-" + tt.name,
 				Tags:          tt.tags,
 			})
@@ -1150,10 +1213,10 @@ func TestRefinement2_TagValidation_TagResource(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-tagres-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-tagres-"+tt.name))
 			require.NoError(t, err)
 
-			err = b.TagResource(fs.FileSystemID, tt.tags)
+			err = b.TagResource(context.Background(), fs.FileSystemID, tt.tags)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -1219,7 +1282,13 @@ func TestRefinement2_ErrorBodyShape(t *testing.T) {
 					// noop, just to ensure rec is captured
 				}
 				_ = importJSON
-				rec := doRESTRefinement(t, h, http.MethodDelete, "/2015-02-01/file-systems/"+fsID, nil)
+				rec := doRESTRefinement(
+					t,
+					h,
+					http.MethodDelete,
+					"/2015-02-01/file-systems/"+fsID,
+					nil,
+				)
 				assert.Equal(t, tt.wantStatus, rec.Code)
 				assert.Equal(t, tt.wantErrorType, rec.Header().Get("X-Amzn-Errortype"))
 				_ = bodyBytes
@@ -1270,19 +1339,27 @@ func TestRefinement2_ThroughputCooldown(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-cooldown-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-cooldown-"+tt.name))
 			require.NoError(t, err)
 
 			// First throughput change.
-			_, err = b.UpdateFileSystem(fs.FileSystemID, efs.UpdateFileSystemRequest{
-				ThroughputMode: tt.firstMode,
-			})
+			_, err = b.UpdateFileSystem(
+				context.Background(),
+				fs.FileSystemID,
+				efs.UpdateFileSystemRequest{
+					ThroughputMode: tt.firstMode,
+				},
+			)
 			require.NoError(t, err)
 
 			if tt.secondMode != "" {
-				_, err = b.UpdateFileSystem(fs.FileSystemID, efs.UpdateFileSystemRequest{
-					ThroughputMode: tt.secondMode,
-				})
+				_, err = b.UpdateFileSystem(
+					context.Background(),
+					fs.FileSystemID,
+					efs.UpdateFileSystemRequest{
+						ThroughputMode: tt.secondMode,
+					},
+				)
 
 				if tt.wantSecondErr {
 					require.ErrorIs(t, err, tt.wantErrIs)
@@ -1329,11 +1406,20 @@ func TestRefinement2_DescribeFileSystems_Pagination(t *testing.T) {
 
 			b := newRefinementBackend()
 			for i := range tt.total {
-				_, err := b.CreateFileSystem(fsReq("tok-page-" + tt.name + "-" + string(rune('a'+i))))
+				_, err := b.CreateFileSystem(
+					context.Background(),
+					fsReq("tok-page-"+tt.name+"-"+string(rune('a'+i))),
+				)
 				require.NoError(t, err)
 			}
 
-			list, nextMarker, err := b.DescribeFileSystems("", "", "", tt.maxItems)
+			list, nextMarker, err := b.DescribeFileSystems(
+				context.Background(),
+				"",
+				"",
+				"",
+				tt.maxItems,
+			)
 			require.NoError(t, err)
 			assert.Len(t, list, tt.wantFirst)
 
@@ -1341,7 +1427,13 @@ func TestRefinement2_DescribeFileSystems_Pagination(t *testing.T) {
 				assert.NotEmpty(t, nextMarker)
 
 				// Fetch second page.
-				list2, _, err2 := b.DescribeFileSystems("", "", nextMarker, tt.maxItems)
+				list2, _, err2 := b.DescribeFileSystems(
+					context.Background(),
+					"",
+					"",
+					nextMarker,
+					tt.maxItems,
+				)
 				require.NoError(t, err2)
 				assert.NotEmpty(t, list2)
 			} else {
@@ -1383,15 +1475,24 @@ func TestRefinement2_DescribeMountTargets_Pagination(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-mt-page-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-mt-page-"+tt.name))
 			require.NoError(t, err)
 
 			for i := range tt.numMTs {
-				_, mtErr := b.CreateMountTarget(mtReq(fs.FileSystemID, "sn-"+string(rune('a'+i))))
+				_, mtErr := b.CreateMountTarget(
+					context.Background(),
+					mtReq(fs.FileSystemID, "sn-"+string(rune('a'+i))),
+				)
 				require.NoError(t, mtErr)
 			}
 
-			list, nextMarker, err := b.DescribeMountTargets(fs.FileSystemID, "", "", tt.maxItems)
+			list, nextMarker, err := b.DescribeMountTargets(
+				context.Background(),
+				fs.FileSystemID,
+				"",
+				"",
+				tt.maxItems,
+			)
 			require.NoError(t, err)
 			assert.Len(t, list, tt.wantFirst)
 
@@ -1436,15 +1537,21 @@ func TestRefinement2_DescribeAccessPoints_Pagination(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-ap-page-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-ap-page-"+tt.name))
 			require.NoError(t, err)
 
 			for range tt.numAPs {
-				_, apErr := b.CreateAccessPoint(apReq(fs.FileSystemID))
+				_, apErr := b.CreateAccessPoint(context.Background(), apReq(fs.FileSystemID))
 				require.NoError(t, apErr)
 			}
 
-			list, nextToken, err := b.DescribeAccessPoints(fs.FileSystemID, "", "", tt.maxItems)
+			list, nextToken, err := b.DescribeAccessPoints(
+				context.Background(),
+				fs.FileSystemID,
+				"",
+				"",
+				tt.maxItems,
+			)
 			require.NoError(t, err)
 			assert.Len(t, list, tt.wantFirst)
 
@@ -1478,26 +1585,30 @@ func TestRefinement2_DeleteReplication_ProtectionFlip(t *testing.T) {
 			t.Parallel()
 
 			b := newRefinementBackend()
-			fs, err := b.CreateFileSystem(fsReq("tok-repl-prot-" + tt.name))
+			fs, err := b.CreateFileSystem(context.Background(), fsReq("tok-repl-prot-"+tt.name))
 			require.NoError(t, err)
 
-			_, err = b.CreateReplicationConfiguration(fs.FileSystemID, []efs.ReplicationDestination{
-				{Region: "us-west-2", Status: "ENABLED"},
-			})
+			_, err = b.CreateReplicationConfiguration(
+				context.Background(),
+				fs.FileSystemID,
+				[]efs.ReplicationDestination{
+					{Region: "us-west-2", Status: "ENABLED"},
+				},
+			)
 			require.NoError(t, err)
 
 			// After create, source should be REPLICATING.
-			list, _, err := b.DescribeFileSystems(fs.FileSystemID, "", "", 0)
+			list, _, err := b.DescribeFileSystems(context.Background(), fs.FileSystemID, "", "", 0)
 			require.NoError(t, err)
 			require.Len(t, list, 1)
 			assert.Equal(t, "REPLICATING", list[0].ReplicationOverwriteProtection)
 
 			// Delete the replication config.
-			err = b.DeleteReplicationConfiguration(fs.FileSystemID)
+			err = b.DeleteReplicationConfiguration(context.Background(), fs.FileSystemID)
 			require.NoError(t, err)
 
 			// Source protection should revert.
-			list2, _, err := b.DescribeFileSystems(fs.FileSystemID, "", "", 0)
+			list2, _, err := b.DescribeFileSystems(context.Background(), fs.FileSystemID, "", "", 0)
 			require.NoError(t, err)
 			require.Len(t, list2, 1)
 			assert.Equal(t, tt.wantProtection, list2[0].ReplicationOverwriteProtection)
@@ -1606,7 +1717,7 @@ func TestRefinement2_UpdateFileSystem_ProvisionedThroughput(t *testing.T) {
 
 			b := newRefinementBackend()
 			// Create a provisioned FS so we can update its throughput.
-			fs, err := b.CreateFileSystem(efs.CreateFileSystemRequest{
+			fs, err := b.CreateFileSystem(context.Background(), efs.CreateFileSystemRequest{
 				CreationToken:            "tok-upd-tp-" + tt.name,
 				ThroughputMode:           "provisioned",
 				ProvisionedThroughputMib: 100,
@@ -1617,7 +1728,7 @@ func TestRefinement2_UpdateFileSystem_ProvisionedThroughput(t *testing.T) {
 			fs.LastThroughputChange = time.Time{}
 			b.AddFileSystemInternal(fs)
 
-			_, err = b.UpdateFileSystem(fs.FileSystemID, tt.updateReq)
+			_, err = b.UpdateFileSystem(context.Background(), fs.FileSystemID, tt.updateReq)
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, tt.wantErrIs)

--- a/services/efs/isolation_test.go
+++ b/services/efs/isolation_test.go
@@ -1,0 +1,171 @@
+package efs //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region, mirroring what the
+// handler injects from the SigV4-derived request region.
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestEFSRegionIsolation proves that same-named EFS resources created in two
+// different regions are fully isolated: separate stores, separate ARNs, and
+// operations in one region never observe or mutate the other.
+func TestEFSRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// 1. Create a file system with the same creation token in both regions.
+	eastFS, err := backend.CreateFileSystem(ctxEast, CreateFileSystemRequest{
+		CreationToken:   "shared-token",
+		Tags:            map[string]string{"Name": "shared"},
+		ThroughputMode:  throughputModeBursting,
+		PerformanceMode: performanceModeGeneral,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, eastFS.FileSystemArn, "us-east-1")
+	assert.Equal(t, "us-east-1", eastFS.Region)
+
+	westFS, err := backend.CreateFileSystem(ctxWest, CreateFileSystemRequest{
+		CreationToken:   "shared-token",
+		Tags:            map[string]string{"Name": "shared"},
+		ThroughputMode:  throughputModeElastic,
+		PerformanceMode: performanceModeGeneral,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, westFS.FileSystemArn, "us-west-2")
+	assert.Equal(t, "us-west-2", westFS.Region)
+
+	// The two file systems are distinct despite sharing a creation token.
+	assert.NotEqual(t, eastFS.FileSystemID, westFS.FileSystemID)
+
+	// 2. Each region sees only its own file system.
+	eastList, _, err := backend.DescribeFileSystems(ctxEast, "", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, eastFS.FileSystemID, eastList[0].FileSystemID)
+	assert.Equal(t, throughputModeBursting, eastList[0].ThroughputMode)
+
+	westList, _, err := backend.DescribeFileSystems(ctxWest, "", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, westList, 1)
+	assert.Equal(t, westFS.FileSystemID, westList[0].FileSystemID)
+	assert.Equal(t, throughputModeElastic, westList[0].ThroughputMode)
+
+	// 3. Looking up the west file system ID in the east region must fail.
+	_, _, err = backend.DescribeFileSystems(ctxEast, westFS.FileSystemID, "", "", 0)
+	require.Error(t, err)
+
+	// 4. Mount targets and access points are likewise isolated per region.
+	eastMT, err := backend.CreateMountTarget(ctxEast, CreateMountTargetRequest{
+		FileSystemID: eastFS.FileSystemID,
+		SubnetID:     "subnet-east",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, eastMT.MountTargetArn, "us-east-1")
+
+	westMT, err := backend.CreateMountTarget(ctxWest, CreateMountTargetRequest{
+		FileSystemID: westFS.FileSystemID,
+		SubnetID:     "subnet-west",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, westMT.MountTargetArn, "us-west-2")
+
+	eastMTs, _, err := backend.DescribeMountTargets(ctxEast, "", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, eastMTs, 1)
+	assert.Equal(t, eastMT.MountTargetID, eastMTs[0].MountTargetID)
+
+	westMTs, _, err := backend.DescribeMountTargets(ctxWest, "", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, westMTs, 1)
+	assert.Equal(t, westMT.MountTargetID, westMTs[0].MountTargetID)
+
+	// 5. Tagging via the cross-index (ARN) store only affects the owning region.
+	require.NoError(t, backend.TagResource(ctxEast, eastFS.FileSystemArn, map[string]string{"env": "east"}))
+
+	// The east ARN is unknown in the west region.
+	err = backend.TagResource(ctxWest, eastFS.FileSystemArn, map[string]string{"env": "west"})
+	require.Error(t, err)
+
+	eastTags, err := backend.ListTagsForResource(ctxEast, eastFS.FileSystemArn)
+	require.NoError(t, err)
+	assert.Equal(t, "east", eastTags["env"])
+
+	// 6. Deleting the east file system (after removing its mount target) leaves
+	//    the west region untouched.
+	require.NoError(t, backend.DeleteMountTarget(ctxEast, eastMT.MountTargetID))
+	require.NoError(t, backend.DeleteFileSystem(ctxEast, eastFS.FileSystemID))
+
+	eastAfter, _, err := backend.DescribeFileSystems(ctxEast, "", "", "", 0)
+	require.NoError(t, err)
+	assert.Empty(t, eastAfter)
+
+	westAfter, _, err := backend.DescribeFileSystems(ctxWest, "", "", "", 0)
+	require.NoError(t, err)
+	assert.Len(t, westAfter, 1)
+}
+
+// TestEFSAccessPointRegionIsolation proves access points (and their client-token
+// idempotency index) are isolated across regions.
+func TestEFSAccessPointRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	eastFS, err := backend.CreateFileSystem(ctxEast, CreateFileSystemRequest{CreationToken: "ap-east"})
+	require.NoError(t, err)
+
+	westFS, err := backend.CreateFileSystem(ctxWest, CreateFileSystemRequest{CreationToken: "ap-west"})
+	require.NoError(t, err)
+
+	// Same client token in both regions yields independent access points.
+	eastAP, err := backend.CreateAccessPoint(ctxEast, CreateAccessPointRequest{
+		FileSystemID: eastFS.FileSystemID,
+		ClientToken:  "tok",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, eastAP.AccessPointArn, "us-east-1")
+
+	westAP, err := backend.CreateAccessPoint(ctxWest, CreateAccessPointRequest{
+		FileSystemID: westFS.FileSystemID,
+		ClientToken:  "tok",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, westAP.AccessPointArn, "us-west-2")
+	assert.NotEqual(t, eastAP.AccessPointID, westAP.AccessPointID)
+
+	eastAPs, _, err := backend.DescribeAccessPoints(ctxEast, "", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, eastAPs, 1)
+	assert.Equal(t, eastAP.AccessPointID, eastAPs[0].AccessPointID)
+
+	westAPs, _, err := backend.DescribeAccessPoints(ctxWest, "", "", "", 0)
+	require.NoError(t, err)
+	require.Len(t, westAPs, 1)
+	assert.Equal(t, westAP.AccessPointID, westAPs[0].AccessPointID)
+
+	// Deleting the east access point does not affect the west one.
+	require.NoError(t, backend.DeleteAccessPoint(ctxEast, eastAP.AccessPointID))
+
+	eastAfter, _, err := backend.DescribeAccessPoints(ctxEast, "", "", "", 0)
+	require.NoError(t, err)
+	assert.Empty(t, eastAfter)
+
+	westAfter, _, err := backend.DescribeAccessPoints(ctxWest, "", "", "", 0)
+	require.NoError(t, err)
+	assert.Len(t, westAfter, 1)
+}

--- a/services/efs/persistence.go
+++ b/services/efs/persistence.go
@@ -7,39 +7,41 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
+// backendSnapshot serialises the backend state. All resource maps are nested by
+// region (outer key = region) so region isolation survives snapshot/restore.
 type backendSnapshot struct {
-	FileSystems        map[string]*FileSystem               `json:"fileSystems"`
-	MountTargets       map[string]*MountTarget              `json:"mountTargets"`
-	AccessPoints       map[string]*AccessPoint              `json:"accessPoints"`
-	LifecyclePolicies  map[string][]LifecyclePolicy         `json:"lifecyclePolicies"`
-	ReplicationConfigs map[string]*ReplicationConfiguration `json:"replicationConfigs"`
-	BackupPolicies     map[string]string                    `json:"backupPolicies"`
-	FileSystemPolicies map[string]string                    `json:"fileSystemPolicies"`
-	AccountID          string                               `json:"accountID"`
-	Region             string                               `json:"region"`
+	FileSystems        map[string]map[string]*FileSystem               `json:"fileSystems"`
+	MountTargets       map[string]map[string]*MountTarget              `json:"mountTargets"`
+	AccessPoints       map[string]map[string]*AccessPoint              `json:"accessPoints"`
+	LifecyclePolicies  map[string]map[string][]LifecyclePolicy         `json:"lifecyclePolicies"`
+	ReplicationConfigs map[string]map[string]*ReplicationConfiguration `json:"replicationConfigs"`
+	BackupPolicies     map[string]map[string]string                    `json:"backupPolicies"`
+	FileSystemPolicies map[string]map[string]string                    `json:"fileSystemPolicies"`
+	AccountID          string                                          `json:"accountID"`
+	Region             string                                          `json:"region"`
 }
 
 func (s *backendSnapshot) ensureNonNil() {
 	if s.FileSystems == nil {
-		s.FileSystems = make(map[string]*FileSystem)
+		s.FileSystems = make(map[string]map[string]*FileSystem)
 	}
 	if s.MountTargets == nil {
-		s.MountTargets = make(map[string]*MountTarget)
+		s.MountTargets = make(map[string]map[string]*MountTarget)
 	}
 	if s.AccessPoints == nil {
-		s.AccessPoints = make(map[string]*AccessPoint)
+		s.AccessPoints = make(map[string]map[string]*AccessPoint)
 	}
 	if s.LifecyclePolicies == nil {
-		s.LifecyclePolicies = make(map[string][]LifecyclePolicy)
+		s.LifecyclePolicies = make(map[string]map[string][]LifecyclePolicy)
 	}
 	if s.ReplicationConfigs == nil {
-		s.ReplicationConfigs = make(map[string]*ReplicationConfiguration)
+		s.ReplicationConfigs = make(map[string]map[string]*ReplicationConfiguration)
 	}
 	if s.BackupPolicies == nil {
-		s.BackupPolicies = make(map[string]string)
+		s.BackupPolicies = make(map[string]map[string]string)
 	}
 	if s.FileSystemPolicies == nil {
-		s.FileSystemPolicies = make(map[string]string)
+		s.FileSystemPolicies = make(map[string]map[string]string)
 	}
 }
 
@@ -98,34 +100,49 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	return nil
 }
 
-// rebuildARNIndexes reconstructs all ARN-keyed maps, client-token index, and reinitialises nil tag registries.
+// rebuildARNIndexes reconstructs all region-nested ARN-keyed maps, the client-token
+// index, and reinitialises nil tag registries.
 func (b *InMemoryBackend) rebuildARNIndexes() {
-	b.fileSystemsByARN = make(map[string]*FileSystem, len(b.fileSystems))
+	b.fileSystemsByARN = make(map[string]map[string]*FileSystem, len(b.fileSystems))
 
-	for _, fs := range b.fileSystems {
-		if fs.Tags == nil {
-			fs.Tags = tags.New("efs.filesystem." + fs.FileSystemID + ".tags")
+	for region, regionFS := range b.fileSystems {
+		arnIndex := make(map[string]*FileSystem, len(regionFS))
+		for _, fs := range regionFS {
+			if fs.Tags == nil {
+				fs.Tags = tags.New("efs.filesystem." + fs.FileSystemID + ".tags")
+			}
+			arnIndex[fs.FileSystemArn] = fs
 		}
-		b.fileSystemsByARN[fs.FileSystemArn] = fs
+		b.fileSystemsByARN[region] = arnIndex
 	}
 
-	b.mountTargetsByARN = make(map[string]*MountTarget, len(b.mountTargets))
+	b.mountTargetsByARN = make(map[string]map[string]*MountTarget, len(b.mountTargets))
 
-	for _, mt := range b.mountTargets {
-		b.mountTargetsByARN[mt.MountTargetArn] = mt
+	for region, regionMT := range b.mountTargets {
+		arnIndex := make(map[string]*MountTarget, len(regionMT))
+		for _, mt := range regionMT {
+			arnIndex[mt.MountTargetArn] = mt
+		}
+		b.mountTargetsByARN[region] = arnIndex
 	}
 
-	b.accessPointsByARN = make(map[string]*AccessPoint, len(b.accessPoints))
-	b.accessPointsByClientToken = make(map[string]*AccessPoint)
+	b.accessPointsByARN = make(map[string]map[string]*AccessPoint, len(b.accessPoints))
+	b.accessPointsByClientToken = make(map[string]map[string]*AccessPoint, len(b.accessPoints))
 
-	for _, ap := range b.accessPoints {
-		if ap.Tags == nil {
-			ap.Tags = tags.New("efs.accesspoint." + ap.AccessPointID + ".tags")
+	for region, regionAP := range b.accessPoints {
+		arnIndex := make(map[string]*AccessPoint, len(regionAP))
+		tokenIndex := make(map[string]*AccessPoint)
+		for _, ap := range regionAP {
+			if ap.Tags == nil {
+				ap.Tags = tags.New("efs.accesspoint." + ap.AccessPointID + ".tags")
+			}
+			arnIndex[ap.AccessPointArn] = ap
+			if ap.ClientToken != "" {
+				tokenIndex[ap.ClientToken] = ap
+			}
 		}
-		b.accessPointsByARN[ap.AccessPointArn] = ap
-		if ap.ClientToken != "" {
-			b.accessPointsByClientToken[ap.ClientToken] = ap
-		}
+		b.accessPointsByARN[region] = arnIndex
+		b.accessPointsByClientToken[region] = tokenIndex
 	}
 }
 

--- a/services/elasticsearch/backend.go
+++ b/services/elasticsearch/backend.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -12,6 +13,30 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
+}
 
 const (
 	statusActiveCap                = "Active"
@@ -183,18 +208,22 @@ type UpdateConfig struct {
 }
 
 // InMemoryBackend is the in-memory store for Elasticsearch domains.
+//
+// All resource maps are nested by region (outer key = region) so that same-named
+// resources in different regions are fully isolated. Elasticsearch resources are
+// region-scoped in AWS, so every map carries a region dimension.
 type InMemoryBackend struct {
 	dnsRegistrar        DNSRegistrar
-	domains             map[string]*Domain
-	arnIndex            map[string]string // ARN → domain name
-	packages            map[string]*Package
-	packagesByName      map[string]string   // package name → package ID
-	packageAssociations map[string][]string // package ID → []domain names
-	inboundConnections  map[string]*InboundConnection
-	outboundConnections map[string]*OutboundConnection
-	vpcEndpoints        map[string]*VpcEndpoint
-	vpcAccess           map[string][]string
-	reservedInstances   map[string]*ReservedInstance
+	domains             map[string]map[string]*Domain
+	arnIndex            map[string]map[string]string // region → ARN → domain name
+	packages            map[string]map[string]*Package
+	packagesByName      map[string]map[string]string   // region → package name → package ID
+	packageAssociations map[string]map[string][]string // region → package ID → []domain names
+	inboundConnections  map[string]map[string]*InboundConnection
+	outboundConnections map[string]map[string]*OutboundConnection
+	vpcEndpoints        map[string]map[string]*VpcEndpoint
+	vpcAccess           map[string]map[string][]string
+	reservedInstances   map[string]map[string]*ReservedInstance
 	mu                  *lockmetrics.RWMutex
 	accountID           string
 	region              string
@@ -204,20 +233,106 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		domains:             make(map[string]*Domain),
-		arnIndex:            make(map[string]string),
-		packages:            make(map[string]*Package),
-		packagesByName:      make(map[string]string),
-		packageAssociations: make(map[string][]string),
-		inboundConnections:  make(map[string]*InboundConnection),
-		outboundConnections: make(map[string]*OutboundConnection),
-		vpcEndpoints:        make(map[string]*VpcEndpoint),
-		vpcAccess:           make(map[string][]string),
-		reservedInstances:   make(map[string]*ReservedInstance),
+		domains:             make(map[string]map[string]*Domain),
+		arnIndex:            make(map[string]map[string]string),
+		packages:            make(map[string]map[string]*Package),
+		packagesByName:      make(map[string]map[string]string),
+		packageAssociations: make(map[string]map[string][]string),
+		inboundConnections:  make(map[string]map[string]*InboundConnection),
+		outboundConnections: make(map[string]map[string]*OutboundConnection),
+		vpcEndpoints:        make(map[string]map[string]*VpcEndpoint),
+		vpcAccess:           make(map[string]map[string][]string),
+		reservedInstances:   make(map[string]map[string]*ReservedInstance),
 		accountID:           accountID,
 		region:              region,
 		mu:                  lockmetrics.New("elasticsearch"),
 	}
+}
+
+// Region returns the backend's default AWS region.
+func (b *InMemoryBackend) Region() string { return b.region }
+
+// The following lazy per-region store helpers return the resource map for the
+// given region, creating it on first use. Callers must hold b.mu.
+
+func (b *InMemoryBackend) domainsStore(region string) map[string]*Domain {
+	if b.domains[region] == nil {
+		b.domains[region] = make(map[string]*Domain)
+	}
+
+	return b.domains[region]
+}
+
+func (b *InMemoryBackend) arnIndexStore(region string) map[string]string {
+	if b.arnIndex[region] == nil {
+		b.arnIndex[region] = make(map[string]string)
+	}
+
+	return b.arnIndex[region]
+}
+
+func (b *InMemoryBackend) packagesStore(region string) map[string]*Package {
+	if b.packages[region] == nil {
+		b.packages[region] = make(map[string]*Package)
+	}
+
+	return b.packages[region]
+}
+
+func (b *InMemoryBackend) packagesByNameStore(region string) map[string]string {
+	if b.packagesByName[region] == nil {
+		b.packagesByName[region] = make(map[string]string)
+	}
+
+	return b.packagesByName[region]
+}
+
+func (b *InMemoryBackend) packageAssociationsStore(region string) map[string][]string {
+	if b.packageAssociations[region] == nil {
+		b.packageAssociations[region] = make(map[string][]string)
+	}
+
+	return b.packageAssociations[region]
+}
+
+func (b *InMemoryBackend) inboundConnectionsStore(region string) map[string]*InboundConnection {
+	if b.inboundConnections[region] == nil {
+		b.inboundConnections[region] = make(map[string]*InboundConnection)
+	}
+
+	return b.inboundConnections[region]
+}
+
+func (b *InMemoryBackend) outboundConnectionsStore(region string) map[string]*OutboundConnection {
+	if b.outboundConnections[region] == nil {
+		b.outboundConnections[region] = make(map[string]*OutboundConnection)
+	}
+
+	return b.outboundConnections[region]
+}
+
+func (b *InMemoryBackend) vpcEndpointsStore(region string) map[string]*VpcEndpoint {
+	if b.vpcEndpoints[region] == nil {
+		b.vpcEndpoints[region] = make(map[string]*VpcEndpoint)
+	}
+
+	return b.vpcEndpoints[region]
+}
+
+func (b *InMemoryBackend) vpcAccessStore(region string) map[string][]string {
+	if b.vpcAccess[region] == nil {
+		b.vpcAccess[region] = make(map[string][]string)
+	}
+
+	return b.vpcAccess[region]
+}
+
+func (b *InMemoryBackend) reservedInstancesStore(region string) map[string]*ReservedInstance {
+	if b.reservedInstances[region] == nil {
+		b.reservedInstances[region] = make(map[string]*ReservedInstance)
+	}
+
+	return b.reservedInstances[region]
 }
 
 // SetDNSRegistrar wires a DNS server so Elasticsearch domain hostnames are auto-registered.
@@ -230,6 +345,7 @@ func (b *InMemoryBackend) SetDNSRegistrar(dns DNSRegistrar) {
 
 // CreateDomain creates a new Elasticsearch domain.
 func (b *InMemoryBackend) CreateDomain(
+	ctx context.Context,
 	name, esVersion string,
 	clusterConfig ClusterConfig,
 	ebsOpts EBSOptions,
@@ -245,10 +361,12 @@ func (b *InMemoryBackend) CreateDomain(
 		)
 	}
 
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDomain")
 	defer b.mu.Unlock()
 
-	if _, exists := b.domains[name]; exists {
+	domains := b.domainsStore(region)
+	if _, exists := domains[name]; exists {
 		return nil, fmt.Errorf("%w: domain %s already exists", ErrDomainAlreadyExists, name)
 	}
 
@@ -258,9 +376,9 @@ func (b *InMemoryBackend) CreateDomain(
 		return nil, fmt.Errorf("%w: invalid ElasticsearchVersion %q", ErrValidation, esVersion)
 	}
 
-	domainARN := arn.Build("es", b.region, b.accountID, "domain/"+name)
+	domainARN := arn.Build("es", region, b.accountID, "domain/"+name)
 	domainID := b.accountID + "/" + name
-	endpoint := fmt.Sprintf("search-%s-%s.%s.es.amazonaws.com", name, b.accountID, b.region)
+	endpoint := fmt.Sprintf("search-%s-%s.%s.es.amazonaws.com", name, b.accountID, region)
 
 	if clusterConfig.InstanceCount == 0 {
 		clusterConfig.InstanceCount = 1
@@ -279,10 +397,10 @@ func (b *InMemoryBackend) CreateDomain(
 		Status:               statusActiveCap,
 		ClusterConfig:        clusterConfig,
 		EBSOptions:           ebsOpts,
-		Tags:                 tags.New("elasticsearch." + name + ".tags"),
+		Tags:                 tags.New("elasticsearch." + region + "." + name + ".tags"),
 	}
-	b.domains[name] = d
-	b.arnIndex[domainARN] = name
+	domains[name] = d
+	b.arnIndexStore(region)[domainARN] = name
 
 	if b.dnsRegistrar != nil {
 		b.dnsRegistrar.Register(endpoint)
@@ -292,19 +410,21 @@ func (b *InMemoryBackend) CreateDomain(
 }
 
 // DeleteDomain removes a domain by name.
-func (b *InMemoryBackend) DeleteDomain(name string) (*Domain, error) {
+func (b *InMemoryBackend) DeleteDomain(ctx context.Context, name string) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDomain")
 	defer b.mu.Unlock()
 
-	d, exists := b.domains[name]
+	domains := b.domainsStore(region)
+	d, exists := domains[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, name)
 	}
 
 	cp := domainCopy(d)
 	d.Tags.Close()
-	delete(b.arnIndex, d.ARN)
-	delete(b.domains, name)
+	delete(b.arnIndexStore(region), d.ARN)
+	delete(domains, name)
 
 	if b.dnsRegistrar != nil {
 		b.dnsRegistrar.Deregister(cp.Endpoint)
@@ -314,11 +434,12 @@ func (b *InMemoryBackend) DeleteDomain(name string) (*Domain, error) {
 }
 
 // DescribeDomain returns details about a domain.
-func (b *InMemoryBackend) DescribeDomain(name string) (*Domain, error) {
+func (b *InMemoryBackend) DescribeDomain(ctx context.Context, name string) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDomain")
 	defer b.mu.RUnlock()
 
-	d, exists := b.domains[name]
+	d, exists := b.domainsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, name)
 	}
@@ -326,13 +447,15 @@ func (b *InMemoryBackend) DescribeDomain(name string) (*Domain, error) {
 	return domainCopy(d), nil
 }
 
-// ListDomainNames returns the sorted names of all domains.
-func (b *InMemoryBackend) ListDomainNames() []string {
+// ListDomainNames returns the sorted names of all domains in the request's region.
+func (b *InMemoryBackend) ListDomainNames(ctx context.Context) []string {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("ListDomainNames")
 	defer b.mu.RUnlock()
 
-	names := make([]string, 0, len(b.domains))
-	for name := range b.domains {
+	domains := b.domainsStore(region)
+	names := make([]string, 0, len(domains))
+	for name := range domains {
 		names = append(names, name)
 	}
 
@@ -342,11 +465,12 @@ func (b *InMemoryBackend) ListDomainNames() []string {
 }
 
 // UpdateDomainConfig updates the cluster configuration and/or EBS options for a domain.
-func (b *InMemoryBackend) UpdateDomainConfig(name string, cfg UpdateConfig) (*Domain, error) {
+func (b *InMemoryBackend) UpdateDomainConfig(ctx context.Context, name string, cfg UpdateConfig) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("UpdateDomainConfig")
 	defer b.mu.Unlock()
 
-	d, exists := b.domains[name]
+	d, exists := b.domainsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, name)
 	}
@@ -362,23 +486,25 @@ func (b *InMemoryBackend) UpdateDomainConfig(name string, cfg UpdateConfig) (*Do
 	return domainCopy(d), nil
 }
 
-// findDomainByARN returns the domain matching the given ARN, or nil if not found.
-// Caller must hold at least a read lock.
-func (b *InMemoryBackend) findDomainByARN(domainARN string) *Domain {
-	name, ok := b.arnIndex[domainARN]
+// findDomainByARN returns the domain matching the given ARN within the given
+// region, or nil if not found. Caller must hold at least a read lock.
+func (b *InMemoryBackend) findDomainByARN(region, domainARN string) *Domain {
+	name, ok := b.arnIndexStore(region)[domainARN]
 	if !ok {
 		return nil
 	}
 
-	return b.domains[name]
+	return b.domainsStore(region)[name]
 }
 
-// ListTags returns tags for the domain identified by ARN.
-func (b *InMemoryBackend) ListTags(domainARN string) (map[string]string, error) {
+// ListTags returns tags for the domain identified by ARN. The region is resolved
+// from the ARN, falling back to the ctx region.
+func (b *InMemoryBackend) ListTags(ctx context.Context, domainARN string) (map[string]string, error) {
+	region := regionFromARN(domainARN, getRegion(ctx, b.region))
 	b.mu.RLock("ListTags")
 	defer b.mu.RUnlock()
 
-	d := b.findDomainByARN(domainARN)
+	d := b.findDomainByARN(region, domainARN)
 	if d == nil {
 		return nil, fmt.Errorf("%w: domain not found for ARN %s", ErrDomainNotFound, domainARN)
 	}
@@ -387,11 +513,12 @@ func (b *InMemoryBackend) ListTags(domainARN string) (map[string]string, error) 
 }
 
 // AddTags adds or updates tags on the domain identified by ARN.
-func (b *InMemoryBackend) AddTags(domainARN string, kv map[string]string) error {
+func (b *InMemoryBackend) AddTags(ctx context.Context, domainARN string, kv map[string]string) error {
+	region := regionFromARN(domainARN, getRegion(ctx, b.region))
 	b.mu.Lock("AddTags")
 	defer b.mu.Unlock()
 
-	d := b.findDomainByARN(domainARN)
+	d := b.findDomainByARN(region, domainARN)
 	if d == nil {
 		return fmt.Errorf("%w: domain not found for ARN %s", ErrDomainNotFound, domainARN)
 	}
@@ -402,11 +529,12 @@ func (b *InMemoryBackend) AddTags(domainARN string, kv map[string]string) error 
 }
 
 // RemoveTags removes tag keys from the domain identified by ARN.
-func (b *InMemoryBackend) RemoveTags(domainARN string, keys []string) error {
+func (b *InMemoryBackend) RemoveTags(ctx context.Context, domainARN string, keys []string) error {
+	region := regionFromARN(domainARN, getRegion(ctx, b.region))
 	b.mu.Lock("RemoveTags")
 	defer b.mu.Unlock()
 
-	d := b.findDomainByARN(domainARN)
+	d := b.findDomainByARN(region, domainARN)
 	if d == nil {
 		return fmt.Errorf("%w: domain not found for ARN %s", ErrDomainNotFound, domainARN)
 	}
@@ -417,25 +545,27 @@ func (b *InMemoryBackend) RemoveTags(domainARN string, keys []string) error {
 }
 
 // Reset clears all in-memory state. It closes all domain Tags to release
-// Prometheus metrics before discarding the domain map.
+// Prometheus metrics before discarding the domain maps.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, d := range b.domains {
-		d.Tags.Close()
+	for _, regionDomains := range b.domains {
+		for _, d := range regionDomains {
+			d.Tags.Close()
+		}
 	}
 
-	b.domains = make(map[string]*Domain)
-	b.arnIndex = make(map[string]string)
-	b.packages = make(map[string]*Package)
-	b.packagesByName = make(map[string]string)
-	b.packageAssociations = make(map[string][]string)
-	b.inboundConnections = make(map[string]*InboundConnection)
-	b.outboundConnections = make(map[string]*OutboundConnection)
-	b.vpcEndpoints = make(map[string]*VpcEndpoint)
-	b.vpcAccess = make(map[string][]string)
-	b.reservedInstances = make(map[string]*ReservedInstance)
+	b.domains = make(map[string]map[string]*Domain)
+	b.arnIndex = make(map[string]map[string]string)
+	b.packages = make(map[string]map[string]*Package)
+	b.packagesByName = make(map[string]map[string]string)
+	b.packageAssociations = make(map[string]map[string][]string)
+	b.inboundConnections = make(map[string]map[string]*InboundConnection)
+	b.outboundConnections = make(map[string]map[string]*OutboundConnection)
+	b.vpcEndpoints = make(map[string]map[string]*VpcEndpoint)
+	b.vpcAccess = make(map[string]map[string][]string)
+	b.reservedInstances = make(map[string]map[string]*ReservedInstance)
 	b.nextID = 0
 }
 
@@ -448,7 +578,7 @@ func (b *InMemoryBackend) nextIDLocked() int {
 }
 
 // CreatePackage creates a new Elasticsearch package (e.g., a dictionary file).
-func (b *InMemoryBackend) CreatePackage(name, packageType, description string) (*Package, error) {
+func (b *InMemoryBackend) CreatePackage(ctx context.Context, name, packageType, description string) (*Package, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: PackageName is required", ErrValidation)
 	}
@@ -461,10 +591,12 @@ func (b *InMemoryBackend) CreatePackage(name, packageType, description string) (
 		)
 	}
 
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreatePackage")
 	defer b.mu.Unlock()
 
-	if _, exists := b.packagesByName[name]; exists {
+	packagesByName := b.packagesByNameStore(region)
+	if _, exists := packagesByName[name]; exists {
 		return nil, fmt.Errorf("%w: package %s already exists", ErrDomainAlreadyExists, name)
 	}
 
@@ -476,8 +608,8 @@ func (b *InMemoryBackend) CreatePackage(name, packageType, description string) (
 		Description: description,
 		Status:      "AVAILABLE",
 	}
-	b.packages[id] = pkg
-	b.packagesByName[name] = id
+	b.packagesStore(region)[id] = pkg
+	packagesByName[name] = id
 
 	cp := *pkg
 
@@ -485,37 +617,42 @@ func (b *InMemoryBackend) CreatePackage(name, packageType, description string) (
 }
 
 // AssociatePackage associates an Elasticsearch package with a domain.
-func (b *InMemoryBackend) AssociatePackage(packageID, domainName string) error {
+func (b *InMemoryBackend) AssociatePackage(ctx context.Context, packageID, domainName string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AssociatePackage")
 	defer b.mu.Unlock()
 
-	if _, exists := b.packages[packageID]; !exists {
+	if _, exists := b.packagesStore(region)[packageID]; !exists {
 		return fmt.Errorf("%w: package %s not found", ErrPackageNotFound, packageID)
 	}
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	if slices.Contains(b.packageAssociations[packageID], domainName) {
+	assocs := b.packageAssociationsStore(region)
+	if slices.Contains(assocs[packageID], domainName) {
 		return fmt.Errorf(
 			"%w: package %s is already associated with domain %s",
 			ErrPackageAlreadyAssociated, packageID, domainName,
 		)
 	}
 
-	b.packageAssociations[packageID] = append(b.packageAssociations[packageID], domainName)
+	assocs[packageID] = append(assocs[packageID], domainName)
 
 	return nil
 }
 
 // AcceptInboundCrossClusterSearchConnection accepts a pending inbound cross-cluster
 // search connection.
-func (b *InMemoryBackend) AcceptInboundCrossClusterSearchConnection(connectionID string) (*InboundConnection, error) {
+func (b *InMemoryBackend) AcceptInboundCrossClusterSearchConnection(
+	ctx context.Context, connectionID string,
+) (*InboundConnection, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AcceptInboundCrossClusterSearchConnection")
 	defer b.mu.Unlock()
 
-	conn, exists := b.inboundConnections[connectionID]
+	conn, exists := b.inboundConnectionsStore(region)[connectionID]
 	if !exists {
 		return nil, fmt.Errorf("%w: inbound connection %s not found", ErrConnectionNotFound, connectionID)
 	}
@@ -527,17 +664,19 @@ func (b *InMemoryBackend) AcceptInboundCrossClusterSearchConnection(connectionID
 }
 
 // AddInboundConnectionInternal seeds an inbound connection for testing.
-func (b *InMemoryBackend) AddInboundConnectionInternal(conn InboundConnection) {
+func (b *InMemoryBackend) AddInboundConnectionInternal(ctx context.Context, conn InboundConnection) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AddInboundConnectionInternal")
 	defer b.mu.Unlock()
 
 	cp := conn
-	b.inboundConnections[conn.ConnectionID] = &cp
+	b.inboundConnectionsStore(region)[conn.ConnectionID] = &cp
 }
 
 // CreateOutboundCrossClusterSearchConnection creates a new outbound cross-cluster
 // search connection request.
 func (b *InMemoryBackend) CreateOutboundCrossClusterSearchConnection(
+	ctx context.Context,
 	localDomain, remoteDomain CrossClusterDomainInfo,
 	alias string,
 ) (*OutboundConnection, error) {
@@ -545,6 +684,7 @@ func (b *InMemoryBackend) CreateOutboundCrossClusterSearchConnection(
 		return nil, fmt.Errorf("%w: ConnectionAlias is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateOutboundCrossClusterSearchConnection")
 	defer b.mu.Unlock()
 
@@ -556,18 +696,22 @@ func (b *InMemoryBackend) CreateOutboundCrossClusterSearchConnection(
 		LocalDomainInfo:  localDomain,
 		RemoteDomainInfo: remoteDomain,
 	}
-	b.outboundConnections[id] = conn
+	b.outboundConnectionsStore(region)[id] = conn
 	cp := *conn
 
 	return &cp, nil
 }
 
 // CreateVpcEndpoint creates a managed VPC endpoint for an Elasticsearch domain.
-func (b *InMemoryBackend) CreateVpcEndpoint(domainARN string, vpcOptions map[string]string) (*VpcEndpoint, error) {
+// The endpoint's region is resolved from the domain ARN, falling back to ctx.
+func (b *InMemoryBackend) CreateVpcEndpoint(
+	ctx context.Context, domainARN string, vpcOptions map[string]string,
+) (*VpcEndpoint, error) {
 	if domainARN == "" {
 		return nil, fmt.Errorf("%w: DomainArn is required", ErrValidation)
 	}
 
+	region := regionFromARN(domainARN, getRegion(ctx, b.region))
 	b.mu.Lock("CreateVpcEndpoint")
 	defer b.mu.Unlock()
 
@@ -580,31 +724,33 @@ func (b *InMemoryBackend) CreateVpcEndpoint(domainARN string, vpcOptions map[str
 		ID:             id,
 		OwnerAccountID: b.accountID,
 		DomainARN:      domainARN,
-		Endpoint:       fmt.Sprintf("vpc-%s.%s.es.amazonaws.com", id, b.region),
+		Endpoint:       fmt.Sprintf("vpc-%s.%s.es.amazonaws.com", id, region),
 		Status:         statusActive,
 		VpcOptions:     optsCopy,
 	}
-	b.vpcEndpoints[id] = endpoint
+	b.vpcEndpointsStore(region)[id] = endpoint
 
 	return vpcEndpointCopy(endpoint), nil
 }
 
 // AuthorizeVpcEndpointAccess grants an account or service access to the domain's VPC endpoint.
-func (b *InMemoryBackend) AuthorizeVpcEndpointAccess(domainName, account string) error {
+func (b *InMemoryBackend) AuthorizeVpcEndpointAccess(ctx context.Context, domainName, account string) error {
 	if account == "" {
 		return fmt.Errorf("%w: account principal is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AuthorizeVpcEndpointAccess")
 	defer b.mu.Unlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	if !slices.Contains(b.vpcAccess[domainName], account) {
-		b.vpcAccess[domainName] = append(b.vpcAccess[domainName], account)
-		slices.Sort(b.vpcAccess[domainName])
+	access := b.vpcAccessStore(region)
+	if !slices.Contains(access[domainName], account) {
+		access[domainName] = append(access[domainName], account)
+		slices.Sort(access[domainName])
 	}
 
 	return nil
@@ -612,11 +758,12 @@ func (b *InMemoryBackend) AuthorizeVpcEndpointAccess(domainName, account string)
 
 // CancelDomainConfigChange cancels any in-progress configuration change for a domain.
 // Because the in-memory backend applies changes synchronously this is a no-op.
-func (b *InMemoryBackend) CancelDomainConfigChange(domainName string) (*Domain, error) {
+func (b *InMemoryBackend) CancelDomainConfigChange(ctx context.Context, domainName string) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("CancelDomainConfigChange")
 	defer b.mu.RUnlock()
 
-	d, exists := b.domains[domainName]
+	d, exists := b.domainsStore(region)[domainName]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
@@ -626,11 +773,14 @@ func (b *InMemoryBackend) CancelDomainConfigChange(domainName string) (*Domain, 
 
 // CancelElasticsearchServiceSoftwareUpdate cancels a scheduled software update.
 // Because the in-memory backend never schedules updates this is a no-op.
-func (b *InMemoryBackend) CancelElasticsearchServiceSoftwareUpdate(domainName string) (*Domain, error) {
+func (b *InMemoryBackend) CancelElasticsearchServiceSoftwareUpdate(
+	ctx context.Context, domainName string,
+) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("CancelElasticsearchServiceSoftwareUpdate")
 	defer b.mu.RUnlock()
 
-	d, exists := b.domains[domainName]
+	d, exists := b.domainsStore(region)[domainName]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
@@ -655,60 +805,72 @@ func domainCopy(d *Domain) *Domain {
 
 // AddDomainInternal seeds a domain directly into the backend for testing.
 // Tags are initialised fresh for the seeded domain.
-func (b *InMemoryBackend) AddDomainInternal(d Domain) {
+func (b *InMemoryBackend) AddDomainInternal(ctx context.Context, d Domain) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AddDomainInternal")
 	defer b.mu.Unlock()
 
 	cp := d
 	if cp.Tags == nil {
-		cp.Tags = tags.New("elasticsearch." + cp.Name + ".tags")
+		cp.Tags = tags.New("elasticsearch." + region + "." + cp.Name + ".tags")
 	}
 
-	b.domains[cp.Name] = &cp
+	b.domainsStore(region)[cp.Name] = &cp
 
 	if cp.ARN != "" {
-		b.arnIndex[cp.ARN] = cp.Name
+		b.arnIndexStore(region)[cp.ARN] = cp.Name
 	}
 }
 
 // DeleteInboundCrossClusterSearchConnection removes an inbound cross-cluster connection.
-func (b *InMemoryBackend) DeleteInboundCrossClusterSearchConnection(connectionID string) (*InboundConnection, error) {
+func (b *InMemoryBackend) DeleteInboundCrossClusterSearchConnection(
+	ctx context.Context, connectionID string,
+) (*InboundConnection, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteInboundCrossClusterSearchConnection")
 	defer b.mu.Unlock()
 
-	conn, exists := b.inboundConnections[connectionID]
+	conns := b.inboundConnectionsStore(region)
+	conn, exists := conns[connectionID]
 	if !exists {
 		return nil, fmt.Errorf("%w: inbound connection %s not found", ErrConnectionNotFound, connectionID)
 	}
 
 	cp := *conn
-	delete(b.inboundConnections, connectionID)
+	delete(conns, connectionID)
 
 	return &cp, nil
 }
 
 // DeleteOutboundCrossClusterSearchConnection removes an outbound cross-cluster connection.
-func (b *InMemoryBackend) DeleteOutboundCrossClusterSearchConnection(connectionID string) (*OutboundConnection, error) {
+func (b *InMemoryBackend) DeleteOutboundCrossClusterSearchConnection(
+	ctx context.Context, connectionID string,
+) (*OutboundConnection, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteOutboundCrossClusterSearchConnection")
 	defer b.mu.Unlock()
 
-	conn, exists := b.outboundConnections[connectionID]
+	conns := b.outboundConnectionsStore(region)
+	conn, exists := conns[connectionID]
 	if !exists {
 		return nil, fmt.Errorf("%w: outbound connection %s not found", ErrConnectionNotFound, connectionID)
 	}
 
 	cp := *conn
-	delete(b.outboundConnections, connectionID)
+	delete(conns, connectionID)
 
 	return &cp, nil
 }
 
 // RejectInboundCrossClusterSearchConnection rejects a pending inbound connection.
-func (b *InMemoryBackend) RejectInboundCrossClusterSearchConnection(connectionID string) (*InboundConnection, error) {
+func (b *InMemoryBackend) RejectInboundCrossClusterSearchConnection(
+	ctx context.Context, connectionID string,
+) (*InboundConnection, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RejectInboundCrossClusterSearchConnection")
 	defer b.mu.Unlock()
 
-	conn, exists := b.inboundConnections[connectionID]
+	conn, exists := b.inboundConnectionsStore(region)[connectionID]
 	if !exists {
 		return nil, fmt.Errorf("%w: inbound connection %s not found", ErrConnectionNotFound, connectionID)
 	}
@@ -720,12 +882,14 @@ func (b *InMemoryBackend) RejectInboundCrossClusterSearchConnection(connectionID
 }
 
 // DescribeInboundCrossClusterSearchConnections returns all inbound cross-cluster connections.
-func (b *InMemoryBackend) DescribeInboundCrossClusterSearchConnections() []*InboundConnection {
+func (b *InMemoryBackend) DescribeInboundCrossClusterSearchConnections(ctx context.Context) []*InboundConnection {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeInboundCrossClusterSearchConnections")
 	defer b.mu.RUnlock()
 
-	result := make([]*InboundConnection, 0, len(b.inboundConnections))
-	for _, conn := range b.inboundConnections {
+	conns := b.inboundConnectionsStore(region)
+	result := make([]*InboundConnection, 0, len(conns))
+	for _, conn := range conns {
 		cp := *conn
 		result = append(result, &cp)
 	}
@@ -734,12 +898,14 @@ func (b *InMemoryBackend) DescribeInboundCrossClusterSearchConnections() []*Inbo
 }
 
 // DescribeOutboundCrossClusterSearchConnections returns all outbound cross-cluster connections.
-func (b *InMemoryBackend) DescribeOutboundCrossClusterSearchConnections() []*OutboundConnection {
+func (b *InMemoryBackend) DescribeOutboundCrossClusterSearchConnections(ctx context.Context) []*OutboundConnection {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeOutboundCrossClusterSearchConnections")
 	defer b.mu.RUnlock()
 
-	result := make([]*OutboundConnection, 0, len(b.outboundConnections))
-	for _, conn := range b.outboundConnections {
+	conns := b.outboundConnectionsStore(region)
+	result := make([]*OutboundConnection, 0, len(conns))
+	for _, conn := range conns {
 		cp := *conn
 		result = append(result, &cp)
 	}
@@ -748,31 +914,35 @@ func (b *InMemoryBackend) DescribeOutboundCrossClusterSearchConnections() []*Out
 }
 
 // DeletePackage removes a package by ID.
-func (b *InMemoryBackend) DeletePackage(packageID string) (*Package, error) {
+func (b *InMemoryBackend) DeletePackage(ctx context.Context, packageID string) (*Package, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeletePackage")
 	defer b.mu.Unlock()
 
-	pkg, exists := b.packages[packageID]
+	packages := b.packagesStore(region)
+	pkg, exists := packages[packageID]
 	if !exists {
 		return nil, fmt.Errorf("%w: package %s not found", ErrPackageNotFound, packageID)
 	}
 
 	cp := *pkg
-	delete(b.packagesByName, pkg.Name)
-	delete(b.packages, packageID)
-	delete(b.packageAssociations, packageID)
+	delete(b.packagesByNameStore(region), pkg.Name)
+	delete(packages, packageID)
+	delete(b.packageAssociationsStore(region), packageID)
 
 	return &cp, nil
 }
 
 // DescribePackages returns packages matching the given IDs, or all packages if the list is empty.
-func (b *InMemoryBackend) DescribePackages(packageIDs []string) []*Package {
+func (b *InMemoryBackend) DescribePackages(ctx context.Context, packageIDs []string) []*Package {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribePackages")
 	defer b.mu.RUnlock()
 
+	packages := b.packagesStore(region)
 	if len(packageIDs) == 0 {
-		result := make([]*Package, 0, len(b.packages))
-		for _, pkg := range b.packages {
+		result := make([]*Package, 0, len(packages))
+		for _, pkg := range packages {
 			cp := *pkg
 			result = append(result, &cp)
 		}
@@ -782,7 +952,7 @@ func (b *InMemoryBackend) DescribePackages(packageIDs []string) []*Package {
 
 	result := make([]*Package, 0, len(packageIDs))
 	for _, id := range packageIDs {
-		if pkg, exists := b.packages[id]; exists {
+		if pkg, exists := packages[id]; exists {
 			cp := *pkg
 			result = append(result, &cp)
 		}
@@ -792,22 +962,24 @@ func (b *InMemoryBackend) DescribePackages(packageIDs []string) []*Package {
 }
 
 // DissociatePackage removes a package association from a domain.
-func (b *InMemoryBackend) DissociatePackage(packageID, domainName string) error {
+func (b *InMemoryBackend) DissociatePackage(ctx context.Context, packageID, domainName string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DissociatePackage")
 	defer b.mu.Unlock()
 
-	if _, exists := b.packages[packageID]; !exists {
+	if _, exists := b.packagesStore(region)[packageID]; !exists {
 		return fmt.Errorf("%w: package %s not found", ErrPackageNotFound, packageID)
 	}
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	assocs := b.packageAssociations[packageID]
+	associations := b.packageAssociationsStore(region)
+	assocs := associations[packageID]
 	for i, name := range assocs {
 		if name == domainName {
-			b.packageAssociations[packageID] = append(assocs[:i], assocs[i+1:]...)
+			associations[packageID] = append(assocs[:i], assocs[i+1:]...)
 
 			return nil
 		}
@@ -817,11 +989,12 @@ func (b *InMemoryBackend) DissociatePackage(packageID, domainName string) error 
 }
 
 // GetPackageVersionHistory returns the version history for a package.
-func (b *InMemoryBackend) GetPackageVersionHistory(packageID string) ([]*Package, error) {
+func (b *InMemoryBackend) GetPackageVersionHistory(ctx context.Context, packageID string) ([]*Package, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("GetPackageVersionHistory")
 	defer b.mu.RUnlock()
 
-	pkg, exists := b.packages[packageID]
+	pkg, exists := b.packagesStore(region)[packageID]
 	if !exists {
 		return nil, fmt.Errorf("%w: package %s not found", ErrPackageNotFound, packageID)
 	}
@@ -832,15 +1005,16 @@ func (b *InMemoryBackend) GetPackageVersionHistory(packageID string) ([]*Package
 }
 
 // ListDomainsForPackage returns all domain names associated with a package.
-func (b *InMemoryBackend) ListDomainsForPackage(packageID string) ([]string, error) {
+func (b *InMemoryBackend) ListDomainsForPackage(ctx context.Context, packageID string) ([]string, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("ListDomainsForPackage")
 	defer b.mu.RUnlock()
 
-	if _, exists := b.packages[packageID]; !exists {
+	if _, exists := b.packagesStore(region)[packageID]; !exists {
 		return nil, fmt.Errorf("%w: package %s not found", ErrPackageNotFound, packageID)
 	}
 
-	assocs := b.packageAssociations[packageID]
+	assocs := b.packageAssociationsStore(region)[packageID]
 	result := make([]string, len(assocs))
 	copy(result, assocs)
 
@@ -848,14 +1022,16 @@ func (b *InMemoryBackend) ListDomainsForPackage(packageID string) ([]string, err
 }
 
 // ListPackagesForDomain returns all packages associated with a domain.
-func (b *InMemoryBackend) ListPackagesForDomain(domainName string) []*Package {
+func (b *InMemoryBackend) ListPackagesForDomain(ctx context.Context, domainName string) []*Package {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("ListPackagesForDomain")
 	defer b.mu.RUnlock()
 
+	packages := b.packagesStore(region)
 	var result []*Package
-	for packageID, assocs := range b.packageAssociations {
+	for packageID, assocs := range b.packageAssociationsStore(region) {
 		if slices.Contains(assocs, domainName) {
-			if pkg, exists := b.packages[packageID]; exists {
+			if pkg, exists := packages[packageID]; exists {
 				cp := *pkg
 				result = append(result, &cp)
 			}
@@ -866,11 +1042,12 @@ func (b *InMemoryBackend) ListPackagesForDomain(domainName string) []*Package {
 }
 
 // UpdatePackage updates a package description.
-func (b *InMemoryBackend) UpdatePackage(packageID, description string) (*Package, error) {
+func (b *InMemoryBackend) UpdatePackage(ctx context.Context, packageID, description string) (*Package, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("UpdatePackage")
 	defer b.mu.Unlock()
 
-	pkg, exists := b.packages[packageID]
+	pkg, exists := b.packagesStore(region)[packageID]
 	if !exists {
 		return nil, fmt.Errorf("%w: package %s not found", ErrPackageNotFound, packageID)
 	}
@@ -882,29 +1059,33 @@ func (b *InMemoryBackend) UpdatePackage(packageID, description string) (*Package
 }
 
 // DeleteVpcEndpoint removes a VPC endpoint by ID.
-func (b *InMemoryBackend) DeleteVpcEndpoint(vpcEndpointID string) (*VpcEndpoint, error) {
+func (b *InMemoryBackend) DeleteVpcEndpoint(ctx context.Context, vpcEndpointID string) (*VpcEndpoint, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteVpcEndpoint")
 	defer b.mu.Unlock()
 
-	endpoint, exists := b.vpcEndpoints[vpcEndpointID]
+	endpoints := b.vpcEndpointsStore(region)
+	endpoint, exists := endpoints[vpcEndpointID]
 	if !exists {
 		return nil, fmt.Errorf("%w: VPC endpoint %s not found", ErrVpcEndpointNotFound, vpcEndpointID)
 	}
 
 	cp := *endpoint
-	delete(b.vpcEndpoints, vpcEndpointID)
+	delete(endpoints, vpcEndpointID)
 
 	return vpcEndpointCopy(&cp), nil
 }
 
 // DescribeVpcEndpoints returns VPC endpoints matching the given IDs, or all endpoints if empty.
-func (b *InMemoryBackend) DescribeVpcEndpoints(vpcEndpointIDs []string) []*VpcEndpoint {
+func (b *InMemoryBackend) DescribeVpcEndpoints(ctx context.Context, vpcEndpointIDs []string) []*VpcEndpoint {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeVpcEndpoints")
 	defer b.mu.RUnlock()
 
+	endpoints := b.vpcEndpointsStore(region)
 	if len(vpcEndpointIDs) == 0 {
-		result := make([]*VpcEndpoint, 0, len(b.vpcEndpoints))
-		for _, ep := range b.vpcEndpoints {
+		result := make([]*VpcEndpoint, 0, len(endpoints))
+		for _, ep := range endpoints {
 			result = append(result, vpcEndpointCopy(ep))
 		}
 
@@ -913,7 +1094,7 @@ func (b *InMemoryBackend) DescribeVpcEndpoints(vpcEndpointIDs []string) []*VpcEn
 
 	result := make([]*VpcEndpoint, 0, len(vpcEndpointIDs))
 	for _, id := range vpcEndpointIDs {
-		if ep, exists := b.vpcEndpoints[id]; exists {
+		if ep, exists := endpoints[id]; exists {
 			result = append(result, vpcEndpointCopy(ep))
 		}
 	}
@@ -922,24 +1103,27 @@ func (b *InMemoryBackend) DescribeVpcEndpoints(vpcEndpointIDs []string) []*VpcEn
 }
 
 // ListVpcEndpointAccess returns authorized account principals for a domain's VPC endpoint access.
-func (b *InMemoryBackend) ListVpcEndpointAccess(domainName string) ([]string, error) {
+func (b *InMemoryBackend) ListVpcEndpointAccess(ctx context.Context, domainName string) ([]string, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("ListVpcEndpointAccess")
 	defer b.mu.RUnlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	return slices.Clone(b.vpcAccess[domainName]), nil
+	return slices.Clone(b.vpcAccessStore(region)[domainName]), nil
 }
 
-// ListVpcEndpoints returns all VPC endpoints.
-func (b *InMemoryBackend) ListVpcEndpoints() []*VpcEndpoint {
+// ListVpcEndpoints returns all VPC endpoints in the request's region.
+func (b *InMemoryBackend) ListVpcEndpoints(ctx context.Context) []*VpcEndpoint {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("ListVpcEndpoints")
 	defer b.mu.RUnlock()
 
-	result := make([]*VpcEndpoint, 0, len(b.vpcEndpoints))
-	for _, ep := range b.vpcEndpoints {
+	endpoints := b.vpcEndpointsStore(region)
+	result := make([]*VpcEndpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
 		result = append(result, vpcEndpointCopy(ep))
 	}
 
@@ -947,17 +1131,18 @@ func (b *InMemoryBackend) ListVpcEndpoints() []*VpcEndpoint {
 }
 
 // ListVpcEndpointsForDomain returns VPC endpoints associated with a specific domain ARN.
-func (b *InMemoryBackend) ListVpcEndpointsForDomain(domainName string) []*VpcEndpoint {
+func (b *InMemoryBackend) ListVpcEndpointsForDomain(ctx context.Context, domainName string) []*VpcEndpoint {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("ListVpcEndpointsForDomain")
 	defer b.mu.RUnlock()
 
-	d, exists := b.domains[domainName]
+	d, exists := b.domainsStore(region)[domainName]
 	if !exists {
 		return nil
 	}
 
 	var result []*VpcEndpoint
-	for _, ep := range b.vpcEndpoints {
+	for _, ep := range b.vpcEndpointsStore(region) {
 		if ep.DomainARN == d.ARN {
 			result = append(result, vpcEndpointCopy(ep))
 		}
@@ -967,22 +1152,24 @@ func (b *InMemoryBackend) ListVpcEndpointsForDomain(domainName string) []*VpcEnd
 }
 
 // RevokeVpcEndpointAccess revokes an account's access to a domain's VPC endpoint.
-func (b *InMemoryBackend) RevokeVpcEndpointAccess(domainName, account string) error {
+func (b *InMemoryBackend) RevokeVpcEndpointAccess(ctx context.Context, domainName, account string) error {
 	if account == "" {
 		return fmt.Errorf("%w: account principal is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RevokeVpcEndpointAccess")
 	defer b.mu.Unlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
-	accounts := b.vpcAccess[domainName]
+	access := b.vpcAccessStore(region)
+	accounts := access[domainName]
 	for i, authorized := range accounts {
 		if authorized == account {
-			b.vpcAccess[domainName] = append(accounts[:i], accounts[i+1:]...)
+			access[domainName] = append(accounts[:i], accounts[i+1:]...)
 
 			break
 		}
@@ -992,11 +1179,14 @@ func (b *InMemoryBackend) RevokeVpcEndpointAccess(domainName, account string) er
 }
 
 // UpdateVpcEndpoint updates the VPC options of a VPC endpoint.
-func (b *InMemoryBackend) UpdateVpcEndpoint(vpcEndpointID string, vpcOptions map[string]string) (*VpcEndpoint, error) {
+func (b *InMemoryBackend) UpdateVpcEndpoint(
+	ctx context.Context, vpcEndpointID string, vpcOptions map[string]string,
+) (*VpcEndpoint, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("UpdateVpcEndpoint")
 	defer b.mu.Unlock()
 
-	endpoint, exists := b.vpcEndpoints[vpcEndpointID]
+	endpoint, exists := b.vpcEndpointsStore(region)[vpcEndpointID]
 	if !exists {
 		return nil, fmt.Errorf("%w: VPC endpoint %s not found", ErrVpcEndpointNotFound, vpcEndpointID)
 	}
@@ -1017,11 +1207,12 @@ func vpcEndpointCopy(endpoint *VpcEndpoint) *VpcEndpoint {
 }
 
 // DescribeDomainAutoTunes validates a domain exists and returns (the in-memory backend has no auto-tune state).
-func (b *InMemoryBackend) DescribeDomainAutoTunes(domainName string) error {
+func (b *InMemoryBackend) DescribeDomainAutoTunes(ctx context.Context, domainName string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDomainAutoTunes")
 	defer b.mu.RUnlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
@@ -1029,11 +1220,12 @@ func (b *InMemoryBackend) DescribeDomainAutoTunes(domainName string) error {
 }
 
 // DescribeDomainChangeProgress validates a domain exists and returns (changes are synchronous in-memory).
-func (b *InMemoryBackend) DescribeDomainChangeProgress(domainName string) error {
+func (b *InMemoryBackend) DescribeDomainChangeProgress(ctx context.Context, domainName string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDomainChangeProgress")
 	defer b.mu.RUnlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
@@ -1041,11 +1233,12 @@ func (b *InMemoryBackend) DescribeDomainChangeProgress(domainName string) error 
 }
 
 // GetUpgradeHistory validates a domain exists and returns empty history (no upgrade state tracked).
-func (b *InMemoryBackend) GetUpgradeHistory(domainName string) error {
+func (b *InMemoryBackend) GetUpgradeHistory(ctx context.Context, domainName string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("GetUpgradeHistory")
 	defer b.mu.RUnlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
@@ -1053,11 +1246,12 @@ func (b *InMemoryBackend) GetUpgradeHistory(domainName string) error {
 }
 
 // GetUpgradeStatus validates a domain exists and returns (no upgrade in progress in-memory).
-func (b *InMemoryBackend) GetUpgradeStatus(domainName string) error {
+func (b *InMemoryBackend) GetUpgradeStatus(ctx context.Context, domainName string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("GetUpgradeStatus")
 	defer b.mu.RUnlock()
 
-	if _, exists := b.domains[domainName]; !exists {
+	if _, exists := b.domainsStore(region)[domainName]; !exists {
 		return fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
 
@@ -1065,11 +1259,14 @@ func (b *InMemoryBackend) GetUpgradeStatus(domainName string) error {
 }
 
 // StartElasticsearchServiceSoftwareUpdate schedules a software update (no-op in-memory).
-func (b *InMemoryBackend) StartElasticsearchServiceSoftwareUpdate(domainName string) (*Domain, error) {
+func (b *InMemoryBackend) StartElasticsearchServiceSoftwareUpdate(
+	ctx context.Context, domainName string,
+) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("StartElasticsearchServiceSoftwareUpdate")
 	defer b.mu.RUnlock()
 
-	d, exists := b.domains[domainName]
+	d, exists := b.domainsStore(region)[domainName]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
@@ -1078,11 +1275,14 @@ func (b *InMemoryBackend) StartElasticsearchServiceSoftwareUpdate(domainName str
 }
 
 // UpgradeElasticsearchDomain upgrades a domain to the target version.
-func (b *InMemoryBackend) UpgradeElasticsearchDomain(domainName, targetVersion string) (*Domain, error) {
+func (b *InMemoryBackend) UpgradeElasticsearchDomain(
+	ctx context.Context, domainName, targetVersion string,
+) (*Domain, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("UpgradeElasticsearchDomain")
 	defer b.mu.Unlock()
 
-	d, exists := b.domains[domainName]
+	d, exists := b.domainsStore(region)[domainName]
 	if !exists {
 		return nil, fmt.Errorf("%w: domain %s not found", ErrDomainNotFound, domainName)
 	}
@@ -1105,13 +1305,15 @@ func (b *InMemoryBackend) DescribeReservedElasticsearchInstanceOfferings() []Res
 	}}
 }
 
-// DescribeReservedElasticsearchInstances returns purchased reserved instances.
-func (b *InMemoryBackend) DescribeReservedElasticsearchInstances() []ReservedInstance {
+// DescribeReservedElasticsearchInstances returns purchased reserved instances for the request's region.
+func (b *InMemoryBackend) DescribeReservedElasticsearchInstances(ctx context.Context) []ReservedInstance {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeReservedElasticsearchInstances")
 	defer b.mu.RUnlock()
 
-	instances := make([]ReservedInstance, 0, len(b.reservedInstances))
-	for _, instance := range b.reservedInstances {
+	reserved := b.reservedInstancesStore(region)
+	instances := make([]ReservedInstance, 0, len(reserved))
+	for _, instance := range reserved {
 		instances = append(instances, *instance)
 	}
 
@@ -1124,12 +1326,13 @@ func (b *InMemoryBackend) DescribeReservedElasticsearchInstances() []ReservedIns
 
 // PurchaseReservedElasticsearchInstanceOffering purchases a reserved instance offering.
 func (b *InMemoryBackend) PurchaseReservedElasticsearchInstanceOffering(
-	offeringID, name string, count int,
+	ctx context.Context, offeringID, name string, count int,
 ) (*ReservedInstance, error) {
 	if offeringID == "" {
 		return nil, fmt.Errorf("%w: ReservedElasticsearchInstanceOfferingId is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("PurchaseReservedElasticsearchInstanceOffering")
 	defer b.mu.Unlock()
 
@@ -1156,7 +1359,7 @@ func (b *InMemoryBackend) PurchaseReservedElasticsearchInstanceOffering(
 		}
 	}
 
-	b.reservedInstances[id] = instance
+	b.reservedInstancesStore(region)[id] = instance
 	cp := *instance
 
 	return &cp, nil

--- a/services/elasticsearch/export_test.go
+++ b/services/elasticsearch/export_test.go
@@ -1,42 +1,67 @@
 package elasticsearch
 
-// DomainCount returns the number of domains stored in the backend.
+// DomainCount returns the total number of domains stored across all regions.
 // Used only in tests to verify backend state without going through the HTTP handler.
 func (b *InMemoryBackend) DomainCount() int {
 	b.mu.RLock("DomainCount")
 	defer b.mu.RUnlock()
 
-	return len(b.domains)
+	count := 0
+	for _, regionDomains := range b.domains {
+		count += len(regionDomains)
+	}
+
+	return count
 }
 
-// PackageCount returns the number of packages stored in the backend.
+// PackageCount returns the total number of packages stored across all regions.
 func (b *InMemoryBackend) PackageCount() int {
 	b.mu.RLock("PackageCount")
 	defer b.mu.RUnlock()
 
-	return len(b.packages)
+	count := 0
+	for _, regionPackages := range b.packages {
+		count += len(regionPackages)
+	}
+
+	return count
 }
 
-// InboundConnectionCount returns the number of inbound cross-cluster connections.
+// InboundConnectionCount returns the total number of inbound cross-cluster connections across all regions.
 func (b *InMemoryBackend) InboundConnectionCount() int {
 	b.mu.RLock("InboundConnectionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.inboundConnections)
+	count := 0
+	for _, regionConns := range b.inboundConnections {
+		count += len(regionConns)
+	}
+
+	return count
 }
 
-// OutboundConnectionCount returns the number of outbound cross-cluster connections.
+// OutboundConnectionCount returns the total number of outbound cross-cluster connections across all regions.
 func (b *InMemoryBackend) OutboundConnectionCount() int {
 	b.mu.RLock("OutboundConnectionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.outboundConnections)
+	count := 0
+	for _, regionConns := range b.outboundConnections {
+		count += len(regionConns)
+	}
+
+	return count
 }
 
-// VpcEndpointCount returns the number of VPC endpoints stored in the backend.
+// VpcEndpointCount returns the total number of VPC endpoints stored across all regions.
 func (b *InMemoryBackend) VpcEndpointCount() int {
 	b.mu.RLock("VpcEndpointCount")
 	defer b.mu.RUnlock()
 
-	return len(b.vpcEndpoints)
+	count := 0
+	for _, regionEndpoints := range b.vpcEndpoints {
+		count += len(regionEndpoints)
+	}
+
+	return count
 }

--- a/services/elasticsearch/handler.go
+++ b/services/elasticsearch/handler.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -117,6 +118,14 @@ func (h *Handler) buildOps() map[string]http.HandlerFunc {
 
 // Name returns the service name.
 func (h *Handler) Name() string { return "Elasticsearch" }
+
+// reqContext returns the request context with the SigV4-derived AWS region
+// attached so backend operations route to the correct per-region store.
+func (h *Handler) reqContext(r *http.Request) context.Context {
+	region := httputils.ExtractRegionFromRequest(r, h.Backend.Region())
+
+	return context.WithValue(r.Context(), regionContextKey{}, region)
+}
 
 // MatchPriority returns the routing priority.
 func (h *Handler) MatchPriority() int { return service.PriorityPathSubdomain }
@@ -901,7 +910,7 @@ func (h *Handler) handleCreateDomain(w http.ResponseWriter, r *http.Request) {
 		ebsOpts.VolumeType = req.EBSOptions.VolumeType
 	}
 
-	domain, err := h.Backend.CreateDomain(req.DomainName, req.ElasticsearchVersion, cfg, ebsOpts)
+	domain, err := h.Backend.CreateDomain(h.reqContext(r), req.DomainName, req.ElasticsearchVersion, cfg, ebsOpts)
 	if err != nil {
 		h.handleDomainError(r, w, err)
 
@@ -928,7 +937,7 @@ func (h *Handler) handleDomainError(r *http.Request, w http.ResponseWriter, err 
 }
 
 func (h *Handler) handleDescribeDomain(w http.ResponseWriter, r *http.Request, name string) {
-	domain, err := h.Backend.DescribeDomain(name)
+	domain, err := h.Backend.DescribeDomain(h.reqContext(r), name)
 	if err != nil {
 		if errors.Is(err, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -945,7 +954,7 @@ func (h *Handler) handleDescribeDomain(w http.ResponseWriter, r *http.Request, n
 }
 
 func (h *Handler) handleDeleteDomain(w http.ResponseWriter, r *http.Request, name string) {
-	domain, err := h.Backend.DeleteDomain(name)
+	domain, err := h.Backend.DeleteDomain(h.reqContext(r), name)
 	if err != nil {
 		if errors.Is(err, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -962,11 +971,12 @@ func (h *Handler) handleDeleteDomain(w http.ResponseWriter, r *http.Request, nam
 }
 
 func (h *Handler) handleListDomainNames(w http.ResponseWriter, r *http.Request) {
-	names := h.Backend.ListDomainNames()
+	ctx := h.reqContext(r)
+	names := h.Backend.ListDomainNames(ctx)
 	entries := make([]domainNameEntry, 0, len(names))
 
 	for _, name := range names {
-		d, err := h.Backend.DescribeDomain(name)
+		d, err := h.Backend.DescribeDomain(ctx, name)
 		if err != nil {
 			continue
 		}
@@ -1008,9 +1018,10 @@ func (h *Handler) handleDescribeElasticsearchDomains(w http.ResponseWriter, r *h
 	}
 
 	list := make([]domainStatusJSON, 0, len(req.DomainNames))
+	ctx := h.reqContext(r)
 
 	for _, name := range req.DomainNames {
-		d, descErr := h.Backend.DescribeDomain(name)
+		d, descErr := h.Backend.DescribeDomain(ctx, name)
 		if descErr != nil {
 			continue
 		}
@@ -1053,7 +1064,7 @@ func (h *Handler) handleUpdateDomainConfig(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	domain, err := h.Backend.UpdateDomainConfig(name, upd)
+	domain, err := h.Backend.UpdateDomainConfig(h.reqContext(r), name, upd)
 	if err != nil {
 		if errors.Is(err, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -1153,7 +1164,7 @@ type describeDomainConfigOutput struct {
 func (h *Handler) handleListTags(w http.ResponseWriter, r *http.Request) {
 	domainARN := r.URL.Query().Get("arn")
 
-	tags, err := h.Backend.ListTags(domainARN)
+	tags, err := h.Backend.ListTags(h.reqContext(r), domainARN)
 	if err != nil {
 		h.writeJSON(r, w, &listTagsOutput{TagList: []svcTags.KV{}})
 
@@ -1213,7 +1224,8 @@ func (h *Handler) handleAddTags(w http.ResponseWriter, r *http.Request) {
 		tagMap[t.Key] = t.Value
 	}
 
-	existing, _ := h.Backend.ListTags(req.ARN)
+	ctx := h.reqContext(r)
+	existing, _ := h.Backend.ListTags(ctx, req.ARN)
 	maps.Copy(existing, tagMap)
 
 	if len(existing) > maxTagsPerResource {
@@ -1223,7 +1235,7 @@ func (h *Handler) handleAddTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.Backend.AddTags(req.ARN, tagMap)
+	_ = h.Backend.AddTags(ctx, req.ARN, tagMap)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1247,12 +1259,12 @@ func (h *Handler) handleRemoveTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.Backend.RemoveTags(req.ARN, req.TagKeys)
+	_ = h.Backend.RemoveTags(h.reqContext(r), req.ARN, req.TagKeys)
 	w.WriteHeader(http.StatusOK)
 }
 
 func (h *Handler) handleDescribeDomainConfig(w http.ResponseWriter, r *http.Request, name string) {
-	d, err := h.Backend.DescribeDomain(name)
+	d, err := h.Backend.DescribeDomain(h.reqContext(r), name)
 	if err != nil {
 		if errors.Is(err, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException",
@@ -1322,7 +1334,7 @@ func (h *Handler) handleCreatePackage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pkg, createErr := h.Backend.CreatePackage(req.PackageName, req.PackageType, req.PackageDescription)
+	pkg, createErr := h.Backend.CreatePackage(h.reqContext(r), req.PackageName, req.PackageType, req.PackageDescription)
 	if createErr != nil {
 		if errors.Is(createErr, ErrDomainAlreadyExists) {
 			h.writeError(r, w, http.StatusConflict, "ResourceAlreadyExistsException", createErr.Error())
@@ -1381,7 +1393,7 @@ func (h *Handler) handleAssociatePackage(w http.ResponseWriter, r *http.Request)
 
 	packageID, domainName := parts[0], parts[1]
 
-	if assocErr := h.Backend.AssociatePackage(packageID, domainName); assocErr != nil {
+	if assocErr := h.Backend.AssociatePackage(h.reqContext(r), packageID, domainName); assocErr != nil {
 		switch {
 		case errors.Is(assocErr, ErrDomainNotFound) || errors.Is(assocErr, ErrPackageNotFound):
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", assocErr.Error())
@@ -1430,7 +1442,7 @@ func (h *Handler) handleAcceptInboundCrossClusterSearchConnection(w http.Respons
 	rest := strings.TrimPrefix(r.URL.Path, elasticsearchCCSInbound+"/")
 	connectionID, _ := strings.CutSuffix(rest, "/accept")
 
-	conn, err := h.Backend.AcceptInboundCrossClusterSearchConnection(connectionID)
+	conn, err := h.Backend.AcceptInboundCrossClusterSearchConnection(h.reqContext(r), connectionID)
 	if err != nil {
 		if errors.Is(err, ErrConnectionNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -1515,6 +1527,7 @@ func (h *Handler) handleCreateOutboundCrossClusterSearchConnection(w http.Respon
 	}
 
 	conn, createErr := h.Backend.CreateOutboundCrossClusterSearchConnection(
+		h.reqContext(r),
 		localDomain,
 		remoteDomain,
 		req.ConnectionAlias,
@@ -1584,7 +1597,7 @@ func (h *Handler) handleCreateVpcEndpoint(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	endpoint, createErr := h.Backend.CreateVpcEndpoint(req.DomainArn, req.VpcOptions)
+	endpoint, createErr := h.Backend.CreateVpcEndpoint(h.reqContext(r), req.DomainArn, req.VpcOptions)
 	if createErr != nil {
 		h.writeError(r, w, http.StatusBadRequest, "ValidationException", createErr.Error())
 
@@ -1636,7 +1649,7 @@ func (h *Handler) handleAuthorizeVpcEndpointAccess(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if authErr := h.Backend.AuthorizeVpcEndpointAccess(domainName, req.Account); authErr != nil {
+	if authErr := h.Backend.AuthorizeVpcEndpointAccess(h.reqContext(r), domainName, req.Account); authErr != nil {
 		if errors.Is(authErr, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", authErr.Error())
 		} else {
@@ -1660,7 +1673,7 @@ type cancelDomainConfigChangeOutput struct {
 }
 
 func (h *Handler) handleCancelDomainConfigChange(w http.ResponseWriter, r *http.Request, domainName string) {
-	d, err := h.Backend.CancelDomainConfigChange(domainName)
+	d, err := h.Backend.CancelDomainConfigChange(h.reqContext(r), domainName)
 	if err != nil {
 		if errors.Is(err, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -1734,7 +1747,7 @@ func (h *Handler) handleCancelElasticsearchServiceSoftwareUpdate(w http.Response
 		return
 	}
 
-	_, cancelErr := h.Backend.CancelElasticsearchServiceSoftwareUpdate(req.DomainName)
+	_, cancelErr := h.Backend.CancelElasticsearchServiceSoftwareUpdate(h.reqContext(r), req.DomainName)
 	if cancelErr != nil {
 		if errors.Is(cancelErr, ErrDomainNotFound) {
 			h.writeError(r, w, http.StatusNotFound, "ResourceNotFoundException", cancelErr.Error())
@@ -1766,7 +1779,7 @@ func (h *Handler) handleStartElasticsearchServiceSoftwareUpdate(w http.ResponseW
 		return
 	}
 
-	if _, err := h.Backend.StartElasticsearchServiceSoftwareUpdate(req.DomainName); err != nil {
+	if _, err := h.Backend.StartElasticsearchServiceSoftwareUpdate(h.reqContext(r), req.DomainName); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -1779,7 +1792,7 @@ func (h *Handler) handleStartElasticsearchServiceSoftwareUpdate(w http.ResponseW
 }
 
 func (h *Handler) handleDescribeInboundCrossClusterSearchConnections(w http.ResponseWriter, r *http.Request) {
-	connections := h.Backend.DescribeInboundCrossClusterSearchConnections()
+	connections := h.Backend.DescribeInboundCrossClusterSearchConnections(h.reqContext(r))
 	result := make([]inboundConnectionJSON, 0, len(connections))
 	for _, connection := range connections {
 		result = append(result, toInboundConnectionJSON(connection))
@@ -1789,7 +1802,7 @@ func (h *Handler) handleDescribeInboundCrossClusterSearchConnections(w http.Resp
 }
 
 func (h *Handler) handleDescribeOutboundCrossClusterSearchConnections(w http.ResponseWriter, r *http.Request) {
-	connections := h.Backend.DescribeOutboundCrossClusterSearchConnections()
+	connections := h.Backend.DescribeOutboundCrossClusterSearchConnections(h.reqContext(r))
 	result := make([]outboundConnectionJSON, 0, len(connections))
 	for _, connection := range connections {
 		result = append(result, toOutboundConnectionJSON(connection))
@@ -1806,7 +1819,7 @@ func (h *Handler) handleDescribePackages(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	packages := h.Backend.DescribePackages(req.PackageIDs)
+	packages := h.Backend.DescribePackages(h.reqContext(r), req.PackageIDs)
 	result := make([]packageJSON, 0, len(packages))
 	for _, pkg := range packages {
 		result = append(result, toPackageJSON(pkg))
@@ -1824,7 +1837,7 @@ func (h *Handler) handleUpdatePackage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pkg, err := h.Backend.UpdatePackage(req.PackageID, req.PackageDescription)
+	pkg, err := h.Backend.UpdatePackage(h.reqContext(r), req.PackageID, req.PackageDescription)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -1843,7 +1856,7 @@ func (h *Handler) handleDescribeVpcEndpoints(w http.ResponseWriter, r *http.Requ
 	}
 
 	h.writeJSON(r, w, map[string]any{
-		"VpcEndpoints":      toVpcEndpointsJSON(h.Backend.DescribeVpcEndpoints(req.VpcEndpointIDs)),
+		"VpcEndpoints":      toVpcEndpointsJSON(h.Backend.DescribeVpcEndpoints(h.reqContext(r), req.VpcEndpointIDs)),
 		"VpcEndpointErrors": []any{},
 	})
 }
@@ -1857,7 +1870,7 @@ func (h *Handler) handleUpdateVpcEndpoint(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	endpoint, err := h.Backend.UpdateVpcEndpoint(req.VpcEndpointID, req.VpcOptions)
+	endpoint, err := h.Backend.UpdateVpcEndpoint(h.reqContext(r), req.VpcEndpointID, req.VpcOptions)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -1869,7 +1882,7 @@ func (h *Handler) handleUpdateVpcEndpoint(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handleListVpcEndpoints(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(r, w, map[string]any{
-		"VpcEndpointSummaryList": toVpcEndpointsJSON(h.Backend.ListVpcEndpoints()),
+		"VpcEndpointSummaryList": toVpcEndpointsJSON(h.Backend.ListVpcEndpoints(h.reqContext(r))),
 	})
 }
 
@@ -1897,7 +1910,7 @@ func (h *Handler) handleListElasticsearchVersions(w http.ResponseWriter, r *http
 
 func (h *Handler) handleDeleteInboundCrossClusterSearchConnection(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, elasticsearchCCSInbound+"/")
-	connection, err := h.Backend.DeleteInboundCrossClusterSearchConnection(id)
+	connection, err := h.Backend.DeleteInboundCrossClusterSearchConnection(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -1909,7 +1922,7 @@ func (h *Handler) handleDeleteInboundCrossClusterSearchConnection(w http.Respons
 
 func (h *Handler) handleDeleteOutboundCrossClusterSearchConnection(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, elasticsearchCCSOutbound+"/")
-	connection, err := h.Backend.DeleteOutboundCrossClusterSearchConnection(id)
+	connection, err := h.Backend.DeleteOutboundCrossClusterSearchConnection(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -1921,7 +1934,7 @@ func (h *Handler) handleDeleteOutboundCrossClusterSearchConnection(w http.Respon
 
 func (h *Handler) handleDeleteVpcEndpoint(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, elasticsearchVpcEndpoints+"/")
-	endpoint, err := h.Backend.DeleteVpcEndpoint(id)
+	endpoint, err := h.Backend.DeleteVpcEndpoint(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -1952,7 +1965,7 @@ func (h *Handler) handleDescribeReservedElasticsearchInstanceOfferings(w http.Re
 }
 
 func (h *Handler) handleDescribeReservedElasticsearchInstances(w http.ResponseWriter, r *http.Request) {
-	instances := h.Backend.DescribeReservedElasticsearchInstances()
+	instances := h.Backend.DescribeReservedElasticsearchInstances(h.reqContext(r))
 	result := make([]map[string]any, 0, len(instances))
 	for _, instance := range instances {
 		result = append(result, map[string]any{
@@ -1979,7 +1992,7 @@ func (h *Handler) handleDissociatePackage(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := h.Backend.DissociatePackage(parts[0], parts[1]); err != nil {
+	if err := h.Backend.DissociatePackage(h.reqContext(r), parts[0], parts[1]); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -1994,7 +2007,7 @@ func (h *Handler) handleDissociatePackage(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handleGetPackageVersionHistory(w http.ResponseWriter, r *http.Request) {
 	id := pathID(r.URL.Path, elasticsearchPackages+"/", "/history")
-	packages, err := h.Backend.GetPackageVersionHistory(id)
+	packages, err := h.Backend.GetPackageVersionHistory(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -2020,6 +2033,7 @@ func (h *Handler) handlePurchaseReservedElasticsearchInstanceOffering(w http.Res
 	}
 
 	instance, err := h.Backend.PurchaseReservedElasticsearchInstanceOffering(
+		h.reqContext(r),
 		req.OfferingID,
 		req.ReservationName,
 		req.InstanceCount,
@@ -2038,7 +2052,7 @@ func (h *Handler) handlePurchaseReservedElasticsearchInstanceOffering(w http.Res
 
 func (h *Handler) handleRejectInboundCrossClusterSearchConnection(w http.ResponseWriter, r *http.Request) {
 	id := pathID(r.URL.Path, elasticsearchCCSInbound+"/", "/reject")
-	connection, err := h.Backend.RejectInboundCrossClusterSearchConnection(id)
+	connection, err := h.Backend.RejectInboundCrossClusterSearchConnection(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -2058,13 +2072,14 @@ func (h *Handler) handleUpgradeElasticsearchDomain(w http.ResponseWriter, r *htt
 		return
 	}
 
+	ctx := h.reqContext(r)
 	if !req.PerformCheckOnly {
-		if _, err := h.Backend.UpgradeElasticsearchDomain(req.DomainName, req.TargetVersion); err != nil {
+		if _, err := h.Backend.UpgradeElasticsearchDomain(ctx, req.DomainName, req.TargetVersion); err != nil {
 			h.writeOperationError(r, w, err)
 
 			return
 		}
-	} else if _, err := h.Backend.DescribeDomain(req.DomainName); err != nil {
+	} else if _, err := h.Backend.DescribeDomain(ctx, req.DomainName); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -2075,7 +2090,7 @@ func (h *Handler) handleUpgradeElasticsearchDomain(w http.ResponseWriter, r *htt
 
 func (h *Handler) handleDeletePackage(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, elasticsearchPackages+"/")
-	pkg, err := h.Backend.DeletePackage(id)
+	pkg, err := h.Backend.DeletePackage(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -2086,7 +2101,7 @@ func (h *Handler) handleDeletePackage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleDescribeDomainAutoTunes(w http.ResponseWriter, r *http.Request, domainName string) {
-	if err := h.Backend.DescribeDomainAutoTunes(domainName); err != nil {
+	if err := h.Backend.DescribeDomainAutoTunes(h.reqContext(r), domainName); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -2096,7 +2111,7 @@ func (h *Handler) handleDescribeDomainAutoTunes(w http.ResponseWriter, r *http.R
 }
 
 func (h *Handler) handleDescribeDomainChangeProgress(w http.ResponseWriter, r *http.Request, domainName string) {
-	if err := h.Backend.DescribeDomainChangeProgress(domainName); err != nil {
+	if err := h.Backend.DescribeDomainChangeProgress(h.reqContext(r), domainName); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -2116,7 +2131,7 @@ func (h *Handler) handleDescribeElasticsearchInstanceTypeLimits(w http.ResponseW
 
 func (h *Handler) handleGetUpgradeHistory(w http.ResponseWriter, r *http.Request) {
 	domainName := pathID(r.URL.Path, elasticsearchUpgradeDomain+"/", "/history")
-	if err := h.Backend.GetUpgradeHistory(domainName); err != nil {
+	if err := h.Backend.GetUpgradeHistory(h.reqContext(r), domainName); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -2127,7 +2142,7 @@ func (h *Handler) handleGetUpgradeHistory(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handleGetUpgradeStatus(w http.ResponseWriter, r *http.Request) {
 	domainName := pathID(r.URL.Path, elasticsearchUpgradeDomain+"/", "/status")
-	if err := h.Backend.GetUpgradeStatus(domainName); err != nil {
+	if err := h.Backend.GetUpgradeStatus(h.reqContext(r), domainName); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return
@@ -2138,7 +2153,7 @@ func (h *Handler) handleGetUpgradeStatus(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) handleListDomainsForPackage(w http.ResponseWriter, r *http.Request) {
 	id := pathID(r.URL.Path, elasticsearchPackages+"/", "/domains")
-	domains, err := h.Backend.ListDomainsForPackage(id)
+	domains, err := h.Backend.ListDomainsForPackage(h.reqContext(r), id)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -2164,7 +2179,7 @@ func (h *Handler) handleListElasticsearchInstanceTypes(w http.ResponseWriter, r 
 
 func (h *Handler) handleListPackagesForDomain(w http.ResponseWriter, r *http.Request) {
 	domainName := pathID(r.URL.Path, elasticsearchDomainPackages+"/", "/packages")
-	packages := h.Backend.ListPackagesForDomain(domainName)
+	packages := h.Backend.ListPackagesForDomain(h.reqContext(r), domainName)
 	result := make([]domainPackageJSON, 0, len(packages))
 	for _, pkg := range packages {
 		result = append(result, domainPackageJSON{
@@ -2180,7 +2195,7 @@ func (h *Handler) handleListPackagesForDomain(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handler) handleListVpcEndpointAccess(w http.ResponseWriter, r *http.Request, domainName string) {
-	accounts, err := h.Backend.ListVpcEndpointAccess(domainName)
+	accounts, err := h.Backend.ListVpcEndpointAccess(h.reqContext(r), domainName)
 	if err != nil {
 		h.writeOperationError(r, w, err)
 
@@ -2197,7 +2212,7 @@ func (h *Handler) handleListVpcEndpointAccess(w http.ResponseWriter, r *http.Req
 
 func (h *Handler) handleListVpcEndpointsForDomain(w http.ResponseWriter, r *http.Request, domainName string) {
 	h.writeJSON(r, w, map[string]any{
-		"VpcEndpointSummaryList": toVpcEndpointsJSON(h.Backend.ListVpcEndpointsForDomain(domainName)),
+		"VpcEndpointSummaryList": toVpcEndpointsJSON(h.Backend.ListVpcEndpointsForDomain(h.reqContext(r), domainName)),
 	})
 }
 
@@ -2207,7 +2222,7 @@ func (h *Handler) handleRevokeVpcEndpointAccess(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := h.Backend.RevokeVpcEndpointAccess(domainName, req.Account); err != nil {
+	if err := h.Backend.RevokeVpcEndpointAccess(h.reqContext(r), domainName, req.Account); err != nil {
 		h.writeOperationError(r, w, err)
 
 		return

--- a/services/elasticsearch/handler_audit2_test.go
+++ b/services/elasticsearch/handler_audit2_test.go
@@ -1,6 +1,7 @@
 package elasticsearch_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -238,10 +239,10 @@ func TestAudit2_PackageTypeBackend(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreatePackage("my-pkg", "UNKNOWN", "desc")
+	_, err := b.CreatePackage(context.Background(), "my-pkg", "UNKNOWN", "desc")
 	require.ErrorIs(t, err, elasticsearch.ErrValidation)
 
-	_, err = b.CreatePackage("my-pkg2", "TXT-DICTIONARY", "desc")
+	_, err = b.CreatePackage(context.Background(), "my-pkg2", "TXT-DICTIONARY", "desc")
 	require.NoError(t, err)
 }
 
@@ -251,9 +252,13 @@ func TestAudit2_ESVersionBackend(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreateDomain("ver-dom", "8.0", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "ver-dom", "8.0", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.ErrorIs(t, err, elasticsearch.ErrValidation)
 
-	_, err = b.CreateDomain("ver-dom2", "7.10", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err = b.CreateDomain(
+		context.Background(), "ver-dom2", "7.10", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
 }

--- a/services/elasticsearch/handler_refinement1_test.go
+++ b/services/elasticsearch/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package elasticsearch_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -17,7 +18,7 @@ func TestRefinement1_ErrValidationSentinel(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreateDomain("", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(context.Background(), "", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -51,11 +52,13 @@ func TestRefinement1_SortedListDomainNames(t *testing.T) {
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
 	for _, name := range []string{"zoo-domain", "apple-dom", "mid-domain"} {
-		_, err := b.CreateDomain(name, "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+		_, err := b.CreateDomain(
+			context.Background(), name, "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+		)
 		require.NoError(t, err)
 	}
 
-	names := b.ListDomainNames()
+	names := b.ListDomainNames(context.Background())
 	require.Len(t, names, 3)
 	assert.Equal(t, "apple-dom", names[0])
 	assert.Equal(t, "mid-domain", names[1])
@@ -109,7 +112,7 @@ func TestRefinement1_DomainNameValidationTooShort(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateDomain("ab", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(context.Background(), "ab", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -120,6 +123,7 @@ func TestRefinement1_DomainNameValidationTooLong(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 	_, err := b.CreateDomain(
+		context.Background(),
 		"abcdefghijklmnopqrstuvwxyzabc",
 		"",
 		elasticsearch.ClusterConfig{},
@@ -134,7 +138,9 @@ func TestRefinement1_DomainNameValidationInvalidChars(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateDomain("my_domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "my_domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -144,7 +150,9 @@ func TestRefinement1_DomainNameMustStartWithLetter(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateDomain("1bad-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "1bad-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -155,7 +163,9 @@ func TestRefinement1_VpcEndpointStatusActive(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	ep, err := b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/test", map[string]string{"VpcId": "vpc-1"})
+	ep, err := b.CreateVpcEndpoint(
+		context.Background(), "arn:aws:es:us-east-1:123456789012:domain/test", map[string]string{"VpcId": "vpc-1"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, "ACTIVE", ep.Status)
 }
@@ -167,7 +177,7 @@ func TestRefinement1_VpcOptionsDeepCopy(t *testing.T) {
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 	opts := map[string]string{"VpcId": "vpc-1"}
 
-	ep, err := b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/test", opts)
+	ep, err := b.CreateVpcEndpoint(context.Background(), "arn:aws:es:us-east-1:123456789012:domain/test", opts)
 	require.NoError(t, err)
 
 	// Mutating the original opts must not affect the returned endpoint.
@@ -180,7 +190,7 @@ func TestRefinement1_AddDomainInternal(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	b.AddDomainInternal(elasticsearch.Domain{
+	b.AddDomainInternal(context.Background(), elasticsearch.Domain{
 		Name:                 "seed-domain",
 		ARN:                  "arn:aws:es:us-east-1:123456789012:domain/seed-domain",
 		ElasticsearchVersion: "7.10",
@@ -189,7 +199,7 @@ func TestRefinement1_AddDomainInternal(t *testing.T) {
 
 	assert.Equal(t, 1, b.DomainCount())
 
-	d, err := b.DescribeDomain("seed-domain")
+	d, err := b.DescribeDomain(context.Background(), "seed-domain")
 	require.NoError(t, err)
 	assert.Equal(t, "seed-domain", d.Name)
 	assert.Equal(t, "7.10", d.ElasticsearchVersion)
@@ -208,15 +218,17 @@ func TestRefinement1_ExportCountHelpers(t *testing.T) {
 	assert.Equal(t, 0, b.OutboundConnectionCount())
 	assert.Equal(t, 0, b.VpcEndpointCount())
 
-	_, err := b.CreateDomain("cnt-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "cnt-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, b.DomainCount())
 
-	_, err = b.CreatePackage("my-pkg", "TXT-DICTIONARY", "desc")
+	_, err = b.CreatePackage(context.Background(), "my-pkg", "TXT-DICTIONARY", "desc")
 	require.NoError(t, err)
 	assert.Equal(t, 1, b.PackageCount())
 
-	_, err = b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/cnt-domain", nil)
+	_, err = b.CreateVpcEndpoint(context.Background(), "arn:aws:es:us-east-1:123456789012:domain/cnt-domain", nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, b.VpcEndpointCount())
 
@@ -224,10 +236,11 @@ func TestRefinement1_ExportCountHelpers(t *testing.T) {
 		ConnectionID:     "conn-001",
 		ConnectionStatus: "PENDING_ACCEPTANCE",
 	}
-	b.AddInboundConnectionInternal(conn)
+	b.AddInboundConnectionInternal(context.Background(), conn)
 	assert.Equal(t, 1, b.InboundConnectionCount())
 
 	_, err = b.CreateOutboundCrossClusterSearchConnection(
+		context.Background(),
 		elasticsearch.CrossClusterDomainInfo{DomainName: "local"},
 		elasticsearch.CrossClusterDomainInfo{DomainName: "remote"},
 		"my-alias",
@@ -242,16 +255,18 @@ func TestRefinement1_ResetClearsAllMaps(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreateDomain("reset-dom", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "reset-dom", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
 
-	_, err = b.CreatePackage("pkg1", "TXT-DICTIONARY", "")
+	_, err = b.CreatePackage(context.Background(), "pkg1", "TXT-DICTIONARY", "")
 	require.NoError(t, err)
 
-	_, err = b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/reset-dom", nil)
+	_, err = b.CreateVpcEndpoint(context.Background(), "arn:aws:es:us-east-1:123456789012:domain/reset-dom", nil)
 	require.NoError(t, err)
 
-	b.AddInboundConnectionInternal(elasticsearch.InboundConnection{ConnectionID: "c1"})
+	b.AddInboundConnectionInternal(context.Background(), elasticsearch.InboundConnection{ConnectionID: "c1"})
 
 	h := elasticsearch.NewHandler(b)
 	h.Reset()
@@ -268,13 +283,15 @@ func TestRefinement1_PersistenceCoversAllMaps(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreatePackage("dict-pkg", "TXT-DICTIONARY", "my dictionary")
+	_, err := b.CreatePackage(context.Background(), "dict-pkg", "TXT-DICTIONARY", "my dictionary")
 	require.NoError(t, err)
 
-	_, err = b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/my-dom", map[string]string{"VpcId": "vpc-1"})
+	_, err = b.CreateVpcEndpoint(
+		context.Background(), "arn:aws:es:us-east-1:123456789012:domain/my-dom", map[string]string{"VpcId": "vpc-1"},
+	)
 	require.NoError(t, err)
 
-	b.AddInboundConnectionInternal(elasticsearch.InboundConnection{
+	b.AddInboundConnectionInternal(context.Background(), elasticsearch.InboundConnection{
 		ConnectionID: "conn-snap", ConnectionStatus: "PENDING_ACCEPTANCE",
 	})
 
@@ -306,7 +323,9 @@ func TestRefinement1_HandlerResetDelegatesToBackend(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateDomain("del-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "del-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, b.DomainCount())
 
@@ -355,7 +374,7 @@ func TestRefinement1_PackageValidation(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreatePackage("", "TXT-DICTIONARY", "")
+	_, err := b.CreatePackage(context.Background(), "", "TXT-DICTIONARY", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -366,6 +385,7 @@ func TestRefinement1_OutboundConnectionValidation(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 	_, err := b.CreateOutboundCrossClusterSearchConnection(
+		context.Background(),
 		elasticsearch.CrossClusterDomainInfo{},
 		elasticsearch.CrossClusterDomainInfo{},
 		"",
@@ -379,7 +399,7 @@ func TestRefinement1_VpcEndpointValidation(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateVpcEndpoint("", nil)
+	_, err := b.CreateVpcEndpoint(context.Background(), "", nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -389,10 +409,12 @@ func TestRefinement1_AuthorizeVpcEndpointAccessValidation(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateDomain("vpc-auth-dom", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "vpc-auth-dom", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
 
-	err = b.AuthorizeVpcEndpointAccess("vpc-auth-dom", "")
+	err = b.AuthorizeVpcEndpointAccess(context.Background(), "vpc-auth-dom", "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, elasticsearch.ErrValidation)
 }
@@ -402,13 +424,15 @@ func TestRefinement1_DescribeDomainDeepCopy(t *testing.T) {
 	t.Parallel()
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := b.CreateDomain("copy-domain", "7.10", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := b.CreateDomain(
+		context.Background(), "copy-domain", "7.10", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
 
-	d1, err := b.DescribeDomain("copy-domain")
+	d1, err := b.DescribeDomain(context.Background(), "copy-domain")
 	require.NoError(t, err)
 
-	d2, err := b.DescribeDomain("copy-domain")
+	d2, err := b.DescribeDomain(context.Background(), "copy-domain")
 	require.NoError(t, err)
 
 	// Both copies are independent; modifying one doesn't affect the other or the stored domain.
@@ -434,9 +458,9 @@ func TestRefinement1_PersistenceNextIDPreserved(t *testing.T) {
 
 	b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 
-	_, err := b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/test", nil)
+	_, err := b.CreateVpcEndpoint(context.Background(), "arn:aws:es:us-east-1:123456789012:domain/test", nil)
 	require.NoError(t, err)
-	_, err = b.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/test", nil)
+	_, err = b.CreateVpcEndpoint(context.Background(), "arn:aws:es:us-east-1:123456789012:domain/test", nil)
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
@@ -446,7 +470,7 @@ func TestRefinement1_PersistenceNextIDPreserved(t *testing.T) {
 	require.NoError(t, b2.Restore(snap))
 
 	// After restore, a new endpoint should get id 3, not 1.
-	ep, err := b2.CreateVpcEndpoint("arn:aws:es:us-east-1:123456789012:domain/test", nil)
+	ep, err := b2.CreateVpcEndpoint(context.Background(), "arn:aws:es:us-east-1:123456789012:domain/test", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "vpc-endpoint-0000000003", ep.ID)
 }

--- a/services/elasticsearch/handler_stateful_ops_test.go
+++ b/services/elasticsearch/handler_stateful_ops_test.go
@@ -1,6 +1,7 @@
 package elasticsearch_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -175,7 +176,7 @@ func testStatefulConnections(t *testing.T) {
 	t.Helper()
 
 	backend := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	backend.AddInboundConnectionInternal(elasticsearch.InboundConnection{
+	backend.AddInboundConnectionInternal(context.Background(), elasticsearch.InboundConnection{
 		ConnectionID: "connection-state", ConnectionStatus: "PENDING_ACCEPTANCE",
 	})
 	h := elasticsearch.NewHandler(backend)
@@ -199,17 +200,21 @@ func testStatefulSnapshot(t *testing.T) {
 	t.Helper()
 
 	backend := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
-	_, err := backend.CreateDomain("saved-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+	_, err := backend.CreateDomain(
+		context.Background(), "saved-domain", "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+	)
 	require.NoError(t, err)
-	require.NoError(t, backend.AuthorizeVpcEndpointAccess("saved-domain", "222222222222"))
-	_, err = backend.PurchaseReservedElasticsearchInstanceOffering("offer-t3-small-1y", "saved-reservation", 1)
+	require.NoError(t, backend.AuthorizeVpcEndpointAccess(context.Background(), "saved-domain", "222222222222"))
+	_, err = backend.PurchaseReservedElasticsearchInstanceOffering(
+		context.Background(), "offer-t3-small-1y", "saved-reservation", 1,
+	)
 	require.NoError(t, err)
 
 	restored := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 	require.NoError(t, restored.Restore(backend.Snapshot()))
 
-	accounts, err := restored.ListVpcEndpointAccess("saved-domain")
+	accounts, err := restored.ListVpcEndpointAccess(context.Background(), "saved-domain")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"222222222222"}, accounts)
-	assert.Len(t, restored.DescribeReservedElasticsearchInstances(), 1)
+	assert.Len(t, restored.DescribeReservedElasticsearchInstances(context.Background()), 1)
 }

--- a/services/elasticsearch/handler_test.go
+++ b/services/elasticsearch/handler_test.go
@@ -2,6 +2,7 @@ package elasticsearch_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -602,11 +603,13 @@ func TestElasticsearchBackend_DNSRegistrar(t *testing.T) {
 			b := elasticsearch.NewInMemoryBackend("123456789012", "us-east-1")
 			b.SetDNSRegistrar(registrar)
 
-			domain, err := b.CreateDomain(tt.domainName, "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{})
+			domain, err := b.CreateDomain(
+				context.Background(), tt.domainName, "", elasticsearch.ClusterConfig{}, elasticsearch.EBSOptions{},
+			)
 			require.NoError(t, err)
 
 			if tt.deleteAfter {
-				_, err = b.DeleteDomain(tt.domainName)
+				_, err = b.DeleteDomain(context.Background(), tt.domainName)
 				require.NoError(t, err)
 			}
 
@@ -1067,7 +1070,7 @@ func TestElasticsearchHandler_AcceptInboundCrossClusterSearchConnection(t *testi
 			h := elasticsearch.NewHandler(b)
 
 			if tt.seed != nil {
-				b.AddInboundConnectionInternal(*tt.seed)
+				b.AddInboundConnectionInternal(context.Background(), *tt.seed)
 			}
 
 			resp := doRequest(t, h, http.MethodPut,

--- a/services/elasticsearch/isolation_test.go
+++ b/services/elasticsearch/isolation_test.go
@@ -1,0 +1,138 @@
+package elasticsearch //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region under regionContextKey.
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestElasticsearchDomainRegionIsolation proves that same-named domains in two
+// regions are fully isolated: each region sees only its own domain (with its own
+// region-scoped ARN, endpoint and version), and deleting in one region leaves the
+// other intact.
+func TestElasticsearchDomainRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	const (
+		eastVersion = "7.10"
+		westVersion = "7.1"
+	)
+
+	// 1. Create a domain named "search1" in us-east-1.
+	eastDomain, err := backend.CreateDomain(ctxEast, "search1", eastVersion, ClusterConfig{}, EBSOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, eastDomain.ARN, "us-east-1")
+	assert.Contains(t, eastDomain.Endpoint, "us-east-1")
+	assert.Equal(t, eastVersion, eastDomain.ElasticsearchVersion)
+
+	// 2. Create a domain with the SAME NAME in us-west-2 with a different version.
+	westDomain, err := backend.CreateDomain(ctxWest, "search1", westVersion, ClusterConfig{}, EBSOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, westDomain.ARN, "us-west-2")
+	assert.Contains(t, westDomain.Endpoint, "us-west-2")
+	assert.Equal(t, westVersion, westDomain.ElasticsearchVersion)
+
+	// 3. us-east-1 sees only its own domain with its own ARN and version.
+	eastNames := backend.ListDomainNames(ctxEast)
+	require.Len(t, eastNames, 1)
+	assert.Equal(t, "search1", eastNames[0])
+
+	eastGet, err := backend.DescribeDomain(ctxEast, "search1")
+	require.NoError(t, err)
+	assert.Equal(t, eastVersion, eastGet.ElasticsearchVersion)
+	assert.Contains(t, eastGet.ARN, "us-east-1")
+
+	// 4. us-west-2 sees only its own domain with its own ARN and version.
+	westNames := backend.ListDomainNames(ctxWest)
+	require.Len(t, westNames, 1)
+	assert.Equal(t, "search1", westNames[0])
+
+	westGet, err := backend.DescribeDomain(ctxWest, "search1")
+	require.NoError(t, err)
+	assert.Equal(t, westVersion, westGet.ElasticsearchVersion)
+	assert.Contains(t, westGet.ARN, "us-west-2")
+
+	// 5. Delete in us-east-1; us-west-2 still has its domain.
+	_, err = backend.DeleteDomain(ctxEast, "search1")
+	require.NoError(t, err)
+
+	_, err = backend.DescribeDomain(ctxEast, "search1")
+	require.ErrorIs(t, err, ErrDomainNotFound)
+
+	westAfter, err := backend.DescribeDomain(ctxWest, "search1")
+	require.NoError(t, err)
+	assert.Contains(t, westAfter.ARN, "us-west-2")
+}
+
+// TestElasticsearchTagRegionIsolation proves that ARN-addressed tag operations
+// resolve the region from the ARN itself, so a tag written via a us-east-1 request
+// context lands on the us-west-2 domain when the ARN names us-west-2.
+func TestElasticsearchTagRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// Same-named domain in both regions.
+	eastDomain, err := backend.CreateDomain(ctxEast, "shared-dom", "", ClusterConfig{}, EBSOptions{})
+	require.NoError(t, err)
+
+	westDomain, err := backend.CreateDomain(ctxWest, "shared-dom", "", ClusterConfig{}, EBSOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, eastDomain.ARN, westDomain.ARN)
+
+	// Tag the us-west-2 domain via its ARN, using a us-east-1 request context.
+	// The region is resolved from the ARN, so the tag must land in us-west-2.
+	require.NoError(t, backend.AddTags(ctxEast, westDomain.ARN, map[string]string{"env": "west"}))
+
+	westTags, err := backend.ListTags(ctxEast, westDomain.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, "west", westTags["env"])
+
+	// The us-east-1 domain (different ARN) must remain untagged.
+	eastTags, err := backend.ListTags(ctxEast, eastDomain.ARN)
+	require.NoError(t, err)
+	assert.Empty(t, eastTags)
+}
+
+// TestElasticsearchPackageRegionIsolation proves packages are region-isolated:
+// a package created in one region is invisible to another region.
+func TestElasticsearchPackageRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	pkg, err := backend.CreatePackage(ctxEast, "dict", "TXT-DICTIONARY", "east dictionary")
+	require.NoError(t, err)
+
+	// us-east-1 sees the package.
+	eastPkgs := backend.DescribePackages(ctxEast, nil)
+	require.Len(t, eastPkgs, 1)
+	assert.Equal(t, pkg.ID, eastPkgs[0].ID)
+
+	// us-west-2 sees no packages.
+	westPkgs := backend.DescribePackages(ctxWest, nil)
+	assert.Empty(t, westPkgs)
+
+	// A same-named package can be created independently in us-west-2.
+	_, err = backend.CreatePackage(ctxWest, "dict", "TXT-DICTIONARY", "west dictionary")
+	require.NoError(t, err)
+	assert.Len(t, backend.DescribePackages(ctxWest, nil), 1)
+}

--- a/services/elasticsearch/persistence.go
+++ b/services/elasticsearch/persistence.go
@@ -6,19 +6,22 @@ import (
 	"maps"
 )
 
+// backendSnapshot persists the backend state. All resource maps are nested by
+// region (outer key = region) so same-named resources in different regions stay
+// isolated across snapshot/restore.
 type backendSnapshot struct {
-	Domains             map[string]*Domain             `json:"domains"`
-	Packages            map[string]*Package            `json:"packages"`
-	PackagesByName      map[string]string              `json:"packagesByName"`
-	PackageAssociations map[string][]string            `json:"packageAssociations"`
-	InboundConnections  map[string]*InboundConnection  `json:"inboundConnections"`
-	OutboundConnections map[string]*OutboundConnection `json:"outboundConnections"`
-	VpcEndpoints        map[string]*VpcEndpoint        `json:"vpcEndpoints"`
-	VpcAccess           map[string][]string            `json:"vpcAccess"`
-	ReservedInstances   map[string]*ReservedInstance   `json:"reservedInstances"`
-	AccountID           string                         `json:"accountID"`
-	Region              string                         `json:"region"`
-	NextID              int                            `json:"nextID"`
+	Domains             map[string]map[string]*Domain             `json:"domains"`
+	Packages            map[string]map[string]*Package            `json:"packages"`
+	PackagesByName      map[string]map[string]string              `json:"packagesByName"`
+	PackageAssociations map[string]map[string][]string            `json:"packageAssociations"`
+	InboundConnections  map[string]map[string]*InboundConnection  `json:"inboundConnections"`
+	OutboundConnections map[string]map[string]*OutboundConnection `json:"outboundConnections"`
+	VpcEndpoints        map[string]map[string]*VpcEndpoint        `json:"vpcEndpoints"`
+	VpcAccess           map[string]map[string][]string            `json:"vpcAccess"`
+	ReservedInstances   map[string]map[string]*ReservedInstance   `json:"reservedInstances"`
+	AccountID           string                                    `json:"accountID"`
+	Region              string                                    `json:"region"`
+	NextID              int                                       `json:"nextID"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -26,74 +29,16 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	// Deep-copy all maps so the snapshot is independent of live state.
-	// Domains are serialized with their Tags intact (Tags implements json.Marshaler).
-	domains := make(map[string]*Domain, len(b.domains))
-	for k, v := range b.domains {
-		cp := *v
-		domains[k] = &cp
-	}
-
-	packages := make(map[string]*Package, len(b.packages))
-	for k, v := range b.packages {
-		cp := *v
-		packages[k] = &cp
-	}
-
-	packagesByName := make(map[string]string, len(b.packagesByName))
-	maps.Copy(packagesByName, b.packagesByName)
-
-	packageAssociations := make(map[string][]string, len(b.packageAssociations))
-	for k, v := range b.packageAssociations {
-		cp := make([]string, len(v))
-		copy(cp, v)
-		packageAssociations[k] = cp
-	}
-
-	inbound := make(map[string]*InboundConnection, len(b.inboundConnections))
-	for k, v := range b.inboundConnections {
-		cp := *v
-		inbound[k] = &cp
-	}
-
-	outbound := make(map[string]*OutboundConnection, len(b.outboundConnections))
-	for k, v := range b.outboundConnections {
-		cp := *v
-		outbound[k] = &cp
-	}
-
-	vpcEndpoints := make(map[string]*VpcEndpoint, len(b.vpcEndpoints))
-	for k, v := range b.vpcEndpoints {
-		cp := *v
-		if v.VpcOptions != nil {
-			opts := make(map[string]string, len(v.VpcOptions))
-			maps.Copy(opts, v.VpcOptions)
-			cp.VpcOptions = opts
-		}
-		vpcEndpoints[k] = &cp
-	}
-
-	vpcAccess := make(map[string][]string, len(b.vpcAccess))
-	for domainName, accounts := range b.vpcAccess {
-		vpcAccess[domainName] = append([]string(nil), accounts...)
-	}
-
-	reservedInstances := make(map[string]*ReservedInstance, len(b.reservedInstances))
-	for id, instance := range b.reservedInstances {
-		cp := *instance
-		reservedInstances[id] = &cp
-	}
-
 	snap := backendSnapshot{
-		Domains:             domains,
-		Packages:            packages,
-		PackagesByName:      packagesByName,
-		PackageAssociations: packageAssociations,
-		InboundConnections:  inbound,
-		OutboundConnections: outbound,
-		VpcEndpoints:        vpcEndpoints,
-		VpcAccess:           vpcAccess,
-		ReservedInstances:   reservedInstances,
+		Domains:             snapshotDomains(b.domains),
+		Packages:            snapshotPackages(b.packages),
+		PackagesByName:      snapshotStringMaps(b.packagesByName),
+		PackageAssociations: snapshotStringSliceMaps(b.packageAssociations),
+		InboundConnections:  snapshotInbound(b.inboundConnections),
+		OutboundConnections: snapshotOutbound(b.outboundConnections),
+		VpcEndpoints:        snapshotVpcEndpoints(b.vpcEndpoints),
+		VpcAccess:           snapshotStringSliceMaps(b.vpcAccess),
+		ReservedInstances:   snapshotReserved(b.reservedInstances),
 		AccountID:           b.accountID,
 		Region:              b.region,
 		NextID:              b.nextID,
@@ -109,6 +54,128 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	return data
 }
 
+// snapshotDomains deep-copies the region-nested domain map.
+// Domains are serialized with their Tags intact (Tags implements json.Marshaler).
+func snapshotDomains(src map[string]map[string]*Domain) map[string]map[string]*Domain {
+	out := make(map[string]map[string]*Domain, len(src))
+	for region, domains := range src {
+		regionCopy := make(map[string]*Domain, len(domains))
+		for name, d := range domains {
+			cp := *d
+			regionCopy[name] = &cp
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotPackages deep-copies the region-nested package map.
+func snapshotPackages(src map[string]map[string]*Package) map[string]map[string]*Package {
+	out := make(map[string]map[string]*Package, len(src))
+	for region, packages := range src {
+		regionCopy := make(map[string]*Package, len(packages))
+		for id, p := range packages {
+			cp := *p
+			regionCopy[id] = &cp
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotStringMaps deep-copies a region-nested map[string]string.
+func snapshotStringMaps(src map[string]map[string]string) map[string]map[string]string {
+	out := make(map[string]map[string]string, len(src))
+	for region, inner := range src {
+		regionCopy := make(map[string]string, len(inner))
+		maps.Copy(regionCopy, inner)
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotStringSliceMaps deep-copies a region-nested map[string][]string.
+func snapshotStringSliceMaps(src map[string]map[string][]string) map[string]map[string][]string {
+	out := make(map[string]map[string][]string, len(src))
+	for region, inner := range src {
+		regionCopy := make(map[string][]string, len(inner))
+		for k, v := range inner {
+			regionCopy[k] = append([]string(nil), v...)
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotInbound deep-copies the region-nested inbound connection map.
+func snapshotInbound(src map[string]map[string]*InboundConnection) map[string]map[string]*InboundConnection {
+	out := make(map[string]map[string]*InboundConnection, len(src))
+	for region, conns := range src {
+		regionCopy := make(map[string]*InboundConnection, len(conns))
+		for id, c := range conns {
+			cp := *c
+			regionCopy[id] = &cp
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotOutbound deep-copies the region-nested outbound connection map.
+func snapshotOutbound(src map[string]map[string]*OutboundConnection) map[string]map[string]*OutboundConnection {
+	out := make(map[string]map[string]*OutboundConnection, len(src))
+	for region, conns := range src {
+		regionCopy := make(map[string]*OutboundConnection, len(conns))
+		for id, c := range conns {
+			cp := *c
+			regionCopy[id] = &cp
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotVpcEndpoints deep-copies the region-nested VPC endpoint map, cloning VpcOptions.
+func snapshotVpcEndpoints(src map[string]map[string]*VpcEndpoint) map[string]map[string]*VpcEndpoint {
+	out := make(map[string]map[string]*VpcEndpoint, len(src))
+	for region, endpoints := range src {
+		regionCopy := make(map[string]*VpcEndpoint, len(endpoints))
+		for id, ep := range endpoints {
+			cp := *ep
+			if ep.VpcOptions != nil {
+				opts := make(map[string]string, len(ep.VpcOptions))
+				maps.Copy(opts, ep.VpcOptions)
+				cp.VpcOptions = opts
+			}
+			regionCopy[id] = &cp
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
+// snapshotReserved deep-copies the region-nested reserved instance map.
+func snapshotReserved(src map[string]map[string]*ReservedInstance) map[string]map[string]*ReservedInstance {
+	out := make(map[string]map[string]*ReservedInstance, len(src))
+	for region, reserved := range src {
+		regionCopy := make(map[string]*ReservedInstance, len(reserved))
+		for id, ri := range reserved {
+			cp := *ri
+			regionCopy[id] = &cp
+		}
+		out[region] = regionCopy
+	}
+
+	return out
+}
+
 // Restore loads backend state from a JSON snapshot.
 func (b *InMemoryBackend) Restore(data []byte) error {
 	var snap backendSnapshot
@@ -121,45 +188,13 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	defer b.mu.Unlock()
 
 	// Close existing Tags to release Prometheus metrics before replacing state.
-	for _, d := range b.domains {
-		d.Tags.Close()
+	for _, regionDomains := range b.domains {
+		for _, d := range regionDomains {
+			d.Tags.Close()
+		}
 	}
 
-	if snap.Domains == nil {
-		snap.Domains = make(map[string]*Domain)
-	}
-
-	if snap.Packages == nil {
-		snap.Packages = make(map[string]*Package)
-	}
-
-	if snap.PackagesByName == nil {
-		snap.PackagesByName = make(map[string]string)
-	}
-
-	if snap.PackageAssociations == nil {
-		snap.PackageAssociations = make(map[string][]string)
-	}
-
-	if snap.InboundConnections == nil {
-		snap.InboundConnections = make(map[string]*InboundConnection)
-	}
-
-	if snap.OutboundConnections == nil {
-		snap.OutboundConnections = make(map[string]*OutboundConnection)
-	}
-
-	if snap.VpcEndpoints == nil {
-		snap.VpcEndpoints = make(map[string]*VpcEndpoint)
-	}
-
-	if snap.VpcAccess == nil {
-		snap.VpcAccess = make(map[string][]string)
-	}
-
-	if snap.ReservedInstances == nil {
-		snap.ReservedInstances = make(map[string]*ReservedInstance)
-	}
+	ensureNonNilMaps(&snap)
 
 	b.domains = snap.Domains
 	b.packages = snap.Packages
@@ -174,13 +209,56 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.region = snap.Region
 	b.nextID = snap.NextID
 
-	// Rebuild ARN index from restored state.
-	b.arnIndex = make(map[string]string, len(b.domains))
-	for name, d := range b.domains {
-		b.arnIndex[d.ARN] = name
+	// Rebuild the region-nested ARN index from restored state.
+	b.arnIndex = make(map[string]map[string]string, len(b.domains))
+	for region, domains := range b.domains {
+		index := make(map[string]string, len(domains))
+		for name, d := range domains {
+			index[d.ARN] = name
+		}
+		b.arnIndex[region] = index
 	}
 
 	return nil
+}
+
+// ensureNonNilMaps initialises nil maps in the snapshot to empty maps.
+func ensureNonNilMaps(snap *backendSnapshot) {
+	if snap.Domains == nil {
+		snap.Domains = make(map[string]map[string]*Domain)
+	}
+
+	if snap.Packages == nil {
+		snap.Packages = make(map[string]map[string]*Package)
+	}
+
+	if snap.PackagesByName == nil {
+		snap.PackagesByName = make(map[string]map[string]string)
+	}
+
+	if snap.PackageAssociations == nil {
+		snap.PackageAssociations = make(map[string]map[string][]string)
+	}
+
+	if snap.InboundConnections == nil {
+		snap.InboundConnections = make(map[string]map[string]*InboundConnection)
+	}
+
+	if snap.OutboundConnections == nil {
+		snap.OutboundConnections = make(map[string]map[string]*OutboundConnection)
+	}
+
+	if snap.VpcEndpoints == nil {
+		snap.VpcEndpoints = make(map[string]map[string]*VpcEndpoint)
+	}
+
+	if snap.VpcAccess == nil {
+		snap.VpcAccess = make(map[string]map[string][]string)
+	}
+
+	if snap.ReservedInstances == nil {
+		snap.ReservedInstances = make(map[string]map[string]*ReservedInstance)
+	}
 }
 
 // Snapshot implements persistence.Persistable by delegating to the backend.

--- a/services/elasticsearch/persistence_test.go
+++ b/services/elasticsearch/persistence_test.go
@@ -1,6 +1,7 @@
 package elasticsearch_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,7 @@ func TestElasticsearch_PersistenceSnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *elasticsearch.InMemoryBackend) {
 				t.Helper()
 
-				names := b.ListDomainNames()
+				names := b.ListDomainNames(context.Background())
 				assert.Empty(t, names)
 			},
 		},
@@ -33,6 +34,7 @@ func TestElasticsearch_PersistenceSnapshotRestore(t *testing.T) {
 				t.Helper()
 
 				_, err := b.CreateDomain(
+					context.Background(),
 					"my-domain",
 					"7.10",
 					elasticsearch.ClusterConfig{InstanceType: "t3.small.elasticsearch", InstanceCount: 1},
@@ -43,11 +45,11 @@ func TestElasticsearch_PersistenceSnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *elasticsearch.InMemoryBackend) {
 				t.Helper()
 
-				names := b.ListDomainNames()
+				names := b.ListDomainNames(context.Background())
 				require.Len(t, names, 1)
 				assert.Equal(t, "my-domain", names[0])
 
-				d, err := b.DescribeDomain("my-domain")
+				d, err := b.DescribeDomain(context.Background(), "my-domain")
 				require.NoError(t, err)
 				assert.Equal(t, "7.10", d.ElasticsearchVersion)
 				assert.Equal(t, "Active", d.Status)
@@ -60,6 +62,7 @@ func TestElasticsearch_PersistenceSnapshotRestore(t *testing.T) {
 				t.Helper()
 
 				d, err := b.CreateDomain(
+					context.Background(),
 					"tagged-domain",
 					"",
 					elasticsearch.ClusterConfig{},
@@ -67,20 +70,20 @@ func TestElasticsearch_PersistenceSnapshotRestore(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				require.NoError(t, b.AddTags(d.ARN, map[string]string{"team": "platform"}))
+				require.NoError(t, b.AddTags(context.Background(), d.ARN, map[string]string{"team": "platform"}))
 			},
 			verify: func(t *testing.T, b *elasticsearch.InMemoryBackend) {
 				t.Helper()
 
-				d, err := b.DescribeDomain("tagged-domain")
+				d, err := b.DescribeDomain(context.Background(), "tagged-domain")
 				require.NoError(t, err)
 
-				tagMap, err := b.ListTags(d.ARN)
+				tagMap, err := b.ListTags(context.Background(), d.ARN)
 				require.NoError(t, err)
 				assert.Equal(t, "platform", tagMap["team"])
 
 				// ARN index must be rebuilt: ARN lookup must work.
-				tagMap2, err := b.ListTags(d.ARN)
+				tagMap2, err := b.ListTags(context.Background(), d.ARN)
 				require.NoError(t, err)
 				assert.Equal(t, tagMap, tagMap2)
 			},

--- a/services/elb/backend.go
+++ b/services/elb/backend.go
@@ -3,6 +3,7 @@
 package elb
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 	"regexp"
@@ -17,6 +18,23 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+// Classic ELB load balancers are isolated per region: every backend operation
+// resolves the caller's region from the request context and operates only on
+// that region's nested store. A Classic ELB and all of its listeners, policies,
+// instances, and tags live entirely within a single region, so cross-region
+// references never occur and isolation is always safe.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 const (
 	policyTypeAppCookie   = "AppCookieStickinessPolicyType"
@@ -287,53 +305,75 @@ type PolicyTypeDescription struct {
 }
 
 // StorageBackend is the interface for the ELB in-memory store.
+//
+// Every operation that touches per-load-balancer state takes a context.Context
+// so the backend can resolve the caller's AWS region and route the operation to
+// that region's isolated store. Region returns the backend's default region for
+// callers (e.g. the HTTP handler) that need a fallback when the request omits a
+// region.
 type StorageBackend interface {
 	Reset()
+	Region() string
 
-	CreateLoadBalancer(input CreateLoadBalancerInput) (*LoadBalancer, error)
-	DeleteLoadBalancer(name string) error
-	DescribeLoadBalancers(names []string) ([]LoadBalancer, error)
+	CreateLoadBalancer(ctx context.Context, input CreateLoadBalancerInput) (*LoadBalancer, error)
+	DeleteLoadBalancer(ctx context.Context, name string) error
+	DescribeLoadBalancers(ctx context.Context, names []string) ([]LoadBalancer, error)
 
-	CreateLoadBalancerListeners(name string, listeners []Listener) error
-	DeleteLoadBalancerListeners(name string, ports []int32) error
+	CreateLoadBalancerListeners(ctx context.Context, name string, listeners []Listener) error
+	DeleteLoadBalancerListeners(ctx context.Context, name string, ports []int32) error
 
-	RegisterInstancesWithLoadBalancer(name string, instances []Instance) ([]Instance, error)
-	DeregisterInstancesFromLoadBalancer(name string, instances []Instance) ([]Instance, error)
+	RegisterInstancesWithLoadBalancer(ctx context.Context, name string, instances []Instance) ([]Instance, error)
+	DeregisterInstancesFromLoadBalancer(ctx context.Context, name string, instances []Instance) ([]Instance, error)
 
-	ConfigureHealthCheck(name string, hc HealthCheck) (*HealthCheck, error)
+	ConfigureHealthCheck(ctx context.Context, name string, hc HealthCheck) (*HealthCheck, error)
 
-	ModifyLoadBalancerAttributes(name string, attrs LoadBalancerAttributes) (*LoadBalancerAttributes, error)
-	DescribeLoadBalancerAttributes(name string) (*LoadBalancerAttributes, error)
+	ModifyLoadBalancerAttributes(
+		ctx context.Context, name string, attrs LoadBalancerAttributes,
+	) (*LoadBalancerAttributes, error)
+	DescribeLoadBalancerAttributes(ctx context.Context, name string) (*LoadBalancerAttributes, error)
 
-	AddTags(names []string, kvs []tags.KV) error
-	DescribeTags(names []string) (map[string][]tags.KV, error)
-	RemoveTags(names []string, keys []string) error
+	AddTags(ctx context.Context, names []string, kvs []tags.KV) error
+	DescribeTags(ctx context.Context, names []string) (map[string][]tags.KV, error)
+	RemoveTags(ctx context.Context, names []string, keys []string) error
 
-	ApplySecurityGroupsToLoadBalancer(name string, securityGroups []string) ([]string, error)
-	AttachLoadBalancerToSubnets(name string, subnets []string) ([]string, error)
-	DetachLoadBalancerFromSubnets(name string, subnets []string) ([]string, error)
-	EnableAvailabilityZonesForLoadBalancer(name string, azs []string) ([]string, error)
-	DisableAvailabilityZonesForLoadBalancer(name string, azs []string) ([]string, error)
-	SetLoadBalancerListenerSSLCertificate(name string, port int32, certID string) error
-	SetLoadBalancerPoliciesOfListener(name string, port int32, policyNames []string) error
-	SetLoadBalancerPoliciesForBackendServer(name string, instancePort int32, policyNames []string) error
+	ApplySecurityGroupsToLoadBalancer(ctx context.Context, name string, securityGroups []string) ([]string, error)
+	AttachLoadBalancerToSubnets(ctx context.Context, name string, subnets []string) ([]string, error)
+	DetachLoadBalancerFromSubnets(ctx context.Context, name string, subnets []string) ([]string, error)
+	EnableAvailabilityZonesForLoadBalancer(ctx context.Context, name string, azs []string) ([]string, error)
+	DisableAvailabilityZonesForLoadBalancer(ctx context.Context, name string, azs []string) ([]string, error)
+	SetLoadBalancerListenerSSLCertificate(ctx context.Context, name string, port int32, certID string) error
+	SetLoadBalancerPoliciesOfListener(ctx context.Context, name string, port int32, policyNames []string) error
+	SetLoadBalancerPoliciesForBackendServer(
+		ctx context.Context, name string, instancePort int32, policyNames []string,
+	) error
 
-	CreateAppCookieStickinessPolicy(name, policyName, cookieName string) error
-	CreateLBCookieStickinessPolicy(name, policyName string, cookieExpirationPeriod int64) error
-	CreateLoadBalancerPolicy(name, policyName, policyTypeName string, attrs []PolicyAttribute) error
-	DeleteLoadBalancerPolicy(name, policyName string) error
+	CreateAppCookieStickinessPolicy(ctx context.Context, name, policyName, cookieName string) error
+	CreateLBCookieStickinessPolicy(ctx context.Context, name, policyName string, cookieExpirationPeriod int64) error
+	CreateLoadBalancerPolicy(
+		ctx context.Context,
+		name, policyName, policyTypeName string,
+		attrs []PolicyAttribute,
+	) error
+	DeleteLoadBalancerPolicy(ctx context.Context, name, policyName string) error
 
-	DescribeAccountLimits() ([]AccountLimit, error)
-	DescribeInstanceHealth(name string, instances []Instance) ([]InstanceState, error)
-	DescribeLoadBalancerPolicies(name string, policyNames []string) ([]LoadBalancerPolicy, error)
-	DescribeLoadBalancerPolicyTypes(policyTypeNames []string) ([]PolicyTypeDescription, error)
+	DescribeAccountLimits(ctx context.Context) ([]AccountLimit, error)
+	DescribeInstanceHealth(ctx context.Context, name string, instances []Instance) ([]InstanceState, error)
+	DescribeLoadBalancerPolicies(ctx context.Context, name string, policyNames []string) ([]LoadBalancerPolicy, error)
+	DescribeLoadBalancerPolicyTypes(ctx context.Context, policyTypeNames []string) ([]PolicyTypeDescription, error)
 }
 
 // InMemoryBackend implements StorageBackend using in-memory maps.
+//
+// Both the lbs and policies maps are nested by region (outer key = region) so
+// that same-named load balancers and policies are fully isolated across
+// regions. The per-region inner maps are created lazily via the *Store helpers.
+// Callers must hold b.mu while accessing the inner maps.
 type InMemoryBackend struct {
-	lbs map[string]*LoadBalancer
-	// policies stores load balancer policies keyed by "loadBalancerName/policyName".
-	policies  map[string]*LoadBalancerPolicy
+	// lbs stores load balancers nested by region: lbs[region][loadBalancerName].
+	lbs map[string]map[string]*LoadBalancer
+	// policies stores load balancer policies nested by region and keyed by
+	// "loadBalancerName/policyName": policies[region][key].
+	policies  map[string]map[string]*LoadBalancerPolicy
 	mu        *lockmetrics.RWMutex
 	accountID string
 	region    string
@@ -342,27 +382,54 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		lbs:       make(map[string]*LoadBalancer),
-		policies:  make(map[string]*LoadBalancerPolicy),
+		lbs:       make(map[string]map[string]*LoadBalancer),
+		policies:  make(map[string]map[string]*LoadBalancerPolicy),
 		mu:        lockmetrics.New("elb"),
 		accountID: accountID,
 		region:    region,
 	}
 }
 
-// Reset clears all backend state. All Tags registries are closed to avoid metric leaks.
+// Region returns the AWS region this backend was configured with. It is the
+// fallback region used when a request context carries no region.
+func (b *InMemoryBackend) Region() string { return b.region }
+
+// lbsStore returns the per-region load balancer map, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) lbsStore(region string) map[string]*LoadBalancer {
+	if b.lbs[region] == nil {
+		b.lbs[region] = make(map[string]*LoadBalancer)
+	}
+
+	return b.lbs[region]
+}
+
+// policiesStore returns the per-region policy map, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) policiesStore(region string) map[string]*LoadBalancerPolicy {
+	if b.policies[region] == nil {
+		b.policies[region] = make(map[string]*LoadBalancerPolicy)
+	}
+
+	return b.policies[region]
+}
+
+// Reset clears all backend state across every region. All Tags registries are
+// closed to avoid metric leaks.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, lb := range b.lbs {
-		if lb.Tags != nil {
-			lb.Tags.Close()
+	for _, regionLBs := range b.lbs {
+		for _, lb := range regionLBs {
+			if lb.Tags != nil {
+				lb.Tags.Close()
+			}
 		}
 	}
 
-	b.lbs = make(map[string]*LoadBalancer)
-	b.policies = make(map[string]*LoadBalancerPolicy)
+	b.lbs = make(map[string]map[string]*LoadBalancer)
+	b.policies = make(map[string]map[string]*LoadBalancerPolicy)
 }
 
 // lbCopy returns a deep copy of a LoadBalancer, excluding the Tags pointer (which is
@@ -444,7 +511,7 @@ func (b *InMemoryBackend) AddLoadBalancerInternal(lb LoadBalancer) {
 	}
 
 	cp := lbCopy(&lb)
-	b.lbs[lb.LoadBalancerName] = &cp
+	b.lbsStore(b.region)[lb.LoadBalancerName] = &cp
 }
 
 // validateCreateLBName checks that the LB name is present and well-formed.
@@ -506,8 +573,37 @@ func validateCreateLBZones(input CreateLoadBalancerInput) error {
 	return nil
 }
 
-// CreateLoadBalancer creates a new Classic ELB load balancer.
+// nonNilStrings returns src, or an empty (non-nil) slice when src is nil, so
+// stored load balancers never carry nil slices.
+func nonNilStrings(src []string) []string {
+	if src == nil {
+		return []string{}
+	}
+
+	return src
+}
+
+// deriveVPCID returns the synthetic VPC ID for a load balancer. VPC-mode load
+// balancers (those with subnets) get a stable ID derived from the first 8
+// characters of the account ID; EC2-Classic load balancers get an empty ID.
+func (b *InMemoryBackend) deriveVPCID(subnets []string) string {
+	const vpcSuffixLen = 8
+
+	if len(subnets) == 0 {
+		return ""
+	}
+
+	acctSuffix := b.accountID
+	if len(acctSuffix) > vpcSuffixLen {
+		acctSuffix = acctSuffix[:vpcSuffixLen]
+	}
+
+	return "vpc-" + acctSuffix
+}
+
+// CreateLoadBalancer creates a new Classic ELB load balancer in the caller's region.
 func (b *InMemoryBackend) CreateLoadBalancer(
+	ctx context.Context,
 	input CreateLoadBalancerInput,
 ) (*LoadBalancer, error) {
 	if err := validateCreateLBName(input.LoadBalancerName); err != nil {
@@ -522,12 +618,15 @@ func (b *InMemoryBackend) CreateLoadBalancer(
 	b.mu.Lock("CreateLoadBalancer")
 	defer b.mu.Unlock()
 
-	if _, exists := b.lbs[input.LoadBalancerName]; exists {
+	region := getRegion(ctx, b.region)
+	store := b.lbsStore(region)
+
+	if _, exists := store[input.LoadBalancerName]; exists {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerAlreadyExists, input.LoadBalancerName)
 	}
 
 	const maxLBs = 20
-	if len(b.lbs) >= maxLBs {
+	if len(store) >= maxLBs {
 		return nil, fmt.Errorf(
 			"%w: classic-load-balancers limit of %d exceeded",
 			ErrValidation, maxLBs,
@@ -546,50 +645,27 @@ func (b *InMemoryBackend) CreateLoadBalancer(
 		dnsPrefix = "internal-" + dnsPrefix
 	}
 
-	dnsName := dnsPrefix + "." + b.region + ".elb.amazonaws.com"
-	lbARN := arn.Build("elasticloadbalancing", b.region, b.accountID, "loadbalancer/"+input.LoadBalancerName)
+	dnsName := dnsPrefix + "." + region + ".elb.amazonaws.com"
+	lbARN := arn.Build("elasticloadbalancing", region, b.accountID, "loadbalancer/"+input.LoadBalancerName)
 
 	// Ensure non-nil slices so callers never have to nil-check.
-	azs := input.AvailabilityZones
-	if azs == nil {
-		azs = []string{}
-	}
-
-	sgs := input.SecurityGroups
-	if sgs == nil {
-		sgs = []string{}
-	}
-
-	subnets := input.Subnets
-	if subnets == nil {
-		subnets = []string{}
-	}
+	azs := nonNilStrings(input.AvailabilityZones)
+	sgs := nonNilStrings(input.SecurityGroups)
+	subnets := nonNilStrings(input.Subnets)
 
 	listeners := input.Listeners
 	if listeners == nil {
 		listeners = []Listener{}
 	}
 
-	// Derive VPCId: if subnets are provided (VPC-mode LB) use a stable synthetic ID.
-	// The first 8 characters of the account ID make a reasonably unique VPC identifier.
-	const vpcSuffixLen = 8
-
-	vpcID := ""
-	if len(subnets) > 0 {
-		acctSuffix := b.accountID
-		if len(acctSuffix) > vpcSuffixLen {
-			acctSuffix = acctSuffix[:vpcSuffixLen]
-		}
-
-		vpcID = "vpc-" + acctSuffix
-	}
+	vpcID := b.deriveVPCID(subnets)
 
 	lb := &LoadBalancer{
 		LoadBalancerName:          input.LoadBalancerName,
 		ARN:                       lbARN,
 		DNSName:                   dnsName,
 		CanonicalHostedZoneName:   dnsName,
-		CanonicalHostedZoneNameID: canonicalHostedZoneIDForRegion(b.region),
+		CanonicalHostedZoneNameID: canonicalHostedZoneIDForRegion(region),
 		CreatedTime:               time.Now(),
 		Scheme:                    scheme,
 		AvailabilityZones:         azs,
@@ -601,52 +677,60 @@ func (b *InMemoryBackend) CreateLoadBalancer(
 		BackendServerDescriptions: []BackendServerDescription{},
 		Tags:                      tags.New("elb." + input.LoadBalancerName),
 		AccountID:                 b.accountID,
-		Region:                    b.region,
+		Region:                    region,
 		Attributes:                defaultLBAttributes(),
 		IsVPC:                     isVPC,
 	}
 
-	b.lbs[input.LoadBalancerName] = lb
+	store[input.LoadBalancerName] = lb
 
 	cp := lbCopy(lb)
 
 	return &cp, nil
 }
 
-// DeleteLoadBalancer removes a load balancer by name and all of its policies.
-func (b *InMemoryBackend) DeleteLoadBalancer(name string) error {
+// DeleteLoadBalancer removes a load balancer by name and all of its policies
+// within the caller's region.
+func (b *InMemoryBackend) DeleteLoadBalancer(ctx context.Context, name string) error {
 	b.mu.Lock("DeleteLoadBalancer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	region := getRegion(ctx, b.region)
+	store := b.lbsStore(region)
+
+	lb, ok := store[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	lb.Tags.Close()
-	delete(b.lbs, name)
+	delete(store, name)
 
 	// Cascade-delete all policies that belong to this load balancer.
+	policies := b.policiesStore(region)
 	prefix := name + "/"
-	for k := range b.policies {
+	for k := range policies {
 		if strings.HasPrefix(k, prefix) {
-			delete(b.policies, k)
+			delete(policies, k)
 		}
 	}
 
 	return nil
 }
 
-// DescribeLoadBalancers returns load balancers, optionally filtered by name.
-func (b *InMemoryBackend) DescribeLoadBalancers(names []string) ([]LoadBalancer, error) {
+// DescribeLoadBalancers returns load balancers in the caller's region,
+// optionally filtered by name.
+func (b *InMemoryBackend) DescribeLoadBalancers(ctx context.Context, names []string) ([]LoadBalancer, error) {
 	b.mu.RLock("DescribeLoadBalancers")
 	defer b.mu.RUnlock()
+
+	store := b.lbsStore(getRegion(ctx, b.region))
 
 	if len(names) > 0 {
 		result := make([]LoadBalancer, 0, len(names))
 
 		for _, name := range names {
-			lb, ok := b.lbs[name]
+			lb, ok := store[name]
 			if !ok {
 				return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 			}
@@ -657,8 +741,8 @@ func (b *InMemoryBackend) DescribeLoadBalancers(names []string) ([]LoadBalancer,
 		return result, nil
 	}
 
-	result := make([]LoadBalancer, 0, len(b.lbs))
-	for _, lb := range b.lbs {
+	result := make([]LoadBalancer, 0, len(store))
+	for _, lb := range store {
 		result = append(result, lbCopy(lb))
 	}
 
@@ -670,11 +754,13 @@ func (b *InMemoryBackend) DescribeLoadBalancers(names []string) ([]LoadBalancer,
 }
 
 // RegisterInstancesWithLoadBalancer registers EC2 instances with a load balancer.
-func (b *InMemoryBackend) RegisterInstancesWithLoadBalancer(name string, instances []Instance) ([]Instance, error) {
+func (b *InMemoryBackend) RegisterInstancesWithLoadBalancer(
+	ctx context.Context, name string, instances []Instance,
+) ([]Instance, error) {
 	b.mu.Lock("RegisterInstancesWithLoadBalancer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -724,11 +810,13 @@ func (b *InMemoryBackend) RegisterInstancesWithLoadBalancer(name string, instanc
 }
 
 // DeregisterInstancesFromLoadBalancer removes EC2 instances from a load balancer.
-func (b *InMemoryBackend) DeregisterInstancesFromLoadBalancer(name string, instances []Instance) ([]Instance, error) {
+func (b *InMemoryBackend) DeregisterInstancesFromLoadBalancer(
+	ctx context.Context, name string, instances []Instance,
+) ([]Instance, error) {
 	b.mu.Lock("DeregisterInstancesFromLoadBalancer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -754,11 +842,13 @@ func (b *InMemoryBackend) DeregisterInstancesFromLoadBalancer(name string, insta
 }
 
 // ConfigureHealthCheck sets the health-check configuration on a load balancer.
-func (b *InMemoryBackend) ConfigureHealthCheck(name string, hc HealthCheck) (*HealthCheck, error) {
+func (b *InMemoryBackend) ConfigureHealthCheck(
+	ctx context.Context, name string, hc HealthCheck,
+) (*HealthCheck, error) {
 	b.mu.Lock("ConfigureHealthCheck")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -770,9 +860,11 @@ func (b *InMemoryBackend) ConfigureHealthCheck(name string, hc HealthCheck) (*He
 }
 
 // AddTags adds or updates tags on one or more load balancers.
-func (b *InMemoryBackend) AddTags(names []string, kvs []tags.KV) error {
+func (b *InMemoryBackend) AddTags(ctx context.Context, names []string, kvs []tags.KV) error {
 	b.mu.Lock("AddTags")
 	defer b.mu.Unlock()
+
+	store := b.lbsStore(getRegion(ctx, b.region))
 
 	const maxTagKeyLen = 128
 	const maxTagValueLen = 256
@@ -790,7 +882,7 @@ func (b *InMemoryBackend) AddTags(names []string, kvs []tags.KV) error {
 	}
 
 	for _, name := range names {
-		lb, ok := b.lbs[name]
+		lb, ok := store[name]
 		if !ok {
 			return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 		}
@@ -823,14 +915,15 @@ func (b *InMemoryBackend) AddTags(names []string, kvs []tags.KV) error {
 }
 
 // DescribeTags returns the tags for the given load balancers.
-func (b *InMemoryBackend) DescribeTags(names []string) (map[string][]tags.KV, error) {
+func (b *InMemoryBackend) DescribeTags(ctx context.Context, names []string) (map[string][]tags.KV, error) {
 	b.mu.RLock("DescribeTags")
 	defer b.mu.RUnlock()
 
+	store := b.lbsStore(getRegion(ctx, b.region))
 	result := make(map[string][]tags.KV, len(names))
 
 	for _, name := range names {
-		lb, ok := b.lbs[name]
+		lb, ok := store[name]
 		if !ok {
 			return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 		}
@@ -851,12 +944,14 @@ func (b *InMemoryBackend) DescribeTags(names []string) (map[string][]tags.KV, er
 }
 
 // RemoveTags removes the specified tag keys from one or more load balancers.
-func (b *InMemoryBackend) RemoveTags(names []string, keys []string) error {
+func (b *InMemoryBackend) RemoveTags(ctx context.Context, names []string, keys []string) error {
 	b.mu.Lock("RemoveTags")
 	defer b.mu.Unlock()
 
+	store := b.lbsStore(getRegion(ctx, b.region))
+
 	for _, name := range names {
-		lb, ok := b.lbs[name]
+		lb, ok := store[name]
 		if !ok {
 			return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 		}
@@ -870,11 +965,11 @@ func (b *InMemoryBackend) RemoveTags(names []string, keys []string) error {
 // CreateLoadBalancerListeners adds listeners to an existing load balancer.
 // Idempotent: if a listener on the same port already exists with identical settings,
 // it is a no-op. Returns DuplicateListener if the port is in use with different settings.
-func (b *InMemoryBackend) CreateLoadBalancerListeners(name string, listeners []Listener) error {
+func (b *InMemoryBackend) CreateLoadBalancerListeners(ctx context.Context, name string, listeners []Listener) error {
 	b.mu.Lock("CreateLoadBalancerListeners")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -923,11 +1018,11 @@ func (b *InMemoryBackend) CreateLoadBalancerListeners(name string, listeners []L
 }
 
 // DeleteLoadBalancerListeners removes listeners by port from an existing load balancer.
-func (b *InMemoryBackend) DeleteLoadBalancerListeners(name string, ports []int32) error {
+func (b *InMemoryBackend) DeleteLoadBalancerListeners(ctx context.Context, name string, ports []int32) error {
 	b.mu.Lock("DeleteLoadBalancerListeners")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -951,13 +1046,14 @@ func (b *InMemoryBackend) DeleteLoadBalancerListeners(name string, ports []int32
 
 // ModifyLoadBalancerAttributes updates the tunable attributes for a load balancer.
 func (b *InMemoryBackend) ModifyLoadBalancerAttributes(
+	ctx context.Context,
 	name string,
 	attrs LoadBalancerAttributes,
 ) (*LoadBalancerAttributes, error) {
 	b.mu.Lock("ModifyLoadBalancerAttributes")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -969,11 +1065,13 @@ func (b *InMemoryBackend) ModifyLoadBalancerAttributes(
 }
 
 // DescribeLoadBalancerAttributes returns the tunable attributes for a load balancer.
-func (b *InMemoryBackend) DescribeLoadBalancerAttributes(name string) (*LoadBalancerAttributes, error) {
+func (b *InMemoryBackend) DescribeLoadBalancerAttributes(
+	ctx context.Context, name string,
+) (*LoadBalancerAttributes, error) {
 	b.mu.RLock("DescribeLoadBalancerAttributes")
 	defer b.mu.RUnlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1006,11 +1104,13 @@ func validatePolicyName(policyName string) error {
 }
 
 // ApplySecurityGroupsToLoadBalancer replaces the security groups for a VPC load balancer.
-func (b *InMemoryBackend) ApplySecurityGroupsToLoadBalancer(name string, securityGroups []string) ([]string, error) {
+func (b *InMemoryBackend) ApplySecurityGroupsToLoadBalancer(
+	ctx context.Context, name string, securityGroups []string,
+) ([]string, error) {
 	b.mu.Lock("ApplySecurityGroupsToLoadBalancer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1031,11 +1131,13 @@ func (b *InMemoryBackend) ApplySecurityGroupsToLoadBalancer(name string, securit
 }
 
 // AttachLoadBalancerToSubnets adds subnets to an existing load balancer.
-func (b *InMemoryBackend) AttachLoadBalancerToSubnets(name string, subnets []string) ([]string, error) {
+func (b *InMemoryBackend) AttachLoadBalancerToSubnets(
+	ctx context.Context, name string, subnets []string,
+) ([]string, error) {
 	b.mu.Lock("AttachLoadBalancerToSubnets")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1064,11 +1166,13 @@ func (b *InMemoryBackend) AttachLoadBalancerToSubnets(name string, subnets []str
 }
 
 // DetachLoadBalancerFromSubnets removes subnets from an existing load balancer.
-func (b *InMemoryBackend) DetachLoadBalancerFromSubnets(name string, subnets []string) ([]string, error) {
+func (b *InMemoryBackend) DetachLoadBalancerFromSubnets(
+	ctx context.Context, name string, subnets []string,
+) ([]string, error) {
 	b.mu.Lock("DetachLoadBalancerFromSubnets")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1095,11 +1199,13 @@ func (b *InMemoryBackend) DetachLoadBalancerFromSubnets(name string, subnets []s
 }
 
 // EnableAvailabilityZonesForLoadBalancer adds availability zones to an existing load balancer.
-func (b *InMemoryBackend) EnableAvailabilityZonesForLoadBalancer(name string, azs []string) ([]string, error) {
+func (b *InMemoryBackend) EnableAvailabilityZonesForLoadBalancer(
+	ctx context.Context, name string, azs []string,
+) ([]string, error) {
 	b.mu.Lock("EnableAvailabilityZonesForLoadBalancer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1131,11 +1237,13 @@ func (b *InMemoryBackend) EnableAvailabilityZonesForLoadBalancer(name string, az
 }
 
 // DisableAvailabilityZonesForLoadBalancer removes availability zones from an existing load balancer.
-func (b *InMemoryBackend) DisableAvailabilityZonesForLoadBalancer(name string, azs []string) ([]string, error) {
+func (b *InMemoryBackend) DisableAvailabilityZonesForLoadBalancer(
+	ctx context.Context, name string, azs []string,
+) ([]string, error) {
 	b.mu.Lock("DisableAvailabilityZonesForLoadBalancer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1178,11 +1286,13 @@ func (b *InMemoryBackend) DisableAvailabilityZonesForLoadBalancer(name string, a
 }
 
 // SetLoadBalancerListenerSSLCertificate sets the SSL certificate for an existing listener.
-func (b *InMemoryBackend) SetLoadBalancerListenerSSLCertificate(name string, port int32, certID string) error {
+func (b *InMemoryBackend) SetLoadBalancerListenerSSLCertificate(
+	ctx context.Context, name string, port int32, certID string,
+) error {
 	b.mu.Lock("SetLoadBalancerListenerSSLCertificate")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1226,19 +1336,22 @@ func isStickinessPolicy(pol *LoadBalancerPolicy) bool {
 
 // SetLoadBalancerPoliciesOfListener sets the policies for an existing listener.
 func (b *InMemoryBackend) SetLoadBalancerPoliciesOfListener(
-	name string, port int32, policyNames []string,
+	ctx context.Context, name string, port int32, policyNames []string,
 ) error {
 	b.mu.Lock("SetLoadBalancerPoliciesOfListener")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	region := getRegion(ctx, b.region)
+	policies := b.policiesStore(region)
+
+	lb, ok := b.lbsStore(region)[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	// Validate each policy exists for this LB.
 	for _, p := range policyNames {
-		if _, exists := b.policies[policyKey(name, p)]; !exists {
+		if _, exists := policies[policyKey(name, p)]; !exists {
 			return fmt.Errorf("%w: %q", ErrPolicyNotFound, p)
 		}
 	}
@@ -1247,7 +1360,7 @@ func (b *InMemoryBackend) SetLoadBalancerPoliciesOfListener(
 	proto := listenerProtocolForPort(lb, port)
 	if proto == protoTCP || proto == protoSSL {
 		for _, pName := range policyNames {
-			if isStickinessPolicy(b.policies[policyKey(name, pName)]) {
+			if isStickinessPolicy(policies[policyKey(name, pName)]) {
 				return fmt.Errorf(
 					"%w: stickiness policies cannot be applied to TCP or SSL listeners",
 					ErrInvalidConfiguration,
@@ -1271,6 +1384,7 @@ func (b *InMemoryBackend) SetLoadBalancerPoliciesOfListener(
 
 // SetLoadBalancerPoliciesForBackendServer sets the policies for a backend server instance port.
 func (b *InMemoryBackend) SetLoadBalancerPoliciesForBackendServer(
+	ctx context.Context,
 	name string,
 	instancePort int32,
 	policyNames []string,
@@ -1278,14 +1392,17 @@ func (b *InMemoryBackend) SetLoadBalancerPoliciesForBackendServer(
 	b.mu.Lock("SetLoadBalancerPoliciesForBackendServer")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	region := getRegion(ctx, b.region)
+	policies := b.policiesStore(region)
+
+	lb, ok := b.lbsStore(region)[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	// Validate each policy exists for this LB.
 	for _, p := range policyNames {
-		if _, exists := b.policies[policyKey(name, p)]; !exists {
+		if _, exists := policies[policyKey(name, p)]; !exists {
 			return fmt.Errorf("%w: %q", ErrPolicyNotFound, p)
 		}
 	}
@@ -1323,7 +1440,10 @@ func (b *InMemoryBackend) SetLoadBalancerPoliciesForBackendServer(
 }
 
 // CreateAppCookieStickinessPolicy creates an application-cookie stickiness policy.
-func (b *InMemoryBackend) CreateAppCookieStickinessPolicy(name, policyName, cookieName string) error {
+func (b *InMemoryBackend) CreateAppCookieStickinessPolicy(
+	ctx context.Context,
+	name, policyName, cookieName string,
+) error {
 	if err := validatePolicyName(policyName); err != nil {
 		return err
 	}
@@ -1335,16 +1455,19 @@ func (b *InMemoryBackend) CreateAppCookieStickinessPolicy(name, policyName, cook
 	b.mu.Lock("CreateAppCookieStickinessPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.lbs[name]; !ok {
+	region := getRegion(ctx, b.region)
+	policies := b.policiesStore(region)
+
+	if _, ok := b.lbsStore(region)[name]; !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	k := policyKey(name, policyName)
-	if _, ok := b.policies[k]; ok {
+	if _, ok := policies[k]; ok {
 		return fmt.Errorf("%w: %q", ErrPolicyAlreadyExists, policyName)
 	}
 
-	b.policies[k] = &LoadBalancerPolicy{
+	policies[k] = &LoadBalancerPolicy{
 		PolicyName:       policyName,
 		PolicyTypeName:   policyTypeAppCookie,
 		LoadBalancerName: name,
@@ -1357,7 +1480,9 @@ func (b *InMemoryBackend) CreateAppCookieStickinessPolicy(name, policyName, cook
 }
 
 // CreateLBCookieStickinessPolicy creates an LB-cookie stickiness policy.
-func (b *InMemoryBackend) CreateLBCookieStickinessPolicy(name, policyName string, cookieExpirationPeriod int64) error {
+func (b *InMemoryBackend) CreateLBCookieStickinessPolicy(
+	ctx context.Context, name, policyName string, cookieExpirationPeriod int64,
+) error {
 	if err := validatePolicyName(policyName); err != nil {
 		return err
 	}
@@ -1365,12 +1490,15 @@ func (b *InMemoryBackend) CreateLBCookieStickinessPolicy(name, policyName string
 	b.mu.Lock("CreateLBCookieStickinessPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.lbs[name]; !ok {
+	region := getRegion(ctx, b.region)
+	policies := b.policiesStore(region)
+
+	if _, ok := b.lbsStore(region)[name]; !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	k := policyKey(name, policyName)
-	if _, ok := b.policies[k]; ok {
+	if _, ok := policies[k]; ok {
 		return fmt.Errorf("%w: %q", ErrPolicyAlreadyExists, policyName)
 	}
 
@@ -1379,7 +1507,7 @@ func (b *InMemoryBackend) CreateLBCookieStickinessPolicy(name, policyName string
 		expStr = strconv.FormatInt(cookieExpirationPeriod, 10)
 	}
 
-	b.policies[k] = &LoadBalancerPolicy{
+	policies[k] = &LoadBalancerPolicy{
 		PolicyName:       policyName,
 		PolicyTypeName:   policyTypeLBCookie,
 		LoadBalancerName: name,
@@ -1393,6 +1521,7 @@ func (b *InMemoryBackend) CreateLBCookieStickinessPolicy(name, policyName string
 
 // CreateLoadBalancerPolicy creates a policy with custom attributes.
 func (b *InMemoryBackend) CreateLoadBalancerPolicy(
+	ctx context.Context,
 	name, policyName, policyTypeName string,
 	attrs []PolicyAttribute,
 ) error {
@@ -1403,19 +1532,22 @@ func (b *InMemoryBackend) CreateLoadBalancerPolicy(
 	b.mu.Lock("CreateLoadBalancerPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.lbs[name]; !ok {
+	region := getRegion(ctx, b.region)
+	policies := b.policiesStore(region)
+
+	if _, ok := b.lbsStore(region)[name]; !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	k := policyKey(name, policyName)
-	if _, ok := b.policies[k]; ok {
+	if _, ok := policies[k]; ok {
 		return fmt.Errorf("%w: %q", ErrPolicyAlreadyExists, policyName)
 	}
 
 	attrCopy := make([]PolicyAttribute, len(attrs))
 	copy(attrCopy, attrs)
 
-	b.policies[k] = &LoadBalancerPolicy{
+	policies[k] = &LoadBalancerPolicy{
 		PolicyName:                  policyName,
 		PolicyTypeName:              policyTypeName,
 		LoadBalancerName:            name,
@@ -1426,17 +1558,20 @@ func (b *InMemoryBackend) CreateLoadBalancerPolicy(
 }
 
 // DeleteLoadBalancerPolicy removes a policy from a load balancer.
-func (b *InMemoryBackend) DeleteLoadBalancerPolicy(name, policyName string) error {
+func (b *InMemoryBackend) DeleteLoadBalancerPolicy(ctx context.Context, name, policyName string) error {
 	b.mu.Lock("DeleteLoadBalancerPolicy")
 	defer b.mu.Unlock()
 
-	lb, ok := b.lbs[name]
+	region := getRegion(ctx, b.region)
+	policies := b.policiesStore(region)
+
+	lb, ok := b.lbsStore(region)[name]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
 
 	k := policyKey(name, policyName)
-	if _, exists := b.policies[k]; !exists {
+	if _, exists := policies[k]; !exists {
 		return fmt.Errorf("%w: %q", ErrPolicyNotFound, policyName)
 	}
 
@@ -1464,13 +1599,13 @@ func (b *InMemoryBackend) DeleteLoadBalancerPolicy(name, policyName string) erro
 		}
 	}
 
-	delete(b.policies, k)
+	delete(policies, k)
 
 	return nil
 }
 
 // DescribeAccountLimits returns the current ELB account limits.
-func (b *InMemoryBackend) DescribeAccountLimits() ([]AccountLimit, error) {
+func (b *InMemoryBackend) DescribeAccountLimits(_ context.Context) ([]AccountLimit, error) {
 	b.mu.RLock("DescribeAccountLimits")
 	defer b.mu.RUnlock()
 
@@ -1482,11 +1617,13 @@ func (b *InMemoryBackend) DescribeAccountLimits() ([]AccountLimit, error) {
 }
 
 // DescribeInstanceHealth returns the health state of registered instances.
-func (b *InMemoryBackend) DescribeInstanceHealth(name string, instances []Instance) ([]InstanceState, error) {
+func (b *InMemoryBackend) DescribeInstanceHealth(
+	ctx context.Context, name string, instances []Instance,
+) ([]InstanceState, error) {
 	b.mu.RLock("DescribeInstanceHealth")
 	defer b.mu.RUnlock()
 
-	lb, ok := b.lbs[name]
+	lb, ok := b.lbsStore(getRegion(ctx, b.region))[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 	}
@@ -1551,15 +1688,18 @@ func (b *InMemoryBackend) DescribeInstanceHealth(name string, instances []Instan
 // DescribeLoadBalancerPolicies returns policies associated with the given load balancer,
 // optionally filtered by policy names.
 func (b *InMemoryBackend) DescribeLoadBalancerPolicies(
+	ctx context.Context,
 	name string,
 	policyNames []string,
 ) ([]LoadBalancerPolicy, error) {
 	b.mu.RLock("DescribeLoadBalancerPolicies")
 	defer b.mu.RUnlock()
 
+	region := getRegion(ctx, b.region)
+
 	// When a load balancer name is given, validate it exists.
 	if name != "" {
-		if _, ok := b.lbs[name]; !ok {
+		if _, ok := b.lbsStore(region)[name]; !ok {
 			return nil, fmt.Errorf("%w: %q", ErrLoadBalancerNotFound, name)
 		}
 	}
@@ -1590,8 +1730,9 @@ func (b *InMemoryBackend) DescribeLoadBalancerPolicies(
 		return result, nil
 	}
 
-	result := make([]LoadBalancerPolicy, 0, len(b.policies))
-	for _, p := range b.policies {
+	policies := b.policiesStore(region)
+	result := make([]LoadBalancerPolicy, 0, len(policies))
+	for _, p := range policies {
 		if p.LoadBalancerName != name {
 			continue
 		}
@@ -1761,7 +1902,9 @@ func builtinPolicyTypes() []PolicyTypeDescription {
 
 // DescribeLoadBalancerPolicyTypes returns the specified policy type descriptions.
 // If policyTypeNames is non-empty, an error is returned for any unknown type name.
-func (b *InMemoryBackend) DescribeLoadBalancerPolicyTypes(policyTypeNames []string) ([]PolicyTypeDescription, error) {
+func (b *InMemoryBackend) DescribeLoadBalancerPolicyTypes(
+	_ context.Context, policyTypeNames []string,
+) ([]PolicyTypeDescription, error) {
 	all := builtinPolicyTypes()
 
 	if len(policyTypeNames) == 0 {

--- a/services/elb/export_test.go
+++ b/services/elb/export_test.go
@@ -1,19 +1,39 @@
 package elb
 
-// LoadBalancerCount returns the number of load balancers. Used only in tests.
+import "context"
+
+// LoadBalancerCount returns the total number of load balancers across all
+// regions. Used only in tests.
 func (b *InMemoryBackend) LoadBalancerCount() int {
 	b.mu.RLock("LoadBalancerCount")
 	defer b.mu.RUnlock()
 
-	return len(b.lbs)
+	total := 0
+	for _, regionLBs := range b.lbs {
+		total += len(regionLBs)
+	}
+
+	return total
 }
 
-// PolicyCount returns the total number of policies across all load balancers. Used only in tests.
+// PolicyCount returns the total number of policies across all load balancers
+// and regions. Used only in tests.
 func (b *InMemoryBackend) PolicyCount() int {
 	b.mu.RLock("PolicyCount")
 	defer b.mu.RUnlock()
 
-	return len(b.policies)
+	total := 0
+	for _, regionPolicies := range b.policies {
+		total += len(regionPolicies)
+	}
+
+	return total
+}
+
+// RegionContextForTest returns a context carrying the given region under the
+// unexported regionContextKey, for use by tests in this package.
+func RegionContextForTest(ctx context.Context, region string) context.Context {
+	return context.WithValue(ctx, regionContextKey{}, region)
 }
 
 // HandlerOpsLen returns the number of registered operations in the handler dispatch table.

--- a/services/elb/handler.go
+++ b/services/elb/handler.go
@@ -1,6 +1,7 @@
 package elb
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"errors"
@@ -34,7 +35,7 @@ const (
 type Handler struct {
 	Backend StorageBackend
 	// ops is the pre-built dispatch table mapping action names to handler functions.
-	ops map[string]func(url.Values) (any, error)
+	ops map[string]func(context.Context, url.Values) (any, error)
 }
 
 // NewHandler creates a new ELB handler.
@@ -46,8 +47,8 @@ func NewHandler(backend StorageBackend) *Handler {
 }
 
 // buildOps returns the action-to-handler dispatch table.
-func (h *Handler) buildOps() map[string]func(url.Values) (any, error) {
-	return map[string]func(url.Values) (any, error){
+func (h *Handler) buildOps() map[string]func(context.Context, url.Values) (any, error) {
+	return map[string]func(context.Context, url.Values) (any, error){
 		"CreateLoadBalancer":                      h.handleCreateLoadBalancer,
 		"DeleteLoadBalancer":                      h.handleDeleteLoadBalancer,
 		"DescribeLoadBalancers":                   h.handleDescribeLoadBalancers,
@@ -136,7 +137,7 @@ func (h *Handler) ChaosRegions() []string {
 	}
 
 	if ib, ok := h.Backend.(*InMemoryBackend); ok {
-		return []string{ib.region}
+		return []string{ib.Region()}
 	}
 
 	return []string{config.DefaultRegion}
@@ -216,10 +217,11 @@ func (h *Handler) Handler() echo.HandlerFunc {
 			return h.writeError(c, http.StatusBadRequest, "MissingAction", "missing Action parameter")
 		}
 
-		log := logger.Load(r.Context())
-		log.Debug("elb request", "action", action)
+		ctx := h.contextWithRegion(c)
 
-		resp, opErr := h.dispatch(action, vals)
+		logger.Load(ctx).Debug("elb request", "action", action)
+
+		resp, opErr := h.dispatch(ctx, action, vals)
 		if opErr != nil {
 			return h.handleOpError(c, action, opErr)
 		}
@@ -233,17 +235,28 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	}
 }
 
+// contextWithRegion returns the request context with the resolved AWS region
+// attached under regionContextKey so that backend operations are routed to the
+// correct region. The region is extracted from the request's SigV4
+// Authorization header (or X-Amz headers), falling back to the backend's
+// default region.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
+}
+
 // dispatch routes the ELB action to the appropriate handler.
-func (h *Handler) dispatch(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatch(ctx context.Context, action string, vals url.Values) (any, error) {
 	fn, ok := h.ops[action]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrUnknownAction, action)
 	}
 
-	return fn(vals)
+	return fn(ctx, vals)
 }
 
-func (h *Handler) handleCreateLoadBalancer(vals url.Values) (any, error) {
+func (h *Handler) handleCreateLoadBalancer(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -259,7 +272,7 @@ func (h *Handler) handleCreateLoadBalancer(vals url.Values) (any, error) {
 	subnets := parseMembers(vals, "Subnets.member")
 	scheme := vals.Get("Scheme")
 
-	lb, createErr := h.Backend.CreateLoadBalancer(CreateLoadBalancerInput{
+	lb, createErr := h.Backend.CreateLoadBalancer(ctx, CreateLoadBalancerInput{
 		LoadBalancerName:  name,
 		Scheme:            scheme,
 		AvailabilityZones: azs,
@@ -273,7 +286,7 @@ func (h *Handler) handleCreateLoadBalancer(vals url.Values) (any, error) {
 
 	// AWS allows passing initial Tags at CreateLoadBalancer time.
 	if initialTags := parseTagKVs(vals, "Tags.member"); len(initialTags) > 0 {
-		if tagErr := h.Backend.AddTags([]string{name}, initialTags); tagErr != nil {
+		if tagErr := h.Backend.AddTags(ctx, []string{name}, initialTags); tagErr != nil {
 			return nil, tagErr
 		}
 	}
@@ -287,13 +300,13 @@ func (h *Handler) handleCreateLoadBalancer(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteLoadBalancer(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteLoadBalancer(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
 	}
 
-	if err := h.Backend.DeleteLoadBalancer(name); err != nil {
+	if err := h.Backend.DeleteLoadBalancer(ctx, name); err != nil {
 		return nil, err
 	}
 
@@ -303,10 +316,10 @@ func (h *Handler) handleDeleteLoadBalancer(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeLoadBalancers(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeLoadBalancers(ctx context.Context, vals url.Values) (any, error) {
 	names := parseMembers(vals, "LoadBalancerNames.member")
 
-	lbs, err := h.Backend.DescribeLoadBalancers(names)
+	lbs, err := h.Backend.DescribeLoadBalancers(ctx, names)
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +375,7 @@ func (h *Handler) handleDescribeLoadBalancers(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleRegisterInstances(vals url.Values) (any, error) {
+func (h *Handler) handleRegisterInstances(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -370,7 +383,7 @@ func (h *Handler) handleRegisterInstances(vals url.Values) (any, error) {
 
 	instances := parseInstances(vals)
 
-	remaining, err := h.Backend.RegisterInstancesWithLoadBalancer(name, instances)
+	remaining, err := h.Backend.RegisterInstancesWithLoadBalancer(ctx, name, instances)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +399,7 @@ func (h *Handler) handleRegisterInstances(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeregisterInstances(vals url.Values) (any, error) {
+func (h *Handler) handleDeregisterInstances(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -394,7 +407,7 @@ func (h *Handler) handleDeregisterInstances(vals url.Values) (any, error) {
 
 	instances := parseInstances(vals)
 
-	remaining, err := h.Backend.DeregisterInstancesFromLoadBalancer(name, instances)
+	remaining, err := h.Backend.DeregisterInstancesFromLoadBalancer(ctx, name, instances)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +423,7 @@ func (h *Handler) handleDeregisterInstances(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleConfigureHealthCheck(vals url.Values) (any, error) {
+func (h *Handler) handleConfigureHealthCheck(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -418,7 +431,7 @@ func (h *Handler) handleConfigureHealthCheck(vals url.Values) (any, error) {
 
 	// Check LB exists before validating the remaining parameters; AWS returns
 	// LoadBalancerNotFound before complaining about invalid HC params.
-	if _, err := h.Backend.DescribeLoadBalancers([]string{name}); err != nil {
+	if _, err := h.Backend.DescribeLoadBalancers(ctx, []string{name}); err != nil {
 		return nil, err
 	}
 
@@ -427,7 +440,7 @@ func (h *Handler) handleConfigureHealthCheck(vals url.Values) (any, error) {
 		return nil, err
 	}
 
-	result, hcErr := h.Backend.ConfigureHealthCheck(name, hc)
+	result, hcErr := h.Backend.ConfigureHealthCheck(ctx, name, hc)
 	if hcErr != nil {
 		return nil, hcErr
 	}
@@ -537,7 +550,7 @@ func parseHealthCheckThresholds(vals url.Values) (int32, int32, error) {
 	return unhealthy, healthy, nil
 }
 
-func (h *Handler) handleAddTags(vals url.Values) (any, error) {
+func (h *Handler) handleAddTags(ctx context.Context, vals url.Values) (any, error) {
 	names := parseMembers(vals, "LoadBalancerNames.member")
 	if len(names) == 0 {
 		return nil, fmt.Errorf("%w: at least one LoadBalancerName is required", ErrInvalidParameter)
@@ -551,7 +564,7 @@ func (h *Handler) handleAddTags(vals url.Values) (any, error) {
 		}
 	}
 
-	if err := h.Backend.AddTags(names, kvs); err != nil {
+	if err := h.Backend.AddTags(ctx, names, kvs); err != nil {
 		return nil, err
 	}
 
@@ -561,13 +574,13 @@ func (h *Handler) handleAddTags(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeTags(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeTags(ctx context.Context, vals url.Values) (any, error) {
 	names := parseMembers(vals, "LoadBalancerNames.member")
 	if len(names) == 0 {
 		return nil, fmt.Errorf("%w: at least one LoadBalancerName is required", ErrInvalidParameter)
 	}
 
-	tagMap, err := h.Backend.DescribeTags(names)
+	tagMap, err := h.Backend.DescribeTags(ctx, names)
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +609,7 @@ func (h *Handler) handleDescribeTags(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleRemoveTags(vals url.Values) (any, error) {
+func (h *Handler) handleRemoveTags(ctx context.Context, vals url.Values) (any, error) {
 	names := parseMembers(vals, "LoadBalancerNames.member")
 	if len(names) == 0 {
 		return nil, fmt.Errorf("%w: at least one LoadBalancerName is required", ErrInvalidParameter)
@@ -608,7 +621,7 @@ func (h *Handler) handleRemoveTags(vals url.Values) (any, error) {
 		return nil, fmt.Errorf("%w: Tags must not be empty", ErrInvalidParameter)
 	}
 
-	if err := h.Backend.RemoveTags(names, keys); err != nil {
+	if err := h.Backend.RemoveTags(ctx, names, keys); err != nil {
 		return nil, err
 	}
 
@@ -618,7 +631,7 @@ func (h *Handler) handleRemoveTags(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateLoadBalancerListeners(vals url.Values) (any, error) {
+func (h *Handler) handleCreateLoadBalancerListeners(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -633,7 +646,7 @@ func (h *Handler) handleCreateLoadBalancerListeners(vals url.Values) (any, error
 		return nil, fmt.Errorf("%w: at least one listener is required", ErrInvalidParameter)
 	}
 
-	if createErr := h.Backend.CreateLoadBalancerListeners(name, listeners); createErr != nil {
+	if createErr := h.Backend.CreateLoadBalancerListeners(ctx, name, listeners); createErr != nil {
 		return nil, createErr
 	}
 
@@ -643,7 +656,7 @@ func (h *Handler) handleCreateLoadBalancerListeners(vals url.Values) (any, error
 	}, nil
 }
 
-func (h *Handler) handleDeleteLoadBalancerListeners(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteLoadBalancerListeners(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -651,7 +664,7 @@ func (h *Handler) handleDeleteLoadBalancerListeners(vals url.Values) (any, error
 
 	ports := parseListenerPorts(vals, "LoadBalancerPorts.member")
 
-	if err := h.Backend.DeleteLoadBalancerListeners(name, ports); err != nil {
+	if err := h.Backend.DeleteLoadBalancerListeners(ctx, name, ports); err != nil {
 		return nil, err
 	}
 
@@ -661,7 +674,7 @@ func (h *Handler) handleDeleteLoadBalancerListeners(vals url.Values) (any, error
 	}, nil
 }
 
-func (h *Handler) handleModifyLoadBalancerAttributes(vals url.Values) (any, error) {
+func (h *Handler) handleModifyLoadBalancerAttributes(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -711,7 +724,7 @@ func (h *Handler) handleModifyLoadBalancerAttributes(vals url.Values) (any, erro
 		)
 	}
 
-	result, err := h.Backend.ModifyLoadBalancerAttributes(name, attrs)
+	result, err := h.Backend.ModifyLoadBalancerAttributes(ctx, name, attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -725,13 +738,13 @@ func (h *Handler) handleModifyLoadBalancerAttributes(vals url.Values) (any, erro
 	}, nil
 }
 
-func (h *Handler) handleDescribeLoadBalancerAttributes(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeLoadBalancerAttributes(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
 	}
 
-	attrs, err := h.Backend.DescribeLoadBalancerAttributes(name)
+	attrs, err := h.Backend.DescribeLoadBalancerAttributes(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -745,7 +758,7 @@ func (h *Handler) handleDescribeLoadBalancerAttributes(vals url.Values) (any, er
 	}, nil
 }
 
-func (h *Handler) handleApplySecurityGroupsToLoadBalancer(vals url.Values) (any, error) {
+func (h *Handler) handleApplySecurityGroupsToLoadBalancer(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -753,7 +766,7 @@ func (h *Handler) handleApplySecurityGroupsToLoadBalancer(vals url.Values) (any,
 
 	sgs := parseMembers(vals, "SecurityGroups.member")
 
-	result, err := h.Backend.ApplySecurityGroupsToLoadBalancer(name, sgs)
+	result, err := h.Backend.ApplySecurityGroupsToLoadBalancer(ctx, name, sgs)
 	if err != nil {
 		return nil, err
 	}
@@ -772,7 +785,7 @@ func (h *Handler) handleApplySecurityGroupsToLoadBalancer(vals url.Values) (any,
 	}, nil
 }
 
-func (h *Handler) handleAttachLoadBalancerToSubnets(vals url.Values) (any, error) {
+func (h *Handler) handleAttachLoadBalancerToSubnets(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -780,7 +793,7 @@ func (h *Handler) handleAttachLoadBalancerToSubnets(vals url.Values) (any, error
 
 	subnets := parseMembers(vals, "Subnets.member")
 
-	result, err := h.Backend.AttachLoadBalancerToSubnets(name, subnets)
+	result, err := h.Backend.AttachLoadBalancerToSubnets(ctx, name, subnets)
 	if err != nil {
 		return nil, err
 	}
@@ -799,7 +812,7 @@ func (h *Handler) handleAttachLoadBalancerToSubnets(vals url.Values) (any, error
 	}, nil
 }
 
-func (h *Handler) handleDetachLoadBalancerFromSubnets(vals url.Values) (any, error) {
+func (h *Handler) handleDetachLoadBalancerFromSubnets(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -807,7 +820,7 @@ func (h *Handler) handleDetachLoadBalancerFromSubnets(vals url.Values) (any, err
 
 	subnets := parseMembers(vals, "Subnets.member")
 
-	result, err := h.Backend.DetachLoadBalancerFromSubnets(name, subnets)
+	result, err := h.Backend.DetachLoadBalancerFromSubnets(ctx, name, subnets)
 	if err != nil {
 		return nil, err
 	}
@@ -826,7 +839,7 @@ func (h *Handler) handleDetachLoadBalancerFromSubnets(vals url.Values) (any, err
 	}, nil
 }
 
-func (h *Handler) handleEnableAvailabilityZonesForLoadBalancer(vals url.Values) (any, error) {
+func (h *Handler) handleEnableAvailabilityZonesForLoadBalancer(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -834,7 +847,7 @@ func (h *Handler) handleEnableAvailabilityZonesForLoadBalancer(vals url.Values) 
 
 	azs := parseMembers(vals, "AvailabilityZones.member")
 
-	result, err := h.Backend.EnableAvailabilityZonesForLoadBalancer(name, azs)
+	result, err := h.Backend.EnableAvailabilityZonesForLoadBalancer(ctx, name, azs)
 	if err != nil {
 		return nil, err
 	}
@@ -853,7 +866,7 @@ func (h *Handler) handleEnableAvailabilityZonesForLoadBalancer(vals url.Values) 
 	}, nil
 }
 
-func (h *Handler) handleDisableAvailabilityZonesForLoadBalancer(vals url.Values) (any, error) {
+func (h *Handler) handleDisableAvailabilityZonesForLoadBalancer(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -861,7 +874,7 @@ func (h *Handler) handleDisableAvailabilityZonesForLoadBalancer(vals url.Values)
 
 	azs := parseMembers(vals, "AvailabilityZones.member")
 
-	result, err := h.Backend.DisableAvailabilityZonesForLoadBalancer(name, azs)
+	result, err := h.Backend.DisableAvailabilityZonesForLoadBalancer(ctx, name, azs)
 	if err != nil {
 		return nil, err
 	}
@@ -880,7 +893,7 @@ func (h *Handler) handleDisableAvailabilityZonesForLoadBalancer(vals url.Values)
 	}, nil
 }
 
-func (h *Handler) handleSetLoadBalancerListenerSSLCertificate(vals url.Values) (any, error) {
+func (h *Handler) handleSetLoadBalancerListenerSSLCertificate(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -900,7 +913,7 @@ func (h *Handler) handleSetLoadBalancerListenerSSLCertificate(vals url.Values) (
 		return nil, certErr
 	}
 
-	if setErr := h.Backend.SetLoadBalancerListenerSSLCertificate(name, port, certID); setErr != nil {
+	if setErr := h.Backend.SetLoadBalancerListenerSSLCertificate(ctx, name, port, certID); setErr != nil {
 		return nil, setErr
 	}
 
@@ -910,7 +923,7 @@ func (h *Handler) handleSetLoadBalancerListenerSSLCertificate(vals url.Values) (
 	}, nil
 }
 
-func (h *Handler) handleSetLoadBalancerPoliciesOfListener(vals url.Values) (any, error) {
+func (h *Handler) handleSetLoadBalancerPoliciesOfListener(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -923,7 +936,7 @@ func (h *Handler) handleSetLoadBalancerPoliciesOfListener(vals url.Values) (any,
 
 	policyNames := parseMembers(vals, "PolicyNames.member")
 
-	if setErr := h.Backend.SetLoadBalancerPoliciesOfListener(name, port, policyNames); setErr != nil {
+	if setErr := h.Backend.SetLoadBalancerPoliciesOfListener(ctx, name, port, policyNames); setErr != nil {
 		return nil, setErr
 	}
 
@@ -933,7 +946,7 @@ func (h *Handler) handleSetLoadBalancerPoliciesOfListener(vals url.Values) (any,
 	}, nil
 }
 
-func (h *Handler) handleSetLoadBalancerPoliciesForBackendServer(vals url.Values) (any, error) {
+func (h *Handler) handleSetLoadBalancerPoliciesForBackendServer(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -946,7 +959,8 @@ func (h *Handler) handleSetLoadBalancerPoliciesForBackendServer(vals url.Values)
 
 	policyNames := parseMembers(vals, "PolicyNames.member")
 
-	if setErr := h.Backend.SetLoadBalancerPoliciesForBackendServer(name, instancePort, policyNames); setErr != nil {
+	setErr := h.Backend.SetLoadBalancerPoliciesForBackendServer(ctx, name, instancePort, policyNames)
+	if setErr != nil {
 		return nil, setErr
 	}
 
@@ -956,7 +970,7 @@ func (h *Handler) handleSetLoadBalancerPoliciesForBackendServer(vals url.Values)
 	}, nil
 }
 
-func (h *Handler) handleCreateAppCookieStickinessPolicy(vals url.Values) (any, error) {
+func (h *Handler) handleCreateAppCookieStickinessPolicy(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -980,7 +994,7 @@ func (h *Handler) handleCreateAppCookieStickinessPolicy(vals url.Values) (any, e
 		return nil, fmt.Errorf("%w: CookieName is required", ErrInvalidParameter)
 	}
 
-	if err := h.Backend.CreateAppCookieStickinessPolicy(name, policyName, cookieName); err != nil {
+	if err := h.Backend.CreateAppCookieStickinessPolicy(ctx, name, policyName, cookieName); err != nil {
 		return nil, err
 	}
 
@@ -990,7 +1004,7 @@ func (h *Handler) handleCreateAppCookieStickinessPolicy(vals url.Values) (any, e
 	}, nil
 }
 
-func (h *Handler) handleCreateLBCookieStickinessPolicy(vals url.Values) (any, error) {
+func (h *Handler) handleCreateLBCookieStickinessPolicy(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -1018,7 +1032,7 @@ func (h *Handler) handleCreateLBCookieStickinessPolicy(vals url.Values) (any, er
 		cookieExpiration = n
 	}
 
-	if err := h.Backend.CreateLBCookieStickinessPolicy(name, policyName, cookieExpiration); err != nil {
+	if err := h.Backend.CreateLBCookieStickinessPolicy(ctx, name, policyName, cookieExpiration); err != nil {
 		return nil, err
 	}
 
@@ -1028,7 +1042,7 @@ func (h *Handler) handleCreateLBCookieStickinessPolicy(vals url.Values) (any, er
 	}, nil
 }
 
-func (h *Handler) handleCreateLoadBalancerPolicy(vals url.Values) (any, error) {
+func (h *Handler) handleCreateLoadBalancerPolicy(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -1065,7 +1079,7 @@ func (h *Handler) handleCreateLoadBalancerPolicy(vals url.Values) (any, error) {
 
 	attrs := parsePolicyAttributes(vals)
 
-	if err := h.Backend.CreateLoadBalancerPolicy(name, policyName, policyTypeName, attrs); err != nil {
+	if err := h.Backend.CreateLoadBalancerPolicy(ctx, name, policyName, policyTypeName, attrs); err != nil {
 		return nil, err
 	}
 
@@ -1075,7 +1089,7 @@ func (h *Handler) handleCreateLoadBalancerPolicy(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteLoadBalancerPolicy(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteLoadBalancerPolicy(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -1086,7 +1100,7 @@ func (h *Handler) handleDeleteLoadBalancerPolicy(vals url.Values) (any, error) {
 		return nil, fmt.Errorf("%w: PolicyName is required", ErrInvalidParameter)
 	}
 
-	if err := h.Backend.DeleteLoadBalancerPolicy(name, policyName); err != nil {
+	if err := h.Backend.DeleteLoadBalancerPolicy(ctx, name, policyName); err != nil {
 		return nil, err
 	}
 
@@ -1096,8 +1110,8 @@ func (h *Handler) handleDeleteLoadBalancerPolicy(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeAccountLimits(_ url.Values) (any, error) {
-	limits, err := h.Backend.DescribeAccountLimits()
+func (h *Handler) handleDescribeAccountLimits(ctx context.Context, _ url.Values) (any, error) {
+	limits, err := h.Backend.DescribeAccountLimits(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1116,7 +1130,7 @@ func (h *Handler) handleDescribeAccountLimits(_ url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeInstanceHealth(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeInstanceHealth(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	if name == "" {
 		return nil, fmt.Errorf("%w: LoadBalancerName is required", ErrInvalidParameter)
@@ -1124,7 +1138,7 @@ func (h *Handler) handleDescribeInstanceHealth(vals url.Values) (any, error) {
 
 	instances := parseInstances(vals)
 
-	states, err := h.Backend.DescribeInstanceHealth(name, instances)
+	states, err := h.Backend.DescribeInstanceHealth(ctx, name, instances)
 	if err != nil {
 		return nil, err
 	}
@@ -1143,11 +1157,11 @@ func (h *Handler) handleDescribeInstanceHealth(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeLoadBalancerPolicies(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeLoadBalancerPolicies(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("LoadBalancerName")
 	policyNames := parseMembers(vals, "PolicyNames.member")
 
-	policies, err := h.Backend.DescribeLoadBalancerPolicies(name, policyNames)
+	policies, err := h.Backend.DescribeLoadBalancerPolicies(ctx, name, policyNames)
 	if err != nil {
 		return nil, err
 	}
@@ -1175,10 +1189,10 @@ func (h *Handler) handleDescribeLoadBalancerPolicies(vals url.Values) (any, erro
 	}, nil
 }
 
-func (h *Handler) handleDescribeLoadBalancerPolicyTypes(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeLoadBalancerPolicyTypes(ctx context.Context, vals url.Values) (any, error) {
 	typeNames := parseMembers(vals, "PolicyTypeNames.member")
 
-	types, err := h.Backend.DescribeLoadBalancerPolicyTypes(typeNames)
+	types, err := h.Backend.DescribeLoadBalancerPolicyTypes(ctx, typeNames)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elb/handler_audit1_test.go
+++ b/services/elb/handler_audit1_test.go
@@ -1,6 +1,7 @@
 package elb_test
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/url"
@@ -247,7 +248,7 @@ func TestAudit1_AccessLog_SnapshotRestore(t *testing.T) {
 	b2 := elb.NewInMemoryBackend("123456789012", "us-east-1")
 	require.NoError(t, b2.Restore(snap))
 
-	attrs, err := b2.DescribeLoadBalancerAttributes("al-snap-lb")
+	attrs, err := b2.DescribeLoadBalancerAttributes(context.Background(), "al-snap-lb")
 	require.NoError(t, err)
 	assert.True(t, attrs.AccessLog.Enabled)
 	assert.Equal(t, "snap-bucket", attrs.AccessLog.S3BucketName)
@@ -281,7 +282,7 @@ func TestAudit1_AccessLog_UpdateBucket(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	attrs, err := h.Backend.DescribeLoadBalancerAttributes("al-upd-lb")
+	attrs, err := h.Backend.DescribeLoadBalancerAttributes(context.Background(), "al-upd-lb")
 	require.NoError(t, err)
 	assert.Equal(t, "new-bucket", attrs.AccessLog.S3BucketName)
 	assert.Equal(t, int32(5), attrs.AccessLog.EmitInterval)
@@ -454,7 +455,7 @@ func TestAudit1_CrossZoneLoadBalancing_DefaultFalse(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "czlb-default-lb")
 
-	attrs, err := b.DescribeLoadBalancerAttributes("czlb-default-lb")
+	attrs, err := b.DescribeLoadBalancerAttributes(context.Background(), "czlb-default-lb")
 	require.NoError(t, err)
 	assert.False(t, attrs.CrossZoneLoadBalancing)
 }
@@ -478,7 +479,7 @@ func TestAudit1_CrossZoneLoadBalancing_SnapshotRestore(t *testing.T) {
 	b2 := elb.NewInMemoryBackend("123456789012", "us-east-1")
 	require.NoError(t, b2.Restore(snap))
 
-	attrs, err := b2.DescribeLoadBalancerAttributes("czlb-snap-lb")
+	attrs, err := b2.DescribeLoadBalancerAttributes(context.Background(), "czlb-snap-lb")
 	require.NoError(t, err)
 	assert.True(t, attrs.CrossZoneLoadBalancing)
 }
@@ -525,7 +526,7 @@ func TestAudit1_ConnectionDraining_DefaultValues(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "cd-default-lb")
 
-	attrs, err := b.DescribeLoadBalancerAttributes("cd-default-lb")
+	attrs, err := b.DescribeLoadBalancerAttributes(context.Background(), "cd-default-lb")
 	require.NoError(t, err)
 	assert.False(t, attrs.ConnectionDraining)
 	assert.Equal(t, int32(300), attrs.ConnectionDrainingTimeout)
@@ -556,7 +557,7 @@ func TestAudit1_ConnectionDraining_Disable(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	attrs, err := h.Backend.DescribeLoadBalancerAttributes("cd-disable-lb")
+	attrs, err := h.Backend.DescribeLoadBalancerAttributes(context.Background(), "cd-disable-lb")
 	require.NoError(t, err)
 	assert.False(t, attrs.ConnectionDraining)
 }
@@ -604,7 +605,7 @@ func TestAudit1_ConnectionSettings_IdleTimeout_Default(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "cs-default-lb")
 
-	attrs, err := b.DescribeLoadBalancerAttributes("cs-default-lb")
+	attrs, err := b.DescribeLoadBalancerAttributes(context.Background(), "cs-default-lb")
 	require.NoError(t, err)
 	assert.Equal(t, int32(60), attrs.IdleTimeout)
 }
@@ -817,7 +818,7 @@ func TestAudit1_CreateLoadBalancer_InternetFacingDefault(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "scheme-default-lb")
 
-	lbs, err := b.DescribeLoadBalancers([]string{"scheme-default-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"scheme-default-lb"})
 	require.NoError(t, err)
 	assert.Equal(t, "internet-facing", lbs[0].Scheme)
 }
@@ -912,7 +913,7 @@ func TestAudit1_CreateLoadBalancer_WithInitialTags(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	tagMap, err := b.DescribeTags([]string{"tagged-lb"})
+	tagMap, err := b.DescribeTags(context.Background(), []string{"tagged-lb"})
 	require.NoError(t, err)
 	tags := tagMap["tagged-lb"]
 	require.Len(t, tags, 2)
@@ -1460,7 +1461,7 @@ func TestAudit1_HealthCheck_TargetProtocolNormalized(t *testing.T) {
 		"HealthCheck.HealthyThreshold":   {"3"},
 	})
 
-	lbs, err := b.DescribeLoadBalancers([]string{"hc-norm-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"hc-norm-lb"})
 	require.NoError(t, err)
 	require.NotNil(t, lbs[0].HealthCheck)
 	assert.Equal(t, "HTTP:80/health", lbs[0].HealthCheck.Target, "protocol must be uppercased")
@@ -1921,7 +1922,7 @@ func TestAudit1_BackendServerPolicies_SetAndDescribe(t *testing.T) {
 		"PolicyNames.member.1": {"proxy-pol"},
 	})
 
-	lbs, err := b.DescribeLoadBalancers([]string{"bsd-desc-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"bsd-desc-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 	require.Len(t, lbs[0].BackendServerDescriptions, 1)
@@ -1960,7 +1961,7 @@ func TestAudit1_BackendServerPolicies_ClearByEmptyList(t *testing.T) {
 		"InstancePort":     {"8080"},
 	})
 
-	lbs, err := b.DescribeLoadBalancers([]string{"bsd-clear-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"bsd-clear-lb"})
 	require.NoError(t, err)
 	bsd := lbs[0].BackendServerDescriptions
 	// Either removed or has empty policy list.
@@ -2268,7 +2269,7 @@ func TestAudit1_DesyncMitigationMode_DefaultDefensive(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "desync-def-lb")
 
-	attrs, err := b.DescribeLoadBalancerAttributes("desync-def-lb")
+	attrs, err := b.DescribeLoadBalancerAttributes(context.Background(), "desync-def-lb")
 	require.NoError(t, err)
 	assert.Equal(t, "defensive", attrs.DesyncMitigationMode)
 }
@@ -2572,7 +2573,7 @@ func TestAudit1_Persistence_FullState(t *testing.T) {
 	require.NoError(t, b2.Restore(snap))
 
 	// Verify LB exists.
-	lbs, err := b2.DescribeLoadBalancers([]string{"full-snap-lb"})
+	lbs, err := b2.DescribeLoadBalancers(context.Background(), []string{"full-snap-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 
@@ -2585,7 +2586,7 @@ func TestAudit1_Persistence_FullState(t *testing.T) {
 	assert.Equal(t, 1, b2.PolicyCount())
 
 	// Verify tags.
-	tagMap, err := b2.DescribeTags([]string{"full-snap-lb"})
+	tagMap, err := b2.DescribeTags(context.Background(), []string{"full-snap-lb"})
 	require.NoError(t, err)
 	require.Len(t, tagMap["full-snap-lb"], 1)
 	assert.Equal(t, "Env", tagMap["full-snap-lb"][0].Key)

--- a/services/elb/handler_audit2_test.go
+++ b/services/elb/handler_audit2_test.go
@@ -4,6 +4,7 @@ package elb_test
 // AWS-accuracy audit fixes (issues #8, #11, #12, #13, #19-#26, #28-#30).
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -907,7 +908,7 @@ func TestAudit2_Snapshot_SchemaVersion(t *testing.T) {
 	b2 := elb.NewInMemoryBackend("123456789012", "us-east-1")
 	require.NoError(t, b2.Restore(snap))
 
-	lbs, err := b2.DescribeLoadBalancers([]string{"snap-lb"})
+	lbs, err := b2.DescribeLoadBalancers(context.Background(), []string{"snap-lb"})
 	require.NoError(t, err)
 	assert.Len(t, lbs, 1)
 }

--- a/services/elb/handler_new_ops_test.go
+++ b/services/elb/handler_new_ops_test.go
@@ -1,6 +1,7 @@
 package elb_test
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/url"
@@ -391,7 +392,7 @@ func TestSetLoadBalancerListenerSSLCertificate(t *testing.T) {
 
 			if tt.wantStatus == http.StatusOK && tt.wantCertID != "" {
 				lbName := tt.vals.Get("LoadBalancerName")
-				lbs, err := h.Backend.DescribeLoadBalancers([]string{lbName})
+				lbs, err := h.Backend.DescribeLoadBalancers(context.Background(), []string{lbName})
 				require.NoError(t, err)
 				require.Len(t, lbs, 1)
 
@@ -519,7 +520,7 @@ func TestSetLoadBalancerPoliciesOfListener(t *testing.T) {
 
 			if tt.wantStatus == http.StatusOK {
 				lbName := tt.vals.Get("LoadBalancerName")
-				lbs, err := h.Backend.DescribeLoadBalancers([]string{lbName})
+				lbs, err := h.Backend.DescribeLoadBalancers(context.Background(), []string{lbName})
 				require.NoError(t, err)
 				require.Len(t, lbs, 1)
 
@@ -662,7 +663,7 @@ func TestSetLoadBalancerPoliciesForBackendServer(t *testing.T) {
 
 			if tt.wantStatus == http.StatusOK && tt.wantPort > 0 {
 				lbName := tt.vals.Get("LoadBalancerName")
-				lbs, err := h.Backend.DescribeLoadBalancers([]string{lbName})
+				lbs, err := h.Backend.DescribeLoadBalancers(context.Background(), []string{lbName})
 				require.NoError(t, err)
 				require.Len(t, lbs, 1)
 

--- a/services/elb/handler_refinement1_test.go
+++ b/services/elb/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package elb_test
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"net/http"
@@ -287,7 +288,7 @@ func TestRefinement1_DeepCopy_Listeners(t *testing.T) {
 	mustCreateLB(t, h, "dc-lb")
 
 	// First describe: copy has 1 listener (from mustCreateLB).
-	lbs, err := b.DescribeLoadBalancers([]string{"dc-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"dc-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 
@@ -298,7 +299,7 @@ func TestRefinement1_DeepCopy_Listeners(t *testing.T) {
 	require.Len(t, lbs[0].Listeners, originalCount+1)
 
 	// Second describe: stored state must still have only originalCount listeners.
-	lbs2, err := b.DescribeLoadBalancers([]string{"dc-lb"})
+	lbs2, err := b.DescribeLoadBalancers(context.Background(), []string{"dc-lb"})
 	require.NoError(t, err)
 	assert.Len(t, lbs2[0].Listeners, originalCount, "mutation of returned copy must not modify stored state")
 }
@@ -311,7 +312,7 @@ func TestRefinement1_NonNilSlices(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "non-nil-lb")
 
-	lbs, err := b.DescribeLoadBalancers([]string{"non-nil-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"non-nil-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 
@@ -332,7 +333,7 @@ func TestRefinement1_ARNSet(t *testing.T) {
 	h := elb.NewHandler(b)
 	mustCreateLB(t, h, "arn-lb")
 
-	lbs, err := b.DescribeLoadBalancers([]string{"arn-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"arn-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 
@@ -359,7 +360,7 @@ func TestRefinement1_VPCId_SetFromSubnets(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	lbs, err := b.DescribeLoadBalancers([]string{"vpc-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"vpc-lb"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, lbs[0].VPCId, "VPCId must be set when subnets are provided")
 }
@@ -383,7 +384,7 @@ func TestRefinement1_VPCId_EmptyWithoutSubnets(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	lbs, err := b.DescribeLoadBalancers([]string{"classic-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"classic-lb"})
 	require.NoError(t, err)
 	assert.Empty(t, lbs[0].VPCId, "VPCId must be empty for classic (non-VPC) load balancers")
 }
@@ -399,7 +400,7 @@ func TestRefinement1_SortedDescribeLoadBalancers(t *testing.T) {
 		mustCreateLB(t, h, name)
 	}
 
-	lbs, err := b.DescribeLoadBalancers(nil)
+	lbs, err := b.DescribeLoadBalancers(context.Background(), nil)
 	require.NoError(t, err)
 
 	names := make([]string, len(lbs))
@@ -416,7 +417,7 @@ func TestRefinement1_DescribeAccountLimits_Locked(t *testing.T) {
 	t.Parallel()
 
 	b := newBackend()
-	limits, err := b.DescribeAccountLimits()
+	limits, err := b.DescribeAccountLimits(context.Background())
 	require.NoError(t, err)
 	assert.Len(t, limits, 3)
 }
@@ -427,7 +428,7 @@ func TestRefinement1_DescribeLoadBalancerPolicyTypes_UnknownReturnsError(t *test
 	t.Parallel()
 
 	b := newBackend()
-	_, err := b.DescribeLoadBalancerPolicyTypes([]string{"NoSuchPolicyType"})
+	_, err := b.DescribeLoadBalancerPolicyTypes(context.Background(), []string{"NoSuchPolicyType"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, elb.ErrPolicyNotFound)
 }
@@ -466,11 +467,11 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 	assert.Equal(t, 1, b2.PolicyCount())
 
 	// Verify tags were persisted.
-	lbs, err := b2.DescribeLoadBalancers([]string{"persist-lb"})
+	lbs, err := b2.DescribeLoadBalancers(context.Background(), []string{"persist-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 
-	tagMap, err := b2.DescribeTags([]string{"persist-lb"})
+	tagMap, err := b2.DescribeTags(context.Background(), []string{"persist-lb"})
 	require.NoError(t, err)
 	require.Len(t, tagMap["persist-lb"], 1)
 	assert.Equal(t, "Env", tagMap["persist-lb"][0].Key)
@@ -507,7 +508,7 @@ func TestRefinement1_SeedHelper_DeepCopy(t *testing.T) {
 		elb.Listener{Protocol: "HTTPS", LoadBalancerPort: 443, InstancePort: 8443},
 	)
 
-	lbs, err := b.DescribeLoadBalancers([]string{"seed-dc-lb"})
+	lbs, err := b.DescribeLoadBalancers(context.Background(), []string{"seed-dc-lb"})
 	require.NoError(t, err)
 	require.Len(t, lbs, 1)
 	assert.Len(t, lbs[0].Listeners, 1, "stored LB must not reflect post-seed mutation")

--- a/services/elb/handler_refinement3_test.go
+++ b/services/elb/handler_refinement3_test.go
@@ -1,6 +1,7 @@
 package elb_test
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/url"
@@ -101,7 +102,7 @@ func TestRefinement3_PersistenceRoundTrip(t *testing.T) {
 			require.NoError(t, restored.Restore(snap))
 
 			// Verify the LB can be described on the restored backend.
-			lbs, err := restored.DescribeLoadBalancers([]string{tt.lbName})
+			lbs, err := restored.DescribeLoadBalancers(context.Background(), []string{tt.lbName})
 			require.NoError(t, err)
 			require.Len(t, lbs, 1)
 

--- a/services/elb/isolation_test.go
+++ b/services/elb/isolation_test.go
@@ -1,0 +1,151 @@
+package elb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
+	"github.com/blackbirdworks/gopherstack/services/elb"
+)
+
+// elbCtxRegion returns a context carrying the given region under the
+// region-isolation context key.
+func elbCtxRegion(region string) context.Context {
+	return elb.RegionContextForTest(context.Background(), region)
+}
+
+// classicLBInput returns a minimal valid CreateLoadBalancerInput for a Classic
+// (EC2-Classic / AZ-based) load balancer with a single HTTP listener.
+func classicLBInput(name, az string) elb.CreateLoadBalancerInput {
+	return elb.CreateLoadBalancerInput{
+		LoadBalancerName:  name,
+		Scheme:            "internet-facing",
+		AvailabilityZones: []string{az},
+		Listeners: []elb.Listener{
+			{Protocol: "HTTP", InstanceProtocol: "HTTP", LoadBalancerPort: 80, InstancePort: 8080},
+		},
+	}
+}
+
+// TestELBRegionIsolation proves that same-named Classic ELB load balancers
+// created in two different regions are fully isolated: each region sees only
+// its own load balancer, the ARN and DNS name embed the correct region, tags
+// and policies do not leak across regions, and deleting the load balancer in
+// one region leaves the other untouched.
+func TestELBRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := elb.NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := elbCtxRegion("us-east-1")
+	ctxWest := elbCtxRegion("us-west-2")
+
+	const sharedName = "shared-lb"
+
+	// 1. Create a load balancer with the SAME name in both regions.
+	eastLB, err := backend.CreateLoadBalancer(ctxEast, classicLBInput(sharedName, "us-east-1a"))
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", eastLB.Region)
+	assert.Contains(t, eastLB.ARN, "us-east-1")
+	assert.Contains(t, eastLB.DNSName, "us-east-1")
+
+	westLB, err := backend.CreateLoadBalancer(ctxWest, classicLBInput(sharedName, "us-west-2b"))
+	require.NoError(t, err)
+	assert.Equal(t, "us-west-2", westLB.Region)
+	assert.Contains(t, westLB.ARN, "us-west-2")
+	assert.Contains(t, westLB.DNSName, "us-west-2")
+
+	// The two LBs share a name but are region-qualified, so their ARNs differ.
+	assert.NotEqual(t, eastLB.ARN, westLB.ARN)
+
+	// 2. Each region reads back its own load balancer with the correct AZ.
+	eastList, err := backend.DescribeLoadBalancers(ctxEast, []string{sharedName})
+	require.NoError(t, err)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, []string{"us-east-1a"}, eastList[0].AvailabilityZones)
+	assert.Equal(t, "us-east-1", eastList[0].Region)
+
+	westList, err := backend.DescribeLoadBalancers(ctxWest, []string{sharedName})
+	require.NoError(t, err)
+	require.Len(t, westList, 1)
+	assert.Equal(t, []string{"us-west-2b"}, westList[0].AvailabilityZones)
+	assert.Equal(t, "us-west-2", westList[0].Region)
+
+	// 3. Listing without a filter returns exactly one LB per region.
+	eastAll, err := backend.DescribeLoadBalancers(ctxEast, nil)
+	require.NoError(t, err)
+	require.Len(t, eastAll, 1)
+
+	westAll, err := backend.DescribeLoadBalancers(ctxWest, nil)
+	require.NoError(t, err)
+	require.Len(t, westAll, 1)
+
+	// 4. Tags are region-scoped: a tag added in us-east-1 is invisible in us-west-2.
+	require.NoError(t, backend.AddTags(ctxEast, []string{sharedName}, []tags.KV{{Key: "env", Value: "prod"}}))
+
+	eastTags, err := backend.DescribeTags(ctxEast, []string{sharedName})
+	require.NoError(t, err)
+	require.Len(t, eastTags[sharedName], 1)
+	assert.Equal(t, "prod", eastTags[sharedName][0].Value)
+
+	westTags, err := backend.DescribeTags(ctxWest, []string{sharedName})
+	require.NoError(t, err)
+	assert.Empty(t, westTags[sharedName], "tags must not leak from us-east-1 into us-west-2")
+
+	// 5. Policies are region-scoped: a policy created in us-west-2 is not visible
+	//    when describing the same-named LB in us-east-1.
+	require.NoError(t, backend.CreateAppCookieStickinessPolicy(ctxWest, sharedName, "west-pol", "SESSION"))
+
+	westPolicies, err := backend.DescribeLoadBalancerPolicies(ctxWest, sharedName, nil)
+	require.NoError(t, err)
+	require.Len(t, westPolicies, 1)
+	assert.Equal(t, "west-pol", westPolicies[0].PolicyName)
+
+	eastPolicies, err := backend.DescribeLoadBalancerPolicies(ctxEast, sharedName, nil)
+	require.NoError(t, err)
+	assert.Empty(t, eastPolicies, "policies must not leak from us-west-2 into us-east-1")
+
+	// 6. Deleting the load balancer in us-east-1 must not affect us-west-2.
+	require.NoError(t, backend.DeleteLoadBalancer(ctxEast, sharedName))
+
+	_, err = backend.DescribeLoadBalancers(ctxEast, []string{sharedName})
+	require.Error(t, err, "the us-east-1 load balancer must be gone")
+
+	westStill, err := backend.DescribeLoadBalancers(ctxWest, []string{sharedName})
+	require.NoError(t, err)
+	require.Len(t, westStill, 1)
+	assert.Equal(t, "us-west-2", westStill[0].Region)
+
+	// The us-west-2 policy survives the us-east-1 delete.
+	westPoliciesAfter, err := backend.DescribeLoadBalancerPolicies(ctxWest, sharedName, nil)
+	require.NoError(t, err)
+	require.Len(t, westPoliciesAfter, 1)
+}
+
+// TestELBDefaultRegionFallback verifies that a context without a region falls
+// back to the backend's configured default region, and that a different region
+// sees no resources.
+func TestELBDefaultRegionFallback(t *testing.T) {
+	t.Parallel()
+
+	backend := elb.NewInMemoryBackend("000000000000", "eu-central-1")
+
+	// No region in context -> default region store.
+	created, err := backend.CreateLoadBalancer(context.Background(), classicLBInput("def-lb", "eu-central-1a"))
+	require.NoError(t, err)
+	assert.Equal(t, "eu-central-1", created.Region)
+
+	// Reading via the explicit default region sees it.
+	list, err := backend.DescribeLoadBalancers(elbCtxRegion("eu-central-1"), []string{"def-lb"})
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "eu-central-1", list[0].Region)
+
+	// A different region sees nothing.
+	other, err := backend.DescribeLoadBalancers(elbCtxRegion("ap-south-1"), nil)
+	require.NoError(t, err)
+	assert.Empty(t, other)
+}

--- a/services/elb/persistence.go
+++ b/services/elb/persistence.go
@@ -39,24 +39,28 @@ type tagPair struct {
 }
 
 // backendSnapshot is the top-level JSON structure for Snapshot/Restore.
-// Version 2 adds IsVPC to lbSnapshot.
-const snapshotVersion = 2
+//
+// Version 2 added IsVPC to lbSnapshot. Version 3 nests LoadBalancers and
+// Policies by region (outer key = region) so that region-isolated state
+// round-trips correctly.
+const snapshotVersion = 3
 
 type backendSnapshot struct {
-	LoadBalancers map[string]*lbSnapshot         `json:"loadBalancers"`
-	Policies      map[string]*LoadBalancerPolicy `json:"policies"`
-	AccountID     string                         `json:"accountId"`
-	Region        string                         `json:"region"`
-	Version       int                            `json:"version,omitempty"`
+	// LoadBalancers and Policies are nested by region (outer key = region).
+	LoadBalancers map[string]map[string]*lbSnapshot         `json:"loadBalancers"`
+	Policies      map[string]map[string]*LoadBalancerPolicy `json:"policies"`
+	AccountID     string                                    `json:"accountId"`
+	Region        string                                    `json:"region"`
+	Version       int                                       `json:"version,omitempty"`
 }
 
 func (s *backendSnapshot) ensureNonNil() {
 	if s.LoadBalancers == nil {
-		s.LoadBalancers = make(map[string]*lbSnapshot)
+		s.LoadBalancers = make(map[string]map[string]*lbSnapshot)
 	}
 
 	if s.Policies == nil {
-		s.Policies = make(map[string]*LoadBalancerPolicy)
+		s.Policies = make(map[string]map[string]*LoadBalancerPolicy)
 	}
 }
 
@@ -157,9 +161,13 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	lbSnaps := make(map[string]*lbSnapshot, len(b.lbs))
-	for k, lb := range b.lbs {
-		lbSnaps[k] = toLBSnapshot(lb)
+	lbSnaps := make(map[string]map[string]*lbSnapshot, len(b.lbs))
+	for region, regionLBs := range b.lbs {
+		regionMap := make(map[string]*lbSnapshot, len(regionLBs))
+		for k, lb := range regionLBs {
+			regionMap[k] = toLBSnapshot(lb)
+		}
+		lbSnaps[region] = regionMap
 	}
 
 	snap := backendSnapshot{
@@ -194,20 +202,30 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	defer b.mu.Unlock()
 
 	// Close tags of any existing LBs before overwriting.
-	for _, lb := range b.lbs {
-		if lb.Tags != nil {
-			lb.Tags.Close()
+	for _, regionLBs := range b.lbs {
+		for _, lb := range regionLBs {
+			if lb.Tags != nil {
+				lb.Tags.Close()
+			}
 		}
 	}
 
-	newLBs := make(map[string]*LoadBalancer, len(snap.LoadBalancers))
-	for k, s := range snap.LoadBalancers {
-		newLBs[k] = fromLBSnapshot(s)
+	newLBs := make(map[string]map[string]*LoadBalancer, len(snap.LoadBalancers))
+	for region, regionLBs := range snap.LoadBalancers {
+		regionMap := make(map[string]*LoadBalancer, len(regionLBs))
+		for k, s := range regionLBs {
+			regionMap[k] = fromLBSnapshot(s)
+		}
+		newLBs[region] = regionMap
 	}
 
 	b.lbs = newLBs
 	b.policies = snap.Policies
 	b.accountID = snap.AccountID
+
+	if b.policies == nil {
+		b.policies = make(map[string]map[string]*LoadBalancerPolicy)
+	}
 
 	// Only adopt the persisted region when the backend has no region set yet,
 	// preventing region drift when a snapshot from a different region is loaded

--- a/services/emr/backend.go
+++ b/services/emr/backend.go
@@ -1,11 +1,13 @@
 package emr
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -14,6 +16,30 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 	"github.com/blackbirdworks/gopherstack/pkgs/page"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
+}
 
 var ErrValidation = awserr.New(
 	"ValidationException: required field is missing",
@@ -622,16 +648,21 @@ type ListInstancesParams struct {
 }
 
 // InMemoryBackend stores EMR state in memory.
+//
+// All regional resource maps are nested by region (outer key = region) so that
+// same-named resources in different regions are fully isolated. The
+// block-public-access configuration is account-level (one per region in AWS)
+// and is therefore also region-nested.
 type InMemoryBackend struct {
-	clusters              map[string]*Cluster
-	arnIndex              map[string]string
-	securityConfigs       map[string]*SecurityConfiguration
-	studios               map[string]*Studio
-	studioSessionMappings map[string]*StudioSessionMapping
-	persistentAppUIs      map[string]*PersistentAppUI
-	notebookExecutions    map[string]*NotebookExecution
-	blockPublicAccess     *BlockPublicAccessConfiguration
-	blockPublicAccessMeta *blockPublicAccessMeta
+	clusters              map[string]map[string]*Cluster
+	arnIndex              map[string]map[string]string
+	securityConfigs       map[string]map[string]*SecurityConfiguration
+	studios               map[string]map[string]*Studio
+	studioSessionMappings map[string]map[string]*StudioSessionMapping
+	persistentAppUIs      map[string]map[string]*PersistentAppUI
+	notebookExecutions    map[string]map[string]*NotebookExecution
+	blockPublicAccess     map[string]*BlockPublicAccessConfiguration
+	blockPublicAccessMeta map[string]*blockPublicAccessMeta
 	mu                    *lockmetrics.RWMutex
 	accountID             string
 	region                string
@@ -641,13 +672,15 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		clusters:              make(map[string]*Cluster),
-		arnIndex:              make(map[string]string),
-		securityConfigs:       make(map[string]*SecurityConfiguration),
-		studios:               make(map[string]*Studio),
-		studioSessionMappings: make(map[string]*StudioSessionMapping),
-		persistentAppUIs:      make(map[string]*PersistentAppUI),
-		notebookExecutions:    make(map[string]*NotebookExecution),
+		clusters:              make(map[string]map[string]*Cluster),
+		arnIndex:              make(map[string]map[string]string),
+		securityConfigs:       make(map[string]map[string]*SecurityConfiguration),
+		studios:               make(map[string]map[string]*Studio),
+		studioSessionMappings: make(map[string]map[string]*StudioSessionMapping),
+		persistentAppUIs:      make(map[string]map[string]*PersistentAppUI),
+		notebookExecutions:    make(map[string]map[string]*NotebookExecution),
+		blockPublicAccess:     make(map[string]*BlockPublicAccessConfiguration),
+		blockPublicAccessMeta: make(map[string]*blockPublicAccessMeta),
 		accountID:             accountID,
 		region:                region,
 		mu:                    lockmetrics.New("emr"),
@@ -656,6 +689,65 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 
 // Region returns the AWS region this backend is configured for.
 func (b *InMemoryBackend) Region() string { return b.region }
+
+// The following lazy per-region store helpers return the resource map for the
+// given region, creating it on first use. Callers must hold b.mu.
+
+func (b *InMemoryBackend) clustersStore(region string) map[string]*Cluster {
+	if b.clusters[region] == nil {
+		b.clusters[region] = make(map[string]*Cluster)
+	}
+
+	return b.clusters[region]
+}
+
+func (b *InMemoryBackend) arnIndexStore(region string) map[string]string {
+	if b.arnIndex[region] == nil {
+		b.arnIndex[region] = make(map[string]string)
+	}
+
+	return b.arnIndex[region]
+}
+
+func (b *InMemoryBackend) securityConfigsStore(region string) map[string]*SecurityConfiguration {
+	if b.securityConfigs[region] == nil {
+		b.securityConfigs[region] = make(map[string]*SecurityConfiguration)
+	}
+
+	return b.securityConfigs[region]
+}
+
+func (b *InMemoryBackend) studiosStore(region string) map[string]*Studio {
+	if b.studios[region] == nil {
+		b.studios[region] = make(map[string]*Studio)
+	}
+
+	return b.studios[region]
+}
+
+func (b *InMemoryBackend) studioSessionMappingsStore(region string) map[string]*StudioSessionMapping {
+	if b.studioSessionMappings[region] == nil {
+		b.studioSessionMappings[region] = make(map[string]*StudioSessionMapping)
+	}
+
+	return b.studioSessionMappings[region]
+}
+
+func (b *InMemoryBackend) persistentAppUIsStore(region string) map[string]*PersistentAppUI {
+	if b.persistentAppUIs[region] == nil {
+		b.persistentAppUIs[region] = make(map[string]*PersistentAppUI)
+	}
+
+	return b.persistentAppUIs[region]
+}
+
+func (b *InMemoryBackend) notebookExecutionsStore(region string) map[string]*NotebookExecution {
+	if b.notebookExecutions[region] == nil {
+		b.notebookExecutions[region] = make(map[string]*NotebookExecution)
+	}
+
+	return b.notebookExecutions[region]
+}
 
 func (b *InMemoryBackend) nextID() string {
 	n := b.counter.Add(1)
@@ -811,7 +903,7 @@ func buildEC2Attrs(inst RunJobFlowInstances) *EC2InstanceAttributes {
 }
 
 // RunJobFlow creates a new EMR cluster.
-func (b *InMemoryBackend) RunJobFlow(params RunJobFlowParams) (*Cluster, error) {
+func (b *InMemoryBackend) RunJobFlow(ctx context.Context, params RunJobFlowParams) (*Cluster, error) {
 	releaseLabel := params.ReleaseLabel
 	if releaseLabel == "" {
 		releaseLabel = defaultReleaseLabel
@@ -821,11 +913,13 @@ func (b *InMemoryBackend) RunJobFlow(params RunJobFlowParams) (*Cluster, error) 
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RunJobFlow")
 	defer b.mu.Unlock()
 
 	id := b.nextID()
-	clusterARN := arn.Build("elasticmapreduce", b.region, b.accountID, "cluster/"+id)
+	clusterARN := arn.Build("elasticmapreduce", region, b.accountID, "cluster/"+id)
 
 	tagsCopy := make([]Tag, len(params.Tags))
 	copy(tagsCopy, params.Tags)
@@ -874,19 +968,21 @@ func (b *InMemoryBackend) RunJobFlow(params RunJobFlowParams) (*Cluster, error) 
 		instanceGroups:              groups,
 		steps:                       steps,
 	}
-	b.clusters[id] = cluster
-	b.arnIndex[clusterARN] = id
+	b.clustersStore(region)[id] = cluster
+	b.arnIndexStore(region)[clusterARN] = id
 	cp := cluster.clone()
 
 	return &cp, nil
 }
 
 // DescribeCluster returns a cluster by its ID.
-func (b *InMemoryBackend) DescribeCluster(id string) (*Cluster, error) {
+func (b *InMemoryBackend) DescribeCluster(ctx context.Context, id string) (*Cluster, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeCluster")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[id]
+	cluster, ok := b.clustersStore(region)[id]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, id)
 	}
@@ -944,12 +1040,14 @@ func (c Cluster) clone() Cluster {
 }
 
 // ListClusters returns cluster summaries matching the given filter, sorted by creation time descending.
-func (b *InMemoryBackend) ListClusters(params ListClustersParams) ([]ClusterSummary, string) {
+func (b *InMemoryBackend) ListClusters(ctx context.Context, params ListClustersParams) ([]ClusterSummary, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListClusters")
 	defer b.mu.RUnlock()
 
 	stateSet := buildStateSet(params.ClusterStates)
-	list := b.gatherClusterSummaries(stateSet, params)
+	list := b.gatherClusterSummaries(region, stateSet, params)
 
 	sort.Slice(list, func(i, j int) bool {
 		ti := clusterCreationMillis(list[i])
@@ -983,12 +1081,14 @@ func buildStateSet(states []string) map[string]bool {
 
 // gatherClusterSummaries collects filtered cluster summaries. Caller holds read lock.
 func (b *InMemoryBackend) gatherClusterSummaries(
+	region string,
 	stateSet map[string]bool,
 	params ListClustersParams,
 ) []ClusterSummary {
-	list := make([]ClusterSummary, 0, len(b.clusters))
+	clusters := b.clustersStore(region)
+	list := make([]ClusterSummary, 0, len(clusters))
 
-	for _, c := range b.clusters {
+	for _, c := range clusters {
 		if !clusterMatchesFilter(c, stateSet, params) {
 			continue
 		}
@@ -1058,12 +1158,16 @@ func timelineMillis(timeline map[string]any, key string) int64 {
 
 // TerminateJobFlows marks the specified clusters as TERMINATED.
 // Returns ValidationException if any cluster has termination protection.
-func (b *InMemoryBackend) TerminateJobFlows(ids []string) error {
+func (b *InMemoryBackend) TerminateJobFlows(ctx context.Context, ids []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TerminateJobFlows")
 	defer b.mu.Unlock()
 
+	clusters := b.clustersStore(region)
+
 	for _, id := range ids {
-		if err := b.terminateSingle(id); err != nil {
+		if err := terminateSingle(clusters, id); err != nil {
 			return err
 		}
 	}
@@ -1071,8 +1175,8 @@ func (b *InMemoryBackend) TerminateJobFlows(ids []string) error {
 	return nil
 }
 
-func (b *InMemoryBackend) terminateSingle(id string) error {
-	cluster, ok := b.clusters[id]
+func terminateSingle(clusters map[string]*Cluster, id string) error {
+	cluster, ok := clusters[id]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, id)
 	}
@@ -1099,11 +1203,13 @@ func (b *InMemoryBackend) terminateSingle(id string) error {
 }
 
 // ListInstanceGroups returns the instance groups for a cluster by its ID.
-func (b *InMemoryBackend) ListInstanceGroups(clusterID string) ([]InstanceGroup, error) {
+func (b *InMemoryBackend) ListInstanceGroups(ctx context.Context, clusterID string) ([]InstanceGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListInstanceGroups")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1115,11 +1221,15 @@ func (b *InMemoryBackend) ListInstanceGroups(clusterID string) ([]InstanceGroup,
 }
 
 // AddTags adds or updates tags on a cluster identified by ARN or ID.
-func (b *InMemoryBackend) AddTags(resourceID string, tags []Tag) error {
+// When resourceID is an ARN the region is resolved from the ARN, otherwise the
+// ctx region (falling back to the backend default) is used.
+func (b *InMemoryBackend) AddTags(ctx context.Context, resourceID string, tags []Tag) error {
+	region := regionFromARN(resourceID, getRegion(ctx, b.region))
+
 	b.mu.Lock("AddTags")
 	defer b.mu.Unlock()
 
-	cluster := b.findClusterByIDOrARN(resourceID)
+	cluster := b.findClusterByIDOrARN(region, resourceID)
 	if cluster == nil {
 		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceID)
 	}
@@ -1135,11 +1245,13 @@ func (b *InMemoryBackend) AddTags(resourceID string, tags []Tag) error {
 }
 
 // RemoveTags removes tags from a cluster identified by ARN or ID.
-func (b *InMemoryBackend) RemoveTags(resourceID string, tagKeys []string) error {
+func (b *InMemoryBackend) RemoveTags(ctx context.Context, resourceID string, tagKeys []string) error {
+	region := regionFromARN(resourceID, getRegion(ctx, b.region))
+
 	b.mu.Lock("RemoveTags")
 	defer b.mu.Unlock()
 
-	cluster := b.findClusterByIDOrARN(resourceID)
+	cluster := b.findClusterByIDOrARN(region, resourceID)
 	if cluster == nil {
 		return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceID)
 	}
@@ -1155,11 +1267,13 @@ func (b *InMemoryBackend) RemoveTags(resourceID string, tagKeys []string) error 
 }
 
 // ListTagsForResource returns tags for a cluster identified by ARN or ID, sorted by key.
-func (b *InMemoryBackend) ListTagsForResource(resourceID string) ([]Tag, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceID string) ([]Tag, error) {
+	region := regionFromARN(resourceID, getRegion(ctx, b.region))
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	cluster := b.findClusterByIDOrARN(resourceID)
+	cluster := b.findClusterByIDOrARN(region, resourceID)
 	if cluster == nil {
 		return nil, fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceID)
 	}
@@ -1174,15 +1288,16 @@ func (b *InMemoryBackend) ListTagsForResource(resourceID string) ([]Tag, error) 
 	return tags, nil
 }
 
-// findClusterByIDOrARN looks up a cluster by either its ID or ARN.
-// Caller must hold at least a read lock.
-func (b *InMemoryBackend) findClusterByIDOrARN(idOrARN string) *Cluster {
-	if c, ok := b.clusters[idOrARN]; ok {
+// findClusterByIDOrARN looks up a cluster by either its ID or ARN within the
+// given region. Caller must hold at least a read lock.
+func (b *InMemoryBackend) findClusterByIDOrARN(region, idOrARN string) *Cluster {
+	clusters := b.clustersStore(region)
+	if c, ok := clusters[idOrARN]; ok {
 		return c
 	}
 
-	if id, ok := b.arnIndex[idOrARN]; ok {
-		return b.clusters[id]
+	if id, ok := b.arnIndexStore(region)[idOrARN]; ok {
+		return clusters[id]
 	}
 
 	return nil
@@ -1224,27 +1339,30 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.clusters = make(map[string]*Cluster)
-	b.arnIndex = make(map[string]string)
-	b.securityConfigs = make(map[string]*SecurityConfiguration)
-	b.studios = make(map[string]*Studio)
-	b.studioSessionMappings = make(map[string]*StudioSessionMapping)
-	b.persistentAppUIs = make(map[string]*PersistentAppUI)
-	b.notebookExecutions = make(map[string]*NotebookExecution)
-	b.blockPublicAccess = nil
-	b.blockPublicAccessMeta = nil
+	b.clusters = make(map[string]map[string]*Cluster)
+	b.arnIndex = make(map[string]map[string]string)
+	b.securityConfigs = make(map[string]map[string]*SecurityConfiguration)
+	b.studios = make(map[string]map[string]*Studio)
+	b.studioSessionMappings = make(map[string]map[string]*StudioSessionMapping)
+	b.persistentAppUIs = make(map[string]map[string]*PersistentAppUI)
+	b.notebookExecutions = make(map[string]map[string]*NotebookExecution)
+	b.blockPublicAccess = make(map[string]*BlockPublicAccessConfiguration)
+	b.blockPublicAccessMeta = make(map[string]*blockPublicAccessMeta)
 	b.counter.Store(0)
 }
 
 // AddInstanceFleet adds an instance fleet to an existing cluster.
 func (b *InMemoryBackend) AddInstanceFleet(
+	ctx context.Context,
 	clusterID string,
 	spec InstanceFleetSpec,
 ) (*InstanceFleet, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddInstanceFleet")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, "", fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1267,13 +1385,16 @@ func (b *InMemoryBackend) AddInstanceFleet(
 
 // AddInstanceGroups adds new instance groups to an existing cluster.
 func (b *InMemoryBackend) AddInstanceGroups(
+	ctx context.Context,
 	clusterID string,
 	specs []InstanceGroupSpec,
 ) ([]string, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddInstanceGroups")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, "", fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1306,11 +1427,15 @@ func (b *InMemoryBackend) AddInstanceGroups(
 }
 
 // AddJobFlowSteps adds steps to a cluster and returns their IDs.
-func (b *InMemoryBackend) AddJobFlowSteps(jobFlowID string, specs []StepSpec) ([]string, error) {
+func (b *InMemoryBackend) AddJobFlowSteps(
+	ctx context.Context, jobFlowID string, specs []StepSpec,
+) ([]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddJobFlowSteps")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[jobFlowID]
+	cluster, ok := b.clustersStore(region)[jobFlowID]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, jobFlowID)
 	}
@@ -1344,15 +1469,18 @@ func (b *InMemoryBackend) AddJobFlowSteps(jobFlowID string, specs []StepSpec) ([
 
 // ListSteps returns steps for a cluster, optionally filtered by state and/or ID.
 func (b *InMemoryBackend) ListSteps(
+	ctx context.Context,
 	clusterID string,
 	stepStates []string,
 	stepIDs []string,
 	marker string,
 ) ([]Step, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSteps")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return []Step{}, ""
 	}
@@ -1404,11 +1532,13 @@ func buildStringSet(items []string) map[string]bool {
 }
 
 // DescribeStep returns a single step by cluster ID and step ID.
-func (b *InMemoryBackend) DescribeStep(clusterID, stepID string) (*Step, error) {
+func (b *InMemoryBackend) DescribeStep(ctx context.Context, clusterID, stepID string) (*Step, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeStep")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1425,11 +1555,13 @@ func (b *InMemoryBackend) DescribeStep(clusterID, stepID string) (*Step, error) 
 }
 
 // CancelSteps cancels pending steps on a cluster.
-func (b *InMemoryBackend) CancelSteps(clusterID string, stepIDs []string) error {
+func (b *InMemoryBackend) CancelSteps(ctx context.Context, clusterID string, stepIDs []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CancelSteps")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1447,7 +1579,9 @@ func (b *InMemoryBackend) CancelSteps(clusterID string, stepIDs []string) error 
 }
 
 // ModifyCluster updates StepConcurrencyLevel on a cluster.
-func (b *InMemoryBackend) ModifyCluster(clusterID string, stepConcurrencyLevel int) (int, error) {
+func (b *InMemoryBackend) ModifyCluster(
+	ctx context.Context, clusterID string, stepConcurrencyLevel int,
+) (int, error) {
 	if stepConcurrencyLevel < minStepConcurrency || stepConcurrencyLevel > maxStepConcurrency {
 		return 0, fmt.Errorf(
 			"%w: StepConcurrencyLevel must be between %d and %d",
@@ -1457,10 +1591,12 @@ func (b *InMemoryBackend) ModifyCluster(clusterID string, stepConcurrencyLevel i
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ModifyCluster")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return 0, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1472,13 +1608,16 @@ func (b *InMemoryBackend) ModifyCluster(clusterID string, stepConcurrencyLevel i
 
 // ModifyInstanceGroups updates instance counts for the specified groups.
 func (b *InMemoryBackend) ModifyInstanceGroups(
+	ctx context.Context,
 	clusterID string,
 	mods []InstanceGroupModification,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ModifyInstanceGroups")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1509,13 +1648,16 @@ type InstanceGroupModification struct {
 
 // ModifyInstanceFleet updates target capacities on an instance fleet.
 func (b *InMemoryBackend) ModifyInstanceFleet(
+	ctx context.Context,
 	clusterID string,
 	mod InstanceFleetModification,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ModifyInstanceFleet")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1537,12 +1679,18 @@ type InstanceFleetModification struct {
 }
 
 // SetTerminationProtection sets the TerminationProtected flag on clusters.
-func (b *InMemoryBackend) SetTerminationProtection(jobFlowIDs []string, protect bool) error {
+func (b *InMemoryBackend) SetTerminationProtection(
+	ctx context.Context, jobFlowIDs []string, protect bool,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("SetTerminationProtection")
 	defer b.mu.Unlock()
 
+	clusters := b.clustersStore(region)
+
 	for _, id := range jobFlowIDs {
-		cluster, ok := b.clusters[id]
+		cluster, ok := clusters[id]
 		if !ok {
 			return fmt.Errorf("%w: cluster %s not found", ErrNotFound, id)
 		}
@@ -1554,12 +1702,18 @@ func (b *InMemoryBackend) SetTerminationProtection(jobFlowIDs []string, protect 
 }
 
 // SetKeepJobFlowAliveWhenNoSteps sets the KeepJobFlowAliveWhenNoSteps flag.
-func (b *InMemoryBackend) SetKeepJobFlowAliveWhenNoSteps(jobFlowIDs []string, keep bool) error {
+func (b *InMemoryBackend) SetKeepJobFlowAliveWhenNoSteps(
+	ctx context.Context, jobFlowIDs []string, keep bool,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("SetKeepJobFlowAliveWhenNoSteps")
 	defer b.mu.Unlock()
 
+	clusters := b.clustersStore(region)
+
 	for _, id := range jobFlowIDs {
-		cluster, ok := b.clusters[id]
+		cluster, ok := clusters[id]
 		if !ok {
 			return fmt.Errorf("%w: cluster %s not found", ErrNotFound, id)
 		}
@@ -1571,12 +1725,18 @@ func (b *InMemoryBackend) SetKeepJobFlowAliveWhenNoSteps(jobFlowIDs []string, ke
 }
 
 // SetVisibleToAllUsers sets the VisibleToAllUsers flag.
-func (b *InMemoryBackend) SetVisibleToAllUsers(jobFlowIDs []string, visible bool) error {
+func (b *InMemoryBackend) SetVisibleToAllUsers(
+	ctx context.Context, jobFlowIDs []string, visible bool,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("SetVisibleToAllUsers")
 	defer b.mu.Unlock()
 
+	clusters := b.clustersStore(region)
+
 	for _, id := range jobFlowIDs {
-		cluster, ok := b.clusters[id]
+		cluster, ok := clusters[id]
 		if !ok {
 			return fmt.Errorf("%w: cluster %s not found", ErrNotFound, id)
 		}
@@ -1588,12 +1748,18 @@ func (b *InMemoryBackend) SetVisibleToAllUsers(jobFlowIDs []string, visible bool
 }
 
 // SetUnhealthyNodeReplacement sets the UnhealthyNodeReplacement flag.
-func (b *InMemoryBackend) SetUnhealthyNodeReplacement(jobFlowIDs []string, replace bool) error {
+func (b *InMemoryBackend) SetUnhealthyNodeReplacement(
+	ctx context.Context, jobFlowIDs []string, replace bool,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("SetUnhealthyNodeReplacement")
 	defer b.mu.Unlock()
 
+	clusters := b.clustersStore(region)
+
 	for _, id := range jobFlowIDs {
-		cluster, ok := b.clusters[id]
+		cluster, ok := clusters[id]
 		if !ok {
 			return fmt.Errorf("%w: cluster %s not found", ErrNotFound, id)
 		}
@@ -1606,6 +1772,7 @@ func (b *InMemoryBackend) SetUnhealthyNodeReplacement(jobFlowIDs []string, repla
 
 // PutManagedScalingPolicy sets the managed scaling policy on a cluster.
 func (b *InMemoryBackend) PutManagedScalingPolicy(
+	ctx context.Context,
 	clusterID string,
 	policy ManagedScalingPolicy,
 ) error {
@@ -1613,10 +1780,12 @@ func (b *InMemoryBackend) PutManagedScalingPolicy(
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutManagedScalingPolicy")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1645,11 +1814,15 @@ func validateManagedScalingPolicy(policy ManagedScalingPolicy) error {
 }
 
 // GetManagedScalingPolicy returns the managed scaling policy for a cluster.
-func (b *InMemoryBackend) GetManagedScalingPolicy(clusterID string) (*ManagedScalingPolicy, error) {
+func (b *InMemoryBackend) GetManagedScalingPolicy(
+	ctx context.Context, clusterID string,
+) (*ManagedScalingPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetManagedScalingPolicy")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1666,11 +1839,13 @@ func (b *InMemoryBackend) GetManagedScalingPolicy(clusterID string) (*ManagedSca
 }
 
 // RemoveManagedScalingPolicy clears the managed scaling policy on a cluster.
-func (b *InMemoryBackend) RemoveManagedScalingPolicy(clusterID string) error {
+func (b *InMemoryBackend) RemoveManagedScalingPolicy(ctx context.Context, clusterID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveManagedScalingPolicy")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1682,6 +1857,7 @@ func (b *InMemoryBackend) RemoveManagedScalingPolicy(clusterID string) error {
 
 // PutAutoTerminationPolicy sets the auto-termination policy on a cluster.
 func (b *InMemoryBackend) PutAutoTerminationPolicy(
+	ctx context.Context,
 	clusterID string,
 	policy AutoTerminationPolicy,
 ) error {
@@ -1694,10 +1870,12 @@ func (b *InMemoryBackend) PutAutoTerminationPolicy(
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutAutoTerminationPolicy")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1710,12 +1888,15 @@ func (b *InMemoryBackend) PutAutoTerminationPolicy(
 
 // GetAutoTerminationPolicy returns the auto-termination policy for a cluster.
 func (b *InMemoryBackend) GetAutoTerminationPolicy(
+	ctx context.Context,
 	clusterID string,
 ) (*AutoTerminationPolicy, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetAutoTerminationPolicy")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1732,11 +1913,13 @@ func (b *InMemoryBackend) GetAutoTerminationPolicy(
 }
 
 // RemoveAutoTerminationPolicy clears the auto-termination policy on a cluster.
-func (b *InMemoryBackend) RemoveAutoTerminationPolicy(clusterID string) error {
+func (b *InMemoryBackend) RemoveAutoTerminationPolicy(ctx context.Context, clusterID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveAutoTerminationPolicy")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1748,13 +1931,16 @@ func (b *InMemoryBackend) RemoveAutoTerminationPolicy(clusterID string) error {
 
 // PutAutoScalingPolicy persists an auto-scaling policy on an instance group.
 func (b *InMemoryBackend) PutAutoScalingPolicy(
+	ctx context.Context,
 	clusterID, instanceGroupID string,
 	policy AutoScalingPolicySpec,
 ) (*AutoScalingPolicyDetail, string, string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutAutoScalingPolicy")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, "", "", fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1776,11 +1962,15 @@ func (b *InMemoryBackend) PutAutoScalingPolicy(
 }
 
 // RemoveAutoScalingPolicy clears the auto-scaling policy on an instance group.
-func (b *InMemoryBackend) RemoveAutoScalingPolicy(clusterID, instanceGroupID string) error {
+func (b *InMemoryBackend) RemoveAutoScalingPolicy(
+	ctx context.Context, clusterID, instanceGroupID string,
+) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveAutoScalingPolicy")
 	defer b.mu.Unlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -1797,15 +1987,20 @@ func (b *InMemoryBackend) RemoveAutoScalingPolicy(clusterID, instanceGroupID str
 }
 
 // GetBlockPublicAccessConfiguration returns the account-level block-public-access config.
-func (b *InMemoryBackend) GetBlockPublicAccessConfiguration() (BlockPublicAccessConfiguration, blockPublicAccessMeta) {
+func (b *InMemoryBackend) GetBlockPublicAccessConfiguration(
+	ctx context.Context,
+) (BlockPublicAccessConfiguration, blockPublicAccessMeta) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetBlockPublicAccessConfiguration")
 	defer b.mu.RUnlock()
 
-	if b.blockPublicAccess == nil {
+	cfg := b.blockPublicAccess[region]
+	if cfg == nil {
 		return defaultBlockPublicAccess(), blockPublicAccessMeta{CreationDateTime: time.Now()}
 	}
 
-	return *b.blockPublicAccess, *b.blockPublicAccessMeta
+	return *cfg, *b.blockPublicAccessMeta[region]
 }
 
 func defaultBlockPublicAccess() BlockPublicAccessConfiguration {
@@ -1819,18 +2014,21 @@ func defaultBlockPublicAccess() BlockPublicAccessConfiguration {
 
 // PutBlockPublicAccessConfiguration sets the account-level block-public-access config.
 func (b *InMemoryBackend) PutBlockPublicAccessConfiguration(
+	ctx context.Context,
 	config BlockPublicAccessConfiguration,
 ) error {
 	if err := validatePortRanges(config.PermittedPublicSecurityGroupRuleRanges); err != nil {
 		return err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutBlockPublicAccessConfiguration")
 	defer b.mu.Unlock()
 
 	cp := config
-	b.blockPublicAccess = &cp
-	b.blockPublicAccessMeta = &blockPublicAccessMeta{
+	b.blockPublicAccess[region] = &cp
+	b.blockPublicAccessMeta[region] = &blockPublicAccessMeta{
 		CreationDateTime: time.Now(),
 		CreatedByArn:     arn.Build("iam", "", b.accountID, "root"),
 	}
@@ -1850,14 +2048,18 @@ func validatePortRanges(ranges []PortRange) error {
 
 // ListSecurityConfigurations returns all security configurations, sorted by name.
 func (b *InMemoryBackend) ListSecurityConfigurations(
+	ctx context.Context,
 	marker string,
 ) ([]SecurityConfigSummary, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSecurityConfigurations")
 	defer b.mu.RUnlock()
 
-	summaries := make([]SecurityConfigSummary, 0, len(b.securityConfigs))
+	configs := b.securityConfigsStore(region)
+	summaries := make([]SecurityConfigSummary, 0, len(configs))
 
-	for _, sc := range b.securityConfigs {
+	for _, sc := range configs {
 		summaries = append(summaries, SecurityConfigSummary{
 			Name:             sc.Name,
 			CreationDateTime: sc.CreationDateTime,
@@ -1880,7 +2082,9 @@ type SecurityConfigSummary struct {
 }
 
 // ListReleaseLabels returns release labels optionally filtered by prefix and application.
-func (b *InMemoryBackend) ListReleaseLabels(prefix, application, marker string) ([]string, string) {
+func (b *InMemoryBackend) ListReleaseLabels(
+	_ context.Context, prefix, application, marker string,
+) ([]string, string) {
 	var labels []string
 
 	for label := range releaseLabelApps {
@@ -1916,7 +2120,9 @@ func labelHasApp(label, application string) bool {
 }
 
 // DescribeReleaseLabel returns details about a specific release label.
-func (b *InMemoryBackend) DescribeReleaseLabel(releaseLabel string) (*ReleaseLabel, error) {
+func (b *InMemoryBackend) DescribeReleaseLabel(
+	_ context.Context, releaseLabel string,
+) (*ReleaseLabel, error) {
 	apps, ok := releaseLabelApps[releaseLabel]
 	if !ok {
 		return nil, fmt.Errorf("%w: release label %s not found", ErrNotFound, releaseLabel)
@@ -1932,7 +2138,7 @@ func (b *InMemoryBackend) DescribeReleaseLabel(releaseLabel string) (*ReleaseLab
 
 // ListSupportedInstanceTypes returns the static catalog of EMR-supported instance types.
 func (b *InMemoryBackend) ListSupportedInstanceTypes(
-	releaseLabel, marker string,
+	_ context.Context, releaseLabel, marker string,
 ) ([]SupportedInstanceType, string) {
 	// Validate release label exists (unknown labels → empty list matches AWS behavior).
 	if _, ok := releaseLabelApps[releaseLabel]; !ok {
@@ -1946,13 +2152,16 @@ func (b *InMemoryBackend) ListSupportedInstanceTypes(
 
 // ListInstances synthesizes per-group instances for a cluster.
 func (b *InMemoryBackend) ListInstances(
+	ctx context.Context,
 	clusterID string,
 	params ListInstancesParams,
 ) ([]ClusterInstance, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListInstances")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return []ClusterInstance{}, ""
 	}
@@ -2012,11 +2221,13 @@ func synthesizeInstance(clusterID string, grp InstanceGroup, idx int) ClusterIns
 }
 
 // DescribeStudio returns an EMR Studio by ID.
-func (b *InMemoryBackend) DescribeStudio(studioID string) (*Studio, error) {
+func (b *InMemoryBackend) DescribeStudio(ctx context.Context, studioID string) (*Studio, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeStudio")
 	defer b.mu.RUnlock()
 
-	studio, ok := b.studios[studioID]
+	studio, ok := b.studiosStore(region)[studioID]
 	if !ok {
 		return nil, fmt.Errorf("%w: studio %s not found", ErrNotFound, studioID)
 	}
@@ -2027,13 +2238,16 @@ func (b *InMemoryBackend) DescribeStudio(studioID string) (*Studio, error) {
 }
 
 // ListStudios returns all studios as summaries, sorted by name.
-func (b *InMemoryBackend) ListStudios(marker string) ([]StudioSummary, string) {
+func (b *InMemoryBackend) ListStudios(ctx context.Context, marker string) ([]StudioSummary, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListStudios")
 	defer b.mu.RUnlock()
 
-	summaries := make([]StudioSummary, 0, len(b.studios))
+	studios := b.studiosStore(region)
+	summaries := make([]StudioSummary, 0, len(studios))
 
-	for _, s := range b.studios {
+	for _, s := range studios {
 		summaries = append(summaries, StudioSummary{
 			StudioID:          s.StudioID,
 			StudioArn:         s.StudioArn,
@@ -2058,12 +2272,15 @@ func (b *InMemoryBackend) ListStudios(marker string) ([]StudioSummary, string) {
 
 // UpdateStudio updates mutable fields on an EMR Studio.
 func (b *InMemoryBackend) UpdateStudio(
+	ctx context.Context,
 	studioID, name, description, defaultS3Location, subnetIDsJSON string,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateStudio")
 	defer b.mu.Unlock()
 
-	studio, ok := b.studios[studioID]
+	studio, ok := b.studiosStore(region)[studioID]
 	if !ok {
 		return fmt.Errorf("%w: studio %s not found", ErrNotFound, studioID)
 	}
@@ -2087,14 +2304,17 @@ func (b *InMemoryBackend) UpdateStudio(
 
 // GetStudioSessionMapping returns a session mapping for a studio.
 func (b *InMemoryBackend) GetStudioSessionMapping(
+	ctx context.Context,
 	studioID, identityType, identityID, identityName string,
 ) (*StudioSessionMapping, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetStudioSessionMapping")
 	defer b.mu.RUnlock()
 
 	key := studioSessionKey(studioID, identityType, identityID, identityName)
 
-	mapping, ok := b.studioSessionMappings[key]
+	mapping, ok := b.studioSessionMappingsStore(region)[key]
 	if !ok {
 		return nil, fmt.Errorf("%w: session mapping not found for studio %s", ErrNotFound, studioID)
 	}
@@ -2106,14 +2326,17 @@ func (b *InMemoryBackend) GetStudioSessionMapping(
 
 // ListStudioSessionMappings returns session mappings for a studio, optionally filtered by identity type.
 func (b *InMemoryBackend) ListStudioSessionMappings(
+	ctx context.Context,
 	studioID, identityType string,
 ) []StudioSessionMapping {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListStudioSessionMappings")
 	defer b.mu.RUnlock()
 
 	result := make([]StudioSessionMapping, 0)
 
-	for _, m := range b.studioSessionMappings {
+	for _, m := range b.studioSessionMappingsStore(region) {
 		if m.StudioID != studioID {
 			continue
 		}
@@ -2134,14 +2357,17 @@ func (b *InMemoryBackend) ListStudioSessionMappings(
 
 // UpdateStudioSessionMapping changes the SessionPolicyArn on a mapping.
 func (b *InMemoryBackend) UpdateStudioSessionMapping(
+	ctx context.Context,
 	studioID, identityType, identityID, identityName, sessionPolicyArn string,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateStudioSessionMapping")
 	defer b.mu.Unlock()
 
 	key := studioSessionKey(studioID, identityType, identityID, identityName)
 
-	mapping, ok := b.studioSessionMappings[key]
+	mapping, ok := b.studioSessionMappingsStore(region)[key]
 	if !ok {
 		return fmt.Errorf("%w: session mapping not found for studio %s", ErrNotFound, studioID)
 	}
@@ -2154,9 +2380,12 @@ func (b *InMemoryBackend) UpdateStudioSessionMapping(
 
 // DescribeJobFlows translates clusters into the legacy JobFlow format.
 func (b *InMemoryBackend) DescribeJobFlows(
+	ctx context.Context,
 	ids, states []string,
 	createdAfter, createdBefore *time.Time,
 ) []JobFlow {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeJobFlows")
 	defer b.mu.RUnlock()
 
@@ -2165,7 +2394,7 @@ func (b *InMemoryBackend) DescribeJobFlows(
 
 	flows := make([]JobFlow, 0)
 
-	for _, c := range b.clusters {
+	for _, c := range b.clustersStore(region) {
 		if !jobFlowMatchesFilter(c, idSet, stateSet, createdAfter, createdBefore) {
 			continue
 		}
@@ -2277,11 +2506,13 @@ func clusterToJobFlow(c *Cluster) JobFlow {
 }
 
 // DescribePersistentAppUI returns a persistent app UI by ID.
-func (b *InMemoryBackend) DescribePersistentAppUI(id string) (*PersistentAppUI, error) {
+func (b *InMemoryBackend) DescribePersistentAppUI(ctx context.Context, id string) (*PersistentAppUI, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribePersistentAppUI")
 	defer b.mu.RUnlock()
 
-	ui, ok := b.persistentAppUIs[id]
+	ui, ok := b.persistentAppUIsStore(region)[id]
 	if !ok {
 		return nil, fmt.Errorf("%w: persistent app UI %s not found", ErrNotFound, id)
 	}
@@ -2303,16 +2534,19 @@ func (b *InMemoryBackend) GetPresignedURL(id, region string) string {
 
 // GetClusterSessionCredentials returns synthesized credentials for cluster session access.
 func (b *InMemoryBackend) GetClusterSessionCredentials(
+	ctx context.Context,
 	clusterID, executionRoleArn string,
 ) (map[string]any, time.Time, error) {
 	if executionRoleArn == "" {
 		return nil, time.Time{}, fmt.Errorf("%w: ExecutionRoleArn is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetClusterSessionCredentials")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.clusters[clusterID]; !ok {
+	if _, ok := b.clustersStore(region)[clusterID]; !ok {
 		return nil, time.Time{}, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
 
@@ -2329,11 +2563,14 @@ func (b *InMemoryBackend) GetClusterSessionCredentials(
 
 // CreatePersistentAppUI creates a new persistent application user interface.
 func (b *InMemoryBackend) CreatePersistentAppUI(
+	ctx context.Context,
 	targetResourceArn string,
 ) (*PersistentAppUI, error) {
 	if targetResourceArn == "" {
 		return nil, fmt.Errorf("%w: TargetResourceArn is required", ErrValidation)
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.Lock("CreatePersistentAppUI")
 	defer b.mu.Unlock()
@@ -2345,7 +2582,7 @@ func (b *InMemoryBackend) CreatePersistentAppUI(
 		RuntimeRoleEnabledCluster: false,
 	}
 
-	b.persistentAppUIs[id] = ui
+	b.persistentAppUIsStore(region)[id] = ui
 	cp := *ui
 
 	return &cp, nil
@@ -2353,6 +2590,7 @@ func (b *InMemoryBackend) CreatePersistentAppUI(
 
 // CreateSecurityConfiguration creates a new security configuration.
 func (b *InMemoryBackend) CreateSecurityConfiguration(
+	ctx context.Context,
 	name, securityConfig string,
 ) (*SecurityConfiguration, error) {
 	if name == "" {
@@ -2363,10 +2601,13 @@ func (b *InMemoryBackend) CreateSecurityConfiguration(
 		return nil, fmt.Errorf("%w: SecurityConfiguration must be valid JSON", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateSecurityConfiguration")
 	defer b.mu.Unlock()
 
-	if _, exists := b.securityConfigs[name]; exists {
+	configs := b.securityConfigsStore(region)
+	if _, exists := configs[name]; exists {
 		return nil, fmt.Errorf(
 			"%w: security configuration %s already exists",
 			ErrAlreadyExists,
@@ -2380,7 +2621,7 @@ func (b *InMemoryBackend) CreateSecurityConfiguration(
 		CreationDateTime: time.Now(),
 	}
 
-	b.securityConfigs[name] = sc
+	configs[name] = sc
 
 	cp := *sc
 
@@ -2388,27 +2629,33 @@ func (b *InMemoryBackend) CreateSecurityConfiguration(
 }
 
 // DeleteSecurityConfiguration deletes a security configuration by name.
-func (b *InMemoryBackend) DeleteSecurityConfiguration(name string) error {
+func (b *InMemoryBackend) DeleteSecurityConfiguration(ctx context.Context, name string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteSecurityConfiguration")
 	defer b.mu.Unlock()
 
-	if _, ok := b.securityConfigs[name]; !ok {
+	configs := b.securityConfigsStore(region)
+	if _, ok := configs[name]; !ok {
 		return fmt.Errorf("%w: security configuration %s not found", ErrNotFound, name)
 	}
 
-	delete(b.securityConfigs, name)
+	delete(configs, name)
 
 	return nil
 }
 
 // DescribeSecurityConfiguration returns the details of a security configuration.
 func (b *InMemoryBackend) DescribeSecurityConfiguration(
+	ctx context.Context,
 	name string,
 ) (*SecurityConfiguration, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeSecurityConfiguration")
 	defer b.mu.RUnlock()
 
-	sc, ok := b.securityConfigs[name]
+	sc, ok := b.securityConfigsStore(region)[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: security configuration %s not found", ErrNotFound, name)
 	}
@@ -2420,6 +2667,7 @@ func (b *InMemoryBackend) DescribeSecurityConfiguration(
 
 // CreateStudio creates a new EMR Studio.
 func (b *InMemoryBackend) CreateStudio(
+	ctx context.Context,
 	name, authMode, defaultS3Location, engineSGID, serviceRole, vpcID, workspaceSGID string,
 	subnetIDs []string, tags []Tag,
 ) (*Studio, error) {
@@ -2427,17 +2675,20 @@ func (b *InMemoryBackend) CreateStudio(
 		return nil, fmt.Errorf("%w: Name is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateStudio")
 	defer b.mu.Unlock()
 
-	for _, s := range b.studios {
+	studios := b.studiosStore(region)
+	for _, s := range studios {
 		if s.Name == name {
 			return nil, fmt.Errorf("%w: studio with name %s already exists", ErrAlreadyExists, name)
 		}
 	}
 
 	id := b.nextStudioID()
-	studioARN := arn.Build("elasticmapreduce", b.region, b.accountID, "studio/"+id)
+	studioARN := arn.Build("elasticmapreduce", region, b.accountID, "studio/"+id)
 
 	tagsCopy := make([]Tag, len(tags))
 	copy(tagsCopy, tags)
@@ -2458,10 +2709,10 @@ func (b *InMemoryBackend) CreateStudio(
 		SubnetIDs:                subnetCopy,
 		Tags:                     tagsCopy,
 		CreationTime:             time.Now(),
-		URL:                      "https://studio." + id + ".emrstudio-prod." + b.region + ".amazonaws.com",
+		URL:                      "https://studio." + id + ".emrstudio-prod." + region + ".amazonaws.com",
 	}
 
-	b.studios[id] = studio
+	studios[id] = studio
 
 	cp := *studio
 
@@ -2469,19 +2720,23 @@ func (b *InMemoryBackend) CreateStudio(
 }
 
 // DeleteStudio deletes an EMR Studio by ID.
-func (b *InMemoryBackend) DeleteStudio(studioID string) error {
+func (b *InMemoryBackend) DeleteStudio(ctx context.Context, studioID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteStudio")
 	defer b.mu.Unlock()
 
-	if _, ok := b.studios[studioID]; !ok {
+	studios := b.studiosStore(region)
+	if _, ok := studios[studioID]; !ok {
 		return fmt.Errorf("%w: studio %s not found", ErrNotFound, studioID)
 	}
 
-	delete(b.studios, studioID)
+	delete(studios, studioID)
 
-	for k, m := range b.studioSessionMappings {
+	mappings := b.studioSessionMappingsStore(region)
+	for k, m := range mappings {
 		if m.StudioID == studioID {
-			delete(b.studioSessionMappings, k)
+			delete(mappings, k)
 		}
 	}
 
@@ -2499,21 +2754,24 @@ func studioSessionKey(studioID, identityType, identityID, identityName string) s
 
 // CreateStudioSessionMapping maps a user or group to an EMR Studio.
 func (b *InMemoryBackend) CreateStudioSessionMapping(
+	ctx context.Context,
 	studioID, identityType, identityID, identityName, sessionPolicyArn string,
 ) error {
 	if studioID == "" {
 		return fmt.Errorf("%w: StudioId is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateStudioSessionMapping")
 	defer b.mu.Unlock()
 
-	if _, ok := b.studios[studioID]; !ok {
+	if _, ok := b.studiosStore(region)[studioID]; !ok {
 		return fmt.Errorf("%w: studio %s not found", ErrNotFound, studioID)
 	}
 
 	key := studioSessionKey(studioID, identityType, identityID, identityName)
-	b.studioSessionMappings[key] = &StudioSessionMapping{
+	b.studioSessionMappingsStore(region)[key] = &StudioSessionMapping{
 		StudioID:         studioID,
 		IdentityType:     identityType,
 		IdentityID:       identityID,
@@ -2528,27 +2786,33 @@ func (b *InMemoryBackend) CreateStudioSessionMapping(
 
 // DeleteStudioSessionMapping removes a user or group from an EMR Studio.
 func (b *InMemoryBackend) DeleteStudioSessionMapping(
+	ctx context.Context,
 	studioID, identityType, identityID, identityName string,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteStudioSessionMapping")
 	defer b.mu.Unlock()
 
+	mappings := b.studioSessionMappingsStore(region)
 	key := studioSessionKey(studioID, identityType, identityID, identityName)
-	if _, ok := b.studioSessionMappings[key]; !ok {
+	if _, ok := mappings[key]; !ok {
 		return fmt.Errorf("%w: session mapping not found for studio %s", ErrNotFound, studioID)
 	}
 
-	delete(b.studioSessionMappings, key)
+	delete(mappings, key)
 
 	return nil
 }
 
 // ListInstanceFleets returns the instance fleets for a cluster by its ID.
-func (b *InMemoryBackend) ListInstanceFleets(clusterID string) ([]InstanceFleet, error) {
+func (b *InMemoryBackend) ListInstanceFleets(ctx context.Context, clusterID string) ([]InstanceFleet, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListInstanceFleets")
 	defer b.mu.RUnlock()
 
-	cluster, ok := b.clusters[clusterID]
+	cluster, ok := b.clustersStore(region)[clusterID]
 	if !ok {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrNotFound, clusterID)
 	}
@@ -2560,40 +2824,48 @@ func (b *InMemoryBackend) ListInstanceFleets(clusterID string) ([]InstanceFleet,
 }
 
 // AddClusterInternal seeds a cluster directly into the backend for testing.
-func (b *InMemoryBackend) AddClusterInternal(cluster *Cluster) {
+func (b *InMemoryBackend) AddClusterInternal(ctx context.Context, cluster *Cluster) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddClusterInternal")
 	defer b.mu.Unlock()
 
 	cp := cluster.clone()
-	b.clusters[cluster.ID] = &cp
-	b.arnIndex[cluster.ARN] = cluster.ID
+	b.clustersStore(region)[cluster.ID] = &cp
+	b.arnIndexStore(region)[cluster.ARN] = cluster.ID
 }
 
 // AddSecurityConfigInternal seeds a security configuration directly into the backend for testing.
-func (b *InMemoryBackend) AddSecurityConfigInternal(sc SecurityConfiguration) {
+func (b *InMemoryBackend) AddSecurityConfigInternal(ctx context.Context, sc SecurityConfiguration) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddSecurityConfigInternal")
 	defer b.mu.Unlock()
 
 	cp := sc
-	b.securityConfigs[sc.Name] = &cp
+	b.securityConfigsStore(region)[sc.Name] = &cp
 }
 
 // AddStudioInternal seeds a studio directly into the backend for testing.
-func (b *InMemoryBackend) AddStudioInternal(studio Studio) {
+func (b *InMemoryBackend) AddStudioInternal(ctx context.Context, studio Studio) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddStudioInternal")
 	defer b.mu.Unlock()
 
 	cp := studio
-	b.studios[studio.StudioID] = &cp
+	b.studiosStore(region)[studio.StudioID] = &cp
 }
 
 // AddPersistentAppUIInternal seeds a persistent app UI directly into the backend for testing.
-func (b *InMemoryBackend) AddPersistentAppUIInternal(ui PersistentAppUI) {
+func (b *InMemoryBackend) AddPersistentAppUIInternal(ctx context.Context, ui PersistentAppUI) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AddPersistentAppUIInternal")
 	defer b.mu.Unlock()
 
 	cp := ui
-	b.persistentAppUIs[ui.ID] = &cp
+	b.persistentAppUIsStore(region)[ui.ID] = &cp
 }
 
 // nextNotebookExecID generates a unique notebook execution ID.
@@ -2605,9 +2877,12 @@ func (b *InMemoryBackend) nextNotebookExecID() string {
 
 // StartNotebookExecution creates a new notebook execution in RUNNING state.
 func (b *InMemoryBackend) StartNotebookExecution(
+	ctx context.Context,
 	editorID, name, params, engineID string,
 	tags []Tag,
 ) (*NotebookExecution, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("StartNotebookExecution")
 	defer b.mu.Unlock()
 
@@ -2627,7 +2902,7 @@ func (b *InMemoryBackend) StartNotebookExecution(
 		Tags:                  tagsCopy,
 	}
 
-	b.notebookExecutions[id] = ne
+	b.notebookExecutionsStore(region)[id] = ne
 
 	cp := *ne
 
@@ -2635,11 +2910,13 @@ func (b *InMemoryBackend) StartNotebookExecution(
 }
 
 // StopNotebookExecution transitions a RUNNING execution to STOPPED.
-func (b *InMemoryBackend) StopNotebookExecution(id string) error {
+func (b *InMemoryBackend) StopNotebookExecution(ctx context.Context, id string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("StopNotebookExecution")
 	defer b.mu.Unlock()
 
-	ne, ok := b.notebookExecutions[id]
+	ne, ok := b.notebookExecutionsStore(region)[id]
 	if !ok {
 		return fmt.Errorf("%w: notebook execution %s not found", ErrNotFound, id)
 	}
@@ -2653,11 +2930,13 @@ func (b *InMemoryBackend) StopNotebookExecution(id string) error {
 }
 
 // DescribeNotebookExecution returns a notebook execution by ID.
-func (b *InMemoryBackend) DescribeNotebookExecution(id string) (*NotebookExecution, error) {
+func (b *InMemoryBackend) DescribeNotebookExecution(ctx context.Context, id string) (*NotebookExecution, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeNotebookExecution")
 	defer b.mu.RUnlock()
 
-	ne, ok := b.notebookExecutions[id]
+	ne, ok := b.notebookExecutionsStore(region)[id]
 	if !ok {
 		return nil, fmt.Errorf("%w: notebook execution %s not found", ErrNotFound, id)
 	}
@@ -2675,13 +2954,18 @@ type ListNotebookExecutionsParams struct {
 }
 
 // ListNotebookExecutions returns paginated notebook executions matching the filter.
-func (b *InMemoryBackend) ListNotebookExecutions(params ListNotebookExecutionsParams) ([]NotebookExecution, string) {
+func (b *InMemoryBackend) ListNotebookExecutions(
+	ctx context.Context, params ListNotebookExecutionsParams,
+) ([]NotebookExecution, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListNotebookExecutions")
 	defer b.mu.RUnlock()
 
-	list := make([]NotebookExecution, 0, len(b.notebookExecutions))
+	executions := b.notebookExecutionsStore(region)
+	list := make([]NotebookExecution, 0, len(executions))
 
-	for _, ne := range b.notebookExecutions {
+	for _, ne := range executions {
 		if params.EditorID != "" && ne.EditorID != params.EditorID {
 			continue
 		}

--- a/services/emr/export_test.go
+++ b/services/emr/export_test.go
@@ -23,44 +23,54 @@ func (h *Handler) GetJanitorTerminatedTTL() time.Duration {
 	return h.janitor.TerminatedTTL
 }
 
-// ClusterCount returns the number of clusters in the backend. Used only in tests.
+// countNested sums the sizes of all per-region inner maps in a region-nested store.
+func countNested[V any](outer map[string]map[string]V) int {
+	total := 0
+	for _, inner := range outer {
+		total += len(inner)
+	}
+
+	return total
+}
+
+// ClusterCount returns the total number of clusters across all regions. Used only in tests.
 func (b *InMemoryBackend) ClusterCount() int {
 	b.mu.RLock("ClusterCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusters)
+	return countNested(b.clusters)
 }
 
-// SecurityConfigCount returns the number of security configurations in the backend.
+// SecurityConfigCount returns the total number of security configurations across all regions.
 func (b *InMemoryBackend) SecurityConfigCount() int {
 	b.mu.RLock("SecurityConfigCount")
 	defer b.mu.RUnlock()
 
-	return len(b.securityConfigs)
+	return countNested(b.securityConfigs)
 }
 
-// StudioCount returns the number of studios in the backend.
+// StudioCount returns the total number of studios across all regions.
 func (b *InMemoryBackend) StudioCount() int {
 	b.mu.RLock("StudioCount")
 	defer b.mu.RUnlock()
 
-	return len(b.studios)
+	return countNested(b.studios)
 }
 
-// PersistentAppUICount returns the number of persistent app UIs in the backend.
+// PersistentAppUICount returns the total number of persistent app UIs across all regions.
 func (b *InMemoryBackend) PersistentAppUICount() int {
 	b.mu.RLock("PersistentAppUICount")
 	defer b.mu.RUnlock()
 
-	return len(b.persistentAppUIs)
+	return countNested(b.persistentAppUIs)
 }
 
-// StudioSessionMappingCount returns the number of studio session mappings in the backend.
+// StudioSessionMappingCount returns the total number of studio session mappings across all regions.
 func (b *InMemoryBackend) StudioSessionMappingCount() int {
 	b.mu.RLock("StudioSessionMappingCount")
 	defer b.mu.RUnlock()
 
-	return len(b.studioSessionMappings)
+	return countNested(b.studioSessionMappings)
 }
 
 // HandlerOpsLen returns the number of operations in the cached dispatch table.

--- a/services/emr/handler.go
+++ b/services/emr/handler.go
@@ -204,11 +204,17 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // Handler returns the Echo handler function for EMR requests.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		// Resolve the per-request region (from SigV4 / X-Amz-Region) and attach
+		// it to the context so backend operations are region-scoped.
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
 		return service.HandleTarget(
 			c, logger.Load(c.Request().Context()),
 			"EMR", "application/x-amz-json-1.1",
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(ctx context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(context.WithValue(ctx, regionContextKey{}, region), action, body)
+			},
 			h.handleError,
 		)
 	}
@@ -342,8 +348,8 @@ type runJobFlowOutput struct {
 	ClusterArn string `json:"ClusterArn"`
 }
 
-func (h *Handler) handleRunJobFlow(_ context.Context, in *runJobFlowInput) (*runJobFlowOutput, error) {
-	cluster, err := h.Backend.RunJobFlow(RunJobFlowParams{
+func (h *Handler) handleRunJobFlow(ctx context.Context, in *runJobFlowInput) (*runJobFlowOutput, error) {
+	cluster, err := h.Backend.RunJobFlow(ctx, RunJobFlowParams{
 		Name:                    in.Name,
 		ReleaseLabel:            in.ReleaseLabel,
 		OSReleaseLabel:          in.OSReleaseLabel,
@@ -384,8 +390,8 @@ type describeClusterOutput struct {
 	Cluster *Cluster `json:"Cluster"`
 }
 
-func (h *Handler) handleDescribeCluster(_ context.Context, in *describeClusterInput) (*describeClusterOutput, error) {
-	cluster, err := h.Backend.DescribeCluster(in.ClusterID)
+func (h *Handler) handleDescribeCluster(ctx context.Context, in *describeClusterInput) (*describeClusterOutput, error) {
+	cluster, err := h.Backend.DescribeCluster(ctx, in.ClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +413,7 @@ type listClustersOutput struct {
 	Clusters []ClusterSummary `json:"Clusters"`
 }
 
-func (h *Handler) handleListClusters(_ context.Context, in *listClustersInput) (*listClustersOutput, error) {
+func (h *Handler) handleListClusters(ctx context.Context, in *listClustersInput) (*listClustersOutput, error) {
 	params := ListClustersParams{
 		ClusterStates: in.ClusterStates,
 		Marker:        in.Marker,
@@ -423,7 +429,7 @@ func (h *Handler) handleListClusters(_ context.Context, in *listClustersInput) (
 		params.CreatedBefore = &t
 	}
 
-	clusters, nextMarker := h.Backend.ListClusters(params)
+	clusters, nextMarker := h.Backend.ListClusters(ctx, params)
 
 	return &listClustersOutput{Clusters: clusters, Marker: nextMarker}, nil
 }
@@ -437,10 +443,10 @@ type terminateJobFlowsInput struct {
 type emptyOutput struct{}
 
 func (h *Handler) handleTerminateJobFlows(
-	_ context.Context,
+	ctx context.Context,
 	in *terminateJobFlowsInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.TerminateJobFlows(in.JobFlowIDs); err != nil {
+	if err := h.Backend.TerminateJobFlows(ctx, in.JobFlowIDs); err != nil {
 		return nil, err
 	}
 
@@ -454,8 +460,8 @@ type addTagsInput struct {
 	Tags       []Tag  `json:"Tags"`
 }
 
-func (h *Handler) handleAddTags(_ context.Context, in *addTagsInput) (*emptyOutput, error) {
-	if err := h.Backend.AddTags(in.ResourceID, in.Tags); err != nil {
+func (h *Handler) handleAddTags(ctx context.Context, in *addTagsInput) (*emptyOutput, error) {
+	if err := h.Backend.AddTags(ctx, in.ResourceID, in.Tags); err != nil {
 		return nil, err
 	}
 
@@ -469,8 +475,8 @@ type removeTagsInput struct {
 	TagKeys    []string `json:"TagKeys"`
 }
 
-func (h *Handler) handleRemoveTags(_ context.Context, in *removeTagsInput) (*emptyOutput, error) {
-	if err := h.Backend.RemoveTags(in.ResourceID, in.TagKeys); err != nil {
+func (h *Handler) handleRemoveTags(ctx context.Context, in *removeTagsInput) (*emptyOutput, error) {
+	if err := h.Backend.RemoveTags(ctx, in.ResourceID, in.TagKeys); err != nil {
 		return nil, err
 	}
 
@@ -488,10 +494,10 @@ type listTagsForResourceOutput struct {
 }
 
 func (h *Handler) handleListTagsForResource(
-	_ context.Context,
+	ctx context.Context,
 	in *listTagsForResourceInput,
 ) (*listTagsForResourceOutput, error) {
-	tags, err := h.Backend.ListTagsForResource(in.ResourceID)
+	tags, err := h.Backend.ListTagsForResource(ctx, in.ResourceID)
 	if err != nil {
 		return nil, err
 	}
@@ -513,8 +519,8 @@ type listStepsOutput struct {
 	Steps  []Step `json:"Steps"`
 }
 
-func (h *Handler) handleListSteps(_ context.Context, in *listStepsInput) (*listStepsOutput, error) {
-	steps, nextMarker := h.Backend.ListSteps(in.ClusterID, in.StepStates, in.StepIDs, in.Marker)
+func (h *Handler) handleListSteps(ctx context.Context, in *listStepsInput) (*listStepsOutput, error) {
+	steps, nextMarker := h.Backend.ListSteps(ctx, in.ClusterID, in.StepStates, in.StepIDs, in.Marker)
 
 	return &listStepsOutput{Steps: steps, Marker: nextMarker}, nil
 }
@@ -531,10 +537,10 @@ type addJobFlowStepsOutput struct {
 }
 
 func (h *Handler) handleAddJobFlowSteps(
-	_ context.Context,
+	ctx context.Context,
 	in *addJobFlowStepsInput,
 ) (*addJobFlowStepsOutput, error) {
-	ids, err := h.Backend.AddJobFlowSteps(in.JobFlowID, in.Steps)
+	ids, err := h.Backend.AddJobFlowSteps(ctx, in.JobFlowID, in.Steps)
 	if err != nil {
 		return nil, err
 	}
@@ -553,10 +559,10 @@ type listInstanceGroupsOutput struct {
 }
 
 func (h *Handler) handleListInstanceGroups(
-	_ context.Context,
+	ctx context.Context,
 	in *listInstanceGroupsInput,
 ) (*listInstanceGroupsOutput, error) {
-	groups, err := h.Backend.ListInstanceGroups(in.ClusterID)
+	groups, err := h.Backend.ListInstanceGroups(ctx, in.ClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -575,10 +581,10 @@ type listInstanceFleetsOutput struct {
 }
 
 func (h *Handler) handleListInstanceFleets(
-	_ context.Context,
+	ctx context.Context,
 	in *listInstanceFleetsInput,
 ) (*listInstanceFleetsOutput, error) {
-	fleets, err := h.Backend.ListInstanceFleets(in.ClusterID)
+	fleets, err := h.Backend.ListInstanceFleets(ctx, in.ClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -614,10 +620,10 @@ type getAutoTerminationPolicyOutput struct {
 }
 
 func (h *Handler) handleGetAutoTerminationPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *getAutoTerminationPolicyInput,
 ) (*getAutoTerminationPolicyOutput, error) {
-	policy, err := h.Backend.GetAutoTerminationPolicy(in.ClusterID)
+	policy, err := h.Backend.GetAutoTerminationPolicy(ctx, in.ClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -640,10 +646,10 @@ type getManagedScalingPolicyOutput struct {
 }
 
 func (h *Handler) handleGetManagedScalingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *getManagedScalingPolicyInput,
 ) (*getManagedScalingPolicyOutput, error) {
-	policy, err := h.Backend.GetManagedScalingPolicy(in.ClusterID)
+	policy, err := h.Backend.GetManagedScalingPolicy(ctx, in.ClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -669,10 +675,10 @@ type addInstanceFleetOutput struct {
 }
 
 func (h *Handler) handleAddInstanceFleet(
-	_ context.Context,
+	ctx context.Context,
 	in *addInstanceFleetInput,
 ) (*addInstanceFleetOutput, error) {
-	fleet, clusterARN, err := h.Backend.AddInstanceFleet(in.ClusterID, in.InstanceFleet)
+	fleet, clusterARN, err := h.Backend.AddInstanceFleet(ctx, in.ClusterID, in.InstanceFleet)
 	if err != nil {
 		return nil, err
 	}
@@ -698,10 +704,10 @@ type addInstanceGroupsOutput struct {
 }
 
 func (h *Handler) handleAddInstanceGroups(
-	_ context.Context,
+	ctx context.Context,
 	in *addInstanceGroupsInput,
 ) (*addInstanceGroupsOutput, error) {
-	groupIDs, clusterARN, err := h.Backend.AddInstanceGroups(in.JobFlowID, in.InstanceGroups)
+	groupIDs, clusterARN, err := h.Backend.AddInstanceGroups(ctx, in.JobFlowID, in.InstanceGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -725,10 +731,10 @@ type cancelStepsOutput struct {
 }
 
 func (h *Handler) handleCancelSteps(
-	_ context.Context,
+	ctx context.Context,
 	in *cancelStepsInput,
 ) (*cancelStepsOutput, error) {
-	if err := h.Backend.CancelSteps(in.ClusterID, in.StepIDs); err != nil {
+	if err := h.Backend.CancelSteps(ctx, in.ClusterID, in.StepIDs); err != nil {
 		return nil, err
 	}
 
@@ -747,10 +753,10 @@ type createPersistentAppUIOutput struct {
 }
 
 func (h *Handler) handleCreatePersistentAppUI(
-	_ context.Context,
+	ctx context.Context,
 	in *createPersistentAppUIInput,
 ) (*createPersistentAppUIOutput, error) {
-	ui, err := h.Backend.CreatePersistentAppUI(in.TargetResourceArn)
+	ui, err := h.Backend.CreatePersistentAppUI(ctx, in.TargetResourceArn)
 	if err != nil {
 		return nil, err
 	}
@@ -774,10 +780,10 @@ type createSecurityConfigurationOutput struct {
 }
 
 func (h *Handler) handleCreateSecurityConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	in *createSecurityConfigurationInput,
 ) (*createSecurityConfigurationOutput, error) {
-	sc, err := h.Backend.CreateSecurityConfiguration(in.Name, in.SecurityConfiguration)
+	sc, err := h.Backend.CreateSecurityConfiguration(ctx, in.Name, in.SecurityConfiguration)
 	if err != nil {
 		return nil, err
 	}
@@ -795,10 +801,10 @@ type deleteSecurityConfigurationInput struct {
 }
 
 func (h *Handler) handleDeleteSecurityConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteSecurityConfigurationInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.DeleteSecurityConfiguration(in.Name); err != nil {
+	if err := h.Backend.DeleteSecurityConfiguration(ctx, in.Name); err != nil {
 		return nil, err
 	}
 
@@ -825,11 +831,10 @@ type createStudioOutput struct {
 }
 
 func (h *Handler) handleCreateStudio(
-	_ context.Context,
+	ctx context.Context,
 	in *createStudioInput,
 ) (*createStudioOutput, error) {
-	studio, err := h.Backend.CreateStudio(
-		in.Name,
+	studio, err := h.Backend.CreateStudio(ctx, in.Name,
 		in.AuthMode,
 		in.DefaultS3Location,
 		in.EngineSecurityGroupID,
@@ -856,10 +861,10 @@ type deleteStudioInput struct {
 }
 
 func (h *Handler) handleDeleteStudio(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteStudioInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.DeleteStudio(in.StudioID); err != nil {
+	if err := h.Backend.DeleteStudio(ctx, in.StudioID); err != nil {
 		return nil, err
 	}
 
@@ -877,11 +882,10 @@ type createStudioSessionMappingInput struct {
 }
 
 func (h *Handler) handleCreateStudioSessionMapping(
-	_ context.Context,
+	ctx context.Context,
 	in *createStudioSessionMappingInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.CreateStudioSessionMapping(
-		in.StudioID,
+	if err := h.Backend.CreateStudioSessionMapping(ctx, in.StudioID,
 		in.IdentityType,
 		in.IdentityID,
 		in.IdentityName,
@@ -903,11 +907,10 @@ type deleteStudioSessionMappingInput struct {
 }
 
 func (h *Handler) handleDeleteStudioSessionMapping(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteStudioSessionMappingInput,
 ) (*emptyOutput, error) {
-	if err := h.Backend.DeleteStudioSessionMapping(
-		in.StudioID,
+	if err := h.Backend.DeleteStudioSessionMapping(ctx, in.StudioID,
 		in.IdentityType,
 		in.IdentityID,
 		in.IdentityName,
@@ -931,10 +934,10 @@ type describeSecurityConfigurationOutput struct {
 }
 
 func (h *Handler) handleDescribeSecurityConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	in *describeSecurityConfigurationInput,
 ) (*describeSecurityConfigurationOutput, error) {
-	sc, err := h.Backend.DescribeSecurityConfiguration(in.Name)
+	sc, err := h.Backend.DescribeSecurityConfiguration(ctx, in.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/services/emr/handler_accuracy_test.go
+++ b/services/emr/handler_accuracy_test.go
@@ -1,6 +1,7 @@
 package emr_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -737,7 +738,7 @@ func TestAccuracy_Persistence_InstanceGroups(t *testing.T) {
 	t.Parallel()
 
 	src := emr.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := src.RunJobFlow(emr.RunJobFlowParams{
+	_, err := src.RunJobFlow(context.Background(), emr.RunJobFlowParams{
 		Name:         "persist-ig-cluster",
 		ReleaseLabel: "emr-7.3.0",
 		Instances: emr.RunJobFlowInstances{
@@ -755,10 +756,10 @@ func TestAccuracy_Persistence_InstanceGroups(t *testing.T) {
 	dst := emr.NewInMemoryBackend(testAccountID, testRegion)
 	require.NoError(t, dst.Restore(snap))
 
-	clusters, _ := dst.ListClusters(emr.ListClustersParams{})
+	clusters, _ := dst.ListClusters(context.Background(), emr.ListClustersParams{})
 	require.Len(t, clusters, 1)
 
-	groups, err := dst.ListInstanceGroups(clusters[0].ID)
+	groups, err := dst.ListInstanceGroups(context.Background(), clusters[0].ID)
 	require.NoError(t, err)
 	assert.Len(t, groups, 2)
 }
@@ -1198,7 +1199,7 @@ func TestAccuracy_NotebookExecution_Persistence(t *testing.T) {
 	t.Parallel()
 
 	src := emr.NewInMemoryBackend(testAccountID, testRegion)
-	ne, err := src.StartNotebookExecution("e-ED1", "persist-run", "{}", "j-1", nil)
+	ne, err := src.StartNotebookExecution(context.Background(), "e-ED1", "persist-run", "{}", "j-1", nil)
 	require.NoError(t, err)
 
 	snap := src.Snapshot()
@@ -1207,7 +1208,7 @@ func TestAccuracy_NotebookExecution_Persistence(t *testing.T) {
 	dst := emr.NewInMemoryBackend("", "")
 	require.NoError(t, dst.Restore(snap))
 
-	restored, err := dst.DescribeNotebookExecution(ne.NotebookExecutionID)
+	restored, err := dst.DescribeNotebookExecution(context.Background(), ne.NotebookExecutionID)
 	require.NoError(t, err)
 	assert.Equal(t, "persist-run", restored.NotebookExecutionName)
 	assert.Equal(t, "RUNNING", restored.Status)

--- a/services/emr/handler_missing.go
+++ b/services/emr/handler_missing.go
@@ -19,7 +19,7 @@ type describeJobFlowsOutput struct {
 }
 
 func (h *Handler) handleDescribeJobFlows(
-	_ context.Context, in *describeJobFlowsInput,
+	ctx context.Context, in *describeJobFlowsInput,
 ) (*describeJobFlowsOutput, error) {
 	var createdAfter, createdBefore *time.Time
 
@@ -33,7 +33,7 @@ func (h *Handler) handleDescribeJobFlows(
 		createdBefore = &t
 	}
 
-	flows := h.Backend.DescribeJobFlows(in.JobFlowIDs, in.JobFlowStates, createdAfter, createdBefore)
+	flows := h.Backend.DescribeJobFlows(ctx, in.JobFlowIDs, in.JobFlowStates, createdAfter, createdBefore)
 
 	return &describeJobFlowsOutput{JobFlows: flows}, nil
 }
@@ -49,10 +49,10 @@ type describeNotebookExecutionOutput struct {
 }
 
 func (h *Handler) handleDescribeNotebookExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *describeNotebookExecutionInput,
 ) (*describeNotebookExecutionOutput, error) {
-	ne, err := h.Backend.DescribeNotebookExecution(in.NotebookExecutionID)
+	ne, err := h.Backend.DescribeNotebookExecution(ctx, in.NotebookExecutionID)
 	if err != nil {
 		return nil, err
 	}
@@ -71,10 +71,10 @@ type describePersistentAppUIOutput struct {
 }
 
 func (h *Handler) handleDescribePersistentAppUI(
-	_ context.Context,
+	ctx context.Context,
 	in *describePersistentAppUIInput,
 ) (*describePersistentAppUIOutput, error) {
-	ui, err := h.Backend.DescribePersistentAppUI(in.PersistentAppUIId)
+	ui, err := h.Backend.DescribePersistentAppUI(ctx, in.PersistentAppUIId)
 	if err != nil {
 		return nil, err
 	}
@@ -94,10 +94,10 @@ type describeReleaseLabelOutput struct {
 }
 
 func (h *Handler) handleDescribeReleaseLabel(
-	_ context.Context,
+	ctx context.Context,
 	in *describeReleaseLabelInput,
 ) (*describeReleaseLabelOutput, error) {
-	rl, err := h.Backend.DescribeReleaseLabel(in.ReleaseLabel)
+	rl, err := h.Backend.DescribeReleaseLabel(ctx, in.ReleaseLabel)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +119,8 @@ type describeStepOutput struct {
 	Step *Step `json:"Step"`
 }
 
-func (h *Handler) handleDescribeStep(_ context.Context, in *describeStepInput) (*describeStepOutput, error) {
-	step, err := h.Backend.DescribeStep(in.ClusterID, in.StepID)
+func (h *Handler) handleDescribeStep(ctx context.Context, in *describeStepInput) (*describeStepOutput, error) {
+	step, err := h.Backend.DescribeStep(ctx, in.ClusterID, in.StepID)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +138,8 @@ type describeStudioOutput struct {
 	Studio *Studio `json:"Studio"`
 }
 
-func (h *Handler) handleDescribeStudio(_ context.Context, in *describeStudioInput) (*describeStudioOutput, error) {
-	studio, err := h.Backend.DescribeStudio(in.StudioID)
+func (h *Handler) handleDescribeStudio(ctx context.Context, in *describeStudioInput) (*describeStudioOutput, error) {
+	studio, err := h.Backend.DescribeStudio(ctx, in.StudioID)
 	if err != nil {
 		return nil, err
 	}
@@ -162,10 +162,10 @@ type blockPublicAccessConfigurationMetadata struct {
 }
 
 func (h *Handler) handleGetBlockPublicAccessConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	_ *getBlockPublicAccessConfigurationInput,
 ) (*getBlockPublicAccessConfigurationOutput, error) {
-	cfg, meta := h.Backend.GetBlockPublicAccessConfiguration()
+	cfg, meta := h.Backend.GetBlockPublicAccessConfiguration(ctx)
 
 	return &getBlockPublicAccessConfigurationOutput{
 		BlockPublicAccessConfiguration: cfg,
@@ -189,10 +189,10 @@ type getClusterSessionCredentialsOutput struct {
 }
 
 func (h *Handler) handleGetClusterSessionCredentials(
-	_ context.Context,
+	ctx context.Context,
 	in *getClusterSessionCredentialsInput,
 ) (*getClusterSessionCredentialsOutput, error) {
-	creds, expiry, err := h.Backend.GetClusterSessionCredentials(in.ClusterID, in.ExecutionRoleArn)
+	creds, expiry, err := h.Backend.GetClusterSessionCredentials(ctx, in.ClusterID, in.ExecutionRoleArn)
 	if err != nil {
 		return nil, err
 	}
@@ -214,10 +214,10 @@ type getOnClusterAppUIPresignedURLOutput struct {
 }
 
 func (h *Handler) handleGetOnClusterAppUIPresignedURL(
-	_ context.Context,
+	ctx context.Context,
 	in *getOnClusterAppUIPresignedURLInput,
 ) (*getOnClusterAppUIPresignedURLOutput, error) {
-	url := h.Backend.GetPresignedURL(in.ClusterID, h.Backend.region)
+	url := h.Backend.GetPresignedURL(in.ClusterID, getRegion(ctx, h.Backend.region))
 
 	return &getOnClusterAppUIPresignedURLOutput{URL: url}, nil
 }
@@ -233,10 +233,10 @@ type getPersistentAppUIPresignedURLOutput struct {
 }
 
 func (h *Handler) handleGetPersistentAppUIPresignedURL(
-	_ context.Context,
+	ctx context.Context,
 	in *getPersistentAppUIPresignedURLInput,
 ) (*getPersistentAppUIPresignedURLOutput, error) {
-	url := h.Backend.GetPresignedURL(in.PersistentAppUIId, h.Backend.region)
+	url := h.Backend.GetPresignedURL(in.PersistentAppUIId, getRegion(ctx, h.Backend.region))
 
 	return &getPersistentAppUIPresignedURLOutput{PresignedURL: url}, nil
 }
@@ -255,10 +255,10 @@ type getStudioSessionMappingOutput struct {
 }
 
 func (h *Handler) handleGetStudioSessionMapping(
-	_ context.Context,
+	ctx context.Context,
 	in *getStudioSessionMappingInput,
 ) (*getStudioSessionMappingOutput, error) {
-	mapping, err := h.Backend.GetStudioSessionMapping(in.StudioID, in.IdentityType, in.IdentityID, in.IdentityName)
+	mapping, err := h.Backend.GetStudioSessionMapping(ctx, in.StudioID, in.IdentityType, in.IdentityID, in.IdentityName)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ type listInstancesOutput struct {
 	Instances []ClusterInstance `json:"Instances"`
 }
 
-func (h *Handler) handleListInstances(_ context.Context, in *listInstancesInput) (*listInstancesOutput, error) {
+func (h *Handler) handleListInstances(ctx context.Context, in *listInstancesInput) (*listInstancesOutput, error) {
 	params := ListInstancesParams{
 		InstanceGroupID:    in.InstanceGroupID,
 		InstanceFleetID:    in.InstanceFleetID,
@@ -291,7 +291,7 @@ func (h *Handler) handleListInstances(_ context.Context, in *listInstancesInput)
 		Marker:             in.Marker,
 	}
 
-	instances, nextMarker := h.Backend.ListInstances(in.ClusterID, params)
+	instances, nextMarker := h.Backend.ListInstances(ctx, in.ClusterID, params)
 
 	return &listInstancesOutput{Instances: instances, Marker: nextMarker}, nil
 }
@@ -310,10 +310,10 @@ type listNotebookExecutionsOutput struct {
 }
 
 func (h *Handler) handleListNotebookExecutions(
-	_ context.Context,
+	ctx context.Context,
 	in *listNotebookExecutionsInput,
 ) (*listNotebookExecutionsOutput, error) {
-	list, marker := h.Backend.ListNotebookExecutions(ListNotebookExecutionsParams{
+	list, marker := h.Backend.ListNotebookExecutions(ctx, ListNotebookExecutionsParams{
 		EditorID: in.EditorID,
 		Status:   in.Status,
 		Marker:   in.Marker,
@@ -341,10 +341,10 @@ type listReleaseLabelsOutput struct {
 }
 
 func (h *Handler) handleListReleaseLabels(
-	_ context.Context,
+	ctx context.Context,
 	in *listReleaseLabelsInput,
 ) (*listReleaseLabelsOutput, error) {
-	labels, next := h.Backend.ListReleaseLabels(in.Filters.Prefix, in.Filters.Application, in.Marker)
+	labels, next := h.Backend.ListReleaseLabels(ctx, in.Filters.Prefix, in.Filters.Application, in.Marker)
 
 	return &listReleaseLabelsOutput{ReleaseLabels: labels, NextToken: next}, nil
 }
@@ -361,10 +361,10 @@ type listSecurityConfigurationsOutput struct {
 }
 
 func (h *Handler) handleListSecurityConfigurations(
-	_ context.Context,
+	ctx context.Context,
 	in *listSecurityConfigurationsInput,
 ) (*listSecurityConfigurationsOutput, error) {
-	configs, nextMarker := h.Backend.ListSecurityConfigurations(in.Marker)
+	configs, nextMarker := h.Backend.ListSecurityConfigurations(ctx, in.Marker)
 
 	return &listSecurityConfigurationsOutput{
 		SecurityConfigurations: configs,
@@ -384,10 +384,10 @@ type listStudioSessionMappingsOutput struct {
 }
 
 func (h *Handler) handleListStudioSessionMappings(
-	_ context.Context,
+	ctx context.Context,
 	in *listStudioSessionMappingsInput,
 ) (*listStudioSessionMappingsOutput, error) {
-	mappings := h.Backend.ListStudioSessionMappings(in.StudioID, in.IdentityType)
+	mappings := h.Backend.ListStudioSessionMappings(ctx, in.StudioID, in.IdentityType)
 
 	return &listStudioSessionMappingsOutput{SessionMappings: mappings}, nil
 }
@@ -403,8 +403,8 @@ type listStudiosOutput struct {
 	Studios []StudioSummary `json:"Studios"`
 }
 
-func (h *Handler) handleListStudios(_ context.Context, in *listStudiosInput) (*listStudiosOutput, error) {
-	studios, nextMarker := h.Backend.ListStudios(in.Marker)
+func (h *Handler) handleListStudios(ctx context.Context, in *listStudiosInput) (*listStudiosOutput, error) {
+	studios, nextMarker := h.Backend.ListStudios(ctx, in.Marker)
 
 	return &listStudiosOutput{Studios: studios, Marker: nextMarker}, nil
 }
@@ -422,10 +422,10 @@ type listSupportedInstanceTypesOutput struct {
 }
 
 func (h *Handler) handleListSupportedInstanceTypes(
-	_ context.Context,
+	ctx context.Context,
 	in *listSupportedInstanceTypesInput,
 ) (*listSupportedInstanceTypesOutput, error) {
-	types, nextMarker := h.Backend.ListSupportedInstanceTypes(in.ReleaseLabel, in.Marker)
+	types, nextMarker := h.Backend.ListSupportedInstanceTypes(ctx, in.ReleaseLabel, in.Marker)
 
 	return &listSupportedInstanceTypesOutput{
 		SupportedInstanceTypes: types,
@@ -444,8 +444,8 @@ type modifyClusterOutput struct {
 	StepConcurrencyLevel int `json:"StepConcurrencyLevel"`
 }
 
-func (h *Handler) handleModifyCluster(_ context.Context, in *modifyClusterInput) (*modifyClusterOutput, error) {
-	level, err := h.Backend.ModifyCluster(in.ClusterID, in.StepConcurrencyLevel)
+func (h *Handler) handleModifyCluster(ctx context.Context, in *modifyClusterInput) (*modifyClusterOutput, error) {
+	level, err := h.Backend.ModifyCluster(ctx, in.ClusterID, in.StepConcurrencyLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -463,10 +463,10 @@ type modifyInstanceFleetInput struct {
 type modifyInstanceFleetOutput struct{}
 
 func (h *Handler) handleModifyInstanceFleet(
-	_ context.Context,
+	ctx context.Context,
 	in *modifyInstanceFleetInput,
 ) (*modifyInstanceFleetOutput, error) {
-	if err := h.Backend.ModifyInstanceFleet(in.ClusterID, in.InstanceFleet); err != nil {
+	if err := h.Backend.ModifyInstanceFleet(ctx, in.ClusterID, in.InstanceFleet); err != nil {
 		return nil, err
 	}
 
@@ -483,10 +483,10 @@ type modifyInstanceGroupsInput struct {
 type modifyInstanceGroupsOutput struct{}
 
 func (h *Handler) handleModifyInstanceGroups(
-	_ context.Context,
+	ctx context.Context,
 	in *modifyInstanceGroupsInput,
 ) (*modifyInstanceGroupsOutput, error) {
-	if err := h.Backend.ModifyInstanceGroups(in.ClusterID, in.InstanceGroups); err != nil {
+	if err := h.Backend.ModifyInstanceGroups(ctx, in.ClusterID, in.InstanceGroups); err != nil {
 		return nil, err
 	}
 
@@ -509,11 +509,14 @@ type putAutoScalingPolicyOutput struct {
 }
 
 func (h *Handler) handlePutAutoScalingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *putAutoScalingPolicyInput,
 ) (*putAutoScalingPolicyOutput, error) {
 	detail, clusterARN, groupID, err := h.Backend.PutAutoScalingPolicy(
-		in.ClusterID, in.InstanceGroupID, in.AutoScalingPolicy,
+		ctx,
+		in.ClusterID,
+		in.InstanceGroupID,
+		in.AutoScalingPolicy,
 	)
 	if err != nil {
 		return nil, err
@@ -537,10 +540,10 @@ type putAutoTerminationPolicyInput struct {
 type putAutoTerminationPolicyOutput struct{}
 
 func (h *Handler) handlePutAutoTerminationPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *putAutoTerminationPolicyInput,
 ) (*putAutoTerminationPolicyOutput, error) {
-	if err := h.Backend.PutAutoTerminationPolicy(in.ClusterID, in.AutoTerminationPolicy); err != nil {
+	if err := h.Backend.PutAutoTerminationPolicy(ctx, in.ClusterID, in.AutoTerminationPolicy); err != nil {
 		return nil, err
 	}
 
@@ -556,10 +559,10 @@ type putBlockPublicAccessConfigurationInput struct {
 type putBlockPublicAccessConfigurationOutput struct{}
 
 func (h *Handler) handlePutBlockPublicAccessConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	in *putBlockPublicAccessConfigurationInput,
 ) (*putBlockPublicAccessConfigurationOutput, error) {
-	if err := h.Backend.PutBlockPublicAccessConfiguration(in.BlockPublicAccessConfiguration); err != nil {
+	if err := h.Backend.PutBlockPublicAccessConfiguration(ctx, in.BlockPublicAccessConfiguration); err != nil {
 		return nil, err
 	}
 
@@ -576,10 +579,10 @@ type putManagedScalingPolicyInput struct {
 type putManagedScalingPolicyOutput struct{}
 
 func (h *Handler) handlePutManagedScalingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *putManagedScalingPolicyInput,
 ) (*putManagedScalingPolicyOutput, error) {
-	if err := h.Backend.PutManagedScalingPolicy(in.ClusterID, in.ManagedScalingPolicy); err != nil {
+	if err := h.Backend.PutManagedScalingPolicy(ctx, in.ClusterID, in.ManagedScalingPolicy); err != nil {
 		return nil, err
 	}
 
@@ -596,10 +599,10 @@ type removeAutoScalingPolicyInput struct {
 type removeAutoScalingPolicyOutput struct{}
 
 func (h *Handler) handleRemoveAutoScalingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *removeAutoScalingPolicyInput,
 ) (*removeAutoScalingPolicyOutput, error) {
-	if err := h.Backend.RemoveAutoScalingPolicy(in.ClusterID, in.InstanceGroupID); err != nil {
+	if err := h.Backend.RemoveAutoScalingPolicy(ctx, in.ClusterID, in.InstanceGroupID); err != nil {
 		return nil, err
 	}
 
@@ -615,10 +618,10 @@ type removeAutoTerminationPolicyInput struct {
 type removeAutoTerminationPolicyOutput struct{}
 
 func (h *Handler) handleRemoveAutoTerminationPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *removeAutoTerminationPolicyInput,
 ) (*removeAutoTerminationPolicyOutput, error) {
-	if err := h.Backend.RemoveAutoTerminationPolicy(in.ClusterID); err != nil {
+	if err := h.Backend.RemoveAutoTerminationPolicy(ctx, in.ClusterID); err != nil {
 		return nil, err
 	}
 
@@ -634,10 +637,10 @@ type removeManagedScalingPolicyInput struct {
 type removeManagedScalingPolicyOutput struct{}
 
 func (h *Handler) handleRemoveManagedScalingPolicy(
-	_ context.Context,
+	ctx context.Context,
 	in *removeManagedScalingPolicyInput,
 ) (*removeManagedScalingPolicyOutput, error) {
-	if err := h.Backend.RemoveManagedScalingPolicy(in.ClusterID); err != nil {
+	if err := h.Backend.RemoveManagedScalingPolicy(ctx, in.ClusterID); err != nil {
 		return nil, err
 	}
 
@@ -654,10 +657,10 @@ type setKeepJobFlowAliveWhenNoStepsInput struct {
 type setKeepJobFlowAliveWhenNoStepsOutput struct{}
 
 func (h *Handler) handleSetKeepJobFlowAliveWhenNoSteps(
-	_ context.Context,
+	ctx context.Context,
 	in *setKeepJobFlowAliveWhenNoStepsInput,
 ) (*setKeepJobFlowAliveWhenNoStepsOutput, error) {
-	if err := h.Backend.SetKeepJobFlowAliveWhenNoSteps(in.JobFlowIDs, in.KeepJobFlowAliveWhenNoSteps); err != nil {
+	if err := h.Backend.SetKeepJobFlowAliveWhenNoSteps(ctx, in.JobFlowIDs, in.KeepJobFlowAliveWhenNoSteps); err != nil {
 		return nil, err
 	}
 
@@ -674,10 +677,10 @@ type setTerminationProtectionInput struct {
 type setTerminationProtectionOutput struct{}
 
 func (h *Handler) handleSetTerminationProtection(
-	_ context.Context,
+	ctx context.Context,
 	in *setTerminationProtectionInput,
 ) (*setTerminationProtectionOutput, error) {
-	if err := h.Backend.SetTerminationProtection(in.JobFlowIDs, in.TerminationProtected); err != nil {
+	if err := h.Backend.SetTerminationProtection(ctx, in.JobFlowIDs, in.TerminationProtected); err != nil {
 		return nil, err
 	}
 
@@ -694,10 +697,10 @@ type setUnhealthyNodeReplacementInput struct {
 type setUnhealthyNodeReplacementOutput struct{}
 
 func (h *Handler) handleSetUnhealthyNodeReplacement(
-	_ context.Context,
+	ctx context.Context,
 	in *setUnhealthyNodeReplacementInput,
 ) (*setUnhealthyNodeReplacementOutput, error) {
-	if err := h.Backend.SetUnhealthyNodeReplacement(in.JobFlowIDs, in.UnhealthyNodeReplacement); err != nil {
+	if err := h.Backend.SetUnhealthyNodeReplacement(ctx, in.JobFlowIDs, in.UnhealthyNodeReplacement); err != nil {
 		return nil, err
 	}
 
@@ -714,10 +717,10 @@ type setVisibleToAllUsersInput struct {
 type setVisibleToAllUsersOutput struct{}
 
 func (h *Handler) handleSetVisibleToAllUsers(
-	_ context.Context,
+	ctx context.Context,
 	in *setVisibleToAllUsersInput,
 ) (*setVisibleToAllUsersOutput, error) {
-	if err := h.Backend.SetVisibleToAllUsers(in.JobFlowIDs, in.VisibleToAllUsers); err != nil {
+	if err := h.Backend.SetVisibleToAllUsers(ctx, in.JobFlowIDs, in.VisibleToAllUsers); err != nil {
 		return nil, err
 	}
 
@@ -741,11 +744,10 @@ type startNotebookExecutionOutput struct {
 }
 
 func (h *Handler) handleStartNotebookExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *startNotebookExecutionInput,
 ) (*startNotebookExecutionOutput, error) {
-	ne, err := h.Backend.StartNotebookExecution(
-		in.EditorID,
+	ne, err := h.Backend.StartNotebookExecution(ctx, in.EditorID,
 		in.NotebookExecutionName,
 		in.NotebookParams,
 		in.ExecutionEngineConfig.ID,
@@ -767,10 +769,10 @@ type stopNotebookExecutionInput struct {
 type stopNotebookExecutionOutput struct{}
 
 func (h *Handler) handleStopNotebookExecution(
-	_ context.Context,
+	ctx context.Context,
 	in *stopNotebookExecutionInput,
 ) (*stopNotebookExecutionOutput, error) {
-	if err := h.Backend.StopNotebookExecution(in.NotebookExecutionID); err != nil {
+	if err := h.Backend.StopNotebookExecution(ctx, in.NotebookExecutionID); err != nil {
 		return nil, err
 	}
 
@@ -789,8 +791,8 @@ type updateStudioInput struct {
 
 type updateStudioOutput struct{}
 
-func (h *Handler) handleUpdateStudio(_ context.Context, in *updateStudioInput) (*updateStudioOutput, error) {
-	if err := h.Backend.UpdateStudio(in.StudioID, in.Name, in.Description, in.DefaultS3Location, ""); err != nil {
+func (h *Handler) handleUpdateStudio(ctx context.Context, in *updateStudioInput) (*updateStudioOutput, error) {
+	if err := h.Backend.UpdateStudio(ctx, in.StudioID, in.Name, in.Description, in.DefaultS3Location, ""); err != nil {
 		return nil, err
 	}
 
@@ -810,11 +812,10 @@ type updateStudioSessionMappingInput struct {
 type updateStudioSessionMappingOutput struct{}
 
 func (h *Handler) handleUpdateStudioSessionMapping(
-	_ context.Context,
+	ctx context.Context,
 	in *updateStudioSessionMappingInput,
 ) (*updateStudioSessionMappingOutput, error) {
-	if err := h.Backend.UpdateStudioSessionMapping(
-		in.StudioID,
+	if err := h.Backend.UpdateStudioSessionMapping(ctx, in.StudioID,
 		in.IdentityType,
 		in.IdentityID,
 		in.IdentityName,

--- a/services/emr/handler_refinement1_test.go
+++ b/services/emr/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package emr_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -18,7 +19,7 @@ func TestRefinement1_Reset(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "cluster1", ReleaseLabel: "emr-6.0.0"})
+	_, err := b.RunJobFlow(context.Background(), emr.RunJobFlowParams{Name: "cluster1", ReleaseLabel: "emr-6.0.0"})
 	require.NoError(t, err)
 	require.Equal(t, 1, b.ClusterCount())
 
@@ -47,7 +48,10 @@ func TestRefinement1_HandlerReset(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHandler(t)
-	_, err := h.Backend.RunJobFlow(emr.RunJobFlowParams{Name: "cluster1", ReleaseLabel: "emr-6.0.0"})
+	_, err := h.Backend.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "cluster1", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
 	h.Reset()
@@ -121,22 +125,22 @@ func TestRefinement1_SeedHelpers(t *testing.T) {
 			State: emr.StateWaiting,
 		},
 	}
-	b.AddClusterInternal(cluster)
+	b.AddClusterInternal(context.Background(), cluster)
 	assert.Equal(t, 1, b.ClusterCount())
 
-	b.AddSecurityConfigInternal(emr.SecurityConfiguration{
+	b.AddSecurityConfigInternal(context.Background(), emr.SecurityConfiguration{
 		Name:           "sc1",
 		SecurityConfig: `{"EncryptionConfiguration":{}}`,
 	})
 	assert.Equal(t, 1, b.SecurityConfigCount())
 
-	b.AddStudioInternal(emr.Studio{
+	b.AddStudioInternal(context.Background(), emr.Studio{
 		StudioID: "es-0000000000001",
 		Name:     "studio1",
 	})
 	assert.Equal(t, 1, b.StudioCount())
 
-	b.AddPersistentAppUIInternal(emr.PersistentAppUI{
+	b.AddPersistentAppUIInternal(context.Background(), emr.PersistentAppUI{
 		ID:                "pau-0000000000001",
 		TargetResourceArn: cluster.ARN,
 	})
@@ -153,7 +157,7 @@ func TestRefinement1_SeedHelpers_DeepCopy(t *testing.T) {
 		Name:           "sc-deep-copy",
 		SecurityConfig: `{"original":true}`,
 	}
-	b.AddSecurityConfigInternal(sc)
+	b.AddSecurityConfigInternal(context.Background(), sc)
 
 	sc.Name = "mutated"
 	assert.Equal(t, 1, b.SecurityConfigCount())
@@ -176,14 +180,14 @@ func TestRefinement1_SortedListClusters(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "clusterA", ReleaseLabel: "emr-6.0.0"})
+	_, err := b.RunJobFlow(context.Background(), emr.RunJobFlowParams{Name: "clusterA", ReleaseLabel: "emr-6.0.0"})
 	require.NoError(t, err)
-	_, err = b.RunJobFlow(emr.RunJobFlowParams{Name: "clusterB", ReleaseLabel: "emr-6.0.0"})
+	_, err = b.RunJobFlow(context.Background(), emr.RunJobFlowParams{Name: "clusterB", ReleaseLabel: "emr-6.0.0"})
 	require.NoError(t, err)
-	_, err = b.RunJobFlow(emr.RunJobFlowParams{Name: "clusterC", ReleaseLabel: "emr-6.0.0"})
+	_, err = b.RunJobFlow(context.Background(), emr.RunJobFlowParams{Name: "clusterC", ReleaseLabel: "emr-6.0.0"})
 	require.NoError(t, err)
 
-	clusters, _ := b.ListClusters(emr.ListClustersParams{})
+	clusters, _ := b.ListClusters(context.Background(), emr.ListClustersParams{})
 	require.Len(t, clusters, 3)
 
 	// ListClusters returns most recently created first (creation-time descending).
@@ -198,14 +202,17 @@ func TestRefinement1_SortedListTagsForResource(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "tag-cluster", ReleaseLabel: "emr-6.0.0", Tags: []emr.Tag{
-		{Key: "zzz", Value: "last"},
-		{Key: "aaa", Value: "first"},
-		{Key: "mmm", Value: "middle"},
-	}})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "tag-cluster", ReleaseLabel: "emr-6.0.0", Tags: []emr.Tag{
+			{Key: "zzz", Value: "last"},
+			{Key: "aaa", Value: "first"},
+			{Key: "mmm", Value: "middle"},
+		}},
+	)
 	require.NoError(t, err)
 
-	tags, err := b.ListTagsForResource(cluster.ID)
+	tags, err := b.ListTagsForResource(context.Background(), cluster.ID)
 	require.NoError(t, err)
 	require.Len(t, tags, 3)
 	assert.Equal(t, "aaa", tags[0].Key)
@@ -219,7 +226,10 @@ func TestRefinement1_CreationDateTime(t *testing.T) {
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
 	before := time.Now().UnixMilli()
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "ts-cluster", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "ts-cluster", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 	after := time.Now().UnixMilli()
 
@@ -237,7 +247,7 @@ func TestRefinement1_CreatePersistentAppUI_ReturnsCopy(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	ui, err := b.CreatePersistentAppUI("arn:aws:elasticmapreduce:us-east-1:123:cluster/j-1")
+	ui, err := b.CreatePersistentAppUI(context.Background(), "arn:aws:elasticmapreduce:us-east-1:123:cluster/j-1")
 	require.NoError(t, err)
 	require.NotNil(t, ui)
 
@@ -245,7 +255,7 @@ func TestRefinement1_CreatePersistentAppUI_ReturnsCopy(t *testing.T) {
 	originalID := ui.ID
 	ui.ID = "mutated"
 
-	ui2, err := b.CreatePersistentAppUI("arn:aws:elasticmapreduce:us-east-1:123:cluster/j-2")
+	ui2, err := b.CreatePersistentAppUI(context.Background(), "arn:aws:elasticmapreduce:us-east-1:123:cluster/j-2")
 	require.NoError(t, err)
 	assert.NotEqual(t, "mutated", originalID)
 	assert.NotEqual(t, ui.ID, ui2.ID)
@@ -256,10 +266,32 @@ func TestRefinement1_Studio_NameUniqueness(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.CreateStudio("my-studio", "SSO", "s3://bucket", "sg-1", "arn:role", "vpc-1", "sg-2", nil, nil)
+	_, err := b.CreateStudio(
+		context.Background(),
+		"my-studio",
+		"SSO",
+		"s3://bucket",
+		"sg-1",
+		"arn:role",
+		"vpc-1",
+		"sg-2",
+		nil,
+		nil,
+	)
 	require.NoError(t, err)
 
-	_, err = b.CreateStudio("my-studio", "SSO", "s3://bucket", "sg-1", "arn:role", "vpc-1", "sg-2", nil, nil)
+	_, err = b.CreateStudio(
+		context.Background(),
+		"my-studio",
+		"SSO",
+		"s3://bucket",
+		"sg-1",
+		"arn:role",
+		"vpc-1",
+		"sg-2",
+		nil,
+		nil,
+	)
 	require.Error(t, err)
 }
 
@@ -288,18 +320,47 @@ func TestRefinement1_StudioSessionMapping_CreationTime(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	studio, err := b.CreateStudio("ct-studio", "SSO", "s3://b", "sg-1", "arn:r", "vpc-1", "sg-2", nil, nil)
+	studio, err := b.CreateStudio(
+		context.Background(),
+		"ct-studio",
+		"SSO",
+		"s3://b",
+		"sg-1",
+		"arn:r",
+		"vpc-1",
+		"sg-2",
+		nil,
+		nil,
+	)
 	require.NoError(t, err)
 
 	before := time.Now().Truncate(time.Second)
-	err = b.CreateStudioSessionMapping(studio.StudioID, "USER", "user-id", "", "arn:policy")
+	err = b.CreateStudioSessionMapping(context.Background(), studio.StudioID, "USER", "user-id", "", "arn:policy")
 	require.NoError(t, err)
 
 	// Verify through the HTTP layer.
 	h := newTestHandler(t)
-	studioOut, err := h.Backend.CreateStudio("http-studio", "SSO", "s3://b", "sg-1", "arn:r", "vpc-1", "sg-2", nil, nil)
+	studioOut, err := h.Backend.CreateStudio(
+		context.Background(),
+		"http-studio",
+		"SSO",
+		"s3://b",
+		"sg-1",
+		"arn:r",
+		"vpc-1",
+		"sg-2",
+		nil,
+		nil,
+	)
 	require.NoError(t, err)
-	err = h.Backend.CreateStudioSessionMapping(studioOut.StudioID, "USER", "user2", "", "arn:policy2")
+	err = h.Backend.CreateStudioSessionMapping(
+		context.Background(),
+		studioOut.StudioID,
+		"USER",
+		"user2",
+		"",
+		"arn:policy2",
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, h.Backend.StudioSessionMappingCount())
@@ -368,17 +429,28 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	src := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := src.RunJobFlow(emr.RunJobFlowParams{
+	cluster, err := src.RunJobFlow(context.Background(), emr.RunJobFlowParams{
 		Name:         "persist-cluster",
 		ReleaseLabel: "emr-6.8.0",
 		Tags:         []emr.Tag{{Key: "env", Value: "dev"}},
 	})
 	require.NoError(t, err)
-	_, err = src.CreateSecurityConfiguration("sc-1", `{"EncryptionConfiguration":{}}`)
+	_, err = src.CreateSecurityConfiguration(context.Background(), "sc-1", `{"EncryptionConfiguration":{}}`)
 	require.NoError(t, err)
-	studio, err := src.CreateStudio("studio-persist", "SSO", "s3://b", "sg-1", "arn:role", "vpc-1", "sg-2", nil, nil)
+	studio, err := src.CreateStudio(
+		context.Background(),
+		"studio-persist",
+		"SSO",
+		"s3://b",
+		"sg-1",
+		"arn:role",
+		"vpc-1",
+		"sg-2",
+		nil,
+		nil,
+	)
 	require.NoError(t, err)
-	err = src.CreateStudioSessionMapping(studio.StudioID, "USER", "uid-1", "", "arn:policy")
+	err = src.CreateStudioSessionMapping(context.Background(), studio.StudioID, "USER", "uid-1", "", "arn:policy")
 	require.NoError(t, err)
 
 	snap := src.Snapshot()
@@ -392,12 +464,12 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 	assert.Equal(t, 1, dst.StudioCount())
 	assert.Equal(t, 1, dst.StudioSessionMappingCount())
 
-	c, err := dst.DescribeCluster(cluster.ID)
+	c, err := dst.DescribeCluster(context.Background(), cluster.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "persist-cluster", c.Name)
 	assert.Equal(t, "emr-6.8.0", c.ReleaseLabel)
 
-	sc, err := dst.DescribeSecurityConfiguration("sc-1")
+	sc, err := dst.DescribeSecurityConfiguration(context.Background(), "sc-1")
 	require.NoError(t, err)
 	assert.Equal(t, "sc-1", sc.Name)
 }
@@ -420,10 +492,13 @@ func TestRefinement1_NonNilInstanceGroups(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "nogroup-cluster", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "nogroup-cluster", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
-	groups, err := b.ListInstanceGroups(cluster.ID)
+	groups, err := b.ListInstanceGroups(context.Background(), cluster.ID)
 	require.NoError(t, err)
 	assert.NotNil(t, groups)
 	assert.Empty(t, groups)
@@ -434,10 +509,13 @@ func TestRefinement1_NonNilInstanceFleets(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "nofleet-cluster", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "nofleet-cluster", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
-	fleets, err := b.ListInstanceFleets(cluster.ID)
+	fleets, err := b.ListInstanceFleets(context.Background(), cluster.ID)
 	require.NoError(t, err)
 	assert.NotNil(t, fleets)
 	assert.Empty(t, fleets)
@@ -448,12 +526,15 @@ func TestRefinement1_TerminateJobFlows_StateChangeReason(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "scr-cluster", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "scr-cluster", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
-	require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+	require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 
-	c, err := b.DescribeCluster(cluster.ID)
+	c, err := b.DescribeCluster(context.Background(), cluster.ID)
 	require.NoError(t, err)
 	assert.Equal(t, emr.StateTerminated, c.Status.State)
 	assert.NotEmpty(t, c.Status.StateChangeReason["Code"])
@@ -499,15 +580,18 @@ func TestRefinement1_AddInstanceGroups_UniqueIDs(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "multi-ig", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "multi-ig", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
-	ids1, _, err := b.AddInstanceGroups(cluster.ID, []emr.InstanceGroupSpec{
+	ids1, _, err := b.AddInstanceGroups(context.Background(), cluster.ID, []emr.InstanceGroupSpec{
 		{Name: "g1", InstanceRole: "TASK", InstanceType: "m5.xlarge", InstanceCount: 2},
 	})
 	require.NoError(t, err)
 
-	ids2, _, err := b.AddInstanceGroups(cluster.ID, []emr.InstanceGroupSpec{
+	ids2, _, err := b.AddInstanceGroups(context.Background(), cluster.ID, []emr.InstanceGroupSpec{
 		{Name: "g2", InstanceRole: "TASK", InstanceType: "m5.xlarge", InstanceCount: 2},
 	})
 	require.NoError(t, err)

--- a/services/emr/handler_test.go
+++ b/services/emr/handler_test.go
@@ -2,6 +2,7 @@ package emr_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -827,7 +828,7 @@ func TestEMR_Backend_ListTagsForResource(t *testing.T) {
 			t.Parallel()
 
 			b := emr.NewInMemoryBackend(testAccountID, testRegion)
-			cluster, err := b.RunJobFlow(emr.RunJobFlowParams{
+			cluster, err := b.RunJobFlow(context.Background(), emr.RunJobFlowParams{
 				Name: "test-cluster", ReleaseLabel: "emr-6.0.0",
 				Tags: []emr.Tag{{Key: "env", Value: "test"}},
 			})
@@ -838,7 +839,7 @@ func TestEMR_Backend_ListTagsForResource(t *testing.T) {
 				resourceID = cluster.ID
 			}
 
-			tags, err := b.ListTagsForResource(resourceID)
+			tags, err := b.ListTagsForResource(context.Background(), resourceID)
 			if tt.wantErr {
 				require.Error(t, err)
 
@@ -855,13 +856,13 @@ func TestEMR_Backend_ListTagsForResourceByARN(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{
+	cluster, err := b.RunJobFlow(context.Background(), emr.RunJobFlowParams{
 		Name: "test-cluster", ReleaseLabel: "emr-6.0.0",
 		Tags: []emr.Tag{{Key: "key", Value: "val"}},
 	})
 	require.NoError(t, err)
 
-	tags, err := b.ListTagsForResource(cluster.ARN)
+	tags, err := b.ListTagsForResource(context.Background(), cluster.ARN)
 	require.NoError(t, err)
 	require.Len(t, tags, 1)
 	assert.Equal(t, "key", tags[0].Key)
@@ -872,27 +873,33 @@ func TestEMR_TerminateJobFlows_Idempotent(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "idem-cluster", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "idem-cluster", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
 	// First termination succeeds.
-	require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+	require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 
 	// Second termination on an already-terminal cluster must be a no-op, not an error.
-	require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+	require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 }
 
 func TestEMR_TerminateJobFlows_SetsEndDateTime(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "timeline-cluster", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "timeline-cluster", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
 	before := time.Now().UnixMilli()
-	require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+	require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 
-	c, err := b.DescribeCluster(cluster.ID)
+	c, err := b.DescribeCluster(context.Background(), cluster.ID)
 	require.NoError(t, err)
 
 	endRaw, ok := c.Status.Timeline["EndDateTime"]

--- a/services/emr/isolation_test.go
+++ b/services/emr/isolation_test.go
@@ -1,0 +1,180 @@
+package emr //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testReleaseLabel6 is a stable EMR 6.x release label used across isolation tests.
+const testReleaseLabel6 = "emr-6.0.0"
+
+func emrCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestEMRClusterRegionIsolation proves that EMR clusters with the same name
+// created in two different regions are fully isolated: each region sees only
+// its own cluster, ARNs embed the correct region, and terminating in one
+// region leaves the other untouched.
+func TestEMRClusterRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := emrCtxRegion("us-east-1")
+	ctxWest := emrCtxRegion("us-west-2")
+
+	// Create a cluster with the SAME name in both regions.
+	eastCluster, err := backend.RunJobFlow(ctxEast, RunJobFlowParams{
+		Name:         "shared-cluster",
+		ReleaseLabel: testReleaseLabel6,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, eastCluster.ARN, "us-east-1")
+
+	westCluster, err := backend.RunJobFlow(ctxWest, RunJobFlowParams{
+		Name:         "shared-cluster",
+		ReleaseLabel: "emr-7.0.0",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, westCluster.ARN, "us-west-2")
+
+	// IDs and ARNs differ (region-qualified) even though names match.
+	assert.NotEqual(t, eastCluster.ID, westCluster.ID)
+	assert.NotEqual(t, eastCluster.ARN, westCluster.ARN)
+
+	// Each region reads back only its own cluster, with its own release label.
+	eastDesc, err := backend.DescribeCluster(ctxEast, eastCluster.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "emr-6.0.0", eastDesc.ReleaseLabel)
+
+	westDesc, err := backend.DescribeCluster(ctxWest, westCluster.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "emr-7.0.0", westDesc.ReleaseLabel)
+
+	// The west cluster ID is not resolvable from the east region.
+	_, err = backend.DescribeCluster(ctxEast, westCluster.ID)
+	require.Error(t, err)
+
+	// ListClusters returns exactly one cluster per region.
+	eastList, _ := backend.ListClusters(ctxEast, ListClustersParams{})
+	require.Len(t, eastList, 1)
+	assert.Equal(t, eastCluster.ID, eastList[0].ID)
+
+	westList, _ := backend.ListClusters(ctxWest, ListClustersParams{})
+	require.Len(t, westList, 1)
+	assert.Equal(t, westCluster.ID, westList[0].ID)
+
+	// Terminating the east cluster must not affect the west cluster.
+	require.NoError(t, backend.TerminateJobFlows(ctxEast, []string{eastCluster.ID}))
+
+	eastAfter, err := backend.DescribeCluster(ctxEast, eastCluster.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StateTerminated, eastAfter.Status.State)
+
+	westAfter, err := backend.DescribeCluster(ctxWest, westCluster.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, StateTerminated, westAfter.Status.State)
+}
+
+// TestEMRResourceRegionIsolation proves that EMR studios, security
+// configurations, and tags (resolved by ARN) are scoped to the request region.
+func TestEMRResourceRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := emrCtxRegion("us-east-1")
+	ctxWest := emrCtxRegion("us-west-2")
+
+	// Same-named studio in both regions.
+	eastStudio, err := backend.CreateStudio(
+		ctxEast, "shared-studio", "IAM", "s3://east", "sg-east", "role-east", "vpc-east", "sg-w-east", nil, nil,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, eastStudio.StudioArn, "us-east-1")
+
+	westStudio, err := backend.CreateStudio(
+		ctxWest, "shared-studio", "IAM", "s3://west", "sg-west", "role-west", "vpc-west", "sg-w-west", nil, nil,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, westStudio.StudioArn, "us-west-2")
+
+	// Each region sees exactly one studio.
+	eastStudios, _ := backend.ListStudios(ctxEast, "")
+	require.Len(t, eastStudios, 1)
+	assert.Equal(t, "s3://east", eastStudios[0].DefaultS3Location)
+
+	westStudios, _ := backend.ListStudios(ctxWest, "")
+	require.Len(t, westStudios, 1)
+	assert.Equal(t, "s3://west", westStudios[0].DefaultS3Location)
+
+	// Same-named security configuration in both regions, isolated.
+	_, err = backend.CreateSecurityConfiguration(ctxEast, "shared-sc", `{"k":"east"}`)
+	require.NoError(t, err)
+	_, err = backend.CreateSecurityConfiguration(ctxWest, "shared-sc", `{"k":"west"}`)
+	require.NoError(t, err)
+
+	eastSC, err := backend.DescribeSecurityConfiguration(ctxEast, "shared-sc")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"k":"east"}`, eastSC.SecurityConfig)
+
+	westSC, err := backend.DescribeSecurityConfiguration(ctxWest, "shared-sc")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"k":"west"}`, westSC.SecurityConfig)
+
+	// Tags addressed by a bare cluster ID are scoped to the request region.
+	eastCluster, err := backend.RunJobFlow(ctxEast, RunJobFlowParams{Name: "tag-c", ReleaseLabel: testReleaseLabel6})
+	require.NoError(t, err)
+
+	require.NoError(t, backend.AddTags(ctxEast, eastCluster.ID, []Tag{{Key: "env", Value: "prod"}}))
+
+	eastTags, err := backend.ListTagsForResource(ctxEast, eastCluster.ID)
+	require.NoError(t, err)
+	require.Len(t, eastTags, 1)
+	assert.Equal(t, "prod", eastTags[0].Value)
+
+	// The east cluster ID must not resolve in the west region (bare IDs fall
+	// back to the ctx region rather than embedding one like an ARN).
+	_, err = backend.ListTagsForResource(ctxWest, eastCluster.ID)
+	require.Error(t, err, "east cluster ID must not be tag-resolvable from the west region")
+
+	// Addressing the same cluster by its (region-qualified) ARN resolves
+	// regardless of the ctx region, because the ARN carries its own region.
+	arnTags, err := backend.ListTagsForResource(ctxWest, eastCluster.ARN)
+	require.NoError(t, err, "ARN carries its region and must resolve from any ctx")
+	require.Len(t, arnTags, 1)
+	assert.Equal(t, "prod", arnTags[0].Value)
+
+	// Deleting the east studio leaves the west studio intact.
+	require.NoError(t, backend.DeleteStudio(ctxEast, eastStudio.StudioID))
+	require.NoError(t, backend.DeleteStudio(ctxWest, westStudio.StudioID)) // west still exists
+}
+
+// TestEMRDefaultRegionFallback verifies that a context without a region falls
+// back to the backend's configured default region (single-region behavior is
+// unchanged).
+func TestEMRDefaultRegionFallback(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "eu-central-1")
+
+	// No region in context -> default region store.
+	cluster, err := backend.RunJobFlow(context.Background(), RunJobFlowParams{
+		Name:         "def-cluster",
+		ReleaseLabel: testReleaseLabel6,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, cluster.ARN, "eu-central-1")
+
+	// Reading via the explicit default region sees it.
+	list, _ := backend.ListClusters(emrCtxRegion("eu-central-1"), ListClustersParams{})
+	require.Len(t, list, 1)
+
+	// A different region sees nothing.
+	other, _ := backend.ListClusters(emrCtxRegion("ap-south-1"), ListClustersParams{})
+	assert.Empty(t, other)
+}

--- a/services/emr/janitor.go
+++ b/services/emr/janitor.go
@@ -85,12 +85,17 @@ func (j *Janitor) sweepTerminatedClusters(ctx context.Context) {
 
 	var swept []string
 
-	for id, c := range j.Backend.clusters {
-		terminal := c.Status.State == StateTerminated || c.Status.State == StateTerminatedWithErrors
-		if terminal && !c.TerminatedAt.IsZero() && c.TerminatedAt.Before(cutoff) {
-			swept = append(swept, id)
-			delete(j.Backend.clusters, id)
-			delete(j.Backend.arnIndex, c.ARN)
+	// Clusters are region-nested (outer key = region); sweep every region.
+	for region, clusters := range j.Backend.clusters {
+		for id, c := range clusters {
+			terminal := c.Status.State == StateTerminated || c.Status.State == StateTerminatedWithErrors
+			if terminal && !c.TerminatedAt.IsZero() && c.TerminatedAt.Before(cutoff) {
+				swept = append(swept, id)
+				delete(clusters, id)
+				if arnIndex := j.Backend.arnIndex[region]; arnIndex != nil {
+					delete(arnIndex, c.ARN)
+				}
+			}
 		}
 	}
 

--- a/services/emr/janitor_test.go
+++ b/services/emr/janitor_test.go
@@ -16,10 +16,13 @@ func TestEMR_Janitor_SweepsTerminatedClusters(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "sweep-test", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "sweep-test", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
-	require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+	require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 
 	janitor := emr.NewJanitor(b, 10*time.Millisecond, 50*time.Millisecond)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -29,7 +32,7 @@ func TestEMR_Janitor_SweepsTerminatedClusters(t *testing.T) {
 
 	// Wait until the cluster is swept from the backend.
 	require.Eventually(t, func() bool {
-		_, descErr := b.DescribeCluster(cluster.ID)
+		_, descErr := b.DescribeCluster(context.Background(), cluster.ID)
 
 		return descErr != nil
 	}, 2*time.Second, 20*time.Millisecond, "terminated cluster should be swept")
@@ -39,7 +42,10 @@ func TestEMR_Janitor_ActiveClusterNotSwept(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "active-test", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "active-test", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
 	// Do NOT terminate the cluster — it should never be swept.
@@ -52,7 +58,7 @@ func TestEMR_Janitor_ActiveClusterNotSwept(t *testing.T) {
 	// Wait for the janitor context to expire (several ticks), then verify cluster still exists.
 	<-ctx.Done()
 
-	_, err = b.DescribeCluster(cluster.ID)
+	_, err = b.DescribeCluster(context.Background(), cluster.ID)
 	require.NoError(t, err, "active cluster must not be swept")
 }
 
@@ -60,10 +66,13 @@ func TestEMR_Janitor_RecentlyTerminatedNotSwept(t *testing.T) {
 	t.Parallel()
 
 	b := emr.NewInMemoryBackend(testAccountID, testRegion)
-	cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "recent-terminated", ReleaseLabel: "emr-6.0.0"})
+	cluster, err := b.RunJobFlow(
+		context.Background(),
+		emr.RunJobFlowParams{Name: "recent-terminated", ReleaseLabel: "emr-6.0.0"},
+	)
 	require.NoError(t, err)
 
-	require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+	require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 
 	// Use a very long TTL so the cluster should not be swept.
 	janitor := emr.NewJanitor(b, 10*time.Millisecond, 24*time.Hour)
@@ -75,7 +84,7 @@ func TestEMR_Janitor_RecentlyTerminatedNotSwept(t *testing.T) {
 	<-ctx.Done()
 
 	// Cluster should still be reachable with TERMINATED state.
-	c, err := b.DescribeCluster(cluster.ID)
+	c, err := b.DescribeCluster(context.Background(), cluster.ID)
 	require.NoError(t, err)
 	assert.Equal(t, emr.StateTerminated, c.Status.State)
 }
@@ -136,10 +145,13 @@ func TestEMR_Janitor_SweepOnce(t *testing.T) {
 			t.Parallel()
 
 			b := emr.NewInMemoryBackend(testAccountID, testRegion)
-			cluster, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "sweep-once-test", ReleaseLabel: "emr-6.0.0"})
+			cluster, err := b.RunJobFlow(
+				context.Background(),
+				emr.RunJobFlowParams{Name: "sweep-once-test", ReleaseLabel: "emr-6.0.0"},
+			)
 			require.NoError(t, err)
 
-			require.NoError(t, b.TerminateJobFlows([]string{cluster.ID}))
+			require.NoError(t, b.TerminateJobFlows(context.Background(), []string{cluster.ID}))
 
 			ttl := 24 * time.Hour
 			if tt.clusterOld {
@@ -155,7 +167,7 @@ func TestEMR_Janitor_SweepOnce(t *testing.T) {
 
 			j.SweepOnce(t.Context())
 
-			_, err = b.DescribeCluster(cluster.ID)
+			_, err = b.DescribeCluster(context.Background(), cluster.ID)
 
 			if tt.wantSwept {
 				require.Error(t, err, "cluster should have been swept")
@@ -201,13 +213,16 @@ func TestEMR_Backend_Reset(t *testing.T) {
 			b := emr.NewInMemoryBackend(testAccountID, testRegion)
 
 			for range tt.createClusters {
-				_, err := b.RunJobFlow(emr.RunJobFlowParams{Name: "cluster", ReleaseLabel: "emr-6.0.0"})
+				_, err := b.RunJobFlow(
+					context.Background(),
+					emr.RunJobFlowParams{Name: "cluster", ReleaseLabel: "emr-6.0.0"},
+				)
 				require.NoError(t, err)
 			}
 
 			b.Reset()
 
-			clusters, _ := b.ListClusters(emr.ListClustersParams{})
+			clusters, _ := b.ListClusters(context.Background(), emr.ListClustersParams{})
 			assert.Len(t, clusters, tt.wantAfterReset)
 		})
 	}

--- a/services/emr/persistence.go
+++ b/services/emr/persistence.go
@@ -14,52 +14,61 @@ type clusterExtra struct {
 	Steps                 []Step                 `json:"steps,omitempty"`
 }
 
+// backendSnapshot mirrors the region-nested backend maps (outer key = region).
 type backendSnapshot struct {
-	Clusters              map[string]*Cluster               `json:"clusters"`
-	ClusterExtras         map[string]*clusterExtra          `json:"clusterExtras,omitempty"`
-	ArnIndex              map[string]string                 `json:"arnIndex"`
-	SecurityConfigs       map[string]*SecurityConfiguration `json:"securityConfigs"`
-	Studios               map[string]*Studio                `json:"studios"`
-	StudioSessionMappings map[string]*StudioSessionMapping  `json:"studioSessionMappings"`
-	PersistentAppUIs      map[string]*PersistentAppUI       `json:"persistentAppUIs"`
-	NotebookExecutions    map[string]*NotebookExecution     `json:"notebookExecutions,omitempty"`
-	BlockPublicAccess     *BlockPublicAccessConfiguration   `json:"blockPublicAccess,omitempty"`
-	BlockPublicAccessMeta *blockPublicAccessMeta            `json:"blockPublicAccessMeta,omitempty"`
-	AccountID             string                            `json:"accountID"`
-	Region                string                            `json:"region"`
+	Clusters              map[string]map[string]*Cluster               `json:"clusters"`
+	ClusterExtras         map[string]map[string]*clusterExtra          `json:"clusterExtras,omitempty"`
+	ArnIndex              map[string]map[string]string                 `json:"arnIndex"`
+	SecurityConfigs       map[string]map[string]*SecurityConfiguration `json:"securityConfigs"`
+	Studios               map[string]map[string]*Studio                `json:"studios"`
+	StudioSessionMappings map[string]map[string]*StudioSessionMapping  `json:"studioSessionMappings"`
+	PersistentAppUIs      map[string]map[string]*PersistentAppUI       `json:"persistentAppUIs"`
+	NotebookExecutions    map[string]map[string]*NotebookExecution     `json:"notebookExecutions,omitempty"`
+	BlockPublicAccess     map[string]*BlockPublicAccessConfiguration   `json:"blockPublicAccess,omitempty"`
+	BlockPublicAccessMeta map[string]*blockPublicAccessMeta            `json:"blockPublicAccessMeta,omitempty"`
+	AccountID             string                                       `json:"accountID"`
+	Region                string                                       `json:"region"`
 }
 
 func (s *backendSnapshot) ensureNonNil() {
 	if s.Clusters == nil {
-		s.Clusters = make(map[string]*Cluster)
+		s.Clusters = make(map[string]map[string]*Cluster)
 	}
 
 	if s.ClusterExtras == nil {
-		s.ClusterExtras = make(map[string]*clusterExtra)
+		s.ClusterExtras = make(map[string]map[string]*clusterExtra)
 	}
 
 	if s.ArnIndex == nil {
-		s.ArnIndex = make(map[string]string)
+		s.ArnIndex = make(map[string]map[string]string)
 	}
 
 	if s.SecurityConfigs == nil {
-		s.SecurityConfigs = make(map[string]*SecurityConfiguration)
+		s.SecurityConfigs = make(map[string]map[string]*SecurityConfiguration)
 	}
 
 	if s.Studios == nil {
-		s.Studios = make(map[string]*Studio)
+		s.Studios = make(map[string]map[string]*Studio)
 	}
 
 	if s.StudioSessionMappings == nil {
-		s.StudioSessionMappings = make(map[string]*StudioSessionMapping)
+		s.StudioSessionMappings = make(map[string]map[string]*StudioSessionMapping)
 	}
 
 	if s.PersistentAppUIs == nil {
-		s.PersistentAppUIs = make(map[string]*PersistentAppUI)
+		s.PersistentAppUIs = make(map[string]map[string]*PersistentAppUI)
 	}
 
 	if s.NotebookExecutions == nil {
-		s.NotebookExecutions = make(map[string]*NotebookExecution)
+		s.NotebookExecutions = make(map[string]map[string]*NotebookExecution)
+	}
+
+	if s.BlockPublicAccess == nil {
+		s.BlockPublicAccess = make(map[string]*BlockPublicAccessConfiguration)
+	}
+
+	if s.BlockPublicAccessMeta == nil {
+		s.BlockPublicAccessMeta = make(map[string]*blockPublicAccessMeta)
 	}
 }
 
@@ -68,22 +77,15 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	extras := make(map[string]*clusterExtra, len(b.clusters))
+	extras := make(map[string]map[string]*clusterExtra, len(b.clusters))
 
-	for id, c := range b.clusters {
-		extras[id] = extractClusterExtra(c)
-	}
+	for region, clusters := range b.clusters {
+		regionExtras := make(map[string]*clusterExtra, len(clusters))
+		for id, c := range clusters {
+			regionExtras[id] = extractClusterExtra(c)
+		}
 
-	var bpa *BlockPublicAccessConfiguration
-	if b.blockPublicAccess != nil {
-		cp := *b.blockPublicAccess
-		bpa = &cp
-	}
-
-	var bpam *blockPublicAccessMeta
-	if b.blockPublicAccessMeta != nil {
-		cp := *b.blockPublicAccessMeta
-		bpam = &cp
+		extras[region] = regionExtras
 	}
 
 	snap := backendSnapshot{
@@ -95,8 +97,8 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		StudioSessionMappings: b.studioSessionMappings,
 		PersistentAppUIs:      b.persistentAppUIs,
 		NotebookExecutions:    b.notebookExecutions,
-		BlockPublicAccess:     bpa,
-		BlockPublicAccessMeta: bpam,
+		BlockPublicAccess:     cloneBlockPublicAccess(b.blockPublicAccess),
+		BlockPublicAccessMeta: cloneBlockPublicAccessMeta(b.blockPublicAccessMeta),
 		AccountID:             b.accountID,
 		Region:                b.region,
 	}
@@ -109,6 +111,40 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	}
 
 	return data
+}
+
+// cloneBlockPublicAccess deep-copies the per-region block-public-access configs.
+func cloneBlockPublicAccess(
+	src map[string]*BlockPublicAccessConfiguration,
+) map[string]*BlockPublicAccessConfiguration {
+	out := make(map[string]*BlockPublicAccessConfiguration, len(src))
+	for region, cfg := range src {
+		if cfg == nil {
+			continue
+		}
+
+		cp := *cfg
+		out[region] = &cp
+	}
+
+	return out
+}
+
+// cloneBlockPublicAccessMeta deep-copies the per-region block-public-access metadata.
+func cloneBlockPublicAccessMeta(
+	src map[string]*blockPublicAccessMeta,
+) map[string]*blockPublicAccessMeta {
+	out := make(map[string]*blockPublicAccessMeta, len(src))
+	for region, meta := range src {
+		if meta == nil {
+			continue
+		}
+
+		cp := *meta
+		out[region] = &cp
+	}
+
+	return out
 }
 
 func extractClusterExtra(c *Cluster) *clusterExtra {
@@ -143,7 +179,10 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	}
 
 	snap.ensureNonNil()
-	applyClusterExtras(snap.Clusters, snap.ClusterExtras)
+
+	for region, clusters := range snap.Clusters {
+		applyClusterExtras(clusters, snap.ClusterExtras[region])
+	}
 
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()

--- a/services/glacier/isolation_test.go
+++ b/services/glacier/isolation_test.go
@@ -1,0 +1,69 @@
+package glacier_test
+
+import (
+	"testing"
+
+	"github.com/blackbirdworks/gopherstack/services/glacier"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGlacierRegionIsolation proves that a same-named vault created in two
+// different regions stays fully isolated: each region sees only its own vault,
+// the ARNs carry the correct region, and deleting in one region leaves the
+// other region's vault intact.
+//
+// Glacier isolates by a composite map key (accountID + region + vaultName), so
+// the region is part of every resource's identity. This test locks that
+// behaviour in.
+func TestGlacierRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		account = "000000000000"
+		east    = "us-east-1"
+		west    = "us-west-2"
+		vault   = "shared-name"
+	)
+
+	b := glacier.NewInMemoryBackend()
+
+	// 1. Create a vault named "shared-name" in us-east-1.
+	eastVault, err := b.CreateVault(account, east, vault)
+	require.NoError(t, err)
+	assert.Contains(t, eastVault.VaultARN, ":"+east+":")
+
+	// 2. Create a vault with the SAME NAME in us-west-2 — must NOT collide.
+	westVault, err := b.CreateVault(account, west, vault)
+	require.NoError(t, err)
+	assert.Contains(t, westVault.VaultARN, ":"+west+":")
+
+	// 3. Each region lists exactly its own vault.
+	eastList := b.ListVaults(account, east)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, vault, eastList[0].VaultName)
+	assert.Contains(t, eastList[0].VaultARN, ":"+east+":")
+
+	westList := b.ListVaults(account, west)
+	require.Len(t, westList, 1)
+	assert.Equal(t, vault, westList[0].VaultName)
+	assert.Contains(t, westList[0].VaultARN, ":"+west+":")
+
+	// 4. Describe is region-scoped.
+	gotEast, err := b.DescribeVault(account, east, vault)
+	require.NoError(t, err)
+	assert.Contains(t, gotEast.VaultARN, ":"+east+":")
+
+	// 5. Deleting in us-east-1 leaves us-west-2 intact.
+	require.NoError(t, b.DeleteVault(account, east, vault))
+
+	_, err = b.DescribeVault(account, east, vault)
+	require.Error(t, err)
+
+	stillWest, err := b.DescribeVault(account, west, vault)
+	require.NoError(t, err)
+	assert.Contains(t, stillWest.VaultARN, ":"+west+":")
+
+	assert.Empty(t, b.ListVaults(account, east))
+	assert.Len(t, b.ListVaults(account, west), 1)
+}

--- a/services/kafka/backend.go
+++ b/services/kafka/backend.go
@@ -2,6 +2,7 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -14,6 +15,34 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
 
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+// MSK resources are isolated per region: every backend operation resolves the
+// caller's region from the request context (for create/list operations) or from
+// the resource ARN (for operations that target an existing ARN) and operates only
+// on that region's nested store.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
+}
+
 var (
 	// ErrNotFound is returned when a requested resource does not exist.
 	ErrNotFound = awserr.New("NotFoundException", awserr.ErrNotFound)
@@ -21,6 +50,13 @@ var (
 	ErrAlreadyExists = awserr.New("ConflictException", awserr.ErrAlreadyExists)
 	// ErrValidation is returned when input validation fails.
 	ErrValidation = awserr.New("BadRequestException", awserr.ErrInvalidParameter)
+)
+
+const (
+	// kafkaVersion360 is the MSK Kafka 3.6.0 version identifier.
+	kafkaVersion360 = "3.6.0"
+	// kafkaVersion351 is the MSK Kafka 3.5.1 version identifier.
+	kafkaVersion351 = "3.5.1"
 )
 
 const (
@@ -334,15 +370,21 @@ type Configuration struct {
 }
 
 // InMemoryBackend stores MSK state in memory.
+//
+// All resource maps are nested by region (outer key = region) so that same-named
+// resources in different regions are fully isolated. Operations that take an
+// existing resource ARN resolve their region from the ARN itself; create and
+// list operations resolve it from the request context (falling back to the
+// backend's default region).
 type InMemoryBackend struct {
-	clusters          map[string]*Cluster          // key: clusterArn
-	configurations    map[string]*Configuration    // key: configArn
-	scramSecrets      map[string][]string          // key: clusterArn → []secretArn
-	replicators       map[string]*Replicator       // key: replicatorArn
-	topics            map[string]*Topic            // key: clusterArn + "|" + topicName
-	vpcConnections    map[string]*VpcConnection    // key: vpcConnectionArn
-	clusterPolicies   map[string]string            // key: clusterArn → policy document
-	clusterOperations map[string]*ClusterOperation // key: clusterOperationArn
+	clusters          map[string]map[string]*Cluster          // region → clusterArn → cluster
+	configurations    map[string]map[string]*Configuration    // region → configArn → configuration
+	scramSecrets      map[string]map[string][]string          // region → clusterArn → []secretArn
+	replicators       map[string]map[string]*Replicator       // region → replicatorArn → replicator
+	topics            map[string]map[string]*Topic            // region → clusterArn|topicName → topic
+	vpcConnections    map[string]map[string]*VpcConnection    // region → vpcConnectionArn → connection
+	clusterPolicies   map[string]map[string]string            // region → clusterArn → policy document
+	clusterOperations map[string]map[string]*ClusterOperation // region → clusterOperationArn → operation
 	mu                *lockmetrics.RWMutex
 	accountID         string
 	region            string
@@ -351,14 +393,14 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new in-memory MSK backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		clusters:          make(map[string]*Cluster),
-		configurations:    make(map[string]*Configuration),
-		scramSecrets:      make(map[string][]string),
-		replicators:       make(map[string]*Replicator),
-		topics:            make(map[string]*Topic),
-		vpcConnections:    make(map[string]*VpcConnection),
-		clusterPolicies:   make(map[string]string),
-		clusterOperations: make(map[string]*ClusterOperation),
+		clusters:          make(map[string]map[string]*Cluster),
+		configurations:    make(map[string]map[string]*Configuration),
+		scramSecrets:      make(map[string]map[string][]string),
+		replicators:       make(map[string]map[string]*Replicator),
+		topics:            make(map[string]map[string]*Topic),
+		vpcConnections:    make(map[string]map[string]*VpcConnection),
+		clusterPolicies:   make(map[string]map[string]string),
+		clusterOperations: make(map[string]map[string]*ClusterOperation),
 		mu:                lockmetrics.New("kafka"),
 		accountID:         accountID,
 		region:            region,
@@ -371,66 +413,140 @@ func (b *InMemoryBackend) Region() string { return b.region }
 // AccountID returns the backend account ID.
 func (b *InMemoryBackend) AccountID() string { return b.accountID }
 
+// --- Per-region store accessors (callers must hold b.mu) ---
+
+// clustersStore returns the cluster map for region, lazily creating it.
+func (b *InMemoryBackend) clustersStore(region string) map[string]*Cluster {
+	if b.clusters[region] == nil {
+		b.clusters[region] = make(map[string]*Cluster)
+	}
+
+	return b.clusters[region]
+}
+
+// configurationsStore returns the configuration map for region, lazily creating it.
+func (b *InMemoryBackend) configurationsStore(region string) map[string]*Configuration {
+	if b.configurations[region] == nil {
+		b.configurations[region] = make(map[string]*Configuration)
+	}
+
+	return b.configurations[region]
+}
+
+// scramSecretsStore returns the SCRAM secret map for region, lazily creating it.
+func (b *InMemoryBackend) scramSecretsStore(region string) map[string][]string {
+	if b.scramSecrets[region] == nil {
+		b.scramSecrets[region] = make(map[string][]string)
+	}
+
+	return b.scramSecrets[region]
+}
+
+// replicatorsStore returns the replicator map for region, lazily creating it.
+func (b *InMemoryBackend) replicatorsStore(region string) map[string]*Replicator {
+	if b.replicators[region] == nil {
+		b.replicators[region] = make(map[string]*Replicator)
+	}
+
+	return b.replicators[region]
+}
+
+// topicsStore returns the topic map for region, lazily creating it.
+func (b *InMemoryBackend) topicsStore(region string) map[string]*Topic {
+	if b.topics[region] == nil {
+		b.topics[region] = make(map[string]*Topic)
+	}
+
+	return b.topics[region]
+}
+
+// vpcConnectionsStore returns the VPC connection map for region, lazily creating it.
+func (b *InMemoryBackend) vpcConnectionsStore(region string) map[string]*VpcConnection {
+	if b.vpcConnections[region] == nil {
+		b.vpcConnections[region] = make(map[string]*VpcConnection)
+	}
+
+	return b.vpcConnections[region]
+}
+
+// clusterPoliciesStore returns the cluster policy map for region, lazily creating it.
+func (b *InMemoryBackend) clusterPoliciesStore(region string) map[string]string {
+	if b.clusterPolicies[region] == nil {
+		b.clusterPolicies[region] = make(map[string]string)
+	}
+
+	return b.clusterPolicies[region]
+}
+
+// clusterOperationsStore returns the cluster operation map for region, lazily creating it.
+func (b *InMemoryBackend) clusterOperationsStore(region string) map[string]*ClusterOperation {
+	if b.clusterOperations[region] == nil {
+		b.clusterOperations[region] = make(map[string]*ClusterOperation)
+	}
+
+	return b.clusterOperations[region]
+}
+
 // Reset clears all state, returning the backend to a clean empty state.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	b.clusters = make(map[string]*Cluster)
-	b.configurations = make(map[string]*Configuration)
-	b.scramSecrets = make(map[string][]string)
-	b.replicators = make(map[string]*Replicator)
-	b.topics = make(map[string]*Topic)
-	b.vpcConnections = make(map[string]*VpcConnection)
-	b.clusterPolicies = make(map[string]string)
-	b.clusterOperations = make(map[string]*ClusterOperation)
+	b.clusters = make(map[string]map[string]*Cluster)
+	b.configurations = make(map[string]map[string]*Configuration)
+	b.scramSecrets = make(map[string]map[string][]string)
+	b.replicators = make(map[string]map[string]*Replicator)
+	b.topics = make(map[string]map[string]*Topic)
+	b.vpcConnections = make(map[string]map[string]*VpcConnection)
+	b.clusterPolicies = make(map[string]map[string]string)
+	b.clusterOperations = make(map[string]map[string]*ClusterOperation)
 }
 
-// clusterARN builds an ARN for an MSK cluster.
-func (b *InMemoryBackend) clusterARN(name string) string {
+// clusterARN builds an ARN for an MSK cluster in region.
+func (b *InMemoryBackend) clusterARN(region, name string) string {
 	return arn.Build(
 		"kafka",
-		b.region,
+		region,
 		b.accountID,
 		fmt.Sprintf("cluster/%s/%s", name, uuid.New().String()),
 	)
 }
 
-// configurationARN builds an ARN for an MSK configuration.
-func (b *InMemoryBackend) configurationARN(name string) string {
+// configurationARN builds an ARN for an MSK configuration in region.
+func (b *InMemoryBackend) configurationARN(region, name string) string {
 	return arn.Build(
 		"kafka",
-		b.region,
+		region,
 		b.accountID,
 		fmt.Sprintf("configuration/%s/%s", name, uuid.New().String()),
 	)
 }
 
-// replicatorARN builds an ARN for an MSK replicator.
-func (b *InMemoryBackend) replicatorARN(name string) string {
+// replicatorARN builds an ARN for an MSK replicator in region.
+func (b *InMemoryBackend) replicatorARN(region, name string) string {
 	return arn.Build(
 		"kafka",
-		b.region,
+		region,
 		b.accountID,
 		fmt.Sprintf("replicator/%s/%s", name, uuid.New().String()),
 	)
 }
 
-// vpcConnectionARN builds an ARN for an MSK VPC connection.
-func (b *InMemoryBackend) vpcConnectionARN(clusterArn, vpcID string) string {
+// vpcConnectionARN builds an ARN for an MSK VPC connection in region.
+func (b *InMemoryBackend) vpcConnectionARN(region, clusterArn, vpcID string) string {
 	return arn.Build(
 		"kafka",
-		b.region,
+		region,
 		b.accountID,
 		fmt.Sprintf("vpc-connection/%s/%s/%s", clusterArn, vpcID, uuid.New().String()),
 	)
 }
 
-// clusterOperationARN builds an ARN for an MSK cluster operation.
-func (b *InMemoryBackend) clusterOperationARN(clusterArn string) string {
+// clusterOperationARN builds an ARN for an MSK cluster operation in region.
+func (b *InMemoryBackend) clusterOperationARN(region, clusterArn string) string {
 	return arn.Build(
 		"kafka",
-		b.region,
+		region,
 		b.accountID,
 		fmt.Sprintf("cluster-operation/%s/%s", clusterArn, uuid.New().String()),
 	)
@@ -445,6 +561,7 @@ func topicKey(clusterArn, topicName string) string {
 
 // CreateCluster creates a new MSK cluster.
 func (b *InMemoryBackend) CreateCluster(
+	ctx context.Context,
 	name, kafkaVersion string,
 	numBrokers int32,
 	brokerInfo BrokerNodeGroupInfo,
@@ -455,16 +572,19 @@ func (b *InMemoryBackend) CreateCluster(
 		return nil, fmt.Errorf("clusterName is required: %w", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateCluster")
 	defer b.mu.Unlock()
 
-	for _, c := range b.clusters {
+	clusters := b.clustersStore(region)
+	for _, c := range clusters {
 		if c.ClusterName == name {
 			return nil, ErrAlreadyExists
 		}
 	}
 
-	clusterArn := b.clusterARN(name)
+	clusterArn := b.clusterARN(region, name)
 	safeInfo := BrokerNodeGroupInfo{
 		BrokerAZDistribution: brokerInfo.BrokerAZDistribution,
 		InstanceType:         brokerInfo.InstanceType,
@@ -492,13 +612,14 @@ func (b *InMemoryBackend) CreateCluster(
 		CurrentVersion:       DefaultClusterVersion,
 		Tags:                 nonNilTagsCopy(tags),
 	}
-	b.clusters[clusterArn] = cluster
+	clusters[clusterArn] = cluster
 
 	return cloneCluster(cluster), nil
 }
 
 // CreateServerlessCluster creates a new MSK Serverless cluster.
 func (b *InMemoryBackend) CreateServerlessCluster(
+	ctx context.Context,
 	name string,
 	serverless *ServerlessClusterInfo,
 	tags map[string]string,
@@ -507,16 +628,19 @@ func (b *InMemoryBackend) CreateServerlessCluster(
 		return nil, fmt.Errorf("clusterName is required: %w", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateServerlessCluster")
 	defer b.mu.Unlock()
 
-	for _, c := range b.clusters {
+	clusters := b.clustersStore(region)
+	for _, c := range clusters {
 		if c.ClusterName == name {
 			return nil, ErrAlreadyExists
 		}
 	}
 
-	clusterArn := b.clusterARN(name)
+	clusterArn := b.clusterARN(region, name)
 	cluster := &Cluster{
 		ClusterArn:     clusterArn,
 		ClusterName:    name,
@@ -526,17 +650,19 @@ func (b *InMemoryBackend) CreateServerlessCluster(
 		Tags:           nonNilTagsCopy(tags),
 		Serverless:     cloneServerless(serverless),
 	}
-	b.clusters[clusterArn] = cluster
+	clusters[clusterArn] = cluster
 
 	return cloneCluster(cluster), nil
 }
 
 // DescribeCluster retrieves a cluster by ARN.
-func (b *InMemoryBackend) DescribeCluster(clusterArn string) (*Cluster, error) {
+func (b *InMemoryBackend) DescribeCluster(ctx context.Context, clusterArn string) (*Cluster, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeCluster")
 	defer b.mu.RUnlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -544,13 +670,16 @@ func (b *InMemoryBackend) DescribeCluster(clusterArn string) (*Cluster, error) {
 	return cloneCluster(c), nil
 }
 
-// ListClusters returns all MSK clusters sorted by name.
-func (b *InMemoryBackend) ListClusters() []*Cluster {
+// ListClusters returns all MSK clusters in the request's region sorted by name.
+func (b *InMemoryBackend) ListClusters(ctx context.Context) []*Cluster {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListClusters")
 	defer b.mu.RUnlock()
 
-	out := make([]*Cluster, 0, len(b.clusters))
-	for _, c := range b.clusters {
+	clusters := b.clustersStore(region)
+	out := make([]*Cluster, 0, len(clusters))
+	for _, c := range clusters {
 		out = append(out, cloneCluster(c))
 	}
 
@@ -569,23 +698,27 @@ func (b *InMemoryBackend) ListClusters() []*Cluster {
 }
 
 // DeleteCluster deletes a cluster by ARN, cascading to its SCRAM secrets, topics and cluster policy.
-func (b *InMemoryBackend) DeleteCluster(clusterArn string) error {
+func (b *InMemoryBackend) DeleteCluster(ctx context.Context, clusterArn string) error {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("DeleteCluster")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	clusters := b.clustersStore(region)
+	if _, ok := clusters[clusterArn]; !ok {
 		return ErrNotFound
 	}
 
-	delete(b.clusters, clusterArn)
-	delete(b.scramSecrets, clusterArn)
-	delete(b.clusterPolicies, clusterArn)
+	delete(clusters, clusterArn)
+	delete(b.scramSecretsStore(region), clusterArn)
+	delete(b.clusterPoliciesStore(region), clusterArn)
 
 	// Remove all topics belonging to this cluster.
+	topics := b.topicsStore(region)
 	prefix := clusterArn + topicKeySeparator
-	for k := range b.topics {
+	for k := range topics {
 		if strings.HasPrefix(k, prefix) {
-			delete(b.topics, k)
+			delete(topics, k)
 		}
 	}
 
@@ -596,6 +729,7 @@ func (b *InMemoryBackend) DeleteCluster(clusterArn string) error {
 
 // CreateConfiguration creates a new MSK configuration.
 func (b *InMemoryBackend) CreateConfiguration(
+	ctx context.Context,
 	name, description string,
 	kafkaVersions []string,
 	serverProperties string,
@@ -604,16 +738,19 @@ func (b *InMemoryBackend) CreateConfiguration(
 		return nil, fmt.Errorf("name is required: %w", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateConfiguration")
 	defer b.mu.Unlock()
 
-	for _, c := range b.configurations {
+	configurations := b.configurationsStore(region)
+	for _, c := range configurations {
 		if c.Name == name {
 			return nil, ErrAlreadyExists
 		}
 	}
 
-	configArn := b.configurationARN(name)
+	configArn := b.configurationARN(region, name)
 	kvs := make([]string, len(kafkaVersions))
 	copy(kvs, kafkaVersions)
 	config := &Configuration{
@@ -624,17 +761,19 @@ func (b *InMemoryBackend) CreateConfiguration(
 		ServerProperties: serverProperties,
 		Tags:             make(map[string]string),
 	}
-	b.configurations[configArn] = config
+	configurations[configArn] = config
 
 	return cloneConfiguration(config), nil
 }
 
 // DescribeConfiguration retrieves a configuration by ARN.
-func (b *InMemoryBackend) DescribeConfiguration(configArn string) (*Configuration, error) {
+func (b *InMemoryBackend) DescribeConfiguration(ctx context.Context, configArn string) (*Configuration, error) {
+	region := regionFromARN(configArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeConfiguration")
 	defer b.mu.RUnlock()
 
-	c, ok := b.configurations[configArn]
+	c, ok := b.configurationsStore(region)[configArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -642,13 +781,16 @@ func (b *InMemoryBackend) DescribeConfiguration(configArn string) (*Configuratio
 	return cloneConfiguration(c), nil
 }
 
-// ListConfigurations returns all MSK configurations sorted by name.
-func (b *InMemoryBackend) ListConfigurations() []*Configuration {
+// ListConfigurations returns all MSK configurations in the request's region sorted by name.
+func (b *InMemoryBackend) ListConfigurations(ctx context.Context) []*Configuration {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListConfigurations")
 	defer b.mu.RUnlock()
 
-	out := make([]*Configuration, 0, len(b.configurations))
-	for _, c := range b.configurations {
+	configurations := b.configurationsStore(region)
+	out := make([]*Configuration, 0, len(configurations))
+	for _, c := range configurations {
 		out = append(out, cloneConfiguration(c))
 	}
 
@@ -667,15 +809,18 @@ func (b *InMemoryBackend) ListConfigurations() []*Configuration {
 }
 
 // DeleteConfiguration deletes a configuration by ARN.
-func (b *InMemoryBackend) DeleteConfiguration(configArn string) error {
+func (b *InMemoryBackend) DeleteConfiguration(ctx context.Context, configArn string) error {
+	region := regionFromARN(configArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("DeleteConfiguration")
 	defer b.mu.Unlock()
 
-	if _, ok := b.configurations[configArn]; !ok {
+	configurations := b.configurationsStore(region)
+	if _, ok := configurations[configArn]; !ok {
 		return ErrNotFound
 	}
 
-	delete(b.configurations, configArn)
+	delete(configurations, configArn)
 
 	return nil
 }
@@ -683,29 +828,31 @@ func (b *InMemoryBackend) DeleteConfiguration(configArn string) error {
 // --- Tag operations ---
 
 // TagResource adds tags to a cluster, configuration, replicator, or VPC connection by ARN.
-func (b *InMemoryBackend) TagResource(resourceArn string, tags map[string]string) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceArn string, tags map[string]string) error {
+	region := regionFromARN(resourceArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	if c, ok := b.clusters[resourceArn]; ok {
+	if c, ok := b.clustersStore(region)[resourceArn]; ok {
 		maps.Copy(c.Tags, tags)
 
 		return nil
 	}
 
-	if c, ok := b.configurations[resourceArn]; ok {
+	if c, ok := b.configurationsStore(region)[resourceArn]; ok {
 		maps.Copy(c.Tags, tags)
 
 		return nil
 	}
 
-	if r, ok := b.replicators[resourceArn]; ok {
+	if r, ok := b.replicatorsStore(region)[resourceArn]; ok {
 		maps.Copy(r.Tags, tags)
 
 		return nil
 	}
 
-	if v, ok := b.vpcConnections[resourceArn]; ok {
+	if v, ok := b.vpcConnectionsStore(region)[resourceArn]; ok {
 		maps.Copy(v.Tags, tags)
 
 		return nil
@@ -715,11 +862,13 @@ func (b *InMemoryBackend) TagResource(resourceArn string, tags map[string]string
 }
 
 // UntagResource removes tags from a cluster, configuration, replicator, or VPC connection by ARN.
-func (b *InMemoryBackend) UntagResource(resourceArn string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceArn string, tagKeys []string) error {
+	region := regionFromARN(resourceArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	if c, ok := b.clusters[resourceArn]; ok {
+	if c, ok := b.clustersStore(region)[resourceArn]; ok {
 		for _, k := range tagKeys {
 			delete(c.Tags, k)
 		}
@@ -727,7 +876,7 @@ func (b *InMemoryBackend) UntagResource(resourceArn string, tagKeys []string) er
 		return nil
 	}
 
-	if c, ok := b.configurations[resourceArn]; ok {
+	if c, ok := b.configurationsStore(region)[resourceArn]; ok {
 		for _, k := range tagKeys {
 			delete(c.Tags, k)
 		}
@@ -735,7 +884,7 @@ func (b *InMemoryBackend) UntagResource(resourceArn string, tagKeys []string) er
 		return nil
 	}
 
-	if r, ok := b.replicators[resourceArn]; ok {
+	if r, ok := b.replicatorsStore(region)[resourceArn]; ok {
 		for _, k := range tagKeys {
 			delete(r.Tags, k)
 		}
@@ -743,7 +892,7 @@ func (b *InMemoryBackend) UntagResource(resourceArn string, tagKeys []string) er
 		return nil
 	}
 
-	if v, ok := b.vpcConnections[resourceArn]; ok {
+	if v, ok := b.vpcConnectionsStore(region)[resourceArn]; ok {
 		for _, k := range tagKeys {
 			delete(v.Tags, k)
 		}
@@ -755,23 +904,25 @@ func (b *InMemoryBackend) UntagResource(resourceArn string, tagKeys []string) er
 }
 
 // GetTags retrieves tags for a cluster, configuration, replicator, or VPC connection by ARN.
-func (b *InMemoryBackend) GetTags(resourceArn string) (map[string]string, error) {
+func (b *InMemoryBackend) GetTags(ctx context.Context, resourceArn string) (map[string]string, error) {
+	region := regionFromARN(resourceArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("GetTags")
 	defer b.mu.RUnlock()
 
-	if c, ok := b.clusters[resourceArn]; ok {
+	if c, ok := b.clustersStore(region)[resourceArn]; ok {
 		return maps.Clone(c.Tags), nil
 	}
 
-	if c, ok := b.configurations[resourceArn]; ok {
+	if c, ok := b.configurationsStore(region)[resourceArn]; ok {
 		return maps.Clone(c.Tags), nil
 	}
 
-	if r, ok := b.replicators[resourceArn]; ok {
+	if r, ok := b.replicatorsStore(region)[resourceArn]; ok {
 		return maps.Clone(r.Tags), nil
 	}
 
-	if v, ok := b.vpcConnections[resourceArn]; ok {
+	if v, ok := b.vpcConnectionsStore(region)[resourceArn]; ok {
 		return maps.Clone(v.Tags), nil
 	}
 
@@ -783,17 +934,21 @@ func (b *InMemoryBackend) GetTags(resourceArn string) (map[string]string, error)
 // BatchAssociateScramSecret associates a list of SCRAM secrets with a cluster.
 // It returns any errors that occurred for individual secrets.
 func (b *InMemoryBackend) BatchAssociateScramSecret(
+	ctx context.Context,
 	clusterArn string,
 	secretArnList []string,
 ) ([]ScramSecretError, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("BatchAssociateScramSecret")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
-	existing := b.scramSecrets[clusterArn]
+	scramSecrets := b.scramSecretsStore(region)
+	existing := scramSecrets[clusterArn]
 	existingSet := make(map[string]struct{}, len(existing))
 
 	for _, s := range existing {
@@ -807,7 +962,7 @@ func (b *InMemoryBackend) BatchAssociateScramSecret(
 		}
 	}
 
-	b.scramSecrets[clusterArn] = existing
+	scramSecrets[clusterArn] = existing
 
 	return []ScramSecretError{}, nil
 }
@@ -815,13 +970,16 @@ func (b *InMemoryBackend) BatchAssociateScramSecret(
 // BatchDisassociateScramSecret disassociates a list of SCRAM secrets from a cluster.
 // It returns any errors that occurred for individual secrets.
 func (b *InMemoryBackend) BatchDisassociateScramSecret(
+	ctx context.Context,
 	clusterArn string,
 	secretArnList []string,
 ) ([]ScramSecretError, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("BatchDisassociateScramSecret")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
@@ -831,7 +989,8 @@ func (b *InMemoryBackend) BatchDisassociateScramSecret(
 		removeSet[s] = struct{}{}
 	}
 
-	existing := b.scramSecrets[clusterArn]
+	scramSecrets := b.scramSecretsStore(region)
+	existing := scramSecrets[clusterArn]
 	kept := make([]string, 0, len(existing))
 
 	for _, s := range existing {
@@ -840,7 +999,7 @@ func (b *InMemoryBackend) BatchDisassociateScramSecret(
 		}
 	}
 
-	b.scramSecrets[clusterArn] = kept
+	scramSecrets[clusterArn] = kept
 
 	return []ScramSecretError{}, nil
 }
@@ -849,6 +1008,7 @@ func (b *InMemoryBackend) BatchDisassociateScramSecret(
 
 // CreateReplicator creates a new MSK replicator.
 func (b *InMemoryBackend) CreateReplicator(
+	ctx context.Context,
 	name, description, serviceExecutionRoleArn string,
 	tags map[string]string,
 ) (*Replicator, error) {
@@ -856,16 +1016,19 @@ func (b *InMemoryBackend) CreateReplicator(
 		return nil, fmt.Errorf("replicatorName is required: %w", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateReplicator")
 	defer b.mu.Unlock()
 
-	for _, r := range b.replicators {
+	replicators := b.replicatorsStore(region)
+	for _, r := range replicators {
 		if r.ReplicatorName == name {
 			return nil, ErrAlreadyExists
 		}
 	}
 
-	replicatorArn := b.replicatorARN(name)
+	replicatorArn := b.replicatorARN(region, name)
 	replicator := &Replicator{
 		ReplicatorArn:           replicatorArn,
 		ReplicatorName:          name,
@@ -874,21 +1037,24 @@ func (b *InMemoryBackend) CreateReplicator(
 		ReplicatorState:         ReplicatorStateRunning,
 		Tags:                    nonNilTagsCopy(tags),
 	}
-	b.replicators[replicatorArn] = replicator
+	replicators[replicatorArn] = replicator
 
 	return cloneReplicator(replicator), nil
 }
 
 // DeleteReplicator deletes a replicator by ARN.
-func (b *InMemoryBackend) DeleteReplicator(replicatorArn string) error {
+func (b *InMemoryBackend) DeleteReplicator(ctx context.Context, replicatorArn string) error {
+	region := regionFromARN(replicatorArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("DeleteReplicator")
 	defer b.mu.Unlock()
 
-	if _, ok := b.replicators[replicatorArn]; !ok {
+	replicators := b.replicatorsStore(region)
+	if _, ok := replicators[replicatorArn]; !ok {
 		return ErrNotFound
 	}
 
-	delete(b.replicators, replicatorArn)
+	delete(replicators, replicatorArn)
 
 	return nil
 }
@@ -897,6 +1063,7 @@ func (b *InMemoryBackend) DeleteReplicator(replicatorArn string) error {
 
 // CreateTopic creates a topic on an MSK cluster.
 func (b *InMemoryBackend) CreateTopic(
+	ctx context.Context,
 	clusterArn, topicName string,
 	replicationFactor, numPartitions int32,
 	configEntries map[string]string,
@@ -905,15 +1072,18 @@ func (b *InMemoryBackend) CreateTopic(
 		return nil, fmt.Errorf("topicName is required: %w", ErrValidation)
 	}
 
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("CreateTopic")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
+	topics := b.topicsStore(region)
 	key := topicKey(clusterArn, topicName)
-	if _, ok := b.topics[key]; ok {
+	if _, ok := topics[key]; ok {
 		return nil, ErrAlreadyExists
 	}
 
@@ -924,26 +1094,29 @@ func (b *InMemoryBackend) CreateTopic(
 		NumPartitions:     numPartitions,
 		ConfigEntries:     nonNilMapCopy(configEntries),
 	}
-	b.topics[key] = topic
+	topics[key] = topic
 
 	return cloneTopic(topic), nil
 }
 
 // DeleteTopic deletes a topic from an MSK cluster.
-func (b *InMemoryBackend) DeleteTopic(clusterArn, topicName string) error {
+func (b *InMemoryBackend) DeleteTopic(ctx context.Context, clusterArn, topicName string) error {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("DeleteTopic")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return ErrNotFound
 	}
 
+	topics := b.topicsStore(region)
 	key := topicKey(clusterArn, topicName)
-	if _, ok := b.topics[key]; !ok {
+	if _, ok := topics[key]; !ok {
 		return ErrNotFound
 	}
 
-	delete(b.topics, key)
+	delete(topics, key)
 
 	return nil
 }
@@ -952,17 +1125,20 @@ func (b *InMemoryBackend) DeleteTopic(clusterArn, topicName string) error {
 
 // CreateVpcConnection creates a new VPC connection to an MSK cluster.
 func (b *InMemoryBackend) CreateVpcConnection(
+	ctx context.Context,
 	targetClusterArn, vpcID, authentication string,
 	tags map[string]string,
 ) (*VpcConnection, error) {
+	region := regionFromARN(targetClusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("CreateVpcConnection")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[targetClusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[targetClusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
-	vpcConnectionArn := b.vpcConnectionARN(targetClusterArn, vpcID)
+	vpcConnectionArn := b.vpcConnectionARN(region, targetClusterArn, vpcID)
 	conn := &VpcConnection{
 		VpcConnectionArn: vpcConnectionArn,
 		TargetClusterArn: targetClusterArn,
@@ -971,21 +1147,24 @@ func (b *InMemoryBackend) CreateVpcConnection(
 		State:            VpcConnectionStateAvailable,
 		Tags:             nonNilTagsCopy(tags),
 	}
-	b.vpcConnections[vpcConnectionArn] = conn
+	b.vpcConnectionsStore(region)[vpcConnectionArn] = conn
 
 	return cloneVpcConnection(conn), nil
 }
 
 // DeleteVpcConnection deletes a VPC connection by ARN.
-func (b *InMemoryBackend) DeleteVpcConnection(vpcConnectionArn string) error {
+func (b *InMemoryBackend) DeleteVpcConnection(ctx context.Context, vpcConnectionArn string) error {
+	region := regionFromARN(vpcConnectionArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("DeleteVpcConnection")
 	defer b.mu.Unlock()
 
-	if _, ok := b.vpcConnections[vpcConnectionArn]; !ok {
+	conns := b.vpcConnectionsStore(region)
+	if _, ok := conns[vpcConnectionArn]; !ok {
 		return ErrNotFound
 	}
 
-	delete(b.vpcConnections, vpcConnectionArn)
+	delete(conns, vpcConnectionArn)
 
 	return nil
 }
@@ -993,11 +1172,13 @@ func (b *InMemoryBackend) DeleteVpcConnection(vpcConnectionArn string) error {
 // --- Replicator describe/list/update operations ---
 
 // DescribeReplicator retrieves a replicator by ARN.
-func (b *InMemoryBackend) DescribeReplicator(replicatorArn string) (*Replicator, error) {
+func (b *InMemoryBackend) DescribeReplicator(ctx context.Context, replicatorArn string) (*Replicator, error) {
+	region := regionFromARN(replicatorArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeReplicator")
 	defer b.mu.RUnlock()
 
-	r, ok := b.replicators[replicatorArn]
+	r, ok := b.replicatorsStore(region)[replicatorArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1005,13 +1186,16 @@ func (b *InMemoryBackend) DescribeReplicator(replicatorArn string) (*Replicator,
 	return cloneReplicator(r), nil
 }
 
-// ListReplicators returns all replicators sorted by name.
-func (b *InMemoryBackend) ListReplicators() []*Replicator {
+// ListReplicators returns all replicators in the request's region sorted by name.
+func (b *InMemoryBackend) ListReplicators(ctx context.Context) []*Replicator {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListReplicators")
 	defer b.mu.RUnlock()
 
-	out := make([]*Replicator, 0, len(b.replicators))
-	for _, r := range b.replicators {
+	replicators := b.replicatorsStore(region)
+	out := make([]*Replicator, 0, len(replicators))
+	for _, r := range replicators {
 		out = append(out, cloneReplicator(r))
 	}
 
@@ -1031,12 +1215,15 @@ func (b *InMemoryBackend) ListReplicators() []*Replicator {
 
 // UpdateReplicationInfo updates the replicator description.
 func (b *InMemoryBackend) UpdateReplicationInfo(
+	ctx context.Context,
 	replicatorArn, description string,
 ) (*Replicator, error) {
+	region := regionFromARN(replicatorArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateReplicationInfo")
 	defer b.mu.Unlock()
 
-	r, ok := b.replicators[replicatorArn]
+	r, ok := b.replicatorsStore(region)[replicatorArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1049,12 +1236,14 @@ func (b *InMemoryBackend) UpdateReplicationInfo(
 // --- Topic describe/list/update operations ---
 
 // DescribeTopic retrieves a topic by cluster ARN and topic name.
-func (b *InMemoryBackend) DescribeTopic(clusterArn, topicName string) (*Topic, error) {
+func (b *InMemoryBackend) DescribeTopic(ctx context.Context, clusterArn, topicName string) (*Topic, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeTopic")
 	defer b.mu.RUnlock()
 
 	key := topicKey(clusterArn, topicName)
-	t, ok := b.topics[key]
+	t, ok := b.topicsStore(region)[key]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1063,23 +1252,26 @@ func (b *InMemoryBackend) DescribeTopic(clusterArn, topicName string) (*Topic, e
 }
 
 // DescribeTopicPartitions retrieves a topic's partition count.
-func (b *InMemoryBackend) DescribeTopicPartitions(clusterArn, topicName string) (*Topic, error) {
-	return b.DescribeTopic(clusterArn, topicName)
+func (b *InMemoryBackend) DescribeTopicPartitions(ctx context.Context, clusterArn, topicName string) (*Topic, error) {
+	return b.DescribeTopic(ctx, clusterArn, topicName)
 }
 
 // ListTopics returns all topics for a cluster sorted by topic name.
-func (b *InMemoryBackend) ListTopics(clusterArn string) ([]*Topic, error) {
+func (b *InMemoryBackend) ListTopics(ctx context.Context, clusterArn string) ([]*Topic, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("ListTopics")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
+	topics := b.topicsStore(region)
 	prefix := clusterArn + topicKeySeparator
-	out := make([]*Topic, 0, len(b.topics))
+	out := make([]*Topic, 0, len(topics))
 
-	for k, t := range b.topics {
+	for k, t := range topics {
 		if strings.HasPrefix(k, prefix) {
 			out = append(out, cloneTopic(t))
 		}
@@ -1101,15 +1293,18 @@ func (b *InMemoryBackend) ListTopics(clusterArn string) ([]*Topic, error) {
 
 // UpdateTopic updates a topic's config entries and/or partition count.
 func (b *InMemoryBackend) UpdateTopic(
+	ctx context.Context,
 	clusterArn, topicName string,
 	numPartitions int32,
 	configEntries map[string]string,
 ) (*Topic, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateTopic")
 	defer b.mu.Unlock()
 
 	key := topicKey(clusterArn, topicName)
-	t, ok := b.topics[key]
+	t, ok := b.topicsStore(region)[key]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1128,11 +1323,13 @@ func (b *InMemoryBackend) UpdateTopic(
 // --- VPC connection describe/list/reject operations ---
 
 // DescribeVpcConnection retrieves a VPC connection by ARN.
-func (b *InMemoryBackend) DescribeVpcConnection(vpcConnectionArn string) (*VpcConnection, error) {
+func (b *InMemoryBackend) DescribeVpcConnection(ctx context.Context, vpcConnectionArn string) (*VpcConnection, error) {
+	region := regionFromARN(vpcConnectionArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeVpcConnection")
 	defer b.mu.RUnlock()
 
-	v, ok := b.vpcConnections[vpcConnectionArn]
+	v, ok := b.vpcConnectionsStore(region)[vpcConnectionArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1140,13 +1337,16 @@ func (b *InMemoryBackend) DescribeVpcConnection(vpcConnectionArn string) (*VpcCo
 	return cloneVpcConnection(v), nil
 }
 
-// ListVpcConnections returns all VPC connections sorted by ARN.
-func (b *InMemoryBackend) ListVpcConnections() []*VpcConnection {
+// ListVpcConnections returns all VPC connections in the request's region sorted by ARN.
+func (b *InMemoryBackend) ListVpcConnections(ctx context.Context) []*VpcConnection {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListVpcConnections")
 	defer b.mu.RUnlock()
 
-	out := make([]*VpcConnection, 0, len(b.vpcConnections))
-	for _, v := range b.vpcConnections {
+	conns := b.vpcConnectionsStore(region)
+	out := make([]*VpcConnection, 0, len(conns))
+	for _, v := range conns {
 		out = append(out, cloneVpcConnection(v))
 	}
 
@@ -1164,55 +1364,71 @@ func (b *InMemoryBackend) ListVpcConnections() []*VpcConnection {
 	return out
 }
 
-// ListClientVpcConnections returns all VPC connections for a given cluster.
-func (b *InMemoryBackend) ListClientVpcConnections(clusterArn string) ([]*VpcConnection, error) {
-	b.mu.RLock("ListClientVpcConnections")
-	defer b.mu.RUnlock()
-
-	if _, ok := b.clusters[clusterArn]; !ok {
+// collectClusterChildrenLocked verifies the cluster exists in region, then returns
+// the clones of all items in store that belong to clusterArn (per belongsTo),
+// sorted ascending by sortKey. Callers must hold b.mu (read lock).
+func collectClusterChildrenLocked[T any](
+	clusters map[string]*Cluster,
+	store map[string]*T,
+	clusterArn string,
+	belongsTo func(*T) bool,
+	clone func(*T) *T,
+	sortKey func(*T) string,
+) ([]*T, error) {
+	if _, ok := clusters[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
-	out := make([]*VpcConnection, 0, len(b.vpcConnections))
+	out := make([]*T, 0, len(store))
 
-	for _, v := range b.vpcConnections {
-		if v.TargetClusterArn == clusterArn {
-			out = append(out, cloneVpcConnection(v))
+	for _, item := range store {
+		if belongsTo(item) {
+			out = append(out, clone(item))
 		}
 	}
 
-	slices.SortFunc(out, func(a, b *VpcConnection) int {
-		if a.VpcConnectionArn < b.VpcConnectionArn {
-			return -1
-		}
-		if a.VpcConnectionArn > b.VpcConnectionArn {
-			return 1
-		}
-
-		return 0
-	})
+	slices.SortFunc(out, func(a, b *T) int { return strings.Compare(sortKey(a), sortKey(b)) })
 
 	return out, nil
 }
 
+// ListClientVpcConnections returns all VPC connections for a given cluster.
+func (b *InMemoryBackend) ListClientVpcConnections(ctx context.Context, clusterArn string) ([]*VpcConnection, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
+	b.mu.RLock("ListClientVpcConnections")
+	defer b.mu.RUnlock()
+
+	return collectClusterChildrenLocked(
+		b.clustersStore(region),
+		b.vpcConnectionsStore(region),
+		clusterArn,
+		func(v *VpcConnection) bool { return v.TargetClusterArn == clusterArn },
+		cloneVpcConnection,
+		func(v *VpcConnection) string { return v.VpcConnectionArn },
+	)
+}
+
 // RejectClientVpcConnection rejects (deletes) a VPC connection.
-func (b *InMemoryBackend) RejectClientVpcConnection(vpcConnectionArn string) error {
-	return b.DeleteVpcConnection(vpcConnectionArn)
+func (b *InMemoryBackend) RejectClientVpcConnection(ctx context.Context, vpcConnectionArn string) error {
+	return b.DeleteVpcConnection(ctx, vpcConnectionArn)
 }
 
 // --- Cluster policy get/put operations ---
 
 // GetClusterPolicy retrieves the policy document for a cluster.
 // Returns ErrNotFound when the cluster exists but has no policy set — matching AWS behavior.
-func (b *InMemoryBackend) GetClusterPolicy(clusterArn string) (string, error) {
+func (b *InMemoryBackend) GetClusterPolicy(ctx context.Context, clusterArn string) (string, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("GetClusterPolicy")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return "", ErrNotFound
 	}
 
-	policy, ok := b.clusterPolicies[clusterArn]
+	policy, ok := b.clusterPoliciesStore(region)[clusterArn]
 	if !ok {
 		return "", fmt.Errorf("no resource-based policy found for cluster %q: %w", clusterArn, ErrNotFound)
 	}
@@ -1221,15 +1437,17 @@ func (b *InMemoryBackend) GetClusterPolicy(clusterArn string) (string, error) {
 }
 
 // PutClusterPolicy sets the policy document for a cluster.
-func (b *InMemoryBackend) PutClusterPolicy(clusterArn, policy string) error {
+func (b *InMemoryBackend) PutClusterPolicy(ctx context.Context, clusterArn, policy string) error {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("PutClusterPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return ErrNotFound
 	}
 
-	b.clusterPolicies[clusterArn] = policy
+	b.clusterPoliciesStore(region)[clusterArn] = policy
 
 	return nil
 }
@@ -1237,46 +1455,33 @@ func (b *InMemoryBackend) PutClusterPolicy(clusterArn, policy string) error {
 // --- Cluster operation list operations ---
 
 // ListClusterOperations returns all cluster operations for a cluster.
-func (b *InMemoryBackend) ListClusterOperations(clusterArn string) ([]*ClusterOperation, error) {
+func (b *InMemoryBackend) ListClusterOperations(ctx context.Context, clusterArn string) ([]*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("ListClusterOperations")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
-		return nil, ErrNotFound
-	}
-
-	out := make([]*ClusterOperation, 0, len(b.clusterOperations))
-
-	for _, op := range b.clusterOperations {
-		if op.ClusterArn == clusterArn {
-			out = append(out, cloneClusterOperation(op))
-		}
-	}
-
-	slices.SortFunc(out, func(a, b *ClusterOperation) int {
-		if a.ClusterOperationArn < b.ClusterOperationArn {
-			return -1
-		}
-		if a.ClusterOperationArn > b.ClusterOperationArn {
-			return 1
-		}
-
-		return 0
-	})
-
-	return out, nil
+	return collectClusterChildrenLocked(
+		b.clustersStore(region),
+		b.clusterOperationsStore(region),
+		clusterArn,
+		func(op *ClusterOperation) bool { return op.ClusterArn == clusterArn },
+		cloneClusterOperation,
+		func(op *ClusterOperation) string { return op.ClusterOperationArn },
+	)
 }
 
 // DescribeClusterOperationV2 retrieves a cluster operation (V2) by ARN.
 func (b *InMemoryBackend) DescribeClusterOperationV2(
+	ctx context.Context,
 	clusterOperationArn string,
 ) (*ClusterOperation, error) {
-	return b.DescribeClusterOperation(clusterOperationArn)
+	return b.DescribeClusterOperation(ctx, clusterOperationArn)
 }
 
 // ListClusterOperationsV2 returns all cluster operations for a cluster (V2).
-func (b *InMemoryBackend) ListClusterOperationsV2(clusterArn string) ([]*ClusterOperation, error) {
-	return b.ListClusterOperations(clusterArn)
+func (b *InMemoryBackend) ListClusterOperationsV2(ctx context.Context, clusterArn string) ([]*ClusterOperation, error) {
+	return b.ListClusterOperations(ctx, clusterArn)
 }
 
 // --- Configuration revision operations ---
@@ -1292,13 +1497,16 @@ type ConfigurationRevision struct {
 // DescribeConfigurationRevision retrieves a configuration revision.
 // In this stub, revision 1 always refers to the current configuration state.
 func (b *InMemoryBackend) DescribeConfigurationRevision(
+	ctx context.Context,
 	configArn string,
 	revision int64,
 ) (*ConfigurationRevision, error) {
+	region := regionFromARN(configArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeConfigurationRevision")
 	defer b.mu.RUnlock()
 
-	c, ok := b.configurations[configArn]
+	c, ok := b.configurationsStore(region)[configArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1313,12 +1521,15 @@ func (b *InMemoryBackend) DescribeConfigurationRevision(
 
 // UpdateConfiguration updates a configuration's server properties and description.
 func (b *InMemoryBackend) UpdateConfiguration(
+	ctx context.Context,
 	configArn, description, serverProperties string,
 ) (*Configuration, error) {
+	region := regionFromARN(configArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateConfiguration")
 	defer b.mu.Unlock()
 
-	c, ok := b.configurations[configArn]
+	c, ok := b.configurationsStore(region)[configArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1337,12 +1548,15 @@ func (b *InMemoryBackend) UpdateConfiguration(
 // ListConfigurationRevisions lists revisions for a configuration.
 // In this stub, every configuration has a single revision (revision 1).
 func (b *InMemoryBackend) ListConfigurationRevisions(
+	ctx context.Context,
 	configArn string,
 ) ([]*ConfigurationRevision, error) {
+	region := regionFromARN(configArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("ListConfigurationRevisions")
 	defer b.mu.RUnlock()
 
-	c, ok := b.configurations[configArn]
+	c, ok := b.configurationsStore(region)[configArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1361,13 +1575,16 @@ func (b *InMemoryBackend) ListConfigurationRevisions(
 
 // UpdateBrokerCount updates the number of broker nodes in a cluster.
 func (b *InMemoryBackend) UpdateBrokerCount(
+	ctx context.Context,
 	clusterArn string,
 	numBrokers int32,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateBrokerCount")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1375,20 +1592,23 @@ func (b *InMemoryBackend) UpdateBrokerCount(
 	source := &MutableClusterInfo{NumberOfBrokerNodes: c.NumberOfBrokerNodes}
 	c.NumberOfBrokerNodes = numBrokers
 	target := &MutableClusterInfo{NumberOfBrokerNodes: numBrokers}
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_BROKER_COUNT", source, target)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_BROKER_COUNT", source, target)
 
 	return op, nil
 }
 
 // UpdateBrokerStorage updates the EBS storage size for broker nodes.
 func (b *InMemoryBackend) UpdateBrokerStorage(
+	ctx context.Context,
 	clusterArn string,
 	volumeSize int32,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateBrokerStorage")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1403,38 +1623,44 @@ func (b *InMemoryBackend) UpdateBrokerStorage(
 
 	c.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.VolumeSize = volumeSize
 	target := &MutableClusterInfo{BrokerEBSVolumeInfo: []BrokerEBSVolumeInfo{{VolumeSizeGB: volumeSize}}}
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_BROKER_STORAGE", nil, target)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_BROKER_STORAGE", nil, target)
 
 	return op, nil
 }
 
 // UpdateBrokerType updates the instance type for broker nodes.
 func (b *InMemoryBackend) UpdateBrokerType(
+	ctx context.Context,
 	clusterArn, instanceType string,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateBrokerType")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
 
 	c.BrokerNodeGroupInfo.InstanceType = instanceType
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_BROKER_TYPE", nil, nil)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_BROKER_TYPE", nil, nil)
 
 	return op, nil
 }
 
 // UpdateClusterConfiguration updates the configuration for a cluster.
 func (b *InMemoryBackend) UpdateClusterConfiguration(
+	ctx context.Context,
 	clusterArn, configArn string,
 	revision int64,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateClusterConfiguration")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1443,25 +1669,28 @@ func (b *InMemoryBackend) UpdateClusterConfiguration(
 		Arn:      configArn,
 		Revision: revision,
 	}
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CLUSTER_CONFIGURATION", nil, nil)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_CLUSTER_CONFIGURATION", nil, nil)
 
 	return op, nil
 }
 
 // UpdateClusterKafkaVersion updates the Kafka version for a cluster.
 func (b *InMemoryBackend) UpdateClusterKafkaVersion(
+	ctx context.Context,
 	clusterArn, targetKafkaVersion string,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateClusterKafkaVersion")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
 
 	c.KafkaVersion = targetKafkaVersion
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CLUSTER_KAFKA_VERSION", nil, nil)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_CLUSTER_KAFKA_VERSION", nil, nil)
 
 	return op, nil
 }
@@ -1495,12 +1724,15 @@ type UpdateStorageSettings struct {
 // the new ConnectivityInfo onto the broker node group and recording an operation
 // whose source/target reflect the before/after state.
 func (b *InMemoryBackend) UpdateConnectivity(
+	ctx context.Context,
 	clusterArn string, settings UpdateConnectivitySettings,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateConnectivity")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1514,7 +1746,7 @@ func (b *InMemoryBackend) UpdateConnectivity(
 		c.BrokerNodeGroupInfo.ConnectivityInfo = cloneConnectivityInfo(settings.ConnectivityInfo)
 	}
 
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_CONNECTIVITY", source, target)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_CONNECTIVITY", source, target)
 
 	return op, nil
 }
@@ -1522,12 +1754,15 @@ func (b *InMemoryBackend) UpdateConnectivity(
 // UpdateMonitoring updates monitoring/logging settings for a cluster, persisting the
 // new EnhancedMonitoring/OpenMonitoring/LoggingInfo and recording an operation.
 func (b *InMemoryBackend) UpdateMonitoring(
+	ctx context.Context,
 	clusterArn string, settings UpdateMonitoringSettings,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateMonitoring")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1553,7 +1788,7 @@ func (b *InMemoryBackend) UpdateMonitoring(
 		c.LoggingInfo = cloneLoggingInfo(settings.LoggingInfo)
 	}
 
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_MONITORING", source, target)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_MONITORING", source, target)
 
 	return op, nil
 }
@@ -1561,15 +1796,17 @@ func (b *InMemoryBackend) UpdateMonitoring(
 // UpdateRebalancing records a rebalancing operation for a cluster. AWS MSK exposes
 // no per-field rebalancing configuration to persist (it is an action, not a setting),
 // so this validates the cluster and records the operation.
-func (b *InMemoryBackend) UpdateRebalancing(clusterArn string) (*ClusterOperation, error) {
+func (b *InMemoryBackend) UpdateRebalancing(ctx context.Context, clusterArn string) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateRebalancing")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_REBALANCING", nil, nil)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_REBALANCING", nil, nil)
 
 	return op, nil
 }
@@ -1577,12 +1814,15 @@ func (b *InMemoryBackend) UpdateRebalancing(clusterArn string) (*ClusterOperatio
 // UpdateSecurity updates authentication/encryption settings for a cluster, persisting
 // the new ClientAuthentication/EncryptionInfo and recording an operation.
 func (b *InMemoryBackend) UpdateSecurity(
+	ctx context.Context,
 	clusterArn string, settings UpdateSecuritySettings,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateSecurity")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1603,7 +1843,7 @@ func (b *InMemoryBackend) UpdateSecurity(
 		c.EncryptionInfo = cloneEncryptionInfo(settings.EncryptionInfo)
 	}
 
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_SECURITY", source, target)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_SECURITY", source, target)
 
 	return op, nil
 }
@@ -1611,12 +1851,15 @@ func (b *InMemoryBackend) UpdateSecurity(
 // UpdateStorage updates broker storage settings for a cluster, persisting the new
 // StorageMode and EBS volume size/throughput and recording an operation.
 func (b *InMemoryBackend) UpdateStorage(
+	ctx context.Context,
 	clusterArn string, settings UpdateStorageSettings,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("UpdateStorage")
 	defer b.mu.Unlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1644,7 +1887,7 @@ func (b *InMemoryBackend) UpdateStorage(
 		applyStorageUpdateLocked(c, settings)
 	}
 
-	op := b.newClusterOperationLocked(clusterArn, "UPDATE_STORAGE", source, target)
+	op := b.newClusterOperationLocked(region, clusterArn, "UPDATE_STORAGE", source, target)
 
 	return op, nil
 }
@@ -1678,15 +1921,17 @@ func cloneProvisionedThroughput(pt *ProvisionedThroughput) *ProvisionedThroughpu
 }
 
 // RebootBroker initiates a broker reboot operation.
-func (b *InMemoryBackend) RebootBroker(clusterArn string, _ []string) (*ClusterOperation, error) {
+func (b *InMemoryBackend) RebootBroker(ctx context.Context, clusterArn string, _ []string) (*ClusterOperation, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("RebootBroker")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
-	op := b.newClusterOperationLocked(clusterArn, "REBOOT_BROKER", nil, nil)
+	op := b.newClusterOperationLocked(region, clusterArn, "REBOOT_BROKER", nil, nil)
 
 	return op, nil
 }
@@ -1694,15 +1939,17 @@ func (b *InMemoryBackend) RebootBroker(clusterArn string, _ []string) (*ClusterO
 // --- SCRAM secret list operations ---
 
 // ListScramSecrets returns all SCRAM secrets for a cluster.
-func (b *InMemoryBackend) ListScramSecrets(clusterArn string) ([]string, error) {
+func (b *InMemoryBackend) ListScramSecrets(ctx context.Context, clusterArn string) ([]string, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("ListScramSecrets")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return nil, ErrNotFound
 	}
 
-	secrets := b.scramSecrets[clusterArn]
+	secrets := b.scramSecretsStore(region)[clusterArn]
 	out := make([]string, len(secrets))
 	copy(out, secrets)
 
@@ -1712,11 +1959,13 @@ func (b *InMemoryBackend) ListScramSecrets(clusterArn string) ([]string, error) 
 // --- Misc read ops ---
 
 // ListNodes returns broker node stubs for a cluster.
-func (b *InMemoryBackend) ListNodes(clusterArn string) ([]*BrokerNode, error) {
+func (b *InMemoryBackend) ListNodes(ctx context.Context, clusterArn string) ([]*BrokerNode, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("ListNodes")
 	defer b.mu.RUnlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1734,12 +1983,13 @@ func (b *InMemoryBackend) ListNodes(clusterArn string) ([]*BrokerNode, error) {
 }
 
 // ListKafkaVersions returns supported Kafka versions, matching current MSK availability.
-func (b *InMemoryBackend) ListKafkaVersions() []*MSKVersion {
+// Kafka versions are global (not region-scoped), so ctx is unused.
+func (b *InMemoryBackend) ListKafkaVersions(_ context.Context) []*MSKVersion {
 	return []*MSKVersion{
 		{Version: "3.8.0.kraft", Status: ClusterStateActive},
 		{Version: "3.7.x.kraft", Status: ClusterStateActive},
-		{Version: "3.6.0", Status: ClusterStateActive},
-		{Version: "3.5.1", Status: ClusterStateActive},
+		{Version: kafkaVersion360, Status: ClusterStateActive},
+		{Version: kafkaVersion351, Status: ClusterStateActive},
 		{Version: "3.4.0", Status: ClusterStateActive},
 		{Version: "3.3.2", Status: ClusterStateActive},
 		{Version: "3.3.1", Status: ClusterStateActive},
@@ -1752,11 +2002,13 @@ func (b *InMemoryBackend) ListKafkaVersions() []*MSKVersion {
 
 // GetCompatibleKafkaVersions returns Kafka versions compatible with the cluster's current version.
 // KRaft clusters can only target KRaft versions. ZooKeeper clusters can target ZooKeeper versions up to 3.x.
-func (b *InMemoryBackend) GetCompatibleKafkaVersions(clusterArn string) ([]*MSKVersion, error) {
+func (b *InMemoryBackend) GetCompatibleKafkaVersions(ctx context.Context, clusterArn string) ([]*MSKVersion, error) {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("GetCompatibleKafkaVersions")
 	defer b.mu.RUnlock()
 
-	c, ok := b.clusters[clusterArn]
+	c, ok := b.clustersStore(region)[clusterArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1774,8 +2026,8 @@ func (b *InMemoryBackend) GetCompatibleKafkaVersions(clusterArn string) ([]*MSKV
 	// ZooKeeper-based: return non-KRaft active versions higher than current.
 	// For simplicity, return a curated list of ZooKeeper-compatible upgrades.
 	return []*MSKVersion{
-		{Version: "3.6.0", Status: ClusterStateActive},
-		{Version: "3.5.1", Status: ClusterStateActive},
+		{Version: kafkaVersion360, Status: ClusterStateActive},
+		{Version: kafkaVersion351, Status: ClusterStateActive},
 		{Version: "3.4.0", Status: ClusterStateActive},
 		{Version: "3.3.2", Status: ClusterStateActive},
 		{Version: "2.8.2.tiered", Status: ClusterStateActive},
@@ -1797,9 +2049,9 @@ type MSKVersion struct {
 // newClusterOperationLocked creates and stores a cluster operation.
 // MUST be called with b.mu write lock held.
 func (b *InMemoryBackend) newClusterOperationLocked(
-	clusterArn, operationType string, source, target *MutableClusterInfo,
+	region, clusterArn, operationType string, source, target *MutableClusterInfo,
 ) *ClusterOperation {
-	clusterOperationArn := b.clusterOperationARN(clusterArn)
+	clusterOperationArn := b.clusterOperationARN(region, clusterArn)
 	op := &ClusterOperation{
 		ClusterOperationArn: clusterOperationArn,
 		ClusterArn:          clusterArn,
@@ -1808,7 +2060,7 @@ func (b *InMemoryBackend) newClusterOperationLocked(
 		SourceClusterInfo:   source,
 		TargetClusterInfo:   target,
 	}
-	b.clusterOperations[clusterOperationArn] = op
+	b.clusterOperationsStore(region)[clusterOperationArn] = op
 
 	return cloneClusterOperation(op)
 }
@@ -1816,15 +2068,17 @@ func (b *InMemoryBackend) newClusterOperationLocked(
 // --- Cluster policy operations ---
 
 // DeleteClusterPolicy deletes the policy attached to an MSK cluster.
-func (b *InMemoryBackend) DeleteClusterPolicy(clusterArn string) error {
+func (b *InMemoryBackend) DeleteClusterPolicy(ctx context.Context, clusterArn string) error {
+	region := regionFromARN(clusterArn, getRegion(ctx, b.region))
+
 	b.mu.Lock("DeleteClusterPolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.clusters[clusterArn]; !ok {
+	if _, ok := b.clustersStore(region)[clusterArn]; !ok {
 		return ErrNotFound
 	}
 
-	delete(b.clusterPolicies, clusterArn)
+	delete(b.clusterPoliciesStore(region), clusterArn)
 
 	return nil
 }
@@ -1833,12 +2087,15 @@ func (b *InMemoryBackend) DeleteClusterPolicy(clusterArn string) error {
 
 // DescribeClusterOperation retrieves a cluster operation by ARN.
 func (b *InMemoryBackend) DescribeClusterOperation(
+	ctx context.Context,
 	clusterOperationArn string,
 ) (*ClusterOperation, error) {
+	region := regionFromARN(clusterOperationArn, getRegion(ctx, b.region))
+
 	b.mu.RLock("DescribeClusterOperation")
 	defer b.mu.RUnlock()
 
-	op, ok := b.clusterOperations[clusterOperationArn]
+	op, ok := b.clusterOperationsStore(region)[clusterOperationArn]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1853,14 +2110,15 @@ func (b *InMemoryBackend) AddClusterOperationInternal(
 	b.mu.Lock("AddClusterOperationInternal")
 	defer b.mu.Unlock()
 
-	clusterOperationArn := b.clusterOperationARN(clusterArn)
+	region := regionFromARN(clusterArn, b.region)
+	clusterOperationArn := b.clusterOperationARN(region, clusterArn)
 	op := &ClusterOperation{
 		ClusterOperationArn: clusterOperationArn,
 		ClusterArn:          clusterArn,
 		OperationType:       operationType,
 		OperationState:      ClusterOperationStateUpdateComplete,
 	}
-	b.clusterOperations[clusterOperationArn] = op
+	b.clusterOperationsStore(region)[clusterOperationArn] = op
 
 	return cloneClusterOperation(op)
 }
@@ -1870,7 +2128,7 @@ func (b *InMemoryBackend) AddClusterInternal(name, kafkaVersion string) *Cluster
 	b.mu.Lock("AddClusterInternal")
 	defer b.mu.Unlock()
 
-	clusterArn := b.clusterARN(name)
+	clusterArn := b.clusterARN(b.region, name)
 	cluster := &Cluster{
 		ClusterArn:          clusterArn,
 		ClusterName:         name,
@@ -1881,7 +2139,7 @@ func (b *InMemoryBackend) AddClusterInternal(name, kafkaVersion string) *Cluster
 		CurrentVersion:      DefaultClusterVersion,
 		Tags:                make(map[string]string),
 	}
-	b.clusters[clusterArn] = cluster
+	b.clustersStore(b.region)[clusterArn] = cluster
 
 	return cloneCluster(cluster)
 }
@@ -1890,14 +2148,14 @@ func (b *InMemoryBackend) AddConfigurationInternal(name string) *Configuration {
 	b.mu.Lock("AddConfigurationInternal")
 	defer b.mu.Unlock()
 
-	configArn := b.configurationARN(name)
+	configArn := b.configurationARN(b.region, name)
 	config := &Configuration{
 		Arn:           configArn,
 		Name:          name,
 		KafkaVersions: []string{"2.8.0"},
 		Tags:          make(map[string]string),
 	}
-	b.configurations[configArn] = config
+	b.configurationsStore(b.region)[configArn] = config
 
 	return cloneConfiguration(config)
 }
@@ -1907,14 +2165,14 @@ func (b *InMemoryBackend) AddReplicatorInternal(name string) *Replicator {
 	b.mu.Lock("AddReplicatorInternal")
 	defer b.mu.Unlock()
 
-	replicatorArn := b.replicatorARN(name)
+	replicatorArn := b.replicatorARN(b.region, name)
 	replicator := &Replicator{
 		ReplicatorArn:   replicatorArn,
 		ReplicatorName:  name,
 		ReplicatorState: ReplicatorStateRunning,
 		Tags:            make(map[string]string),
 	}
-	b.replicators[replicatorArn] = replicator
+	b.replicatorsStore(b.region)[replicatorArn] = replicator
 
 	return cloneReplicator(replicator)
 }
@@ -1924,6 +2182,7 @@ func (b *InMemoryBackend) AddTopicInternal(clusterArn, topicName string) *Topic 
 	b.mu.Lock("AddTopicInternal")
 	defer b.mu.Unlock()
 
+	region := regionFromARN(clusterArn, b.region)
 	topic := &Topic{
 		TopicName:         topicName,
 		ClusterArn:        clusterArn,
@@ -1931,7 +2190,7 @@ func (b *InMemoryBackend) AddTopicInternal(clusterArn, topicName string) *Topic 
 		NumPartitions:     defaultPartitionCount,
 		ConfigEntries:     make(map[string]string),
 	}
-	b.topics[topicKey(clusterArn, topicName)] = topic
+	b.topicsStore(region)[topicKey(clusterArn, topicName)] = topic
 
 	return cloneTopic(topic)
 }
@@ -1941,7 +2200,8 @@ func (b *InMemoryBackend) AddVpcConnectionInternal(clusterArn, vpcID string) *Vp
 	b.mu.Lock("AddVpcConnectionInternal")
 	defer b.mu.Unlock()
 
-	vpcConnectionArn := b.vpcConnectionARN(clusterArn, vpcID)
+	region := regionFromARN(clusterArn, b.region)
+	vpcConnectionArn := b.vpcConnectionARN(region, clusterArn, vpcID)
 	conn := &VpcConnection{
 		VpcConnectionArn: vpcConnectionArn,
 		TargetClusterArn: clusterArn,
@@ -1949,7 +2209,7 @@ func (b *InMemoryBackend) AddVpcConnectionInternal(clusterArn, vpcID string) *Vp
 		State:            VpcConnectionStateAvailable,
 		Tags:             make(map[string]string),
 	}
-	b.vpcConnections[vpcConnectionArn] = conn
+	b.vpcConnectionsStore(region)[vpcConnectionArn] = conn
 
 	return cloneVpcConnection(conn)
 }

--- a/services/kafka/backend_test.go
+++ b/services/kafka/backend_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -62,11 +63,19 @@ func TestBackend_CreateCluster(t *testing.T) {
 
 			// Pre-create if testing duplicate
 			if tt.wantErr {
-				_, err := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				_, err := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 				require.NoError(t, err)
 			}
 
-			cluster, err := b.CreateCluster(
+			cluster, err := b.CreateCluster(context.Background(),
 				tt.clusterName,
 				"2.8.0",
 				3,
@@ -101,7 +110,15 @@ func TestBackend_DescribeCluster(t *testing.T) {
 		{
 			name: "existing_cluster",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, err := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, err := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 				if err != nil {
 					return ""
 				}
@@ -125,7 +142,7 @@ func TestBackend_DescribeCluster(t *testing.T) {
 			b := newTestBackend(t)
 			arn := tt.setup(b)
 
-			cluster, err := b.DescribeCluster(arn)
+			cluster, err := b.DescribeCluster(context.Background(), arn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -155,8 +172,24 @@ func TestBackend_ListClusters(t *testing.T) {
 		{
 			name: "multiple",
 			setup: func(b *kafka.InMemoryBackend) {
-				_, _ = b.CreateCluster("cluster-a", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
-				_, _ = b.CreateCluster("cluster-b", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				_, _ = b.CreateCluster(
+					context.Background(),
+					"cluster-a",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
+				_, _ = b.CreateCluster(
+					context.Background(),
+					"cluster-b",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 			},
 			wantCount: 2,
 		},
@@ -169,7 +202,7 @@ func TestBackend_ListClusters(t *testing.T) {
 			b := newTestBackend(t)
 			tt.setup(b)
 
-			clusters := b.ListClusters()
+			clusters := b.ListClusters(context.Background())
 			assert.Len(t, clusters, tt.wantCount)
 		})
 	}
@@ -186,7 +219,15 @@ func TestBackend_DeleteCluster(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn
 			},
@@ -207,7 +248,7 @@ func TestBackend_DeleteCluster(t *testing.T) {
 			b := newTestBackend(t)
 			arn := tt.setup(b)
 
-			err := b.DeleteCluster(arn)
+			err := b.DeleteCluster(context.Background(), arn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -217,7 +258,7 @@ func TestBackend_DeleteCluster(t *testing.T) {
 
 			require.NoError(t, err)
 
-			_, err = b.DescribeCluster(arn)
+			_, err = b.DescribeCluster(context.Background(), arn)
 			require.Error(t, err)
 		})
 	}
@@ -241,7 +282,13 @@ func TestBackend_CreateConfiguration(t *testing.T) {
 			name:     "duplicate_name",
 			confName: "my-config",
 			setup: func(b *kafka.InMemoryBackend) {
-				_, _ = b.CreateConfiguration("my-config", "", []string{"2.8.0"}, "auto.create.topics.enable=false")
+				_, _ = b.CreateConfiguration(
+					context.Background(),
+					"my-config",
+					"",
+					[]string{"2.8.0"},
+					"auto.create.topics.enable=false",
+				)
 			},
 			wantErr: true,
 		},
@@ -254,7 +301,7 @@ func TestBackend_CreateConfiguration(t *testing.T) {
 			b := newTestBackend(t)
 			tt.setup(b)
 
-			config, err := b.CreateConfiguration(
+			config, err := b.CreateConfiguration(context.Background(),
 				tt.confName,
 				"test config",
 				[]string{"2.8.0"},
@@ -286,7 +333,7 @@ func TestBackend_DescribeConfiguration(t *testing.T) {
 		{
 			name: "existing_config",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateConfiguration("my-config", "", []string{"2.8.0"}, "")
+				c, _ := b.CreateConfiguration(context.Background(), "my-config", "", []string{"2.8.0"}, "")
 
 				return c.Arn
 			},
@@ -307,7 +354,7 @@ func TestBackend_DescribeConfiguration(t *testing.T) {
 			b := newTestBackend(t)
 			arn := tt.setup(b)
 
-			config, err := b.DescribeConfiguration(arn)
+			config, err := b.DescribeConfiguration(context.Background(), arn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -335,7 +382,15 @@ func TestBackend_TagOperations(t *testing.T) {
 		{
 			name: "tag_and_untag_cluster",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("tagged-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"tagged-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn
 			},
@@ -368,7 +423,7 @@ func TestBackend_TagOperations(t *testing.T) {
 			arn := tt.setup(b)
 
 			if tt.tags != nil {
-				err := b.TagResource(arn, tt.tags)
+				err := b.TagResource(context.Background(), arn, tt.tags)
 
 				if tt.wantErr {
 					require.Error(t, err)
@@ -380,18 +435,18 @@ func TestBackend_TagOperations(t *testing.T) {
 			}
 
 			if tt.removKeys != nil {
-				err := b.UntagResource(arn, tt.removKeys)
+				err := b.UntagResource(context.Background(), arn, tt.removKeys)
 				require.NoError(t, err)
 			}
 
 			if !tt.wantErr && tt.wantTags != nil {
-				got, err := b.GetTags(arn)
+				got, err := b.GetTags(context.Background(), arn)
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantTags, got)
 			}
 
 			if tt.wantErr && tt.tags == nil {
-				_, err := b.GetTags(arn)
+				_, err := b.GetTags(context.Background(), arn)
 				require.Error(t, err)
 			}
 		})
@@ -410,7 +465,15 @@ func TestBackend_BatchAssociateScramSecret(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn
 			},
@@ -433,7 +496,7 @@ func TestBackend_BatchAssociateScramSecret(t *testing.T) {
 			b := newTestBackend(t)
 			clusterArn := tt.setup(b)
 
-			errs, err := b.BatchAssociateScramSecret(clusterArn, tt.secretArns)
+			errs, err := b.BatchAssociateScramSecret(context.Background(), clusterArn, tt.secretArns)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -459,8 +522,16 @@ func TestBackend_BatchDisassociateScramSecret(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
-				_, _ = b.BatchAssociateScramSecret(
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
+				_, _ = b.BatchAssociateScramSecret(context.Background(),
 					c.ClusterArn,
 					[]string{"arn:aws:secretsmanager:us-east-1:000000000000:secret/my-secret"},
 				)
@@ -486,7 +557,7 @@ func TestBackend_BatchDisassociateScramSecret(t *testing.T) {
 			b := newTestBackend(t)
 			clusterArn := tt.setup(b)
 
-			errs, err := b.BatchDisassociateScramSecret(clusterArn, tt.secretArns)
+			errs, err := b.BatchDisassociateScramSecret(context.Background(), clusterArn, tt.secretArns)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -518,7 +589,13 @@ func TestBackend_CreateReplicator(t *testing.T) {
 			name:    "duplicate_name",
 			repName: "my-replicator",
 			setup: func(b *kafka.InMemoryBackend) {
-				_, _ = b.CreateReplicator("my-replicator", "", "arn:aws:iam::000000000000:role/my-role", nil)
+				_, _ = b.CreateReplicator(
+					context.Background(),
+					"my-replicator",
+					"",
+					"arn:aws:iam::000000000000:role/my-role",
+					nil,
+				)
 			},
 			wantErr: true,
 		},
@@ -531,7 +608,7 @@ func TestBackend_CreateReplicator(t *testing.T) {
 			b := newTestBackend(t)
 			tt.setup(b)
 
-			replicator, err := b.CreateReplicator(
+			replicator, err := b.CreateReplicator(context.Background(),
 				tt.repName,
 				"test replicator",
 				"arn:aws:iam::000000000000:role/my-role",
@@ -563,7 +640,13 @@ func TestBackend_DeleteReplicator(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				r, _ := b.CreateReplicator("my-replicator", "", "arn:aws:iam::000000000000:role/my-role", nil)
+				r, _ := b.CreateReplicator(
+					context.Background(),
+					"my-replicator",
+					"",
+					"arn:aws:iam::000000000000:role/my-role",
+					nil,
+				)
 
 				return r.ReplicatorArn
 			},
@@ -584,7 +667,7 @@ func TestBackend_DeleteReplicator(t *testing.T) {
 			b := newTestBackend(t)
 			replicatorArn := tt.setup(b)
 
-			err := b.DeleteReplicator(replicatorArn)
+			err := b.DeleteReplicator(context.Background(), replicatorArn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -609,7 +692,15 @@ func TestBackend_CreateTopic(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn
 			},
@@ -618,8 +709,16 @@ func TestBackend_CreateTopic(t *testing.T) {
 		{
 			name: "duplicate_topic",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
-				_, _ = b.CreateTopic(c.ClusterArn, "my-topic", 1, 3, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
+				_, _ = b.CreateTopic(context.Background(), c.ClusterArn, "my-topic", 1, 3, nil)
 
 				return c.ClusterArn
 			},
@@ -643,7 +742,7 @@ func TestBackend_CreateTopic(t *testing.T) {
 			b := newTestBackend(t)
 			clusterArn := tt.setup(b)
 
-			topic, err := b.CreateTopic(clusterArn, tt.topicName, 1, 3, nil)
+			topic, err := b.CreateTopic(context.Background(), clusterArn, tt.topicName, 1, 3, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -669,8 +768,16 @@ func TestBackend_DeleteTopic(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) (string, string) {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
-				_, _ = b.CreateTopic(c.ClusterArn, "my-topic", 1, 3, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
+				_, _ = b.CreateTopic(context.Background(), c.ClusterArn, "my-topic", 1, 3, nil)
 
 				return c.ClusterArn, "my-topic"
 			},
@@ -678,7 +785,15 @@ func TestBackend_DeleteTopic(t *testing.T) {
 		{
 			name: "topic_not_found",
 			setup: func(b *kafka.InMemoryBackend) (string, string) {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn, "nonexistent-topic"
 			},
@@ -700,7 +815,7 @@ func TestBackend_DeleteTopic(t *testing.T) {
 			b := newTestBackend(t)
 			clusterArn, topicName := tt.setup(b)
 
-			err := b.DeleteTopic(clusterArn, topicName)
+			err := b.DeleteTopic(context.Background(), clusterArn, topicName)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -724,7 +839,15 @@ func TestBackend_CreateVpcConnection(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn
 			},
@@ -745,7 +868,7 @@ func TestBackend_CreateVpcConnection(t *testing.T) {
 			b := newTestBackend(t)
 			clusterArn := tt.setup(b)
 
-			conn, err := b.CreateVpcConnection(clusterArn, "vpc-12345", "SASL_IAM", nil)
+			conn, err := b.CreateVpcConnection(context.Background(), clusterArn, "vpc-12345", "SASL_IAM", nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -772,8 +895,16 @@ func TestBackend_DeleteVpcConnection(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
-				conn, _ := b.CreateVpcConnection(c.ClusterArn, "vpc-12345", "SASL_IAM", nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
+				conn, _ := b.CreateVpcConnection(context.Background(), c.ClusterArn, "vpc-12345", "SASL_IAM", nil)
 
 				return conn.VpcConnectionArn
 			},
@@ -794,7 +925,7 @@ func TestBackend_DeleteVpcConnection(t *testing.T) {
 			b := newTestBackend(t)
 			vpcConnectionArn := tt.setup(b)
 
-			err := b.DeleteVpcConnection(vpcConnectionArn)
+			err := b.DeleteVpcConnection(context.Background(), vpcConnectionArn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -818,7 +949,15 @@ func TestBackend_DeleteClusterPolicy(t *testing.T) {
 		{
 			name: "success_no_policy",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return c.ClusterArn
 			},
@@ -839,7 +978,7 @@ func TestBackend_DeleteClusterPolicy(t *testing.T) {
 			b := newTestBackend(t)
 			clusterArn := tt.setup(b)
 
-			err := b.DeleteClusterPolicy(clusterArn)
+			err := b.DeleteClusterPolicy(context.Background(), clusterArn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -863,7 +1002,15 @@ func TestBackend_DescribeClusterOperation(t *testing.T) {
 		{
 			name: "success",
 			setup: func(b *kafka.InMemoryBackend) string {
-				c, _ := b.CreateCluster("my-cluster", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				c, _ := b.CreateCluster(
+					context.Background(),
+					"my-cluster",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 				op := b.AddClusterOperationInternal(c.ClusterArn, "UPDATE_BROKER_COUNT")
 
 				return op.ClusterOperationArn
@@ -885,7 +1032,7 @@ func TestBackend_DescribeClusterOperation(t *testing.T) {
 			b := newTestBackend(t)
 			clusterOperationArn := tt.setup(b)
 
-			op, err := b.DescribeClusterOperation(clusterOperationArn)
+			op, err := b.DescribeClusterOperation(context.Background(), clusterOperationArn)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/services/kafka/coverage_ops_test.go
+++ b/services/kafka/coverage_ops_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -109,31 +110,37 @@ func TestKafkaCoverage_Topics(t *testing.T) {
 	clusterArn := createCoverageCluster(t, h, be, "topic-cluster")
 
 	// CreateTopic
-	topic, err := be.CreateTopic(clusterArn, "my-topic", 1, 3, nil)
+	topic, err := be.CreateTopic(context.Background(), clusterArn, "my-topic", 1, 3, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "my-topic", topic.TopicName)
 
 	// DescribeTopic (via DescribeTopicPartitions)
-	tp, err := be.DescribeTopicPartitions(clusterArn, "my-topic")
+	tp, err := be.DescribeTopicPartitions(context.Background(), clusterArn, "my-topic")
 	require.NoError(t, err)
 	assert.Equal(t, "my-topic", tp.TopicName)
 
 	// ListTopics
-	topics, err := be.ListTopics(clusterArn)
+	topics, err := be.ListTopics(context.Background(), clusterArn)
 	require.NoError(t, err)
 	assert.NotEmpty(t, topics)
 
 	// UpdateTopic
-	updated, err := be.UpdateTopic(clusterArn, "my-topic", 6, map[string]string{"retention.ms": "86400000"})
+	updated, err := be.UpdateTopic(
+		context.Background(),
+		clusterArn,
+		"my-topic",
+		6,
+		map[string]string{"retention.ms": "86400000"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, int32(6), updated.NumPartitions)
 
 	// DeleteTopic
-	err = be.DeleteTopic(clusterArn, "my-topic")
+	err = be.DeleteTopic(context.Background(), clusterArn, "my-topic")
 	require.NoError(t, err)
 
 	// DescribeTopic after delete → not found
-	_, err = be.DescribeTopicPartitions(clusterArn, "my-topic")
+	_, err = be.DescribeTopicPartitions(context.Background(), clusterArn, "my-topic")
 	assert.Error(t, err)
 }
 
@@ -145,11 +152,11 @@ func TestKafkaCoverage_DescribeTopic(t *testing.T) {
 	_ = be
 	clusterArn := createCoverageCluster(t, h, be2, "dt-cluster")
 
-	_, err := be2.CreateTopic(clusterArn, "dt-topic", 1, 1, nil)
+	_, err := be2.CreateTopic(context.Background(), clusterArn, "dt-topic", 1, 1, nil)
 	require.NoError(t, err)
 
 	// DescribeTopic
-	topic, err := be2.DescribeTopic(clusterArn, "dt-topic")
+	topic, err := be2.DescribeTopic(context.Background(), clusterArn, "dt-topic")
 	require.NoError(t, err)
 	assert.Equal(t, "dt-topic", topic.TopicName)
 }
@@ -161,26 +168,26 @@ func TestKafkaCoverage_VpcConnections(t *testing.T) {
 	clusterArn := createCoverageCluster(t, h, be, "vpc-cluster")
 
 	// CreateVpcConnection
-	conn, err := be.CreateVpcConnection(clusterArn, "vpc-abc", "PLAINTEXT", nil)
+	conn, err := be.CreateVpcConnection(context.Background(), clusterArn, "vpc-abc", "PLAINTEXT", nil)
 	require.NoError(t, err)
 	connArn := conn.VpcConnectionArn
 
 	// DescribeVpcConnection
-	c, err := be.DescribeVpcConnection(connArn)
+	c, err := be.DescribeVpcConnection(context.Background(), connArn)
 	require.NoError(t, err)
 	assert.Equal(t, connArn, c.VpcConnectionArn)
 
 	// ListVpcConnections
-	conns := be.ListVpcConnections()
+	conns := be.ListVpcConnections(context.Background())
 	assert.NotEmpty(t, conns)
 
 	// ListClientVpcConnections
-	clientConns, err := be.ListClientVpcConnections(clusterArn)
+	clientConns, err := be.ListClientVpcConnections(context.Background(), clusterArn)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientConns)
 
 	// RejectClientVpcConnection
-	err = be.RejectClientVpcConnection(connArn)
+	err = be.RejectClientVpcConnection(context.Background(), connArn)
 	require.NoError(t, err)
 }
 
@@ -192,10 +199,10 @@ func TestKafkaCoverage_ClusterPolicy(t *testing.T) {
 
 	policy := `{"Version":"2012-10-17","Statement":[]}`
 
-	err := be.PutClusterPolicy(clusterArn, policy)
+	err := be.PutClusterPolicy(context.Background(), clusterArn, policy)
 	require.NoError(t, err)
 
-	p, err := be.GetClusterPolicy(clusterArn)
+	p, err := be.GetClusterPolicy(context.Background(), clusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, policy, p)
 }
@@ -206,21 +213,21 @@ func TestKafkaCoverage_ClusterOperations(t *testing.T) {
 	h, be := newTestHandlerWithBackend(t)
 	clusterArn := createCoverageCluster(t, h, be, "ops-cluster")
 
-	_, err := be.UpdateBrokerCount(clusterArn, 2)
+	_, err := be.UpdateBrokerCount(context.Background(), clusterArn, 2)
 	require.NoError(t, err)
 
 	// ListClusterOperations
-	ops, err := be.ListClusterOperations(clusterArn)
+	ops, err := be.ListClusterOperations(context.Background(), clusterArn)
 	require.NoError(t, err)
 	assert.NotEmpty(t, ops)
 
 	// ListClusterOperationsV2
-	ops2, err := be.ListClusterOperationsV2(clusterArn)
+	ops2, err := be.ListClusterOperationsV2(context.Background(), clusterArn)
 	require.NoError(t, err)
 	assert.NotEmpty(t, ops2)
 
 	if len(ops2) > 0 {
-		op, opErr := be.DescribeClusterOperationV2(ops2[0].ClusterOperationArn)
+		op, opErr := be.DescribeClusterOperationV2(context.Background(), ops2[0].ClusterOperationArn)
 		require.NoError(t, opErr)
 		assert.Equal(t, ops2[0].ClusterOperationArn, op.ClusterOperationArn)
 	}
@@ -236,21 +243,27 @@ func TestKafkaCoverage_ConfigurationRevisions(t *testing.T) {
 	// Use backend directly for revision tests
 	_, be2 := newTestHandlerWithBackend(t)
 
-	cfg, err := be2.CreateConfiguration("cfg2", "", []string{"2.8.0"}, "auto.create.topics.enable=false")
+	cfg, err := be2.CreateConfiguration(
+		context.Background(),
+		"cfg2",
+		"",
+		[]string{"2.8.0"},
+		"auto.create.topics.enable=false",
+	)
 	require.NoError(t, err)
 
 	// DescribeConfigurationRevision
-	revision, err := be2.DescribeConfigurationRevision(cfg.Arn, 1)
+	revision, err := be2.DescribeConfigurationRevision(context.Background(), cfg.Arn, 1)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), revision.Revision)
 
 	// ListConfigurationRevisions
-	revs, err := be2.ListConfigurationRevisions(cfg.Arn)
+	revs, err := be2.ListConfigurationRevisions(context.Background(), cfg.Arn)
 	require.NoError(t, err)
 	assert.NotEmpty(t, revs)
 
 	// UpdateConfiguration (description, serverProperties)
-	updated, err := be2.UpdateConfiguration(cfg.Arn, "v2 desc", "auto.create.topics.enable=true")
+	updated, err := be2.UpdateConfiguration(context.Background(), cfg.Arn, "v2 desc", "auto.create.topics.enable=true")
 	require.NoError(t, err)
 	assert.NotEmpty(t, updated.Arn)
 }

--- a/services/kafka/export_test.go
+++ b/services/kafka/export_test.go
@@ -11,62 +11,94 @@ func ParseKafkaPathForTest(method, path string) (string, string) {
 	return parseKafkaPath(method, path)
 }
 
-// ClusterCount returns the number of clusters in the backend.
+// ClusterCount returns the number of clusters in the backend across all regions.
 func ClusterCount(b *InMemoryBackend) int {
 	b.mu.RLock("ClusterCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusters)
+	total := 0
+	for _, regionClusters := range b.clusters {
+		total += len(regionClusters)
+	}
+
+	return total
 }
 
-// ConfigurationCount returns the number of configurations in the backend.
+// ConfigurationCount returns the number of configurations in the backend across all regions.
 func ConfigurationCount(b *InMemoryBackend) int {
 	b.mu.RLock("ConfigurationCount")
 	defer b.mu.RUnlock()
 
-	return len(b.configurations)
+	total := 0
+	for _, regionConfigs := range b.configurations {
+		total += len(regionConfigs)
+	}
+
+	return total
 }
 
-// ReplicatorCount returns the number of replicators in the backend.
+// ReplicatorCount returns the number of replicators in the backend across all regions.
 func ReplicatorCount(b *InMemoryBackend) int {
 	b.mu.RLock("ReplicatorCount")
 	defer b.mu.RUnlock()
 
-	return len(b.replicators)
+	total := 0
+	for _, regionReplicators := range b.replicators {
+		total += len(regionReplicators)
+	}
+
+	return total
 }
 
-// TopicCount returns the number of topics in the backend.
+// TopicCount returns the number of topics in the backend across all regions.
 func TopicCount(b *InMemoryBackend) int {
 	b.mu.RLock("TopicCount")
 	defer b.mu.RUnlock()
 
-	return len(b.topics)
+	total := 0
+	for _, regionTopics := range b.topics {
+		total += len(regionTopics)
+	}
+
+	return total
 }
 
-// VpcConnectionCount returns the number of VPC connections in the backend.
+// VpcConnectionCount returns the number of VPC connections in the backend across all regions.
 func VpcConnectionCount(b *InMemoryBackend) int {
 	b.mu.RLock("VpcConnectionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.vpcConnections)
+	total := 0
+	for _, regionConns := range b.vpcConnections {
+		total += len(regionConns)
+	}
+
+	return total
 }
 
-// ClusterOperationCount returns the number of cluster operations in the backend.
+// ClusterOperationCount returns the number of cluster operations in the backend across all regions.
 func ClusterOperationCount(b *InMemoryBackend) int {
 	b.mu.RLock("ClusterOperationCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusterOperations)
+	total := 0
+	for _, regionOps := range b.clusterOperations {
+		total += len(regionOps)
+	}
+
+	return total
 }
 
-// ScramSecretCount returns the number of SCRAM secrets across all clusters.
+// ScramSecretCount returns the number of SCRAM secrets across all clusters and regions.
 func ScramSecretCount(b *InMemoryBackend) int {
 	b.mu.RLock("ScramSecretCount")
 	defer b.mu.RUnlock()
 
 	total := 0
-	for _, secrets := range b.scramSecrets {
-		total += len(secrets)
+	for _, regionSecrets := range b.scramSecrets {
+		for _, secrets := range regionSecrets {
+			total += len(secrets)
+		}
 	}
 
 	return total
@@ -77,7 +109,8 @@ func HasClusterPolicy(b *InMemoryBackend, clusterArn string) bool {
 	b.mu.RLock("HasClusterPolicy")
 	defer b.mu.RUnlock()
 
-	_, ok := b.clusterPolicies[clusterArn]
+	region := regionFromARN(clusterArn, b.region)
+	_, ok := b.clusterPolicies[region][clusterArn]
 
 	return ok
 }
@@ -87,5 +120,7 @@ func GetStoredCluster(b *InMemoryBackend, clusterArn string) *Cluster {
 	b.mu.RLock("GetStoredCluster")
 	defer b.mu.RUnlock()
 
-	return b.clusters[clusterArn]
+	region := regionFromARN(clusterArn, b.region)
+
+	return b.clusters[region][clusterArn]
 }

--- a/services/kafka/handler.go
+++ b/services/kafka/handler.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -270,7 +271,7 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // Handler returns the Echo handler function for MSK requests.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
-		ctx := c.Request().Context()
+		ctx := h.contextWithRegion(c)
 		log := logger.Load(ctx)
 
 		method := c.Request().Method
@@ -295,8 +296,18 @@ func (h *Handler) Handler() echo.HandlerFunc {
 
 		log.DebugContext(ctx, "kafka request", "op", op, "resource", resource)
 
-		return h.dispatch(c, op, resource, body)
+		return h.dispatch(ctx, c, op, resource, body)
 	}
+}
+
+// contextWithRegion returns the request context with the resolved AWS region attached
+// under regionContextKey so that backend operations are routed to the correct region.
+// The SigV4 credential-scope region in the Authorization header (extracted by
+// httputils.ExtractRegionFromRequest) takes precedence over the backend default.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
 }
 
 // effectivePath returns the raw (percent-encoded) path if available, otherwise the decoded path.
@@ -755,16 +766,16 @@ func parseVpcConnectionResource(method, remainder string) (string, string) {
 }
 
 // dispatch routes a parsed operation to the appropriate handler.
-func (h *Handler) dispatch(c *echo.Context, op, resource string, body []byte) error {
-	if ok, err := h.dispatchCoreOps(c, op, resource, body); ok {
+func (h *Handler) dispatch(ctx context.Context, c *echo.Context, op, resource string, body []byte) error {
+	if ok, err := h.dispatchCoreOps(ctx, c, op, resource, body); ok {
 		return err
 	}
 
-	if ok, err := h.dispatchNewOps(c, op, resource, body); ok {
+	if ok, err := h.dispatchNewOps(ctx, c, op, resource, body); ok {
 		return err
 	}
 
-	if ok, err := h.dispatchUpdateOps(c, op, resource, body); ok {
+	if ok, err := h.dispatchUpdateOps(ctx, c, op, resource, body); ok {
 		return err
 	}
 
@@ -773,55 +784,58 @@ func (h *Handler) dispatch(c *echo.Context, op, resource string, body []byte) er
 
 // dispatchCoreOps handles cluster, configuration, and tag operations.
 // Returns (true, err) if the operation was handled, (false, nil) otherwise.
-func (h *Handler) dispatchCoreOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
-	if ok, err := h.dispatchClusterOps(c, op, resource, body); ok {
+func (h *Handler) dispatchCoreOps(ctx context.Context,
+	c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if ok, err := h.dispatchClusterOps(ctx, c, op, resource, body); ok {
 		return true, err
 	}
 
-	return h.dispatchConfigTagOps(c, op, resource, body)
+	return h.dispatchConfigTagOps(ctx, c, op, resource, body)
 }
 
 // dispatchClusterOps handles cluster CRUD and bootstrap operations.
-func (h *Handler) dispatchClusterOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+func (h *Handler) dispatchClusterOps(ctx context.Context,
+	c *echo.Context, op, resource string, body []byte) (bool, error) {
 	switch op {
 	case opCreateCluster:
-		return true, h.handleCreateCluster(c, body)
+		return true, h.handleCreateCluster(ctx, c, body)
 	case opCreateClusterV2:
-		return true, h.handleCreateClusterV2(c, body)
+		return true, h.handleCreateClusterV2(ctx, c, body)
 	case opListClusters:
-		return true, h.handleListClusters(c)
+		return true, h.handleListClusters(ctx, c)
 	case opListClustersV2:
-		return true, h.handleListClustersV2(c)
+		return true, h.handleListClustersV2(ctx, c)
 	case opDescribeCluster:
-		return true, h.handleDescribeCluster(c, resource)
+		return true, h.handleDescribeCluster(ctx, c, resource)
 	case opDescribeClusterV2:
-		return true, h.handleDescribeClusterV2(c, resource)
+		return true, h.handleDescribeClusterV2(ctx, c, resource)
 	case opDeleteCluster:
-		return true, h.handleDeleteCluster(c, resource)
+		return true, h.handleDeleteCluster(ctx, c, resource)
 	case opGetBootstrapBrokers:
-		return true, h.handleGetBootstrapBrokers(c, resource)
+		return true, h.handleGetBootstrapBrokers(ctx, c, resource)
 	}
 
 	return false, nil
 }
 
 // dispatchConfigTagOps handles configuration and tag operations.
-func (h *Handler) dispatchConfigTagOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
+func (h *Handler) dispatchConfigTagOps(ctx context.Context,
+	c *echo.Context, op, resource string, body []byte) (bool, error) {
 	switch op {
 	case opCreateConfiguration:
-		return true, h.handleCreateConfiguration(c, body)
+		return true, h.handleCreateConfiguration(ctx, c, body)
 	case opListConfigurations:
-		return true, h.handleListConfigurations(c)
+		return true, h.handleListConfigurations(ctx, c)
 	case opDescribeConfiguration:
-		return true, h.handleDescribeConfiguration(c, resource)
+		return true, h.handleDescribeConfiguration(ctx, c, resource)
 	case opDeleteConfiguration:
-		return true, h.handleDeleteConfiguration(c, resource)
+		return true, h.handleDeleteConfiguration(ctx, c, resource)
 	case opListTagsForResource:
-		return true, h.handleListTagsForResource(c, resource)
+		return true, h.handleListTagsForResource(ctx, c, resource)
 	case opTagResource:
-		return true, h.handleTagResource(c, resource, body)
+		return true, h.handleTagResource(ctx, c, resource, body)
 	case opUntagResource:
-		return true, h.handleUntagResource(c, resource, c.Request().URL)
+		return true, h.handleUntagResource(ctx, c, resource, c.Request().URL)
 	}
 
 	return false, nil
@@ -829,42 +843,44 @@ func (h *Handler) dispatchConfigTagOps(c *echo.Context, op, resource string, bod
 
 // dispatchNewOps handles SCRAM secrets, replicator, topic, VPC connection, and cluster policy operations.
 // Returns (true, err) if the operation was handled, (false, nil) otherwise.
-func (h *Handler) dispatchNewOps(c *echo.Context, op, resource string, body []byte) (bool, error) {
-	if ok, err := h.dispatchScramAndReplicatorOps(c, op, resource, body); ok {
+func (h *Handler) dispatchNewOps(ctx context.Context,
+	c *echo.Context, op, resource string, body []byte) (bool, error) {
+	if ok, err := h.dispatchScramAndReplicatorOps(ctx, c, op, resource, body); ok {
 		return ok, err
 	}
 
-	if ok, err := h.dispatchTopicAndVpcOps(c, op, resource, body); ok {
+	if ok, err := h.dispatchTopicAndVpcOps(ctx, c, op, resource, body); ok {
 		return ok, err
 	}
 
-	return h.dispatchPolicyAndMiscOps(c, op, resource, body)
+	return h.dispatchPolicyAndMiscOps(ctx, c, op, resource, body)
 }
 
 // dispatchScramAndReplicatorOps handles SCRAM and replicator ops.
 // Returns (true, err) if handled.
 func (h *Handler) dispatchScramAndReplicatorOps(
+	ctx context.Context,
 	c *echo.Context,
 	op, resource string,
 	body []byte,
 ) (bool, error) {
 	switch op {
 	case opBatchAssociateScramSecret:
-		return true, h.handleBatchAssociateScramSecret(c, resource, body)
+		return true, h.handleBatchAssociateScramSecret(ctx, c, resource, body)
 	case opBatchDisassociateScramSecret:
-		return true, h.handleBatchDisassociateScramSecret(c, resource, body)
+		return true, h.handleBatchDisassociateScramSecret(ctx, c, resource, body)
 	case opListScramSecrets:
-		return true, h.handleListScramSecrets(c, resource)
+		return true, h.handleListScramSecrets(ctx, c, resource)
 	case opCreateReplicator:
-		return true, h.handleCreateReplicator(c, body)
+		return true, h.handleCreateReplicator(ctx, c, body)
 	case opDeleteReplicator:
-		return true, h.handleDeleteReplicator(c, resource)
+		return true, h.handleDeleteReplicator(ctx, c, resource)
 	case opDescribeReplicator:
-		return true, h.handleDescribeReplicator(c, resource)
+		return true, h.handleDescribeReplicator(ctx, c, resource)
 	case opListReplicators:
-		return true, h.handleListReplicators(c)
+		return true, h.handleListReplicators(ctx, c)
 	case opUpdateReplicationInfo:
-		return true, h.handleUpdateReplicationInfo(c, resource, body)
+		return true, h.handleUpdateReplicationInfo(ctx, c, resource, body)
 	}
 
 	return false, nil
@@ -873,35 +889,36 @@ func (h *Handler) dispatchScramAndReplicatorOps(
 // dispatchTopicAndVpcOps handles topic and VPC connection ops.
 // Returns (true, err) if handled.
 func (h *Handler) dispatchTopicAndVpcOps(
+	ctx context.Context,
 	c *echo.Context,
 	op, resource string,
 	body []byte,
 ) (bool, error) {
 	switch op {
 	case opCreateTopic:
-		return true, h.handleCreateTopic(c, resource, body)
+		return true, h.handleCreateTopic(ctx, c, resource, body)
 	case opDeleteTopic:
-		return true, h.handleDeleteTopic(c, resource)
+		return true, h.handleDeleteTopic(ctx, c, resource)
 	case opDescribeTopic:
-		return true, h.handleDescribeTopic(c, resource)
+		return true, h.handleDescribeTopic(ctx, c, resource)
 	case opDescribeTopicPartitions:
-		return true, h.handleDescribeTopicPartitions(c, resource)
+		return true, h.handleDescribeTopicPartitions(ctx, c, resource)
 	case opListTopics:
-		return true, h.handleListTopics(c, resource)
+		return true, h.handleListTopics(ctx, c, resource)
 	case opUpdateTopic:
-		return true, h.handleUpdateTopic(c, resource, body)
+		return true, h.handleUpdateTopic(ctx, c, resource, body)
 	case opCreateVpcConnection:
-		return true, h.handleCreateVpcConnection(c, body)
+		return true, h.handleCreateVpcConnection(ctx, c, body)
 	case opDeleteVpcConnection:
-		return true, h.handleDeleteVpcConnection(c, resource)
+		return true, h.handleDeleteVpcConnection(ctx, c, resource)
 	case opDescribeVpcConnection:
-		return true, h.handleDescribeVpcConnection(c, resource)
+		return true, h.handleDescribeVpcConnection(ctx, c, resource)
 	case opListVpcConnections:
-		return true, h.handleListVpcConnections(c)
+		return true, h.handleListVpcConnections(ctx, c)
 	case opListClientVpcConnections:
-		return true, h.handleListClientVpcConnections(c, resource)
+		return true, h.handleListClientVpcConnections(ctx, c, resource)
 	case opRejectClientVpcConnection:
-		return true, h.handleRejectClientVpcConnection(c, resource)
+		return true, h.handleRejectClientVpcConnection(ctx, c, resource)
 	}
 
 	return false, nil
@@ -910,39 +927,40 @@ func (h *Handler) dispatchTopicAndVpcOps(
 // dispatchPolicyAndMiscOps handles cluster policy, operations, configuration revision,
 // and node/version ops. Returns (true, err) if handled.
 func (h *Handler) dispatchPolicyAndMiscOps(
+	ctx context.Context,
 	c *echo.Context,
 	op, resource string,
 	body []byte,
 ) (bool, error) {
 	switch op {
 	case opDeleteClusterPolicy:
-		return true, h.handleDeleteClusterPolicy(c, resource)
+		return true, h.handleDeleteClusterPolicy(ctx, c, resource)
 	case opGetClusterPolicy:
-		return true, h.handleGetClusterPolicy(c, resource)
+		return true, h.handleGetClusterPolicy(ctx, c, resource)
 	case opPutClusterPolicy:
-		return true, h.handlePutClusterPolicy(c, resource, body)
+		return true, h.handlePutClusterPolicy(ctx, c, resource, body)
 	case opDescribeClusterOperation:
-		return true, h.handleDescribeClusterOperation(c, resource)
+		return true, h.handleDescribeClusterOperation(ctx, c, resource)
 	case opDescribeClusterOperationV2:
-		return true, h.handleDescribeClusterOperationV2(c, resource)
+		return true, h.handleDescribeClusterOperationV2(ctx, c, resource)
 	case opListClusterOperations:
-		return true, h.handleListClusterOperations(c, resource)
+		return true, h.handleListClusterOperations(ctx, c, resource)
 	case opListClusterOperationsV2:
-		return true, h.handleListClusterOperationsV2(c, resource)
+		return true, h.handleListClusterOperationsV2(ctx, c, resource)
 	case opDescribeConfigurationRevision:
-		return true, h.handleDescribeConfigurationRevision(c, resource)
+		return true, h.handleDescribeConfigurationRevision(ctx, c, resource)
 	case opListConfigurationRevisions:
-		return true, h.handleListConfigurationRevisions(c, resource)
+		return true, h.handleListConfigurationRevisions(ctx, c, resource)
 	case opUpdateConfiguration:
-		return true, h.handleUpdateConfiguration(c, resource, body)
+		return true, h.handleUpdateConfiguration(ctx, c, resource, body)
 	case opListKafkaVersions:
-		return true, h.handleListKafkaVersions(c)
+		return true, h.handleListKafkaVersions(ctx, c)
 	case opGetCompatibleKafkaVersions:
-		return true, h.handleGetCompatibleKafkaVersions(c, resource)
+		return true, h.handleGetCompatibleKafkaVersions(ctx, c, resource)
 	case opListNodes:
-		return true, h.handleListNodes(c, resource)
+		return true, h.handleListNodes(ctx, c, resource)
 	case opRebootBroker:
-		return true, h.handleRebootBroker(c, resource, body)
+		return true, h.handleRebootBroker(ctx, c, resource, body)
 	}
 
 	return false, nil
@@ -951,31 +969,32 @@ func (h *Handler) dispatchPolicyAndMiscOps(
 // dispatchUpdateOps handles cluster and broker update operations.
 // Returns (true, err) if the operation was handled, (false, nil) otherwise.
 func (h *Handler) dispatchUpdateOps(
+	ctx context.Context,
 	c *echo.Context,
 	op, resource string,
 	body []byte,
 ) (bool, error) {
 	switch op {
 	case opUpdateBrokerCount:
-		return true, h.handleUpdateBrokerCount(c, resource, body)
+		return true, h.handleUpdateBrokerCount(ctx, c, resource, body)
 	case opUpdateBrokerStorage:
-		return true, h.handleUpdateBrokerStorage(c, resource, body)
+		return true, h.handleUpdateBrokerStorage(ctx, c, resource, body)
 	case opUpdateBrokerType:
-		return true, h.handleUpdateBrokerType(c, resource, body)
+		return true, h.handleUpdateBrokerType(ctx, c, resource, body)
 	case opUpdateClusterConfiguration:
-		return true, h.handleUpdateClusterConfiguration(c, resource, body)
+		return true, h.handleUpdateClusterConfiguration(ctx, c, resource, body)
 	case opUpdateClusterKafkaVersion:
-		return true, h.handleUpdateClusterKafkaVersion(c, resource, body)
+		return true, h.handleUpdateClusterKafkaVersion(ctx, c, resource, body)
 	case opUpdateConnectivity:
-		return true, h.handleUpdateConnectivity(c, resource, body)
+		return true, h.handleUpdateConnectivity(ctx, c, resource, body)
 	case opUpdateMonitoring:
-		return true, h.handleUpdateMonitoring(c, resource, body)
+		return true, h.handleUpdateMonitoring(ctx, c, resource, body)
 	case opUpdateRebalancing:
-		return true, h.handleUpdateRebalancing(c, resource, body)
+		return true, h.handleUpdateRebalancing(ctx, c, resource, body)
 	case opUpdateSecurity:
-		return true, h.handleUpdateSecurity(c, resource, body)
+		return true, h.handleUpdateSecurity(ctx, c, resource, body)
 	case opUpdateStorage:
-		return true, h.handleUpdateStorage(c, resource, body)
+		return true, h.handleUpdateStorage(ctx, c, resource, body)
 	}
 
 	return false, nil
@@ -1163,7 +1182,7 @@ type kafkaErrorResponse struct {
 // Cluster handlers
 // ----------------------------------------
 
-func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
+func (h *Handler) handleCreateCluster(ctx context.Context, c *echo.Context, body []byte) error {
 	var in createClusterInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1174,7 +1193,7 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 		)
 	}
 
-	cluster, err := h.Backend.CreateCluster(
+	cluster, err := h.Backend.CreateCluster(ctx,
 		in.ClusterName,
 		in.KafkaVersion,
 		in.NumberOfBrokerNodes,
@@ -1193,7 +1212,7 @@ func (h *Handler) handleCreateCluster(c *echo.Context, body []byte) error {
 	})
 }
 
-func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
+func (h *Handler) handleCreateClusterV2(ctx context.Context, c *echo.Context, body []byte) error {
 	var in createClusterV2Input
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1225,7 +1244,7 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 			serverlessInfo.VpcConfigs = append(serverlessInfo.VpcConfigs, ServerlessVpcConfig(vc))
 		}
 
-		cluster, err := h.Backend.CreateServerlessCluster(in.ClusterName, serverlessInfo, in.Tags)
+		cluster, err := h.Backend.CreateServerlessCluster(ctx, in.ClusterName, serverlessInfo, in.Tags)
 		if err != nil {
 			return h.writeBackendError(c, err)
 		}
@@ -1252,7 +1271,7 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 		clientAuth = in.Provisioned.ClientAuthentication
 	}
 
-	cluster, err := h.Backend.CreateCluster(
+	cluster, err := h.Backend.CreateCluster(ctx,
 		in.ClusterName,
 		kafkaVersion,
 		numBrokers,
@@ -1271,8 +1290,8 @@ func (h *Handler) handleCreateClusterV2(c *echo.Context, body []byte) error {
 	})
 }
 
-func (h *Handler) handleListClusters(c *echo.Context) error {
-	clusters := h.Backend.ListClusters()
+func (h *Handler) handleListClusters(ctx context.Context, c *echo.Context) error {
+	clusters := h.Backend.ListClusters(ctx)
 	out := make([]*clusterInfoV1, 0, len(clusters))
 
 	for _, cl := range clusters {
@@ -1282,8 +1301,8 @@ func (h *Handler) handleListClusters(c *echo.Context) error {
 	return c.JSON(http.StatusOK, listClustersOutput{ClusterInfoList: out})
 }
 
-func (h *Handler) handleListClustersV2(c *echo.Context) error {
-	clusters := h.Backend.ListClusters()
+func (h *Handler) handleListClustersV2(ctx context.Context, c *echo.Context) error {
+	clusters := h.Backend.ListClusters(ctx)
 	out := make([]*clusterInfoV2, 0, len(clusters))
 
 	for _, cl := range clusters {
@@ -1293,8 +1312,8 @@ func (h *Handler) handleListClustersV2(c *echo.Context) error {
 	return c.JSON(http.StatusOK, listClustersV2Output{ClusterInfoList: out})
 }
 
-func (h *Handler) handleDescribeCluster(c *echo.Context, clusterArn string) error {
-	cluster, err := h.Backend.DescribeCluster(clusterArn)
+func (h *Handler) handleDescribeCluster(ctx context.Context, c *echo.Context, clusterArn string) error {
+	cluster, err := h.Backend.DescribeCluster(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1302,8 +1321,8 @@ func (h *Handler) handleDescribeCluster(c *echo.Context, clusterArn string) erro
 	return c.JSON(http.StatusOK, describeClusterOutput{ClusterInfo: toClusterInfoV1(cluster)})
 }
 
-func (h *Handler) handleDescribeClusterV2(c *echo.Context, clusterArn string) error {
-	cluster, err := h.Backend.DescribeCluster(clusterArn)
+func (h *Handler) handleDescribeClusterV2(ctx context.Context, c *echo.Context, clusterArn string) error {
+	cluster, err := h.Backend.DescribeCluster(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1311,16 +1330,16 @@ func (h *Handler) handleDescribeClusterV2(c *echo.Context, clusterArn string) er
 	return c.JSON(http.StatusOK, describeClusterV2Output{ClusterInfo: toClusterInfoV2(cluster)})
 }
 
-func (h *Handler) handleDeleteCluster(c *echo.Context, clusterArn string) error {
-	if err := h.Backend.DeleteCluster(clusterArn); err != nil {
+func (h *Handler) handleDeleteCluster(ctx context.Context, c *echo.Context, clusterArn string) error {
+	if err := h.Backend.DeleteCluster(ctx, clusterArn); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
 	return c.NoContent(http.StatusOK)
 }
 
-func (h *Handler) handleGetBootstrapBrokers(c *echo.Context, clusterArn string) error {
-	cluster, err := h.Backend.DescribeCluster(clusterArn)
+func (h *Handler) handleGetBootstrapBrokers(ctx context.Context, c *echo.Context, clusterArn string) error {
+	cluster, err := h.Backend.DescribeCluster(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1535,7 +1554,7 @@ func toClusterInfoV2(cl *Cluster) *clusterInfoV2 {
 // Configuration handlers
 // ----------------------------------------
 
-func (h *Handler) handleCreateConfiguration(c *echo.Context, body []byte) error {
+func (h *Handler) handleCreateConfiguration(ctx context.Context, c *echo.Context, body []byte) error {
 	var in createConfigurationInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1546,7 +1565,7 @@ func (h *Handler) handleCreateConfiguration(c *echo.Context, body []byte) error 
 		)
 	}
 
-	config, err := h.Backend.CreateConfiguration(
+	config, err := h.Backend.CreateConfiguration(ctx,
 		in.Name,
 		in.Description,
 		in.KafkaVersions,
@@ -1562,14 +1581,14 @@ func (h *Handler) handleCreateConfiguration(c *echo.Context, body []byte) error 
 	})
 }
 
-func (h *Handler) handleListConfigurations(c *echo.Context) error {
-	configs := h.Backend.ListConfigurations()
+func (h *Handler) handleListConfigurations(ctx context.Context, c *echo.Context) error {
+	configs := h.Backend.ListConfigurations(ctx)
 
 	return c.JSON(http.StatusOK, listConfigurationsOutput{Configurations: configs})
 }
 
-func (h *Handler) handleDescribeConfiguration(c *echo.Context, configArn string) error {
-	config, err := h.Backend.DescribeConfiguration(configArn)
+func (h *Handler) handleDescribeConfiguration(ctx context.Context, c *echo.Context, configArn string) error {
+	config, err := h.Backend.DescribeConfiguration(ctx, configArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1587,8 +1606,8 @@ func (h *Handler) handleDescribeConfiguration(c *echo.Context, configArn string)
 	})
 }
 
-func (h *Handler) handleDeleteConfiguration(c *echo.Context, configArn string) error {
-	if err := h.Backend.DeleteConfiguration(configArn); err != nil {
+func (h *Handler) handleDeleteConfiguration(ctx context.Context, c *echo.Context, configArn string) error {
+	if err := h.Backend.DeleteConfiguration(ctx, configArn); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -1599,8 +1618,8 @@ func (h *Handler) handleDeleteConfiguration(c *echo.Context, configArn string) e
 // Tag handlers
 // ----------------------------------------
 
-func (h *Handler) handleListTagsForResource(c *echo.Context, resourceArn string) error {
-	tags, err := h.Backend.GetTags(resourceArn)
+func (h *Handler) handleListTagsForResource(ctx context.Context, c *echo.Context, resourceArn string) error {
+	tags, err := h.Backend.GetTags(ctx, resourceArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1608,7 +1627,7 @@ func (h *Handler) handleListTagsForResource(c *echo.Context, resourceArn string)
 	return c.JSON(http.StatusOK, listTagsOutput{Tags: tags})
 }
 
-func (h *Handler) handleTagResource(c *echo.Context, resourceArn string, body []byte) error {
+func (h *Handler) handleTagResource(ctx context.Context, c *echo.Context, resourceArn string, body []byte) error {
 	var in tagResourceInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1619,17 +1638,17 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceArn string, body []
 		)
 	}
 
-	if err := h.Backend.TagResource(resourceArn, in.Tags); err != nil {
+	if err := h.Backend.TagResource(ctx, resourceArn, in.Tags); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
 	return c.NoContent(http.StatusOK)
 }
 
-func (h *Handler) handleUntagResource(c *echo.Context, resourceArn string, u *url.URL) error {
+func (h *Handler) handleUntagResource(ctx context.Context, c *echo.Context, resourceArn string, u *url.URL) error {
 	tagKeys := u.Query()["tagKeys"]
 
-	if err := h.Backend.UntagResource(resourceArn, tagKeys); err != nil {
+	if err := h.Backend.UntagResource(ctx, resourceArn, tagKeys); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -1653,6 +1672,7 @@ type batchScramSecretOutput struct {
 // ----------------------------------------
 
 func (h *Handler) handleBatchAssociateScramSecret(
+	ctx context.Context,
 	c *echo.Context,
 	clusterArn string,
 	body []byte,
@@ -1667,7 +1687,7 @@ func (h *Handler) handleBatchAssociateScramSecret(
 		)
 	}
 
-	errs, err := h.Backend.BatchAssociateScramSecret(clusterArn, in.SecretArnList)
+	errs, err := h.Backend.BatchAssociateScramSecret(ctx, clusterArn, in.SecretArnList)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1676,6 +1696,7 @@ func (h *Handler) handleBatchAssociateScramSecret(
 }
 
 func (h *Handler) handleBatchDisassociateScramSecret(
+	ctx context.Context,
 	c *echo.Context,
 	clusterArn string,
 	body []byte,
@@ -1690,7 +1711,7 @@ func (h *Handler) handleBatchDisassociateScramSecret(
 		)
 	}
 
-	errs, err := h.Backend.BatchDisassociateScramSecret(clusterArn, in.SecretArnList)
+	errs, err := h.Backend.BatchDisassociateScramSecret(ctx, clusterArn, in.SecretArnList)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1719,7 +1740,7 @@ type createReplicatorOutput struct {
 // Replicator handlers
 // ----------------------------------------
 
-func (h *Handler) handleCreateReplicator(c *echo.Context, body []byte) error {
+func (h *Handler) handleCreateReplicator(ctx context.Context, c *echo.Context, body []byte) error {
 	var in createReplicatorInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1730,7 +1751,7 @@ func (h *Handler) handleCreateReplicator(c *echo.Context, body []byte) error {
 		)
 	}
 
-	replicator, err := h.Backend.CreateReplicator(
+	replicator, err := h.Backend.CreateReplicator(ctx,
 		in.ReplicatorName,
 		in.Description,
 		in.ServiceExecutionRoleArn,
@@ -1747,8 +1768,8 @@ func (h *Handler) handleCreateReplicator(c *echo.Context, body []byte) error {
 	})
 }
 
-func (h *Handler) handleDeleteReplicator(c *echo.Context, replicatorArn string) error {
-	if err := h.Backend.DeleteReplicator(replicatorArn); err != nil {
+func (h *Handler) handleDeleteReplicator(ctx context.Context, c *echo.Context, replicatorArn string) error {
+	if err := h.Backend.DeleteReplicator(ctx, replicatorArn); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -1777,7 +1798,7 @@ type createTopicOutput struct {
 // Topic handlers
 // ----------------------------------------
 
-func (h *Handler) handleCreateTopic(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleCreateTopic(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in createTopicInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1788,7 +1809,7 @@ func (h *Handler) handleCreateTopic(c *echo.Context, clusterArn string, body []b
 		)
 	}
 
-	topic, err := h.Backend.CreateTopic(
+	topic, err := h.Backend.CreateTopic(ctx,
 		clusterArn,
 		in.TopicName,
 		in.ReplicationFactor,
@@ -1807,7 +1828,7 @@ func (h *Handler) handleCreateTopic(c *echo.Context, clusterArn string, body []b
 	})
 }
 
-func (h *Handler) handleDeleteTopic(c *echo.Context, resource string) error {
+func (h *Handler) handleDeleteTopic(ctx context.Context, c *echo.Context, resource string) error {
 	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
 	if len(parts) != topicKeySeparatorParts {
 		return h.writeError(
@@ -1820,7 +1841,7 @@ func (h *Handler) handleDeleteTopic(c *echo.Context, resource string) error {
 
 	clusterArn, topicName := parts[0], parts[1]
 
-	if err := h.Backend.DeleteTopic(clusterArn, topicName); err != nil {
+	if err := h.Backend.DeleteTopic(ctx, clusterArn, topicName); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -1849,7 +1870,7 @@ type createVpcConnectionOutput struct {
 // VPC connection handlers
 // ----------------------------------------
 
-func (h *Handler) handleCreateVpcConnection(c *echo.Context, body []byte) error {
+func (h *Handler) handleCreateVpcConnection(ctx context.Context, c *echo.Context, body []byte) error {
 	var in createVpcConnectionInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -1860,7 +1881,7 @@ func (h *Handler) handleCreateVpcConnection(c *echo.Context, body []byte) error 
 		)
 	}
 
-	conn, err := h.Backend.CreateVpcConnection(
+	conn, err := h.Backend.CreateVpcConnection(ctx,
 		in.TargetClusterArn,
 		in.VpcID,
 		in.Authentication,
@@ -1878,8 +1899,8 @@ func (h *Handler) handleCreateVpcConnection(c *echo.Context, body []byte) error 
 	})
 }
 
-func (h *Handler) handleDeleteVpcConnection(c *echo.Context, vpcConnectionArn string) error {
-	if err := h.Backend.DeleteVpcConnection(vpcConnectionArn); err != nil {
+func (h *Handler) handleDeleteVpcConnection(ctx context.Context, c *echo.Context, vpcConnectionArn string) error {
+	if err := h.Backend.DeleteVpcConnection(ctx, vpcConnectionArn); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -1890,8 +1911,8 @@ func (h *Handler) handleDeleteVpcConnection(c *echo.Context, vpcConnectionArn st
 // Cluster policy handlers
 // ----------------------------------------
 
-func (h *Handler) handleDeleteClusterPolicy(c *echo.Context, clusterArn string) error {
-	if err := h.Backend.DeleteClusterPolicy(clusterArn); err != nil {
+func (h *Handler) handleDeleteClusterPolicy(ctx context.Context, c *echo.Context, clusterArn string) error {
+	if err := h.Backend.DeleteClusterPolicy(ctx, clusterArn); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -1911,10 +1932,11 @@ type describeClusterOperationOutput struct {
 // ----------------------------------------
 
 func (h *Handler) handleDescribeClusterOperation(
+	ctx context.Context,
 	c *echo.Context,
 	clusterOperationArn string,
 ) error {
-	op, err := h.Backend.DescribeClusterOperation(clusterOperationArn)
+	op, err := h.Backend.DescribeClusterOperation(ctx, clusterOperationArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1930,8 +1952,8 @@ type listScramSecretsOutput struct {
 	SecretArnList []string `json:"secretArnList"`
 }
 
-func (h *Handler) handleListScramSecrets(c *echo.Context, clusterArn string) error {
-	secrets, err := h.Backend.ListScramSecrets(clusterArn)
+func (h *Handler) handleListScramSecrets(ctx context.Context, c *echo.Context, clusterArn string) error {
+	secrets, err := h.Backend.ListScramSecrets(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1956,8 +1978,8 @@ type updateReplicationInfoOutput struct {
 	ReplicatorState string `json:"replicatorState"`
 }
 
-func (h *Handler) handleDescribeReplicator(c *echo.Context, replicatorArn string) error {
-	r, err := h.Backend.DescribeReplicator(replicatorArn)
+func (h *Handler) handleDescribeReplicator(ctx context.Context, c *echo.Context, replicatorArn string) error {
+	r, err := h.Backend.DescribeReplicator(ctx, replicatorArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -1965,13 +1987,14 @@ func (h *Handler) handleDescribeReplicator(c *echo.Context, replicatorArn string
 	return c.JSON(http.StatusOK, r)
 }
 
-func (h *Handler) handleListReplicators(c *echo.Context) error {
-	replicators := h.Backend.ListReplicators()
+func (h *Handler) handleListReplicators(ctx context.Context, c *echo.Context) error {
+	replicators := h.Backend.ListReplicators(ctx)
 
 	return c.JSON(http.StatusOK, listReplicatorsOutput{Replicators: replicators})
 }
 
 func (h *Handler) handleUpdateReplicationInfo(
+	ctx context.Context,
 	c *echo.Context,
 	replicatorArn string,
 	body []byte,
@@ -1986,7 +2009,7 @@ func (h *Handler) handleUpdateReplicationInfo(
 		)
 	}
 
-	r, err := h.Backend.UpdateReplicationInfo(replicatorArn, in.Description)
+	r, err := h.Backend.UpdateReplicationInfo(ctx, replicatorArn, in.Description)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2010,7 +2033,7 @@ type updateTopicInput struct {
 	NumPartitions int32             `json:"numPartitions"`
 }
 
-func (h *Handler) handleDescribeTopic(c *echo.Context, resource string) error {
+func (h *Handler) handleDescribeTopic(ctx context.Context, c *echo.Context, resource string) error {
 	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
 	if len(parts) != topicKeySeparatorParts {
 		return h.writeError(
@@ -2021,7 +2044,7 @@ func (h *Handler) handleDescribeTopic(c *echo.Context, resource string) error {
 		)
 	}
 
-	topic, err := h.Backend.DescribeTopic(parts[0], parts[1])
+	topic, err := h.Backend.DescribeTopic(ctx, parts[0], parts[1])
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2029,7 +2052,7 @@ func (h *Handler) handleDescribeTopic(c *echo.Context, resource string) error {
 	return c.JSON(http.StatusOK, topic)
 }
 
-func (h *Handler) handleDescribeTopicPartitions(c *echo.Context, resource string) error {
+func (h *Handler) handleDescribeTopicPartitions(ctx context.Context, c *echo.Context, resource string) error {
 	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
 	if len(parts) != topicKeySeparatorParts {
 		return h.writeError(
@@ -2040,7 +2063,7 @@ func (h *Handler) handleDescribeTopicPartitions(c *echo.Context, resource string
 		)
 	}
 
-	topic, err := h.Backend.DescribeTopicPartitions(parts[0], parts[1])
+	topic, err := h.Backend.DescribeTopicPartitions(ctx, parts[0], parts[1])
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2048,8 +2071,8 @@ func (h *Handler) handleDescribeTopicPartitions(c *echo.Context, resource string
 	return c.JSON(http.StatusOK, topic)
 }
 
-func (h *Handler) handleListTopics(c *echo.Context, clusterArn string) error {
-	topics, err := h.Backend.ListTopics(clusterArn)
+func (h *Handler) handleListTopics(ctx context.Context, c *echo.Context, clusterArn string) error {
+	topics, err := h.Backend.ListTopics(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2057,7 +2080,7 @@ func (h *Handler) handleListTopics(c *echo.Context, clusterArn string) error {
 	return c.JSON(http.StatusOK, listTopicsOutput{Topics: topics})
 }
 
-func (h *Handler) handleUpdateTopic(c *echo.Context, resource string, body []byte) error {
+func (h *Handler) handleUpdateTopic(ctx context.Context, c *echo.Context, resource string, body []byte) error {
 	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
 	if len(parts) != topicKeySeparatorParts {
 		return h.writeError(
@@ -2078,7 +2101,7 @@ func (h *Handler) handleUpdateTopic(c *echo.Context, resource string, body []byt
 		)
 	}
 
-	topic, err := h.Backend.UpdateTopic(parts[0], parts[1], in.NumPartitions, in.ConfigEntries)
+	topic, err := h.Backend.UpdateTopic(ctx, parts[0], parts[1], in.NumPartitions, in.ConfigEntries)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2094,8 +2117,8 @@ type listVpcConnectionsOutput struct {
 	VpcConnections []*VpcConnection `json:"vpcConnections"`
 }
 
-func (h *Handler) handleDescribeVpcConnection(c *echo.Context, vpcConnectionArn string) error {
-	v, err := h.Backend.DescribeVpcConnection(vpcConnectionArn)
+func (h *Handler) handleDescribeVpcConnection(ctx context.Context, c *echo.Context, vpcConnectionArn string) error {
+	v, err := h.Backend.DescribeVpcConnection(ctx, vpcConnectionArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2103,14 +2126,14 @@ func (h *Handler) handleDescribeVpcConnection(c *echo.Context, vpcConnectionArn 
 	return c.JSON(http.StatusOK, v)
 }
 
-func (h *Handler) handleListVpcConnections(c *echo.Context) error {
-	conns := h.Backend.ListVpcConnections()
+func (h *Handler) handleListVpcConnections(ctx context.Context, c *echo.Context) error {
+	conns := h.Backend.ListVpcConnections(ctx)
 
 	return c.JSON(http.StatusOK, listVpcConnectionsOutput{VpcConnections: conns})
 }
 
-func (h *Handler) handleListClientVpcConnections(c *echo.Context, clusterArn string) error {
-	conns, err := h.Backend.ListClientVpcConnections(clusterArn)
+func (h *Handler) handleListClientVpcConnections(ctx context.Context, c *echo.Context, clusterArn string) error {
+	conns, err := h.Backend.ListClientVpcConnections(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2118,8 +2141,8 @@ func (h *Handler) handleListClientVpcConnections(c *echo.Context, clusterArn str
 	return c.JSON(http.StatusOK, listVpcConnectionsOutput{VpcConnections: conns})
 }
 
-func (h *Handler) handleRejectClientVpcConnection(c *echo.Context, vpcConnectionArn string) error {
-	if err := h.Backend.RejectClientVpcConnection(vpcConnectionArn); err != nil {
+func (h *Handler) handleRejectClientVpcConnection(ctx context.Context, c *echo.Context, vpcConnectionArn string) error {
+	if err := h.Backend.RejectClientVpcConnection(ctx, vpcConnectionArn); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -2138,8 +2161,8 @@ type putClusterPolicyInput struct {
 	Policy string `json:"policy"`
 }
 
-func (h *Handler) handleGetClusterPolicy(c *echo.Context, clusterArn string) error {
-	policy, err := h.Backend.GetClusterPolicy(clusterArn)
+func (h *Handler) handleGetClusterPolicy(ctx context.Context, c *echo.Context, clusterArn string) error {
+	policy, err := h.Backend.GetClusterPolicy(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2147,7 +2170,7 @@ func (h *Handler) handleGetClusterPolicy(c *echo.Context, clusterArn string) err
 	return c.JSON(http.StatusOK, getClusterPolicyOutput{Policy: policy})
 }
 
-func (h *Handler) handlePutClusterPolicy(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handlePutClusterPolicy(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in putClusterPolicyInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -2158,7 +2181,7 @@ func (h *Handler) handlePutClusterPolicy(c *echo.Context, clusterArn string, bod
 		)
 	}
 
-	if err := h.Backend.PutClusterPolicy(clusterArn, in.Policy); err != nil {
+	if err := h.Backend.PutClusterPolicy(ctx, clusterArn, in.Policy); err != nil {
 		return h.writeBackendError(c, err)
 	}
 
@@ -2182,10 +2205,11 @@ type listClusterOperationsV2Output struct {
 }
 
 func (h *Handler) handleDescribeClusterOperationV2(
+	ctx context.Context,
 	c *echo.Context,
 	clusterOperationArn string,
 ) error {
-	op, err := h.Backend.DescribeClusterOperationV2(clusterOperationArn)
+	op, err := h.Backend.DescribeClusterOperationV2(ctx, clusterOperationArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2193,8 +2217,8 @@ func (h *Handler) handleDescribeClusterOperationV2(
 	return c.JSON(http.StatusOK, describeClusterOperationV2Output{ClusterOperationInfo: op})
 }
 
-func (h *Handler) handleListClusterOperations(c *echo.Context, clusterArn string) error {
-	ops, err := h.Backend.ListClusterOperations(clusterArn)
+func (h *Handler) handleListClusterOperations(ctx context.Context, c *echo.Context, clusterArn string) error {
+	ops, err := h.Backend.ListClusterOperations(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2202,8 +2226,8 @@ func (h *Handler) handleListClusterOperations(c *echo.Context, clusterArn string
 	return c.JSON(http.StatusOK, listClusterOperationsOutput{ClusterOperationInfoList: ops})
 }
 
-func (h *Handler) handleListClusterOperationsV2(c *echo.Context, clusterArn string) error {
-	ops, err := h.Backend.ListClusterOperationsV2(clusterArn)
+func (h *Handler) handleListClusterOperationsV2(ctx context.Context, c *echo.Context, clusterArn string) error {
+	ops, err := h.Backend.ListClusterOperationsV2(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2224,7 +2248,7 @@ type updateConfigurationInput struct {
 	ServerProperties string `json:"serverProperties,omitempty"`
 }
 
-func (h *Handler) handleDescribeConfigurationRevision(c *echo.Context, resource string) error {
+func (h *Handler) handleDescribeConfigurationRevision(ctx context.Context, c *echo.Context, resource string) error {
 	parts := strings.SplitN(resource, topicKeySeparator, topicKeySeparatorParts)
 	if len(parts) != topicKeySeparatorParts {
 		return h.writeError(c, http.StatusBadRequest, "BadRequestException", "invalid resource")
@@ -2238,7 +2262,7 @@ func (h *Handler) handleDescribeConfigurationRevision(c *echo.Context, resource 
 		revision = 1
 	}
 
-	rev, err := h.Backend.DescribeConfigurationRevision(configArn, revision)
+	rev, err := h.Backend.DescribeConfigurationRevision(ctx, configArn, revision)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2246,8 +2270,8 @@ func (h *Handler) handleDescribeConfigurationRevision(c *echo.Context, resource 
 	return c.JSON(http.StatusOK, rev)
 }
 
-func (h *Handler) handleListConfigurationRevisions(c *echo.Context, configArn string) error {
-	revisions, err := h.Backend.ListConfigurationRevisions(configArn)
+func (h *Handler) handleListConfigurationRevisions(ctx context.Context, c *echo.Context, configArn string) error {
+	revisions, err := h.Backend.ListConfigurationRevisions(ctx, configArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2255,7 +2279,7 @@ func (h *Handler) handleListConfigurationRevisions(c *echo.Context, configArn st
 	return c.JSON(http.StatusOK, listConfigurationRevisionsOutput{Revisions: revisions})
 }
 
-func (h *Handler) handleUpdateConfiguration(c *echo.Context, configArn string, body []byte) error {
+func (h *Handler) handleUpdateConfiguration(ctx context.Context, c *echo.Context, configArn string, body []byte) error {
 	var in updateConfigurationInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -2266,7 +2290,7 @@ func (h *Handler) handleUpdateConfiguration(c *echo.Context, configArn string, b
 		)
 	}
 
-	config, err := h.Backend.UpdateConfiguration(configArn, in.Description, in.ServerProperties)
+	config, err := h.Backend.UpdateConfiguration(ctx, configArn, in.Description, in.ServerProperties)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2290,14 +2314,14 @@ type listNodesOutput struct {
 	NodeInfoList []*BrokerNode `json:"nodeInfoList"`
 }
 
-func (h *Handler) handleListKafkaVersions(c *echo.Context) error {
-	versions := h.Backend.ListKafkaVersions()
+func (h *Handler) handleListKafkaVersions(ctx context.Context, c *echo.Context) error {
+	versions := h.Backend.ListKafkaVersions(ctx)
 
 	return c.JSON(http.StatusOK, listKafkaVersionsOutput{KafkaVersions: versions})
 }
 
-func (h *Handler) handleGetCompatibleKafkaVersions(c *echo.Context, clusterArn string) error {
-	versions, err := h.Backend.GetCompatibleKafkaVersions(clusterArn)
+func (h *Handler) handleGetCompatibleKafkaVersions(ctx context.Context, c *echo.Context, clusterArn string) error {
+	versions, err := h.Backend.GetCompatibleKafkaVersions(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2305,8 +2329,8 @@ func (h *Handler) handleGetCompatibleKafkaVersions(c *echo.Context, clusterArn s
 	return c.JSON(http.StatusOK, compatibleKafkaVersionsOutput{CompatibleKafkaVersions: versions})
 }
 
-func (h *Handler) handleListNodes(c *echo.Context, clusterArn string) error {
-	nodes, err := h.Backend.ListNodes(clusterArn)
+func (h *Handler) handleListNodes(ctx context.Context, c *echo.Context, clusterArn string) error {
+	nodes, err := h.Backend.ListNodes(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2326,7 +2350,7 @@ type clusterOperationOutput struct {
 	ClusterOperationArn string `json:"clusterOperationArn"`
 }
 
-func (h *Handler) handleRebootBroker(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleRebootBroker(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in rebootBrokerInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -2337,7 +2361,7 @@ func (h *Handler) handleRebootBroker(c *echo.Context, clusterArn string, body []
 		)
 	}
 
-	op, err := h.Backend.RebootBroker(clusterArn, in.BrokerIDs)
+	op, err := h.Backend.RebootBroker(ctx, clusterArn, in.BrokerIDs)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2382,7 +2406,7 @@ type updateClusterKafkaVersionInput struct {
 	TargetKafkaVersion string `json:"targetKafkaVersion"`
 }
 
-func (h *Handler) handleUpdateBrokerCount(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateBrokerCount(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in updateBrokerCountInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -2393,7 +2417,7 @@ func (h *Handler) handleUpdateBrokerCount(c *echo.Context, clusterArn string, bo
 		)
 	}
 
-	op, err := h.Backend.UpdateBrokerCount(clusterArn, in.TargetNumberOfBrokerNodes)
+	op, err := h.Backend.UpdateBrokerCount(ctx, clusterArn, in.TargetNumberOfBrokerNodes)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2404,7 +2428,12 @@ func (h *Handler) handleUpdateBrokerCount(c *echo.Context, clusterArn string, bo
 	)
 }
 
-func (h *Handler) handleUpdateBrokerStorage(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateBrokerStorage(
+	ctx context.Context,
+	c *echo.Context,
+	clusterArn string,
+	body []byte,
+) error {
 	var in updateBrokerStorageInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -2420,7 +2449,7 @@ func (h *Handler) handleUpdateBrokerStorage(c *echo.Context, clusterArn string, 
 		volumeSize = in.TargetBrokerEBSVolumeInfo[0].VolumeSizeGB
 	}
 
-	op, err := h.Backend.UpdateBrokerStorage(clusterArn, volumeSize)
+	op, err := h.Backend.UpdateBrokerStorage(ctx, clusterArn, volumeSize)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2431,7 +2460,7 @@ func (h *Handler) handleUpdateBrokerStorage(c *echo.Context, clusterArn string, 
 	)
 }
 
-func (h *Handler) handleUpdateBrokerType(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateBrokerType(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in updateBrokerTypeInput
 	if err := json.Unmarshal(body, &in); err != nil {
 		return h.writeError(
@@ -2442,7 +2471,7 @@ func (h *Handler) handleUpdateBrokerType(c *echo.Context, clusterArn string, bod
 		)
 	}
 
-	op, err := h.Backend.UpdateBrokerType(clusterArn, in.TargetInstanceType)
+	op, err := h.Backend.UpdateBrokerType(ctx, clusterArn, in.TargetInstanceType)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2454,6 +2483,7 @@ func (h *Handler) handleUpdateBrokerType(c *echo.Context, clusterArn string, bod
 }
 
 func (h *Handler) handleUpdateClusterConfiguration(
+	ctx context.Context,
 	c *echo.Context,
 	clusterArn string,
 	body []byte,
@@ -2468,7 +2498,7 @@ func (h *Handler) handleUpdateClusterConfiguration(
 		)
 	}
 
-	op, err := h.Backend.UpdateClusterConfiguration(
+	op, err := h.Backend.UpdateClusterConfiguration(ctx,
 		clusterArn,
 		in.ConfigurationInfo.Arn,
 		in.ConfigurationInfo.Revision,
@@ -2484,6 +2514,7 @@ func (h *Handler) handleUpdateClusterConfiguration(
 }
 
 func (h *Handler) handleUpdateClusterKafkaVersion(
+	ctx context.Context,
 	c *echo.Context,
 	clusterArn string,
 	body []byte,
@@ -2498,7 +2529,7 @@ func (h *Handler) handleUpdateClusterKafkaVersion(
 		)
 	}
 
-	op, err := h.Backend.UpdateClusterKafkaVersion(clusterArn, in.TargetKafkaVersion)
+	op, err := h.Backend.UpdateClusterKafkaVersion(ctx, clusterArn, in.TargetKafkaVersion)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2515,13 +2546,13 @@ type updateConnectivityInput struct {
 	CurrentVersion   string            `json:"currentVersion"`
 }
 
-func (h *Handler) handleUpdateConnectivity(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateConnectivity(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in updateConnectivityInput
 	if err := decodeJSONBody(body, &in); err != nil {
 		return h.writeError(c, http.StatusBadRequest, "BadRequestException", err.Error())
 	}
 
-	op, err := h.Backend.UpdateConnectivity(clusterArn, UpdateConnectivitySettings{
+	op, err := h.Backend.UpdateConnectivity(ctx, clusterArn, UpdateConnectivitySettings{
 		ConnectivityInfo: in.ConnectivityInfo,
 	})
 	if err != nil {
@@ -2542,13 +2573,13 @@ type updateMonitoringInput struct {
 	CurrentVersion     string          `json:"currentVersion"`
 }
 
-func (h *Handler) handleUpdateMonitoring(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateMonitoring(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in updateMonitoringInput
 	if err := decodeJSONBody(body, &in); err != nil {
 		return h.writeError(c, http.StatusBadRequest, "BadRequestException", err.Error())
 	}
 
-	op, err := h.Backend.UpdateMonitoring(clusterArn, UpdateMonitoringSettings{
+	op, err := h.Backend.UpdateMonitoring(ctx, clusterArn, UpdateMonitoringSettings{
 		EnhancedMonitoring: in.EnhancedMonitoring,
 		OpenMonitoring:     in.OpenMonitoring,
 		LoggingInfo:        in.LoggingInfo,
@@ -2563,8 +2594,8 @@ func (h *Handler) handleUpdateMonitoring(c *echo.Context, clusterArn string, bod
 	)
 }
 
-func (h *Handler) handleUpdateRebalancing(c *echo.Context, clusterArn string, _ []byte) error {
-	op, err := h.Backend.UpdateRebalancing(clusterArn)
+func (h *Handler) handleUpdateRebalancing(ctx context.Context, c *echo.Context, clusterArn string, _ []byte) error {
+	op, err := h.Backend.UpdateRebalancing(ctx, clusterArn)
 	if err != nil {
 		return h.writeBackendError(c, err)
 	}
@@ -2582,13 +2613,13 @@ type updateSecurityInput struct {
 	CurrentVersion       string                `json:"currentVersion"`
 }
 
-func (h *Handler) handleUpdateSecurity(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateSecurity(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in updateSecurityInput
 	if err := decodeJSONBody(body, &in); err != nil {
 		return h.writeError(c, http.StatusBadRequest, "BadRequestException", err.Error())
 	}
 
-	op, err := h.Backend.UpdateSecurity(clusterArn, UpdateSecuritySettings{
+	op, err := h.Backend.UpdateSecurity(ctx, clusterArn, UpdateSecuritySettings{
 		ClientAuthentication: in.ClientAuthentication,
 		EncryptionInfo:       in.EncryptionInfo,
 	})
@@ -2610,13 +2641,13 @@ type updateStorageInput struct {
 	VolumeSizeGB          int32                  `json:"volumeSizeGB"`
 }
 
-func (h *Handler) handleUpdateStorage(c *echo.Context, clusterArn string, body []byte) error {
+func (h *Handler) handleUpdateStorage(ctx context.Context, c *echo.Context, clusterArn string, body []byte) error {
 	var in updateStorageInput
 	if err := decodeJSONBody(body, &in); err != nil {
 		return h.writeError(c, http.StatusBadRequest, "BadRequestException", err.Error())
 	}
 
-	op, err := h.Backend.UpdateStorage(clusterArn, UpdateStorageSettings{
+	op, err := h.Backend.UpdateStorage(ctx, clusterArn, UpdateStorageSettings{
 		StorageMode:           in.StorageMode,
 		VolumeSizeGB:          in.VolumeSizeGB,
 		ProvisionedThroughput: in.ProvisionedThroughput,

--- a/services/kafka/handler_refinement1_test.go
+++ b/services/kafka/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -181,7 +182,7 @@ func TestRefinement1_SortedListClusters(t *testing.T) {
 	b.AddClusterInternal("aaa-cluster", "2.8.0")
 	b.AddClusterInternal("mmm-cluster", "2.8.0")
 
-	clusters := b.ListClusters()
+	clusters := b.ListClusters(context.Background())
 	require.Len(t, clusters, 3)
 	assert.Equal(t, "aaa-cluster", clusters[0].ClusterName)
 	assert.Equal(t, "mmm-cluster", clusters[1].ClusterName)
@@ -196,7 +197,7 @@ func TestRefinement1_SortedListConfigurations(t *testing.T) {
 	b.AddConfigurationInternal("aaa-cfg")
 	b.AddConfigurationInternal("mmm-cfg")
 
-	cfgs := b.ListConfigurations()
+	cfgs := b.ListConfigurations(context.Background())
 	require.Len(t, cfgs, 3)
 	assert.Equal(t, "aaa-cfg", cfgs[0].Name)
 	assert.Equal(t, "mmm-cfg", cfgs[1].Name)
@@ -240,7 +241,7 @@ func TestRefinement1_DeleteCluster_CascadesTopicsAndScram(t *testing.T) {
 	b.AddTopicInternal(cl.ClusterArn, "t1")
 	b.AddTopicInternal(cl.ClusterArn, "t2")
 
-	_, err := b.BatchAssociateScramSecret(
+	_, err := b.BatchAssociateScramSecret(context.Background(),
 		cl.ClusterArn,
 		[]string{"arn:aws:secretsmanager:us-east-1:000000000000:secret:s1"},
 	)
@@ -249,7 +250,7 @@ func TestRefinement1_DeleteCluster_CascadesTopicsAndScram(t *testing.T) {
 	require.Equal(t, 2, kafka.TopicCount(b))
 	require.Equal(t, 1, kafka.ScramSecretCount(b))
 
-	err = b.DeleteCluster(cl.ClusterArn)
+	err = b.DeleteCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, kafka.TopicCount(b))
@@ -262,10 +263,10 @@ func TestRefinement1_TagResource_Replicator(t *testing.T) {
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	rep := b.AddReplicatorInternal("rep1")
 
-	err := b.TagResource(rep.ReplicatorArn, map[string]string{"env": "prod"})
+	err := b.TagResource(context.Background(), rep.ReplicatorArn, map[string]string{"env": "prod"})
 	require.NoError(t, err)
 
-	tags, err := b.GetTags(rep.ReplicatorArn)
+	tags, err := b.GetTags(context.Background(), rep.ReplicatorArn)
 	require.NoError(t, err)
 	assert.Equal(t, "prod", tags["env"])
 }
@@ -277,10 +278,10 @@ func TestRefinement1_TagResource_VpcConnection(t *testing.T) {
 	cl := b.AddClusterInternal("c1", "2.8.0")
 	vpc := b.AddVpcConnectionInternal(cl.ClusterArn, "vpc-1")
 
-	err := b.TagResource(vpc.VpcConnectionArn, map[string]string{"team": "infra"})
+	err := b.TagResource(context.Background(), vpc.VpcConnectionArn, map[string]string{"team": "infra"})
 	require.NoError(t, err)
 
-	tags, err := b.GetTags(vpc.VpcConnectionArn)
+	tags, err := b.GetTags(context.Background(), vpc.VpcConnectionArn)
 	require.NoError(t, err)
 	assert.Equal(t, "infra", tags["team"])
 }
@@ -293,7 +294,7 @@ func TestRefinement1_DeepCopy_ClusterDoesNotAlias(t *testing.T) {
 
 	// Mutating the returned clone must not affect the stored cluster.
 	cl.ClusterName = "mutated"
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, "c1", described.ClusterName)
 }
@@ -305,7 +306,7 @@ func TestRefinement1_DeepCopy_ConfigurationDoesNotAlias(t *testing.T) {
 	cfg := b.AddConfigurationInternal("cfg1")
 
 	cfg.Name = "mutated"
-	described, err := b.DescribeConfiguration(cfg.Arn)
+	described, err := b.DescribeConfiguration(context.Background(), cfg.Arn)
 	require.NoError(t, err)
 	assert.Equal(t, "cfg1", described.Name)
 }
@@ -354,7 +355,7 @@ func TestRefinement1_CreateCluster_RequiresName(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.CreateCluster("", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+	_, err := b.CreateCluster(context.Background(), "", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, kafka.ErrValidation)
@@ -364,7 +365,7 @@ func TestRefinement1_CreateConfiguration_RequiresName(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.CreateConfiguration("", "", nil, "")
+	_, err := b.CreateConfiguration(context.Background(), "", "", nil, "")
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, kafka.ErrValidation)
@@ -374,7 +375,7 @@ func TestRefinement1_CreateReplicator_RequiresName(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.CreateReplicator("", "", "", nil)
+	_, err := b.CreateReplicator(context.Background(), "", "", "", nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, kafka.ErrValidation)
@@ -385,7 +386,7 @@ func TestRefinement1_CreateTopic_RequiresName(t *testing.T) {
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	cl := b.AddClusterInternal("c1", "2.8.0")
-	_, err := b.CreateTopic(cl.ClusterArn, "", 3, 1, nil)
+	_, err := b.CreateTopic(context.Background(), cl.ClusterArn, "", 3, 1, nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, kafka.ErrValidation)
@@ -440,11 +441,11 @@ func TestRefinement1_ScramSecretCount(t *testing.T) {
 		"arn:aws:secretsmanager:us-east-1:000000000000:secret:s1",
 		"arn:aws:secretsmanager:us-east-1:000000000000:secret:s2",
 	}
-	_, err := b.BatchAssociateScramSecret(cl.ClusterArn, secrets)
+	_, err := b.BatchAssociateScramSecret(context.Background(), cl.ClusterArn, secrets)
 	require.NoError(t, err)
 	assert.Equal(t, 2, kafka.ScramSecretCount(b))
 
-	_, err = b.BatchDisassociateScramSecret(cl.ClusterArn, secrets[:1])
+	_, err = b.BatchDisassociateScramSecret(context.Background(), cl.ClusterArn, secrets[:1])
 	require.NoError(t, err)
 	assert.Equal(t, 1, kafka.ScramSecretCount(b))
 }
@@ -526,7 +527,15 @@ func TestRefinement1_ErrAlreadyExistsMapping(t *testing.T) {
 			name: "duplicate_cluster",
 			fn: func(b *kafka.InMemoryBackend) error {
 				b.AddClusterInternal("dup", "2.8.0")
-				_, err := b.CreateCluster("dup", "2.8.0", 3, kafka.BrokerNodeGroupInfo{}, nil, nil)
+				_, err := b.CreateCluster(
+					context.Background(),
+					"dup",
+					"2.8.0",
+					3,
+					kafka.BrokerNodeGroupInfo{},
+					nil,
+					nil,
+				)
 
 				return err
 			},
@@ -535,7 +544,7 @@ func TestRefinement1_ErrAlreadyExistsMapping(t *testing.T) {
 			name: "duplicate_configuration",
 			fn: func(b *kafka.InMemoryBackend) error {
 				b.AddConfigurationInternal("dup-cfg")
-				_, err := b.CreateConfiguration("dup-cfg", "", nil, "")
+				_, err := b.CreateConfiguration(context.Background(), "dup-cfg", "", nil, "")
 
 				return err
 			},
@@ -544,7 +553,7 @@ func TestRefinement1_ErrAlreadyExistsMapping(t *testing.T) {
 			name: "duplicate_replicator",
 			fn: func(b *kafka.InMemoryBackend) error {
 				b.AddReplicatorInternal("dup-rep")
-				_, err := b.CreateReplicator("dup-rep", "", "", nil)
+				_, err := b.CreateReplicator(context.Background(), "dup-rep", "", "", nil)
 
 				return err
 			},

--- a/services/kafka/handler_refinement2_test.go
+++ b/services/kafka/handler_refinement2_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -28,7 +29,7 @@ func TestRefinement2_ClusterTypeProvisioned(t *testing.T) {
 		{
 			name: "CreateCluster",
 			create: func(b *kafka.InMemoryBackend) *kafka.Cluster {
-				c, err := b.CreateCluster("c1", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+				c, err := b.CreateCluster(context.Background(), "c1", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 					InstanceType:  "kafka.m5.large",
 					ClientSubnets: []string{"subnet-1"},
 				}, nil, nil)
@@ -56,7 +57,7 @@ func TestRefinement2_ClusterTypeProvisioned(t *testing.T) {
 			assert.Equal(t, tt.wantTyp, cl.ClusterType)
 
 			// Round-trip via DescribeCluster.
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantTyp, described.ClusterType)
 		})
@@ -107,7 +108,7 @@ func TestRefinement2_CreateServerlessCluster(t *testing.T) {
 			t.Parallel()
 
 			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-			cl, err := b.CreateServerlessCluster(tt.clName, tt.serverless, nil)
+			cl, err := b.CreateServerlessCluster(context.Background(), tt.clName, tt.serverless, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -130,10 +131,10 @@ func TestRefinement2_CreateServerlessCluster_NoDuplicate(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.CreateServerlessCluster("srv", &kafka.ServerlessClusterInfo{}, nil)
+	_, err := b.CreateServerlessCluster(context.Background(), "srv", &kafka.ServerlessClusterInfo{}, nil)
 	require.NoError(t, err)
 
-	_, err = b.CreateServerlessCluster("srv", &kafka.ServerlessClusterInfo{}, nil)
+	_, err = b.CreateServerlessCluster(context.Background(), "srv", &kafka.ServerlessClusterInfo{}, nil)
 	require.ErrorIs(t, err, kafka.ErrAlreadyExists)
 }
 
@@ -154,10 +155,10 @@ func TestRefinement2_ServerlessCluster_Roundtrip(t *testing.T) {
 	}
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	cl, err := b.CreateServerlessCluster("srv-rt", srv, nil)
+	cl, err := b.CreateServerlessCluster(context.Background(), "srv-rt", srv, nil)
 	require.NoError(t, err)
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.Serverless)
 	require.Len(t, described.Serverless.VpcConfigs, 1)
@@ -258,7 +259,7 @@ func TestRefinement2_DescribeClusterV2_ServerlessArm(t *testing.T) {
 			{SubnetIDs: []string{"subnet-x"}},
 		},
 	}
-	cl, err := backend.CreateServerlessCluster("srv-v2", srv, nil)
+	cl, err := backend.CreateServerlessCluster(context.Background(), "srv-v2", srv, nil)
 	require.NoError(t, err)
 
 	rec := doKafkaRequest(t, h, http.MethodGet, "/api/v2/clusters/"+url.PathEscape(cl.ClusterArn), nil)
@@ -340,7 +341,7 @@ func TestRefinement2_EncryptionInfo_Roundtrip(t *testing.T) {
 			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
 			stored.EncryptionInfo = tt.encIn
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 
 			if tt.encIn == nil {
@@ -477,7 +478,7 @@ func TestRefinement2_OpenMonitoring_Roundtrip(t *testing.T) {
 			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
 			stored.OpenMonitoring = tt.om
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 
 			if tt.om == nil {
@@ -555,7 +556,7 @@ func TestRefinement2_LoggingInfo_Roundtrip(t *testing.T) {
 			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
 			stored.LoggingInfo = tt.li
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 
 			if tt.li == nil {
@@ -598,13 +599,13 @@ func TestRefinement2_ClientAuthentication_Unauthenticated(t *testing.T) {
 	auth := &kafka.ClientAuthentication{
 		Unauthenticated: &kafka.UnauthenticatedSettings{Enabled: true},
 	}
-	cl, err := b.CreateCluster("ua-cluster", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "ua-cluster", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 	}, auth, nil)
 	require.NoError(t, err)
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.ClientAuthentication)
 	require.NotNil(t, described.ClientAuthentication.Unauthenticated)
@@ -627,13 +628,13 @@ func TestRefinement2_ClientAuthentication_TLSWithCAArns(t *testing.T) {
 			CertificateAuthorityArnList: caArns,
 		},
 	}
-	cl, err := b.CreateCluster("tls-ca-cluster", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "tls-ca-cluster", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 	}, auth, nil)
 	require.NoError(t, err)
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.ClientAuthentication)
 	require.NotNil(t, described.ClientAuthentication.TLS)
@@ -653,7 +654,7 @@ func TestRefinement2_ClientAuthentication_TLS_NoAlias(t *testing.T) {
 			CertificateAuthorityArnList: caArns,
 		},
 	}
-	cl, err := b.CreateCluster("alias-test", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "alias-test", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 	}, auth, nil)
@@ -662,7 +663,7 @@ func TestRefinement2_ClientAuthentication_TLS_NoAlias(t *testing.T) {
 	// Mutate original slice — should not affect stored cluster.
 	caArns[0] = "mutated"
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, "arn:aws:acm-pca:us-east-1:123:ca/x",
 		described.ClientAuthentication.TLS.CertificateAuthorityArnList[0])
@@ -673,7 +674,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ZoneIds(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	cl, err := b.CreateCluster("zone-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "zone-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:         "kafka.m5.large",
 		ClientSubnets:        []string{"subnet-1", "subnet-2", "subnet-3"},
 		ZoneIDs:              []string{"use1-az1", "use1-az2", "use1-az3"},
@@ -681,7 +682,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ZoneIds(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"use1-az1", "use1-az2", "use1-az3"},
 		described.BrokerNodeGroupInfo.ZoneIDs)
@@ -692,7 +693,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ProvisionedThroughput(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	cl, err := b.CreateCluster("pt-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "pt-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 		StorageInfo: &kafka.StorageInfo{
@@ -707,7 +708,7 @@ func TestRefinement2_BrokerNodeGroupInfo_ProvisionedThroughput(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.BrokerNodeGroupInfo.StorageInfo)
 	require.NotNil(t, described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo)
@@ -766,14 +767,14 @@ func TestRefinement2_BrokerNodeGroupInfo_ConnectivityInfo(t *testing.T) {
 			t.Parallel()
 
 			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-			cl, err := b.CreateCluster("ci-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+			cl, err := b.CreateCluster(context.Background(), "ci-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 				InstanceType:     "kafka.m5.large",
 				ClientSubnets:    []string{"subnet-1"},
 				ConnectivityInfo: tt.ci,
 			}, nil, nil)
 			require.NoError(t, err)
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 			require.NotNil(t, described.BrokerNodeGroupInfo.ConnectivityInfo)
 
@@ -811,7 +812,7 @@ func TestRefinement2_GetClusterPolicy_NotFoundException(t *testing.T) {
 		{
 			name: "policy_set",
 			setup: func(b *kafka.InMemoryBackend, clusterArn string) {
-				err := b.PutClusterPolicy(clusterArn, `{"Version":"2012-10-17"}`)
+				err := b.PutClusterPolicy(context.Background(), clusterArn, `{"Version":"2012-10-17"}`)
 				require.NoError(t, err)
 			},
 			wantErr:   false,
@@ -820,8 +821,8 @@ func TestRefinement2_GetClusterPolicy_NotFoundException(t *testing.T) {
 		{
 			name: "policy_put_then_deleted",
 			setup: func(b *kafka.InMemoryBackend, clusterArn string) {
-				_ = b.PutClusterPolicy(clusterArn, `{"Version":"2012-10-17"}`)
-				_ = b.DeleteClusterPolicy(clusterArn)
+				_ = b.PutClusterPolicy(context.Background(), clusterArn, `{"Version":"2012-10-17"}`)
+				_ = b.DeleteClusterPolicy(context.Background(), clusterArn)
 			},
 			wantErr:   true,
 			wantFound: false,
@@ -837,7 +838,7 @@ func TestRefinement2_GetClusterPolicy_NotFoundException(t *testing.T) {
 
 			tt.setup(b, cl.ClusterArn)
 
-			_, err := b.GetClusterPolicy(cl.ClusterArn)
+			_, err := b.GetClusterPolicy(context.Background(), cl.ClusterArn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -923,12 +924,12 @@ func TestRefinement2_UpdateClusterConfiguration_PersistsConfig(t *testing.T) {
 			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 			cl := b.AddClusterInternal("cfg-update-cl", "3.5.1")
 
-			op, err := b.UpdateClusterConfiguration(cl.ClusterArn, tt.configArn, tt.revision)
+			op, err := b.UpdateClusterConfiguration(context.Background(), cl.ClusterArn, tt.configArn, tt.revision)
 			require.NoError(t, err)
 			require.NotNil(t, op)
 			assert.Equal(t, "UPDATE_CLUSTER_CONFIGURATION", op.OperationType)
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 
 			if tt.wantArnSet {
@@ -946,7 +947,7 @@ func TestRefinement2_ListKafkaVersions_IncludesKRaft(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	versions := b.ListKafkaVersions()
+	versions := b.ListKafkaVersions(context.Background())
 
 	versionMap := make(map[string]string, len(versions))
 	for _, v := range versions {
@@ -1015,7 +1016,7 @@ func TestRefinement2_GetCompatibleKafkaVersions_KRaftOnly(t *testing.T) {
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	cl := b.AddClusterInternal("kraft-cl", "3.7.x.kraft")
 
-	versions, err := b.GetCompatibleKafkaVersions(cl.ClusterArn)
+	versions, err := b.GetCompatibleKafkaVersions(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 
 	versionStrs := make([]string, 0, len(versions))
@@ -1039,7 +1040,7 @@ func TestRefinement2_GetCompatibleKafkaVersions_ZooKeeperNoKRaft(t *testing.T) {
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	cl := b.AddClusterInternal("zk-cl", "2.8.1")
 
-	versions, err := b.GetCompatibleKafkaVersions(cl.ClusterArn)
+	versions, err := b.GetCompatibleKafkaVersions(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotEmpty(t, versions)
 
@@ -1054,7 +1055,7 @@ func TestRefinement2_GetCompatibleKafkaVersions_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	_, err := b.GetCompatibleKafkaVersions("arn:aws:kafka:us-east-1:123:cluster/nonexistent/abc")
+	_, err := b.GetCompatibleKafkaVersions(context.Background(), "arn:aws:kafka:us-east-1:123:cluster/nonexistent/abc")
 	require.ErrorIs(t, err, kafka.ErrNotFound)
 }
 
@@ -1140,7 +1141,7 @@ func TestRefinement2_GetBootstrapBrokers_Variants(t *testing.T) {
 			t.Parallel()
 
 			h, backend := newTestHandlerWithBackend(t)
-			cl, err := backend.CreateCluster("bs-cl", "3.5.1", 3,
+			cl, err := backend.CreateCluster(context.Background(), "bs-cl", "3.5.1", 3,
 				kafka.BrokerNodeGroupInfo{
 					InstanceType:     "kafka.m5.large",
 					ClientSubnets:    []string{"subnet-1"},
@@ -1220,7 +1221,7 @@ func TestRefinement2_StateInfo_Roundtrip(t *testing.T) {
 		Message: "EBS volume ran out of space",
 	}
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, kafka.ClusterStateFailed, described.State)
 	require.NotNil(t, described.StateInfo)
@@ -1309,7 +1310,7 @@ func TestRefinement2_StorageMode_Roundtrip(t *testing.T) {
 			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
 			stored.StorageMode = tt.mode
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 			assert.Equal(t, tt.mode, described.StorageMode)
 		})
@@ -1340,7 +1341,7 @@ func TestRefinement2_EnhancedMonitoring_Roundtrip(t *testing.T) {
 			stored := kafka.GetStoredCluster(b, cl.ClusterArn)
 			stored.EnhancedMonitoring = tt.level
 
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 			assert.Equal(t, tt.level, described.EnhancedMonitoring)
 		})
@@ -1354,13 +1355,13 @@ func TestRefinement2_ListClustersV2_ClusterType(t *testing.T) {
 	h, backend := newTestHandlerWithBackend(t)
 
 	// Create one provisioned and one serverless.
-	_, err := backend.CreateCluster("prov-list", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	_, err := backend.CreateCluster(context.Background(), "prov-list", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 	}, nil, nil)
 	require.NoError(t, err)
 
-	_, err = backend.CreateServerlessCluster("srv-list", &kafka.ServerlessClusterInfo{
+	_, err = backend.CreateServerlessCluster(context.Background(), "srv-list", &kafka.ServerlessClusterInfo{
 		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIDs: []string{"subnet-2"}}},
 	}, nil)
 	require.NoError(t, err)
@@ -1389,7 +1390,7 @@ func TestRefinement2_ListClustersV2_ServerlessHasNoProvisionedArm(t *testing.T) 
 	t.Parallel()
 
 	h, backend := newTestHandlerWithBackend(t)
-	_, err := backend.CreateServerlessCluster("srv-noarm", &kafka.ServerlessClusterInfo{
+	_, err := backend.CreateServerlessCluster(context.Background(), "srv-noarm", &kafka.ServerlessClusterInfo{
 		VpcConfigs: []kafka.ServerlessVpcConfig{{SubnetIDs: []string{"subnet-1"}}},
 	}, nil)
 	require.NoError(t, err)
@@ -1418,7 +1419,7 @@ func TestRefinement2_Persistence_ServerlessCluster(t *testing.T) {
 			{SubnetIDs: []string{"subnet-1"}, SecurityGroupIDs: []string{"sg-1"}},
 		},
 	}
-	cl, err := b.CreateServerlessCluster("srv-persist", srv, map[string]string{"env": "test"})
+	cl, err := b.CreateServerlessCluster(context.Background(), "srv-persist", srv, map[string]string{"env": "test"})
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
@@ -1427,7 +1428,7 @@ func TestRefinement2_Persistence_ServerlessCluster(t *testing.T) {
 	b2 := kafka.NewInMemoryBackend("other", "eu-west-1")
 	require.NoError(t, b2.Restore(snap))
 
-	described, err := b2.DescribeCluster(cl.ClusterArn)
+	described, err := b2.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, kafka.ClusterTypeServerless, described.ClusterType)
 	require.NotNil(t, described.Serverless)
@@ -1457,7 +1458,7 @@ func TestRefinement2_Persistence_EncryptionInfo(t *testing.T) {
 	b2 := kafka.NewInMemoryBackend("other", "eu-west-1")
 	require.NoError(t, b2.Restore(snap))
 
-	described, err := b2.DescribeCluster(cl.ClusterArn)
+	described, err := b2.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.EncryptionInfo)
 	require.NotNil(t, described.EncryptionInfo.EncryptionAtRest)
@@ -1472,7 +1473,7 @@ func TestRefinement2_Persistence_ConfigurationInfo(t *testing.T) {
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	cl := b.AddClusterInternal("cfginfo-persist", "3.5.1")
 
-	_, err := b.UpdateClusterConfiguration(cl.ClusterArn,
+	_, err := b.UpdateClusterConfiguration(context.Background(), cl.ClusterArn,
 		"arn:aws:kafka:us-east-1:123:configuration/my-cfg/xyz",
 		3)
 	require.NoError(t, err)
@@ -1481,7 +1482,7 @@ func TestRefinement2_Persistence_ConfigurationInfo(t *testing.T) {
 	b2 := kafka.NewInMemoryBackend("other", "eu-west-1")
 	require.NoError(t, b2.Restore(snap))
 
-	described, err := b2.DescribeCluster(cl.ClusterArn)
+	described, err := b2.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.ConfigurationInfo)
 	assert.Equal(t, "arn:aws:kafka:us-east-1:123:configuration/my-cfg/xyz",
@@ -1494,7 +1495,7 @@ func TestRefinement2_DeepCopy_ProvisionedThroughput(t *testing.T) {
 	t.Parallel()
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-	cl, err := b.CreateCluster("pt-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "pt-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 		StorageInfo: &kafka.StorageInfo{
@@ -1512,7 +1513,7 @@ func TestRefinement2_DeepCopy_ProvisionedThroughput(t *testing.T) {
 	// Mutate returned cluster's ProvisionedThroughput — should not affect stored.
 	cl.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput.VolumeThroughput = 999
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, int32(250),
 		described.BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.ProvisionedThroughput.VolumeThroughput)
@@ -1524,7 +1525,7 @@ func TestRefinement2_DeepCopy_ZoneIds(t *testing.T) {
 
 	b := kafka.NewInMemoryBackend(testAccountID, testRegion)
 	zones := []string{"us-east-1a", "us-east-1b"}
-	cl, err := b.CreateCluster("zone-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+	cl, err := b.CreateCluster(context.Background(), "zone-alias", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 		InstanceType:  "kafka.m5.large",
 		ClientSubnets: []string{"subnet-1"},
 		ZoneIDs:       zones,
@@ -1535,7 +1536,7 @@ func TestRefinement2_DeepCopy_ZoneIds(t *testing.T) {
 	zones[0] = "mutated"
 	cl.BrokerNodeGroupInfo.ZoneIDs[0] = "also-mutated"
 
-	described, err := b.DescribeCluster(cl.ClusterArn)
+	described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	assert.Equal(t, "us-east-1a", described.BrokerNodeGroupInfo.ZoneIDs[0])
 }
@@ -1636,7 +1637,7 @@ func TestRefinement2_CreateCluster_AllAuthModes(t *testing.T) {
 			t.Parallel()
 
 			b := kafka.NewInMemoryBackend(testAccountID, testRegion)
-			cl, err := b.CreateCluster("auth-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+			cl, err := b.CreateCluster(context.Background(), "auth-cl", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 				InstanceType:  "kafka.m5.large",
 				ClientSubnets: []string{"subnet-1"},
 			}, tt.auth, nil)
@@ -1644,7 +1645,7 @@ func TestRefinement2_CreateCluster_AllAuthModes(t *testing.T) {
 			require.NotNil(t, cl)
 
 			// Verify round-trip.
-			described, err := b.DescribeCluster(cl.ClusterArn)
+			described, err := b.DescribeCluster(context.Background(), cl.ClusterArn)
 			require.NoError(t, err)
 
 			if tt.auth == nil {
@@ -1766,7 +1767,7 @@ func TestRefinement2_UpdateClusterConfiguration_HTTP(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify via DescribeCluster.
-	described, err := backend.DescribeCluster(cl.ClusterArn)
+	described, err := backend.DescribeCluster(context.Background(), cl.ClusterArn)
 	require.NoError(t, err)
 	require.NotNil(t, described.ConfigurationInfo)
 	assert.Equal(t, configArn, described.ConfigurationInfo.Arn)
@@ -1778,7 +1779,7 @@ func TestRefinement2_GetBootstrapBrokers_ScramPublic(t *testing.T) {
 	t.Parallel()
 
 	h, backend := newTestHandlerWithBackend(t)
-	cl, err := backend.CreateCluster("scram-pub", "3.5.1", 3,
+	cl, err := backend.CreateCluster(context.Background(), "scram-pub", "3.5.1", 3,
 		kafka.BrokerNodeGroupInfo{
 			InstanceType:  "kafka.m5.large",
 			ClientSubnets: []string{"subnet-1"},

--- a/services/kafka/interfaces.go
+++ b/services/kafka/interfaces.go
@@ -1,103 +1,139 @@
 package kafka
 
+import "context"
+
 // StorageBackend defines the interface for Kafka (MSK) backend implementations.
 // All mutating methods must be safe for concurrent use.
+//
+// Every operation takes a context.Context so the backend can resolve the caller's
+// AWS region (for create/list operations) and route to the correct per-region
+// store. Operations that target an existing resource ARN resolve their region
+// from the ARN itself, falling back to the context region.
 type StorageBackend interface {
 	// Cluster operations
 	CreateCluster(
+		ctx context.Context,
 		name, kafkaVersion string,
 		numBrokers int32,
 		brokerInfo BrokerNodeGroupInfo,
 		clientAuth *ClientAuthentication,
 		tags map[string]string,
 	) (*Cluster, error)
-	CreateServerlessCluster(name string, serverless *ServerlessClusterInfo, tags map[string]string) (*Cluster, error)
-	DescribeCluster(clusterArn string) (*Cluster, error)
-	ListClusters() []*Cluster
-	DeleteCluster(clusterArn string) error
+	CreateServerlessCluster(
+		ctx context.Context, name string, serverless *ServerlessClusterInfo, tags map[string]string,
+	) (*Cluster, error)
+	DescribeCluster(ctx context.Context, clusterArn string) (*Cluster, error)
+	ListClusters(ctx context.Context) []*Cluster
+	DeleteCluster(ctx context.Context, clusterArn string) error
 
 	// Configuration operations
 	CreateConfiguration(
+		ctx context.Context,
 		name, description string,
 		kafkaVersions []string,
 		serverProperties string,
 	) (*Configuration, error)
-	DescribeConfiguration(configArn string) (*Configuration, error)
-	ListConfigurations() []*Configuration
-	DeleteConfiguration(configArn string) error
+	DescribeConfiguration(ctx context.Context, configArn string) (*Configuration, error)
+	ListConfigurations(ctx context.Context) []*Configuration
+	DeleteConfiguration(ctx context.Context, configArn string) error
 
 	// Tag operations
-	TagResource(resourceArn string, tags map[string]string) error
-	UntagResource(resourceArn string, tagKeys []string) error
-	GetTags(resourceArn string) (map[string]string, error)
+	TagResource(ctx context.Context, resourceArn string, tags map[string]string) error
+	UntagResource(ctx context.Context, resourceArn string, tagKeys []string) error
+	GetTags(ctx context.Context, resourceArn string) (map[string]string, error)
 
 	// SCRAM secret operations
-	BatchAssociateScramSecret(clusterArn string, secretArnList []string) ([]ScramSecretError, error)
-	BatchDisassociateScramSecret(clusterArn string, secretArnList []string) ([]ScramSecretError, error)
+	BatchAssociateScramSecret(
+		ctx context.Context,
+		clusterArn string,
+		secretArnList []string,
+	) ([]ScramSecretError, error)
+	BatchDisassociateScramSecret(
+		ctx context.Context, clusterArn string, secretArnList []string,
+	) ([]ScramSecretError, error)
 
 	// Replicator operations
-	CreateReplicator(name, description, serviceExecutionRoleArn string, tags map[string]string) (*Replicator, error)
-	DeleteReplicator(replicatorArn string) error
-	DescribeReplicator(replicatorArn string) (*Replicator, error)
-	ListReplicators() []*Replicator
-	UpdateReplicationInfo(replicatorArn, description string) (*Replicator, error)
+	CreateReplicator(
+		ctx context.Context, name, description, serviceExecutionRoleArn string, tags map[string]string,
+	) (*Replicator, error)
+	DeleteReplicator(ctx context.Context, replicatorArn string) error
+	DescribeReplicator(ctx context.Context, replicatorArn string) (*Replicator, error)
+	ListReplicators(ctx context.Context) []*Replicator
+	UpdateReplicationInfo(ctx context.Context, replicatorArn, description string) (*Replicator, error)
 
 	// Topic operations
 	CreateTopic(
+		ctx context.Context,
 		clusterArn, topicName string,
 		replicationFactor, numPartitions int32,
 		configEntries map[string]string,
 	) (*Topic, error)
-	DeleteTopic(clusterArn, topicName string) error
-	DescribeTopic(clusterArn, topicName string) (*Topic, error)
-	DescribeTopicPartitions(clusterArn, topicName string) (*Topic, error)
-	ListTopics(clusterArn string) ([]*Topic, error)
-	UpdateTopic(clusterArn, topicName string, numPartitions int32, configEntries map[string]string) (*Topic, error)
+	DeleteTopic(ctx context.Context, clusterArn, topicName string) error
+	DescribeTopic(ctx context.Context, clusterArn, topicName string) (*Topic, error)
+	DescribeTopicPartitions(ctx context.Context, clusterArn, topicName string) (*Topic, error)
+	ListTopics(ctx context.Context, clusterArn string) ([]*Topic, error)
+	UpdateTopic(
+		ctx context.Context, clusterArn, topicName string, numPartitions int32, configEntries map[string]string,
+	) (*Topic, error)
 
 	// VPC connection operations
-	CreateVpcConnection(targetClusterArn, vpcID, authentication string, tags map[string]string) (*VpcConnection, error)
-	DeleteVpcConnection(vpcConnectionArn string) error
-	DescribeVpcConnection(vpcConnectionArn string) (*VpcConnection, error)
-	ListVpcConnections() []*VpcConnection
-	ListClientVpcConnections(clusterArn string) ([]*VpcConnection, error)
-	RejectClientVpcConnection(vpcConnectionArn string) error
+	CreateVpcConnection(
+		ctx context.Context, targetClusterArn, vpcID, authentication string, tags map[string]string,
+	) (*VpcConnection, error)
+	DeleteVpcConnection(ctx context.Context, vpcConnectionArn string) error
+	DescribeVpcConnection(ctx context.Context, vpcConnectionArn string) (*VpcConnection, error)
+	ListVpcConnections(ctx context.Context) []*VpcConnection
+	ListClientVpcConnections(ctx context.Context, clusterArn string) ([]*VpcConnection, error)
+	RejectClientVpcConnection(ctx context.Context, vpcConnectionArn string) error
 
 	// Cluster policy operations
-	DeleteClusterPolicy(clusterArn string) error
-	GetClusterPolicy(clusterArn string) (string, error)
-	PutClusterPolicy(clusterArn, policy string) error
+	DeleteClusterPolicy(ctx context.Context, clusterArn string) error
+	GetClusterPolicy(ctx context.Context, clusterArn string) (string, error)
+	PutClusterPolicy(ctx context.Context, clusterArn, policy string) error
 
 	// Cluster operation operations
-	DescribeClusterOperation(clusterOperationArn string) (*ClusterOperation, error)
-	DescribeClusterOperationV2(clusterOperationArn string) (*ClusterOperation, error)
-	ListClusterOperations(clusterArn string) ([]*ClusterOperation, error)
-	ListClusterOperationsV2(clusterArn string) ([]*ClusterOperation, error)
+	DescribeClusterOperation(ctx context.Context, clusterOperationArn string) (*ClusterOperation, error)
+	DescribeClusterOperationV2(ctx context.Context, clusterOperationArn string) (*ClusterOperation, error)
+	ListClusterOperations(ctx context.Context, clusterArn string) ([]*ClusterOperation, error)
+	ListClusterOperationsV2(ctx context.Context, clusterArn string) ([]*ClusterOperation, error)
 
 	// Configuration revision operations
-	DescribeConfigurationRevision(configArn string, revision int64) (*ConfigurationRevision, error)
-	UpdateConfiguration(configArn, description, serverProperties string) (*Configuration, error)
-	ListConfigurationRevisions(configArn string) ([]*ConfigurationRevision, error)
+	DescribeConfigurationRevision(ctx context.Context, configArn string, revision int64) (*ConfigurationRevision, error)
+	UpdateConfiguration(ctx context.Context, configArn, description, serverProperties string) (*Configuration, error)
+	ListConfigurationRevisions(ctx context.Context, configArn string) ([]*ConfigurationRevision, error)
 
 	// Broker / cluster update operations
-	UpdateBrokerCount(clusterArn string, numBrokers int32) (*ClusterOperation, error)
-	UpdateBrokerStorage(clusterArn string, volumeSize int32) (*ClusterOperation, error)
-	UpdateBrokerType(clusterArn, instanceType string) (*ClusterOperation, error)
-	UpdateClusterConfiguration(clusterArn, configArn string, revision int64) (*ClusterOperation, error)
-	UpdateClusterKafkaVersion(clusterArn, targetKafkaVersion string) (*ClusterOperation, error)
-	UpdateConnectivity(clusterArn string, settings UpdateConnectivitySettings) (*ClusterOperation, error)
-	UpdateMonitoring(clusterArn string, settings UpdateMonitoringSettings) (*ClusterOperation, error)
-	UpdateRebalancing(clusterArn string) (*ClusterOperation, error)
-	UpdateSecurity(clusterArn string, settings UpdateSecuritySettings) (*ClusterOperation, error)
-	UpdateStorage(clusterArn string, settings UpdateStorageSettings) (*ClusterOperation, error)
-	RebootBroker(clusterArn string, brokerIDs []string) (*ClusterOperation, error)
+	UpdateBrokerCount(ctx context.Context, clusterArn string, numBrokers int32) (*ClusterOperation, error)
+	UpdateBrokerStorage(ctx context.Context, clusterArn string, volumeSize int32) (*ClusterOperation, error)
+	UpdateBrokerType(ctx context.Context, clusterArn, instanceType string) (*ClusterOperation, error)
+	UpdateClusterConfiguration(
+		ctx context.Context,
+		clusterArn, configArn string,
+		revision int64,
+	) (*ClusterOperation, error)
+	UpdateClusterKafkaVersion(ctx context.Context, clusterArn, targetKafkaVersion string) (*ClusterOperation, error)
+	UpdateConnectivity(
+		ctx context.Context,
+		clusterArn string,
+		settings UpdateConnectivitySettings,
+	) (*ClusterOperation, error)
+	UpdateMonitoring(
+		ctx context.Context,
+		clusterArn string,
+		settings UpdateMonitoringSettings,
+	) (*ClusterOperation, error)
+	UpdateRebalancing(ctx context.Context, clusterArn string) (*ClusterOperation, error)
+	UpdateSecurity(ctx context.Context, clusterArn string, settings UpdateSecuritySettings) (*ClusterOperation, error)
+	UpdateStorage(ctx context.Context, clusterArn string, settings UpdateStorageSettings) (*ClusterOperation, error)
+	RebootBroker(ctx context.Context, clusterArn string, brokerIDs []string) (*ClusterOperation, error)
 
 	// SCRAM secret list
-	ListScramSecrets(clusterArn string) ([]string, error)
+	ListScramSecrets(ctx context.Context, clusterArn string) ([]string, error)
 
 	// Node / version ops
-	ListNodes(clusterArn string) ([]*BrokerNode, error)
-	ListKafkaVersions() []*MSKVersion
-	GetCompatibleKafkaVersions(clusterArn string) ([]*MSKVersion, error)
+	ListNodes(ctx context.Context, clusterArn string) ([]*BrokerNode, error)
+	ListKafkaVersions(ctx context.Context) []*MSKVersion
+	GetCompatibleKafkaVersions(ctx context.Context, clusterArn string) ([]*MSKVersion, error)
 
 	// Lifecycle
 	Reset()

--- a/services/kafka/isolation_test.go
+++ b/services/kafka/isolation_test.go
@@ -1,0 +1,168 @@
+package kafka //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region under regionContextKey,
+// mirroring what the HTTP handler injects from the SigV4 credential scope.
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func newKafkaBrokerInfo() BrokerNodeGroupInfo {
+	return BrokerNodeGroupInfo{
+		InstanceType:  "kafka.m5.large",
+		ClientSubnets: []string{"subnet-00000000"},
+	}
+}
+
+// TestKafkaClusterRegionIsolation proves that same-named clusters created in two
+// regions are fully isolated: each region sees only its own cluster, ARNs carry
+// the correct region, and deleting in one region leaves the other intact.
+func TestKafkaClusterRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// 1. Create a cluster named "shared" in us-east-1.
+	eastCluster, err := backend.CreateCluster(
+		ctxEast, "shared", "3.5.1", 3, newKafkaBrokerInfo(), nil, map[string]string{"env": "east"},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, eastCluster.ClusterArn, "us-east-1")
+
+	// 2. Create a cluster with the SAME NAME in us-west-2; no conflict across regions.
+	westCluster, err := backend.CreateCluster(
+		ctxWest, "shared", "3.6.0", 2, newKafkaBrokerInfo(), nil, map[string]string{"env": "west"},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, westCluster.ClusterArn, "us-west-2")
+	assert.NotEqual(t, eastCluster.ClusterArn, westCluster.ClusterArn)
+
+	// 3. Each region lists only its own cluster with its own attributes.
+	eastList := backend.ListClusters(ctxEast)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, "shared", eastList[0].ClusterName)
+	assert.Equal(t, "3.5.1", eastList[0].KafkaVersion)
+	assert.Contains(t, eastList[0].ClusterArn, "us-east-1")
+
+	westList := backend.ListClusters(ctxWest)
+	require.Len(t, westList, 1)
+	assert.Equal(t, "shared", westList[0].ClusterName)
+	assert.Equal(t, "3.6.0", westList[0].KafkaVersion)
+	assert.Contains(t, westList[0].ClusterArn, "us-west-2")
+
+	// 4. Describe-by-ARN resolves the region from the ARN regardless of ctx region.
+	got, err := backend.DescribeCluster(ctxEast, westCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, "3.6.0", got.KafkaVersion)
+
+	// 5. The east cluster ARN is not visible from the west region's nested store
+	//    when looked up with a mismatched ctx — ARN region wins, so it still resolves.
+	got, err = backend.DescribeCluster(ctxWest, eastCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, "3.5.1", got.KafkaVersion)
+
+	// 6. Deleting in us-east-1 leaves us-west-2 intact.
+	require.NoError(t, backend.DeleteCluster(ctxEast, eastCluster.ClusterArn))
+
+	assert.Empty(t, backend.ListClusters(ctxEast))
+	assert.Len(t, backend.ListClusters(ctxWest), 1)
+
+	// The deleted east cluster is gone; the west cluster is still describable.
+	_, err = backend.DescribeCluster(ctxEast, eastCluster.ClusterArn)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	_, err = backend.DescribeCluster(ctxWest, westCluster.ClusterArn)
+	require.NoError(t, err)
+}
+
+// TestKafkaTopicAndPolicyRegionIsolation proves that resources hanging off a
+// cluster (topics, cluster policies) and tags are isolated per region: a topic
+// or policy created against a cluster in one region is invisible from the other.
+func TestKafkaTopicAndPolicyRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	eastCluster, err := backend.CreateCluster(
+		ctxEast, "c1", "3.5.1", 3, newKafkaBrokerInfo(), nil, nil,
+	)
+	require.NoError(t, err)
+
+	westCluster, err := backend.CreateCluster(
+		ctxWest, "c1", "3.5.1", 3, newKafkaBrokerInfo(), nil, nil,
+	)
+	require.NoError(t, err)
+
+	// Topic created on the east cluster (region resolved from the cluster ARN).
+	_, err = backend.CreateTopic(ctxEast, eastCluster.ClusterArn, "orders", 3, 6, nil)
+	require.NoError(t, err)
+
+	eastTopics, err := backend.ListTopics(ctxEast, eastCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Len(t, eastTopics, 1)
+
+	// The west cluster (same name) has no topics.
+	westTopics, err := backend.ListTopics(ctxWest, westCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Empty(t, westTopics)
+
+	// Cluster policy isolation.
+	require.NoError(t, backend.PutClusterPolicy(ctxEast, eastCluster.ClusterArn, `{"east":true}`))
+
+	_, err = backend.GetClusterPolicy(ctxWest, westCluster.ClusterArn)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	policy, err := backend.GetClusterPolicy(ctxEast, eastCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, `{"east":true}`, policy)
+
+	// Tag isolation: tagging the east cluster does not leak to the west cluster.
+	require.NoError(t, backend.TagResource(ctxEast, eastCluster.ClusterArn, map[string]string{"team": "data"}))
+
+	westTags, err := backend.GetTags(ctxWest, westCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Empty(t, westTags)
+
+	eastTags, err := backend.GetTags(ctxEast, eastCluster.ClusterArn)
+	require.NoError(t, err)
+	assert.Equal(t, "data", eastTags["team"])
+}
+
+// TestKafkaConfigurationRegionIsolation proves configurations (which are not tied
+// to a cluster) are isolated per request-context region.
+func TestKafkaConfigurationRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	eastCfg, err := backend.CreateConfiguration(ctxEast, "cfg", "east cfg", []string{"3.5.1"}, "auto.create=true")
+	require.NoError(t, err)
+	assert.Contains(t, eastCfg.Arn, "us-east-1")
+
+	westCfg, err := backend.CreateConfiguration(ctxWest, "cfg", "west cfg", []string{"3.6.0"}, "auto.create=false")
+	require.NoError(t, err)
+	assert.Contains(t, westCfg.Arn, "us-west-2")
+
+	assert.Len(t, backend.ListConfigurations(ctxEast), 1)
+	assert.Len(t, backend.ListConfigurations(ctxWest), 1)
+
+	require.NoError(t, backend.DeleteConfiguration(ctxEast, eastCfg.Arn))
+	assert.Empty(t, backend.ListConfigurations(ctxEast))
+	assert.Len(t, backend.ListConfigurations(ctxWest), 1)
+}

--- a/services/kafka/persistence.go
+++ b/services/kafka/persistence.go
@@ -5,17 +5,20 @@ import (
 	"log/slog"
 )
 
+// backendSnapshot is the persisted form of the backend state. All resource maps
+// are nested by region (outer key = region) to mirror the in-memory layout and
+// keep same-named resources in different regions fully isolated across restarts.
 type backendSnapshot struct {
-	Clusters          map[string]*Cluster          `json:"clusters"`
-	Configurations    map[string]*Configuration    `json:"configurations"`
-	ScramSecrets      map[string][]string          `json:"scramSecrets"`
-	Replicators       map[string]*Replicator       `json:"replicators"`
-	Topics            map[string]*Topic            `json:"topics"`
-	VpcConnections    map[string]*VpcConnection    `json:"vpcConnections"`
-	ClusterPolicies   map[string]string            `json:"clusterPolicies"`
-	ClusterOperations map[string]*ClusterOperation `json:"clusterOperations"`
-	AccountID         string                       `json:"accountID"`
-	Region            string                       `json:"region"`
+	Clusters          map[string]map[string]*Cluster          `json:"clusters"`
+	Configurations    map[string]map[string]*Configuration    `json:"configurations"`
+	ScramSecrets      map[string]map[string][]string          `json:"scramSecrets"`
+	Replicators       map[string]map[string]*Replicator       `json:"replicators"`
+	Topics            map[string]map[string]*Topic            `json:"topics"`
+	VpcConnections    map[string]map[string]*VpcConnection    `json:"vpcConnections"`
+	ClusterPolicies   map[string]map[string]string            `json:"clusterPolicies"`
+	ClusterOperations map[string]map[string]*ClusterOperation `json:"clusterOperations"`
+	AccountID         string                                  `json:"accountID"`
+	Region            string                                  `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -74,64 +77,58 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	return nil
 }
 
-// ensureNonNilMaps initialises nil maps in the snapshot to empty maps.
+// ensureNonNilMaps initialises nil region maps in the snapshot to empty maps.
 func ensureNonNilMaps(snap *backendSnapshot) {
 	if snap.Clusters == nil {
-		snap.Clusters = make(map[string]*Cluster)
+		snap.Clusters = make(map[string]map[string]*Cluster)
 	}
 
 	if snap.Configurations == nil {
-		snap.Configurations = make(map[string]*Configuration)
+		snap.Configurations = make(map[string]map[string]*Configuration)
 	}
 
 	if snap.ScramSecrets == nil {
-		snap.ScramSecrets = make(map[string][]string)
+		snap.ScramSecrets = make(map[string]map[string][]string)
 	}
 
 	if snap.Replicators == nil {
-		snap.Replicators = make(map[string]*Replicator)
+		snap.Replicators = make(map[string]map[string]*Replicator)
 	}
 
 	if snap.Topics == nil {
-		snap.Topics = make(map[string]*Topic)
+		snap.Topics = make(map[string]map[string]*Topic)
 	}
 
 	if snap.VpcConnections == nil {
-		snap.VpcConnections = make(map[string]*VpcConnection)
+		snap.VpcConnections = make(map[string]map[string]*VpcConnection)
 	}
 
 	if snap.ClusterPolicies == nil {
-		snap.ClusterPolicies = make(map[string]string)
+		snap.ClusterPolicies = make(map[string]map[string]string)
 	}
 
 	if snap.ClusterOperations == nil {
-		snap.ClusterOperations = make(map[string]*ClusterOperation)
+		snap.ClusterOperations = make(map[string]map[string]*ClusterOperation)
 	}
 }
 
-// fixNilTags ensures restored resources have non-nil tag maps.
+// fixNilTags ensures restored resources have non-nil tag maps, across every region.
 func fixNilTags(snap *backendSnapshot) {
-	for _, c := range snap.Clusters {
-		if c.Tags == nil {
-			c.Tags = make(map[string]string)
-		}
-	}
+	fixRegionTags(snap.Clusters, func(c *Cluster) *map[string]string { return &c.Tags })
+	fixRegionTags(snap.Configurations, func(c *Configuration) *map[string]string { return &c.Tags })
+	fixRegionTags(snap.Replicators, func(r *Replicator) *map[string]string { return &r.Tags })
+	fixRegionTags(snap.VpcConnections, func(v *VpcConnection) *map[string]string { return &v.Tags })
+}
 
-	for _, c := range snap.Configurations {
-		if c.Tags == nil {
-			c.Tags = make(map[string]string)
-		}
-	}
-
-	for _, r := range snap.Replicators {
-		if r.Tags == nil {
-			r.Tags = make(map[string]string)
-		}
-	}
-
-	for _, v := range snap.VpcConnections {
-		if v.Tags == nil {
-			v.Tags = make(map[string]string)
+// fixRegionTags walks a region-nested resource map and replaces any nil tag map
+// (located via tagsOf) with an empty map so restored resources are tag-safe.
+func fixRegionTags[T any](byRegion map[string]map[string]*T, tagsOf func(*T) *map[string]string) {
+	for _, byKey := range byRegion {
+		for _, item := range byKey {
+			tags := tagsOf(item)
+			if *tags == nil {
+				*tags = make(map[string]string)
+			}
 		}
 	}
 }

--- a/services/kafka/update_settings_test.go
+++ b/services/kafka/update_settings_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			opType: "UPDATE_CONNECTIVITY",
 			apply: func(t *testing.T, b *kafka.InMemoryBackend, arn string) string {
 				t.Helper()
-				op, err := b.UpdateConnectivity(arn, kafka.UpdateConnectivitySettings{
+				op, err := b.UpdateConnectivity(context.Background(), arn, kafka.UpdateConnectivitySettings{
 					ConnectivityInfo: &kafka.ConnectivityInfo{
 						PublicAccess: &kafka.PublicAccess{Type: "SERVICE_PROVIDED_EIPS"},
 					},
@@ -53,7 +54,7 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			opType: "UPDATE_MONITORING",
 			apply: func(t *testing.T, b *kafka.InMemoryBackend, arn string) string {
 				t.Helper()
-				op, err := b.UpdateMonitoring(arn, kafka.UpdateMonitoringSettings{
+				op, err := b.UpdateMonitoring(context.Background(), arn, kafka.UpdateMonitoringSettings{
 					EnhancedMonitoring: "PER_TOPIC_PER_BROKER",
 					OpenMonitoring: &kafka.OpenMonitoring{
 						Prometheus: &kafka.PrometheusInfo{
@@ -83,7 +84,7 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			opType: "UPDATE_SECURITY",
 			apply: func(t *testing.T, b *kafka.InMemoryBackend, arn string) string {
 				t.Helper()
-				op, err := b.UpdateSecurity(arn, kafka.UpdateSecuritySettings{
+				op, err := b.UpdateSecurity(context.Background(), arn, kafka.UpdateSecuritySettings{
 					ClientAuthentication: &kafka.ClientAuthentication{
 						Sasl: &kafka.SaslSettings{Iam: &kafka.SaslIam{Enabled: true}},
 					},
@@ -113,7 +114,7 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			opType: "UPDATE_STORAGE",
 			apply: func(t *testing.T, b *kafka.InMemoryBackend, arn string) string {
 				t.Helper()
-				op, err := b.UpdateStorage(arn, kafka.UpdateStorageSettings{
+				op, err := b.UpdateStorage(context.Background(), arn, kafka.UpdateStorageSettings{
 					StorageMode:  "TIERED",
 					VolumeSizeGB: 2048,
 					ProvisionedThroughput: &kafka.ProvisionedThroughput{
@@ -146,7 +147,7 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			opType: "UPDATE_REBALANCING",
 			apply: func(t *testing.T, b *kafka.InMemoryBackend, arn string) string {
 				t.Helper()
-				op, err := b.UpdateRebalancing(arn)
+				op, err := b.UpdateRebalancing(context.Background(), arn)
 				require.NoError(t, err)
 
 				return op.ClusterOperationArn
@@ -164,7 +165,7 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBackend(t)
-			cluster, err := b.CreateCluster("c1", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
+			cluster, err := b.CreateCluster(context.Background(), "c1", "3.5.1", 3, kafka.BrokerNodeGroupInfo{
 				InstanceType:  "kafka.m5.large",
 				ClientSubnets: []string{"subnet-1"},
 			}, nil, nil)
@@ -173,12 +174,12 @@ func TestBackend_UpdateSettings(t *testing.T) {
 			opArn := tt.apply(t, b, cluster.ClusterArn)
 			assert.NotEmpty(t, opArn)
 
-			op, descErr := b.DescribeClusterOperation(opArn)
+			op, descErr := b.DescribeClusterOperation(context.Background(), opArn)
 			require.NoError(t, descErr)
 			assert.Equal(t, tt.opType, op.OperationType)
 			assert.Equal(t, cluster.ClusterArn, op.ClusterArn)
 
-			updated, getErr := b.DescribeCluster(cluster.ClusterArn)
+			updated, getErr := b.DescribeCluster(context.Background(), cluster.ClusterArn)
 			require.NoError(t, getErr)
 
 			tt.verify(t, updated, op)
@@ -193,14 +194,14 @@ func TestBackend_UpdateSettings_NotFound(t *testing.T) {
 	b := newTestBackend(t)
 	missing := "arn:aws:kafka:us-east-1:000000000000:cluster/missing/abc"
 
-	_, err := b.UpdateConnectivity(missing, kafka.UpdateConnectivitySettings{})
+	_, err := b.UpdateConnectivity(context.Background(), missing, kafka.UpdateConnectivitySettings{})
 	require.Error(t, err)
-	_, err = b.UpdateMonitoring(missing, kafka.UpdateMonitoringSettings{})
+	_, err = b.UpdateMonitoring(context.Background(), missing, kafka.UpdateMonitoringSettings{})
 	require.Error(t, err)
-	_, err = b.UpdateSecurity(missing, kafka.UpdateSecuritySettings{})
+	_, err = b.UpdateSecurity(context.Background(), missing, kafka.UpdateSecuritySettings{})
 	require.Error(t, err)
-	_, err = b.UpdateStorage(missing, kafka.UpdateStorageSettings{})
+	_, err = b.UpdateStorage(context.Background(), missing, kafka.UpdateStorageSettings{})
 	require.Error(t, err)
-	_, err = b.UpdateRebalancing(missing)
+	_, err = b.UpdateRebalancing(context.Background(), missing)
 	require.Error(t, err)
 }

--- a/services/kinesis/accuracy_batch2_ops_test.go
+++ b/services/kinesis/accuracy_batch2_ops_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -112,7 +113,7 @@ func TestAccuracyBatch2_DescribeStream_ByARN(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "arn-describe-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "arn-describe-stream"})
+	desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "arn-describe-stream"})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -157,7 +158,7 @@ func TestAccuracyBatch2_DescribeStreamSummary_ByARN(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "arn-summary-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "arn-summary-stream"})
+	desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "arn-summary-stream"})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -334,7 +335,7 @@ func TestAccuracyBatch2_DeleteStream_ByARN(t *testing.T) {
 			doRequest(t, h, "CreateStream", map[string]any{"StreamName": streamName, "ShardCount": 1})
 
 			b := h.Backend.(*kinesis.InMemoryBackend)
-			desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: streamName})
+			desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: streamName})
 			require.NoError(t, err)
 
 			var deleteBody map[string]any
@@ -369,7 +370,10 @@ func TestAccuracyBatch2_PutRecord_ByARN(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "put-record-arn-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "put-record-arn-stream"})
+	desc, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "put-record-arn-stream"},
+	)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -419,7 +423,10 @@ func TestAccuracyBatch2_PutRecords_ByARN(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "put-records-arn-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "put-records-arn-stream"})
+	desc, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "put-records-arn-stream"},
+	)
 	require.NoError(t, err)
 
 	records := []map[string]any{
@@ -477,7 +484,7 @@ func TestAccuracyBatch2_GetShardIterator_ByARN(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "gsi-arn-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "gsi-arn-stream"})
+	desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "gsi-arn-stream"})
 	require.NoError(t, err)
 	require.NotEmpty(t, desc.Shards)
 	shardID := desc.Shards[0].ShardID

--- a/services/kinesis/backend.go
+++ b/services/kinesis/backend.go
@@ -25,43 +25,105 @@ import (
 )
 
 // StorageBackend defines the interface for a Kinesis backend.
+//
+// Every method takes a context.Context so the per-request AWS region can be
+// threaded through and resources kept isolated per region. The region is read
+// from the context via getRegion, falling back to the backend's default region
+// when the context carries no region.
 type StorageBackend interface {
-	CreateStream(input *CreateStreamInput) error
-	DeleteStream(input *DeleteStreamInput) error
-	DescribeStream(input *DescribeStreamInput) (*DescribeStreamOutput, error)
-	ListStreams(input *ListStreamsInput) (*ListStreamsOutput, error)
-	PutRecord(input *PutRecordInput) (*PutRecordOutput, error)
-	PutRecords(input *PutRecordsInput) (*PutRecordsOutput, error)
-	GetShardIterator(input *GetShardIteratorInput) (*GetShardIteratorOutput, error)
-	GetRecords(input *GetRecordsInput) (*GetRecordsOutput, error)
-	ListShards(input *ListShardsInput) (*ListShardsOutput, error)
-	RegisterStreamConsumer(input *RegisterStreamConsumerInput) (*RegisterStreamConsumerOutput, error)
-	DescribeStreamConsumer(input *DescribeStreamConsumerInput) (*DescribeStreamConsumerOutput, error)
-	ListStreamConsumers(input *ListStreamConsumersInput) (*ListStreamConsumersOutput, error)
-	DeregisterStreamConsumer(input *DeregisterStreamConsumerInput) error
-	SubscribeToShard(input *SubscribeToShardInput) (*SubscribeToShardOutput, error)
-	UpdateShardCount(input *UpdateShardCountInput) (*UpdateShardCountOutput, error)
-	EnableEnhancedMonitoring(input *EnableEnhancedMonitoringInput) (*EnableEnhancedMonitoringOutput, error)
-	DisableEnhancedMonitoring(input *DisableEnhancedMonitoringInput) (*DisableEnhancedMonitoringOutput, error)
-	IncreaseStreamRetentionPeriod(input *IncreaseStreamRetentionPeriodInput) error
-	DecreaseStreamRetentionPeriod(input *DecreaseStreamRetentionPeriodInput) error
-	MergeShards(input *MergeShardsInput) error
-	SplitShard(input *SplitShardInput) error
-	StartStreamEncryption(input *StartStreamEncryptionInput) error
-	StopStreamEncryption(input *StopStreamEncryptionInput) error
-	DeleteResourcePolicy(input *DeleteResourcePolicyInput) error
-	GetResourcePolicy(input *GetResourcePolicyInput) (*GetResourcePolicyOutput, error)
-	PutResourcePolicy(input *PutResourcePolicyInput) error
-	ListTagsForResource(input *ListTagsForResourceInput) (*ListTagsForResourceOutput, error)
-	TagResource(input *TagResourceInput) error
-	UntagResource(input *UntagResourceInput) error
-	UpdateStreamMode(input *UpdateStreamModeInput) error
-	UpdateAccountSettings(input *UpdateAccountSettingsInput) error
-	UpdateMaxRecordSize(input *UpdateMaxRecordSizeInput) error
-	UpdateStreamWarmThroughput(input *UpdateStreamWarmThroughputInput) error
-	DescribeAccountSettings() (*DescribeAccountSettingsOutput, error)
-	CountOpenShards() int
-	ListAll() []StreamInfo
+	CreateStream(ctx context.Context, input *CreateStreamInput) error
+	DeleteStream(ctx context.Context, input *DeleteStreamInput) error
+	DescribeStream(ctx context.Context, input *DescribeStreamInput) (*DescribeStreamOutput, error)
+	ListStreams(ctx context.Context, input *ListStreamsInput) (*ListStreamsOutput, error)
+	PutRecord(ctx context.Context, input *PutRecordInput) (*PutRecordOutput, error)
+	PutRecords(ctx context.Context, input *PutRecordsInput) (*PutRecordsOutput, error)
+	GetShardIterator(ctx context.Context, input *GetShardIteratorInput) (*GetShardIteratorOutput, error)
+	GetRecords(ctx context.Context, input *GetRecordsInput) (*GetRecordsOutput, error)
+	ListShards(ctx context.Context, input *ListShardsInput) (*ListShardsOutput, error)
+	RegisterStreamConsumer(
+		ctx context.Context,
+		input *RegisterStreamConsumerInput,
+	) (*RegisterStreamConsumerOutput, error)
+	DescribeStreamConsumer(
+		ctx context.Context,
+		input *DescribeStreamConsumerInput,
+	) (*DescribeStreamConsumerOutput, error)
+	ListStreamConsumers(ctx context.Context, input *ListStreamConsumersInput) (*ListStreamConsumersOutput, error)
+	DeregisterStreamConsumer(ctx context.Context, input *DeregisterStreamConsumerInput) error
+	SubscribeToShard(ctx context.Context, input *SubscribeToShardInput) (*SubscribeToShardOutput, error)
+	UpdateShardCount(ctx context.Context, input *UpdateShardCountInput) (*UpdateShardCountOutput, error)
+	EnableEnhancedMonitoring(
+		ctx context.Context,
+		input *EnableEnhancedMonitoringInput,
+	) (*EnableEnhancedMonitoringOutput, error)
+	DisableEnhancedMonitoring(
+		ctx context.Context,
+		input *DisableEnhancedMonitoringInput,
+	) (*DisableEnhancedMonitoringOutput, error)
+	IncreaseStreamRetentionPeriod(ctx context.Context, input *IncreaseStreamRetentionPeriodInput) error
+	DecreaseStreamRetentionPeriod(ctx context.Context, input *DecreaseStreamRetentionPeriodInput) error
+	MergeShards(ctx context.Context, input *MergeShardsInput) error
+	SplitShard(ctx context.Context, input *SplitShardInput) error
+	StartStreamEncryption(ctx context.Context, input *StartStreamEncryptionInput) error
+	StopStreamEncryption(ctx context.Context, input *StopStreamEncryptionInput) error
+	DeleteResourcePolicy(ctx context.Context, input *DeleteResourcePolicyInput) error
+	GetResourcePolicy(ctx context.Context, input *GetResourcePolicyInput) (*GetResourcePolicyOutput, error)
+	PutResourcePolicy(ctx context.Context, input *PutResourcePolicyInput) error
+	ListTagsForResource(ctx context.Context, input *ListTagsForResourceInput) (*ListTagsForResourceOutput, error)
+	TagResource(ctx context.Context, input *TagResourceInput) error
+	UntagResource(ctx context.Context, input *UntagResourceInput) error
+	UpdateStreamMode(ctx context.Context, input *UpdateStreamModeInput) error
+	UpdateAccountSettings(ctx context.Context, input *UpdateAccountSettingsInput) error
+	UpdateMaxRecordSize(ctx context.Context, input *UpdateMaxRecordSizeInput) error
+	UpdateStreamWarmThroughput(ctx context.Context, input *UpdateStreamWarmThroughputInput) error
+	DescribeAccountSettings(ctx context.Context) (*DescribeAccountSettingsOutput, error)
+	CountOpenShards(ctx context.Context) int
+	ListAll(ctx context.Context) []StreamInfo
+}
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// contextWithRegion returns ctx with the given region attached under regionContextKey.
+func contextWithRegion(ctx context.Context, region string) context.Context {
+	return context.WithValue(ctx, regionContextKey{}, region)
+}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
+// regionFromARNOrCtx resolves the region for an ARN-addressed operation: it
+// prefers the region embedded in the ARN (so the resource is found in the
+// region it actually lives in), then the ctx region, then defaultRegion.
+func regionFromARNOrCtx(ctx context.Context, a, defaultRegion string) string {
+	if r := regionFromARN(a); r != "" {
+		return r
+	}
+
+	return getRegion(ctx, defaultRegion)
+}
+
+// regionFromARN extracts the region segment from an AWS ARN.
+// ARN format: arn:partition:service:region:account:resource. Returns "" when
+// the input is not a well-formed ARN with a non-empty region segment.
+func regionFromARN(a string) string {
+	const (
+		arnRegionIdx = 3
+		arnMinParts  = 6
+	)
+
+	parts := strings.Split(a, ":")
+	if len(parts) < arnMinParts {
+		return ""
+	}
+
+	return parts[arnRegionIdx]
 }
 
 // Compile-time assertion that InMemoryBackend implements StorageBackend.
@@ -111,11 +173,15 @@ type kinesisThrottleFault struct {
 }
 
 // InMemoryBackend implements StorageBackend using in-memory maps.
+//
+// All resource maps are nested by region (outer key = region) so that
+// same-named streams in different regions are fully isolated — including their
+// shards, records, consumers, FIS throttle faults, and resource policies.
 type InMemoryBackend struct {
-	streams                  map[string]*Stream
-	fisThroughputFaults      map[string]*kinesisThrottleFault
+	streams                  map[string]map[string]*Stream               // region → stream name → stream
+	fisThroughputFaults      map[string]map[string]*kinesisThrottleFault // region → stream name → fault
 	faultsMu                 *lockmetrics.RWMutex
-	resourcePolicies         map[string]string
+	resourcePolicies         map[string]map[string]string // region → resource ARN → policy
 	mu                       *lockmetrics.RWMutex
 	OnStreamPurged           func(string)
 	accountID                string
@@ -131,15 +197,55 @@ func NewInMemoryBackend() *InMemoryBackend {
 // NewInMemoryBackendWithConfig creates a new InMemoryBackend with the given account ID and region.
 func NewInMemoryBackendWithConfig(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		streams:                  make(map[string]*Stream),
-		fisThroughputFaults:      make(map[string]*kinesisThrottleFault),
+		streams:                  make(map[string]map[string]*Stream),
+		fisThroughputFaults:      make(map[string]map[string]*kinesisThrottleFault),
 		faultsMu:                 lockmetrics.New("kinesis.faults"),
-		resourcePolicies:         make(map[string]string),
+		resourcePolicies:         make(map[string]map[string]string),
 		accountID:                accountID,
 		region:                   region,
 		mu:                       lockmetrics.New("kinesis"),
 		onDemandStreamCountLimit: defaultOnDemandStreamCountLimit,
 	}
+}
+
+// Region returns the AWS region this backend is configured to use as its default.
+func (b *InMemoryBackend) Region() string { return b.region }
+
+// streamsStore returns the stream map for the given region, lazily creating it.
+// Callers must hold b.mu (write lock).
+func (b *InMemoryBackend) streamsStore(region string) map[string]*Stream {
+	if b.streams[region] == nil {
+		b.streams[region] = make(map[string]*Stream)
+	}
+
+	return b.streams[region]
+}
+
+// streamsView returns the existing stream map for the given region without
+// creating it. A nil map (region never written) reads as empty. Safe under a
+// read lock. Callers must hold b.mu (read or write lock).
+func (b *InMemoryBackend) streamsView(region string) map[string]*Stream {
+	return b.streams[region]
+}
+
+// faultsStore returns the FIS throttle-fault map for the given region, lazily
+// creating it. Callers must hold b.faultsMu.
+func (b *InMemoryBackend) faultsStore(region string) map[string]*kinesisThrottleFault {
+	if b.fisThroughputFaults[region] == nil {
+		b.fisThroughputFaults[region] = make(map[string]*kinesisThrottleFault)
+	}
+
+	return b.fisThroughputFaults[region]
+}
+
+// policiesStore returns the resource-policy map for the given region, lazily
+// creating it. Callers must hold b.mu.
+func (b *InMemoryBackend) policiesStore(region string) map[string]string {
+	if b.resourcePolicies[region] == nil {
+		b.resourcePolicies[region] = make(map[string]string)
+	}
+
+	return b.resourcePolicies[region]
 }
 
 func newStreamLock(streamName string) *lockmetrics.RWMutex {
@@ -219,7 +325,12 @@ func (s *Shard) nextSequenceNumber() string {
 }
 
 // CreateStream creates a new Kinesis stream.
-func (b *InMemoryBackend) CreateStream(input *CreateStreamInput) error {
+func (b *InMemoryBackend) CreateStream(ctx context.Context, input *CreateStreamInput) error {
+	region := getRegion(ctx, b.region)
+	if input.Region != "" {
+		region = input.Region
+	}
+
 	b.mu.Lock("CreateStream")
 	defer b.mu.Unlock()
 
@@ -227,7 +338,8 @@ func (b *InMemoryBackend) CreateStream(input *CreateStreamInput) error {
 		return ErrValidation
 	}
 
-	if _, exists := b.streams[input.StreamName]; exists {
+	streams := b.streamsStore(region)
+	if _, exists := streams[input.StreamName]; exists {
 		return ErrStreamAlreadyExists
 	}
 
@@ -281,11 +393,6 @@ func (b *InMemoryBackend) CreateStream(input *CreateStreamInput) error {
 		accountID = input.AccountID
 	}
 
-	region := b.region
-	if input.Region != "" {
-		region = input.Region
-	}
-
 	streamMode := input.StreamMode
 	if streamMode == "" {
 		streamMode = streamModeProvisioned
@@ -293,7 +400,7 @@ func (b *InMemoryBackend) CreateStream(input *CreateStreamInput) error {
 
 	if streamMode == streamModeOnDemand {
 		onDemandCount := 0
-		for _, s := range b.streams {
+		for _, s := range streams {
 			if s.StreamMode == streamModeOnDemand {
 				onDemandCount++
 			}
@@ -305,7 +412,7 @@ func (b *InMemoryBackend) CreateStream(input *CreateStreamInput) error {
 
 	streamARN := arn.Build("kinesis", region, accountID, "stream/"+input.StreamName)
 
-	b.streams[input.StreamName] = &Stream{
+	streams[input.StreamName] = &Stream{
 		Name:               input.StreamName,
 		ARN:                streamARN,
 		Status:             streamStatusActive,
@@ -323,10 +430,13 @@ func (b *InMemoryBackend) CreateStream(input *CreateStreamInput) error {
 }
 
 // DeleteStream removes a stream.
-func (b *InMemoryBackend) DeleteStream(input *DeleteStreamInput) error {
+func (b *InMemoryBackend) DeleteStream(ctx context.Context, input *DeleteStreamInput) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteStream")
 
-	stream, exists := b.streams[input.StreamName]
+	streams := b.streamsStore(region)
+	stream, exists := streams[input.StreamName]
 	if !exists {
 		b.mu.Unlock()
 
@@ -341,10 +451,10 @@ func (b *InMemoryBackend) DeleteStream(input *DeleteStreamInput) error {
 
 	// Mark the stream as deleting before removing it (AWS-realistic status transition).
 	stream.Status = streamStatusDeleting
-	delete(b.streams, input.StreamName)
+	delete(streams, input.StreamName)
 	b.mu.Unlock()
 	b.faultsMu.Lock("DeleteStream.faults")
-	delete(b.fisThroughputFaults, input.StreamName)
+	delete(b.faultsStore(region), input.StreamName)
 	b.faultsMu.Unlock()
 
 	// Release lockmetrics resources for the deleted stream to prevent memory leaks.
@@ -354,10 +464,15 @@ func (b *InMemoryBackend) DeleteStream(input *DeleteStreamInput) error {
 }
 
 // DescribeStream returns full stream details including shards.
-func (b *InMemoryBackend) DescribeStream(input *DescribeStreamInput) (*DescribeStreamOutput, error) {
+func (b *InMemoryBackend) DescribeStream(
+	ctx context.Context,
+	input *DescribeStreamInput,
+) (*DescribeStreamOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeStream")
 
-	stream, exists := b.streams[input.StreamName]
+	stream, exists := b.streamsView(region)[input.StreamName]
 	if !exists {
 		b.mu.RUnlock()
 
@@ -422,12 +537,14 @@ func (b *InMemoryBackend) DescribeStream(input *DescribeStreamInput) (*DescribeS
 // either `ExclusiveStartStreamName` or the opaque `NextToken` (which we treat
 // as the previously returned last stream name) so that callers can iterate
 // over arbitrarily large account inventories.
-func (b *InMemoryBackend) ListStreams(input *ListStreamsInput) (*ListStreamsOutput, error) {
+func (b *InMemoryBackend) ListStreams(ctx context.Context, input *ListStreamsInput) (*ListStreamsOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListStreams")
 	defer b.mu.RUnlock()
 
 	// AWS returns stream names in alphabetical order.
-	names := sortedKeys(b.streams)
+	names := sortedKeys(b.streamsView(region))
 
 	// Apply pagination start point: prefer ExclusiveStartStreamName, then NextToken.
 	start := input.ExclusiveStartStreamName
@@ -471,10 +588,12 @@ func (b *InMemoryBackend) ListStreams(input *ListStreamsInput) (*ListStreamsOutp
 }
 
 // PutRecord writes a single record to a stream shard.
-func (b *InMemoryBackend) PutRecord(input *PutRecordInput) (*PutRecordOutput, error) {
+func (b *InMemoryBackend) PutRecord(ctx context.Context, input *PutRecordInput) (*PutRecordOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("PutRecord")
 
-	stream, exists := b.streams[input.StreamName]
+	stream, exists := b.streamsView(region)[input.StreamName]
 	if !exists {
 		b.mu.RUnlock()
 
@@ -484,7 +603,7 @@ func (b *InMemoryBackend) PutRecord(input *PutRecordInput) (*PutRecordOutput, er
 	b.mu.RUnlock()
 	defer stream.mu.Unlock()
 
-	if b.isThroughputFaultActive(input.StreamName) {
+	if b.isThroughputFaultActive(region, input.StreamName) {
 		return nil, ErrProvisionedThroughputExceeded
 	}
 
@@ -569,7 +688,7 @@ func putRecordErrorCode(err error) string {
 }
 
 // PutRecords writes multiple records to a stream.
-func (b *InMemoryBackend) PutRecords(input *PutRecordsInput) (*PutRecordsOutput, error) {
+func (b *InMemoryBackend) PutRecords(ctx context.Context, input *PutRecordsInput) (*PutRecordsOutput, error) {
 	// AWS PutRecords caps a request at 500 records and 5 MiB total payload
 	// (sum of partition-key + data bytes across every entry).
 	const (
@@ -594,7 +713,7 @@ func (b *InMemoryBackend) PutRecords(input *PutRecordsInput) (*PutRecordsOutput,
 	failedCount := 0
 
 	for i, entry := range input.Records {
-		out, err := b.PutRecord(&PutRecordInput{
+		out, err := b.PutRecord(ctx, &PutRecordInput{
 			StreamName:      input.StreamName,
 			PartitionKey:    entry.PartitionKey,
 			ExplicitHashKey: entry.ExplicitHashKey,
@@ -651,10 +770,15 @@ func decodeIterator(token string) (*ShardIterator, error) {
 }
 
 // GetShardIterator returns an iterator for reading records from a shard.
-func (b *InMemoryBackend) GetShardIterator(input *GetShardIteratorInput) (*GetShardIteratorOutput, error) {
+func (b *InMemoryBackend) GetShardIterator(
+	ctx context.Context,
+	input *GetShardIteratorInput,
+) (*GetShardIteratorOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetShardIterator")
 
-	stream, exists := b.streams[input.StreamName]
+	stream, exists := b.streamsView(region)[input.StreamName]
 	if !exists {
 		b.mu.RUnlock()
 
@@ -698,6 +822,7 @@ func (b *InMemoryBackend) GetShardIterator(input *GetShardIteratorInput) (*GetSh
 		ShardID:        input.ShardID,
 		Position:       position,
 		SequenceNumber: input.StartingSequenceNumber,
+		Region:         region,
 		CreatedAt:      time.Now(),
 	}
 
@@ -721,15 +846,25 @@ func findShard(shards []*Shard, shardID string) *Shard {
 }
 
 // GetRecords retrieves records starting at the given shard iterator position.
-func (b *InMemoryBackend) GetRecords(input *GetRecordsInput) (*GetRecordsOutput, error) {
+//
+// The region is taken from the iterator token (encoded by GetShardIterator),
+// not from ctx, so an iterator issued for one region always reads that region's
+// records even if the GetRecords call carries a different ctx region.
+func (b *InMemoryBackend) GetRecords(ctx context.Context, input *GetRecordsInput) (*GetRecordsOutput, error) {
 	it, err := decodeIterator(input.ShardIterator)
 	if err != nil {
 		return nil, err
 	}
 
+	region := it.Region
+	if region == "" {
+		// Legacy token without an embedded region: fall back to the ctx region.
+		region = getRegion(ctx, b.region)
+	}
+
 	b.mu.RLock("GetRecords")
 
-	stream, exists := b.streams[it.StreamName]
+	stream, exists := b.streamsView(region)[it.StreamName]
 	if !exists {
 		b.mu.RUnlock()
 
@@ -739,7 +874,7 @@ func (b *InMemoryBackend) GetRecords(input *GetRecordsInput) (*GetRecordsOutput,
 	b.mu.RUnlock()
 	defer stream.mu.RUnlock()
 
-	if b.isThroughputFaultActive(it.StreamName) {
+	if b.isThroughputFaultActive(region, it.StreamName) {
 		return nil, ErrProvisionedThroughputExceeded
 	}
 
@@ -786,6 +921,7 @@ func (b *InMemoryBackend) GetRecords(input *GetRecordsInput) (*GetRecordsOutput,
 	newIt := &ShardIterator{
 		StreamName: it.StreamName,
 		ShardID:    it.ShardID,
+		Region:     region,
 		Position:   actualEnd,
 	}
 
@@ -861,10 +997,12 @@ func shardFilterIncludesAll(filter string) bool {
 }
 
 // ListShards returns the shards for a stream.
-func (b *InMemoryBackend) ListShards(input *ListShardsInput) (*ListShardsOutput, error) {
+func (b *InMemoryBackend) ListShards(ctx context.Context, input *ListShardsInput) (*ListShardsOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListShards")
 
-	stream, exists := b.streams[input.StreamName]
+	stream, exists := b.streamsView(region)[input.StreamName]
 	if !exists {
 		b.mu.RUnlock()
 
@@ -917,21 +1055,24 @@ func (b *InMemoryBackend) ListShards(input *ListShardsInput) (*ListShardsOutput,
 	return &ListShardsOutput{Shards: result}, nil
 }
 
-// ListAll returns a snapshot of all streams as StreamInfo values.
-func (b *InMemoryBackend) ListAll() []StreamInfo {
+// ListAll returns a snapshot of all streams as StreamInfo values across every
+// region. It is used by the dashboard, which presents a global inventory.
+func (b *InMemoryBackend) ListAll(_ context.Context) []StreamInfo {
 	b.mu.RLock("ListAll")
 	defer b.mu.RUnlock()
 
-	result := make([]StreamInfo, 0, len(b.streams))
-	for _, s := range b.streams {
-		s.mu.RLock("ListAll.stream")
-		result = append(result, StreamInfo{
-			Name:       s.Name,
-			ARN:        s.ARN,
-			Status:     s.Status,
-			ShardCount: len(s.Shards),
-		})
-		s.mu.RUnlock()
+	result := make([]StreamInfo, 0)
+	for _, regionStreams := range b.streams {
+		for _, s := range regionStreams {
+			s.mu.RLock("ListAll.stream")
+			result = append(result, StreamInfo{
+				Name:       s.Name,
+				ARN:        s.ARN,
+				Status:     s.Status,
+				ShardCount: len(s.Shards),
+			})
+			s.mu.RUnlock()
+		}
 	}
 
 	return result
@@ -941,18 +1082,19 @@ func (b *InMemoryBackend) ListAll() []StreamInfo {
 // applied to the current request for the given stream name, using probability-based
 // sampling when percentage < 100.
 // The method lazily removes expired fault entries to prevent unbounded map growth.
-func (b *InMemoryBackend) isThroughputFaultActive(streamName string) bool {
+func (b *InMemoryBackend) isThroughputFaultActive(region, streamName string) bool {
 	b.faultsMu.Lock("isThroughputFaultActive")
 	defer b.faultsMu.Unlock()
 
-	fault, ok := b.fisThroughputFaults[streamName]
+	regionFaults := b.fisThroughputFaults[region]
+	fault, ok := regionFaults[streamName]
 	if !ok || fault == nil {
 		return false
 	}
 
 	if !fault.expiry.IsZero() && time.Now().After(fault.expiry) {
 		// Lazily evict expired entry.
-		delete(b.fisThroughputFaults, streamName)
+		delete(regionFaults, streamName)
 
 		return false
 	}
@@ -1041,12 +1183,15 @@ func removeStrings(ss, remove []string) []string {
 
 // RegisterStreamConsumer registers a new enhanced fan-out consumer on a stream.
 func (b *InMemoryBackend) RegisterStreamConsumer(
+	ctx context.Context,
 	input *RegisterStreamConsumerInput,
 ) (*RegisterStreamConsumerOutput, error) {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.RLock("RegisterStreamConsumer")
 
 	streamName := streamNameFromARN(input.StreamARN)
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(region)[streamName]
 
 	if !ok {
 		b.mu.RUnlock()
@@ -1087,19 +1232,25 @@ func (b *InMemoryBackend) RegisterStreamConsumer(
 // DescribeStreamConsumer returns details about a registered consumer.
 // Lookup is by ConsumerARN, or by StreamARN + ConsumerName.
 func (b *InMemoryBackend) DescribeStreamConsumer(
+	ctx context.Context,
 	input *DescribeStreamConsumerInput,
 ) (*DescribeStreamConsumerOutput, error) {
 	var sName string
 	var cName string
+	var arnForRegion string
 	if input.ConsumerARN != "" {
 		sName, cName = consumerInfoFromARN(input.ConsumerARN)
+		arnForRegion = input.ConsumerARN
 	} else {
 		sName = streamNameFromARN(input.StreamARN)
 		cName = input.ConsumerName
+		arnForRegion = input.StreamARN
 	}
 
+	region := regionFromARNOrCtx(ctx, arnForRegion, b.region)
+
 	b.mu.RLock("DescribeStreamConsumer")
-	stream, ok := b.streams[sName]
+	stream, ok := b.streamsView(region)[sName]
 	if !ok {
 		b.mu.RUnlock()
 		if input.ConsumerARN != "" {
@@ -1121,11 +1272,16 @@ func (b *InMemoryBackend) DescribeStreamConsumer(
 }
 
 // ListStreamConsumers lists all registered consumers for a stream.
-func (b *InMemoryBackend) ListStreamConsumers(input *ListStreamConsumersInput) (*ListStreamConsumersOutput, error) {
+func (b *InMemoryBackend) ListStreamConsumers(
+	ctx context.Context,
+	input *ListStreamConsumersInput,
+) (*ListStreamConsumersOutput, error) {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.RLock("ListStreamConsumers")
 
 	streamName := streamNameFromARN(input.StreamARN)
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(region)[streamName]
 
 	if !ok {
 		b.mu.RUnlock()
@@ -1166,7 +1322,7 @@ func (b *InMemoryBackend) ListStreamConsumers(input *ListStreamConsumersInput) (
 }
 
 // DeregisterStreamConsumer removes a registered consumer from a stream.
-func (b *InMemoryBackend) DeregisterStreamConsumer(input *DeregisterStreamConsumerInput) error {
+func (b *InMemoryBackend) DeregisterStreamConsumer(ctx context.Context, input *DeregisterStreamConsumerInput) error {
 	sName, cName := func() (string, string) {
 		if input.ConsumerARN != "" {
 			return consumerInfoFromARN(input.ConsumerARN)
@@ -1175,8 +1331,14 @@ func (b *InMemoryBackend) DeregisterStreamConsumer(input *DeregisterStreamConsum
 		return streamNameFromARN(input.StreamARN), input.ConsumerName
 	}()
 
+	arnForRegion := input.StreamARN
+	if input.ConsumerARN != "" {
+		arnForRegion = input.ConsumerARN
+	}
+	region := regionFromARNOrCtx(ctx, arnForRegion, b.region)
+
 	b.mu.RLock("DeregisterStreamConsumer")
-	stream, ok := b.streams[sName]
+	stream, ok := b.streamsView(region)[sName]
 	if !ok {
 		b.mu.RUnlock()
 
@@ -1197,12 +1359,16 @@ func (b *InMemoryBackend) DeregisterStreamConsumer(input *DeregisterStreamConsum
 
 // SubscribeToShard delivers records from a shard to an enhanced fan-out consumer.
 // For mock purposes this is a single-shot delivery of all available records.
-func (b *InMemoryBackend) SubscribeToShard(input *SubscribeToShardInput) (*SubscribeToShardOutput, error) {
+func (b *InMemoryBackend) SubscribeToShard(
+	ctx context.Context,
+	input *SubscribeToShardInput,
+) (*SubscribeToShardOutput, error) {
 	sName, cName := consumerInfoFromARN(input.ConsumerARN)
+	region := regionFromARNOrCtx(ctx, input.ConsumerARN, b.region)
 
 	b.mu.RLock("SubscribeToShard")
 
-	stream, ok := b.streams[sName]
+	stream, ok := b.streamsView(region)[sName]
 	if !ok {
 		b.mu.RUnlock()
 
@@ -1277,11 +1443,16 @@ func (b *InMemoryBackend) SubscribeToShard(input *SubscribeToShardInput) (*Subsc
 
 // UpdateShardCount resizes a stream to the given number of shards.
 // Existing records in the stream are not migrated; new shards start empty.
-func (b *InMemoryBackend) UpdateShardCount(input *UpdateShardCountInput) (*UpdateShardCountOutput, error) {
+func (b *InMemoryBackend) UpdateShardCount(
+	ctx context.Context,
+	input *UpdateShardCountInput,
+) (*UpdateShardCountOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateShardCount")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[input.StreamName]
+	stream, ok := b.streamsStore(region)[input.StreamName]
 	if !ok {
 		return nil, ErrStreamNotFound
 	}
@@ -1364,12 +1535,15 @@ func (b *InMemoryBackend) UpdateShardCount(input *UpdateShardCountInput) (*Updat
 
 // EnableEnhancedMonitoring adds shard-level metrics to a stream.
 func (b *InMemoryBackend) EnableEnhancedMonitoring(
+	ctx context.Context,
 	input *EnableEnhancedMonitoringInput,
 ) (*EnableEnhancedMonitoringOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("EnableEnhancedMonitoring")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[input.StreamName]
+	stream, ok := b.streamsStore(region)[input.StreamName]
 	if !ok {
 		return nil, ErrStreamNotFound
 	}
@@ -1394,12 +1568,15 @@ func (b *InMemoryBackend) EnableEnhancedMonitoring(
 
 // DisableEnhancedMonitoring removes shard-level metrics from a stream.
 func (b *InMemoryBackend) DisableEnhancedMonitoring(
+	ctx context.Context,
 	input *DisableEnhancedMonitoringInput,
 ) (*DisableEnhancedMonitoringOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DisableEnhancedMonitoring")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[input.StreamName]
+	stream, ok := b.streamsStore(region)[input.StreamName]
 	if !ok {
 		return nil, ErrStreamNotFound
 	}
@@ -1425,12 +1602,15 @@ func (b *InMemoryBackend) DisableEnhancedMonitoring(
 // AWS Terraform provider, which may call this with the default value (24h) even
 // on freshly created streams. The new value must not exceed maxRetentionHours.
 func (b *InMemoryBackend) IncreaseStreamRetentionPeriod(
+	ctx context.Context,
 	input *IncreaseStreamRetentionPeriodInput,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("IncreaseStreamRetentionPeriod")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[input.StreamName]
+	stream, ok := b.streamsStore(region)[input.StreamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -1457,12 +1637,15 @@ func (b *InMemoryBackend) IncreaseStreamRetentionPeriod(
 // If the new value equals the current retention period the call is a no-op
 // and returns success. The new value must be at least minRetentionHours.
 func (b *InMemoryBackend) DecreaseStreamRetentionPeriod(
+	ctx context.Context,
 	input *DecreaseStreamRetentionPeriodInput,
 ) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DecreaseStreamRetentionPeriod")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[input.StreamName]
+	stream, ok := b.streamsStore(region)[input.StreamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -1506,7 +1689,9 @@ func nextShardID(shards []*Shard) string {
 
 // MergeShards merges two adjacent shards into one.
 // The merged shard spans the combined hash key range of both parent shards.
-func (b *InMemoryBackend) MergeShards(input *MergeShardsInput) error {
+func (b *InMemoryBackend) MergeShards(ctx context.Context, input *MergeShardsInput) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.Lock("MergeShards")
 	defer b.mu.Unlock()
 
@@ -1515,7 +1700,7 @@ func (b *InMemoryBackend) MergeShards(input *MergeShardsInput) error {
 		streamName = streamNameFromARN(input.StreamARN)
 	}
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsStore(region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -1582,7 +1767,9 @@ func (b *InMemoryBackend) MergeShards(input *MergeShardsInput) error {
 }
 
 // SplitShard splits a shard into two at the given new starting hash key.
-func (b *InMemoryBackend) SplitShard(input *SplitShardInput) error {
+func (b *InMemoryBackend) SplitShard(ctx context.Context, input *SplitShardInput) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.Lock("SplitShard")
 	defer b.mu.Unlock()
 
@@ -1591,7 +1778,7 @@ func (b *InMemoryBackend) SplitShard(input *SplitShardInput) error {
 		streamName = streamNameFromARN(input.StreamARN)
 	}
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsStore(region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -1661,7 +1848,9 @@ func (b *InMemoryBackend) SplitShard(input *SplitShardInput) error {
 }
 
 // StartStreamEncryption enables server-side encryption on a stream.
-func (b *InMemoryBackend) StartStreamEncryption(input *StartStreamEncryptionInput) error {
+func (b *InMemoryBackend) StartStreamEncryption(ctx context.Context, input *StartStreamEncryptionInput) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.Lock("StartStreamEncryption")
 	defer b.mu.Unlock()
 
@@ -1670,7 +1859,7 @@ func (b *InMemoryBackend) StartStreamEncryption(input *StartStreamEncryptionInpu
 		streamName = streamNameFromARN(input.StreamARN)
 	}
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsStore(region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -1688,7 +1877,9 @@ func (b *InMemoryBackend) StartStreamEncryption(input *StartStreamEncryptionInpu
 }
 
 // StopStreamEncryption disables server-side encryption on a stream.
-func (b *InMemoryBackend) StopStreamEncryption(input *StopStreamEncryptionInput) error {
+func (b *InMemoryBackend) StopStreamEncryption(ctx context.Context, input *StopStreamEncryptionInput) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.Lock("StopStreamEncryption")
 	defer b.mu.Unlock()
 
@@ -1697,7 +1888,7 @@ func (b *InMemoryBackend) StopStreamEncryption(input *StopStreamEncryptionInput)
 		streamName = streamNameFromARN(input.StreamARN)
 	}
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsStore(region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -1711,21 +1902,28 @@ func (b *InMemoryBackend) StopStreamEncryption(input *StopStreamEncryptionInput)
 }
 
 // PutResourcePolicy stores a resource-based policy for the given stream or consumer ARN.
-func (b *InMemoryBackend) PutResourcePolicy(input *PutResourcePolicyInput) error {
+func (b *InMemoryBackend) PutResourcePolicy(ctx context.Context, input *PutResourcePolicyInput) error {
+	region := regionFromARNOrCtx(ctx, input.ResourceARN, b.region)
+
 	b.mu.Lock("PutResourcePolicy")
 	defer b.mu.Unlock()
 
-	b.resourcePolicies[input.ResourceARN] = input.Policy
+	b.policiesStore(region)[input.ResourceARN] = input.Policy
 
 	return nil
 }
 
 // GetResourcePolicy retrieves the resource-based policy for the given stream or consumer ARN.
-func (b *InMemoryBackend) GetResourcePolicy(input *GetResourcePolicyInput) (*GetResourcePolicyOutput, error) {
+func (b *InMemoryBackend) GetResourcePolicy(
+	ctx context.Context,
+	input *GetResourcePolicyInput,
+) (*GetResourcePolicyOutput, error) {
+	region := regionFromARNOrCtx(ctx, input.ResourceARN, b.region)
+
 	b.mu.RLock("GetResourcePolicy")
 	defer b.mu.RUnlock()
 
-	policy, ok := b.resourcePolicies[input.ResourceARN]
+	policy, ok := b.resourcePolicies[region][input.ResourceARN]
 	if !ok {
 		return nil, ErrResourcePolicyNotFound
 	}
@@ -1734,26 +1932,34 @@ func (b *InMemoryBackend) GetResourcePolicy(input *GetResourcePolicyInput) (*Get
 }
 
 // DeleteResourcePolicy removes the resource-based policy for the given stream or consumer ARN.
-func (b *InMemoryBackend) DeleteResourcePolicy(input *DeleteResourcePolicyInput) error {
+func (b *InMemoryBackend) DeleteResourcePolicy(ctx context.Context, input *DeleteResourcePolicyInput) error {
+	region := regionFromARNOrCtx(ctx, input.ResourceARN, b.region)
+
 	b.mu.Lock("DeleteResourcePolicy")
 	defer b.mu.Unlock()
 
-	if _, ok := b.resourcePolicies[input.ResourceARN]; !ok {
+	regionPolicies := b.resourcePolicies[region]
+	if _, ok := regionPolicies[input.ResourceARN]; !ok {
 		return ErrResourcePolicyNotFound
 	}
 
-	delete(b.resourcePolicies, input.ResourceARN)
+	delete(regionPolicies, input.ResourceARN)
 
 	return nil
 }
 
 // ListTagsForResource returns the tags associated with a stream identified by its ARN.
 // Tags are those stored on the stream's internal Tags store (set via TagResource).
-func (b *InMemoryBackend) ListTagsForResource(input *ListTagsForResourceInput) (*ListTagsForResourceOutput, error) {
+func (b *InMemoryBackend) ListTagsForResource(
+	ctx context.Context,
+	input *ListTagsForResourceInput,
+) (*ListTagsForResourceOutput, error) {
+	region := regionFromARNOrCtx(ctx, input.ResourceARN, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 
 	streamName := streamNameFromARN(input.ResourceARN)
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(region)[streamName]
 
 	if !ok {
 		b.mu.RUnlock()
@@ -1773,12 +1979,16 @@ func (b *InMemoryBackend) ListTagsForResource(input *ListTagsForResourceInput) (
 }
 
 // DescribeAccountSettings returns account-level limits for this Kinesis account.
-func (b *InMemoryBackend) DescribeAccountSettings() (*DescribeAccountSettingsOutput, error) {
+// The ON_DEMAND stream count is reported per region (AWS account-level limits
+// are tracked per region), using the region carried on ctx.
+func (b *InMemoryBackend) DescribeAccountSettings(ctx context.Context) (*DescribeAccountSettingsOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeAccountSettings")
 	defer b.mu.RUnlock()
 
 	onDemandCount := 0
-	for _, s := range b.streams {
+	for _, s := range b.streamsView(region) {
 		s.mu.RLock("DescribeAccountSettings.stream")
 		if s.StreamMode == streamModeOnDemand {
 			onDemandCount++
@@ -1799,24 +2009,27 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, stream := range b.streams {
-		stream.mu.Lock("Reset.stream")
-		if stream.Tags != nil {
-			stream.Tags.Close()
+	for _, regionStreams := range b.streams {
+		for _, stream := range regionStreams {
+			stream.mu.Lock("Reset.stream")
+			if stream.Tags != nil {
+				stream.Tags.Close()
+			}
+			stream.mu.Unlock()
 		}
-		stream.mu.Unlock()
 	}
 
-	b.streams = make(map[string]*Stream)
+	b.streams = make(map[string]map[string]*Stream)
 	b.faultsMu.Lock("Reset.faults")
-	b.fisThroughputFaults = make(map[string]*kinesisThrottleFault)
+	b.fisThroughputFaults = make(map[string]map[string]*kinesisThrottleFault)
 	b.faultsMu.Unlock()
-	b.resourcePolicies = make(map[string]string)
+	b.resourcePolicies = make(map[string]map[string]string)
 }
 
-// purgeStreamEntry removes s from b.streams when it predates cutoff, or evicts its stale
-// consumers otherwise. Must be called with b.mu held. Returns true when the stream was removed.
-func (b *InMemoryBackend) purgeStreamEntry(name string, s *Stream, cutoff time.Time) bool {
+// purgeStreamEntry removes s from the given region's stream map when it predates
+// cutoff, or evicts its stale consumers otherwise. Must be called with b.mu held.
+// Returns true when the stream was removed.
+func (b *InMemoryBackend) purgeStreamEntry(region, name string, s *Stream, cutoff time.Time) bool {
 	s.mu.Lock("Purge.stream")
 	defer s.mu.Unlock()
 
@@ -1824,9 +2037,9 @@ func (b *InMemoryBackend) purgeStreamEntry(name string, s *Stream, cutoff time.T
 		if s.Tags != nil {
 			s.Tags.Close()
 		}
-		delete(b.streams, name)
+		delete(b.streamsStore(region), name)
 		b.faultsMu.Lock("Purge.faults")
-		delete(b.fisThroughputFaults, name)
+		delete(b.faultsStore(region), name)
 		b.faultsMu.Unlock()
 
 		return true
@@ -1861,12 +2074,17 @@ func (b *InMemoryBackend) Purge(ctx context.Context, cutoff time.Time) {
 	var purgedNames []string
 
 	b.mu.Lock("Purge")
-	for name, s := range b.streams {
+	for region, regionStreams := range b.streams {
 		if ctx.Err() != nil {
 			break
 		}
-		if b.purgeStreamEntry(name, s, cutoff) {
-			purgedNames = append(purgedNames, name)
+		for name, s := range regionStreams {
+			if ctx.Err() != nil {
+				break
+			}
+			if b.purgeStreamEntry(region, name, s, cutoff) {
+				purgedNames = append(purgedNames, name)
+			}
 		}
 	}
 	b.mu.Unlock()
@@ -1874,13 +2092,17 @@ func (b *InMemoryBackend) Purge(ctx context.Context, cutoff time.Time) {
 	b.fireStreamPurgedCallbacks(purgedNames)
 }
 
-// CountOpenShards returns the total number of open (non-closed) shards across all streams.
-func (b *InMemoryBackend) CountOpenShards() int {
+// CountOpenShards returns the total number of open (non-closed) shards across
+// every stream in the region carried on ctx. DescribeLimits is region-scoped in
+// AWS, so this counts within a single region.
+func (b *InMemoryBackend) CountOpenShards(ctx context.Context) int {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("CountOpenShards")
 	defer b.mu.RUnlock()
 
 	count := 0
-	for _, s := range b.streams {
+	for _, s := range b.streamsView(region) {
 		s.mu.RLock("CountOpenShards.stream")
 		for _, sh := range s.Shards {
 			if !sh.Closed {
@@ -1894,7 +2116,7 @@ func (b *InMemoryBackend) CountOpenShards() int {
 }
 
 // UpdateAccountSettings updates account-level settings such as the ON_DEMAND stream count limit.
-func (b *InMemoryBackend) UpdateAccountSettings(input *UpdateAccountSettingsInput) error {
+func (b *InMemoryBackend) UpdateAccountSettings(_ context.Context, input *UpdateAccountSettingsInput) error {
 	b.mu.Lock("UpdateAccountSettings")
 	defer b.mu.Unlock()
 
@@ -1912,7 +2134,9 @@ func (b *InMemoryBackend) UpdateAccountSettings(input *UpdateAccountSettingsInpu
 // UpdateMaxRecordSize changes the per-record data payload size limit for a stream.
 // The value must be between defaultMaxRecordSizeBytes (1 MiB) and
 // absoluteMaxRecordSizeBytes (10 MiB).
-func (b *InMemoryBackend) UpdateMaxRecordSize(input *UpdateMaxRecordSizeInput) error {
+func (b *InMemoryBackend) UpdateMaxRecordSize(ctx context.Context, input *UpdateMaxRecordSizeInput) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.RLock("UpdateMaxRecordSize")
 
 	streamName := input.StreamName
@@ -1920,7 +2144,7 @@ func (b *InMemoryBackend) UpdateMaxRecordSize(input *UpdateMaxRecordSizeInput) e
 		streamName = streamNameFromARN(input.StreamARN)
 	}
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(region)[streamName]
 	if !ok {
 		b.mu.RUnlock()
 
@@ -1941,7 +2165,12 @@ func (b *InMemoryBackend) UpdateMaxRecordSize(input *UpdateMaxRecordSizeInput) e
 
 // UpdateStreamWarmThroughput configures pre-warmed throughput for a stream.
 // This is a no-op in the in-memory backend (no actual warm-up is needed).
-func (b *InMemoryBackend) UpdateStreamWarmThroughput(input *UpdateStreamWarmThroughputInput) error {
+func (b *InMemoryBackend) UpdateStreamWarmThroughput(
+	ctx context.Context,
+	input *UpdateStreamWarmThroughputInput,
+) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.RLock("UpdateStreamWarmThroughput")
 
 	streamName := input.StreamName
@@ -1949,7 +2178,7 @@ func (b *InMemoryBackend) UpdateStreamWarmThroughput(input *UpdateStreamWarmThro
 		streamName = streamNameFromARN(input.StreamARN)
 	}
 
-	_, ok := b.streams[streamName]
+	_, ok := b.streamsView(region)[streamName]
 	b.mu.RUnlock()
 
 	if !ok {
@@ -1961,11 +2190,13 @@ func (b *InMemoryBackend) UpdateStreamWarmThroughput(input *UpdateStreamWarmThro
 
 // TagResource adds or updates tags on a stream identified by its ARN.
 // This is the ARN-based counterpart to AddTagsToStream.
-func (b *InMemoryBackend) TagResource(input *TagResourceInput) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, input *TagResourceInput) error {
+	region := regionFromARNOrCtx(ctx, input.ResourceARN, b.region)
+
 	b.mu.RLock("TagResource")
 
 	streamName := streamNameFromARN(input.ResourceARN)
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(region)[streamName]
 
 	if !ok {
 		b.mu.RUnlock()
@@ -1987,11 +2218,13 @@ func (b *InMemoryBackend) TagResource(input *TagResourceInput) error {
 
 // UntagResource removes tags from a stream identified by its ARN.
 // This is the ARN-based counterpart to RemoveTagsFromStream.
-func (b *InMemoryBackend) UntagResource(input *UntagResourceInput) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, input *UntagResourceInput) error {
+	region := regionFromARNOrCtx(ctx, input.ResourceARN, b.region)
+
 	b.mu.RLock("UntagResource")
 
 	streamName := streamNameFromARN(input.ResourceARN)
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(region)[streamName]
 
 	if !ok {
 		b.mu.RUnlock()
@@ -2010,23 +2243,32 @@ func (b *InMemoryBackend) UntagResource(input *UntagResourceInput) error {
 }
 
 // AddStreamInternal seeds a stream directly into the backend for testing.
-// Caller must provide a non-nil stream with at least Name and ARN set.
+// Caller must provide a non-nil stream with at least Name and ARN set. The
+// stream is placed in the region encoded in its ARN, falling back to the
+// backend's default region when the ARN carries none.
 func (b *InMemoryBackend) AddStreamInternal(stream *Stream) {
 	b.mu.Lock("AddStreamInternal")
 	defer b.mu.Unlock()
 
 	initializeStreamRuntime(stream, stream.Name)
 
-	b.streams[stream.Name] = stream
+	region := regionFromARN(stream.ARN)
+	if region == "" {
+		region = b.region
+	}
+
+	b.streamsStore(region)[stream.Name] = stream
 }
 
 // UpdateStreamMode changes the mode of a stream identified by its ARN.
-func (b *InMemoryBackend) UpdateStreamMode(input *UpdateStreamModeInput) error {
+func (b *InMemoryBackend) UpdateStreamMode(ctx context.Context, input *UpdateStreamModeInput) error {
+	region := regionFromARNOrCtx(ctx, input.StreamARN, b.region)
+
 	b.mu.Lock("UpdateStreamMode")
 	defer b.mu.Unlock()
 
 	streamName := streamNameFromARN(input.StreamARN)
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsStore(region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}

--- a/services/kinesis/backend_test.go
+++ b/services/kinesis/backend_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -81,14 +82,14 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "gap-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "gap-stream"}))
 
-	desc, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "gap-stream"})
+	desc, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "gap-stream"})
 	require.NoError(t, err)
 	shardID := desc.Shards[0].ShardID
 
 	// Put a record - get seq "00000000000000000001"
-	out1, err := bk.PutRecord(&kinesis.PutRecordInput{
+	out1, err := bk.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "gap-stream",
 		PartitionKey: "pk",
 		Data:         []byte("first"),
@@ -96,7 +97,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	require.NoError(t, err)
 
 	// Put another - get seq "00000000000000000002"
-	out2, err := bk.PutRecord(&kinesis.PutRecordInput{
+	out2, err := bk.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "gap-stream",
 		PartitionKey: "pk",
 		Data:         []byte("second"),
@@ -104,7 +105,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	require.NoError(t, err)
 
 	// AT_SEQUENCE_NUMBER for out1.SequenceNumber should return index 0 (inclusive)
-	iterOut, err := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:             "gap-stream",
 		ShardID:                shardID,
 		ShardIteratorType:      "AT_SEQUENCE_NUMBER",
@@ -112,7 +113,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	records, err := bk.GetRecords(&kinesis.GetRecordsInput{
+	records, err := bk.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         10,
 	})
@@ -121,7 +122,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	assert.Equal(t, out1.SequenceNumber, records.Records[0].SequenceNumber)
 
 	// AFTER_SEQUENCE_NUMBER for out1 should start at index 1
-	iterOut2, err := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut2, err := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:             "gap-stream",
 		ShardID:                shardID,
 		ShardIteratorType:      "AFTER_SEQUENCE_NUMBER",
@@ -129,7 +130,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	records2, err := bk.GetRecords(&kinesis.GetRecordsInput{
+	records2, err := bk.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut2.ShardIterator,
 		Limit:         10,
 	})
@@ -139,7 +140,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 
 	// AT_SEQUENCE_NUMBER for a sequence number that is lexicographically larger than all records
 	// should return empty (positions at end)
-	iterOut3, err := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut3, err := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:             "gap-stream",
 		ShardID:                shardID,
 		ShardIteratorType:      "AT_SEQUENCE_NUMBER",
@@ -147,7 +148,7 @@ func TestKinesisBackend_FindSequencePositionGaps(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	records3, err := bk.GetRecords(&kinesis.GetRecordsInput{
+	records3, err := bk.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut3.ShardIterator,
 		Limit:         10,
 	})
@@ -159,13 +160,13 @@ func TestKinesisBackend_GetRecordsDeletedStream(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "deleted-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "deleted-stream"}))
 
-	desc, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "deleted-stream"})
+	desc, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "deleted-stream"})
 	require.NoError(t, err)
 	shardID := desc.Shards[0].ShardID
 
-	iterOut, err := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "deleted-stream",
 		ShardID:           shardID,
 		ShardIteratorType: "TRIM_HORIZON",
@@ -173,10 +174,10 @@ func TestKinesisBackend_GetRecordsDeletedStream(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete stream
-	require.NoError(t, bk.DeleteStream(&kinesis.DeleteStreamInput{StreamName: "deleted-stream"}))
+	require.NoError(t, bk.DeleteStream(context.Background(), &kinesis.DeleteStreamInput{StreamName: "deleted-stream"}))
 
 	// GetRecords should return stream not found
-	_, err = bk.GetRecords(&kinesis.GetRecordsInput{ShardIterator: iterOut.ShardIterator})
+	_, err = bk.GetRecords(context.Background(), &kinesis.GetRecordsInput{ShardIterator: iterOut.ShardIterator})
 	assert.ErrorIs(t, err, kinesis.ErrStreamNotFound)
 }
 
@@ -184,13 +185,16 @@ func TestKinesisBackend_GetRecordsInvalidShard(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "shard-gone-stream"}))
+	require.NoError(
+		t,
+		bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "shard-gone-stream"}),
+	)
 
-	desc, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "shard-gone-stream"})
+	desc, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "shard-gone-stream"})
 	require.NoError(t, err)
 	shardID := desc.Shards[0].ShardID
 
-	iterOut, err := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "shard-gone-stream",
 		ShardID:           shardID,
 		ShardIteratorType: "TRIM_HORIZON",
@@ -199,10 +203,13 @@ func TestKinesisBackend_GetRecordsInvalidShard(t *testing.T) {
 
 	// Delete and recreate the stream (new shards will have the same IDs so this won't test the gap,
 	// but we can test invalid shard via ListShards with wrong stream name)
-	require.NoError(t, bk.DeleteStream(&kinesis.DeleteStreamInput{StreamName: "shard-gone-stream"}))
+	require.NoError(
+		t,
+		bk.DeleteStream(context.Background(), &kinesis.DeleteStreamInput{StreamName: "shard-gone-stream"}),
+	)
 
 	// Recreate stream (iterator now points to deleted stream)
-	_, err = bk.GetRecords(&kinesis.GetRecordsInput{ShardIterator: iterOut.ShardIterator})
+	_, err = bk.GetRecords(context.Background(), &kinesis.GetRecordsInput{ShardIterator: iterOut.ShardIterator})
 	assert.Error(t, err)
 }
 
@@ -211,12 +218,12 @@ func TestKinesisBackend_ListStreamsLimit(t *testing.T) {
 
 	bk := kinesis.NewInMemoryBackend()
 	for i := range 5 {
-		require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: fmt.Sprintf("limit-stream-%d", i),
 		}))
 	}
 
-	out, err := bk.ListStreams(&kinesis.ListStreamsInput{Limit: 3})
+	out, err := bk.ListStreams(context.Background(), &kinesis.ListStreamsInput{Limit: 3})
 	require.NoError(t, err)
 	assert.Len(t, out.StreamNames, 3)
 	assert.True(t, out.HasMoreStreams)
@@ -229,10 +236,10 @@ func TestListStreams_Sorted(t *testing.T) {
 	bk := kinesis.NewInMemoryBackend()
 
 	for _, name := range []string{"charlie", "alpha", "bravo"} {
-		require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: name}))
+		require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: name}))
 	}
 
-	out, err := bk.ListStreams(&kinesis.ListStreamsInput{})
+	out, err := bk.ListStreams(context.Background(), &kinesis.ListStreamsInput{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, out.StreamNames)
 }
@@ -247,7 +254,7 @@ func TestListStreams_Pagination(t *testing.T) {
 
 	bk := kinesis.NewInMemoryBackend()
 	for _, n := range []string{"a", "b", "c", "d", "e"} {
-		require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: n}))
+		require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: n}))
 	}
 
 	tests := []struct {
@@ -289,7 +296,7 @@ func TestListStreams_Pagination(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := bk.ListStreams(tt.input)
+			out, err := bk.ListStreams(context.Background(), tt.input)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, out.StreamNames)
 			assert.Equal(t, tt.wantMore, out.HasMoreStreams)
@@ -311,28 +318,34 @@ func TestIncreaseDecreaseRetentionPeriod(t *testing.T) {
 		{
 			name: "increase_from_24_to_48",
 			setup: func(bk *kinesis.InMemoryBackend) {
-				_ = bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s"})
+				_ = bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s"})
 			},
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-					StreamName:           "s",
-					RetentionPeriodHours: 48,
-				})
+				return bk.IncreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.IncreaseStreamRetentionPeriodInput{
+						StreamName:           "s",
+						RetentionPeriodHours: 48,
+					},
+				)
 			},
 		},
 		{
 			name: "decrease_from_48_to_24",
 			setup: func(bk *kinesis.InMemoryBackend) {
-				_ = bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s"})
-				_ = bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+				_ = bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s"})
+				_ = bk.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 					StreamName: "s", RetentionPeriodHours: 48,
 				})
 			},
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.DecreaseStreamRetentionPeriod(&kinesis.DecreaseStreamRetentionPeriodInput{
-					StreamName:           "s",
-					RetentionPeriodHours: 24,
-				})
+				return bk.DecreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.DecreaseStreamRetentionPeriodInput{
+						StreamName:           "s",
+						RetentionPeriodHours: 24,
+					},
+				)
 			},
 		},
 		{
@@ -340,33 +353,42 @@ func TestIncreaseDecreaseRetentionPeriod(t *testing.T) {
 			setup:   func(_ *kinesis.InMemoryBackend) {},
 			wantErr: true,
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-					StreamName: "missing", RetentionPeriodHours: 48,
-				})
+				return bk.IncreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.IncreaseStreamRetentionPeriodInput{
+						StreamName: "missing", RetentionPeriodHours: 48,
+					},
+				)
 			},
 		},
 		{
 			name: "increase_same_value_is_noop",
 			setup: func(bk *kinesis.InMemoryBackend) {
-				_ = bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s"})
+				_ = bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s"})
 			},
 			wantErr: false, // idempotent: same value → success
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-					StreamName: "s", RetentionPeriodHours: 24, // same as default — no-op
-				})
+				return bk.IncreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.IncreaseStreamRetentionPeriodInput{
+						StreamName: "s", RetentionPeriodHours: 24, // same as default — no-op
+					},
+				)
 			},
 		},
 		{
 			name: "increase_above_max_rejected",
 			setup: func(bk *kinesis.InMemoryBackend) {
-				_ = bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s"})
+				_ = bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s"})
 			},
 			wantErr: true,
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-					StreamName: "s", RetentionPeriodHours: 9999,
-				})
+				return bk.IncreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.IncreaseStreamRetentionPeriodInput{
+						StreamName: "s", RetentionPeriodHours: 9999,
+					},
+				)
 			},
 		},
 		{
@@ -374,39 +396,48 @@ func TestIncreaseDecreaseRetentionPeriod(t *testing.T) {
 			setup:   func(_ *kinesis.InMemoryBackend) {},
 			wantErr: true,
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.DecreaseStreamRetentionPeriod(&kinesis.DecreaseStreamRetentionPeriodInput{
-					StreamName: "missing", RetentionPeriodHours: 24,
-				})
+				return bk.DecreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.DecreaseStreamRetentionPeriodInput{
+						StreamName: "missing", RetentionPeriodHours: 24,
+					},
+				)
 			},
 		},
 		{
 			name: "decrease_below_min_rejected",
 			setup: func(bk *kinesis.InMemoryBackend) {
-				_ = bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s"})
-				_ = bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+				_ = bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s"})
+				_ = bk.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 					StreamName: "s", RetentionPeriodHours: 48,
 				})
 			},
 			wantErr: true,
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.DecreaseStreamRetentionPeriod(&kinesis.DecreaseStreamRetentionPeriodInput{
-					StreamName: "s", RetentionPeriodHours: 10, // below 24h minimum
-				})
+				return bk.DecreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.DecreaseStreamRetentionPeriodInput{
+						StreamName: "s", RetentionPeriodHours: 10, // below 24h minimum
+					},
+				)
 			},
 		},
 		{
 			name: "decrease_same_value_is_noop",
 			setup: func(bk *kinesis.InMemoryBackend) {
-				_ = bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s"})
-				_ = bk.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+				_ = bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s"})
+				_ = bk.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 					StreamName: "s", RetentionPeriodHours: 48,
 				})
 			},
 			wantErr: false, // idempotent: same value → success
 			action: func(bk *kinesis.InMemoryBackend) error {
-				return bk.DecreaseStreamRetentionPeriod(&kinesis.DecreaseStreamRetentionPeriodInput{
-					StreamName: "s", RetentionPeriodHours: 48, // same as current — no-op
-				})
+				return bk.DecreaseStreamRetentionPeriod(
+					context.Background(),
+					&kinesis.DecreaseStreamRetentionPeriodInput{
+						StreamName: "s", RetentionPeriodHours: 48, // same as current — no-op
+					},
+				)
 			},
 		},
 	}
@@ -436,13 +467,13 @@ func TestDeleteStream_ClosesTags(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "tagged-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "tagged-stream"}))
 
 	// Delete should not panic (Close is safe to call).
-	require.NoError(t, bk.DeleteStream(&kinesis.DeleteStreamInput{StreamName: "tagged-stream"}))
+	require.NoError(t, bk.DeleteStream(context.Background(), &kinesis.DeleteStreamInput{StreamName: "tagged-stream"}))
 
 	// Recreating with the same name should succeed (Tags registry released).
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "tagged-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "tagged-stream"}))
 }
 
 // TestPutRecords_ThroughputErrorCode verifies that when FIS throughput fault is active,
@@ -452,11 +483,11 @@ func TestPutRecords_ThroughputErrorCode(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "fault-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "fault-stream"}))
 
 	bk.InjectFaultForTest("fault-stream")
 
-	out, err := bk.PutRecords(&kinesis.PutRecordsInput{
+	out, err := bk.PutRecords(context.Background(), &kinesis.PutRecordsInput{
 		StreamName: "fault-stream",
 		Records: []kinesis.PutRecordsEntry{
 			{PartitionKey: "pk", Data: []byte("data")},
@@ -472,10 +503,13 @@ func TestSplitShard_Basic(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "split-stream", ShardCount: 1}))
+	require.NoError(
+		t,
+		bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "split-stream", ShardCount: 1}),
+	)
 
 	// Get the initial shard list.
-	listOut, err := bk.ListShards(&kinesis.ListShardsInput{StreamName: "split-stream"})
+	listOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "split-stream"})
 	require.NoError(t, err)
 	require.Len(t, listOut.Shards, 1)
 
@@ -483,7 +517,7 @@ func TestSplitShard_Basic(t *testing.T) {
 	// Split at a midpoint well inside the shard range.
 	splitKey := "170141183460469231731687303715884105728" // 2^127 / 1
 
-	err = bk.SplitShard(&kinesis.SplitShardInput{
+	err = bk.SplitShard(context.Background(), &kinesis.SplitShardInput{
 		StreamName:         "split-stream",
 		ShardToSplit:       parentID,
 		NewStartingHashKey: splitKey,
@@ -491,7 +525,7 @@ func TestSplitShard_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Default list (open shards only) should now have 2 shards.
-	listOut, err = bk.ListShards(&kinesis.ListShardsInput{StreamName: "split-stream"})
+	listOut, err = bk.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "split-stream"})
 	require.NoError(t, err)
 	assert.Len(t, listOut.Shards, 2, "split should produce 2 open child shards")
 
@@ -501,7 +535,7 @@ func TestSplitShard_Basic(t *testing.T) {
 	}
 
 	// Full list includes the closed parent + 2 children.
-	fullOut, err := bk.ListShards(&kinesis.ListShardsInput{
+	fullOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:  "split-stream",
 		ShardFilter: "FROM_TRIM_HORIZON",
 	})
@@ -513,16 +547,19 @@ func TestMergeShards_Basic(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "merge-stream", ShardCount: 2}))
+	require.NoError(
+		t,
+		bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "merge-stream", ShardCount: 2}),
+	)
 
-	listOut, err := bk.ListShards(&kinesis.ListShardsInput{StreamName: "merge-stream"})
+	listOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "merge-stream"})
 	require.NoError(t, err)
 	require.Len(t, listOut.Shards, 2)
 
 	shard1 := listOut.Shards[0].ShardID
 	shard2 := listOut.Shards[1].ShardID
 
-	err = bk.MergeShards(&kinesis.MergeShardsInput{
+	err = bk.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 		StreamName:           "merge-stream",
 		ShardToMerge:         shard1,
 		AdjacentShardToMerge: shard2,
@@ -530,7 +567,7 @@ func TestMergeShards_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Only 1 open shard (the merged one).
-	openOut, err := bk.ListShards(&kinesis.ListShardsInput{StreamName: "merge-stream"})
+	openOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "merge-stream"})
 	require.NoError(t, err)
 	assert.Len(t, openOut.Shards, 1)
 
@@ -539,7 +576,7 @@ func TestMergeShards_Basic(t *testing.T) {
 	assert.Equal(t, shard2, merged.AdjacentParentShardID)
 
 	// Full list: 2 closed parents + 1 open merged = 3.
-	fullOut, err := bk.ListShards(&kinesis.ListShardsInput{
+	fullOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:  "merge-stream",
 		ShardFilter: "FROM_TRIM_HORIZON",
 	})
@@ -551,34 +588,34 @@ func TestStreamEncryption_StartStop(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "enc-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "enc-stream"}))
 
 	// Initially no encryption.
-	descOut, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "enc-stream"})
+	descOut, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "enc-stream"})
 	require.NoError(t, err)
 	assert.Equal(t, "NONE", descOut.EncryptionType)
 	assert.Empty(t, descOut.KeyID)
 
 	// Start encryption.
-	require.NoError(t, bk.StartStreamEncryption(&kinesis.StartStreamEncryptionInput{
+	require.NoError(t, bk.StartStreamEncryption(context.Background(), &kinesis.StartStreamEncryptionInput{
 		StreamName:     "enc-stream",
 		EncryptionType: "KMS",
 		KeyID:          "alias/aws/kinesis",
 	}))
 
-	descOut, err = bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "enc-stream"})
+	descOut, err = bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "enc-stream"})
 	require.NoError(t, err)
 	assert.Equal(t, "KMS", descOut.EncryptionType)
 	assert.Equal(t, "alias/aws/kinesis", descOut.KeyID)
 
 	// Stop encryption.
-	require.NoError(t, bk.StopStreamEncryption(&kinesis.StopStreamEncryptionInput{
+	require.NoError(t, bk.StopStreamEncryption(context.Background(), &kinesis.StopStreamEncryptionInput{
 		StreamName:     "enc-stream",
 		EncryptionType: "KMS",
 		KeyID:          "alias/aws/kinesis",
 	}))
 
-	descOut, err = bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "enc-stream"})
+	descOut, err = bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "enc-stream"})
 	require.NoError(t, err)
 	assert.Equal(t, "NONE", descOut.EncryptionType)
 	assert.Empty(t, descOut.KeyID)
@@ -588,12 +625,15 @@ func TestConsumerRegistrationAndList(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "consumer-lifecycle2"}))
+	require.NoError(
+		t,
+		bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "consumer-lifecycle2"}),
+	)
 
 	streamARN := "arn:aws:kinesis:us-east-1:123456789012:stream/consumer-lifecycle2"
 
 	// Register two consumers.
-	regOut1, err := bk.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+	regOut1, err := bk.RegisterStreamConsumer(context.Background(), &kinesis.RegisterStreamConsumerInput{
 		StreamARN:    streamARN,
 		ConsumerName: "app-1",
 	})
@@ -601,37 +641,40 @@ func TestConsumerRegistrationAndList(t *testing.T) {
 	assert.Equal(t, "app-1", regOut1.Consumer.ConsumerName)
 	assert.NotEmpty(t, regOut1.Consumer.ConsumerARN)
 
-	_, err = bk.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+	_, err = bk.RegisterStreamConsumer(context.Background(), &kinesis.RegisterStreamConsumerInput{
 		StreamARN:    streamARN,
 		ConsumerName: "app-2",
 	})
 	require.NoError(t, err)
 
 	// Duplicate registration should fail.
-	_, err = bk.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+	_, err = bk.RegisterStreamConsumer(context.Background(), &kinesis.RegisterStreamConsumerInput{
 		StreamARN:    streamARN,
 		ConsumerName: "app-1",
 	})
 	require.Error(t, err)
 
 	// ListStreamConsumers returns both.
-	listOut, err := bk.ListStreamConsumers(&kinesis.ListStreamConsumersInput{StreamARN: streamARN})
+	listOut, err := bk.ListStreamConsumers(
+		context.Background(),
+		&kinesis.ListStreamConsumersInput{StreamARN: streamARN},
+	)
 	require.NoError(t, err)
 	assert.Len(t, listOut.Consumers, 2)
 
 	// DescribeStreamConsumer by ARN.
-	descOut, err := bk.DescribeStreamConsumer(&kinesis.DescribeStreamConsumerInput{
+	descOut, err := bk.DescribeStreamConsumer(context.Background(), &kinesis.DescribeStreamConsumerInput{
 		ConsumerARN: regOut1.Consumer.ConsumerARN,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "app-1", descOut.ConsumerDescription.ConsumerName)
 
 	// Deregister.
-	require.NoError(t, bk.DeregisterStreamConsumer(&kinesis.DeregisterStreamConsumerInput{
+	require.NoError(t, bk.DeregisterStreamConsumer(context.Background(), &kinesis.DeregisterStreamConsumerInput{
 		ConsumerARN: regOut1.Consumer.ConsumerARN,
 	}))
 
-	listOut, err = bk.ListStreamConsumers(&kinesis.ListStreamConsumersInput{StreamARN: streamARN})
+	listOut, err = bk.ListStreamConsumers(context.Background(), &kinesis.ListStreamConsumersInput{StreamARN: streamARN})
 	require.NoError(t, err)
 	assert.Len(t, listOut.Consumers, 1)
 	assert.Equal(t, "app-2", listOut.Consumers[0].ConsumerName)
@@ -641,30 +684,36 @@ func TestSubscribeToShard_ReturnsRecords(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "subscribe-stream", ShardCount: 1}))
+	require.NoError(
+		t,
+		bk.CreateStream(
+			context.Background(),
+			&kinesis.CreateStreamInput{StreamName: "subscribe-stream", ShardCount: 1},
+		),
+	)
 
 	streamARN := "arn:aws:kinesis:us-east-1:123456789012:stream/subscribe-stream"
 
-	regOut, err := bk.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+	regOut, err := bk.RegisterStreamConsumer(context.Background(), &kinesis.RegisterStreamConsumerInput{
 		StreamARN:    streamARN,
 		ConsumerName: "reader",
 	})
 	require.NoError(t, err)
 
 	// Put some records.
-	_, err = bk.PutRecord(&kinesis.PutRecordInput{
+	_, err = bk.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "subscribe-stream",
 		PartitionKey: "pk1",
 		Data:         []byte("hello"),
 	})
 	require.NoError(t, err)
 
-	shardOut, err := bk.ListShards(&kinesis.ListShardsInput{StreamName: "subscribe-stream"})
+	shardOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "subscribe-stream"})
 	require.NoError(t, err)
 	require.Len(t, shardOut.Shards, 1)
 	shardID := shardOut.Shards[0].ShardID
 
-	subOut, err := bk.SubscribeToShard(&kinesis.SubscribeToShardInput{
+	subOut, err := bk.SubscribeToShard(context.Background(), &kinesis.SubscribeToShardInput{
 		ConsumerARN: regOut.Consumer.ConsumerARN,
 		ShardID:     shardID,
 		StartingPosition: kinesis.StartingPosition{
@@ -680,15 +729,18 @@ func TestListShards_AfterShardID(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "filter-stream", ShardCount: 4}))
+	require.NoError(
+		t,
+		bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "filter-stream", ShardCount: 4}),
+	)
 
 	// List all 4 shards.
-	allOut, err := bk.ListShards(&kinesis.ListShardsInput{StreamName: "filter-stream"})
+	allOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "filter-stream"})
 	require.NoError(t, err)
 	require.Len(t, allOut.Shards, 4)
 
 	// Use ExclusiveStartShardID to skip first two.
-	filtOut, err := bk.ListShards(&kinesis.ListShardsInput{
+	filtOut, err := bk.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:            "filter-stream",
 		ExclusiveStartShardID: allOut.Shards[1].ShardID,
 	})
@@ -728,18 +780,21 @@ func TestDeregisterStreamConsumer_ByIdentifier(t *testing.T) {
 			t.Parallel()
 
 			bk := kinesis.NewInMemoryBackend()
-			require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "consumer-stream"}))
+			require.NoError(
+				t,
+				bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "consumer-stream"}),
+			)
 
-			registered, err := bk.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+			registered, err := bk.RegisterStreamConsumer(context.Background(), &kinesis.RegisterStreamConsumerInput{
 				StreamARN:    "arn:aws:kinesis:us-east-1:123456789012:stream/consumer-stream",
 				ConsumerName: "consumer-a",
 			})
 			require.NoError(t, err)
 
-			err = bk.DeregisterStreamConsumer(tt.input(registered.Consumer.ConsumerARN))
+			err = bk.DeregisterStreamConsumer(context.Background(), tt.input(registered.Consumer.ConsumerARN))
 			require.NoError(t, err)
 
-			listOut, err := bk.ListStreamConsumers(&kinesis.ListStreamConsumersInput{
+			listOut, err := bk.ListStreamConsumers(context.Background(), &kinesis.ListStreamConsumersInput{
 				StreamARN: "arn:aws:kinesis:us-east-1:123456789012:stream/consumer-stream",
 			})
 			require.NoError(t, err)

--- a/services/kinesis/export_test.go
+++ b/services/kinesis/export_test.go
@@ -21,19 +21,24 @@ func (b *InMemoryBackend) InjectExpiredThroughputFaultForTest(streamName string)
 	b.faultsMu.Lock("InjectExpiredThroughputFaultForTest")
 	defer b.faultsMu.Unlock()
 
-	b.fisThroughputFaults[streamName] = &kinesisThrottleFault{
+	b.faultsStore(b.region)[streamName] = &kinesisThrottleFault{
 		expiry:      time.Now().Add(-time.Hour), // already expired
 		probability: 1.0,
 	}
 }
 
 // ScheduleThroughputFaultCleanupForTest exposes scheduleThroughputFaultCleanup for tests.
+// Names are resolved against the backend's default region.
 func (b *InMemoryBackend) ScheduleThroughputFaultCleanupForTest(
 	ctx context.Context,
 	names []string,
 	dur time.Duration,
 ) {
-	b.scheduleThroughputFaultCleanup(ctx, names, dur)
+	targets := make([]regionStreamTarget, len(names))
+	for i, n := range names {
+		targets[i] = regionStreamTarget{region: b.region, name: n}
+	}
+	b.scheduleThroughputFaultCleanup(ctx, targets, dur)
 }
 
 // InjectFaultForTest inserts an active (non-expired) throughput fault for testing.
@@ -41,7 +46,7 @@ func (b *InMemoryBackend) InjectFaultForTest(streamName string) {
 	b.faultsMu.Lock("InjectFaultForTest")
 	defer b.faultsMu.Unlock()
 
-	b.fisThroughputFaults[streamName] = &kinesisThrottleFault{
+	b.faultsStore(b.region)[streamName] = &kinesisThrottleFault{
 		probability: 1.0,
 	}
 }
@@ -51,7 +56,7 @@ func (b *InMemoryBackend) HasFaultForTest(streamName string) bool {
 	b.faultsMu.RLock("HasFaultForTest")
 	defer b.faultsMu.RUnlock()
 
-	_, ok := b.fisThroughputFaults[streamName]
+	_, ok := b.fisThroughputFaults[b.region][streamName]
 
 	return ok
 }
@@ -60,7 +65,7 @@ func (b *InMemoryBackend) HasFaultForTest(streamName string) bool {
 func (b *InMemoryBackend) ShardRecordCountForTest(streamName string, shardIdx int) int {
 	b.mu.RLock("ShardRecordCountForTest")
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(b.region)[streamName]
 	if !ok || shardIdx >= len(stream.Shards) {
 		b.mu.RUnlock()
 
@@ -88,7 +93,7 @@ func (b *InMemoryBackend) SetRetentionPeriodForTest(streamName string, hours int
 	b.mu.Lock("SetRetentionPeriodForTest")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(b.region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -106,7 +111,7 @@ func (b *InMemoryBackend) PushOldRecordForTest(streamName string, shardIdx int, 
 	b.mu.Lock("PushOldRecordForTest")
 	defer b.mu.Unlock()
 
-	stream, ok := b.streams[streamName]
+	stream, ok := b.streamsView(b.region)[streamName]
 	if !ok {
 		return ErrStreamNotFound
 	}
@@ -150,20 +155,31 @@ func (h *Handler) GetJanitorTaskTimeout() time.Duration {
 	return h.janitor.TaskTimeout
 }
 
-// StreamCount returns the number of streams in the backend.
+// StreamCount returns the total number of streams in the backend across all regions.
 func (b *InMemoryBackend) StreamCount() int {
 	b.mu.RLock("StreamCount")
 	defer b.mu.RUnlock()
 
-	return len(b.streams)
+	count := 0
+	for _, regionStreams := range b.streams {
+		count += len(regionStreams)
+	}
+
+	return count
 }
 
-// ResourcePolicyCount returns the number of resource policies in the backend.
+// ResourcePolicyCount returns the total number of resource policies in the backend
+// across all regions.
 func (b *InMemoryBackend) ResourcePolicyCount() int {
 	b.mu.RLock("ResourcePolicyCount")
 	defer b.mu.RUnlock()
 
-	return len(b.resourcePolicies)
+	count := 0
+	for _, regionPolicies := range b.resourcePolicies {
+		count += len(regionPolicies)
+	}
+
+	return count
 }
 
 // HandlerOpsLen returns the number of pre-built handler ops.

--- a/services/kinesis/fis.go
+++ b/services/kinesis/fis.go
@@ -48,15 +48,42 @@ func (h *Handler) ExecuteFISAction(ctx context.Context, action service.FISAction
 
 	prob := parseThrottlePercentage(action.Parameters["percentage"])
 
-	return b.activateThroughputFault(ctx, streamNamesFromARNs(action.Targets), action.Duration, prob)
+	return b.activateThroughputFault(ctx, regionStreamTargetsFromARNs(action.Targets), action.Duration, prob)
 }
 
-// activateThroughputFault enables the throughput exception on the named streams.
+// regionStreamTarget identifies a single stream in a single region for fault injection.
+type regionStreamTarget struct {
+	region string
+	name   string
+}
+
+// regionStreamTargetsFromARNs converts FIS target ARNs (or bare stream names)
+// into region/stream pairs. ARNs carry their own region; bare names get an empty
+// region, which activateThroughputFault resolves to the backend's default region.
+func regionStreamTargetsFromARNs(arns []string) []regionStreamTarget {
+	names := streamNamesFromARNs(arns)
+	targets := make([]regionStreamTarget, 0, len(arns))
+
+	for i, a := range arns {
+		if i >= len(names) {
+			break
+		}
+		targets = append(targets, regionStreamTarget{
+			region: regionFromARN(a),
+			name:   names[i],
+		})
+	}
+
+	return targets
+}
+
+// activateThroughputFault enables the throughput exception on the named streams,
+// keyed by each target's region so faults stay isolated per region.
 // It always registers a goroutine that clears the fault when ctx is cancelled
 // (experiment stopped), and also schedules time-based expiry when dur > 0.
 func (b *InMemoryBackend) activateThroughputFault(
 	ctx context.Context,
-	names []string,
+	targets []regionStreamTarget,
 	dur time.Duration,
 	prob float64,
 ) error {
@@ -67,8 +94,12 @@ func (b *InMemoryBackend) activateThroughputFault(
 
 	b.faultsMu.Lock("FISThroughputException")
 
-	for _, name := range names {
-		b.fisThroughputFaults[name] = &kinesisThrottleFault{
+	for _, t := range targets {
+		region := t.region
+		if region == "" {
+			region = b.region
+		}
+		b.faultsStore(region)[t.name] = &kinesisThrottleFault{
 			expiry:      expiry,
 			probability: prob,
 		}
@@ -78,7 +109,7 @@ func (b *InMemoryBackend) activateThroughputFault(
 
 	if dur > 0 {
 		// Time-limited: clear after duration or on cancellation.
-		go b.scheduleThroughputFaultCleanup(ctx, names, dur)
+		go b.scheduleThroughputFaultCleanup(ctx, targets, dur)
 	} else {
 		// Indefinite fault (dur==0): the goroutine blocks on ctx.Done().
 		// It terminates when StopExperiment cancels the experiment context,
@@ -91,8 +122,12 @@ func (b *InMemoryBackend) activateThroughputFault(
 			b.faultsMu.Lock("FISThroughputException-ctxcancel")
 			defer b.faultsMu.Unlock()
 
-			for _, name := range names {
-				delete(b.fisThroughputFaults, name)
+			for _, t := range targets {
+				region := t.region
+				if region == "" {
+					region = b.region
+				}
+				delete(b.faultsStore(region), t.name)
 			}
 		}()
 	}
@@ -104,7 +139,11 @@ func (b *InMemoryBackend) activateThroughputFault(
 // duration or when ctx is cancelled (whichever comes first).
 // On ctx cancellation, entries are removed unconditionally so that StopExperiment
 // always clears active faults regardless of remaining time.
-func (b *InMemoryBackend) scheduleThroughputFaultCleanup(ctx context.Context, names []string, dur time.Duration) {
+func (b *InMemoryBackend) scheduleThroughputFaultCleanup(
+	ctx context.Context,
+	targets []regionStreamTarget,
+	dur time.Duration,
+) {
 	ctxCancelled := false
 
 	timer := time.NewTimer(dur)
@@ -121,15 +160,20 @@ func (b *InMemoryBackend) scheduleThroughputFaultCleanup(ctx context.Context, na
 
 	now := time.Now()
 
-	for _, name := range names {
-		fault, exists := b.fisThroughputFaults[name]
+	for _, t := range targets {
+		region := t.region
+		if region == "" {
+			region = b.region
+		}
+		regionFaults := b.faultsStore(region)
+		fault, exists := regionFaults[t.name]
 		if !exists || fault == nil {
 			continue
 		}
 
 		// On ctx cancellation always remove; on timeout only remove if expired.
 		if ctxCancelled || (!fault.expiry.IsZero() && now.After(fault.expiry)) {
-			delete(b.fisThroughputFaults, name)
+			delete(regionFaults, t.name)
 		}
 	}
 }

--- a/services/kinesis/fis_test.go
+++ b/services/kinesis/fis_test.go
@@ -97,7 +97,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException(t *testing.T) {
 
 			// Create the stream if needed.
 			if tt.stream != "" {
-				err := h.Backend.CreateStream(&kinesis.CreateStreamInput{
+				err := h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 					StreamName: tt.stream,
 					ShardCount: 1,
 				})
@@ -114,7 +114,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException(t *testing.T) {
 
 			// Verify throughput exception is active on the stream.
 			if tt.stream != "" && len(tt.targets) > 0 {
-				_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+				_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 					StreamName:   tt.stream,
 					PartitionKey: "key",
 					Data:         []byte("data"),
@@ -125,7 +125,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException(t *testing.T) {
 				if tt.duration > 0 {
 					time.Sleep(tt.duration + 50*time.Millisecond)
 
-					_, putAfter := h.Backend.PutRecord(&kinesis.PutRecordInput{
+					_, putAfter := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 						StreamName:   tt.stream,
 						PartitionKey: "key",
 						Data:         []byte("data"),
@@ -145,7 +145,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException_ZeroPercentage(t *testing.
 	const streamName = "zero-pct-stream"
 	const sampleSize = 50
 
-	err := h.Backend.CreateStream(&kinesis.CreateStreamInput{
+	err := h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: streamName,
 		ShardCount: 1,
 	})
@@ -161,7 +161,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException_ZeroPercentage(t *testing.
 
 	// With 0% probability, all PutRecord calls should succeed.
 	for range sampleSize {
-		_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+		_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   streamName,
 			PartitionKey: "key",
 			Data:         []byte("data"),
@@ -217,7 +217,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException_CtxCancel(t *testing.T) {
 
 	const streamName = "ctx-cancel-stream"
 
-	err := h.Backend.CreateStream(&kinesis.CreateStreamInput{
+	err := h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: streamName,
 		ShardCount: 1,
 	})
@@ -233,7 +233,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException_CtxCancel(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+	_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   streamName,
 		PartitionKey: "key",
 		Data:         []byte("data"),
@@ -245,7 +245,7 @@ func TestKinesis_ExecuteFISAction_ThroughputException_CtxCancel(t *testing.T) {
 
 	// Fault should clear promptly.
 	require.Eventually(t, func() bool {
-		_, putAfterErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+		_, putAfterErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   streamName,
 			PartitionKey: "key",
 			Data:         []byte("data"),
@@ -262,7 +262,7 @@ func TestKinesis_ThroughputFault_ZeroPercentage_NoThrottle(t *testing.T) {
 
 	const streamName = "zero-pct-stream"
 
-	err := h.Backend.CreateStream(&kinesis.CreateStreamInput{
+	err := h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: streamName,
 		ShardCount: 1,
 	})
@@ -281,7 +281,7 @@ func TestKinesis_ThroughputFault_ZeroPercentage_NoThrottle(t *testing.T) {
 
 	// With 0% probability, PutRecord should never be throttled.
 	for range 10 {
-		_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+		_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   streamName,
 			PartitionKey: "key",
 			Data:         []byte("data"),
@@ -297,7 +297,7 @@ func TestKinesis_ThroughputFault_PartialPercentage(t *testing.T) {
 
 	const streamName = "partial-pct-stream"
 
-	err := h.Backend.CreateStream(&kinesis.CreateStreamInput{
+	err := h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: streamName,
 		ShardCount: 1,
 	})
@@ -320,7 +320,7 @@ func TestKinesis_ThroughputFault_PartialPercentage(t *testing.T) {
 	total := 50
 
 	for range total {
-		_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+		_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   streamName,
 			PartitionKey: "key",
 			Data:         []byte("data"),
@@ -356,7 +356,7 @@ func TestKinesis_ThroughputFaultActiveLocked_LazyEviction(t *testing.T) {
 
 	const streamName = "lazy-evict-kinesis-stream"
 
-	err := backend.CreateStream(&kinesis.CreateStreamInput{
+	err := backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: streamName,
 		ShardCount: 1,
 	})
@@ -366,7 +366,7 @@ func TestKinesis_ThroughputFaultActiveLocked_LazyEviction(t *testing.T) {
 	backend.InjectExpiredThroughputFaultForTest(streamName)
 
 	// PutRecord should succeed because the fault is expired — lazy eviction fires inside.
-	_, putErr := backend.PutRecord(&kinesis.PutRecordInput{
+	_, putErr := backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   streamName,
 		PartitionKey: "key",
 		Data:         []byte("data"),
@@ -374,7 +374,7 @@ func TestKinesis_ThroughputFaultActiveLocked_LazyEviction(t *testing.T) {
 	require.NoError(t, putErr, "expired fault should not throttle requests")
 
 	// After lazy eviction, a second PutRecord should also succeed.
-	_, putErr2 := backend.PutRecord(&kinesis.PutRecordInput{
+	_, putErr2 := backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   streamName,
 		PartitionKey: "key2",
 		Data:         []byte("data2"),
@@ -407,7 +407,7 @@ func TestKinesis_FIS_MultiStream_CtxCancel_ClearsAll(t *testing.T) {
 	)
 
 	for _, name := range []string{streamA, streamB, streamC} {
-		require.NoError(t, h.Backend.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: name,
 			ShardCount: 1,
 		}))
@@ -426,7 +426,7 @@ func TestKinesis_FIS_MultiStream_CtxCancel_ClearsAll(t *testing.T) {
 
 	// Verify all three streams are throttled.
 	for _, name := range []string{streamA, streamB, streamC} {
-		_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+		_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName: name, PartitionKey: "k", Data: []byte("d"),
 		})
 		require.ErrorIs(t, putErr, kinesis.ErrProvisionedThroughputExceeded, "stream %s should be throttled", name)
@@ -439,7 +439,7 @@ func TestKinesis_FIS_MultiStream_CtxCancel_ClearsAll(t *testing.T) {
 	for _, name := range []string{streamA, streamB, streamC} {
 		streamName := name
 		require.Eventually(t, func() bool {
-			_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+			_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 				StreamName: streamName, PartitionKey: "k", Data: []byte("d"),
 			})
 
@@ -459,7 +459,7 @@ func TestKinesis_FIS_MultipleActions_AllClearedOnCtxCancel(t *testing.T) {
 	)
 
 	for _, name := range []string{streamX, streamY} {
-		require.NoError(t, h.Backend.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: name,
 			ShardCount: 1,
 		}))
@@ -486,7 +486,7 @@ func TestKinesis_FIS_MultipleActions_AllClearedOnCtxCancel(t *testing.T) {
 
 	// Both streams should be throttled.
 	for _, name := range []string{streamX, streamY} {
-		_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+		_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName: name, PartitionKey: "k", Data: []byte("d"),
 		})
 		require.ErrorIs(t, putErr, kinesis.ErrProvisionedThroughputExceeded, "stream %s should be throttled", name)
@@ -498,7 +498,7 @@ func TestKinesis_FIS_MultipleActions_AllClearedOnCtxCancel(t *testing.T) {
 	for _, name := range []string{streamX, streamY} {
 		streamName := name
 		require.Eventually(t, func() bool {
-			_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+			_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 				StreamName: streamName, PartitionKey: "k", Data: []byte("d"),
 			})
 
@@ -518,7 +518,7 @@ func TestKinesis_FIS_TimedFault_MultiStream_CtxCancelOverridesTimer(t *testing.T
 	)
 
 	for _, name := range []string{streamP, streamQ} {
-		require.NoError(t, h.Backend.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, h.Backend.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: name,
 			ShardCount: 1,
 		}))
@@ -542,7 +542,7 @@ func TestKinesis_FIS_TimedFault_MultiStream_CtxCancelOverridesTimer(t *testing.T
 	for _, name := range []string{streamP, streamQ} {
 		streamName := name
 		require.Eventually(t, func() bool {
-			_, putErr := h.Backend.PutRecord(&kinesis.PutRecordInput{
+			_, putErr := h.Backend.PutRecord(context.Background(), &kinesis.PutRecordInput{
 				StreamName: streamName, PartitionKey: "k", Data: []byte("d"),
 			})
 

--- a/services/kinesis/handler.go
+++ b/services/kinesis/handler.go
@@ -58,12 +58,20 @@ func (h *Handler) WithJanitor(interval time.Duration, taskTimeout ...time.Durati
 		}
 		// Wire the cleanup callback so that when a stream is purged from the backend
 		// the handler-level tag registry for that stream is also closed and removed.
+		// Tags are keyed by "region/streamName", so a purge of a given stream name
+		// clears that stream's tag registry across every region it appears in.
 		mem.OnStreamPurged = func(streamName string) {
+			suffix := "/" + streamName
 			h.tagsMu.Lock("OnStreamPurged")
-			if t := h.tags[streamName]; t != nil {
-				t.Close()
+			for key, t := range h.tags {
+				if !strings.HasSuffix(key, suffix) {
+					continue
+				}
+				if t != nil {
+					t.Close()
+				}
+				delete(h.tags, key)
 			}
-			delete(h.tags, streamName)
 			h.tagsMu.Unlock()
 		}
 		h.janitor = j
@@ -81,27 +89,52 @@ func (h *Handler) StartWorker(ctx context.Context) error {
 	return nil
 }
 
-func (h *Handler) setTags(resourceID string, kv map[string]string) {
-	h.tagsMu.Lock("setTags")
-	defer h.tagsMu.Unlock()
-	if h.tags[resourceID] == nil {
-		h.tags[resourceID] = svcTags.New("kinesis." + resourceID + ".tags")
+// defaultRegion returns the region the handler should fall back to when a
+// request carries no SigV4 region. It prefers the explicitly configured
+// DefaultRegion and otherwise mirrors the backend's region so that the
+// handler-level tag store and the backend's stream store agree on the region.
+func (h *Handler) defaultRegion() string {
+	if h.DefaultRegion != "" {
+		return h.DefaultRegion
 	}
-	h.tags[resourceID].Merge(kv)
+
+	if br, ok := h.Backend.(interface{ Region() string }); ok {
+		return br.Region()
+	}
+
+	return h.DefaultRegion
 }
 
-func (h *Handler) removeTags(resourceID string, keys []string) {
+// tagKey builds the region-scoped key under which a stream's handler-level tags
+// are stored, keeping tags for same-named streams in different regions isolated.
+func tagKey(region, streamName string) string {
+	return region + "/" + streamName
+}
+
+func (h *Handler) setTags(region, resourceID string, kv map[string]string) {
+	key := tagKey(region, resourceID)
+	h.tagsMu.Lock("setTags")
+	defer h.tagsMu.Unlock()
+	if h.tags[key] == nil {
+		h.tags[key] = svcTags.New("kinesis." + key + ".tags")
+	}
+	h.tags[key].Merge(kv)
+}
+
+func (h *Handler) removeTags(region, resourceID string, keys []string) {
+	key := tagKey(region, resourceID)
 	h.tagsMu.RLock("removeTags")
-	t := h.tags[resourceID]
+	t := h.tags[key]
 	h.tagsMu.RUnlock()
 	if t != nil {
 		t.DeleteKeys(keys)
 	}
 }
 
-func (h *Handler) getTags(resourceID string) map[string]string {
+func (h *Handler) getTags(region, resourceID string) map[string]string {
+	key := tagKey(region, resourceID)
 	h.tagsMu.RLock("getTags")
-	t := h.tags[resourceID]
+	t := h.tags[key]
 	h.tagsMu.RUnlock()
 	if t == nil {
 		return map[string]string{}
@@ -167,7 +200,7 @@ func (h *Handler) ChaosServiceName() string { return "kinesis" }
 func (h *Handler) ChaosOperations() []string { return h.GetSupportedOperations() }
 
 // ChaosRegions returns all regions this Kinesis instance handles.
-func (h *Handler) ChaosRegions() []string { return []string{h.DefaultRegion} }
+func (h *Handler) ChaosRegions() []string { return []string{h.defaultRegion()} }
 
 // kinesisTargetPrefix is the X-Amz-Target prefix used by the AWS Kinesis SDK.
 const kinesisTargetPrefix = "Kinesis_20131202."
@@ -283,11 +316,17 @@ func (h *Handler) buildOps() map[string]kinesisDispatchFn {
 }
 
 // kinesisRoute dispatches a Kinesis action to the appropriate handler method.
+// It resolves the per-request AWS region from the SigV4 credential scope and
+// attaches it to the context so the backend routes the operation to the right
+// region's resources.
 func (h *Handler) kinesisRoute(ctx context.Context, r *http.Request, action string, body []byte) ([]byte, error) {
 	fn, ok := h.ops[action]
 	if !ok {
 		return nil, ErrUnknownAction
 	}
+
+	region := httputils.ExtractRegionFromRequest(r, h.defaultRegion())
+	ctx = contextWithRegion(ctx, region)
 
 	result, err := fn(ctx, r, body)
 	if err != nil {
@@ -510,7 +549,7 @@ type jsonRetentionPeriodReq struct {
 
 func (h *Handler) handleCreateStream(
 	ctx context.Context,
-	r *http.Request,
+	_ *http.Request,
 	body []byte,
 ) (any, error) {
 	var req jsonCreateStreamReq
@@ -518,7 +557,7 @@ func (h *Handler) handleCreateStream(
 		return nil, ErrInvalidArgument
 	}
 
-	region := httputils.ExtractRegionFromRequest(r, h.DefaultRegion)
+	region := getRegion(ctx, h.defaultRegion())
 
 	var streamMode string
 	if req.StreamModeDetails != nil {
@@ -532,7 +571,7 @@ func (h *Handler) handleCreateStream(
 		return nil, ErrInvalidArgument
 	}
 
-	err := h.Backend.CreateStream(&CreateStreamInput{
+	err := h.Backend.CreateStream(ctx, &CreateStreamInput{
 		StreamName: req.StreamName,
 		ShardCount: shardCount,
 		Region:     region,
@@ -548,14 +587,14 @@ func (h *Handler) handleCreateStream(
 	}
 
 	if len(req.Tags) > 0 {
-		h.setTags(req.StreamName, req.Tags)
+		h.setTags(region, req.StreamName, req.Tags)
 	}
 
 	return struct{}{}, nil
 }
 
 func (h *Handler) handleDeleteStream(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -569,17 +608,26 @@ func (h *Handler) handleDeleteStream(
 		streamName = streamNameFromARN(req.StreamARN)
 	}
 
-	if err := h.Backend.DeleteStream(&DeleteStreamInput{StreamName: streamName}); err != nil {
+	// When the request addresses the stream by ARN, route to the ARN's region;
+	// otherwise use the region carried on ctx.
+	region := getRegion(ctx, h.defaultRegion())
+	if req.StreamARN != "" {
+		region = regionFromARNOrCtx(ctx, req.StreamARN, h.defaultRegion())
+	}
+	regionCtx := contextWithRegion(ctx, region)
+
+	if err := h.Backend.DeleteStream(regionCtx, &DeleteStreamInput{StreamName: streamName}); err != nil {
 		return nil, err
 	}
 
 	// Clean up handler-level tags to prevent resource/metric leaks.
+	key := tagKey(region, streamName)
 	h.tagsMu.Lock("handleDeleteStream")
-	if t := h.tags[streamName]; t != nil {
+	if t := h.tags[key]; t != nil {
 		t.Close()
 	}
 
-	delete(h.tags, streamName)
+	delete(h.tags, key)
 	h.tagsMu.Unlock()
 
 	return struct{}{}, nil
@@ -596,7 +644,7 @@ func enhancedMonitoringEntries(metrics []string) []jsonEnhancedMonitoringEntry {
 }
 
 func (h *Handler) handleDescribeStream(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -610,7 +658,7 @@ func (h *Handler) handleDescribeStream(
 		streamName = streamNameFromARN(req.StreamARN)
 	}
 
-	out, err := h.Backend.DescribeStream(&DescribeStreamInput{StreamName: streamName})
+	out, err := h.Backend.DescribeStream(ctx, &DescribeStreamInput{StreamName: streamName})
 	if err != nil {
 		return nil, err
 	}
@@ -650,7 +698,7 @@ func (h *Handler) handleDescribeStream(
 }
 
 func (h *Handler) handleDescribeStreamSummary(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -664,7 +712,7 @@ func (h *Handler) handleDescribeStreamSummary(
 		summaryStreamName = streamNameFromARN(req.StreamARN)
 	}
 
-	out, err := h.Backend.DescribeStream(&DescribeStreamInput{StreamName: summaryStreamName})
+	out, err := h.Backend.DescribeStream(ctx, &DescribeStreamInput{StreamName: summaryStreamName})
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +725,7 @@ func (h *Handler) handleDescribeStreamSummary(
 	}
 
 	// Fetch the live consumer count.
-	consumerList, _ := h.Backend.ListStreamConsumers(&ListStreamConsumersInput{StreamARN: out.StreamARN})
+	consumerList, _ := h.Backend.ListStreamConsumers(ctx, &ListStreamConsumersInput{StreamARN: out.StreamARN})
 	consumerCount := 0
 	if consumerList != nil {
 		consumerCount = len(consumerList.Consumers)
@@ -701,14 +749,14 @@ func (h *Handler) handleDescribeStreamSummary(
 }
 
 func (h *Handler) handleListStreams(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
 	var req jsonListStreamsReq
 	_ = json.Unmarshal(body, &req)
 
-	out, err := h.Backend.ListStreams(&ListStreamsInput{
+	out, err := h.Backend.ListStreams(ctx, &ListStreamsInput{
 		Limit:                    req.Limit,
 		NextToken:                req.NextToken,
 		ExclusiveStartStreamName: req.ExclusiveStartStreamName,
@@ -730,7 +778,7 @@ func (h *Handler) handleListStreams(
 }
 
 func (h *Handler) handlePutRecord(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -744,7 +792,7 @@ func (h *Handler) handlePutRecord(
 		streamName = streamNameFromARN(req.StreamARN)
 	}
 
-	out, err := h.Backend.PutRecord(&PutRecordInput{
+	out, err := h.Backend.PutRecord(ctx, &PutRecordInput{
 		StreamName:      streamName,
 		PartitionKey:    req.PartitionKey,
 		ExplicitHashKey: req.ExplicitHashKey,
@@ -762,7 +810,7 @@ func (h *Handler) handlePutRecord(
 }
 
 func (h *Handler) handlePutRecords(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -786,7 +834,7 @@ func (h *Handler) handlePutRecords(
 		entries[i] = PutRecordsEntry(r)
 	}
 
-	out, err := h.Backend.PutRecords(&PutRecordsInput{
+	out, err := h.Backend.PutRecords(ctx, &PutRecordsInput{
 		StreamName: streamName,
 		Records:    entries,
 	})
@@ -806,7 +854,7 @@ func (h *Handler) handlePutRecords(
 }
 
 func (h *Handler) handleGetShardIterator(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -820,7 +868,7 @@ func (h *Handler) handleGetShardIterator(
 		streamName = streamNameFromARN(req.StreamARN)
 	}
 
-	out, err := h.Backend.GetShardIterator(&GetShardIteratorInput{
+	out, err := h.Backend.GetShardIterator(ctx, &GetShardIteratorInput{
 		StreamName:             streamName,
 		ShardID:                req.ShardID,
 		ShardIteratorType:      req.ShardIteratorType,
@@ -837,7 +885,7 @@ func (h *Handler) handleGetShardIterator(
 }
 
 func (h *Handler) handleGetRecords(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -846,7 +894,7 @@ func (h *Handler) handleGetRecords(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.GetRecords(&GetRecordsInput{
+	out, err := h.Backend.GetRecords(ctx, &GetRecordsInput{
 		ShardIterator: req.ShardIterator,
 		Limit:         req.Limit,
 	})
@@ -877,7 +925,7 @@ func (h *Handler) handleGetRecords(
 }
 
 func (h *Handler) handleListShards(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -918,7 +966,7 @@ func (h *Handler) handleListShards(
 			shardFilterStr = shardFilterType
 		}
 	}
-	out, err := h.Backend.ListShards(&ListShardsInput{
+	out, err := h.Backend.ListShards(ctx, &ListShardsInput{
 		StreamName:            streamName,
 		NextToken:             backendNextToken,
 		MaxResults:            req.MaxResults,
@@ -1044,7 +1092,7 @@ type handleAddTagsToStreamInput struct {
 }
 
 func (h *Handler) handleAddTagsToStream(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1053,7 +1101,7 @@ func (h *Handler) handleAddTagsToStream(
 		return nil, ErrInvalidArgument
 	}
 
-	if _, err := h.Backend.DescribeStream(&DescribeStreamInput{StreamName: req.StreamName}); err != nil {
+	if _, err := h.Backend.DescribeStream(ctx, &DescribeStreamInput{StreamName: req.StreamName}); err != nil {
 		return nil, err
 	}
 
@@ -1066,14 +1114,15 @@ func (h *Handler) handleAddTagsToStream(
 		return nil, err
 	}
 
-	existing := h.getTags(req.StreamName)
+	region := getRegion(ctx, h.defaultRegion())
+	existing := h.getTags(region, req.StreamName)
 	merged := make(map[string]string, len(existing))
 	maps.Copy(merged, existing)
 	maps.Copy(merged, kv)
 	if len(merged) > maxTagsPerStream {
 		return nil, ErrTagLimitExceeded
 	}
-	h.setTags(req.StreamName, kv)
+	h.setTags(region, req.StreamName, kv)
 
 	return struct{}{}, nil
 }
@@ -1084,7 +1133,7 @@ type handleRemoveTagsFromStreamInput struct {
 }
 
 func (h *Handler) handleRemoveTagsFromStream(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1093,11 +1142,11 @@ func (h *Handler) handleRemoveTagsFromStream(
 		return nil, ErrInvalidArgument
 	}
 
-	if _, err := h.Backend.DescribeStream(&DescribeStreamInput{StreamName: req.StreamName}); err != nil {
+	if _, err := h.Backend.DescribeStream(ctx, &DescribeStreamInput{StreamName: req.StreamName}); err != nil {
 		return nil, err
 	}
 
-	h.removeTags(req.StreamName, req.TagKeys)
+	h.removeTags(getRegion(ctx, h.defaultRegion()), req.StreamName, req.TagKeys)
 
 	return struct{}{}, nil
 }
@@ -1109,7 +1158,7 @@ type listTagsForStreamReq struct {
 }
 
 func (h *Handler) handleListTagsForStream(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1118,11 +1167,11 @@ func (h *Handler) handleListTagsForStream(
 		return nil, ErrInvalidArgument
 	}
 
-	if _, err := h.Backend.DescribeStream(&DescribeStreamInput{StreamName: req.StreamName}); err != nil {
+	if _, err := h.Backend.DescribeStream(ctx, &DescribeStreamInput{StreamName: req.StreamName}); err != nil {
 		return nil, err
 	}
 
-	tagsMap := h.getTags(req.StreamName)
+	tagsMap := h.getTags(getRegion(ctx, h.defaultRegion()), req.StreamName)
 
 	keys := make([]string, 0, len(tagsMap))
 	for k := range tagsMap {
@@ -1160,7 +1209,7 @@ func (h *Handler) handleListTagsForStream(
 }
 
 func (h *Handler) handleIncreaseStreamRetentionPeriod(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1169,7 +1218,7 @@ func (h *Handler) handleIncreaseStreamRetentionPeriod(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.IncreaseStreamRetentionPeriod(&IncreaseStreamRetentionPeriodInput{
+	if err := h.Backend.IncreaseStreamRetentionPeriod(ctx, &IncreaseStreamRetentionPeriodInput{
 		StreamName:           req.StreamName,
 		RetentionPeriodHours: req.RetentionPeriodHours,
 	}); err != nil {
@@ -1180,7 +1229,7 @@ func (h *Handler) handleIncreaseStreamRetentionPeriod(
 }
 
 func (h *Handler) handleDecreaseStreamRetentionPeriod(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1189,7 +1238,7 @@ func (h *Handler) handleDecreaseStreamRetentionPeriod(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.DecreaseStreamRetentionPeriod(&DecreaseStreamRetentionPeriodInput{
+	if err := h.Backend.DecreaseStreamRetentionPeriod(ctx, &DecreaseStreamRetentionPeriodInput{
 		StreamName:           req.StreamName,
 		RetentionPeriodHours: req.RetentionPeriodHours,
 	}); err != nil {
@@ -1200,12 +1249,12 @@ func (h *Handler) handleDecreaseStreamRetentionPeriod(
 }
 
 func (h *Handler) handleDescribeLimits(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	_ []byte,
 ) (any, error) {
 	return &describeLimitsOutput{
-		OpenShardCount: h.Backend.CountOpenShards(),
+		OpenShardCount: h.Backend.CountOpenShards(ctx),
 		ShardLimit:     kinesisDefaultShardLimit,
 	}, nil
 }
@@ -1259,11 +1308,11 @@ type jsonListTagsForResourceResp struct {
 // --- Handler methods for new operations ---
 
 func (h *Handler) handleDescribeAccountSettings(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	_ []byte,
 ) (any, error) {
-	out, err := h.Backend.DescribeAccountSettings()
+	out, err := h.Backend.DescribeAccountSettings(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1276,7 +1325,7 @@ func (h *Handler) handleDescribeAccountSettings(
 }
 
 func (h *Handler) handleMergeShards(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1285,7 +1334,7 @@ func (h *Handler) handleMergeShards(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.MergeShards(&MergeShardsInput{
+	if err := h.Backend.MergeShards(ctx, &MergeShardsInput{
 		StreamName:           req.StreamName,
 		StreamARN:            req.StreamARN,
 		ShardToMerge:         req.ShardToMerge,
@@ -1298,7 +1347,7 @@ func (h *Handler) handleMergeShards(
 }
 
 func (h *Handler) handleSplitShard(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1307,7 +1356,7 @@ func (h *Handler) handleSplitShard(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.SplitShard(&SplitShardInput{
+	if err := h.Backend.SplitShard(ctx, &SplitShardInput{
 		StreamName:         req.StreamName,
 		StreamARN:          req.StreamARN,
 		ShardToSplit:       req.ShardToSplit,
@@ -1320,7 +1369,7 @@ func (h *Handler) handleSplitShard(
 }
 
 func (h *Handler) handleStartStreamEncryption(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1329,7 +1378,7 @@ func (h *Handler) handleStartStreamEncryption(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.StartStreamEncryption(&StartStreamEncryptionInput{
+	if err := h.Backend.StartStreamEncryption(ctx, &StartStreamEncryptionInput{
 		StreamName:     req.StreamName,
 		StreamARN:      req.StreamARN,
 		EncryptionType: req.EncryptionType,
@@ -1342,7 +1391,7 @@ func (h *Handler) handleStartStreamEncryption(
 }
 
 func (h *Handler) handleStopStreamEncryption(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1351,7 +1400,7 @@ func (h *Handler) handleStopStreamEncryption(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.StopStreamEncryption(&StopStreamEncryptionInput{
+	if err := h.Backend.StopStreamEncryption(ctx, &StopStreamEncryptionInput{
 		StreamName:     req.StreamName,
 		StreamARN:      req.StreamARN,
 		EncryptionType: req.EncryptionType,
@@ -1364,7 +1413,7 @@ func (h *Handler) handleStopStreamEncryption(
 }
 
 func (h *Handler) handlePutResourcePolicy(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1373,7 +1422,7 @@ func (h *Handler) handlePutResourcePolicy(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.PutResourcePolicy(&PutResourcePolicyInput{
+	if err := h.Backend.PutResourcePolicy(ctx, &PutResourcePolicyInput{
 		ResourceARN: req.ResourceARN,
 		Policy:      req.Policy,
 	}); err != nil {
@@ -1384,7 +1433,7 @@ func (h *Handler) handlePutResourcePolicy(
 }
 
 func (h *Handler) handleGetResourcePolicy(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1393,7 +1442,7 @@ func (h *Handler) handleGetResourcePolicy(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.GetResourcePolicy(&GetResourcePolicyInput{
+	out, err := h.Backend.GetResourcePolicy(ctx, &GetResourcePolicyInput{
 		ResourceARN: req.ResourceARN,
 	})
 	if err != nil {
@@ -1404,7 +1453,7 @@ func (h *Handler) handleGetResourcePolicy(
 }
 
 func (h *Handler) handleDeleteResourcePolicy(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1413,7 +1462,7 @@ func (h *Handler) handleDeleteResourcePolicy(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.DeleteResourcePolicy(&DeleteResourcePolicyInput{
+	if err := h.Backend.DeleteResourcePolicy(ctx, &DeleteResourcePolicyInput{
 		ResourceARN: req.ResourceARN,
 	}); err != nil {
 		return nil, err
@@ -1423,7 +1472,7 @@ func (h *Handler) handleDeleteResourcePolicy(
 }
 
 func (h *Handler) handleListTagsForResource(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1433,13 +1482,15 @@ func (h *Handler) handleListTagsForResource(
 	}
 
 	streamName := streamNameFromARN(req.ResourceARN)
+	region := regionFromARNOrCtx(ctx, req.ResourceARN, h.defaultRegion())
+	regionCtx := contextWithRegion(ctx, region)
 
 	// Validate the stream exists before returning tags.
-	if _, err := h.Backend.DescribeStream(&DescribeStreamInput{StreamName: streamName}); err != nil {
+	if _, err := h.Backend.DescribeStream(regionCtx, &DescribeStreamInput{StreamName: streamName}); err != nil {
 		return nil, err
 	}
 
-	tags := h.getTags(streamName)
+	tags := h.getTags(region, streamName)
 	tagList := make([]svcTags.KV, 0, len(tags))
 	for k, v := range tags {
 		tagList = append(tagList, svcTags.KV{Key: k, Value: v})
@@ -1550,7 +1601,7 @@ func toJSONConsumer(c Consumer) jsonConsumer {
 }
 
 func (h *Handler) handleRegisterStreamConsumer(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1559,7 +1610,7 @@ func (h *Handler) handleRegisterStreamConsumer(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.RegisterStreamConsumer(&RegisterStreamConsumerInput{
+	out, err := h.Backend.RegisterStreamConsumer(ctx, &RegisterStreamConsumerInput{
 		StreamARN:    req.StreamARN,
 		ConsumerName: req.ConsumerName,
 	})
@@ -1571,7 +1622,7 @@ func (h *Handler) handleRegisterStreamConsumer(
 }
 
 func (h *Handler) handleDescribeStreamConsumer(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1580,7 +1631,7 @@ func (h *Handler) handleDescribeStreamConsumer(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.DescribeStreamConsumer(&DescribeStreamConsumerInput{
+	out, err := h.Backend.DescribeStreamConsumer(ctx, &DescribeStreamConsumerInput{
 		StreamARN:    req.StreamARN,
 		ConsumerARN:  req.ConsumerARN,
 		ConsumerName: req.ConsumerName,
@@ -1593,14 +1644,14 @@ func (h *Handler) handleDescribeStreamConsumer(
 }
 
 func (h *Handler) handleListStreamConsumers(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
 	var req jsonListStreamConsumersReq
 	_ = json.Unmarshal(body, &req)
 
-	out, err := h.Backend.ListStreamConsumers(&ListStreamConsumersInput{
+	out, err := h.Backend.ListStreamConsumers(ctx, &ListStreamConsumersInput{
 		StreamARN:  req.StreamARN,
 		NextToken:  req.NextToken,
 		MaxResults: req.MaxResults,
@@ -1618,7 +1669,7 @@ func (h *Handler) handleListStreamConsumers(
 }
 
 func (h *Handler) handleDeregisterStreamConsumer(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1627,7 +1678,7 @@ func (h *Handler) handleDeregisterStreamConsumer(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.DeregisterStreamConsumer(&DeregisterStreamConsumerInput{
+	if err := h.Backend.DeregisterStreamConsumer(ctx, &DeregisterStreamConsumerInput{
 		StreamARN:    req.StreamARN,
 		ConsumerARN:  req.ConsumerARN,
 		ConsumerName: req.ConsumerName,
@@ -1639,7 +1690,7 @@ func (h *Handler) handleDeregisterStreamConsumer(
 }
 
 func (h *Handler) handleUpdateShardCount(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1648,7 +1699,7 @@ func (h *Handler) handleUpdateShardCount(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.UpdateShardCount(&UpdateShardCountInput{
+	out, err := h.Backend.UpdateShardCount(ctx, &UpdateShardCountInput{
 		StreamName:       req.StreamName,
 		TargetShardCount: req.TargetShardCount,
 		ScalingType:      req.ScalingType,
@@ -1665,7 +1716,7 @@ func (h *Handler) handleUpdateShardCount(
 }
 
 func (h *Handler) handleEnableEnhancedMonitoring(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1674,7 +1725,7 @@ func (h *Handler) handleEnableEnhancedMonitoring(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.EnableEnhancedMonitoring(&EnableEnhancedMonitoringInput{
+	out, err := h.Backend.EnableEnhancedMonitoring(ctx, &EnableEnhancedMonitoringInput{
 		StreamName:        req.StreamName,
 		ShardLevelMetrics: req.ShardLevelMetrics,
 	})
@@ -1690,7 +1741,7 @@ func (h *Handler) handleEnableEnhancedMonitoring(
 }
 
 func (h *Handler) handleDisableEnhancedMonitoring(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -1699,7 +1750,7 @@ func (h *Handler) handleDisableEnhancedMonitoring(
 		return nil, ErrInvalidArgument
 	}
 
-	out, err := h.Backend.DisableEnhancedMonitoring(&DisableEnhancedMonitoringInput{
+	out, err := h.Backend.DisableEnhancedMonitoring(ctx, &DisableEnhancedMonitoringInput{
 		StreamName:        req.StreamName,
 		ShardLevelMetrics: req.ShardLevelMetrics,
 	})
@@ -1798,7 +1849,8 @@ const subscribeToShardMaxIdlePolls = 3
 // binary protocol. It keeps the response stream open for up to 5 minutes, pushing records as
 // they arrive via periodic polling with chunked flushing.
 func (h *Handler) handleSubscribeToShardHTTP(c *echo.Context) error {
-	ctx := c.Request().Context()
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.defaultRegion())
+	ctx := contextWithRegion(c.Request().Context(), region)
 	log := logger.Load(ctx)
 
 	body, err := httputils.ReadBody(c.Request())
@@ -1824,7 +1876,7 @@ func (h *Handler) handleSubscribeToShardHTTP(c *echo.Context) error {
 	}
 
 	// Validate consumer/shard before opening the stream.
-	if _, err = h.Backend.SubscribeToShard(&SubscribeToShardInput{
+	if _, err = h.Backend.SubscribeToShard(ctx, &SubscribeToShardInput{
 		ConsumerARN:      req.ConsumerARN,
 		ShardID:          req.ShardID,
 		StartingPosition: sp,
@@ -1866,7 +1918,7 @@ func (h *Handler) handleSubscribeToShardHTTP(c *echo.Context) error {
 				return nil
 			}
 
-			if stop, next := h.advanceShardCursor(req, curSP, c.Response(), flusher, canFlush, &idlePolls); stop {
+			if stop, next := h.advanceShardCursor(ctx, req, curSP, c.Response(), flusher, canFlush, &idlePolls); stop {
 				return nil
 			} else if next != nil {
 				curSP = *next
@@ -1878,6 +1930,7 @@ func (h *Handler) handleSubscribeToShardHTTP(c *echo.Context) error {
 // advanceShardCursor calls pollSubscribeToShardTick and returns (stop=true, nil) when the
 // stream should close, or (false, nextSP) when it should continue (nextSP may be nil).
 func (h *Handler) advanceShardCursor(
+	ctx context.Context,
 	req jsonSubscribeToShardReq,
 	curSP StartingPosition,
 	w http.ResponseWriter,
@@ -1885,7 +1938,7 @@ func (h *Handler) advanceShardCursor(
 	canFlush bool,
 	idlePolls *int,
 ) (bool, *StartingPosition) {
-	done, next, tickErr := h.pollSubscribeToShardTick(req, curSP, w, flusher, canFlush, idlePolls)
+	done, next, tickErr := h.pollSubscribeToShardTick(ctx, req, curSP, w, flusher, canFlush, idlePolls)
 	if tickErr != nil || done {
 		return true, nil
 	}
@@ -1898,6 +1951,7 @@ func (h *Handler) advanceShardCursor(
 // (false, nextSP, nil) when records were delivered (nextSP non-nil means cursor advanced),
 // and (false, nil, err) on a write error.
 func (h *Handler) pollSubscribeToShardTick(
+	ctx context.Context,
 	req jsonSubscribeToShardReq,
 	curSP StartingPosition,
 	w http.ResponseWriter,
@@ -1905,7 +1959,7 @@ func (h *Handler) pollSubscribeToShardTick(
 	canFlush bool,
 	idlePolls *int,
 ) (bool, *StartingPosition, error) {
-	out, pollErr := h.Backend.SubscribeToShard(&SubscribeToShardInput{
+	out, pollErr := h.Backend.SubscribeToShard(ctx, &SubscribeToShardInput{
 		ConsumerARN:      req.ConsumerARN,
 		ShardID:          req.ShardID,
 		StartingPosition: curSP,
@@ -1994,7 +2048,7 @@ func (h *Handler) Purge(ctx context.Context, cutoff time.Time) {
 	}
 }
 
-func (h *Handler) handleUpdateStreamMode(_ context.Context, _ *http.Request, body []byte) (any, error) {
+func (h *Handler) handleUpdateStreamMode(ctx context.Context, _ *http.Request, body []byte) (any, error) {
 	var req struct {
 		StreamModeDetails *jsonStreamModeDetails `json:"StreamModeDetails"`
 		StreamARN         string                 `json:"StreamARN"`
@@ -2006,7 +2060,7 @@ func (h *Handler) handleUpdateStreamMode(_ context.Context, _ *http.Request, bod
 		return nil, ErrInvalidArgument
 	}
 
-	return struct{}{}, h.Backend.UpdateStreamMode(&UpdateStreamModeInput{
+	return struct{}{}, h.Backend.UpdateStreamMode(ctx, &UpdateStreamModeInput{
 		StreamARN:         req.StreamARN,
 		StreamModeDetails: StreamModeDetails{StreamMode: req.StreamModeDetails.StreamMode},
 	})
@@ -2025,7 +2079,7 @@ type jsonUntagResourceReq struct {
 }
 
 func (h *Handler) handleTagResource(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -2038,7 +2092,7 @@ func (h *Handler) handleTagResource(
 		return nil, err
 	}
 
-	if err := h.Backend.TagResource(&TagResourceInput{
+	if err := h.Backend.TagResource(ctx, &TagResourceInput{
 		ResourceARN: req.ResourceARN,
 		Tags:        req.Tags,
 	}); err != nil {
@@ -2048,14 +2102,14 @@ func (h *Handler) handleTagResource(
 	// Mirror into the handler-level tag store for ListTagsForStream compatibility.
 	streamName := streamNameFromARN(req.ResourceARN)
 	if streamName != "" {
-		h.setTags(streamName, req.Tags)
+		h.setTags(regionFromARNOrCtx(ctx, req.ResourceARN, h.defaultRegion()), streamName, req.Tags)
 	}
 
 	return struct{}{}, nil
 }
 
 func (h *Handler) handleUntagResource(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -2064,7 +2118,7 @@ func (h *Handler) handleUntagResource(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.UntagResource(&UntagResourceInput{
+	if err := h.Backend.UntagResource(ctx, &UntagResourceInput{
 		ResourceARN: req.ResourceARN,
 		TagKeys:     req.TagKeys,
 	}); err != nil {
@@ -2074,7 +2128,7 @@ func (h *Handler) handleUntagResource(
 	// Mirror removal into the handler-level tag store.
 	streamName := streamNameFromARN(req.ResourceARN)
 	if streamName != "" {
-		h.removeTags(streamName, req.TagKeys)
+		h.removeTags(regionFromARNOrCtx(ctx, req.ResourceARN, h.defaultRegion()), streamName, req.TagKeys)
 	}
 
 	return struct{}{}, nil
@@ -2085,7 +2139,7 @@ type jsonUpdateAccountSettingsReq struct {
 }
 
 func (h *Handler) handleUpdateAccountSettings(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -2094,7 +2148,7 @@ func (h *Handler) handleUpdateAccountSettings(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.UpdateAccountSettings(&UpdateAccountSettingsInput{
+	if err := h.Backend.UpdateAccountSettings(ctx, &UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: req.OnDemandStreamCountLimit,
 	}); err != nil {
 		return nil, err
@@ -2110,7 +2164,7 @@ type jsonUpdateMaxRecordSizeReq struct {
 }
 
 func (h *Handler) handleUpdateMaxRecordSize(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -2119,7 +2173,7 @@ func (h *Handler) handleUpdateMaxRecordSize(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.UpdateMaxRecordSize(&UpdateMaxRecordSizeInput{
+	if err := h.Backend.UpdateMaxRecordSize(ctx, &UpdateMaxRecordSizeInput{
 		StreamName:         req.StreamName,
 		StreamARN:          req.StreamARN,
 		MaxRecordSizeBytes: req.MaxRecordSizeBytes,
@@ -2138,7 +2192,7 @@ type jsonUpdateStreamWarmThroughputReq struct {
 }
 
 func (h *Handler) handleUpdateStreamWarmThroughput(
-	_ context.Context,
+	ctx context.Context,
 	_ *http.Request,
 	body []byte,
 ) (any, error) {
@@ -2147,7 +2201,7 @@ func (h *Handler) handleUpdateStreamWarmThroughput(
 		return nil, ErrInvalidArgument
 	}
 
-	if err := h.Backend.UpdateStreamWarmThroughput(&UpdateStreamWarmThroughputInput{
+	if err := h.Backend.UpdateStreamWarmThroughput(ctx, &UpdateStreamWarmThroughputInput{
 		StreamName:         req.StreamName,
 		StreamARN:          req.StreamARN,
 		WriteCapacityUnits: req.WriteCapacityUnits,

--- a/services/kinesis/handler_audit2_test.go
+++ b/services/kinesis/handler_audit2_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -120,7 +121,7 @@ func TestAudit2_TagResource_KeyTooLong(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "tagres-kv-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "tagres-kv-stream"})
+	desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "tagres-kv-stream"})
 	require.NoError(t, err)
 
 	longKey := strings.Repeat("k", 129)
@@ -145,7 +146,7 @@ func TestAudit2_TagResource_ValueTooLong(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "tagres-val-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "tagres-val-stream"})
+	desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "tagres-val-stream"})
 	require.NoError(t, err)
 
 	longVal := strings.Repeat("v", 257)
@@ -336,7 +337,7 @@ func TestAudit2_MergeShards_ProvisionedAllowed(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "prov-merge", "ShardCount": 2})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	out, err := b.ListShards(&kinesis.ListShardsInput{StreamName: "prov-merge"})
+	out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "prov-merge"})
 	require.NoError(t, err)
 	require.Len(t, out.Shards, 2)
 
@@ -374,7 +375,10 @@ func TestAudit2_RegisterStreamConsumer_InvalidName(t *testing.T) {
 			doRequest(t, h, "CreateStream", map[string]any{"StreamName": "consumer-name-stream", "ShardCount": 1})
 
 			b := h.Backend.(*kinesis.InMemoryBackend)
-			desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "consumer-name-stream"})
+			desc, err := b.DescribeStream(
+				context.Background(),
+				&kinesis.DescribeStreamInput{StreamName: "consumer-name-stream"},
+			)
 			require.NoError(t, err)
 
 			rec := doRequest(t, h, "RegisterStreamConsumer", map[string]any{
@@ -412,7 +416,10 @@ func TestAudit2_RegisterStreamConsumer_ValidNames(t *testing.T) {
 			doRequest(t, h, "CreateStream", map[string]any{"StreamName": "valid-consumer-stream", "ShardCount": 1})
 
 			b := h.Backend.(*kinesis.InMemoryBackend)
-			desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "valid-consumer-stream"})
+			desc, err := b.DescribeStream(
+				context.Background(),
+				&kinesis.DescribeStreamInput{StreamName: "valid-consumer-stream"},
+			)
 			require.NoError(t, err)
 
 			rec := doRequest(t, h, "RegisterStreamConsumer", map[string]any{
@@ -436,7 +443,10 @@ func TestAudit2_ListStreamConsumers_MaxResultsPagination(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "consumer-page-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "consumer-page-stream"})
+	desc, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "consumer-page-stream"},
+	)
 	require.NoError(t, err)
 
 	// Register 5 consumers.
@@ -523,7 +533,7 @@ func TestAudit2_ListStreamConsumers_NoMaxResults_ReturnsAll(t *testing.T) {
 	doRequest(t, h, "CreateStream", map[string]any{"StreamName": "consumer-all-stream", "ShardCount": 1})
 
 	b := h.Backend.(*kinesis.InMemoryBackend)
-	desc, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "consumer-all-stream"})
+	desc, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "consumer-all-stream"})
 	require.NoError(t, err)
 
 	for i := range 3 {

--- a/services/kinesis/handler_refinement1_test.go
+++ b/services/kinesis/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -483,13 +484,13 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 
 	b1 := kinesis.NewInMemoryBackend()
 
-	require.NoError(t, b1.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b1.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "persist-stream",
 		ShardCount: 2,
 		Region:     "us-east-1",
 		AccountID:  "123456789012",
 	}))
-	require.NoError(t, b1.PutResourcePolicy(&kinesis.PutResourcePolicyInput{
+	require.NoError(t, b1.PutResourcePolicy(context.Background(), &kinesis.PutResourcePolicyInput{
 		ResourceARN: "arn:aws:kinesis:us-east-1:123:stream/other",
 		Policy:      `{"Version":"2012-10-17"}`,
 	}))

--- a/services/kinesis/handler_refinement2_test.go
+++ b/services/kinesis/handler_refinement2_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -252,12 +253,12 @@ func TestRefinement2_UpdateStreamMode_InvalidMode(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: "inv-mode-stream",
 				ShardCount: 1,
 			}))
 
-			err := b.UpdateStreamMode(&kinesis.UpdateStreamModeInput{
+			err := b.UpdateStreamMode(context.Background(), &kinesis.UpdateStreamModeInput{
 				StreamARN:         "arn:aws:kinesis:us-east-1:123456789012:stream/inv-mode-stream",
 				StreamModeDetails: kinesis.StreamModeDetails{StreamMode: tt.mode},
 			})
@@ -293,7 +294,7 @@ func TestRefinement2_UpdateStreamMode_NotFound(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			err := b.UpdateStreamMode(&kinesis.UpdateStreamModeInput{
+			err := b.UpdateStreamMode(context.Background(), &kinesis.UpdateStreamModeInput{
 				StreamARN:         tt.streamARN,
 				StreamModeDetails: kinesis.StreamModeDetails{StreamMode: kinesis.StreamModeOnDemand},
 			})
@@ -526,22 +527,22 @@ func TestRefinement2_MergeShards_KeepsClosedShards(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: tt.streamName,
 				ShardCount: tt.shardCount,
 			}))
 
-			out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			out, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 			require.Len(t, out.Shards, 2)
 
-			require.NoError(t, b.MergeShards(&kinesis.MergeShardsInput{
+			require.NoError(t, b.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 				StreamName:           tt.streamName,
 				ShardToMerge:         out.Shards[0].ShardID,
 				AdjacentShardToMerge: out.Shards[1].ShardID,
 			}))
 
-			out2, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			out2, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 
 			assert.Len(t, out2.Shards, tt.wantTotalShards)
@@ -581,24 +582,24 @@ func TestRefinement2_SplitShard_KeepsClosedShards(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: tt.streamName,
 				ShardCount: 1,
 			}))
 
-			out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			out, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 			require.Len(t, out.Shards, 1)
 
 			newHashKey := "170141183460469231731687303715884105727"
 
-			require.NoError(t, b.SplitShard(&kinesis.SplitShardInput{
+			require.NoError(t, b.SplitShard(context.Background(), &kinesis.SplitShardInput{
 				StreamName:         tt.streamName,
 				ShardToSplit:       out.Shards[0].ShardID,
 				NewStartingHashKey: newHashKey,
 			}))
 
-			out2, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			out2, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 
 			assert.Len(t, out2.Shards, tt.wantTotalShards)
@@ -635,22 +636,25 @@ func TestRefinement2_CountOpenShards_ExcludesClosedShards(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: tt.streamName,
 				ShardCount: tt.shardCount,
 			}))
 
 			if tt.doMerge {
-				out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+				out, err := b.DescribeStream(
+					context.Background(),
+					&kinesis.DescribeStreamInput{StreamName: tt.streamName},
+				)
 				require.NoError(t, err)
-				require.NoError(t, b.MergeShards(&kinesis.MergeShardsInput{
+				require.NoError(t, b.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 					StreamName:           tt.streamName,
 					ShardToMerge:         out.Shards[0].ShardID,
 					AdjacentShardToMerge: out.Shards[1].ShardID,
 				}))
 			}
 
-			assert.Equal(t, tt.wantCount, b.CountOpenShards())
+			assert.Equal(t, tt.wantCount, b.CountOpenShards(context.Background()))
 		})
 	}
 }
@@ -677,21 +681,21 @@ func TestRefinement2_DescribeAccountSettings_OnDemandCount(t *testing.T) {
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
 			for i := range tt.provisionedCount {
-				require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+				require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 					StreamName: "prov-acct-" + tt.name + "-" + string(rune('a'+i)),
 					ShardCount: 1,
 					StreamMode: kinesis.StreamModeProvisioned,
 				}))
 			}
 			for i := range tt.onDemandCount {
-				require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+				require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 					StreamName: "od-acct-" + tt.name + "-" + string(rune('a'+i)),
 					ShardCount: 1,
 					StreamMode: kinesis.StreamModeOnDemand,
 				}))
 			}
 
-			out, err := b.DescribeAccountSettings()
+			out, err := b.DescribeAccountSettings(context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantOnDemandCount, out.OnDemandStreamCount)
 		})
@@ -722,12 +726,12 @@ func TestRefinement2_PutRecord_ExplicitHashKey(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: "ehk-stream-" + tt.name,
 				ShardCount: tt.shardCount,
 			}))
 
-			out, err := b.PutRecord(&kinesis.PutRecordInput{
+			out, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 				StreamName:      "ehk-stream-" + tt.name,
 				PartitionKey:    "some-key",
 				ExplicitHashKey: tt.explicitHashKey,
@@ -760,12 +764,12 @@ func TestRefinement2_ListShards_ExclusiveStartShardId(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: "list-shards-excl-" + tt.name,
 				ShardCount: tt.shardCount,
 			}))
 
-			out, err := b.ListShards(&kinesis.ListShardsInput{
+			out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 				StreamName:            "list-shards-excl-" + tt.name,
 				ExclusiveStartShardID: tt.exclusiveStartShardID,
 			})
@@ -794,22 +798,22 @@ func TestRefinement2_ListShards_IncludesClosedShards(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: tt.streamName,
 				ShardCount: tt.shardCount,
 			}))
 
-			ds, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			ds, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 
-			require.NoError(t, b.MergeShards(&kinesis.MergeShardsInput{
+			require.NoError(t, b.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 				StreamName:           tt.streamName,
 				ShardToMerge:         ds.Shards[0].ShardID,
 				AdjacentShardToMerge: ds.Shards[1].ShardID,
 			}))
 
 			// Use FROM_TRIM_HORIZON filter to retrieve all shards including closed ones.
-			out, err := b.ListShards(&kinesis.ListShardsInput{
+			out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 				StreamName:  tt.streamName,
 				ShardFilter: "FROM_TRIM_HORIZON",
 			})
@@ -817,7 +821,7 @@ func TestRefinement2_ListShards_IncludesClosedShards(t *testing.T) {
 			assert.Len(t, out.Shards, tt.wantTotalShards)
 
 			// Without a filter, only open shards are returned (matching AWS default behavior).
-			openOut, err := b.ListShards(&kinesis.ListShardsInput{StreamName: tt.streamName})
+			openOut, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 			assert.Len(t, openOut.Shards, 1, "expected only the 1 open (merged) shard without filter")
 		})
@@ -841,24 +845,24 @@ func TestRefinement2_ShardDescription_ParentShardId(t *testing.T) {
 			h := newTestHandler(t)
 			b := h.Backend.(*kinesis.InMemoryBackend)
 
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: tt.streamName,
 				ShardCount: 2,
 			}))
 
-			ds, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			ds, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 
 			shard0ID := ds.Shards[0].ShardID
 			shard1ID := ds.Shards[1].ShardID
 
-			require.NoError(t, b.MergeShards(&kinesis.MergeShardsInput{
+			require.NoError(t, b.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 				StreamName:           tt.streamName,
 				ShardToMerge:         shard0ID,
 				AdjacentShardToMerge: shard1ID,
 			}))
 
-			ds2, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			ds2, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 
 			var mergedShard *kinesis.ShardDescription
@@ -891,12 +895,12 @@ func TestRefinement2_NextSeq_Serialized(t *testing.T) {
 			t.Parallel()
 
 			b := kinesis.NewInMemoryBackend()
-			require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+			require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 				StreamName: tt.streamName,
 				ShardCount: 1,
 			}))
 
-			out, err := b.PutRecord(&kinesis.PutRecordInput{
+			out, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 				StreamName:   tt.streamName,
 				PartitionKey: "key",
 				Data:         []byte("data"),
@@ -910,7 +914,7 @@ func TestRefinement2_NextSeq_Serialized(t *testing.T) {
 			b2 := kinesis.NewInMemoryBackend()
 			require.NoError(t, b2.Restore(snapshot))
 
-			out2, err := b2.PutRecord(&kinesis.PutRecordInput{
+			out2, err := b2.PutRecord(context.Background(), &kinesis.PutRecordInput{
 				StreamName:   tt.streamName,
 				PartitionKey: "key2",
 				Data:         []byte("data2"),
@@ -952,7 +956,7 @@ func TestRefinement2_AddStreamInternal_DefaultsStreamMode(t *testing.T) {
 				StreamMode: tt.streamMode,
 			})
 
-			out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: tt.streamName})
+			out, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: tt.streamName})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantMode, out.StreamMode)
 		})

--- a/services/kinesis/handler_refinement3_test.go
+++ b/services/kinesis/handler_refinement3_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,7 +24,7 @@ func TestRefinement3_GetRecords_10MBCap_StopsAtLimit(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "big-records-stream",
 		ShardCount: 1,
 	}))
@@ -33,7 +34,7 @@ func TestRefinement3_GetRecords_10MBCap_StopsAtLimit(t *testing.T) {
 
 	// Put 12 records (12 MiB total, well above the 10 MiB cap).
 	for i := range 12 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "big-records-stream",
 			PartitionKey: fmt.Sprintf("pk%d", i),
 			Data:         oneMiB,
@@ -41,14 +42,14 @@ func TestRefinement3_GetRecords_10MBCap_StopsAtLimit(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	out, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	out, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "big-records-stream",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: out.ShardIterator,
 		Limit:         10000,
 	})
@@ -65,19 +66,19 @@ func TestRefinement3_GetRecords_10MBCap_SingleLargeRecordAllowed(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "single-big-record",
 		ShardCount: 1,
 	}))
 
 	// Increase the record size limit to 10 MiB first.
-	require.NoError(t, b.UpdateMaxRecordSize(&kinesis.UpdateMaxRecordSizeInput{
+	require.NoError(t, b.UpdateMaxRecordSize(context.Background(), &kinesis.UpdateMaxRecordSizeInput{
 		StreamName:         "single-big-record",
 		MaxRecordSizeBytes: 10_485_760,
 	}))
 
 	tenMiB := make([]byte, 10_485_760)
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "single-big-record",
 		PartitionKey: "pk",
 		Data:         tenMiB,
@@ -85,21 +86,21 @@ func TestRefinement3_GetRecords_10MBCap_SingleLargeRecordAllowed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Put a second record so we can verify MillisBehindLatest.
-	_, err = b.PutRecord(&kinesis.PutRecordInput{
+	_, err = b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "single-big-record",
 		PartitionKey: "pk2",
 		Data:         []byte("small"),
 	})
 	require.NoError(t, err)
 
-	out, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	out, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "single-big-record",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: out.ShardIterator,
 		Limit:         10000,
 	})
@@ -116,13 +117,13 @@ func TestRefinement3_GetRecords_10MBCap_IteratorAdvancesCorrectly(t *testing.T) 
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "cap-advance-stream",
 		ShardCount: 1,
 	}))
 
 	// Use UpdateMaxRecordSize to allow 6 MiB records (> default 1 MiB limit).
-	require.NoError(t, b.UpdateMaxRecordSize(&kinesis.UpdateMaxRecordSizeInput{
+	require.NoError(t, b.UpdateMaxRecordSize(context.Background(), &kinesis.UpdateMaxRecordSizeInput{
 		StreamName:         "cap-advance-stream",
 		MaxRecordSizeBytes: 10_485_760,
 	}))
@@ -130,7 +131,7 @@ func TestRefinement3_GetRecords_10MBCap_IteratorAdvancesCorrectly(t *testing.T) 
 	// 4 MiB records × 3 = 12 MiB total: first call gets 2 (8MB), second call gets 1.
 	fourMiB := make([]byte, 4_194_304)
 	for i := range 3 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "cap-advance-stream",
 			PartitionKey: fmt.Sprintf("pk%d", i),
 			Data:         fourMiB,
@@ -138,14 +139,14 @@ func TestRefinement3_GetRecords_10MBCap_IteratorAdvancesCorrectly(t *testing.T) 
 		require.NoError(t, err)
 	}
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "cap-advance-stream",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	first, err := b.GetRecords(&kinesis.GetRecordsInput{
+	first, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         10000,
 	})
@@ -154,7 +155,7 @@ func TestRefinement3_GetRecords_10MBCap_IteratorAdvancesCorrectly(t *testing.T) 
 	require.NotEmpty(t, first.NextShardIterator)
 
 	// Second call should return the remaining records.
-	second, err := b.GetRecords(&kinesis.GetRecordsInput{
+	second, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: first.NextShardIterator,
 		Limit:         10000,
 	})
@@ -174,13 +175,13 @@ func TestRefinement3_CreateStream_OnDemandLimitEnforced(t *testing.T) {
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
 	// Set a tight limit of 2 ON_DEMAND streams.
-	require.NoError(t, b.UpdateAccountSettings(&kinesis.UpdateAccountSettingsInput{
+	require.NoError(t, b.UpdateAccountSettings(context.Background(), &kinesis.UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: 2,
 	}))
 
 	// Create 2 ON_DEMAND streams (should succeed).
 	for i := range 2 {
-		require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: fmt.Sprintf("od-limit-stream-%d", i),
 			ShardCount: 1,
 			StreamMode: "ON_DEMAND",
@@ -188,7 +189,7 @@ func TestRefinement3_CreateStream_OnDemandLimitEnforced(t *testing.T) {
 	}
 
 	// Third ON_DEMAND stream should fail with LimitExceededException.
-	err := b.CreateStream(&kinesis.CreateStreamInput{
+	err := b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "od-limit-stream-overflow",
 		ShardCount: 1,
 		StreamMode: "ON_DEMAND",
@@ -202,7 +203,7 @@ func TestRefinement3_CreateStream_OnDemandLimit_ViaHandler(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.UpdateAccountSettings(&kinesis.UpdateAccountSettingsInput{
+	require.NoError(t, b.UpdateAccountSettings(context.Background(), &kinesis.UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: 1,
 	}))
 
@@ -233,12 +234,12 @@ func TestRefinement3_CreateStream_ProvisionedNotAffectedByOnDemandLimit(t *testi
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.UpdateAccountSettings(&kinesis.UpdateAccountSettingsInput{
+	require.NoError(t, b.UpdateAccountSettings(context.Background(), &kinesis.UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: 1,
 	}))
 
 	// Fill the ON_DEMAND quota.
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "od-quota-stream",
 		ShardCount: 1,
 		StreamMode: "ON_DEMAND",
@@ -259,28 +260,28 @@ func TestRefinement3_CreateStream_OnDemandLimit_DeleteFreesSlot(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.UpdateAccountSettings(&kinesis.UpdateAccountSettingsInput{
+	require.NoError(t, b.UpdateAccountSettings(context.Background(), &kinesis.UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: 1,
 	}))
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "od-del-stream",
 		ShardCount: 1,
 		StreamMode: "ON_DEMAND",
 	}))
 
 	// Limit reached.
-	require.Error(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.Error(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "od-del-stream-2",
 		ShardCount: 1,
 		StreamMode: "ON_DEMAND",
 	}))
 
 	// Delete the first stream to free the slot.
-	require.NoError(t, b.DeleteStream(&kinesis.DeleteStreamInput{StreamName: "od-del-stream"}))
+	require.NoError(t, b.DeleteStream(context.Background(), &kinesis.DeleteStreamInput{StreamName: "od-del-stream"}))
 
 	// Now the second stream should succeed.
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "od-del-stream-2",
 		ShardCount: 1,
 		StreamMode: "ON_DEMAND",
@@ -417,13 +418,13 @@ func TestRefinement3_IncreaseRetention_BelowMinRejected(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "retention-min-stream",
 		ShardCount: 1,
 	}))
 
 	// Attempting to set retention to 0 (below minimum 24h) should fail.
-	err := b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+	err := b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 		StreamName:           "retention-min-stream",
 		RetentionPeriodHours: 0,
 	})
@@ -436,13 +437,13 @@ func TestRefinement3_IncreaseRetention_AboveMaxRejected(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "retention-max-stream",
 		ShardCount: 1,
 	}))
 
 	// 8761 hours > maxRetentionHours (8760) should fail.
-	err := b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+	err := b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 		StreamName:           "retention-max-stream",
 		RetentionPeriodHours: 8761,
 	})
@@ -455,19 +456,22 @@ func TestRefinement3_IncreaseRetention_ValidRangeAccepted(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "retention-valid-stream",
 		ShardCount: 1,
 	}))
 
 	// 168 h (7 days) is within valid range [24, 8760].
-	err := b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+	err := b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 		StreamName:           "retention-valid-stream",
 		RetentionPeriodHours: 168,
 	})
 	require.NoError(t, err)
 
-	out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "retention-valid-stream"})
+	out, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "retention-valid-stream"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 168, out.RetentionPeriodHours)
 }
@@ -478,13 +482,13 @@ func TestRefinement3_IncreaseRetention_MaxBoundaryAccepted(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "retention-boundary-stream",
 		ShardCount: 1,
 	}))
 
 	// Exactly maxRetentionHours (8760) should succeed.
-	err := b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
+	err := b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
 		StreamName:           "retention-boundary-stream",
 		RetentionPeriodHours: 8760,
 	})
@@ -501,13 +505,13 @@ func TestRefinement3_ListShards_MaxResults(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "list-shards-paginated",
 		ShardCount: 5,
 	}))
 
 	// Request only 2 shards.
-	out, err := b.ListShards(&kinesis.ListShardsInput{
+	out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName: "list-shards-paginated",
 		MaxResults: 2,
 	})
@@ -522,7 +526,7 @@ func TestRefinement3_ListShards_NextToken_Pagination(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "list-shards-nexttoken",
 		ShardCount: 5,
 	}))
@@ -531,7 +535,7 @@ func TestRefinement3_ListShards_NextToken_Pagination(t *testing.T) {
 	var nextToken string
 
 	for {
-		out, err := b.ListShards(&kinesis.ListShardsInput{
+		out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 			StreamName: "list-shards-nexttoken",
 			MaxResults: 2,
 			NextToken:  nextToken,
@@ -560,12 +564,12 @@ func TestRefinement3_ListShards_NoMaxResults_ReturnsAll(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "list-shards-nomax",
 		ShardCount: 4,
 	}))
 
-	out, err := b.ListShards(&kinesis.ListShardsInput{StreamName: "list-shards-nomax"})
+	out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "list-shards-nomax"})
 	require.NoError(t, err)
 	assert.Len(t, out.Shards, 4)
 	assert.Empty(t, out.NextToken)
@@ -618,12 +622,12 @@ func TestRefinement3_ListShards_MaxResults_ExactlyFits(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "list-shards-exact",
 		ShardCount: 3,
 	}))
 
-	out, err := b.ListShards(&kinesis.ListShardsInput{
+	out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName: "list-shards-exact",
 		MaxResults: 3,
 	})
@@ -642,14 +646,14 @@ func TestRefinement3_GetRecords_MillisBehindLatest_UsesLastRecord(t *testing.T) 
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "millis-behind-stream",
 		ShardCount: 1,
 	}))
 
 	// Put 3 records and introduce a small delay so their timestamps are in the past.
 	for i := range 3 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "millis-behind-stream",
 			PartitionKey: fmt.Sprintf("pk%d", i),
 			Data:         []byte("d"),
@@ -660,7 +664,7 @@ func TestRefinement3_GetRecords_MillisBehindLatest_UsesLastRecord(t *testing.T) 
 	// Wait briefly so the records have a measurable age.
 	time.Sleep(5 * time.Millisecond)
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "millis-behind-stream",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
@@ -668,7 +672,7 @@ func TestRefinement3_GetRecords_MillisBehindLatest_UsesLastRecord(t *testing.T) 
 	require.NoError(t, err)
 
 	// Get only 1 record (leaving 2 unread).
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         1,
 	})
@@ -685,19 +689,19 @@ func TestRefinement3_GetRecords_MillisBehindLatest_ZeroWhenCaughtUp(t *testing.T
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "millis-caught-up",
 		ShardCount: 1,
 	}))
 
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "millis-caught-up",
 		PartitionKey: "pk",
 		Data:         []byte("d"),
 	})
 	require.NoError(t, err)
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "millis-caught-up",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
@@ -705,7 +709,7 @@ func TestRefinement3_GetRecords_MillisBehindLatest_ZeroWhenCaughtUp(t *testing.T
 	require.NoError(t, err)
 
 	// Consume all records.
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         10000,
 	})
@@ -726,17 +730,20 @@ func TestRefinement3_UpdateShardCount_OldShardsMarkedClosed(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "update-shardcount-closed",
 		ShardCount: 2,
 	}))
 
-	out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "update-shardcount-closed"})
+	out, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "update-shardcount-closed"},
+	)
 	require.NoError(t, err)
 	require.Len(t, out.Shards, 2)
 
 	// Scale up to 4.
-	_, err = b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	_, err = b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "update-shardcount-closed",
 		TargetShardCount: 4,
 		ScalingType:      "UNIFORM_SCALING",
@@ -744,7 +751,10 @@ func TestRefinement3_UpdateShardCount_OldShardsMarkedClosed(t *testing.T) {
 	require.NoError(t, err)
 
 	// DescribeStream must include old closed shards + new open ones.
-	out2, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "update-shardcount-closed"})
+	out2, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "update-shardcount-closed"},
+	)
 	require.NoError(t, err)
 
 	openCount := 0
@@ -768,12 +778,12 @@ func TestRefinement3_UpdateShardCount_ListShardsOnlyReturnsOpenShards(t *testing
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "update-listshard-stream",
 		ShardCount: 2,
 	}))
 
-	_, err := b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	_, err := b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "update-listshard-stream",
 		TargetShardCount: 3,
 		ScalingType:      "UNIFORM_SCALING",
@@ -781,7 +791,7 @@ func TestRefinement3_UpdateShardCount_ListShardsOnlyReturnsOpenShards(t *testing
 	require.NoError(t, err)
 
 	// ListShards default = open shards only.
-	list, err := b.ListShards(&kinesis.ListShardsInput{StreamName: "update-listshard-stream"})
+	list, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "update-listshard-stream"})
 	require.NoError(t, err)
 	assert.Len(t, list.Shards, 3, "ListShards should return only the 3 new open shards")
 }
@@ -792,12 +802,12 @@ func TestRefinement3_UpdateShardCount_CurrentCountIsOpenShards(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "update-currentcount-stream",
 		ShardCount: 4,
 	}))
 
-	out, err := b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	out, err := b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "update-currentcount-stream",
 		TargetShardCount: 2,
 		ScalingType:      "UNIFORM_SCALING",
@@ -815,12 +825,12 @@ func TestRefinement3_UpdateShardCount_UniqueShardIDs(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "update-uniqueids-stream",
 		ShardCount: 2,
 	}))
 
-	_, err := b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	_, err := b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "update-uniqueids-stream",
 		TargetShardCount: 3,
 		ScalingType:      "UNIFORM_SCALING",
@@ -828,14 +838,17 @@ func TestRefinement3_UpdateShardCount_UniqueShardIDs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Scale again.
-	_, err = b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	_, err = b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "update-uniqueids-stream",
 		TargetShardCount: 1,
 		ScalingType:      "UNIFORM_SCALING",
 	})
 	require.NoError(t, err)
 
-	out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "update-uniqueids-stream"})
+	out, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "update-uniqueids-stream"},
+	)
 	require.NoError(t, err)
 
 	seen := make(map[string]struct{})
@@ -964,14 +977,14 @@ func TestRefinement3_PutRecord_ExplicitHashKey_AboveMaxRejected(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "hashkey-bound-stream",
 		ShardCount: 1,
 	}))
 
 	// 2^128 is one above the maximum valid hash key.
 	twoTo128 := "340282366920938463463374607431768211456"
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "hashkey-bound-stream",
 		PartitionKey:    "pk",
 		ExplicitHashKey: twoTo128,
@@ -986,12 +999,12 @@ func TestRefinement3_PutRecord_ExplicitHashKey_NegativeRejected(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "hashkey-negative-stream",
 		ShardCount: 1,
 	}))
 
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "hashkey-negative-stream",
 		PartitionKey:    "pk",
 		ExplicitHashKey: "-1",
@@ -1006,12 +1019,12 @@ func TestRefinement3_PutRecord_ExplicitHashKey_ZeroAccepted(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "hashkey-zero-stream",
 		ShardCount: 1,
 	}))
 
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "hashkey-zero-stream",
 		PartitionKey:    "pk",
 		ExplicitHashKey: "0",
@@ -1026,14 +1039,14 @@ func TestRefinement3_PutRecord_ExplicitHashKey_MaxAccepted(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "hashkey-maxval-stream",
 		ShardCount: 1,
 	}))
 
 	// 2^128-1 is the maximum valid hash key.
 	maxKey := "340282366920938463463374607431768211455"
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "hashkey-maxval-stream",
 		PartitionKey:    "pk",
 		ExplicitHashKey: maxKey,
@@ -1073,14 +1086,14 @@ func TestRefinement3_GetRecords_SmallRecords_NoCap(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "small-records-stream",
 		ShardCount: 1,
 	}))
 
 	// Put 100 small records (well under 10 MiB).
 	for i := range 100 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "small-records-stream",
 			PartitionKey: fmt.Sprintf("pk%d", i),
 			Data:         []byte("hello"),
@@ -1088,14 +1101,14 @@ func TestRefinement3_GetRecords_SmallRecords_NoCap(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "small-records-stream",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         10000,
 	})
@@ -1110,23 +1123,26 @@ func TestRefinement3_ListShards_WithMaxResults_PlusClosedShards(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "listshards-closed-paged",
 		ShardCount: 2,
 	}))
 
-	out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "listshards-closed-paged"})
+	out, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "listshards-closed-paged"},
+	)
 	require.NoError(t, err)
 
 	// Merge to produce 1 open + 2 closed = 3 total.
-	require.NoError(t, b.MergeShards(&kinesis.MergeShardsInput{
+	require.NoError(t, b.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 		StreamName:           "listshards-closed-paged",
 		ShardToMerge:         out.Shards[0].ShardID,
 		AdjacentShardToMerge: out.Shards[1].ShardID,
 	}))
 
 	// FROM_TRIM_HORIZON includes all shards; MaxResults=2 → page 1 of 2.
-	list, err := b.ListShards(&kinesis.ListShardsInput{
+	list, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:  "listshards-closed-paged",
 		ShardFilter: "FROM_TRIM_HORIZON",
 		MaxResults:  2,
@@ -1136,7 +1152,7 @@ func TestRefinement3_ListShards_WithMaxResults_PlusClosedShards(t *testing.T) {
 	assert.NotEmpty(t, list.NextToken)
 
 	// Page 2.
-	list2, err := b.ListShards(&kinesis.ListShardsInput{
+	list2, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:  "listshards-closed-paged",
 		ShardFilter: "FROM_TRIM_HORIZON",
 		MaxResults:  2,
@@ -1153,20 +1169,20 @@ func TestRefinement3_DescribeAccountSettings_OnDemandCount(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.UpdateAccountSettings(&kinesis.UpdateAccountSettingsInput{
+	require.NoError(t, b.UpdateAccountSettings(context.Background(), &kinesis.UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: 5,
 	}))
 
 	// Create 2 ON_DEMAND streams.
 	for i := range 2 {
-		require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: fmt.Sprintf("acct-od-stream-%d", i),
 			ShardCount: 1,
 			StreamMode: "ON_DEMAND",
 		}))
 	}
 
-	out, err := b.DescribeAccountSettings()
+	out, err := b.DescribeAccountSettings(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 2, out.OnDemandStreamCount)
 	assert.Equal(t, 5, out.OnDemandStreamCountLimit)
@@ -1272,12 +1288,12 @@ func TestRefinement3_GetRecords_10MBCap_ExactlyAtLimit(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "exact-cap-stream",
 		ShardCount: 1,
 	}))
 
-	require.NoError(t, b.UpdateMaxRecordSize(&kinesis.UpdateMaxRecordSizeInput{
+	require.NoError(t, b.UpdateMaxRecordSize(context.Background(), &kinesis.UpdateMaxRecordSizeInput{
 		StreamName:         "exact-cap-stream",
 		MaxRecordSizeBytes: 10_485_760,
 	}))
@@ -1285,7 +1301,7 @@ func TestRefinement3_GetRecords_10MBCap_ExactlyAtLimit(t *testing.T) {
 	// Two 5 MiB records = exactly 10 MiB; both should fit in one response.
 	fiveMiB := make([]byte, 5_242_880)
 	for i := range 2 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "exact-cap-stream",
 			PartitionKey: fmt.Sprintf("pk%d", i),
 			Data:         fiveMiB,
@@ -1293,21 +1309,21 @@ func TestRefinement3_GetRecords_10MBCap_ExactlyAtLimit(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// Third 1-byte record (so we can check lag).
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "exact-cap-stream",
 		PartitionKey: "extra",
 		Data:         []byte("x"),
 	})
 	require.NoError(t, err)
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "exact-cap-stream",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         10000,
 	})
@@ -1324,14 +1340,14 @@ func TestRefinement3_GetRecords_ZeroLimitUsesDefault(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "default-limit-stream",
 		ShardCount: 1,
 	}))
 
 	// Put more than defaultGetRecordsLimit records.
 	for i := range 5 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "default-limit-stream",
 			PartitionKey: fmt.Sprintf("pk%d", i),
 			Data:         []byte("d"),
@@ -1339,7 +1355,7 @@ func TestRefinement3_GetRecords_ZeroLimitUsesDefault(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "default-limit-stream",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
@@ -1347,7 +1363,7 @@ func TestRefinement3_GetRecords_ZeroLimitUsesDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	// Limit=0 uses the default (1000).
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         0,
 	})
@@ -1361,7 +1377,7 @@ func TestRefinement3_OnDemandLimit_DefaultLimitIsPositive(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	out, err := b.DescribeAccountSettings()
+	out, err := b.DescribeAccountSettings(context.Background())
 	require.NoError(t, err)
 	assert.Positive(t, out.OnDemandStreamCountLimit, "default ON_DEMAND limit should be positive")
 }
@@ -1372,12 +1388,12 @@ func TestRefinement3_CreateStream_OnDemandLimit_AtBoundary(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.UpdateAccountSettings(&kinesis.UpdateAccountSettingsInput{
+	require.NoError(t, b.UpdateAccountSettings(context.Background(), &kinesis.UpdateAccountSettingsInput{
 		OnDemandStreamCountLimit: 3,
 	}))
 
 	for i := range 3 {
-		require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+		require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 			StreamName: fmt.Sprintf("od-boundary-%d", i),
 			ShardCount: 1,
 			StreamMode: "ON_DEMAND",
@@ -1385,7 +1401,7 @@ func TestRefinement3_CreateStream_OnDemandLimit_AtBoundary(t *testing.T) {
 	}
 
 	// The 4th should fail.
-	err := b.CreateStream(&kinesis.CreateStreamInput{
+	err := b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "od-boundary-overflow",
 		ShardCount: 1,
 		StreamMode: "ON_DEMAND",
@@ -1399,13 +1415,13 @@ func TestRefinement3_ListShards_NextToken_SinglePage(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "listshards-single-page",
 		ShardCount: 2,
 	}))
 
 	// MaxResults > total shards → single page, no NextToken.
-	out, err := b.ListShards(&kinesis.ListShardsInput{
+	out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName: "listshards-single-page",
 		MaxResults: 10,
 	})
@@ -1420,7 +1436,7 @@ func TestRefinement3_ListShards_NextToken_OddPageSize(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "listshards-odd-page",
 		ShardCount: 7,
 	}))
@@ -1429,7 +1445,7 @@ func TestRefinement3_ListShards_NextToken_OddPageSize(t *testing.T) {
 	nextToken := ""
 
 	for {
-		out, err := b.ListShards(&kinesis.ListShardsInput{
+		out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 			StreamName: "listshards-odd-page",
 			MaxResults: 3,
 			NextToken:  nextToken,
@@ -1481,19 +1497,19 @@ func TestRefinement3_UpdateShardCount_SecondScaleStillWorks(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "double-scale-stream",
 		ShardCount: 1,
 	}))
 
-	_, err := b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	_, err := b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "double-scale-stream",
 		TargetShardCount: 3,
 		ScalingType:      "UNIFORM_SCALING",
 	})
 	require.NoError(t, err)
 
-	out2, err := b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	out2, err := b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "double-scale-stream",
 		TargetShardCount: 2,
 		ScalingType:      "UNIFORM_SCALING",
@@ -1509,14 +1525,14 @@ func TestRefinement3_ExplicitHashKey_PartitionKeyOverride(t *testing.T) {
 	h := newTestHandler(t)
 	b := h.Backend.(*kinesis.InMemoryBackend)
 
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "explicit-hash-override",
 		ShardCount: 2,
 	}))
 
 	// Use a hash key in the upper half to target the second shard.
 	upperHalfKey := "255211775190703847597592248818726428672"
-	out, err := b.PutRecord(&kinesis.PutRecordInput{
+	out, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "explicit-hash-override",
 		PartitionKey:    "ignored-partition-key",
 		ExplicitHashKey: upperHalfKey,
@@ -1530,14 +1546,14 @@ func TestRefinement3_PutRecord_ExplicitHashKey_OneAboveMax(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "above-max-hash",
 		ShardCount: 1,
 	}))
 
 	// 2^128 is one above max (2^128-1).
 	oneAboveMax := "340282366920938463463374607431768211456"
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "above-max-hash",
 		PartitionKey:    "pk",
 		ExplicitHashKey: oneAboveMax,
@@ -1550,24 +1566,30 @@ func TestRefinement3_RetentionPeriod_IdempotentIncrease(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "idempotent-retention",
 		ShardCount: 1,
 	}))
 
 	// Set retention to 48 hours.
-	require.NoError(t, b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-		StreamName:           "idempotent-retention",
-		RetentionPeriodHours: 48,
-	}))
+	require.NoError(
+		t,
+		b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
+			StreamName:           "idempotent-retention",
+			RetentionPeriodHours: 48,
+		}),
+	)
 
 	// Set it to the same value again — should be a no-op.
-	require.NoError(t, b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-		StreamName:           "idempotent-retention",
-		RetentionPeriodHours: 48,
-	}))
+	require.NoError(
+		t,
+		b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
+			StreamName:           "idempotent-retention",
+			RetentionPeriodHours: 48,
+		}),
+	)
 
-	out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "idempotent-retention"})
+	out, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "idempotent-retention"})
 	require.NoError(t, err)
 	assert.Equal(t, 48, out.RetentionPeriodHours)
 }
@@ -1576,22 +1598,28 @@ func TestRefinement3_RetentionPeriod_DecreaseStillWorks(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "decrease-retention",
 		ShardCount: 1,
 	}))
 
-	require.NoError(t, b.IncreaseStreamRetentionPeriod(&kinesis.IncreaseStreamRetentionPeriodInput{
-		StreamName:           "decrease-retention",
-		RetentionPeriodHours: 168,
-	}))
+	require.NoError(
+		t,
+		b.IncreaseStreamRetentionPeriod(context.Background(), &kinesis.IncreaseStreamRetentionPeriodInput{
+			StreamName:           "decrease-retention",
+			RetentionPeriodHours: 168,
+		}),
+	)
 
-	require.NoError(t, b.DecreaseStreamRetentionPeriod(&kinesis.DecreaseStreamRetentionPeriodInput{
-		StreamName:           "decrease-retention",
-		RetentionPeriodHours: 48,
-	}))
+	require.NoError(
+		t,
+		b.DecreaseStreamRetentionPeriod(context.Background(), &kinesis.DecreaseStreamRetentionPeriodInput{
+			StreamName:           "decrease-retention",
+			RetentionPeriodHours: 48,
+		}),
+	)
 
-	out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "decrease-retention"})
+	out, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "decrease-retention"})
 	require.NoError(t, err)
 	assert.Equal(t, 48, out.RetentionPeriodHours)
 }
@@ -1600,14 +1628,14 @@ func TestRefinement3_PutRecords_MixedOversizeAndValid(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "putrecords-mixed",
 		ShardCount: 1,
 	}))
 
 	// 3 records: valid, oversize, valid.
 	oversize := make([]byte, 1_048_577) // 1 MiB + 1 byte
-	out, err := b.PutRecords(&kinesis.PutRecordsInput{
+	out, err := b.PutRecords(context.Background(), &kinesis.PutRecordsInput{
 		StreamName: "putrecords-mixed",
 		Records: []kinesis.PutRecordsEntry{
 			{PartitionKey: "pk1", Data: []byte("ok1")},
@@ -1627,27 +1655,30 @@ func TestRefinement3_ListShards_ClosedShards_IncludedWithFilter(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "listshards-closed-filter",
 		ShardCount: 2,
 	}))
 
-	ds, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "listshards-closed-filter"})
+	ds, err := b.DescribeStream(
+		context.Background(),
+		&kinesis.DescribeStreamInput{StreamName: "listshards-closed-filter"},
+	)
 	require.NoError(t, err)
 
-	require.NoError(t, b.MergeShards(&kinesis.MergeShardsInput{
+	require.NoError(t, b.MergeShards(context.Background(), &kinesis.MergeShardsInput{
 		StreamName:           "listshards-closed-filter",
 		ShardToMerge:         ds.Shards[0].ShardID,
 		AdjacentShardToMerge: ds.Shards[1].ShardID,
 	}))
 
 	// Default: only open shards.
-	open, err := b.ListShards(&kinesis.ListShardsInput{StreamName: "listshards-closed-filter"})
+	open, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "listshards-closed-filter"})
 	require.NoError(t, err)
 	assert.Len(t, open.Shards, 1)
 
 	// FROM_TRIM_HORIZON: all shards.
-	all, err := b.ListShards(&kinesis.ListShardsInput{
+	all, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:  "listshards-closed-filter",
 		ShardFilter: "FROM_TRIM_HORIZON",
 	})
@@ -1659,12 +1690,12 @@ func TestRefinement3_UpdateShardCount_LargeScale(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "large-scale-stream",
 		ShardCount: 1,
 	}))
 
-	out, err := b.UpdateShardCount(&kinesis.UpdateShardCountInput{
+	out, err := b.UpdateShardCount(context.Background(), &kinesis.UpdateShardCountInput{
 		StreamName:       "large-scale-stream",
 		TargetShardCount: 10,
 		ScalingType:      "UNIFORM_SCALING",
@@ -1674,7 +1705,7 @@ func TestRefinement3_UpdateShardCount_LargeScale(t *testing.T) {
 	assert.Equal(t, 10, out.TargetShardCount)
 
 	// Verify 10 open shards via ListShards.
-	list, err := b.ListShards(&kinesis.ListShardsInput{StreamName: "large-scale-stream"})
+	list, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{StreamName: "large-scale-stream"})
 	require.NoError(t, err)
 	assert.Len(t, list.Shards, 10)
 }
@@ -1683,19 +1714,19 @@ func TestRefinement3_GetRecords_EmptyShard_MillisBehindZero(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "empty-shard-millis",
 		ShardCount: 1,
 	}))
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "empty-shard-millis",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         100,
 	})
@@ -1767,14 +1798,14 @@ func TestRefinement3_ExplicitHashKey_ValidMidRange(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "midrange-hash",
 		ShardCount: 2,
 	}))
 
 	// Hash key exactly at the midpoint of 2^128 space.
 	midpoint := "170141183460469231731687303715884105728"
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:      "midrange-hash",
 		PartitionKey:    "pk",
 		ExplicitHashKey: midpoint,
@@ -1787,13 +1818,13 @@ func TestRefinement3_PutRecords_EmptyBatch(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "empty-batch-stream",
 		ShardCount: 1,
 	}))
 
 	// Empty records slice.
-	out, err := b.PutRecords(&kinesis.PutRecordsInput{
+	out, err := b.PutRecords(context.Background(), &kinesis.PutRecordsInput{
 		StreamName: "empty-batch-stream",
 		Records:    []kinesis.PutRecordsEntry{},
 	})
@@ -1806,13 +1837,13 @@ func TestRefinement3_ListShards_ExclusiveStart_WithMaxResults(t *testing.T) {
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "listshards-start-max",
 		ShardCount: 5,
 	}))
 
 	// Start after shard 1 (exclusive), take 2.
-	out, err := b.ListShards(&kinesis.ListShardsInput{
+	out, err := b.ListShards(context.Background(), &kinesis.ListShardsInput{
 		StreamName:            "listshards-start-max",
 		ExclusiveStartShardID: "shardId-000000000001",
 		MaxResults:            2,
@@ -1829,19 +1860,19 @@ func TestRefinement3_GetRecords_10MBCap_RecordsBeforeCapNotDropped(t *testing.T)
 	t.Parallel()
 
 	b := kinesis.NewInMemoryBackend()
-	require.NoError(t, b.CreateStream(&kinesis.CreateStreamInput{
+	require.NoError(t, b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 		StreamName: "precap-records",
 		ShardCount: 1,
 	}))
 
-	require.NoError(t, b.UpdateMaxRecordSize(&kinesis.UpdateMaxRecordSizeInput{
+	require.NoError(t, b.UpdateMaxRecordSize(context.Background(), &kinesis.UpdateMaxRecordSizeInput{
 		StreamName:         "precap-records",
 		MaxRecordSizeBytes: 10_485_760,
 	}))
 
 	// Put 3 small + 1 huge record (order matters for iteration).
 	for i := range 3 {
-		_, err := b.PutRecord(&kinesis.PutRecordInput{
+		_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "precap-records",
 			PartitionKey: fmt.Sprintf("small%d", i),
 			Data:         []byte("tiny"),
@@ -1850,21 +1881,21 @@ func TestRefinement3_GetRecords_10MBCap_RecordsBeforeCapNotDropped(t *testing.T)
 	}
 
 	bigData := make([]byte, 9_000_000)
-	_, err := b.PutRecord(&kinesis.PutRecordInput{
+	_, err := b.PutRecord(context.Background(), &kinesis.PutRecordInput{
 		StreamName:   "precap-records",
 		PartitionKey: "big",
 		Data:         bigData,
 	})
 	require.NoError(t, err)
 
-	iterOut, err := b.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := b.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:        "precap-records",
 		ShardID:           "shardId-000000000000",
 		ShardIteratorType: "TRIM_HORIZON",
 	})
 	require.NoError(t, err)
 
-	rec, err := b.GetRecords(&kinesis.GetRecordsInput{
+	rec, err := b.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 		ShardIterator: iterOut.ShardIterator,
 		Limit:         10000,
 	})

--- a/services/kinesis/handler_test.go
+++ b/services/kinesis/handler_test.go
@@ -2,6 +2,7 @@ package kinesis_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -510,13 +511,13 @@ func TestListAll(t *testing.T) {
 	bk := kinesis.NewInMemoryBackend()
 
 	// Empty
-	assert.Empty(t, bk.ListAll())
+	assert.Empty(t, bk.ListAll(context.Background()))
 
 	// Create some streams
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s1"}))
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "s2"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s1"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "s2"}))
 
-	all := bk.ListAll()
+	all := bk.ListAll(context.Background())
 	assert.Len(t, all, 2)
 
 	names := make([]string, len(all))
@@ -533,9 +534,9 @@ func TestBackendWithConfig(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackendWithConfig("123456789012", "eu-west-1")
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "regional-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "regional-stream"}))
 
-	all := bk.ListAll()
+	all := bk.ListAll(context.Background())
 	require.Len(t, all, 1)
 	assert.Contains(t, all[0].ARN, "eu-west-1")
 	assert.Contains(t, all[0].ARN, "123456789012")

--- a/services/kinesis/isolation_test.go
+++ b/services/kinesis/isolation_test.go
@@ -1,0 +1,181 @@
+package kinesis //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region, mirroring what the
+// handler injects from the SigV4 credential scope.
+func ctxRegion(region string) context.Context {
+	return contextWithRegion(context.Background(), region)
+}
+
+// TestKinesisRegionIsolation proves that a same-named stream created in two
+// regions stays fully isolated: ARNs, shards, and records do not leak across
+// regions, and deleting in one region leaves the other intact.
+func TestKinesisRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// 1. Create a stream named "shared" in us-east-1.
+	require.NoError(t, backend.CreateStream(ctxEast, &CreateStreamInput{
+		StreamName: "shared",
+		ShardCount: 1,
+	}))
+
+	// 2. Create a stream with the SAME NAME in us-west-2.
+	require.NoError(t, backend.CreateStream(ctxWest, &CreateStreamInput{
+		StreamName: "shared",
+		ShardCount: 2,
+	}))
+
+	// 3. Each region's stream carries its own ARN region and shard count.
+	eastDesc, err := backend.DescribeStream(ctxEast, &DescribeStreamInput{StreamName: "shared"})
+	require.NoError(t, err)
+	assert.Contains(t, eastDesc.StreamARN, "us-east-1")
+	assert.Len(t, eastDesc.Shards, 1)
+
+	westDesc, err := backend.DescribeStream(ctxWest, &DescribeStreamInput{StreamName: "shared"})
+	require.NoError(t, err)
+	assert.Contains(t, westDesc.StreamARN, "us-west-2")
+	assert.Len(t, westDesc.Shards, 2)
+
+	// 4. ListStreams in each region sees only its own stream.
+	eastList, err := backend.ListStreams(ctxEast, &ListStreamsInput{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared"}, eastList.StreamNames)
+
+	westList, err := backend.ListStreams(ctxWest, &ListStreamsInput{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared"}, westList.StreamNames)
+
+	// A third region that was never written sees no streams.
+	emptyList, err := backend.ListStreams(ctxRegion("eu-west-1"), &ListStreamsInput{})
+	require.NoError(t, err)
+	assert.Empty(t, emptyList.StreamNames)
+
+	// 5. Delete the stream in us-east-1; us-west-2 still has its stream.
+	require.NoError(t, backend.DeleteStream(ctxEast, &DeleteStreamInput{StreamName: "shared"}))
+
+	_, err = backend.DescribeStream(ctxEast, &DescribeStreamInput{StreamName: "shared"})
+	require.ErrorIs(t, err, ErrStreamNotFound)
+
+	stillWest, err := backend.DescribeStream(ctxWest, &DescribeStreamInput{StreamName: "shared"})
+	require.NoError(t, err)
+	assert.Contains(t, stillWest.StreamARN, "us-west-2")
+}
+
+// TestKinesisRecordRegionIsolation proves records written to a same-named
+// stream in two regions never cross over, and that a shard iterator issued in
+// one region reads only that region's records even when GetRecords carries a
+// different ctx region (the region is encoded into the iterator token).
+func TestKinesisRecordRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	for _, c := range []context.Context{ctxEast, ctxWest} {
+		require.NoError(t, backend.CreateStream(c, &CreateStreamInput{
+			StreamName: "events",
+			ShardCount: 1,
+		}))
+	}
+
+	// Write distinct records into each region's stream.
+	_, err := backend.PutRecord(ctxEast, &PutRecordInput{
+		StreamName:   "events",
+		PartitionKey: "pk",
+		Data:         []byte("east-record"),
+	})
+	require.NoError(t, err)
+
+	_, err = backend.PutRecord(ctxWest, &PutRecordInput{
+		StreamName:   "events",
+		PartitionKey: "pk",
+		Data:         []byte("west-record"),
+	})
+	require.NoError(t, err)
+
+	// us-east-1 reads only its own record.
+	eastIt, err := backend.GetShardIterator(ctxEast, &GetShardIteratorInput{
+		StreamName:        "events",
+		ShardID:           "shardId-000000000000",
+		ShardIteratorType: iteratorTypeTrimHorizon,
+	})
+	require.NoError(t, err)
+
+	// Deliberately call GetRecords with the WEST ctx to prove the iterator's
+	// embedded region — not the ctx region — selects the record store.
+	eastRecs, err := backend.GetRecords(ctxWest, &GetRecordsInput{ShardIterator: eastIt.ShardIterator})
+	require.NoError(t, err)
+	require.Len(t, eastRecs.Records, 1)
+	assert.Equal(t, []byte("east-record"), eastRecs.Records[0].Data)
+
+	// us-west-2 reads only its own record.
+	westIt, err := backend.GetShardIterator(ctxWest, &GetShardIteratorInput{
+		StreamName:        "events",
+		ShardID:           "shardId-000000000000",
+		ShardIteratorType: iteratorTypeTrimHorizon,
+	})
+	require.NoError(t, err)
+
+	westRecs, err := backend.GetRecords(ctxEast, &GetRecordsInput{ShardIterator: westIt.ShardIterator})
+	require.NoError(t, err)
+	require.Len(t, westRecs.Records, 1)
+	assert.Equal(t, []byte("west-record"), westRecs.Records[0].Data)
+}
+
+// TestKinesisConsumerRegionIsolation proves enhanced fan-out consumers are
+// isolated per region: registering a same-named consumer on a same-named
+// stream in two regions does not collide, and each region lists only its own.
+func TestKinesisConsumerRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	require.NoError(t, backend.CreateStream(ctxEast, &CreateStreamInput{StreamName: "s", ShardCount: 1}))
+	require.NoError(t, backend.CreateStream(ctxWest, &CreateStreamInput{StreamName: "s", ShardCount: 1}))
+
+	eastDesc, err := backend.DescribeStream(ctxEast, &DescribeStreamInput{StreamName: "s"})
+	require.NoError(t, err)
+	westDesc, err := backend.DescribeStream(ctxWest, &DescribeStreamInput{StreamName: "s"})
+	require.NoError(t, err)
+
+	// The consumer ARN carries its region via the stream ARN, so the backend
+	// routes RegisterStreamConsumer to that region regardless of ctx.
+	_, err = backend.RegisterStreamConsumer(ctxEast, &RegisterStreamConsumerInput{
+		StreamARN:    eastDesc.StreamARN,
+		ConsumerName: "fanout",
+	})
+	require.NoError(t, err)
+
+	_, err = backend.RegisterStreamConsumer(ctxWest, &RegisterStreamConsumerInput{
+		StreamARN:    westDesc.StreamARN,
+		ConsumerName: "fanout",
+	})
+	require.NoError(t, err)
+
+	eastConsumers, err := backend.ListStreamConsumers(ctxEast, &ListStreamConsumersInput{StreamARN: eastDesc.StreamARN})
+	require.NoError(t, err)
+	require.Len(t, eastConsumers.Consumers, 1)
+	assert.Contains(t, eastConsumers.Consumers[0].ConsumerARN, "us-east-1")
+
+	westConsumers, err := backend.ListStreamConsumers(ctxWest, &ListStreamConsumersInput{StreamARN: westDesc.StreamARN})
+	require.NoError(t, err)
+	require.Len(t, westConsumers.Consumers, 1)
+	assert.Contains(t, westConsumers.Consumers[0].ConsumerARN, "us-west-2")
+}

--- a/services/kinesis/janitor.go
+++ b/services/kinesis/janitor.go
@@ -78,11 +78,13 @@ func (j *Janitor) sweepRetention(ctx context.Context) {
 
 	j.Backend.mu.Lock("KinesisJanitor")
 
-	for _, stream := range j.Backend.streams {
-		cutoff := now.Add(-time.Duration(stream.RetentionPeriod) * time.Hour)
+	for _, regionStreams := range j.Backend.streams {
+		for _, stream := range regionStreams {
+			cutoff := now.Add(-time.Duration(stream.RetentionPeriod) * time.Hour)
 
-		for _, shard := range stream.Shards {
-			totalTrimmed += shard.Records.trimBefore(cutoff)
+			for _, shard := range stream.Shards {
+				totalTrimmed += shard.Records.trimBefore(cutoff)
+			}
 		}
 	}
 

--- a/services/kinesis/janitor_test.go
+++ b/services/kinesis/janitor_test.go
@@ -47,7 +47,10 @@ func TestJanitor_RetentionSweep(t *testing.T) {
 			t.Parallel()
 
 			bk := kinesis.NewInMemoryBackend()
-			require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "sweep-stream"}))
+			require.NoError(
+				t,
+				bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "sweep-stream"}),
+			)
 			require.NoError(t, bk.SetRetentionPeriodForTest("sweep-stream", tt.retentionHrs))
 
 			// Push a record with an artificial past arrival time.
@@ -69,12 +72,12 @@ func TestJanitor_MultiStreamSweep(t *testing.T) {
 	bk := kinesis.NewInMemoryBackend()
 
 	// Stream A: 24-hour retention, record is 30 hours old (should be evicted).
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "stream-a"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "stream-a"}))
 	require.NoError(t, bk.SetRetentionPeriodForTest("stream-a", 24))
 	require.NoError(t, bk.PushOldRecordForTest("stream-a", 0, 30*time.Hour))
 
 	// Stream B: 48-hour retention, record is 30 hours old (should be kept).
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "stream-b"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "stream-b"}))
 	require.NoError(t, bk.SetRetentionPeriodForTest("stream-b", 48))
 	require.NoError(t, bk.PushOldRecordForTest("stream-b", 0, 30*time.Hour))
 
@@ -90,7 +93,7 @@ func TestJanitor_EmptyStream(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "empty"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "empty"}))
 
 	j := kinesis.NewJanitorForTest(bk, time.Minute)
 
@@ -132,13 +135,13 @@ func TestDeleteStream_CleansFaultEntry(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "fault-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "fault-stream"}))
 
 	// Inject a fault for the stream.
 	bk.InjectFaultForTest("fault-stream")
 	assert.True(t, bk.HasFaultForTest("fault-stream"), "fault should be present before delete")
 
-	require.NoError(t, bk.DeleteStream(&kinesis.DeleteStreamInput{StreamName: "fault-stream"}))
+	require.NoError(t, bk.DeleteStream(context.Background(), &kinesis.DeleteStreamInput{StreamName: "fault-stream"}))
 
 	assert.False(t, bk.HasFaultForTest("fault-stream"), "fault entry should be removed after delete")
 }
@@ -150,9 +153,9 @@ func TestRingBuffer_WrapAround(t *testing.T) {
 
 	const maxCap = 10000
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "ring-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "ring-stream"}))
 
-	desc, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "ring-stream"})
+	desc, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "ring-stream"})
 	require.NoError(t, err)
 	shardID := desc.Shards[0].ShardID
 
@@ -160,7 +163,7 @@ func TestRingBuffer_WrapAround(t *testing.T) {
 	var lastSeq string
 
 	for range maxCap + 5 {
-		out, putErr := bk.PutRecord(&kinesis.PutRecordInput{
+		out, putErr := bk.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "ring-stream",
 			PartitionKey: "pk",
 			Data:         []byte("data"),
@@ -174,7 +177,7 @@ func TestRingBuffer_WrapAround(t *testing.T) {
 	assert.Equal(t, maxCap, bk.ShardRecordCountForTest("ring-stream", 0))
 
 	// The last pushed record must be readable.
-	iterOut, err := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iterOut, err := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 		StreamName:             "ring-stream",
 		ShardID:                shardID,
 		ShardIteratorType:      "AT_SEQUENCE_NUMBER",
@@ -182,7 +185,10 @@ func TestRingBuffer_WrapAround(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	recs, err := bk.GetRecords(&kinesis.GetRecordsInput{ShardIterator: iterOut.ShardIterator, Limit: 1})
+	recs, err := bk.GetRecords(
+		context.Background(),
+		&kinesis.GetRecordsInput{ShardIterator: iterOut.ShardIterator, Limit: 1},
+	)
 	require.NoError(t, err)
 	require.Len(t, recs.Records, 1)
 	assert.Equal(t, lastSeq, recs.Records[0].SequenceNumber)
@@ -194,9 +200,9 @@ func TestBinarySearch_FindSequencePosition(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackend()
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "bsearch-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "bsearch-stream"}))
 
-	desc, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "bsearch-stream"})
+	desc, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "bsearch-stream"})
 	require.NoError(t, err)
 	shardID := desc.Shards[0].ShardID
 
@@ -204,7 +210,7 @@ func TestBinarySearch_FindSequencePosition(t *testing.T) {
 	seqs := make([]string, 100)
 
 	for i := range 100 {
-		out, putErr := bk.PutRecord(&kinesis.PutRecordInput{
+		out, putErr := bk.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "bsearch-stream",
 			PartitionKey: "pk",
 			Data:         []byte("data"),
@@ -260,7 +266,7 @@ func TestBinarySearch_FindSequencePosition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			iterOut, iterErr := bk.GetShardIterator(&kinesis.GetShardIteratorInput{
+			iterOut, iterErr := bk.GetShardIterator(context.Background(), &kinesis.GetShardIteratorInput{
 				StreamName:             "bsearch-stream",
 				ShardID:                shardID,
 				ShardIteratorType:      tt.iterType,
@@ -268,7 +274,7 @@ func TestBinarySearch_FindSequencePosition(t *testing.T) {
 			})
 			require.NoError(t, iterErr)
 
-			recs, recsErr := bk.GetRecords(&kinesis.GetRecordsInput{
+			recs, recsErr := bk.GetRecords(context.Background(), &kinesis.GetRecordsInput{
 				ShardIterator: iterOut.ShardIterator,
 				Limit:         10000,
 			})
@@ -318,7 +324,7 @@ func TestJanitor_WithTaskTimeout_ProviderPath(t *testing.T) {
 	bk := kinesis.NewInMemoryBackend()
 
 	// Push an old record that would normally be swept.
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "timeout-test"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "timeout-test"}))
 	require.NoError(t, bk.SetRetentionPeriodForTest("timeout-test", 24))
 	require.NoError(t, bk.PushOldRecordForTest("timeout-test", 0, 30*time.Hour))
 

--- a/services/kinesis/persistence.go
+++ b/services/kinesis/persistence.go
@@ -5,11 +5,14 @@ import (
 	"log/slog"
 )
 
+// backendSnapshot is the persisted form of the backend. Streams and
+// ResourcePolicies are nested by region (outer key = region) to match the
+// region-isolated in-memory layout.
 type backendSnapshot struct {
-	Streams          map[string]*Stream `json:"streams"`
-	ResourcePolicies map[string]string  `json:"resourcePolicies,omitempty"`
-	AccountID        string             `json:"accountID"`
-	Region           string             `json:"region"`
+	Streams          map[string]map[string]*Stream `json:"streams"`
+	ResourcePolicies map[string]map[string]string  `json:"resourcePolicies,omitempty"`
+	AccountID        string                        `json:"accountID"`
+	Region           string                        `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -49,19 +52,26 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	defer b.mu.Unlock()
 
 	if snap.Streams == nil {
-		snap.Streams = make(map[string]*Stream)
+		snap.Streams = make(map[string]map[string]*Stream)
 	}
 
 	if snap.ResourcePolicies == nil {
-		snap.ResourcePolicies = make(map[string]string)
+		snap.ResourcePolicies = make(map[string]map[string]string)
 	}
-	for name, stream := range snap.Streams {
-		if stream == nil {
-			delete(snap.Streams, name)
 
-			continue
+	for region, regionStreams := range snap.Streams {
+		for name, stream := range regionStreams {
+			if stream == nil {
+				delete(regionStreams, name)
+
+				continue
+			}
+			initializeStreamRuntime(stream, name)
 		}
-		initializeStreamRuntime(stream, name)
+
+		if len(regionStreams) == 0 {
+			delete(snap.Streams, region)
+		}
 	}
 
 	b.streams = snap.Streams

--- a/services/kinesis/persistence_test.go
+++ b/services/kinesis/persistence_test.go
@@ -1,6 +1,7 @@
 package kinesis_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "round_trip_preserves_state",
 			setup: func(b *kinesis.InMemoryBackend) string {
-				err := b.CreateStream(&kinesis.CreateStreamInput{
+				err := b.CreateStream(context.Background(), &kinesis.CreateStreamInput{
 					StreamName: "test-stream",
 					ShardCount: 1,
 				})
@@ -33,7 +34,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *kinesis.InMemoryBackend, id string) {
 				t.Helper()
 
-				out, err := b.DescribeStream(&kinesis.DescribeStreamInput{StreamName: id})
+				out, err := b.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: id})
 				require.NoError(t, err)
 				assert.Equal(t, id, out.StreamName)
 			},
@@ -44,7 +45,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *kinesis.InMemoryBackend, _ string) {
 				t.Helper()
 
-				out, err := b.ListStreams(&kinesis.ListStreamsInput{})
+				out, err := b.ListStreams(context.Background(), &kinesis.ListStreamsInput{})
 				require.NoError(t, err)
 				assert.Empty(t, out.StreamNames)
 			},
@@ -83,7 +84,10 @@ func TestSnapshot_EmptyShardRecords_NoNull(t *testing.T) {
 	t.Parallel()
 
 	bk := kinesis.NewInMemoryBackendWithConfig("000000000000", "us-east-1")
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "empty-shard-stream"}))
+	require.NoError(
+		t,
+		bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "empty-shard-stream"}),
+	)
 
 	snap := bk.Snapshot()
 	require.NotNil(t, snap)
@@ -99,10 +103,10 @@ func TestSnapshot_RestoreClearsOldPointers(t *testing.T) {
 
 	// Create a backend with records in it.
 	bk := kinesis.NewInMemoryBackendWithConfig("000000000000", "us-east-1")
-	require.NoError(t, bk.CreateStream(&kinesis.CreateStreamInput{StreamName: "ptr-stream"}))
+	require.NoError(t, bk.CreateStream(context.Background(), &kinesis.CreateStreamInput{StreamName: "ptr-stream"}))
 
 	for range 5 {
-		_, err := bk.PutRecord(&kinesis.PutRecordInput{
+		_, err := bk.PutRecord(context.Background(), &kinesis.PutRecordInput{
 			StreamName:   "ptr-stream",
 			PartitionKey: "pk",
 			Data:         []byte("data"),
@@ -117,7 +121,7 @@ func TestSnapshot_RestoreClearsOldPointers(t *testing.T) {
 	// Now restore into the same backend (simulating an in-place restore).
 	require.NoError(t, bk.Restore(snap))
 
-	desc, err := bk.DescribeStream(&kinesis.DescribeStreamInput{StreamName: "ptr-stream"})
+	desc, err := bk.DescribeStream(context.Background(), &kinesis.DescribeStreamInput{StreamName: "ptr-stream"})
 	require.NoError(t, err)
 	assert.Len(t, desc.Shards, 1)
 }

--- a/services/kinesis/types.go
+++ b/services/kinesis/types.go
@@ -154,11 +154,15 @@ type StreamInfo struct {
 }
 
 // ShardIterator holds the position within a shard for GetRecords.
+// Region is encoded into the iterator token so that GetRecords resolves the
+// record store of the same region the iterator was issued in, keeping
+// same-named streams in different regions isolated on the record hot path.
 type ShardIterator struct {
 	CreatedAt      time.Time `json:"CreatedAt"`
 	StreamName     string    `json:"StreamName"`
 	ShardID        string    `json:"ShardID"`
 	SequenceNumber string    `json:"SequenceNumber"`
+	Region         string    `json:"Region"`
 	Position       int       `json:"Position"`
 }
 

--- a/services/mwaa/audit_batch1_test.go
+++ b/services/mwaa/audit_batch1_test.go
@@ -14,6 +14,7 @@ package mwaa_test
 // DELETING status on delete response).
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -44,7 +45,7 @@ func TestAudit_LoggingConfig_ValidLogLevels_Create(t *testing.T) {
 			req.LoggingConfiguration = &mwaa.LoggingConfiguration{
 				SchedulerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: level},
 			}
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "log-level-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "log-level-env", req)
 			require.NoError(t, err)
 		})
 	}
@@ -74,7 +75,7 @@ func TestAudit_LoggingConfig_InvalidLogLevel_Create(t *testing.T) {
 			req.LoggingConfiguration = &mwaa.LoggingConfiguration{
 				SchedulerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: tt.logLevel},
 			}
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "inv-log-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "inv-log-env", req)
 			require.Error(t, err)
 		})
 	}
@@ -96,12 +97,12 @@ func TestAudit_LoggingConfig_AllFiveModules_Create(t *testing.T) {
 	req := newCreateReq()
 	req.LoggingConfiguration = lc
 
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "all-modules-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "all-modules-env", req)
 	require.NoError(t, err)
 
 	// Fetch (second call to get AVAILABLE, first would be CREATING)
-	b.GetEnvironment("all-modules-env")
-	got, err := b.GetEnvironment("all-modules-env")
+	b.GetEnvironment(context.Background(), "all-modules-env")
+	got, err := b.GetEnvironment(context.Background(), "all-modules-env")
 	require.NoError(t, err)
 	require.NotNil(t, got.LoggingConfiguration)
 	require.NotNil(t, got.LoggingConfiguration.DagProcessingLogs)
@@ -119,7 +120,7 @@ func TestAudit_LoggingConfig_InvalidLevel_OnDagProcessingLogs(t *testing.T) {
 	req.LoggingConfiguration = &mwaa.LoggingConfiguration{
 		DagProcessingLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: "TRACE"},
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "dag-log-inv", req)
+	_, err := b.CreateEnvironment(context.Background(), "dag-log-inv", req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "DagProcessingLogs")
 }
@@ -132,7 +133,7 @@ func TestAudit_LoggingConfig_InvalidLevel_OnTaskLogs(t *testing.T) {
 	req.LoggingConfiguration = &mwaa.LoggingConfiguration{
 		TaskLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: "NOTSET"},
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "task-log-inv", req)
+	_, err := b.CreateEnvironment(context.Background(), "task-log-inv", req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "TaskLogs")
 }
@@ -145,7 +146,7 @@ func TestAudit_LoggingConfig_InvalidLevel_OnWebserverLogs(t *testing.T) {
 	req.LoggingConfiguration = &mwaa.LoggingConfiguration{
 		WebserverLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: "ACCESS"},
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "web-log-inv", req)
+	_, err := b.CreateEnvironment(context.Background(), "web-log-inv", req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "WebserverLogs")
 }
@@ -158,7 +159,7 @@ func TestAudit_LoggingConfig_InvalidLevel_OnWorkerLogs(t *testing.T) {
 	req.LoggingConfiguration = &mwaa.LoggingConfiguration{
 		WorkerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: "SILLY"},
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "worker-log-inv", req)
+	_, err := b.CreateEnvironment(context.Background(), "worker-log-inv", req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "WorkerLogs")
 }
@@ -170,7 +171,7 @@ func TestAudit_LoggingConfig_NilConfig_AllowedOnCreate(t *testing.T) {
 	req := newCreateReq()
 	req.LoggingConfiguration = nil
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nil-log-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "nil-log-env", req)
 	require.NoError(t, err)
 }
 
@@ -183,7 +184,7 @@ func TestAudit_LoggingConfig_EmptyLogLevel_AllowedOnCreate(t *testing.T) {
 		SchedulerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: ""},
 	}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "empty-level-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "empty-level-env", req)
 	require.NoError(t, err)
 }
 
@@ -209,11 +210,11 @@ func TestAudit_LoggingConfig_ValidLevel_OnUpdate(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "log-upd-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "log-upd-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("log-upd-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "log-upd-env") // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("log-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "log-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				LoggingConfiguration: &mwaa.LoggingConfiguration{
 					SchedulerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: tt.logLevel},
 				},
@@ -285,12 +286,12 @@ func TestAudit_LoggingConfig_Persisted_AfterCreate(t *testing.T) {
 		},
 	}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "log-persist-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "log-persist-env", req)
 	require.NoError(t, err)
 
 	// consume CREATING state
-	b.GetEnvironment("log-persist-env")
-	env, err := b.GetEnvironment("log-persist-env")
+	b.GetEnvironment(context.Background(), "log-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "log-persist-env")
 	require.NoError(t, err)
 	require.NotNil(t, env.LoggingConfiguration)
 	require.NotNil(t, env.LoggingConfiguration.SchedulerLogs)
@@ -303,11 +304,11 @@ func TestAudit_LoggingConfig_Persisted_AfterUpdate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "log-upd-persist", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "log-upd-persist", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("log-upd-persist") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "log-upd-persist") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("log-upd-persist", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "log-upd-persist", &mwaa.ExportedUpdateEnvironmentRequest{
 		LoggingConfiguration: &mwaa.LoggingConfiguration{
 			WorkerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: "DEBUG"},
 		},
@@ -315,8 +316,8 @@ func TestAudit_LoggingConfig_Persisted_AfterUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// consume UPDATING state
-	b.GetEnvironment("log-upd-persist")
-	env, err := b.GetEnvironment("log-upd-persist")
+	b.GetEnvironment(context.Background(), "log-upd-persist")
+	env, err := b.GetEnvironment(context.Background(), "log-upd-persist")
 	require.NoError(t, err)
 	require.NotNil(t, env.LoggingConfiguration)
 	require.NotNil(t, env.LoggingConfiguration.WorkerLogs)
@@ -331,7 +332,7 @@ func TestAudit_Lifecycle_CreateReturnsCreating(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "lc-create-env", newCreateReq())
+	env, err := b.CreateEnvironment(context.Background(), "lc-create-env", newCreateReq())
 	require.NoError(t, err)
 	assert.Equal(t, "CREATING", env.Status)
 }
@@ -340,10 +341,10 @@ func TestAudit_Lifecycle_FirstGetReturnsCreating(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lc-first-get-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-first-get-env", newCreateReq())
 	require.NoError(t, err)
 
-	first, err := b.GetEnvironment("lc-first-get-env")
+	first, err := b.GetEnvironment(context.Background(), "lc-first-get-env")
 	require.NoError(t, err)
 	assert.Equal(t, "CREATING", first.Status)
 }
@@ -352,12 +353,12 @@ func TestAudit_Lifecycle_SecondGetReturnsAvailable(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lc-second-get-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-second-get-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("lc-second-get-env")
+	b.GetEnvironment(context.Background(), "lc-second-get-env")
 
-	second, err := b.GetEnvironment("lc-second-get-env")
+	second, err := b.GetEnvironment(context.Background(), "lc-second-get-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", second.Status)
 }
@@ -366,13 +367,13 @@ func TestAudit_Lifecycle_MultipleGetsStayAvailable(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lc-multi-get-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-multi-get-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("lc-multi-get-env")
+	b.GetEnvironment(context.Background(), "lc-multi-get-env")
 
 	for range 5 {
-		env, err2 := b.GetEnvironment("lc-multi-get-env")
+		env, err2 := b.GetEnvironment(context.Background(), "lc-multi-get-env")
 		require.NoError(t, err2)
 		assert.Equal(t, "AVAILABLE", env.Status)
 	}
@@ -382,29 +383,29 @@ func TestAudit_Lifecycle_CreateThenUpdateStatusFlow(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lc-full-flow-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-full-flow-env", newCreateReq())
 	require.NoError(t, err)
 
 	// CREATING → AVAILABLE
-	first, err := b.GetEnvironment("lc-full-flow-env")
+	first, err := b.GetEnvironment(context.Background(), "lc-full-flow-env")
 	require.NoError(t, err)
 	assert.Equal(t, "CREATING", first.Status)
 
-	second, err := b.GetEnvironment("lc-full-flow-env")
+	second, err := b.GetEnvironment(context.Background(), "lc-full-flow-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", second.Status)
 
 	// Update → UPDATING → AVAILABLE
-	_, err = b.UpdateEnvironment("lc-full-flow-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "lc-full-flow-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		EnvironmentClass: "mw1.medium",
 	})
 	require.NoError(t, err)
 
-	afterUpd, err := b.GetEnvironment("lc-full-flow-env")
+	afterUpd, err := b.GetEnvironment(context.Background(), "lc-full-flow-env")
 	require.NoError(t, err)
 	assert.Equal(t, "UPDATING", afterUpd.Status)
 
-	afterUpd2, err := b.GetEnvironment("lc-full-flow-env")
+	afterUpd2, err := b.GetEnvironment(context.Background(), "lc-full-flow-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", afterUpd2.Status)
 }
@@ -463,10 +464,10 @@ func TestAudit_Lifecycle_DeleteReturnsEnvWithDeletingStatus(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lc-del-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-del-env", newCreateReq())
 	require.NoError(t, err)
 
-	deleted, err := b.DeleteEnvironment("lc-del-env")
+	deleted, err := b.DeleteEnvironment(context.Background(), "lc-del-env")
 	require.NoError(t, err)
 	require.NotNil(t, deleted)
 	// The returned env carries the name.
@@ -477,13 +478,13 @@ func TestAudit_Lifecycle_DeleteThenGetReturns404(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lc-del-get-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-del-get-env", newCreateReq())
 	require.NoError(t, err)
 
-	_, err = b.DeleteEnvironment("lc-del-get-env")
+	_, err = b.DeleteEnvironment(context.Background(), "lc-del-get-env")
 	require.NoError(t, err)
 
-	_, err = b.GetEnvironment("lc-del-get-env")
+	_, err = b.GetEnvironment(context.Background(), "lc-del-get-env")
 	require.Error(t, err)
 	require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound)
 }
@@ -568,7 +569,7 @@ func TestAudit_S3Paths_AllThreePairs_CreateValidation(t *testing.T) {
 			req := newCreateReq()
 			tt.mutate(req)
 
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "s3-pair-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "s3-pair-env", req)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -632,13 +633,13 @@ func TestAudit_S3Paths_AllThreePairs_UpdateValidation(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "s3-upd-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "s3-upd-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("s3-upd-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "s3-upd-env") // promote CREATING → AVAILABLE
 
 			req := new(mwaa.ExportedUpdateEnvironmentRequest)
 			tt.mutate(req)
-			_, err = b.UpdateEnvironment("s3-upd-env", req)
+			_, err = b.UpdateEnvironment(context.Background(), "s3-upd-env", req)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -653,18 +654,18 @@ func TestAudit_S3Paths_Update_PluginsPathVersionPairPersisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "s3-persist-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "s3-persist-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("s3-persist-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "s3-persist-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("s3-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "s3-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		PluginsS3Path:          "plugins.zip",
 		PluginsS3ObjectVersion: "abc123",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("s3-persist-env")
-	env, err := b.GetEnvironment("s3-persist-env")
+	b.GetEnvironment(context.Background(), "s3-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "s3-persist-env")
 	require.NoError(t, err)
 	assert.Equal(t, "plugins.zip", env.PluginsS3Path)
 	assert.Equal(t, "abc123", env.PluginsS3ObjectVersion)
@@ -674,18 +675,18 @@ func TestAudit_S3Paths_Update_RequirementsPathVersionPairPersisted(t *testing.T)
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "req-s3-persist", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "req-s3-persist", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("req-s3-persist") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "req-s3-persist") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("req-s3-persist", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "req-s3-persist", &mwaa.ExportedUpdateEnvironmentRequest{
 		RequirementsS3Path:          "requirements.txt",
 		RequirementsS3ObjectVersion: "def456",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("req-s3-persist")
-	env, err := b.GetEnvironment("req-s3-persist")
+	b.GetEnvironment(context.Background(), "req-s3-persist")
+	env, err := b.GetEnvironment(context.Background(), "req-s3-persist")
 	require.NoError(t, err)
 	assert.Equal(t, "requirements.txt", env.RequirementsS3Path)
 	assert.Equal(t, "def456", env.RequirementsS3ObjectVersion)
@@ -695,18 +696,18 @@ func TestAudit_S3Paths_Update_StartupScriptPathVersionPairPersisted(t *testing.T
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "startup-s3-persist", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "startup-s3-persist", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("startup-s3-persist") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "startup-s3-persist") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("startup-s3-persist", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "startup-s3-persist", &mwaa.ExportedUpdateEnvironmentRequest{
 		StartupScriptS3Path:          "startup.sh",
 		StartupScriptS3ObjectVersion: "ghi789",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("startup-s3-persist")
-	env, err := b.GetEnvironment("startup-s3-persist")
+	b.GetEnvironment(context.Background(), "startup-s3-persist")
+	env, err := b.GetEnvironment(context.Background(), "startup-s3-persist")
 	require.NoError(t, err)
 	assert.Equal(t, "startup.sh", env.StartupScriptS3Path)
 	assert.Equal(t, "ghi789", env.StartupScriptS3ObjectVersion)
@@ -750,7 +751,7 @@ func TestAudit_NetworkConfig_CreateWithSubnetsAndSecGroups(t *testing.T) {
 		SecurityGroupIDs: []string{"sg-ccc333"},
 	}
 
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "nc-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "nc-env", req)
 	require.NoError(t, err)
 	require.NotNil(t, env.NetworkConfiguration)
 	assert.Equal(t, []string{"subnet-aaa111", "subnet-bbb222"}, env.NetworkConfiguration.SubnetIDs)
@@ -764,7 +765,7 @@ func TestAudit_NetworkConfig_CreateWithoutNetworkConfigAllowed(t *testing.T) {
 	req := newCreateReq()
 	req.NetworkConfiguration = nil
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nc-nil-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "nc-nil-env", req)
 	require.NoError(t, err)
 }
 
@@ -772,11 +773,11 @@ func TestAudit_NetworkConfig_UpdateValidNetworkConfig(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nc-upd-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "nc-upd-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("nc-upd-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "nc-upd-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("nc-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "nc-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		NetworkConfiguration: &mwaa.NetworkConfig{
 			SubnetIDs:        []string{"subnet-new1", "subnet-new2"},
 			SecurityGroupIDs: []string{"sg-new1"},
@@ -789,11 +790,11 @@ func TestAudit_NetworkConfig_UpdateEmptySubnetsRejected(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nc-empty-sn", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "nc-empty-sn", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("nc-empty-sn") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "nc-empty-sn") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("nc-empty-sn", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "nc-empty-sn", &mwaa.ExportedUpdateEnvironmentRequest{
 		NetworkConfiguration: &mwaa.NetworkConfig{
 			SecurityGroupIDs: []string{"sg-1"},
 		},
@@ -806,11 +807,11 @@ func TestAudit_NetworkConfig_UpdateEmptySecurityGroupsRejected(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nc-empty-sg", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "nc-empty-sg", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("nc-empty-sg") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "nc-empty-sg") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("nc-empty-sg", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "nc-empty-sg", &mwaa.ExportedUpdateEnvironmentRequest{
 		NetworkConfiguration: &mwaa.NetworkConfig{
 			SubnetIDs: []string{"subnet-1"},
 		},
@@ -823,21 +824,21 @@ func TestAudit_NetworkConfig_UpdatePersisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nc-persist-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "nc-persist-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("nc-persist-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "nc-persist-env") // promote CREATING → AVAILABLE
 
 	newNC := &mwaa.NetworkConfig{
 		SubnetIDs:        []string{"subnet-x1", "subnet-x2"},
 		SecurityGroupIDs: []string{"sg-x1", "sg-x2"},
 	}
-	_, err = b.UpdateEnvironment("nc-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "nc-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		NetworkConfiguration: newNC,
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("nc-persist-env")
-	env, err := b.GetEnvironment("nc-persist-env")
+	b.GetEnvironment(context.Background(), "nc-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "nc-persist-env")
 	require.NoError(t, err)
 	require.NotNil(t, env.NetworkConfiguration)
 	assert.Equal(t, []string{"subnet-x1", "subnet-x2"}, env.NetworkConfiguration.SubnetIDs)
@@ -876,11 +877,11 @@ func TestAudit_AirflowConfig_CreateWithOptions(t *testing.T) {
 		"webserver.expose_config": "true",
 	}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "acfg-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "acfg-env", req)
 	require.NoError(t, err)
 
-	b.GetEnvironment("acfg-env")
-	env, err := b.GetEnvironment("acfg-env")
+	b.GetEnvironment(context.Background(), "acfg-env")
+	env, err := b.GetEnvironment(context.Background(), "acfg-env")
 	require.NoError(t, err)
 	assert.Equal(t, "32", env.AirflowConfigurationOptions["core.parallelism"])
 	assert.Equal(t, "100", env.AirflowConfigurationOptions["scheduler.dag_bag_size"])
@@ -895,19 +896,19 @@ func TestAudit_AirflowConfig_UpdateReplaces_NotMerges(t *testing.T) {
 		"core.parallelism": "32",
 		"old.key":          "old-value",
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "acfg-replace-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "acfg-replace-env", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("acfg-replace-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "acfg-replace-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("acfg-replace-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "acfg-replace-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		AirflowConfigurationOptions: map[string]string{
 			"new.key": "new-value",
 		},
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("acfg-replace-env")
-	env, err := b.GetEnvironment("acfg-replace-env")
+	b.GetEnvironment(context.Background(), "acfg-replace-env")
+	env, err := b.GetEnvironment(context.Background(), "acfg-replace-env")
 	require.NoError(t, err)
 	// old.key should be gone — update replaces, not merges
 	assert.NotContains(t, env.AirflowConfigurationOptions, "old.key")
@@ -922,18 +923,18 @@ func TestAudit_AirflowConfig_UpdateNilOptions_DoesNotClear(t *testing.T) {
 	req.AirflowConfigurationOptions = map[string]string{
 		"core.parallelism": "16",
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "acfg-nil-upd", req)
+	_, err := b.CreateEnvironment(context.Background(), "acfg-nil-upd", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("acfg-nil-upd") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "acfg-nil-upd") // promote CREATING → AVAILABLE
 
 	// Update with nil AirflowConfigurationOptions — should not touch existing config.
-	_, err = b.UpdateEnvironment("acfg-nil-upd", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "acfg-nil-upd", &mwaa.ExportedUpdateEnvironmentRequest{
 		DagS3Path: "new-dags/",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("acfg-nil-upd")
-	env, err := b.GetEnvironment("acfg-nil-upd")
+	b.GetEnvironment(context.Background(), "acfg-nil-upd")
+	env, err := b.GetEnvironment(context.Background(), "acfg-nil-upd")
 	require.NoError(t, err)
 	assert.Equal(t, "16", env.AirflowConfigurationOptions["core.parallelism"])
 }
@@ -946,18 +947,18 @@ func TestAudit_AirflowConfig_EmptyMapClears(t *testing.T) {
 	req.AirflowConfigurationOptions = map[string]string{
 		"some.key": "some-value",
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "acfg-clear-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "acfg-clear-env", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("acfg-clear-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "acfg-clear-env") // promote CREATING → AVAILABLE
 
 	// Update with empty map should replace existing config with empty.
-	_, err = b.UpdateEnvironment("acfg-clear-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "acfg-clear-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		AirflowConfigurationOptions: map[string]string{},
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("acfg-clear-env")
-	env, err := b.GetEnvironment("acfg-clear-env")
+	b.GetEnvironment(context.Background(), "acfg-clear-env")
+	env, err := b.GetEnvironment(context.Background(), "acfg-clear-env")
 	require.NoError(t, err)
 	assert.Empty(t, env.AirflowConfigurationOptions)
 }
@@ -971,12 +972,12 @@ func TestAudit_AirflowConfig_CeleryExecutorOption(t *testing.T) {
 	req.AirflowConfigurationOptions = map[string]string{
 		"core.executor": "CeleryExecutor",
 	}
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "celery-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "celery-env", req)
 	require.NoError(t, err)
 	_ = env
 
-	b.GetEnvironment("celery-env")
-	got, err := b.GetEnvironment("celery-env")
+	b.GetEnvironment(context.Background(), "celery-env")
+	got, err := b.GetEnvironment(context.Background(), "celery-env")
 	require.NoError(t, err)
 	assert.Equal(t, "CeleryExecutor", got.AirflowConfigurationOptions["core.executor"])
 	// CeleryExecutorQueue should be present and non-empty on all environments.
@@ -991,11 +992,11 @@ func TestAudit_AirflowConfig_LocalExecutorOption(t *testing.T) {
 	req.AirflowConfigurationOptions = map[string]string{
 		"core.executor": "LocalExecutor",
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "local-exec-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "local-exec-env", req)
 	require.NoError(t, err)
 
-	b.GetEnvironment("local-exec-env")
-	env, err := b.GetEnvironment("local-exec-env")
+	b.GetEnvironment(context.Background(), "local-exec-env")
+	env, err := b.GetEnvironment(context.Background(), "local-exec-env")
 	require.NoError(t, err)
 	assert.Equal(t, "LocalExecutor", env.AirflowConfigurationOptions["core.executor"])
 }
@@ -1027,7 +1028,7 @@ func TestAudit_KmsKey_ValidationOnCreate(t *testing.T) {
 			req := newCreateReq()
 			req.KmsKey = tt.kmsKey
 
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "kms-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "kms-env", req)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "KmsKey")
@@ -1047,11 +1048,11 @@ func TestAudit_KmsKey_PersisteddInGetEnvironment(t *testing.T) {
 	req := newCreateReq()
 	req.KmsKey = kmsARN
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "kms-persist-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "kms-persist-env", req)
 	require.NoError(t, err)
 
-	b.GetEnvironment("kms-persist-env")
-	env, err := b.GetEnvironment("kms-persist-env")
+	b.GetEnvironment(context.Background(), "kms-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "kms-persist-env")
 	require.NoError(t, err)
 	assert.Equal(t, kmsARN, env.KmsKey)
 }
@@ -1096,7 +1097,7 @@ func TestAudit_EndpointManagement_ValidationAndPersistence(t *testing.T) {
 			req.EndpointManagement = tt.mgmt
 
 			envName := "em-env-" + strings.ReplaceAll(tt.name, "_", "-")
-			env, err := b.CreateEnvironment(testRegion, testAccountID, envName, req)
+			env, err := b.CreateEnvironment(context.Background(), envName, req)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1117,11 +1118,11 @@ func TestAudit_EndpointManagement_CustomerPersistedInGet(t *testing.T) {
 	req := newCreateReq()
 	req.EndpointManagement = "CUSTOMER"
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "em-customer-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "em-customer-env", req)
 	require.NoError(t, err)
 
-	b.GetEnvironment("em-customer-env")
-	env, err := b.GetEnvironment("em-customer-env")
+	b.GetEnvironment(context.Background(), "em-customer-env")
+	env, err := b.GetEnvironment(context.Background(), "em-customer-env")
 	require.NoError(t, err)
 	assert.Equal(t, "CUSTOMER", env.EndpointManagement)
 }
@@ -1181,11 +1182,11 @@ func TestAudit_WeeklyMaintenance_UpdateValidation(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "wmw-upd-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "wmw-upd-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("wmw-upd-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "wmw-upd-env") // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("wmw-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "wmw-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				WeeklyMaintenanceWindowStart: tt.window,
 			})
 
@@ -1202,17 +1203,17 @@ func TestAudit_WeeklyMaintenance_UpdatePersisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wmw-persist-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "wmw-persist-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("wmw-persist-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "wmw-persist-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("wmw-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wmw-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		WeeklyMaintenanceWindowStart: "WED:02:00",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("wmw-persist-env")
-	env, err := b.GetEnvironment("wmw-persist-env")
+	b.GetEnvironment(context.Background(), "wmw-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "wmw-persist-env")
 	require.NoError(t, err)
 	assert.Equal(t, "WED:02:00", env.WeeklyMaintenanceWindowStart)
 }
@@ -1242,12 +1243,12 @@ func TestAudit_WeeklyMaintenance_AllDays_Valid(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "wmw-day-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "wmw-day-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("wmw-day-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "wmw-day-env") // promote CREATING → AVAILABLE
 
 			window := day + ":12:00"
-			_, err = b.UpdateEnvironment("wmw-day-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "wmw-day-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				WeeklyMaintenanceWindowStart: window,
 			})
 			require.NoError(t, err)
@@ -1266,13 +1267,13 @@ func TestAudit_Workers_Update_OnlyMinSet_KeepsExistingMax(t *testing.T) {
 	req := newCreateReq()
 	req.MaxWorkers = 10
 	req.MinWorkers = 1
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wk-only-min-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "wk-only-min-env", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("wk-only-min-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "wk-only-min-env") // promote CREATING → AVAILABLE
 
 	// Update: set MinWorkers=2, leave MaxWorkers=0 (no change).
 	// MinWorkers=2 < existing MaxWorkers=10: should succeed.
-	_, err = b.UpdateEnvironment("wk-only-min-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wk-only-min-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		MinWorkers: 2,
 	})
 	require.NoError(t, err)
@@ -1285,18 +1286,18 @@ func TestAudit_Workers_Update_OnlyMaxSet_KeepsExistingMin(t *testing.T) {
 	req := newCreateReq()
 	req.MaxWorkers = 10
 	req.MinWorkers = 3
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wk-only-max-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "wk-only-max-env", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("wk-only-max-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "wk-only-max-env") // promote CREATING → AVAILABLE
 
 	// Update: set MaxWorkers=15, leave MinWorkers=0 (no change).
-	_, err = b.UpdateEnvironment("wk-only-max-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wk-only-max-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		MaxWorkers: 15,
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("wk-only-max-env")
-	env, err := b.GetEnvironment("wk-only-max-env")
+	b.GetEnvironment(context.Background(), "wk-only-max-env")
+	env, err := b.GetEnvironment(context.Background(), "wk-only-max-env")
 	require.NoError(t, err)
 	assert.Equal(t, int32(15), env.MaxWorkers)
 	assert.Equal(t, int32(3), env.MinWorkers)
@@ -1309,12 +1310,12 @@ func TestAudit_Workers_Update_NewMinExceedsExistingMax(t *testing.T) {
 	req := newCreateReq()
 	req.MaxWorkers = 5
 	req.MinWorkers = 1
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wk-min-exceeds-max", req)
+	_, err := b.CreateEnvironment(context.Background(), "wk-min-exceeds-max", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("wk-min-exceeds-max") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "wk-min-exceeds-max") // promote CREATING → AVAILABLE
 
 	// Set MinWorkers=10 > existing MaxWorkers=5: should fail.
-	_, err = b.UpdateEnvironment("wk-min-exceeds-max", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wk-min-exceeds-max", &mwaa.ExportedUpdateEnvironmentRequest{
 		MinWorkers: 10,
 	})
 	require.Error(t, err)
@@ -1328,12 +1329,12 @@ func TestAudit_Workers_Update_NewMaxBelowExistingMin(t *testing.T) {
 	req := newCreateReq()
 	req.MaxWorkers = 10
 	req.MinWorkers = 5
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wk-max-below-min", req)
+	_, err := b.CreateEnvironment(context.Background(), "wk-max-below-min", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("wk-max-below-min") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "wk-max-below-min") // promote CREATING → AVAILABLE
 
 	// Set MaxWorkers=2 < existing MinWorkers=5: should fail.
-	_, err = b.UpdateEnvironment("wk-max-below-min", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wk-max-below-min", &mwaa.ExportedUpdateEnvironmentRequest{
 		MaxWorkers: 2,
 	})
 	require.Error(t, err)
@@ -1360,11 +1361,11 @@ func TestAudit_Workers_Update_BothSetValidRange(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "wk-both-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "wk-both-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("wk-both-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "wk-both-env") // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("wk-both-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "wk-both-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				MinWorkers: tt.min,
 				MaxWorkers: tt.max,
 			})
@@ -1401,7 +1402,7 @@ func TestAudit_Schedulers_Create_V2_BoundaryValues(t *testing.T) {
 			req := newCreateReq()
 			req.Schedulers = tt.schedulers
 
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "sched-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "sched-env", req)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1437,7 +1438,7 @@ func TestAudit_Webservers_Create_BoundaryValues(t *testing.T) {
 			req.MinWebservers = tt.min
 			req.MaxWebservers = tt.max
 
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "ws-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "ws-env", req)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1455,7 +1456,7 @@ func TestAudit_Metrics_Cap_AtExactLimit(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "metrics-cap-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "metrics-cap-env", newCreateReq())
 	require.NoError(t, err)
 
 	// Publish exactly 1000 metrics.
@@ -1463,7 +1464,11 @@ func TestAudit_Metrics_Cap_AtExactLimit(t *testing.T) {
 	for i := range data {
 		data[i] = mwaa.ExportedMetricDatum{MetricName: fmt.Sprintf("Metric%d", i)}
 	}
-	err = b.PublishMetrics("metrics-cap-env", &mwaa.ExportedPublishMetricsRequest{MetricData: data})
+	err = b.PublishMetrics(
+		context.Background(),
+		"metrics-cap-env",
+		&mwaa.ExportedPublishMetricsRequest{MetricData: data},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1000, mwaa.MetricsCount(b, "metrics-cap-env"))
@@ -1473,7 +1478,7 @@ func TestAudit_Metrics_Cap_ExceedsLimit_TrimsOldest(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "metrics-overflow-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "metrics-overflow-env", newCreateReq())
 	require.NoError(t, err)
 
 	// Publish 1100 metrics in two batches.
@@ -1481,14 +1486,22 @@ func TestAudit_Metrics_Cap_ExceedsLimit_TrimsOldest(t *testing.T) {
 	for i := range first {
 		first[i] = mwaa.ExportedMetricDatum{MetricName: fmt.Sprintf("Old%d", i)}
 	}
-	err = b.PublishMetrics("metrics-overflow-env", &mwaa.ExportedPublishMetricsRequest{MetricData: first})
+	err = b.PublishMetrics(
+		context.Background(),
+		"metrics-overflow-env",
+		&mwaa.ExportedPublishMetricsRequest{MetricData: first},
+	)
 	require.NoError(t, err)
 
 	second := make([]mwaa.ExportedMetricDatum, 500)
 	for i := range second {
 		second[i] = mwaa.ExportedMetricDatum{MetricName: fmt.Sprintf("New%d", i)}
 	}
-	err = b.PublishMetrics("metrics-overflow-env", &mwaa.ExportedPublishMetricsRequest{MetricData: second})
+	err = b.PublishMetrics(
+		context.Background(),
+		"metrics-overflow-env",
+		&mwaa.ExportedPublishMetricsRequest{MetricData: second},
+	)
 	require.NoError(t, err)
 
 	// Total 1100 → capped at 1000.
@@ -1499,14 +1512,18 @@ func TestAudit_Metrics_Cap_PublishSingleBatch_Over1000(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "metrics-big-batch", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "metrics-big-batch", newCreateReq())
 	require.NoError(t, err)
 
 	data := make([]mwaa.ExportedMetricDatum, 1200)
 	for i := range data {
 		data[i] = mwaa.ExportedMetricDatum{MetricName: fmt.Sprintf("Datum%d", i)}
 	}
-	err = b.PublishMetrics("metrics-big-batch", &mwaa.ExportedPublishMetricsRequest{MetricData: data})
+	err = b.PublishMetrics(
+		context.Background(),
+		"metrics-big-batch",
+		&mwaa.ExportedPublishMetricsRequest{MetricData: data},
+	)
 	require.NoError(t, err)
 
 	// Capped at 1000.
@@ -1586,10 +1603,14 @@ func TestAudit_PublishMetrics_DatumFields(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "datum-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "datum-env", newCreateReq())
 			require.NoError(t, err)
 
-			err = b.PublishMetrics("datum-env", &mwaa.ExportedPublishMetricsRequest{MetricData: tt.datums})
+			err = b.PublishMetrics(
+				context.Background(),
+				"datum-env",
+				&mwaa.ExportedPublishMetricsRequest{MetricData: tt.datums},
+			)
 			require.NoError(t, err)
 		})
 	}
@@ -1599,7 +1620,7 @@ func TestAudit_PublishMetrics_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	err := b.PublishMetrics("nonexistent-env", &mwaa.ExportedPublishMetricsRequest{})
+	err := b.PublishMetrics(context.Background(), "nonexistent-env", &mwaa.ExportedPublishMetricsRequest{})
 	require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound)
 }
 
@@ -1607,16 +1628,16 @@ func TestAudit_GetMetrics_ReturnsCopy(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "get-metrics-copy-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "get-metrics-copy-env", newCreateReq())
 	require.NoError(t, err)
 
 	v := 5.0
-	err = b.PublishMetrics("get-metrics-copy-env", &mwaa.ExportedPublishMetricsRequest{
+	err = b.PublishMetrics(context.Background(), "get-metrics-copy-env", &mwaa.ExportedPublishMetricsRequest{
 		MetricData: []mwaa.ExportedMetricDatum{{MetricName: "TaskCount", Value: &v}},
 	})
 	require.NoError(t, err)
 
-	data, err := b.GetMetrics("get-metrics-copy-env")
+	data, err := b.GetMetrics(context.Background(), "get-metrics-copy-env")
 	require.NoError(t, err)
 	assert.Len(t, data, 1)
 	assert.Equal(t, "TaskCount", data[0].MetricName)
@@ -1701,10 +1722,10 @@ func TestAudit_InvokeRestApi_Variations(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "restapi-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "restapi-env", newCreateReq())
 			require.NoError(t, err)
 
-			resp, err := b.InvokeRestAPI("restapi-env", tt.req)
+			resp, err := b.InvokeRestAPI(context.Background(), "restapi-env", tt.req)
 			if tt.wantErr {
 				require.Error(t, err)
 
@@ -1786,11 +1807,11 @@ func TestAudit_Tags_AtCreate_PersistedInGet(t *testing.T) {
 		"cost":  "cc-1234",
 	}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "tagged-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "tagged-env", req)
 	require.NoError(t, err)
 
-	b.GetEnvironment("tagged-env")
-	env, err := b.GetEnvironment("tagged-env")
+	b.GetEnvironment(context.Background(), "tagged-env")
+	env, err := b.GetEnvironment(context.Background(), "tagged-env")
 	require.NoError(t, err)
 	assert.Equal(t, "production", env.Tags["env"])
 	assert.Equal(t, "platform-team", env.Tags["owner"])
@@ -1804,18 +1825,18 @@ func TestAudit_Tags_Update_DoesNotTouchExistingTags(t *testing.T) {
 	req := newCreateReq()
 	req.Tags = map[string]string{"keep": "this"}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "tags-upd-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "tags-upd-env", req)
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("tags-upd-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "tags-upd-env") // promote CREATING → AVAILABLE
 
 	// Update the environment without touching tags.
-	_, err = b.UpdateEnvironment("tags-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "tags-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		DagS3Path: "new-dags/",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("tags-upd-env")
-	env, err := b.GetEnvironment("tags-upd-env")
+	b.GetEnvironment(context.Background(), "tags-upd-env")
+	env, err := b.GetEnvironment(context.Background(), "tags-upd-env")
 	require.NoError(t, err)
 	assert.Equal(t, "this", env.Tags["keep"])
 }
@@ -1827,21 +1848,21 @@ func TestAudit_Tags_NotLeakedBetweenEnvironments(t *testing.T) {
 
 	reqA := newCreateReq()
 	reqA.Tags = map[string]string{"env": "alpha"}
-	envA, err := b.CreateEnvironment(testRegion, testAccountID, "tag-leak-a", reqA)
+	envA, err := b.CreateEnvironment(context.Background(), "tag-leak-a", reqA)
 	require.NoError(t, err)
 
 	reqB := newCreateReq()
 	reqB.Tags = map[string]string{"env": "beta"}
-	_, err = b.CreateEnvironment(testRegion, testAccountID, "tag-leak-b", reqB)
+	_, err = b.CreateEnvironment(context.Background(), "tag-leak-b", reqB)
 	require.NoError(t, err)
 
 	// Add a tag to A's ARN.
-	err = b.TagResource(envA.ARN, map[string]string{"extra": "from-a"})
+	err = b.TagResource(context.Background(), envA.ARN, map[string]string{"extra": "from-a"})
 	require.NoError(t, err)
 
 	// Fetch B — should not have A's extra tag.
-	b.GetEnvironment("tag-leak-b")
-	gotB, err := b.GetEnvironment("tag-leak-b")
+	b.GetEnvironment(context.Background(), "tag-leak-b")
+	gotB, err := b.GetEnvironment(context.Background(), "tag-leak-b")
 	require.NoError(t, err)
 	assert.NotContains(t, gotB.Tags, "extra")
 	assert.Equal(t, "beta", gotB.Tags["env"])
@@ -1881,11 +1902,11 @@ func TestAudit_DerivedFields_CeleryExecutorQueue(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "derived-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "derived-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("derived-env")
-	env, err := b.GetEnvironment("derived-env")
+	b.GetEnvironment(context.Background(), "derived-env")
+	env, err := b.GetEnvironment(context.Background(), "derived-env")
 	require.NoError(t, err)
 
 	// CeleryExecutorQueue must be an SQS URL.
@@ -1902,11 +1923,11 @@ func TestAudit_DerivedFields_ServiceRoleArn(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "sra-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "sra-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("sra-env")
-	env, err := b.GetEnvironment("sra-env")
+	b.GetEnvironment(context.Background(), "sra-env")
+	env, err := b.GetEnvironment(context.Background(), "sra-env")
 	require.NoError(t, err)
 
 	// ServiceRoleArn must be an IAM ARN.
@@ -1923,11 +1944,11 @@ func TestAudit_DerivedFields_WebserverURL(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "ws-url-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "ws-url-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("ws-url-env")
-	env, err := b.GetEnvironment("ws-url-env")
+	b.GetEnvironment(context.Background(), "ws-url-env")
+	env, err := b.GetEnvironment(context.Background(), "ws-url-env")
 	require.NoError(t, err)
 
 	assert.True(
@@ -1943,11 +1964,11 @@ func TestAudit_DerivedFields_VpcEndpointServices(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "vpc-svc-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "vpc-svc-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("vpc-svc-env")
-	env, err := b.GetEnvironment("vpc-svc-env")
+	b.GetEnvironment(context.Background(), "vpc-svc-env")
+	env, err := b.GetEnvironment(context.Background(), "vpc-svc-env")
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, env.DatabaseVpcEndpointService)
@@ -1960,18 +1981,18 @@ func TestAudit_DerivedFields_DifferentForDifferentEnvs(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "diff-derived-a", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "diff-derived-a", newCreateReq())
 	require.NoError(t, err)
-	_, err = b.CreateEnvironment(testRegion, testAccountID, "diff-derived-b", newCreateReq())
+	_, err = b.CreateEnvironment(context.Background(), "diff-derived-b", newCreateReq())
 	require.NoError(t, err)
 
 	// Consume CREATING for both
-	b.GetEnvironment("diff-derived-a")
-	b.GetEnvironment("diff-derived-b")
+	b.GetEnvironment(context.Background(), "diff-derived-a")
+	b.GetEnvironment(context.Background(), "diff-derived-b")
 
-	envA, err := b.GetEnvironment("diff-derived-a")
+	envA, err := b.GetEnvironment(context.Background(), "diff-derived-a")
 	require.NoError(t, err)
-	envB, err := b.GetEnvironment("diff-derived-b")
+	envB, err := b.GetEnvironment(context.Background(), "diff-derived-b")
 	require.NoError(t, err)
 
 	// Each env gets a unique webserver URL and celery queue.
@@ -1990,11 +2011,11 @@ func TestAudit_DagS3Path_CreateAndGet(t *testing.T) {
 	req := newCreateReq()
 	req.DagS3Path = "custom/dags/"
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "dag-path-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "dag-path-env", req)
 	require.NoError(t, err)
 
-	b.GetEnvironment("dag-path-env")
-	env, err := b.GetEnvironment("dag-path-env")
+	b.GetEnvironment(context.Background(), "dag-path-env")
+	env, err := b.GetEnvironment(context.Background(), "dag-path-env")
 	require.NoError(t, err)
 	assert.Equal(t, "custom/dags/", env.DagS3Path)
 }
@@ -2003,17 +2024,17 @@ func TestAudit_DagS3Path_Update_Persisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "dag-upd-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "dag-upd-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("dag-upd-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "dag-upd-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("dag-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "dag-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		DagS3Path: "new/dags/path/",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("dag-upd-env")
-	env, err := b.GetEnvironment("dag-upd-env")
+	b.GetEnvironment(context.Background(), "dag-upd-env")
+	env, err := b.GetEnvironment(context.Background(), "dag-upd-env")
 	require.NoError(t, err)
 	assert.Equal(t, "new/dags/path/", env.DagS3Path)
 }
@@ -2022,7 +2043,7 @@ func TestAudit_DagS3Path_Required_OnCreate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "dag-missing-env", &mwaa.ExportedCreateEnvironmentRequest{
+	_, err := b.CreateEnvironment(context.Background(), "dag-missing-env", &mwaa.ExportedCreateEnvironmentRequest{
 		ExecutionRoleArn: "arn:aws:iam::123456789012:role/r",
 		SourceBucketArn:  "arn:aws:s3:::bucket",
 	})
@@ -2038,7 +2059,7 @@ func TestAudit_RequiredFields_MissingSourceBucketArn(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "req-sb-env", &mwaa.ExportedCreateEnvironmentRequest{
+	_, err := b.CreateEnvironment(context.Background(), "req-sb-env", &mwaa.ExportedCreateEnvironmentRequest{
 		DagS3Path:        "dags/",
 		ExecutionRoleArn: "arn:aws:iam::123456789012:role/r",
 	})
@@ -2050,7 +2071,7 @@ func TestAudit_RequiredFields_MissingExecutionRoleArn(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "req-era-env", &mwaa.ExportedCreateEnvironmentRequest{
+	_, err := b.CreateEnvironment(context.Background(), "req-era-env", &mwaa.ExportedCreateEnvironmentRequest{
 		DagS3Path:       "dags/",
 		SourceBucketArn: "arn:aws:s3:::bucket",
 	})
@@ -2066,20 +2087,20 @@ func TestAudit_Update_ExecutionRoleArnAndSourceBucketArn(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "role-upd-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "role-upd-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("role-upd-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "role-upd-env") // promote CREATING → AVAILABLE
 
 	newRole := "arn:aws:iam::123456789012:role/new-mwaa-role"
 	newBucket := "arn:aws:s3:::new-bucket"
-	_, err = b.UpdateEnvironment("role-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "role-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		ExecutionRoleArn: newRole,
 		SourceBucketArn:  newBucket,
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("role-upd-env")
-	env, err := b.GetEnvironment("role-upd-env")
+	b.GetEnvironment(context.Background(), "role-upd-env")
+	env, err := b.GetEnvironment(context.Background(), "role-upd-env")
 	require.NoError(t, err)
 	assert.Equal(t, newRole, env.ExecutionRoleArn)
 	assert.Equal(t, newBucket, env.SourceBucketArn)
@@ -2093,17 +2114,17 @@ func TestAudit_LastUpdate_PopulatedAfterUpdate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lu-check-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lu-check-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("lu-check-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "lu-check-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("lu-check-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "lu-check-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		DagS3Path: "updated-dags/",
 	})
 	require.NoError(t, err)
 
-	b.GetEnvironment("lu-check-env")
-	env, err := b.GetEnvironment("lu-check-env")
+	b.GetEnvironment(context.Background(), "lu-check-env")
+	env, err := b.GetEnvironment(context.Background(), "lu-check-env")
 	require.NoError(t, err)
 	require.NotNil(t, env.LastUpdate)
 	assert.Equal(t, "SUCCESS", env.LastUpdate.Status)
@@ -2115,11 +2136,11 @@ func TestAudit_LastUpdate_NilBeforeFirstUpdate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lu-nil-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lu-nil-env", newCreateReq())
 	require.NoError(t, err)
 
-	b.GetEnvironment("lu-nil-env")
-	env, err := b.GetEnvironment("lu-nil-env")
+	b.GetEnvironment(context.Background(), "lu-nil-env")
+	env, err := b.GetEnvironment(context.Background(), "lu-nil-env")
 	require.NoError(t, err)
 	assert.Nil(t, env.LastUpdate)
 }
@@ -2134,11 +2155,11 @@ func TestAudit_ListEnvironments_SortedAlphabetically(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	names := []string{"zebra-env", "alpha-env", "middle-env"}
 	for _, n := range names {
-		_, err := b.CreateEnvironment(testRegion, testAccountID, n, newCreateReq())
+		_, err := b.CreateEnvironment(context.Background(), n, newCreateReq())
 		require.NoError(t, err)
 	}
 
-	listed, err := b.ListEnvironments()
+	listed, err := b.ListEnvironments(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"alpha-env", "middle-env", "zebra-env"}, listed)
 }
@@ -2148,24 +2169,24 @@ func TestAudit_ListEnvironments_PaginationConsistentOrder(t *testing.T) {
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	for _, n := range []string{"aa", "bb", "cc", "dd", "ee"} {
-		_, err := b.CreateEnvironment(testRegion, testAccountID, n, newCreateReq())
+		_, err := b.CreateEnvironment(context.Background(), n, newCreateReq())
 		require.NoError(t, err)
 	}
 
 	// Page 1: 2 items
-	page1, tok1, err := b.ListEnvironmentsPage("", 2)
+	page1, tok1, err := b.ListEnvironmentsPage(context.Background(), "", 2)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"aa", "bb"}, page1)
 	assert.Equal(t, "cc", tok1)
 
 	// Page 2: 2 items starting from tok1
-	page2, tok2, err := b.ListEnvironmentsPage(tok1, 2)
+	page2, tok2, err := b.ListEnvironmentsPage(context.Background(), tok1, 2)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"cc", "dd"}, page2)
 	assert.Equal(t, "ee", tok2)
 
 	// Page 3: last 1 item
-	page3, tok3, err := b.ListEnvironmentsPage(tok2, 2)
+	page3, tok3, err := b.ListEnvironmentsPage(context.Background(), tok2, 2)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ee"}, page3)
 	assert.Empty(t, tok3)
@@ -2179,7 +2200,7 @@ func TestAudit_ARN_Format(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "arn-fmt-env", newCreateReq())
+	env, err := b.CreateEnvironment(context.Background(), "arn-fmt-env", newCreateReq())
 	require.NoError(t, err)
 
 	// ARN must match arn:aws:airflow:REGION:ACCOUNT:environment/NAME
@@ -2191,9 +2212,9 @@ func TestAudit_ARN_UniquePerEnvironment(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	envA, err := b.CreateEnvironment(testRegion, testAccountID, "arn-unique-a", newCreateReq())
+	envA, err := b.CreateEnvironment(context.Background(), "arn-unique-a", newCreateReq())
 	require.NoError(t, err)
-	envB, err := b.CreateEnvironment(testRegion, testAccountID, "arn-unique-b", newCreateReq())
+	envB, err := b.CreateEnvironment(context.Background(), "arn-unique-b", newCreateReq())
 	require.NoError(t, err)
 
 	assert.NotEqual(t, envA.ARN, envB.ARN)
@@ -2207,7 +2228,7 @@ func TestAudit_CreatedAt_Set(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "created-at-env", newCreateReq())
+	env, err := b.CreateEnvironment(context.Background(), "created-at-env", newCreateReq())
 	require.NoError(t, err)
 
 	assert.Positive(t, env.CreatedAt, "CreatedAt must be a positive Unix epoch")
@@ -2226,7 +2247,7 @@ func TestAudit_Snapshot_WithLoggingConfig(t *testing.T) {
 		SchedulerLogs: &mwaa.ModuleLoggingConfiguration{LogLevel: "WARNING"},
 	}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "snap-log-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "snap-log-env", req)
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
@@ -2235,8 +2256,8 @@ func TestAudit_Snapshot_WithLoggingConfig(t *testing.T) {
 	b2 := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	require.NoError(t, b2.Restore(snap))
 
-	b2.GetEnvironment("snap-log-env")
-	env, err := b2.GetEnvironment("snap-log-env")
+	b2.GetEnvironment(context.Background(), "snap-log-env")
+	env, err := b2.GetEnvironment(context.Background(), "snap-log-env")
 	require.NoError(t, err)
 	require.NotNil(t, env.LoggingConfiguration)
 	require.NotNil(t, env.LoggingConfiguration.SchedulerLogs)
@@ -2253,15 +2274,15 @@ func TestAudit_Snapshot_WithNetworkConfig(t *testing.T) {
 		SecurityGroupIDs: []string{"sg-snap1"},
 	}
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "snap-nc-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "snap-nc-env", req)
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
 	b2 := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	require.NoError(t, b2.Restore(snap))
 
-	b2.GetEnvironment("snap-nc-env")
-	env, err := b2.GetEnvironment("snap-nc-env")
+	b2.GetEnvironment(context.Background(), "snap-nc-env")
+	env, err := b2.GetEnvironment(context.Background(), "snap-nc-env")
 	require.NoError(t, err)
 	require.NotNil(t, env.NetworkConfiguration)
 	assert.Equal(t, []string{"subnet-snap1"}, env.NetworkConfiguration.SubnetIDs)
@@ -2275,11 +2296,11 @@ func TestAudit_Reset_ClearsMetrics(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "reset-metrics-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "reset-metrics-env", newCreateReq())
 	require.NoError(t, err)
 
 	v := 1.0
-	err = b.PublishMetrics("reset-metrics-env", &mwaa.ExportedPublishMetricsRequest{
+	err = b.PublishMetrics(context.Background(), "reset-metrics-env", &mwaa.ExportedPublishMetricsRequest{
 		MetricData: []mwaa.ExportedMetricDatum{{MetricName: "M", Value: &v}},
 	})
 	require.NoError(t, err)

--- a/services/mwaa/audit_batch2_test.go
+++ b/services/mwaa/audit_batch2_test.go
@@ -12,6 +12,7 @@ package mwaa_test
 // consistency, and ListEnvironments MaxResults validation.
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,7 +51,7 @@ func TestAuditB2_WeeklyMaint_Create_ValidValues(t *testing.T) {
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 			req := newCreateReq()
 			req.WeeklyMaintenanceWindowStart = tt.value
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "wmw-ok-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "wmw-ok-env", req)
 			require.NoError(t, err)
 		})
 	}
@@ -78,7 +79,7 @@ func TestAuditB2_WeeklyMaint_Create_InvalidValues(t *testing.T) {
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 			req := newCreateReq()
 			req.WeeklyMaintenanceWindowStart = tt.value
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "wmw-inv-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "wmw-inv-env", req)
 
 			if tt.value == "" {
 				require.NoError(t, err)
@@ -95,10 +96,10 @@ func TestAuditB2_WeeklyMaint_Create_Persisted(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	req := newCreateReq()
 	req.WeeklyMaintenanceWindowStart = "FRI:03:30"
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wmw-persist-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "wmw-persist-env", req)
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("wmw-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "wmw-persist-env")
 	require.NoError(t, err)
 	assert.Equal(t, "FRI:03:30", env.WeeklyMaintenanceWindowStart)
 }
@@ -143,7 +144,7 @@ func TestAuditB2_Create_MinWorkersExceedsMax(t *testing.T) {
 			req := newCreateReq()
 			req.MinWorkers = tt.min
 			req.MaxWorkers = tt.max
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "worker-range-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "worker-range-env", req)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -161,10 +162,10 @@ func TestAuditB2_Defaults_WorkersStoredOnCreate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "defaults-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "defaults-env", newCreateReq())
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("defaults-env")
+	env, err := b.GetEnvironment(context.Background(), "defaults-env")
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(10), env.MaxWorkers, "default MaxWorkers should be 10")
@@ -175,10 +176,10 @@ func TestAuditB2_Defaults_WebserversStoredOnCreate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "ws-defaults-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "ws-defaults-env", newCreateReq())
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("ws-defaults-env")
+	env, err := b.GetEnvironment(context.Background(), "ws-defaults-env")
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(2), env.MaxWebservers, "default MaxWebservers should be 2")
@@ -191,10 +192,10 @@ func TestAuditB2_Defaults_SchedulersV2OnCreate(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	req := newCreateReq()
 	req.AirflowVersion = "2.9.2"
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "sched-v2-defaults-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "sched-v2-defaults-env", req)
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("sched-v2-defaults-env")
+	env, err := b.GetEnvironment(context.Background(), "sched-v2-defaults-env")
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(2), env.Schedulers, "default Schedulers for v2 should be 2")
@@ -206,10 +207,10 @@ func TestAuditB2_Defaults_SchedulersV1OnCreate(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	req := newCreateReq()
 	req.AirflowVersion = "1.10.12"
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "sched-v1-defaults-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "sched-v1-defaults-env", req)
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("sched-v1-defaults-env")
+	env, err := b.GetEnvironment(context.Background(), "sched-v1-defaults-env")
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), env.Schedulers, "default Schedulers for v1 should be 1")
@@ -239,11 +240,11 @@ func TestAuditB2_Schedulers_Update_V2Boundaries(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "sched-upd-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "sched-upd-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("sched-upd-env")
+			_, _ = b.GetEnvironment(context.Background(), "sched-upd-env")
 
-			_, err = b.UpdateEnvironment("sched-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "sched-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				Schedulers:     tt.schedulers,
 				AirflowVersion: "2.10.3",
 			})
@@ -260,17 +261,17 @@ func TestAuditB2_Schedulers_Update_Persisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "sched-persist-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "sched-persist-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("sched-persist-env")
+	_, _ = b.GetEnvironment(context.Background(), "sched-persist-env")
 
-	_, err = b.UpdateEnvironment("sched-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "sched-persist-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		Schedulers:     4,
 		AirflowVersion: "2.10.3",
 	})
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("sched-persist-env")
+	env, err := b.GetEnvironment(context.Background(), "sched-persist-env")
 	require.NoError(t, err)
 	assert.Equal(t, int32(4), env.Schedulers)
 }
@@ -283,10 +284,10 @@ func TestAuditB2_Webservers_Update_MinExceedsMax(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "ws-upd-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "ws-upd-env", newCreateReq())
 	require.NoError(t, err)
 
-	_, err = b.UpdateEnvironment("ws-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "ws-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		MinWebservers: 4,
 		MaxWebservers: 2,
 	})
@@ -297,17 +298,17 @@ func TestAuditB2_Webservers_Update_ValidRange(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "ws-upd-ok-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "ws-upd-ok-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("ws-upd-ok-env")
+	_, _ = b.GetEnvironment(context.Background(), "ws-upd-ok-env")
 
-	_, err = b.UpdateEnvironment("ws-upd-ok-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "ws-upd-ok-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		MinWebservers: 1,
 		MaxWebservers: 5,
 	})
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("ws-upd-ok-env")
+	env, err := b.GetEnvironment(context.Background(), "ws-upd-ok-env")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), env.MinWebservers)
 	assert.Equal(t, int32(5), env.MaxWebservers)
@@ -317,10 +318,10 @@ func TestAuditB2_Webservers_Update_MaxExceeds5_Rejected(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "ws-upd-over-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "ws-upd-over-env", newCreateReq())
 	require.NoError(t, err)
 
-	_, err = b.UpdateEnvironment("ws-upd-over-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "ws-upd-over-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		MinWebservers: 1,
 		MaxWebservers: 6,
 	})
@@ -338,11 +339,11 @@ func TestAuditB2_Status_CreatingSnapshot_PromotedOnGet(t *testing.T) {
 	env := b.AddEnvironmentInternal("snapshot-env")
 	env.Status = "CREATING_SNAPSHOT"
 
-	got, err := b.GetEnvironment("snapshot-env")
+	got, err := b.GetEnvironment(context.Background(), "snapshot-env")
 	require.NoError(t, err)
 	assert.Equal(t, "CREATING_SNAPSHOT", got.Status, "first Get returns the transient status")
 
-	got2, err := b.GetEnvironment("snapshot-env")
+	got2, err := b.GetEnvironment(context.Background(), "snapshot-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", got2.Status, "second Get promotes to AVAILABLE")
 }
@@ -354,11 +355,11 @@ func TestAuditB2_Status_UpdateRollingBack_PromotedOnGet(t *testing.T) {
 	env := b.AddEnvironmentInternal("rollback-env")
 	env.Status = "UPDATE_ROLLING_BACK"
 
-	got, err := b.GetEnvironment("rollback-env")
+	got, err := b.GetEnvironment(context.Background(), "rollback-env")
 	require.NoError(t, err)
 	assert.Equal(t, "UPDATE_ROLLING_BACK", got.Status)
 
-	got2, err := b.GetEnvironment("rollback-env")
+	got2, err := b.GetEnvironment(context.Background(), "rollback-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", got2.Status)
 }
@@ -370,11 +371,11 @@ func TestAuditB2_Status_Pending_PromotedOnGet(t *testing.T) {
 	env := b.AddEnvironmentInternal("pending-env")
 	env.Status = "PENDING"
 
-	got, err := b.GetEnvironment("pending-env")
+	got, err := b.GetEnvironment(context.Background(), "pending-env")
 	require.NoError(t, err)
 	assert.Equal(t, "PENDING", got.Status)
 
-	got2, err := b.GetEnvironment("pending-env")
+	got2, err := b.GetEnvironment(context.Background(), "pending-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", got2.Status)
 }
@@ -393,11 +394,11 @@ func TestAuditB2_Status_Terminal_NotPromoted(t *testing.T) {
 			env := b.AddEnvironmentInternal("terminal-env-" + status)
 			env.Status = status
 
-			got, err := b.GetEnvironment("terminal-env-" + status)
+			got, err := b.GetEnvironment(context.Background(), "terminal-env-"+status)
 			require.NoError(t, err)
 			assert.Equal(t, status, got.Status, "terminal status %q must not be promoted", status)
 
-			got2, err := b.GetEnvironment("terminal-env-" + status)
+			got2, err := b.GetEnvironment(context.Background(), "terminal-env-"+status)
 			require.NoError(t, err)
 			assert.Equal(t, status, got2.Status, "terminal status %q must not be promoted on second Get", status)
 		})
@@ -414,18 +415,18 @@ func TestAuditB2_GetMetrics_IsolatedBetweenEnvironments(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 
 	for _, name := range []string{"metrics-env-a", "metrics-env-b"} {
-		_, err := b.CreateEnvironment(testRegion, testAccountID, name, newCreateReq())
+		_, err := b.CreateEnvironment(context.Background(), name, newCreateReq())
 		require.NoError(t, err)
 	}
 
-	err := b.PublishMetrics("metrics-env-a", &mwaa.ExportedPublishMetricsRequest{
+	err := b.PublishMetrics(context.Background(), "metrics-env-a", &mwaa.ExportedPublishMetricsRequest{
 		MetricData: []mwaa.ExportedMetricDatum{
 			{MetricName: "OnlyForA"},
 		},
 	})
 	require.NoError(t, err)
 
-	dataB, err := b.GetMetrics("metrics-env-b")
+	dataB, err := b.GetMetrics(context.Background(), "metrics-env-b")
 	require.NoError(t, err)
 	assert.Empty(t, dataB, "metrics for env-b must not contain env-a's metrics")
 }
@@ -434,10 +435,10 @@ func TestAuditB2_GetMetrics_EmptyBeforePublish(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "no-metrics-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "no-metrics-env", newCreateReq())
 	require.NoError(t, err)
 
-	data, err := b.GetMetrics("no-metrics-env")
+	data, err := b.GetMetrics(context.Background(), "no-metrics-env")
 	require.NoError(t, err)
 	assert.Empty(t, data)
 }
@@ -553,10 +554,10 @@ func TestAuditB2_LoggingConfig_Enabled_RoundTrip(t *testing.T) {
 					Enabled:  tt.enabled,
 				},
 			}
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "logging-enabled-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "logging-enabled-env", req)
 			require.NoError(t, err)
 
-			env, err := b.GetEnvironment("logging-enabled-env")
+			env, err := b.GetEnvironment(context.Background(), "logging-enabled-env")
 			require.NoError(t, err)
 			require.NotNil(t, env.LoggingConfiguration)
 			require.NotNil(t, env.LoggingConfiguration.SchedulerLogs)
@@ -582,16 +583,16 @@ func TestAuditB2_Tags_MutationDoesNotAffectStoredEnv(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	req := newCreateReq()
 	req.Tags = map[string]string{"original": "value"}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "deep-copy-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "deep-copy-env", req)
 	require.NoError(t, err)
 
-	env1, err := b.GetEnvironment("deep-copy-env")
+	env1, err := b.GetEnvironment(context.Background(), "deep-copy-env")
 	require.NoError(t, err)
 
 	// Mutate the returned tags.
 	env1.Tags["injected"] = "malicious"
 
-	env2, err := b.GetEnvironment("deep-copy-env")
+	env2, err := b.GetEnvironment(context.Background(), "deep-copy-env")
 	require.NoError(t, err)
 	assert.NotContains(t, env2.Tags, "injected",
 		"mutation of returned tags must not affect the stored environment")
@@ -606,16 +607,16 @@ func TestAuditB2_NetworkConfig_MutationDoesNotAffectStoredEnv(t *testing.T) {
 		SubnetIDs:        []string{"subnet-aaa"},
 		SecurityGroupIDs: []string{"sg-111"},
 	}
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "nc-copy-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "nc-copy-env", req)
 	require.NoError(t, err)
 
-	env1, err := b.GetEnvironment("nc-copy-env")
+	env1, err := b.GetEnvironment(context.Background(), "nc-copy-env")
 	require.NoError(t, err)
 
 	// Replace the pointer entirely.
 	env1.NetworkConfiguration = nil
 
-	env2, err := b.GetEnvironment("nc-copy-env")
+	env2, err := b.GetEnvironment(context.Background(), "nc-copy-env")
 	require.NoError(t, err)
 	require.NotNil(t, env2.NetworkConfiguration,
 		"stored NetworkConfiguration must survive mutation of returned copy")
@@ -633,7 +634,7 @@ func TestAuditB2_ARNIndex_GrowsOnCreate(t *testing.T) {
 	assert.Equal(t, 0, mwaa.ARNIndexSize(b))
 
 	for i := range 3 {
-		_, err := b.CreateEnvironment(testRegion, testAccountID,
+		_, err := b.CreateEnvironment(context.Background(),
 			fmt.Sprintf("arn-env-%d", i), newCreateReq())
 		require.NoError(t, err)
 	}
@@ -646,11 +647,11 @@ func TestAuditB2_ARNIndex_ShrinksOnDelete(t *testing.T) {
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "arn-del-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "arn-del-env", newCreateReq())
 	require.NoError(t, err)
 	assert.Equal(t, 1, mwaa.ARNIndexSize(b))
 
-	_, err = b.DeleteEnvironment("arn-del-env")
+	_, err = b.DeleteEnvironment(context.Background(), "arn-del-env")
 	require.NoError(t, err)
 	assert.Equal(t, 0, mwaa.ARNIndexSize(b))
 }
@@ -755,7 +756,11 @@ func TestAuditB2_UntagResource_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	err := b.UntagResource("arn:aws:airflow:us-east-1:123456789012:environment/ghost", []string{"k"})
+	err := b.UntagResource(
+		context.Background(),
+		"arn:aws:airflow:us-east-1:123456789012:environment/ghost",
+		[]string{"k"},
+	)
 	require.Error(t, err)
 }
 
@@ -763,16 +768,16 @@ func TestAuditB2_UntagResource_MultipleKeys(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "multi-untag-env", newCreateReq())
+	env, err := b.CreateEnvironment(context.Background(), "multi-untag-env", newCreateReq())
 	require.NoError(t, err)
 
-	err = b.TagResource(env.ARN, map[string]string{"a": "1", "b": "2", "c": "3"})
+	err = b.TagResource(context.Background(), env.ARN, map[string]string{"a": "1", "b": "2", "c": "3"})
 	require.NoError(t, err)
 
-	err = b.UntagResource(env.ARN, []string{"a", "c"})
+	err = b.UntagResource(context.Background(), env.ARN, []string{"a", "c"})
 	require.NoError(t, err)
 
-	tags, err := b.ListTagsForResource(env.ARN)
+	tags, err := b.ListTagsForResource(context.Background(), env.ARN)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"b": "2"}, tags)
 }
@@ -787,15 +792,15 @@ func TestAuditB2_EnvironmentCount_CreateDelete(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	assert.Equal(t, 0, mwaa.EnvironmentCount(b))
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "count-env-1", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "count-env-1", newCreateReq())
 	require.NoError(t, err)
 	assert.Equal(t, 1, mwaa.EnvironmentCount(b))
 
-	_, err = b.CreateEnvironment(testRegion, testAccountID, "count-env-2", newCreateReq())
+	_, err = b.CreateEnvironment(context.Background(), "count-env-2", newCreateReq())
 	require.NoError(t, err)
 	assert.Equal(t, 2, mwaa.EnvironmentCount(b))
 
-	_, err = b.DeleteEnvironment("count-env-1")
+	_, err = b.DeleteEnvironment(context.Background(), "count-env-1")
 	require.NoError(t, err)
 	assert.Equal(t, 1, mwaa.EnvironmentCount(b))
 }

--- a/services/mwaa/backend.go
+++ b/services/mwaa/backend.go
@@ -1,6 +1,7 @@
 package mwaa
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -14,6 +15,18 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 const (
 	defaultAirflowVersion      = "2.10.3"
@@ -239,9 +252,11 @@ var _ StorageBackend = (*InMemoryBackend)(nil)
 
 // InMemoryBackend is the in-memory implementation of StorageBackend.
 type InMemoryBackend struct {
-	environments map[string]*Environment
-	arnIndex     map[string]string
-	metrics      map[string][]MetricDatum
+	// All resource maps are nested by region (outer key = region) so that
+	// same-named resources in different regions are fully isolated.
+	environments map[string]map[string]*Environment  // region → name → environment
+	arnIndex     map[string]map[string]string        // region → ARN → name
+	metrics      map[string]map[string][]MetricDatum // region → env name → metrics
 	mu           *lockmetrics.RWMutex
 	region       string
 	accountID    string
@@ -252,9 +267,9 @@ func NewInMemoryBackend(region, accountID string) *InMemoryBackend {
 	return &InMemoryBackend{
 		region:       region,
 		accountID:    accountID,
-		environments: make(map[string]*Environment),
-		arnIndex:     make(map[string]string),
-		metrics:      make(map[string][]MetricDatum),
+		environments: make(map[string]map[string]*Environment),
+		arnIndex:     make(map[string]map[string]string),
+		metrics:      make(map[string]map[string][]MetricDatum),
 		mu:           lockmetrics.New("mwaa"),
 	}
 }
@@ -265,22 +280,58 @@ func (b *InMemoryBackend) Region() string { return b.region }
 // AccountID returns the configured account ID.
 func (b *InMemoryBackend) AccountID() string { return b.accountID }
 
+// environmentsStore returns the environment map for the given region, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) environmentsStore(region string) map[string]*Environment {
+	if b.environments[region] == nil {
+		b.environments[region] = make(map[string]*Environment)
+	}
+
+	return b.environments[region]
+}
+
+// arnIndexStore returns the ARN index for the given region, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) arnIndexStore(region string) map[string]string {
+	if b.arnIndex[region] == nil {
+		b.arnIndex[region] = make(map[string]string)
+	}
+
+	return b.arnIndex[region]
+}
+
+// metricsStore returns the metrics map for the given region, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) metricsStore(region string) map[string][]MetricDatum {
+	if b.metrics[region] == nil {
+		b.metrics[region] = make(map[string][]MetricDatum)
+	}
+
+	return b.metrics[region]
+}
+
 // Reset closes the current mutex and reinitialises all maps.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Close()
 	b.mu = lockmetrics.New("mwaa")
-	b.environments = make(map[string]*Environment)
-	b.arnIndex = make(map[string]string)
-	b.metrics = make(map[string][]MetricDatum)
+	b.environments = make(map[string]map[string]*Environment)
+	b.arnIndex = make(map[string]map[string]string)
+	b.metrics = make(map[string]map[string][]MetricDatum)
 }
 
 // AddEnvironmentInternal creates an environment with minimal defaults, bypassing
-// validation, intended for use in tests only.
+// validation, intended for use in tests only. It uses the backend's default region.
 func (b *InMemoryBackend) AddEnvironmentInternal(name string) *Environment {
+	return b.AddEnvironmentInternalRegion(b.region, name)
+}
+
+// AddEnvironmentInternalRegion creates an environment with minimal defaults in the
+// given region, bypassing validation, intended for use in tests only.
+func (b *InMemoryBackend) AddEnvironmentInternalRegion(region, name string) *Environment {
 	b.mu.Lock("AddEnvironmentInternal")
 	defer b.mu.Unlock()
 
-	envARN := arn.Build("airflow", b.region, b.accountID, "environment/"+name)
+	envARN := arn.Build("airflow", region, b.accountID, "environment/"+name)
 	env := &Environment{
 		Name:      name,
 		ARN:       envARN,
@@ -289,8 +340,8 @@ func (b *InMemoryBackend) AddEnvironmentInternal(name string) *Environment {
 		CreatedAt: epochSecondsNow(),
 	}
 
-	b.environments[name] = env
-	b.arnIndex[envARN] = name
+	b.environmentsStore(region)[name] = env
+	b.arnIndexStore(region)[envARN] = name
 
 	return env
 }
@@ -540,9 +591,10 @@ func validateSchedulers(airflowVersion string, count int32) error {
 	return nil
 }
 
-// CreateEnvironment creates a new MWAA environment.
+// CreateEnvironment creates a new MWAA environment in the region resolved from ctx.
 func (b *InMemoryBackend) CreateEnvironment(
-	region, accountID, name string,
+	ctx context.Context,
+	name string,
 	req *createEnvironmentRequest,
 ) (*Environment, error) {
 	if err := validateEnvironmentName(name); err != nil {
@@ -553,10 +605,13 @@ func (b *InMemoryBackend) CreateEnvironment(
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateEnvironment")
 	defer b.mu.Unlock()
 
-	if _, exists := b.environments[name]; exists {
+	environments := b.environmentsStore(region)
+	if _, exists := environments[name]; exists {
 		return nil, ErrEnvironmentAlreadyExists
 	}
 
@@ -568,10 +623,10 @@ func (b *InMemoryBackend) CreateEnvironment(
 		)
 	}
 
-	env := buildEnvironment(region, accountID, name, req, defaults)
+	env := buildEnvironment(region, b.accountID, name, req, defaults)
 
-	b.environments[name] = env
-	b.arnIndex[env.ARN] = name
+	environments[name] = env
+	b.arnIndexStore(region)[env.ARN] = name
 
 	return env, nil
 }
@@ -705,13 +760,15 @@ func buildEnvironment(
 }
 
 // GetEnvironment retrieves a deep copy of an MWAA environment by name.
-func (b *InMemoryBackend) GetEnvironment(name string) (*Environment, error) {
+func (b *InMemoryBackend) GetEnvironment(ctx context.Context, name string) (*Environment, error) {
+	region := getRegion(ctx, b.region)
+
 	// Full write lock: GetEnvironment may promote a transient lifecycle status
 	// (UPDATING → AVAILABLE) on the stored environment via promoteTransientStatus.
 	b.mu.Lock("GetEnvironment")
 	defer b.mu.Unlock()
 
-	env, ok := b.environments[name]
+	env, ok := b.environmentsStore(region)[name]
 	if !ok {
 		return nil, ErrEnvironmentNotFound
 	}
@@ -737,32 +794,41 @@ func promoteTransientStatus(env *Environment) {
 }
 
 // DeleteEnvironment deletes an MWAA environment by name and cascades to metrics.
-func (b *InMemoryBackend) DeleteEnvironment(name string) (*Environment, error) {
+func (b *InMemoryBackend) DeleteEnvironment(ctx context.Context, name string) (*Environment, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteEnvironment")
 	defer b.mu.Unlock()
 
-	env, ok := b.environments[name]
+	environments := b.environmentsStore(region)
+	env, ok := environments[name]
 	if !ok {
 		return nil, ErrEnvironmentNotFound
 	}
 
-	delete(b.environments, name)
-	delete(b.arnIndex, env.ARN)
-	delete(b.metrics, name)
+	delete(environments, name)
+	delete(b.arnIndexStore(region), env.ARN)
+	delete(b.metricsStore(region), name)
 
 	return env, nil
 }
 
 // UpdateEnvironment updates an existing MWAA environment.
-func (b *InMemoryBackend) UpdateEnvironment(name string, req *updateEnvironmentRequest) (*Environment, error) {
+func (b *InMemoryBackend) UpdateEnvironment(
+	ctx context.Context,
+	name string,
+	req *updateEnvironmentRequest,
+) (*Environment, error) {
 	if err := validateUpdateRequest(req); err != nil {
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateEnvironment")
 	defer b.mu.Unlock()
 
-	env, ok := b.environments[name]
+	env, ok := b.environmentsStore(region)[name]
 	if !ok {
 		return nil, ErrEnvironmentNotFound
 	}
@@ -981,7 +1047,11 @@ func applyUpdateS3Paths(env *Environment, req *updateEnvironmentRequest) {
 // pageSize is clamped to [1, listEnvMaxPageSize]; 0 falls back to listEnvDefaultPageSize.
 // nextToken is the name of the first environment to include in this page (exclusive
 // start cursor of the previous page); empty starts at the beginning.
-func (b *InMemoryBackend) ListEnvironmentsPage(nextToken string, pageSize int) ([]string, string, error) {
+func (b *InMemoryBackend) ListEnvironmentsPage(
+	ctx context.Context,
+	nextToken string,
+	pageSize int,
+) ([]string, string, error) {
 	if pageSize <= 0 {
 		pageSize = listEnvDefaultPageSize
 	}
@@ -990,11 +1060,14 @@ func (b *InMemoryBackend) ListEnvironmentsPage(nextToken string, pageSize int) (
 		pageSize = listEnvMaxPageSize
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListEnvironmentsPage")
 	defer b.mu.RUnlock()
 
-	all := make([]string, 0, len(b.environments))
-	for name := range b.environments {
+	environments := b.environmentsStore(region)
+	all := make([]string, 0, len(environments))
+	for name := range environments {
 		all = append(all, name)
 	}
 
@@ -1025,18 +1098,20 @@ func (b *InMemoryBackend) ListEnvironmentsPage(nextToken string, pageSize int) (
 }
 
 // ListEnvironments returns a sorted list of environment names.
-func (b *InMemoryBackend) ListEnvironments() ([]string, error) {
-	names, _, err := b.ListEnvironmentsPage("", listEnvMaxPageSize)
+func (b *InMemoryBackend) ListEnvironments(ctx context.Context) ([]string, error) {
+	names, _, err := b.ListEnvironmentsPage(ctx, "", listEnvMaxPageSize)
 
 	return names, err
 }
 
 // TagResource adds or updates tags on a resource identified by its ARN.
-func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceARN string, tags map[string]string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	env := b.findByARN(resourceARN)
+	env := b.findByARN(region, resourceARN)
 	if env == nil {
 		return ErrEnvironmentNotFound
 	}
@@ -1062,11 +1137,13 @@ func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string
 }
 
 // UntagResource removes tags from a resource identified by its ARN.
-func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	env := b.findByARN(resourceARN)
+	env := b.findByARN(region, resourceARN)
 	if env == nil {
 		return ErrEnvironmentNotFound
 	}
@@ -1079,11 +1156,13 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) er
 }
 
 // ListTagsForResource returns all tags for a resource identified by its ARN.
-func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]string, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	env := b.findByARN(resourceARN)
+	env := b.findByARN(region, resourceARN)
 	if env == nil {
 		return nil, ErrEnvironmentNotFound
 	}
@@ -1094,22 +1173,29 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]st
 	return result, nil
 }
 
-// findByARN looks up an environment by its ARN using the ARN index. Must be called with lock held.
-func (b *InMemoryBackend) findByARN(resourceARN string) *Environment {
-	name, ok := b.arnIndex[resourceARN]
+// findByARN looks up an environment in the given region by its ARN using the
+// region's ARN index. Must be called with lock held.
+func (b *InMemoryBackend) findByARN(region, resourceARN string) *Environment {
+	name, ok := b.arnIndexStore(region)[resourceARN]
 	if !ok {
 		return nil
 	}
 
-	return b.environments[name]
+	return b.environmentsStore(region)[name]
 }
 
 // InvokeRestAPI simulates calling the Apache Airflow REST API on the specified environment's webserver.
-func (b *InMemoryBackend) InvokeRestAPI(envName string, req *invokeRestAPIRequest) (*InvokeRestAPIResponse, error) {
+func (b *InMemoryBackend) InvokeRestAPI(
+	ctx context.Context,
+	envName string,
+	req *invokeRestAPIRequest,
+) (*InvokeRestAPIResponse, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("InvokeRestAPI")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.environments[envName]; !ok {
+	if _, ok := b.environmentsStore(region)[envName]; !ok {
 		return nil, ErrEnvironmentNotFound
 	}
 
@@ -1129,38 +1215,43 @@ func (b *InMemoryBackend) InvokeRestAPI(envName string, req *invokeRestAPIReques
 
 // PublishMetrics stores internal environment metrics for the specified environment.
 // The total number of metrics per environment is capped at maxMetricsPerEnv.
-func (b *InMemoryBackend) PublishMetrics(envName string, req *publishMetricsRequest) error {
+func (b *InMemoryBackend) PublishMetrics(ctx context.Context, envName string, req *publishMetricsRequest) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PublishMetrics")
 	defer b.mu.Unlock()
 
-	if _, ok := b.environments[envName]; !ok {
+	if _, ok := b.environmentsStore(region)[envName]; !ok {
 		return ErrEnvironmentNotFound
 	}
 
-	b.metrics[envName] = append(b.metrics[envName], req.MetricData...)
+	metrics := b.metricsStore(region)
+	metrics[envName] = append(metrics[envName], req.MetricData...)
 
-	if data := b.metrics[envName]; len(data) > maxMetricsPerEnv {
+	if data := metrics[envName]; len(data) > maxMetricsPerEnv {
 		// Copy the surviving tail into a right-sized slice so the trimmed-off
 		// prefix is released for GC instead of being pinned by an oversized
 		// backing array.
 		trimmed := make([]MetricDatum, maxMetricsPerEnv)
 		copy(trimmed, data[len(data)-maxMetricsPerEnv:])
-		b.metrics[envName] = trimmed
+		metrics[envName] = trimmed
 	}
 
 	return nil
 }
 
 // GetMetrics returns the stored metrics for the specified environment.
-func (b *InMemoryBackend) GetMetrics(envName string) ([]MetricDatum, error) {
+func (b *InMemoryBackend) GetMetrics(ctx context.Context, envName string) ([]MetricDatum, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetMetrics")
 	defer b.mu.RUnlock()
 
-	if _, ok := b.environments[envName]; !ok {
+	if _, ok := b.environmentsStore(region)[envName]; !ok {
 		return nil, ErrEnvironmentNotFound
 	}
 
-	data := b.metrics[envName]
+	data := b.metricsStore(region)[envName]
 	result := make([]MetricDatum, len(data))
 	copy(result, data)
 
@@ -1170,11 +1261,13 @@ func (b *InMemoryBackend) GetMetrics(envName string) ([]MetricDatum, error) {
 // CreateCliToken validates that the environment exists and is AVAILABLE, then
 // returns a JWT-shaped CLI token. AWS returns ResourceNotFoundException when
 // the environment is in any non-AVAILABLE state.
-func (b *InMemoryBackend) CreateCliToken(envName string) (string, error) {
+func (b *InMemoryBackend) CreateCliToken(ctx context.Context, envName string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("CreateCliToken")
 	defer b.mu.RUnlock()
 
-	env, ok := b.environments[envName]
+	env, ok := b.environmentsStore(region)[envName]
 	if !ok {
 		return "", ErrEnvironmentNotFound
 	}
@@ -1189,11 +1282,13 @@ func (b *InMemoryBackend) CreateCliToken(envName string) (string, error) {
 // CreateWebLoginToken validates that the environment exists and is AVAILABLE,
 // then returns a JWT-shaped web login token. AWS returns ResourceNotFoundException
 // when the environment is in any non-AVAILABLE state.
-func (b *InMemoryBackend) CreateWebLoginToken(envName string) (string, error) {
+func (b *InMemoryBackend) CreateWebLoginToken(ctx context.Context, envName string) (string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("CreateWebLoginToken")
 	defer b.mu.RUnlock()
 
-	env, ok := b.environments[envName]
+	env, ok := b.environmentsStore(region)[envName]
 	if !ok {
 		return "", ErrEnvironmentNotFound
 	}

--- a/services/mwaa/backend_test.go
+++ b/services/mwaa/backend_test.go
@@ -1,6 +1,7 @@
 package mwaa_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,11 +71,11 @@ func TestBackend_CreateEnvironment(t *testing.T) {
 			b := newTestBackend()
 
 			if tt.name == "duplicate_returns_error" {
-				_, err := b.CreateEnvironment("us-east-1", "123456789012", tt.envName, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 				require.NoError(t, err)
 			}
 
-			env, err := b.CreateEnvironment("us-east-1", "123456789012", tt.envName, tt.req)
+			env, err := b.CreateEnvironment(context.Background(), tt.envName, tt.req)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -122,11 +123,11 @@ func TestBackend_GetEnvironment(t *testing.T) {
 			b := newTestBackend()
 
 			if tt.seed {
-				_, err := b.CreateEnvironment("us-east-1", "123456789012", tt.envName, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 				require.NoError(t, err)
 			}
 
-			env, err := b.GetEnvironment(tt.envName)
+			env, err := b.GetEnvironment(context.Background(), tt.envName)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -169,11 +170,11 @@ func TestBackend_DeleteEnvironment(t *testing.T) {
 			b := newTestBackend()
 
 			if tt.seed {
-				_, err := b.CreateEnvironment("us-east-1", "123456789012", tt.envName, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 				require.NoError(t, err)
 			}
 
-			deleted, err := b.DeleteEnvironment(tt.envName)
+			deleted, err := b.DeleteEnvironment(context.Background(), tt.envName)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -184,7 +185,7 @@ func TestBackend_DeleteEnvironment(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.envName, deleted.Name)
 
-			_, err = b.GetEnvironment(tt.envName)
+			_, err = b.GetEnvironment(context.Background(), tt.envName)
 			require.Error(t, err, "environment should be gone after delete")
 		})
 	}
@@ -217,11 +218,11 @@ func TestBackend_ListEnvironments(t *testing.T) {
 			b := newTestBackend()
 
 			for _, n := range tt.seedNames {
-				_, err := b.CreateEnvironment("us-east-1", "123456789012", n, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), n, newCreateReq())
 				require.NoError(t, err)
 			}
 
-			names, err := b.ListEnvironments()
+			names, err := b.ListEnvironments(context.Background())
 			require.NoError(t, err)
 			assert.Len(t, names, tt.wantCount)
 		})
@@ -264,12 +265,12 @@ func TestBackend_UpdateEnvironment(t *testing.T) {
 			b := newTestBackend()
 
 			if tt.seed {
-				_, err := b.CreateEnvironment("us-east-1", "123456789012", tt.envName, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 				require.NoError(t, err)
-				_, _ = b.GetEnvironment(tt.envName)
+				_, _ = b.GetEnvironment(context.Background(), tt.envName)
 			}
 
-			env, err := b.UpdateEnvironment(tt.envName, tt.update)
+			env, err := b.UpdateEnvironment(context.Background(), tt.envName, tt.update)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -315,18 +316,18 @@ func TestBackend_Tags(t *testing.T) {
 
 			b := newTestBackend()
 
-			env, err := b.CreateEnvironment("us-east-1", "123456789012", tt.envName, newCreateReq())
+			env, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 			require.NoError(t, err)
 
-			err = b.TagResource(env.ARN, tt.tagsToAdd)
+			err = b.TagResource(context.Background(), env.ARN, tt.tagsToAdd)
 			require.NoError(t, err)
 
 			if len(tt.keysToRemove) > 0 {
-				err = b.UntagResource(env.ARN, tt.keysToRemove)
+				err = b.UntagResource(context.Background(), env.ARN, tt.keysToRemove)
 				require.NoError(t, err)
 			}
 
-			tags, err := b.ListTagsForResource(env.ARN)
+			tags, err := b.ListTagsForResource(context.Background(), env.ARN)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantTags, tags)
 		})

--- a/services/mwaa/export_test.go
+++ b/services/mwaa/export_test.go
@@ -1,37 +1,58 @@
 package mwaa
 
-// EnvironmentCount returns the number of environments in the backend.
+// EnvironmentCount returns the total number of environments in the backend across
+// all regions.
 func EnvironmentCount(b *InMemoryBackend) int {
 	b.mu.RLock("EnvironmentCount")
 	defer b.mu.RUnlock()
 
-	return len(b.environments)
+	total := 0
+	for _, regionEnvs := range b.environments {
+		total += len(regionEnvs)
+	}
+
+	return total
 }
 
-// MetricsCount returns the number of metric data points for an environment.
+// EnvironmentCountRegion returns the number of environments in the given region.
+func EnvironmentCountRegion(b *InMemoryBackend, region string) int {
+	b.mu.RLock("EnvironmentCountRegion")
+	defer b.mu.RUnlock()
+
+	return len(b.environments[region])
+}
+
+// MetricsCount returns the number of metric data points for an environment in the
+// backend's default region.
 func MetricsCount(b *InMemoryBackend, envName string) int {
 	b.mu.RLock("MetricsCount")
 	defer b.mu.RUnlock()
 
-	return len(b.metrics[envName])
+	return len(b.metrics[b.region][envName])
 }
 
 // MetricsCapacity returns the capacity of the backing slice for an
-// environment's metrics. Used to verify trimming does not retain an oversized
-// backing array (a memory leak even though len() is capped).
+// environment's metrics in the backend's default region. Used to verify trimming
+// does not retain an oversized backing array (a memory leak even though len() is
+// capped).
 func MetricsCapacity(b *InMemoryBackend, envName string) int {
 	b.mu.RLock("MetricsCapacity")
 	defer b.mu.RUnlock()
 
-	return cap(b.metrics[envName])
+	return cap(b.metrics[b.region][envName])
 }
 
-// ARNIndexSize returns the number of entries in the ARN index.
+// ARNIndexSize returns the total number of entries in the ARN index across all regions.
 func ARNIndexSize(b *InMemoryBackend) int {
 	b.mu.RLock("ARNIndexSize")
 	defer b.mu.RUnlock()
 
-	return len(b.arnIndex)
+	total := 0
+	for _, regionIndex := range b.arnIndex {
+		total += len(regionIndex)
+	}
+
+	return total
 }
 
 // HandlerOpsLen returns the number of operations returned by GetSupportedOperations.

--- a/services/mwaa/handler.go
+++ b/services/mwaa/handler.go
@@ -1,6 +1,7 @@
 package mwaa
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -209,6 +210,16 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	return h.ServeHTTP
 }
 
+// contextWithRegion returns the request context with the resolved AWS region attached
+// under regionContextKey so that backend operations are routed to the correct region.
+// The region is extracted from the request's SigV4 credential scope, falling back to
+// the handler's default region.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.DefaultRegion)
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
+}
+
 // ServeHTTP dispatches MWAA API requests.
 func (h *Handler) ServeHTTP(c *echo.Context) error {
 	path := c.Request().URL.Path
@@ -295,31 +306,41 @@ func (h *Handler) dispatchEnvironment(c *echo.Context, path string) error {
 	return writeErrorResponse(c, http.StatusMethodNotAllowed, "MethodNotAllowedException", "method not allowed")
 }
 
-func (h *Handler) handleCreateEnvironment(c *echo.Context, name string) error {
+// decodeJSONBody reads the request body and unmarshals it into target. On
+// failure it writes the appropriate MWAA error response and returns false so
+// the caller can return immediately.
+func decodeJSONBody(c *echo.Context, target any) bool {
 	body, err := httputils.ReadBody(c.Request())
 	if err != nil {
-		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "failed to read request body")
+		_ = writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "failed to read request body")
+
+		return false
 	}
 
-	var req createEnvironmentRequest
+	if jsonErr := json.Unmarshal(body, target); jsonErr != nil {
+		_ = writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
 
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+		return false
 	}
 
-	region := httputils.ExtractRegionFromRequest(c.Request(), h.DefaultRegion)
+	return true
+}
 
-	env, err := h.Backend.CreateEnvironment(region, h.AccountID, name, &req)
+// writeEnvironmentResult maps a backend environment error to an MWAA error
+// response, or writes the environment ARN on success. It mirrors AWS, treating
+// ErrAlreadyExists as a 409 Conflict (only produced by CreateEnvironment).
+func writeEnvironmentResult(c *echo.Context, env *Environment, err error) error {
 	if err != nil {
-		if errors.Is(err, awserr.ErrAlreadyExists) {
+		switch {
+		case errors.Is(err, awserr.ErrAlreadyExists):
 			return writeErrorResponse(c, http.StatusConflict, "AlreadyExistsException", err.Error())
-		}
-
-		if errors.Is(err, awserr.ErrInvalidParameter) {
+		case errors.Is(err, awserr.ErrNotFound):
+			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		case errors.Is(err, awserr.ErrInvalidParameter):
 			return writeErrorResponse(c, http.StatusBadRequest, "ValidationException", err.Error())
+		default:
+			return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerException", err.Error())
 		}
-
-		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerException", err.Error())
 	}
 
 	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, map[string]string{
@@ -329,8 +350,19 @@ func (h *Handler) handleCreateEnvironment(c *echo.Context, name string) error {
 	return nil
 }
 
+func (h *Handler) handleCreateEnvironment(c *echo.Context, name string) error {
+	var req createEnvironmentRequest
+	if !decodeJSONBody(c, &req) {
+		return nil
+	}
+
+	env, err := h.Backend.CreateEnvironment(h.contextWithRegion(c), name, &req)
+
+	return writeEnvironmentResult(c, env, err)
+}
+
 func (h *Handler) handleGetEnvironment(c *echo.Context, name string) error {
-	env, err := h.Backend.GetEnvironment(name)
+	env, err := h.Backend.GetEnvironment(h.contextWithRegion(c), name)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -347,52 +379,20 @@ func (h *Handler) handleGetEnvironment(c *echo.Context, name string) error {
 }
 
 func (h *Handler) handleDeleteEnvironment(c *echo.Context, name string) error {
-	env, err := h.Backend.DeleteEnvironment(name)
-	if err != nil {
-		if errors.Is(err, awserr.ErrNotFound) {
-			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
-		}
+	env, err := h.Backend.DeleteEnvironment(h.contextWithRegion(c), name)
 
-		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerException", err.Error())
-	}
-
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, map[string]string{
-		keyArn: env.ARN,
-	})
-
-	return nil
+	return writeEnvironmentResult(c, env, err)
 }
 
 func (h *Handler) handleUpdateEnvironment(c *echo.Context, name string) error {
-	body, err := httputils.ReadBody(c.Request())
-	if err != nil {
-		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "failed to read request body")
-	}
-
 	var req updateEnvironmentRequest
-
-	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
-		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
+	if !decodeJSONBody(c, &req) {
+		return nil
 	}
 
-	env, err := h.Backend.UpdateEnvironment(name, &req)
-	if err != nil {
-		if errors.Is(err, awserr.ErrNotFound) {
-			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
-		}
+	env, err := h.Backend.UpdateEnvironment(h.contextWithRegion(c), name, &req)
 
-		if errors.Is(err, awserr.ErrInvalidParameter) {
-			return writeErrorResponse(c, http.StatusBadRequest, "ValidationException", err.Error())
-		}
-
-		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerException", err.Error())
-	}
-
-	httputils.WriteJSON(c.Request().Context(), c.Response(), http.StatusOK, map[string]string{
-		keyArn: env.ARN,
-	})
-
-	return nil
+	return writeEnvironmentResult(c, env, err)
 }
 
 func (h *Handler) handleListEnvironments(c *echo.Context) error {
@@ -410,7 +410,7 @@ func (h *Handler) handleListEnvironments(c *echo.Context) error {
 		pageSize = n
 	}
 
-	names, outToken, err := h.Backend.ListEnvironmentsPage(nextToken, pageSize)
+	names, outToken, err := h.Backend.ListEnvironmentsPage(h.contextWithRegion(c), nextToken, pageSize)
 	if err != nil {
 		return writeErrorResponse(c, http.StatusInternalServerError, "InternalServerException", err.Error())
 	}
@@ -430,7 +430,7 @@ func (h *Handler) handleListEnvironments(c *echo.Context) error {
 }
 
 func (h *Handler) handleListTagsForResource(c *echo.Context, resourceARN string) error {
-	tags, err := h.Backend.ListTagsForResource(resourceARN)
+	tags, err := h.Backend.ListTagsForResource(h.contextWithRegion(c), resourceARN)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -464,7 +464,7 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceARN string) error {
 		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
 	}
 
-	if tagErr := h.Backend.TagResource(resourceARN, req.Tags); tagErr != nil {
+	if tagErr := h.Backend.TagResource(h.contextWithRegion(c), resourceARN, req.Tags); tagErr != nil {
 		if errors.Is(tagErr, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", tagErr.Error())
 		}
@@ -484,7 +484,7 @@ func (h *Handler) handleTagResource(c *echo.Context, resourceARN string) error {
 func (h *Handler) handleUntagResource(c *echo.Context, resourceARN string) error {
 	tagKeys := c.Request().URL.Query()["tagKeys"]
 
-	if err := h.Backend.UntagResource(resourceARN, tagKeys); err != nil {
+	if err := h.Backend.UntagResource(h.contextWithRegion(c), resourceARN, tagKeys); err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
 		}
@@ -498,7 +498,7 @@ func (h *Handler) handleUntagResource(c *echo.Context, resourceARN string) error
 }
 
 func (h *Handler) handleCreateCliToken(c *echo.Context, name string) error {
-	token, err := h.Backend.CreateCliToken(name)
+	token, err := h.Backend.CreateCliToken(h.contextWithRegion(c), name)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -516,7 +516,7 @@ func (h *Handler) handleCreateCliToken(c *echo.Context, name string) error {
 }
 
 func (h *Handler) handleCreateWebLoginToken(c *echo.Context, name string) error {
-	token, err := h.Backend.CreateWebLoginToken(name)
+	token, err := h.Backend.CreateWebLoginToken(h.contextWithRegion(c), name)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -554,7 +554,7 @@ func (h *Handler) handleInvokeRestAPI(c *echo.Context, name string) error {
 		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
 	}
 
-	resp, err := h.Backend.InvokeRestAPI(name, &req)
+	resp, err := h.Backend.InvokeRestAPI(h.contextWithRegion(c), name, &req)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -586,7 +586,7 @@ func (h *Handler) dispatchMetrics(c *echo.Context, path string) error {
 }
 
 func (h *Handler) handleGetMetrics(c *echo.Context, name string) error {
-	metrics, err := h.Backend.GetMetrics(name)
+	metrics, err := h.Backend.GetMetrics(h.contextWithRegion(c), name)
 	if err != nil {
 		if errors.Is(err, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -618,7 +618,7 @@ func (h *Handler) handlePublishMetrics(c *echo.Context, name string) error {
 		return writeErrorResponse(c, http.StatusBadRequest, "BadRequestException", "invalid request body")
 	}
 
-	if pubErr := h.Backend.PublishMetrics(name, &req); pubErr != nil {
+	if pubErr := h.Backend.PublishMetrics(h.contextWithRegion(c), name, &req); pubErr != nil {
 		if errors.Is(pubErr, awserr.ErrNotFound) {
 			return writeErrorResponse(c, http.StatusNotFound, "ResourceNotFoundException", pubErr.Error())
 		}

--- a/services/mwaa/handler_accuracy_test.go
+++ b/services/mwaa/handler_accuracy_test.go
@@ -1,6 +1,7 @@
 package mwaa_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -40,7 +41,7 @@ func TestAccuracy_EnvironmentName_ValidNames(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, tt.envName, newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 			require.NoError(t, err)
 		})
 	}
@@ -70,7 +71,7 @@ func TestAccuracy_EnvironmentName_InvalidNames(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, tt.envName, newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 			require.Error(t, err)
 		})
 	}
@@ -132,7 +133,7 @@ func TestAccuracy_EnvironmentName_SpaceRejectedByBackend(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "my env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "my env", newCreateReq())
 	require.Error(t, err)
 }
 
@@ -141,7 +142,7 @@ func TestAccuracy_EnvironmentName_ExactlyMaxLength(t *testing.T) {
 
 	envName := "A" + strings.Repeat("b", 79) // 80 chars, starts with letter
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, envName, newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), envName, newCreateReq())
 	require.NoError(t, err)
 }
 
@@ -149,7 +150,7 @@ func TestAccuracy_EnvironmentName_ExactlyMinLength(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "a", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "a", newCreateReq())
 	require.NoError(t, err)
 }
 
@@ -172,7 +173,7 @@ func TestAccuracy_AirflowVersion_SupportedVersions(t *testing.T) {
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 			req := newCreateReq()
 			req.AirflowVersion = v
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "env-v", req)
+			_, err := b.CreateEnvironment(context.Background(), "env-v", req)
 			require.NoError(t, err)
 		})
 	}
@@ -197,7 +198,7 @@ func TestAccuracy_AirflowVersion_UnsupportedVersions(t *testing.T) {
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 			req := newCreateReq()
 			req.AirflowVersion = v
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "env-inv", req)
+			_, err := b.CreateEnvironment(context.Background(), "env-inv", req)
 			require.Error(t, err)
 		})
 	}
@@ -209,7 +210,7 @@ func TestAccuracy_AirflowVersion_EmptyUsesDefault(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	req := newCreateReq()
 	req.AirflowVersion = ""
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "env-default", req)
+	env, err := b.CreateEnvironment(context.Background(), "env-default", req)
 	require.NoError(t, err)
 	assert.NotEmpty(t, env.AirflowVersion)
 }
@@ -244,11 +245,11 @@ func TestAccuracy_AirflowVersion_Update_InvalidVersion(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "update-ver-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "update-ver-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("update-ver-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "update-ver-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("update-ver-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "update-ver-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		AirflowVersion: "99.0.0",
 	})
 	require.Error(t, err)
@@ -258,11 +259,11 @@ func TestAccuracy_AirflowVersion_Update_ValidVersion(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "update-ver-ok", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "update-ver-ok", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("update-ver-ok") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "update-ver-ok") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("update-ver-ok", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "update-ver-ok", &mwaa.ExportedUpdateEnvironmentRequest{
 		AirflowVersion: "2.9.2",
 	})
 	require.NoError(t, err)
@@ -272,11 +273,11 @@ func TestAccuracy_AirflowVersion_Update_EmptyVersionAllowed(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "update-ver-empty", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "update-ver-empty", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("update-ver-empty") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "update-ver-empty") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("update-ver-empty", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "update-ver-empty", &mwaa.ExportedUpdateEnvironmentRequest{
 		DagS3Path: "new-dags/",
 	})
 	require.NoError(t, err)
@@ -324,7 +325,7 @@ func TestAccuracy_MaxWorkers_UpperBound_Create(t *testing.T) {
 			req := newCreateReq()
 			req.MaxWorkers = tt.maxWorkers
 			req.MinWorkers = 1
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "workers-env", req)
+			_, err := b.CreateEnvironment(context.Background(), "workers-env", req)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -352,13 +353,17 @@ func TestAccuracy_MaxWorkers_UpperBound_Update(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "workers-upd-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "workers-upd-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("workers-upd-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "workers-upd-env") // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("workers-upd-env", &mwaa.ExportedUpdateEnvironmentRequest{
-				MaxWorkers: tt.maxWorkers,
-			})
+			_, err = b.UpdateEnvironment(
+				context.Background(),
+				"workers-upd-env",
+				&mwaa.ExportedUpdateEnvironmentRequest{
+					MaxWorkers: tt.maxWorkers,
+				},
+			)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -375,7 +380,7 @@ func TestAccuracy_MaxWorkers_ZeroUnbounded(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	req := newCreateReq()
 	req.MaxWorkers = 0 // 0 means use default, no upper bound check
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "workers-zero", req)
+	_, err := b.CreateEnvironment(context.Background(), "workers-zero", req)
 	require.NoError(t, err)
 }
 
@@ -439,13 +444,17 @@ func TestAccuracy_WorkerReplacementStrategy_ValidValues(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "strategy-env-"+tt.name, newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "strategy-env-"+tt.name, newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("strategy-env-" + tt.name) // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "strategy-env-"+tt.name) // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("strategy-env-"+tt.name, &mwaa.ExportedUpdateEnvironmentRequest{
-				WorkerReplacementStrategy: tt.strategy,
-			})
+			_, err = b.UpdateEnvironment(
+				context.Background(),
+				"strategy-env-"+tt.name,
+				&mwaa.ExportedUpdateEnvironmentRequest{
+					WorkerReplacementStrategy: tt.strategy,
+				},
+			)
 			require.NoError(t, err)
 		})
 	}
@@ -468,12 +477,16 @@ func TestAccuracy_WorkerReplacementStrategy_InvalidValues(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "strategy-inv-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "strategy-inv-env", newCreateReq())
 			require.NoError(t, err)
 
-			_, err = b.UpdateEnvironment("strategy-inv-env", &mwaa.ExportedUpdateEnvironmentRequest{
-				WorkerReplacementStrategy: strategy,
-			})
+			_, err = b.UpdateEnvironment(
+				context.Background(),
+				"strategy-inv-env",
+				&mwaa.ExportedUpdateEnvironmentRequest{
+					WorkerReplacementStrategy: strategy,
+				},
+			)
 			require.Error(t, err)
 		})
 	}
@@ -515,17 +528,17 @@ func TestAccuracy_WorkerReplacementStrategy_StoredInLastUpdate(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "lu-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lu-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("lu-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "lu-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("lu-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "lu-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		WorkerReplacementStrategy: "FORCED",
 	})
 	require.NoError(t, err)
 
 	// Fetch and verify LastUpdate contains the strategy.
-	env, err := b.GetEnvironment("lu-env")
+	env, err := b.GetEnvironment(context.Background(), "lu-env")
 	require.NoError(t, err)
 	require.NotNil(t, env.LastUpdate)
 	assert.Equal(t, "FORCED", env.LastUpdate.WorkerReplacementStrategy)
@@ -553,7 +566,7 @@ func TestAccuracy_TagLimit_CreateEnvironment_Exceeds(t *testing.T) {
 
 	req.Tags = tagMap
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "tag-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "tag-env", req)
 	require.Error(t, err)
 }
 
@@ -569,7 +582,7 @@ func TestAccuracy_TagLimit_CreateEnvironment_AtLimit(t *testing.T) {
 	req := newCreateReq()
 	req.Tags = tags
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "tag-at-limit", req)
+	_, err := b.CreateEnvironment(context.Background(), "tag-at-limit", req)
 	require.NoError(t, err)
 }
 
@@ -587,11 +600,11 @@ func TestAccuracy_TagLimit_TagResource_Exceeds(t *testing.T) {
 	req := newCreateReq()
 	req.Tags = initialTags
 
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "tag-resource-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "tag-resource-env", req)
 	require.NoError(t, err)
 
 	// Adding 3 new tags should exceed the 50-tag limit.
-	err = b.TagResource(env.ARN, map[string]string{"new1": "v", "new2": "v", "new3": "v"})
+	err = b.TagResource(context.Background(), env.ARN, map[string]string{"new1": "v", "new2": "v", "new3": "v"})
 	require.Error(t, err)
 }
 
@@ -609,12 +622,12 @@ func TestAccuracy_TagLimit_TagResource_UpdateExistingTagsOK(t *testing.T) {
 	req := newCreateReq()
 	req.Tags = initialTags
 
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "tag-update-ok", req)
+	env, err := b.CreateEnvironment(context.Background(), "tag-update-ok", req)
 	require.NoError(t, err)
 
 	// Updating an existing tag (same key) does not increase count — should succeed.
 	firstKey := strings.Repeat("k", 1)
-	err = b.TagResource(env.ARN, map[string]string{firstKey: "updated"})
+	err = b.TagResource(context.Background(), env.ARN, map[string]string{firstKey: "updated"})
 	require.NoError(t, err)
 }
 
@@ -632,11 +645,11 @@ func TestAccuracy_TagLimit_TagResource_AddToFull(t *testing.T) {
 	req := newCreateReq()
 	req.Tags = initialTags
 
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "tag-full-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "tag-full-env", req)
 	require.NoError(t, err)
 
 	// Adding even one genuinely new tag must fail.
-	err = b.TagResource(env.ARN, map[string]string{"brand-new-key": "v"})
+	err = b.TagResource(context.Background(), env.ARN, map[string]string{"brand-new-key": "v"})
 	require.Error(t, err)
 }
 
@@ -684,13 +697,17 @@ func TestAccuracy_UpdateWebserverAccessMode_ValidValues(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "wam-env-"+tt.name, newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "wam-env-"+tt.name, newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("wam-env-" + tt.name) // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "wam-env-"+tt.name) // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("wam-env-"+tt.name, &mwaa.ExportedUpdateEnvironmentRequest{
-				WebserverAccessMode: tt.mode,
-			})
+			_, err = b.UpdateEnvironment(
+				context.Background(),
+				"wam-env-"+tt.name,
+				&mwaa.ExportedUpdateEnvironmentRequest{
+					WebserverAccessMode: tt.mode,
+				},
+			)
 			require.NoError(t, err)
 		})
 	}
@@ -700,10 +717,10 @@ func TestAccuracy_UpdateWebserverAccessMode_InvalidValue(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wam-inv-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "wam-inv-env", newCreateReq())
 	require.NoError(t, err)
 
-	_, err = b.UpdateEnvironment("wam-inv-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wam-inv-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		WebserverAccessMode: "BOGUS_MODE",
 	})
 	require.Error(t, err)
@@ -745,16 +762,16 @@ func TestAccuracy_UpdateWebserverAccessMode_Persisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "wam-persist", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "wam-persist", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("wam-persist") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "wam-persist") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("wam-persist", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "wam-persist", &mwaa.ExportedUpdateEnvironmentRequest{
 		WebserverAccessMode: "PRIVATE_ONLY",
 	})
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("wam-persist")
+	env, err := b.GetEnvironment(context.Background(), "wam-persist")
 	require.NoError(t, err)
 	assert.Equal(t, "PRIVATE_ONLY", env.WebserverAccessMode)
 }
@@ -775,11 +792,11 @@ func TestAccuracy_UpdateEnvironmentClass_ValidClasses(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "class-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "class-env", newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("class-env") // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "class-env") // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("class-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "class-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				EnvironmentClass: cls,
 			})
 			require.NoError(t, err)
@@ -799,10 +816,10 @@ func TestAccuracy_UpdateEnvironmentClass_InvalidClass(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "class-inv-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "class-inv-env", newCreateReq())
 			require.NoError(t, err)
 
-			_, err = b.UpdateEnvironment("class-inv-env", &mwaa.ExportedUpdateEnvironmentRequest{
+			_, err = b.UpdateEnvironment(context.Background(), "class-inv-env", &mwaa.ExportedUpdateEnvironmentRequest{
 				EnvironmentClass: cls,
 			})
 			require.Error(t, err)
@@ -814,11 +831,11 @@ func TestAccuracy_UpdateEnvironmentClass_EmptyAllowed(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "class-empty-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "class-empty-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("class-empty-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "class-empty-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("class-empty-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "class-empty-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		EnvironmentClass: "",
 	})
 	require.NoError(t, err)
@@ -859,16 +876,16 @@ func TestAccuracy_UpdateEnvironmentClass_Persisted(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "class-persist", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "class-persist", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("class-persist") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "class-persist") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("class-persist", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "class-persist", &mwaa.ExportedUpdateEnvironmentRequest{
 		EnvironmentClass: "mw1.large",
 	})
 	require.NoError(t, err)
 
-	env, err := b.GetEnvironment("class-persist")
+	env, err := b.GetEnvironment(context.Background(), "class-persist")
 	require.NoError(t, err)
 	assert.Equal(t, "mw1.large", env.EnvironmentClass)
 }
@@ -881,11 +898,11 @@ func TestAccuracy_CliToken_JWTShaped(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "jwt-cli-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "jwt-cli-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("jwt-cli-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "jwt-cli-env") // promote CREATING → AVAILABLE
 
-	token, err := b.CreateCliToken("jwt-cli-env")
+	token, err := b.CreateCliToken(context.Background(), "jwt-cli-env")
 	require.NoError(t, err)
 
 	parts := strings.Split(token, ".")
@@ -899,11 +916,11 @@ func TestAccuracy_WebLoginToken_JWTShaped(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "jwt-web-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "jwt-web-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("jwt-web-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "jwt-web-env") // promote CREATING → AVAILABLE
 
-	token, err := b.CreateWebLoginToken("jwt-web-env")
+	token, err := b.CreateWebLoginToken(context.Background(), "jwt-web-env")
 	require.NoError(t, err)
 
 	parts := strings.Split(token, ".")
@@ -917,14 +934,14 @@ func TestAccuracy_CliToken_DifferentFromWebToken(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "token-diff-env", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "token-diff-env", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("token-diff-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "token-diff-env") // promote CREATING → AVAILABLE
 
-	cli, err := b.CreateCliToken("token-diff-env")
+	cli, err := b.CreateCliToken(context.Background(), "token-diff-env")
 	require.NoError(t, err)
 
-	web, err := b.CreateWebLoginToken("token-diff-env")
+	web, err := b.CreateWebLoginToken(context.Background(), "token-diff-env")
 	require.NoError(t, err)
 
 	assert.NotEqual(t, cli, web, "CLI token and web login token must differ")
@@ -934,17 +951,17 @@ func TestAccuracy_Token_DifferentPerEnvironment(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "env-token-a", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "env-token-a", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("env-token-a") // promote CREATING → AVAILABLE
-	_, err = b.CreateEnvironment(testRegion, testAccountID, "env-token-b", newCreateReq())
+	_, _ = b.GetEnvironment(context.Background(), "env-token-a") // promote CREATING → AVAILABLE
+	_, err = b.CreateEnvironment(context.Background(), "env-token-b", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("env-token-b") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "env-token-b") // promote CREATING → AVAILABLE
 
-	tokenA, err := b.CreateCliToken("env-token-a")
+	tokenA, err := b.CreateCliToken(context.Background(), "env-token-a")
 	require.NoError(t, err)
 
-	tokenB, err := b.CreateCliToken("env-token-b")
+	tokenB, err := b.CreateCliToken(context.Background(), "env-token-b")
 	require.NoError(t, err)
 
 	assert.NotEqual(t, tokenA, tokenB, "tokens for different environments must differ")
@@ -1010,31 +1027,31 @@ func TestAccuracy_FullLifecycle_AllValidations(t *testing.T) {
 	req.MaxWorkers = 20
 	req.MinWorkers = 2
 
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "full-lifecycle-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "full-lifecycle-env", req)
 	require.NoError(t, err)
 	assert.Equal(t, "2.8.1", env.AirflowVersion)
 	assert.Equal(t, "mw1.medium", env.EnvironmentClass)
-	_, _ = b.GetEnvironment("full-lifecycle-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "full-lifecycle-env") // promote CREATING → AVAILABLE
 
 	// Update with valid strategy and access mode.
-	_, err = b.UpdateEnvironment("full-lifecycle-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "full-lifecycle-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		WorkerReplacementStrategy: "TERMINATION_WITH_DRAIN",
 		WebserverAccessMode:       "PRIVATE_ONLY",
 		EnvironmentClass:          "mw1.large",
 	})
 	require.NoError(t, err)
 
-	got, err := b.GetEnvironment("full-lifecycle-env")
+	got, err := b.GetEnvironment(context.Background(), "full-lifecycle-env")
 	require.NoError(t, err)
 	assert.Equal(t, "PRIVATE_ONLY", got.WebserverAccessMode)
 	assert.Equal(t, "mw1.large", got.EnvironmentClass)
 
 	// Tokens should be JWT-shaped.
-	cli, err := b.CreateCliToken("full-lifecycle-env")
+	cli, err := b.CreateCliToken(context.Background(), "full-lifecycle-env")
 	require.NoError(t, err)
 	assert.Len(t, strings.Split(cli, "."), 3)
 
-	web, err := b.CreateWebLoginToken("full-lifecycle-env")
+	web, err := b.CreateWebLoginToken(context.Background(), "full-lifecycle-env")
 	require.NoError(t, err)
 	assert.Len(t, strings.Split(web, "."), 3)
 }
@@ -1048,7 +1065,7 @@ func TestAccuracy_MultipleValidationErrors_FirstReturned(t *testing.T) {
 	req.EnvironmentClass = "mw99.huge"
 	req.MaxWorkers = 999
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "multi-err-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "multi-err-env", req)
 	require.Error(t, err)
 }
 
@@ -1061,7 +1078,7 @@ func TestAccuracy_CreateEnvironment_NameValidationBeforeBodyValidation(t *testin
 	req := newCreateReq()
 	req.DagS3Path = "" // required field
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "1invalid-name", req)
+	_, err := b.CreateEnvironment(context.Background(), "1invalid-name", req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "environment name")
 }
@@ -1079,11 +1096,11 @@ func TestAccuracy_TagLimit_Create_ExactlyAtLimit_ThenOneMore(t *testing.T) {
 
 	req := newCreateReq()
 	req.Tags = tags50
-	env, err := b.CreateEnvironment(testRegion, testAccountID, "tag-boundary-env", req)
+	env, err := b.CreateEnvironment(context.Background(), "tag-boundary-env", req)
 	require.NoError(t, err)
 
 	// One more new tag — must fail.
-	err = b.TagResource(env.ARN, map[string]string{"brand-new": "v"})
+	err = b.TagResource(context.Background(), env.ARN, map[string]string{"brand-new": "v"})
 	require.Error(t, err)
 }
 
@@ -1095,7 +1112,7 @@ func TestAccuracy_AirflowVersion_V1_SchedulerConstraint(t *testing.T) {
 	req.AirflowVersion = "1.10.12"
 	req.Schedulers = 2 // v1 only supports 1 scheduler
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "v1-schedulers-env", req)
+	_, err := b.CreateEnvironment(context.Background(), "v1-schedulers-env", req)
 	require.Error(t, err)
 }
 
@@ -1107,7 +1124,7 @@ func TestAccuracy_AirflowVersion_V1_SingleSchedulerOK(t *testing.T) {
 	req.AirflowVersion = "1.10.12"
 	req.Schedulers = 1
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "v1-scheduler-ok", req)
+	_, err := b.CreateEnvironment(context.Background(), "v1-scheduler-ok", req)
 	require.NoError(t, err)
 }
 
@@ -1115,12 +1132,12 @@ func TestAccuracy_MaxWorkers_Update_ZeroNoCheck(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "workers-zero-upd", newCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "workers-zero-upd", newCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("workers-zero-upd") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "workers-zero-upd") // promote CREATING → AVAILABLE
 
 	// MaxWorkers=0 in update means "don't change" — no validation should fire.
-	_, err = b.UpdateEnvironment("workers-zero-upd", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "workers-zero-upd", &mwaa.ExportedUpdateEnvironmentRequest{
 		MaxWorkers: 0,
 	})
 	require.NoError(t, err)
@@ -1138,7 +1155,7 @@ func TestAccuracy_EnvironmentName_AllSupportedSpecialChars(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, name, newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), name, newCreateReq())
 			require.NoError(t, err)
 		})
 	}
@@ -1160,17 +1177,21 @@ func TestAccuracy_UpdateWorkerReplacementStrategy_Persisted(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "persist-strat-"+tt.name, newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "persist-strat-"+tt.name, newCreateReq())
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("persist-strat-" + tt.name) // promote CREATING → AVAILABLE
+			_, _ = b.GetEnvironment(context.Background(), "persist-strat-"+tt.name) // promote CREATING → AVAILABLE
 
-			_, err = b.UpdateEnvironment("persist-strat-"+tt.name, &mwaa.ExportedUpdateEnvironmentRequest{
-				WorkerReplacementStrategy: tt.strategy,
-			})
+			_, err = b.UpdateEnvironment(
+				context.Background(),
+				"persist-strat-"+tt.name,
+				&mwaa.ExportedUpdateEnvironmentRequest{
+					WorkerReplacementStrategy: tt.strategy,
+				},
+			)
 			require.NoError(t, err)
 
 			// Fetch and check LastUpdate carries the strategy.
-			env, err := b.GetEnvironment("persist-strat-" + tt.name)
+			env, err := b.GetEnvironment(context.Background(), "persist-strat-"+tt.name)
 			require.NoError(t, err)
 			require.NotNil(t, env.LastUpdate)
 			assert.Equal(t, tt.strategy, env.LastUpdate.WorkerReplacementStrategy)

--- a/services/mwaa/handler_refinement1_test.go
+++ b/services/mwaa/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package mwaa_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -47,13 +48,13 @@ func makeEchoContextWithAuth(t *testing.T, method, path, svcName string) *echo.C
 func seedEnv(t *testing.T, b *mwaa.InMemoryBackend, name string) {
 	t.Helper()
 
-	_, err := b.CreateEnvironment("us-east-1", testAccountID, name, &mwaa.ExportedCreateEnvironmentRequest{
+	_, err := b.CreateEnvironment(context.Background(), name, &mwaa.ExportedCreateEnvironmentRequest{
 		DagS3Path:        "dags/",
 		ExecutionRoleArn: "arn:aws:iam::123456789012:role/role",
 		SourceBucketArn:  "arn:aws:s3:::bucket",
 	})
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment(name)
+	_, _ = b.GetEnvironment(context.Background(), name)
 }
 
 // ----------------------------------------
@@ -165,7 +166,7 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 	assert.Equal(t, 1, mwaa.EnvironmentCount(b2))
 	assert.Equal(t, 1, mwaa.ARNIndexSize(b2))
 
-	env, err := b2.GetEnvironment("persist-env")
+	env, err := b2.GetEnvironment(context.Background(), "persist-env")
 	require.NoError(t, err)
 	assert.Equal(t, "persist-env", env.Name)
 }
@@ -209,7 +210,7 @@ func TestRefinement1_CreateEnvironment_RequiredFields(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "env", tt.req)
+			_, err := b.CreateEnvironment(context.Background(), "env", tt.req)
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantMsg)
@@ -236,7 +237,7 @@ func TestRefinement1_CreateEnvironment_WebserverAccessMode(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "env", &mwaa.ExportedCreateEnvironmentRequest{
+			_, err := b.CreateEnvironment(context.Background(), "env", &mwaa.ExportedCreateEnvironmentRequest{
 				DagS3Path:           "dags/",
 				ExecutionRoleArn:    "arn:aws:iam::123456789012:role/role",
 				SourceBucketArn:     "arn:aws:s3:::bucket",
@@ -274,7 +275,7 @@ func TestRefinement1_CreateEnvironment_EnvironmentClass(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "env", &mwaa.ExportedCreateEnvironmentRequest{
+			_, err := b.CreateEnvironment(context.Background(), "env", &mwaa.ExportedCreateEnvironmentRequest{
 				DagS3Path:        "dags/",
 				ExecutionRoleArn: "arn:aws:iam::123456789012:role/role",
 				SourceBucketArn:  "arn:aws:s3:::bucket",
@@ -296,7 +297,7 @@ func TestRefinement1_CreateEnvironment_Duplicate(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	seedEnv(t, b, "dup-env")
 
-	_, err := b.CreateEnvironment(testRegion, testAccountID, "dup-env", &mwaa.ExportedCreateEnvironmentRequest{
+	_, err := b.CreateEnvironment(context.Background(), "dup-env", &mwaa.ExportedCreateEnvironmentRequest{
 		DagS3Path:        "dags/",
 		ExecutionRoleArn: "arn:aws:iam::123456789012:role/role",
 		SourceBucketArn:  "arn:aws:s3:::bucket",
@@ -312,7 +313,7 @@ func TestRefinement1_GetEnvironment_DeepCopy(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	seedEnv(t, b, "deep-copy-env")
 
-	env1, err := b.GetEnvironment("deep-copy-env")
+	env1, err := b.GetEnvironment(context.Background(), "deep-copy-env")
 	require.NoError(t, err)
 
 	// Mutate the returned copy.
@@ -320,7 +321,7 @@ func TestRefinement1_GetEnvironment_DeepCopy(t *testing.T) {
 	env1.Tags["injected"] = "value"
 
 	// Re-fetch should have original name.
-	env2, err := b.GetEnvironment("deep-copy-env")
+	env2, err := b.GetEnvironment(context.Background(), "deep-copy-env")
 	require.NoError(t, err)
 
 	assert.Equal(t, "deep-copy-env", env2.Name)
@@ -334,7 +335,7 @@ func TestRefinement1_DeleteEnvironment_CleansUpMetrics(t *testing.T) {
 	seedEnv(t, b, "metrics-env")
 
 	v := float64(1.0)
-	err := b.PublishMetrics("metrics-env", &mwaa.ExportedPublishMetricsRequest{
+	err := b.PublishMetrics(context.Background(), "metrics-env", &mwaa.ExportedPublishMetricsRequest{
 		MetricData: []mwaa.ExportedMetricDatum{
 			{MetricName: "Workers", Value: &v},
 		},
@@ -342,7 +343,7 @@ func TestRefinement1_DeleteEnvironment_CleansUpMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, mwaa.MetricsCount(b, "metrics-env"))
 
-	_, err = b.DeleteEnvironment("metrics-env")
+	_, err = b.DeleteEnvironment(context.Background(), "metrics-env")
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, mwaa.MetricsCount(b, "metrics-env"))
@@ -352,7 +353,7 @@ func TestRefinement1_PublishMetrics_EnvNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	err := b.PublishMetrics("nonexistent", &mwaa.ExportedPublishMetricsRequest{})
+	err := b.PublishMetrics(context.Background(), "nonexistent", &mwaa.ExportedPublishMetricsRequest{})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound)
@@ -362,7 +363,7 @@ func TestRefinement1_CreateCliToken_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateCliToken("missing-env")
+	_, err := b.CreateCliToken(context.Background(), "missing-env")
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound)
@@ -372,7 +373,7 @@ func TestRefinement1_CreateWebLoginToken_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-	_, err := b.CreateWebLoginToken("missing-env")
+	_, err := b.CreateWebLoginToken(context.Background(), "missing-env")
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound)
@@ -384,7 +385,7 @@ func TestRefinement1_CreateCliToken_HappyPath(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	seedEnv(t, b, "cli-env")
 
-	token, err := b.CreateCliToken("cli-env")
+	token, err := b.CreateCliToken(context.Background(), "cli-env")
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
@@ -399,7 +400,7 @@ func TestRefinement1_CreateWebLoginToken_HappyPath(t *testing.T) {
 	b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 	seedEnv(t, b, "web-env")
 
-	token, err := b.CreateWebLoginToken("web-env")
+	token, err := b.CreateWebLoginToken(context.Background(), "web-env")
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
@@ -501,7 +502,7 @@ func TestRefinement1_UpdateEnvironment_MinMaxWorkers(t *testing.T) {
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 			seedEnv(t, b, "worker-env")
 
-			_, err := b.UpdateEnvironment("worker-env", tt.update)
+			_, err := b.UpdateEnvironment(context.Background(), "worker-env", tt.update)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/services/mwaa/interfaces.go
+++ b/services/mwaa/interfaces.go
@@ -1,28 +1,32 @@
 package mwaa
 
+import "context"
+
 // StorageBackend is the interface for the MWAA in-memory backend.
+// All per-resource operations take a context.Context carrying the request's
+// AWS region so resources are isolated per region.
 type StorageBackend interface {
 	// Environment CRUD
-	CreateEnvironment(region, accountID, name string, req *createEnvironmentRequest) (*Environment, error)
-	GetEnvironment(name string) (*Environment, error)
-	DeleteEnvironment(name string) (*Environment, error)
-	UpdateEnvironment(name string, req *updateEnvironmentRequest) (*Environment, error)
-	ListEnvironments() ([]string, error)
-	ListEnvironmentsPage(nextToken string, pageSize int) ([]string, string, error)
+	CreateEnvironment(ctx context.Context, name string, req *createEnvironmentRequest) (*Environment, error)
+	GetEnvironment(ctx context.Context, name string) (*Environment, error)
+	DeleteEnvironment(ctx context.Context, name string) (*Environment, error)
+	UpdateEnvironment(ctx context.Context, name string, req *updateEnvironmentRequest) (*Environment, error)
+	ListEnvironments(ctx context.Context) ([]string, error)
+	ListEnvironmentsPage(ctx context.Context, nextToken string, pageSize int) ([]string, string, error)
 
 	// Tag operations
-	TagResource(resourceARN string, tags map[string]string) error
-	UntagResource(resourceARN string, tagKeys []string) error
-	ListTagsForResource(resourceARN string) (map[string]string, error)
+	TagResource(ctx context.Context, resourceARN string, tags map[string]string) error
+	UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error
+	ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error)
 
 	// REST API / metrics
-	InvokeRestAPI(envName string, req *invokeRestAPIRequest) (*InvokeRestAPIResponse, error)
-	PublishMetrics(envName string, req *publishMetricsRequest) error
-	GetMetrics(envName string) ([]MetricDatum, error)
+	InvokeRestAPI(ctx context.Context, envName string, req *invokeRestAPIRequest) (*InvokeRestAPIResponse, error)
+	PublishMetrics(ctx context.Context, envName string, req *publishMetricsRequest) error
+	GetMetrics(ctx context.Context, envName string) ([]MetricDatum, error)
 
 	// Token operations
-	CreateCliToken(envName string) (string, error)
-	CreateWebLoginToken(envName string) (string, error)
+	CreateCliToken(ctx context.Context, envName string) (string, error)
+	CreateWebLoginToken(ctx context.Context, envName string) (string, error)
 
 	// Lifecycle
 	Reset()

--- a/services/mwaa/isolation_test.go
+++ b/services/mwaa/isolation_test.go
@@ -1,0 +1,120 @@
+package mwaa //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isoCtxRegion returns a context carrying the given AWS region under the
+// unexported region context key, mirroring what the handler injects per request.
+func isoCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// newIsoCreateReq returns a minimal valid create request for isolation tests.
+func newIsoCreateReq() *createEnvironmentRequest {
+	return &createEnvironmentRequest{
+		DagS3Path:        "dags/",
+		ExecutionRoleArn: "arn:aws:iam::000000000000:role/mwaa",
+		SourceBucketArn:  "arn:aws:s3:::mwaa-bucket",
+	}
+}
+
+func TestMWAAEnvironmentRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("us-east-1", "000000000000")
+
+	ctxEast := isoCtxRegion("us-east-1")
+	ctxWest := isoCtxRegion("us-west-2")
+
+	// 1. Create an environment named "env1" in us-east-1.
+	eastEnv, err := backend.CreateEnvironment(ctxEast, "env1", newIsoCreateReq())
+	require.NoError(t, err)
+	assert.Contains(t, eastEnv.ARN, "us-east-1")
+
+	// 2. Create an environment with the SAME NAME in us-west-2.
+	westReq := newIsoCreateReq()
+	westReq.EnvironmentClass = "mw1.large"
+	westEnv, err := backend.CreateEnvironment(ctxWest, "env1", westReq)
+	require.NoError(t, err)
+	assert.Contains(t, westEnv.ARN, "us-west-2")
+
+	// 3. Each region sees only its own environment.
+	eastList, err := backend.ListEnvironments(ctxEast)
+	require.NoError(t, err)
+	require.Equal(t, []string{"env1"}, eastList)
+
+	westList, err := backend.ListEnvironments(ctxWest)
+	require.NoError(t, err)
+	require.Equal(t, []string{"env1"}, westList)
+
+	// 4. Get returns the region-specific environment (distinct ARN + class).
+	gotEast, err := backend.GetEnvironment(ctxEast, "env1")
+	require.NoError(t, err)
+	assert.Contains(t, gotEast.ARN, "us-east-1")
+	assert.Equal(t, defaultEnvironmentClass, gotEast.EnvironmentClass)
+
+	gotWest, err := backend.GetEnvironment(ctxWest, "env1")
+	require.NoError(t, err)
+	assert.Contains(t, gotWest.ARN, "us-west-2")
+	assert.Equal(t, "mw1.large", gotWest.EnvironmentClass)
+
+	// 5. Deleting in us-east-1 leaves us-west-2's environment intact.
+	_, err = backend.DeleteEnvironment(ctxEast, "env1")
+	require.NoError(t, err)
+
+	_, err = backend.GetEnvironment(ctxEast, "env1")
+	require.ErrorIs(t, err, ErrEnvironmentNotFound)
+
+	stillWest, err := backend.GetEnvironment(ctxWest, "env1")
+	require.NoError(t, err)
+	assert.Contains(t, stillWest.ARN, "us-west-2")
+}
+
+func TestMWAATagsAndMetricsRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("us-east-1", "000000000000")
+
+	ctxEast := isoCtxRegion("us-east-1")
+	ctxWest := isoCtxRegion("us-west-2")
+
+	eastEnv, err := backend.CreateEnvironment(ctxEast, "shared", newIsoCreateReq())
+	require.NoError(t, err)
+
+	westEnv, err := backend.CreateEnvironment(ctxWest, "shared", newIsoCreateReq())
+	require.NoError(t, err)
+
+	// Tag the us-east-1 environment only.
+	require.NoError(t, backend.TagResource(ctxEast, eastEnv.ARN, map[string]string{"team": "east"}))
+
+	eastTags, err := backend.ListTagsForResource(ctxEast, eastEnv.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"team": "east"}, eastTags)
+
+	// us-west-2 environment has no tags and its ARN is unknown to the us-east-1 store.
+	westTags, err := backend.ListTagsForResource(ctxWest, westEnv.ARN)
+	require.NoError(t, err)
+	assert.Empty(t, westTags)
+
+	// The us-east-1 ARN is not resolvable from the us-west-2 region store.
+	_, err = backend.ListTagsForResource(ctxWest, eastEnv.ARN)
+	require.ErrorIs(t, err, ErrEnvironmentNotFound)
+
+	// Publish metrics only into us-west-2; us-east-1 must not see them.
+	require.NoError(t, backend.PublishMetrics(ctxWest, "shared", &publishMetricsRequest{
+		MetricData: []MetricDatum{{MetricName: "m1"}},
+	}))
+
+	westMetrics, err := backend.GetMetrics(ctxWest, "shared")
+	require.NoError(t, err)
+	require.Len(t, westMetrics, 1)
+
+	eastMetrics, err := backend.GetMetrics(ctxEast, "shared")
+	require.NoError(t, err)
+	assert.Empty(t, eastMetrics)
+}

--- a/services/mwaa/leak_test.go
+++ b/services/mwaa/leak_test.go
@@ -1,6 +1,7 @@
 package mwaa_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -29,14 +30,14 @@ func TestPublishMetrics_TrimDoesNotRetainOversizedArray(t *testing.T) {
 			t.Parallel()
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "leak-env", newCreateReq())
+			_, err := b.CreateEnvironment(context.Background(), "leak-env", newCreateReq())
 			require.NoError(t, err)
 
 			data := make([]mwaa.ExportedMetricDatum, tc.publish)
 			for i := range data {
 				data[i] = mwaa.ExportedMetricDatum{MetricName: fmt.Sprintf("M%d", i)}
 			}
-			require.NoError(t, b.PublishMetrics("leak-env",
+			require.NoError(t, b.PublishMetrics(context.Background(), "leak-env",
 				&mwaa.ExportedPublishMetricsRequest{MetricData: data}))
 
 			// len is capped...

--- a/services/mwaa/lifecycle_parity_test.go
+++ b/services/mwaa/lifecycle_parity_test.go
@@ -1,6 +1,7 @@
 package mwaa_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,20 +33,20 @@ func TestUpdateEnvironment_StatusTransitionsToUpdatingThenAvailable(t *testing.T
 
 	b := newLifecycleBackend(t)
 
-	_, err := b.CreateEnvironment("us-east-1", "123456789012", "lc-env", newLifecycleCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "lc-env", newLifecycleCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("lc-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "lc-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("lc-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "lc-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		EnvironmentClass: "mw1.medium",
 	})
 	require.NoError(t, err)
 
-	first, err := b.GetEnvironment("lc-env")
+	first, err := b.GetEnvironment(context.Background(), "lc-env")
 	require.NoError(t, err)
 	assert.Equal(t, "UPDATING", first.Status)
 
-	second, err := b.GetEnvironment("lc-env")
+	second, err := b.GetEnvironment(context.Background(), "lc-env")
 	require.NoError(t, err)
 	assert.Equal(t, "AVAILABLE", second.Status)
 }
@@ -55,11 +56,11 @@ func TestUpdateEnvironment_RejectsEmptyNetworkConfig(t *testing.T) {
 
 	b := newLifecycleBackend(t)
 
-	_, err := b.CreateEnvironment("us-east-1", "123456789012", "nc-env", newLifecycleCreateReq())
+	_, err := b.CreateEnvironment(context.Background(), "nc-env", newLifecycleCreateReq())
 	require.NoError(t, err)
-	_, _ = b.GetEnvironment("nc-env") // promote CREATING → AVAILABLE
+	_, _ = b.GetEnvironment(context.Background(), "nc-env") // promote CREATING → AVAILABLE
 
-	_, err = b.UpdateEnvironment("nc-env", &mwaa.ExportedUpdateEnvironmentRequest{
+	_, err = b.UpdateEnvironment(context.Background(), "nc-env", &mwaa.ExportedUpdateEnvironmentRequest{
 		NetworkConfiguration: &mwaa.NetworkConfig{},
 	})
 	require.Error(t, err)

--- a/services/mwaa/new_operations_test.go
+++ b/services/mwaa/new_operations_test.go
@@ -1,6 +1,7 @@
 package mwaa_test
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -492,7 +493,7 @@ func TestHandler_CreateEnvironment_InvalidJSON(t *testing.T) {
 
 			// Test the create environment validation path via backend directly.
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
-			_, err := b.CreateEnvironment(testRegion, testAccountID, "env-err", &mwaa.ExportedCreateEnvironmentRequest{
+			_, err := b.CreateEnvironment(context.Background(), "env-err", &mwaa.ExportedCreateEnvironmentRequest{
 				DagS3Path:        "dags/",
 				ExecutionRoleArn: "arn:r",
 				SourceBucketArn:  "arn:b",
@@ -543,8 +544,7 @@ func TestBackend_UpdateEnvironment_MinMaxValidation(t *testing.T) {
 
 			b := mwaa.NewInMemoryBackend(testRegion, testAccountID)
 			_, err := b.CreateEnvironment(
-				testRegion,
-				testAccountID,
+				context.Background(),
 				"env-update",
 				&mwaa.ExportedCreateEnvironmentRequest{
 					DagS3Path:        "dags/",
@@ -553,9 +553,9 @@ func TestBackend_UpdateEnvironment_MinMaxValidation(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			_, _ = b.GetEnvironment("env-update")
+			_, _ = b.GetEnvironment(context.Background(), "env-update")
 
-			_, err = b.UpdateEnvironment("env-update", tt.updateReq)
+			_, err = b.UpdateEnvironment(context.Background(), "env-update", tt.updateReq)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1186,11 +1186,11 @@ func TestBackend_InvokeRestApi(t *testing.T) {
 			b := newTestBackend()
 
 			if tt.seed {
-				_, err := b.CreateEnvironment(testRegion, testAccountID, tt.envName, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 				require.NoError(t, err)
 			}
 
-			resp, err := b.InvokeRestAPI(tt.envName, tt.req)
+			resp, err := b.InvokeRestAPI(context.Background(), tt.envName, tt.req)
 			if tt.wantErr {
 				require.Error(t, err)
 
@@ -1246,11 +1246,11 @@ func TestBackend_PublishMetrics(t *testing.T) {
 			b := newTestBackend()
 
 			if tt.seed {
-				_, err := b.CreateEnvironment(testRegion, testAccountID, tt.envName, newCreateReq())
+				_, err := b.CreateEnvironment(context.Background(), tt.envName, newCreateReq())
 				require.NoError(t, err)
 			}
 
-			err := b.PublishMetrics(tt.envName, tt.req)
+			err := b.PublishMetrics(context.Background(), tt.envName, tt.req)
 			if tt.wantErr {
 				require.Error(t, err)
 

--- a/services/mwaa/ops_batch2_audit_test.go
+++ b/services/mwaa/ops_batch2_audit_test.go
@@ -8,6 +8,7 @@ package mwaa_test
 // ValidationException when env is in a transient state such as CREATING).
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestOpsB2_CreateCliToken_RequiresAvailable(t *testing.T) {
 			env := b.AddEnvironmentInternal("cli-state-env-" + tt.name)
 			env.Status = tt.status
 
-			_, err := b.CreateCliToken("cli-state-env-" + tt.name)
+			_, err := b.CreateCliToken(context.Background(), "cli-state-env-"+tt.name)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound,
@@ -97,7 +98,7 @@ func TestOpsB2_CreateWebLoginToken_RequiresAvailable(t *testing.T) {
 			env := b.AddEnvironmentInternal("web-state-env-" + tt.name)
 			env.Status = tt.status
 
-			_, err := b.CreateWebLoginToken("web-state-env-" + tt.name)
+			_, err := b.CreateWebLoginToken(context.Background(), "web-state-env-"+tt.name)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.ErrorIs(t, err, mwaa.ErrEnvironmentNotFound,
@@ -150,9 +151,13 @@ func TestOpsB2_UpdateEnvironment_RequiresAvailable(t *testing.T) {
 			env := b.AddEnvironmentInternal("upd-state-env-" + tt.name)
 			env.Status = tt.status
 
-			_, err := b.UpdateEnvironment("upd-state-env-"+tt.name, &mwaa.ExportedUpdateEnvironmentRequest{
-				DagS3Path: "new-dags/",
-			})
+			_, err := b.UpdateEnvironment(
+				context.Background(),
+				"upd-state-env-"+tt.name,
+				&mwaa.ExportedUpdateEnvironmentRequest{
+					DagS3Path: "new-dags/",
+				},
+			)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.ErrorIs(t, err, mwaa.ErrInvalidParameter,

--- a/services/mwaa/persistence.go
+++ b/services/mwaa/persistence.go
@@ -6,11 +6,13 @@ import (
 )
 
 type backendSnapshot struct {
-	Environments map[string]*Environment  `json:"environments"`
-	ARNIndex     map[string]string        `json:"arnIndex"`
-	Metrics      map[string][]MetricDatum `json:"metrics"`
-	AccountID    string                   `json:"accountID"`
-	Region       string                   `json:"region"`
+	// Environments, ARNIndex and Metrics are nested by region (outer key = region)
+	// so that same-named resources in different regions remain isolated.
+	Environments map[string]map[string]*Environment  `json:"environments"`
+	ARNIndex     map[string]map[string]string        `json:"arnIndex"`
+	Metrics      map[string]map[string][]MetricDatum `json:"metrics"`
+	AccountID    string                              `json:"accountID"`
+	Region       string                              `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -62,23 +64,25 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 // ensureNonNilMaps initialises nil maps in the snapshot to empty maps.
 func ensureNonNilMaps(snap *backendSnapshot) {
 	if snap.Environments == nil {
-		snap.Environments = make(map[string]*Environment)
+		snap.Environments = make(map[string]map[string]*Environment)
 	}
 
 	if snap.ARNIndex == nil {
-		snap.ARNIndex = make(map[string]string)
+		snap.ARNIndex = make(map[string]map[string]string)
 	}
 
 	if snap.Metrics == nil {
-		snap.Metrics = make(map[string][]MetricDatum)
+		snap.Metrics = make(map[string]map[string][]MetricDatum)
 	}
 }
 
 // fixNilEnvTags ensures restored environments have non-nil tag maps.
 func fixNilEnvTags(snap *backendSnapshot) {
-	for _, env := range snap.Environments {
-		if env.Tags == nil {
-			env.Tags = make(map[string]string)
+	for _, regionEnvs := range snap.Environments {
+		for _, env := range regionEnvs {
+			if env.Tags == nil {
+				env.Tags = make(map[string]string)
+			}
 		}
 	}
 }

--- a/services/neptune/backend.go
+++ b/services/neptune/backend.go
@@ -1,6 +1,7 @@
 package neptune
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -9,6 +10,30 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/arn"
 	"github.com/blackbirdworks/gopherstack/pkgs/lockmetrics"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
+}
 
 const (
 	pgFamilyDefaultNeptune13 = "default.neptune1.3"
@@ -256,18 +281,22 @@ type GlobalClusterMember struct {
 }
 
 // InMemoryBackend is a thread-safe in-memory backend for Neptune.
+//
+// All regional resource maps are nested by region (outer key = region) so that
+// same-named resources in different regions are fully isolated. GlobalClusters
+// are global/partition-scoped (like AWS) and therefore are NOT region-nested.
 type InMemoryBackend struct {
-	clusters               map[string]*DBCluster
-	instances              map[string]*DBInstance
-	subnetGroups           map[string]*DBSubnetGroup
-	clusterParameterGroups map[string]*DBClusterParameterGroup
-	clusterSnapshots       map[string]*DBClusterSnapshot
-	parameterGroups        map[string]*DBParameterGroup
-	clusterEndpoints       map[string]*DBClusterEndpoint
-	eventSubscriptions     map[string]*EventSubscription
-	globalClusters         map[string]*GlobalCluster
-	clusterRoles           map[string][]string
-	tags                   map[string][]Tag
+	clusters               map[string]map[string]*DBCluster
+	instances              map[string]map[string]*DBInstance
+	subnetGroups           map[string]map[string]*DBSubnetGroup
+	clusterParameterGroups map[string]map[string]*DBClusterParameterGroup
+	clusterSnapshots       map[string]map[string]*DBClusterSnapshot
+	parameterGroups        map[string]map[string]*DBParameterGroup
+	clusterEndpoints       map[string]map[string]*DBClusterEndpoint
+	eventSubscriptions     map[string]map[string]*EventSubscription
+	clusterRoles           map[string]map[string][]string
+	tags                   map[string]map[string][]Tag
+	globalClusters         map[string]*GlobalCluster // global/partition-scoped, not region-nested
 	mu                     *lockmetrics.RWMutex
 	accountID              string
 	region                 string
@@ -276,17 +305,17 @@ type InMemoryBackend struct {
 // NewInMemoryBackend creates a new in-memory Neptune backend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		clusters:               make(map[string]*DBCluster),
-		instances:              make(map[string]*DBInstance),
-		subnetGroups:           make(map[string]*DBSubnetGroup),
-		clusterParameterGroups: make(map[string]*DBClusterParameterGroup),
-		clusterSnapshots:       make(map[string]*DBClusterSnapshot),
-		parameterGroups:        make(map[string]*DBParameterGroup),
-		clusterEndpoints:       make(map[string]*DBClusterEndpoint),
-		eventSubscriptions:     make(map[string]*EventSubscription),
+		clusters:               make(map[string]map[string]*DBCluster),
+		instances:              make(map[string]map[string]*DBInstance),
+		subnetGroups:           make(map[string]map[string]*DBSubnetGroup),
+		clusterParameterGroups: make(map[string]map[string]*DBClusterParameterGroup),
+		clusterSnapshots:       make(map[string]map[string]*DBClusterSnapshot),
+		parameterGroups:        make(map[string]map[string]*DBParameterGroup),
+		clusterEndpoints:       make(map[string]map[string]*DBClusterEndpoint),
+		eventSubscriptions:     make(map[string]map[string]*EventSubscription),
+		clusterRoles:           make(map[string]map[string][]string),
+		tags:                   make(map[string]map[string][]Tag),
 		globalClusters:         make(map[string]*GlobalCluster),
-		clusterRoles:           make(map[string][]string),
-		tags:                   make(map[string][]Tag),
 		accountID:              accountID,
 		region:                 region,
 		mu:                     lockmetrics.New("neptune"),
@@ -295,6 +324,89 @@ func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 
 // Region returns the backend's AWS region.
 func (b *InMemoryBackend) Region() string { return b.region }
+
+// The following lazy per-region store helpers return the resource map for the
+// given region, creating it on first use. Callers must hold b.mu.
+
+func (b *InMemoryBackend) clustersStore(region string) map[string]*DBCluster {
+	if b.clusters[region] == nil {
+		b.clusters[region] = make(map[string]*DBCluster)
+	}
+
+	return b.clusters[region]
+}
+
+func (b *InMemoryBackend) instancesStore(region string) map[string]*DBInstance {
+	if b.instances[region] == nil {
+		b.instances[region] = make(map[string]*DBInstance)
+	}
+
+	return b.instances[region]
+}
+
+func (b *InMemoryBackend) subnetGroupsStore(region string) map[string]*DBSubnetGroup {
+	if b.subnetGroups[region] == nil {
+		b.subnetGroups[region] = make(map[string]*DBSubnetGroup)
+	}
+
+	return b.subnetGroups[region]
+}
+
+func (b *InMemoryBackend) clusterParameterGroupsStore(region string) map[string]*DBClusterParameterGroup {
+	if b.clusterParameterGroups[region] == nil {
+		b.clusterParameterGroups[region] = make(map[string]*DBClusterParameterGroup)
+	}
+
+	return b.clusterParameterGroups[region]
+}
+
+func (b *InMemoryBackend) clusterSnapshotsStore(region string) map[string]*DBClusterSnapshot {
+	if b.clusterSnapshots[region] == nil {
+		b.clusterSnapshots[region] = make(map[string]*DBClusterSnapshot)
+	}
+
+	return b.clusterSnapshots[region]
+}
+
+func (b *InMemoryBackend) parameterGroupsStore(region string) map[string]*DBParameterGroup {
+	if b.parameterGroups[region] == nil {
+		b.parameterGroups[region] = make(map[string]*DBParameterGroup)
+	}
+
+	return b.parameterGroups[region]
+}
+
+func (b *InMemoryBackend) clusterEndpointsStore(region string) map[string]*DBClusterEndpoint {
+	if b.clusterEndpoints[region] == nil {
+		b.clusterEndpoints[region] = make(map[string]*DBClusterEndpoint)
+	}
+
+	return b.clusterEndpoints[region]
+}
+
+func (b *InMemoryBackend) eventSubscriptionsStore(region string) map[string]*EventSubscription {
+	if b.eventSubscriptions[region] == nil {
+		b.eventSubscriptions[region] = make(map[string]*EventSubscription)
+	}
+
+	return b.eventSubscriptions[region]
+}
+
+func (b *InMemoryBackend) clusterRolesStore(region string) map[string][]string {
+	if b.clusterRoles[region] == nil {
+		b.clusterRoles[region] = make(map[string][]string)
+	}
+
+	return b.clusterRoles[region]
+}
+
+func (b *InMemoryBackend) tagsStore(region string) map[string][]Tag {
+	if b.tags[region] == nil {
+		b.tags[region] = make(map[string][]Tag)
+	}
+
+	return b.tags[region]
+}
 
 // cloneCluster deep-copies a DBCluster to avoid shared slice/pointer mutation.
 func cloneCluster(c *DBCluster) DBCluster {
@@ -313,33 +425,91 @@ func cloneCluster(c *DBCluster) DBCluster {
 	return cp
 }
 
-// clusterARN returns the ARN for a Neptune DB cluster.
-func (b *InMemoryBackend) clusterARN(id string) string {
-	return arn.Build("neptune", b.region, b.accountID, "cluster:"+id)
+// cloneSubnetGroup returns a deep copy of a subnet group (with its SubnetIDs slice copied).
+func cloneSubnetGroup(sg *DBSubnetGroup) DBSubnetGroup {
+	cp := *sg
+	cp.SubnetIDs = make([]string, len(sg.SubnetIDs))
+	copy(cp.SubnetIDs, sg.SubnetIDs)
+
+	return cp
 }
 
-// instanceARN returns the ARN for a Neptune DB instance.
-func (b *InMemoryBackend) instanceARN(id string) string {
-	return arn.Build("neptune", b.region, b.accountID, "db:"+id)
+// cloneEventSubscription returns a deep copy of an event subscription (with its SourceIDs slice copied).
+func cloneEventSubscription(sub *EventSubscription) EventSubscription {
+	cp := *sub
+	cp.SourceIDs = make([]string, len(sub.SourceIDs))
+	copy(cp.SourceIDs, sub.SourceIDs)
+
+	return cp
 }
 
-// subnetGroupARN returns the ARN for a Neptune DB subnet group.
-func (b *InMemoryBackend) subnetGroupARN(name string) string {
-	return arn.Build("rds", b.region, b.accountID, "subgrp:"+name)
+// resolveCopyDescription returns the target description for a copy operation,
+// defaulting to the source's description when the requested target is empty.
+func resolveCopyDescription(targetDescription, sourceDescription string) string {
+	if targetDescription == "" {
+		return sourceDescription
+	}
+
+	return targetDescription
 }
 
-// clusterParameterGroupARN returns the ARN for a Neptune DB cluster parameter group.
-func (b *InMemoryBackend) clusterParameterGroupARN(name string) string {
-	return arn.Build("rds", b.region, b.accountID, "cluster-pg:"+name)
+// copyPreconditions validates the source/target names for a copy operation and
+// returns the source value from store. notFound is returned when the source is
+// missing; alreadyExists when the target already exists.
+func copyPreconditions[V any](
+	store map[string]*V,
+	sourceName, targetName string,
+	missingSourceMsg, missingTargetMsg string,
+	notFound, alreadyExists error,
+) (*V, error) {
+	if sourceName == "" {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidParameter, missingSourceMsg)
+	}
+
+	if targetName == "" {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidParameter, missingTargetMsg)
+	}
+
+	src, exists := store[sourceName]
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", notFound, sourceName)
+	}
+
+	if _, targetExists := store[targetName]; targetExists {
+		return nil, fmt.Errorf("%w: %s", alreadyExists, targetName)
+	}
+
+	return src, nil
 }
 
-// clusterSnapshotARN returns the ARN for a Neptune DB cluster snapshot.
-func (b *InMemoryBackend) clusterSnapshotARN(id string) string {
-	return arn.Build("rds", b.region, b.accountID, "cluster-snapshot:"+id)
+// clusterARN returns the region-scoped ARN for a Neptune DB cluster.
+func (b *InMemoryBackend) clusterARN(region, id string) string {
+	return arn.Build("neptune", region, b.accountID, "cluster:"+id)
+}
+
+// instanceARN returns the region-scoped ARN for a Neptune DB instance.
+func (b *InMemoryBackend) instanceARN(region, id string) string {
+	return arn.Build("neptune", region, b.accountID, "db:"+id)
+}
+
+// subnetGroupARN returns the region-scoped ARN for a Neptune DB subnet group.
+func (b *InMemoryBackend) subnetGroupARN(region, name string) string {
+	return arn.Build("rds", region, b.accountID, "subgrp:"+name)
+}
+
+// clusterParameterGroupARN returns the region-scoped ARN for a Neptune DB cluster parameter group.
+func (b *InMemoryBackend) clusterParameterGroupARN(region, name string) string {
+	return arn.Build("rds", region, b.accountID, "cluster-pg:"+name)
+}
+
+// clusterSnapshotARN returns the region-scoped ARN for a Neptune DB cluster snapshot.
+func (b *InMemoryBackend) clusterSnapshotARN(region, id string) string {
+	return arn.Build("rds", region, b.accountID, "cluster-snapshot:"+id)
 }
 
 // CreateDBCluster creates a new Neptune DB cluster.
 func (b *InMemoryBackend) CreateDBCluster(
+	ctx context.Context,
 	id, paramGroupName string,
 	port int,
 	opts DBClusterCreateOptions,
@@ -347,9 +517,11 @@ func (b *InMemoryBackend) CreateDBCluster(
 	if id == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBCluster")
 	defer b.mu.Unlock()
-	if _, exists := b.clusters[id]; exists {
+	clusters := b.clustersStore(region)
+	if _, exists := clusters[id]; exists {
 		return nil, fmt.Errorf("%w: cluster %s already exists", ErrClusterAlreadyExists, id)
 	}
 	if paramGroupName == "" {
@@ -366,11 +538,11 @@ func (b *InMemoryBackend) CreateDBCluster(
 	if opts.EngineMode != "" {
 		engineMode = opts.EngineMode
 	}
-	endpoint := fmt.Sprintf("%s.cluster.%s.neptune.amazonaws.com", id, b.region)
-	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", id, b.region)
+	endpoint := fmt.Sprintf("%s.cluster.%s.neptune.amazonaws.com", id, region)
+	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", id, region)
 	cluster := &DBCluster{
 		DBClusterIdentifier:             id,
-		DBClusterArn:                    b.clusterARN(id),
+		DBClusterArn:                    b.clusterARN(region, id),
 		Engine:                          neptuneEngine,
 		EngineVersion:                   engineVersion,
 		EngineMode:                      engineMode,
@@ -391,30 +563,32 @@ func (b *InMemoryBackend) CreateDBCluster(
 	}
 	if opts.ManageMasterUserPassword {
 		cluster.MasterUserManagedSecret = &MasterUserManagedSecret{
-			SecretARN:    fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:rds!cluster-%s", b.region, b.accountID, id),
+			SecretARN:    fmt.Sprintf("arn:aws:secretsmanager:%s:%s:secret:rds!cluster-%s", region, b.accountID, id),
 			SecretStatus: "active",
 		}
 	}
-	b.clusters[id] = cluster
+	clusters[id] = cluster
 	cp := cloneCluster(cluster)
 
 	return &cp, nil
 }
 
 // DescribeDBClusters returns all Neptune DB clusters or a specific one.
-func (b *InMemoryBackend) DescribeDBClusters(id string) ([]DBCluster, error) {
+func (b *InMemoryBackend) DescribeDBClusters(ctx context.Context, id string) ([]DBCluster, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBClusters")
 	defer b.mu.RUnlock()
+	clusters := b.clustersStore(region)
 	if id != "" {
-		c, exists := b.clusters[id]
+		c, exists := clusters[id]
 		if !exists {
 			return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, id)
 		}
 
 		return []DBCluster{cloneCluster(c)}, nil
 	}
-	result := make([]DBCluster, 0, len(b.clusters))
-	for _, c := range b.clusters {
+	result := make([]DBCluster, 0, len(clusters))
+	for _, c := range clusters {
 		result = append(result, cloneCluster(c))
 	}
 
@@ -422,10 +596,12 @@ func (b *InMemoryBackend) DescribeDBClusters(id string) ([]DBCluster, error) {
 }
 
 // DeleteDBCluster deletes a Neptune DB cluster and all associated DB instances.
-func (b *InMemoryBackend) DeleteDBCluster(id string) (*DBCluster, error) {
+func (b *InMemoryBackend) DeleteDBCluster(ctx context.Context, id string) (*DBCluster, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBCluster")
 	defer b.mu.Unlock()
-	c, exists := b.clusters[id]
+	clusters := b.clustersStore(region)
+	c, exists := clusters[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, id)
 	}
@@ -437,22 +613,25 @@ func (b *InMemoryBackend) DeleteDBCluster(id string) (*DBCluster, error) {
 		)
 	}
 	cp := cloneCluster(c)
-	delete(b.clusters, id)
-	delete(b.tags, b.clusterARN(id))
-	delete(b.clusterRoles, id)
+	delete(clusters, id)
+	delete(b.tagsStore(region), b.clusterARN(region, id))
+	delete(b.clusterRolesStore(region), id)
 
 	// Clean up all instances associated with this cluster.
-	for instID, inst := range b.instances {
+	instances := b.instancesStore(region)
+	tagStore := b.tagsStore(region)
+	for instID, inst := range instances {
 		if inst.DBClusterIdentifier == id {
-			delete(b.instances, instID)
-			delete(b.tags, b.instanceARN(instID))
+			delete(instances, instID)
+			delete(tagStore, b.instanceARN(region, instID))
 		}
 	}
 
 	// Clean up all custom endpoints associated with this cluster.
-	for epID, ep := range b.clusterEndpoints {
+	endpoints := b.clusterEndpointsStore(region)
+	for epID, ep := range endpoints {
 		if ep.DBClusterIdentifier == id {
-			delete(b.clusterEndpoints, epID)
+			delete(endpoints, epID)
 		}
 	}
 
@@ -460,10 +639,13 @@ func (b *InMemoryBackend) DeleteDBCluster(id string) (*DBCluster, error) {
 }
 
 // ModifyDBCluster modifies a Neptune DB cluster.
-func (b *InMemoryBackend) ModifyDBCluster(id, paramGroupName string, opts DBClusterModifyOptions) (*DBCluster, error) {
+func (b *InMemoryBackend) ModifyDBCluster(
+	ctx context.Context, id, paramGroupName string, opts DBClusterModifyOptions,
+) (*DBCluster, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyDBCluster")
 	defer b.mu.Unlock()
-	c, exists := b.clusters[id]
+	c, exists := b.clustersStore(region)[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, id)
 	}
@@ -494,7 +676,7 @@ func (b *InMemoryBackend) ModifyDBCluster(id, paramGroupName string, opts DBClus
 			c.MasterUserManagedSecret = &MasterUserManagedSecret{
 				SecretARN: fmt.Sprintf(
 					"arn:aws:secretsmanager:%s:%s:secret:rds!cluster-%s",
-					b.region,
+					region,
 					b.accountID,
 					id,
 				),
@@ -508,10 +690,11 @@ func (b *InMemoryBackend) ModifyDBCluster(id, paramGroupName string, opts DBClus
 }
 
 // StopDBCluster stops a Neptune DB cluster.
-func (b *InMemoryBackend) StopDBCluster(id string) (*DBCluster, error) {
+func (b *InMemoryBackend) StopDBCluster(ctx context.Context, id string) (*DBCluster, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("StopDBCluster")
 	defer b.mu.Unlock()
-	c, exists := b.clusters[id]
+	c, exists := b.clustersStore(region)[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, id)
 	}
@@ -525,10 +708,11 @@ func (b *InMemoryBackend) StopDBCluster(id string) (*DBCluster, error) {
 }
 
 // StartDBCluster starts a stopped Neptune DB cluster.
-func (b *InMemoryBackend) StartDBCluster(id string) (*DBCluster, error) {
+func (b *InMemoryBackend) StartDBCluster(ctx context.Context, id string) (*DBCluster, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("StartDBCluster")
 	defer b.mu.Unlock()
-	c, exists := b.clusters[id]
+	c, exists := b.clustersStore(region)[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, id)
 	}
@@ -542,10 +726,11 @@ func (b *InMemoryBackend) StartDBCluster(id string) (*DBCluster, error) {
 }
 
 // FailoverDBCluster triggers a failover for a Neptune DB cluster.
-func (b *InMemoryBackend) FailoverDBCluster(id string) (*DBCluster, error) {
+func (b *InMemoryBackend) FailoverDBCluster(ctx context.Context, id string) (*DBCluster, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("FailoverDBCluster")
 	defer b.mu.Unlock()
-	c, exists := b.clusters[id]
+	c, exists := b.clustersStore(region)[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, id)
 	}
@@ -556,19 +741,23 @@ func (b *InMemoryBackend) FailoverDBCluster(id string) (*DBCluster, error) {
 
 // CreateDBInstance creates a new Neptune DB instance.
 func (b *InMemoryBackend) CreateDBInstance(
+	ctx context.Context,
 	id, clusterID, instanceClass string,
 	opts DBInstanceCreateOptions,
 ) (*DBInstance, error) {
 	if id == "" {
 		return nil, fmt.Errorf("%w: DBInstanceIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBInstance")
 	defer b.mu.Unlock()
-	if _, exists := b.instances[id]; exists {
+	instances := b.instancesStore(region)
+	clusters := b.clustersStore(region)
+	if _, exists := instances[id]; exists {
 		return nil, fmt.Errorf("%w: instance %s already exists", ErrInstanceAlreadyExists, id)
 	}
 	if clusterID != "" {
-		if _, exists := b.clusters[clusterID]; !exists {
+		if _, exists := clusters[clusterID]; !exists {
 			return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, clusterID)
 		}
 	}
@@ -579,16 +768,16 @@ func (b *InMemoryBackend) CreateDBInstance(
 	if opts.PreferredMaintenanceWindow != "" {
 		maintenanceWindow = opts.PreferredMaintenanceWindow
 	}
-	endpoint := fmt.Sprintf("%s.neptune.%s.amazonaws.com", id, b.region)
+	endpoint := fmt.Sprintf("%s.neptune.%s.amazonaws.com", id, region)
 	engineVersion := defaultEngineVersion
 	if clusterID != "" {
-		if cl, ok := b.clusters[clusterID]; ok {
+		if cl, ok := clusters[clusterID]; ok {
 			engineVersion = cl.EngineVersion
 		}
 	}
 	inst := &DBInstance{
 		DBInstanceIdentifier:            id,
-		DBInstanceArn:                   b.instanceARN(id),
+		DBInstanceArn:                   b.instanceARN(region, id),
 		DBClusterIdentifier:             clusterID,
 		DBInstanceClass:                 instanceClass,
 		Engine:                          neptuneEngine,
@@ -609,9 +798,9 @@ func (b *InMemoryBackend) CreateDBInstance(
 	if opts.AutoMinorVersionUpgrade {
 		inst.AutoMinorVersionUpgrade = opts.AutoMinorVersionUpgrade
 	}
-	b.instances[id] = inst
+	instances[id] = inst
 	if clusterID != "" {
-		if cl, ok := b.clusters[clusterID]; ok {
+		if cl, ok := clusters[clusterID]; ok {
 			isWriter := len(cl.DBClusterMembers) == 0
 			cl.DBClusterMembers = append(cl.DBClusterMembers, DBClusterMember{
 				DBInstanceIdentifier: id,
@@ -625,11 +814,13 @@ func (b *InMemoryBackend) CreateDBInstance(
 }
 
 // DescribeDBInstances returns all Neptune DB instances or a specific one by ID.
-func (b *InMemoryBackend) DescribeDBInstances(id string) ([]DBInstance, error) {
+func (b *InMemoryBackend) DescribeDBInstances(ctx context.Context, id string) ([]DBInstance, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBInstances")
 	defer b.mu.RUnlock()
+	instances := b.instancesStore(region)
 	if id != "" {
-		inst, exists := b.instances[id]
+		inst, exists := instances[id]
 		if !exists {
 			return nil, fmt.Errorf("%w: instance %s not found", ErrInstanceNotFound, id)
 		}
@@ -637,8 +828,8 @@ func (b *InMemoryBackend) DescribeDBInstances(id string) ([]DBInstance, error) {
 
 		return []DBInstance{cp}, nil
 	}
-	result := make([]DBInstance, 0, len(b.instances))
-	for _, inst := range b.instances {
+	result := make([]DBInstance, 0, len(instances))
+	for _, inst := range instances {
 		result = append(result, *inst)
 	}
 
@@ -646,18 +837,20 @@ func (b *InMemoryBackend) DescribeDBInstances(id string) ([]DBInstance, error) {
 }
 
 // DeleteDBInstance deletes a Neptune DB instance.
-func (b *InMemoryBackend) DeleteDBInstance(id string) (*DBInstance, error) {
+func (b *InMemoryBackend) DeleteDBInstance(ctx context.Context, id string) (*DBInstance, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBInstance")
 	defer b.mu.Unlock()
-	inst, exists := b.instances[id]
+	instances := b.instancesStore(region)
+	inst, exists := instances[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: instance %s not found", ErrInstanceNotFound, id)
 	}
 	cp := *inst
-	delete(b.instances, id)
-	delete(b.tags, b.instanceARN(id))
+	delete(instances, id)
+	delete(b.tagsStore(region), b.instanceARN(region, id))
 	if cp.DBClusterIdentifier != "" {
-		if cl, ok := b.clusters[cp.DBClusterIdentifier]; ok {
+		if cl, ok := b.clustersStore(region)[cp.DBClusterIdentifier]; ok {
 			members := make([]DBClusterMember, 0, len(cl.DBClusterMembers))
 			for _, m := range cl.DBClusterMembers {
 				if m.DBInstanceIdentifier != id {
@@ -673,12 +866,14 @@ func (b *InMemoryBackend) DeleteDBInstance(id string) (*DBInstance, error) {
 
 // ModifyDBInstance modifies a Neptune DB instance.
 func (b *InMemoryBackend) ModifyDBInstance(
+	ctx context.Context,
 	id, instanceClass string,
 	opts DBInstanceModifyOptions,
 ) (*DBInstance, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyDBInstance")
 	defer b.mu.Unlock()
-	inst, exists := b.instances[id]
+	inst, exists := b.instancesStore(region)[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: instance %s not found", ErrInstanceNotFound, id)
 	}
@@ -712,10 +907,11 @@ func (b *InMemoryBackend) ModifyDBInstance(
 }
 
 // RebootDBInstance reboots a Neptune DB instance.
-func (b *InMemoryBackend) RebootDBInstance(id string) (*DBInstance, error) {
+func (b *InMemoryBackend) RebootDBInstance(ctx context.Context, id string) (*DBInstance, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RebootDBInstance")
 	defer b.mu.Unlock()
-	inst, exists := b.instances[id]
+	inst, exists := b.instancesStore(region)[id]
 	if !exists {
 		return nil, fmt.Errorf("%w: instance %s not found", ErrInstanceNotFound, id)
 	}
@@ -726,15 +922,18 @@ func (b *InMemoryBackend) RebootDBInstance(id string) (*DBInstance, error) {
 
 // CreateDBSubnetGroup creates a new Neptune DB subnet group.
 func (b *InMemoryBackend) CreateDBSubnetGroup(
+	ctx context.Context,
 	name, description, vpcID string,
 	subnetIDs []string,
 ) (*DBSubnetGroup, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: DBSubnetGroupName is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBSubnetGroup")
 	defer b.mu.Unlock()
-	if _, exists := b.subnetGroups[name]; exists {
+	subnetGroups := b.subnetGroupsStore(region)
+	if _, exists := subnetGroups[name]; exists {
 		return nil, fmt.Errorf("%w: subnet group %s already exists", ErrSubnetGroupAlreadyExists, name)
 	}
 	ids := make([]string, len(subnetIDs))
@@ -746,7 +945,7 @@ func (b *InMemoryBackend) CreateDBSubnetGroup(
 		Status:                   "Complete",
 		SubnetIDs:                ids,
 	}
-	b.subnetGroups[name] = sg
+	subnetGroups[name] = sg
 	cp := *sg
 	cp.SubnetIDs = make([]string, len(ids))
 	copy(cp.SubnetIDs, ids)
@@ -755,40 +954,38 @@ func (b *InMemoryBackend) CreateDBSubnetGroup(
 }
 
 // DescribeDBSubnetGroups returns all Neptune DB subnet groups or a specific one.
-func (b *InMemoryBackend) DescribeDBSubnetGroups(name string) ([]DBSubnetGroup, error) {
+func (b *InMemoryBackend) DescribeDBSubnetGroups(ctx context.Context, name string) ([]DBSubnetGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBSubnetGroups")
 	defer b.mu.RUnlock()
+	subnetGroups := b.subnetGroupsStore(region)
 	if name != "" {
-		sg, exists := b.subnetGroups[name]
+		sg, exists := subnetGroups[name]
 		if !exists {
 			return nil, fmt.Errorf("%w: subnet group %s not found", ErrSubnetGroupNotFound, name)
 		}
-		cp := *sg
-		cp.SubnetIDs = make([]string, len(sg.SubnetIDs))
-		copy(cp.SubnetIDs, sg.SubnetIDs)
 
-		return []DBSubnetGroup{cp}, nil
+		return []DBSubnetGroup{cloneSubnetGroup(sg)}, nil
 	}
-	result := make([]DBSubnetGroup, 0, len(b.subnetGroups))
-	for _, sg := range b.subnetGroups {
-		cp := *sg
-		cp.SubnetIDs = make([]string, len(sg.SubnetIDs))
-		copy(cp.SubnetIDs, sg.SubnetIDs)
-		result = append(result, cp)
+	result := make([]DBSubnetGroup, 0, len(subnetGroups))
+	for _, sg := range subnetGroups {
+		result = append(result, cloneSubnetGroup(sg))
 	}
 
 	return result, nil
 }
 
 // DeleteDBSubnetGroup deletes a Neptune DB subnet group.
-func (b *InMemoryBackend) DeleteDBSubnetGroup(name string) error {
+func (b *InMemoryBackend) DeleteDBSubnetGroup(ctx context.Context, name string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBSubnetGroup")
 	defer b.mu.Unlock()
-	if _, exists := b.subnetGroups[name]; !exists {
+	subnetGroups := b.subnetGroupsStore(region)
+	if _, exists := subnetGroups[name]; !exists {
 		return fmt.Errorf("%w: subnet group %s not found", ErrSubnetGroupNotFound, name)
 	}
-	delete(b.subnetGroups, name)
-	delete(b.tags, b.subnetGroupARN(name))
+	delete(subnetGroups, name)
+	delete(b.tagsStore(region), b.subnetGroupARN(region, name))
 
 	return nil
 }
@@ -800,6 +997,7 @@ func validNeptuneParameterGroupFamily(family string) bool {
 
 // CreateDBClusterParameterGroup creates a Neptune DB cluster parameter group.
 func (b *InMemoryBackend) CreateDBClusterParameterGroup(
+	ctx context.Context,
 	name, family, description string,
 ) (*DBClusterParameterGroup, error) {
 	if name == "" {
@@ -812,9 +1010,11 @@ func (b *InMemoryBackend) CreateDBClusterParameterGroup(
 			family,
 		)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBClusterParameterGroup")
 	defer b.mu.Unlock()
-	if _, exists := b.clusterParameterGroups[name]; exists {
+	groups := b.clusterParameterGroupsStore(region)
+	if _, exists := groups[name]; exists {
 		return nil, fmt.Errorf(
 			"%w: cluster parameter group %s already exists",
 			ErrClusterParameterGroupAlreadyExists,
@@ -826,18 +1026,22 @@ func (b *InMemoryBackend) CreateDBClusterParameterGroup(
 		DBParameterGroupFamily:      family,
 		Description:                 description,
 	}
-	b.clusterParameterGroups[name] = pg
+	groups[name] = pg
 	cp := *pg
 
 	return &cp, nil
 }
 
 // DescribeDBClusterParameterGroups returns all Neptune cluster parameter groups or a specific one.
-func (b *InMemoryBackend) DescribeDBClusterParameterGroups(name string) ([]DBClusterParameterGroup, error) {
+func (b *InMemoryBackend) DescribeDBClusterParameterGroups(
+	ctx context.Context, name string,
+) ([]DBClusterParameterGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBClusterParameterGroups")
 	defer b.mu.RUnlock()
+	groups := b.clusterParameterGroupsStore(region)
 	if name != "" {
-		pg, exists := b.clusterParameterGroups[name]
+		pg, exists := groups[name]
 		if !exists {
 			return nil, fmt.Errorf("%w: cluster parameter group %s not found", ErrClusterParameterGroupNotFound, name)
 		}
@@ -845,8 +1049,8 @@ func (b *InMemoryBackend) DescribeDBClusterParameterGroups(name string) ([]DBClu
 
 		return []DBClusterParameterGroup{cp}, nil
 	}
-	result := make([]DBClusterParameterGroup, 0, len(b.clusterParameterGroups))
-	for _, pg := range b.clusterParameterGroups {
+	result := make([]DBClusterParameterGroup, 0, len(groups))
+	for _, pg := range groups {
 		result = append(result, *pg)
 	}
 
@@ -854,23 +1058,28 @@ func (b *InMemoryBackend) DescribeDBClusterParameterGroups(name string) ([]DBClu
 }
 
 // DeleteDBClusterParameterGroup deletes a Neptune DB cluster parameter group.
-func (b *InMemoryBackend) DeleteDBClusterParameterGroup(name string) error {
+func (b *InMemoryBackend) DeleteDBClusterParameterGroup(ctx context.Context, name string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBClusterParameterGroup")
 	defer b.mu.Unlock()
-	if _, exists := b.clusterParameterGroups[name]; !exists {
+	groups := b.clusterParameterGroupsStore(region)
+	if _, exists := groups[name]; !exists {
 		return fmt.Errorf("%w: cluster parameter group %s not found", ErrClusterParameterGroupNotFound, name)
 	}
-	delete(b.clusterParameterGroups, name)
-	delete(b.tags, b.clusterParameterGroupARN(name))
+	delete(groups, name)
+	delete(b.tagsStore(region), b.clusterParameterGroupARN(region, name))
 
 	return nil
 }
 
 // ModifyDBClusterParameterGroup modifies a Neptune DB cluster parameter group.
-func (b *InMemoryBackend) ModifyDBClusterParameterGroup(name string) (*DBClusterParameterGroup, error) {
+func (b *InMemoryBackend) ModifyDBClusterParameterGroup(
+	ctx context.Context, name string,
+) (*DBClusterParameterGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyDBClusterParameterGroup")
 	defer b.mu.Unlock()
-	pg, exists := b.clusterParameterGroups[name]
+	pg, exists := b.clusterParameterGroupsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster parameter group %s not found", ErrClusterParameterGroupNotFound, name)
 	}
@@ -880,25 +1089,29 @@ func (b *InMemoryBackend) ModifyDBClusterParameterGroup(name string) (*DBCluster
 }
 
 // CreateDBClusterSnapshot creates a Neptune DB cluster snapshot.
-func (b *InMemoryBackend) CreateDBClusterSnapshot(snapshotID, clusterID string) (*DBClusterSnapshot, error) {
+func (b *InMemoryBackend) CreateDBClusterSnapshot(
+	ctx context.Context, snapshotID, clusterID string,
+) (*DBClusterSnapshot, error) {
 	if snapshotID == "" {
 		return nil, fmt.Errorf("%w: DBClusterSnapshotIdentifier is required", ErrInvalidParameter)
 	}
 	if clusterID == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBClusterSnapshot")
 	defer b.mu.Unlock()
-	if _, exists := b.clusterSnapshots[snapshotID]; exists {
+	snapshots := b.clusterSnapshotsStore(region)
+	if _, exists := snapshots[snapshotID]; exists {
 		return nil, fmt.Errorf("%w: cluster snapshot %s already exists", ErrClusterSnapshotAlreadyExists, snapshotID)
 	}
-	cl, exists := b.clusters[clusterID]
+	cl, exists := b.clustersStore(region)[clusterID]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, clusterID)
 	}
 	snap := &DBClusterSnapshot{
 		DBClusterSnapshotIdentifier: snapshotID,
-		DBClusterSnapshotArn:        b.clusterSnapshotARN(snapshotID),
+		DBClusterSnapshotArn:        b.clusterSnapshotARN(region, snapshotID),
 		DBClusterIdentifier:         clusterID,
 		Engine:                      neptuneEngine,
 		EngineVersion:               cl.EngineVersion,
@@ -906,7 +1119,7 @@ func (b *InMemoryBackend) CreateDBClusterSnapshot(snapshotID, clusterID string) 
 		StorageEncrypted:            cl.StorageEncrypted,
 		SnapshotType:                snapshotSourceManual,
 	}
-	b.clusterSnapshots[snapshotID] = snap
+	snapshots[snapshotID] = snap
 	cp := *snap
 
 	return &cp, nil
@@ -914,11 +1127,15 @@ func (b *InMemoryBackend) CreateDBClusterSnapshot(snapshotID, clusterID string) 
 
 // DescribeDBClusterSnapshots returns all Neptune cluster snapshots or a specific one.
 // If clusterID is set, results are filtered to that cluster.
-func (b *InMemoryBackend) DescribeDBClusterSnapshots(snapshotID, clusterID string) ([]DBClusterSnapshot, error) {
+func (b *InMemoryBackend) DescribeDBClusterSnapshots(
+	ctx context.Context, snapshotID, clusterID string,
+) ([]DBClusterSnapshot, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBClusterSnapshots")
 	defer b.mu.RUnlock()
+	snapshots := b.clusterSnapshotsStore(region)
 	if snapshotID != "" {
-		snap, exists := b.clusterSnapshots[snapshotID]
+		snap, exists := snapshots[snapshotID]
 		if !exists {
 			return nil, fmt.Errorf("%w: cluster snapshot %s not found", ErrClusterSnapshotNotFound, snapshotID)
 		}
@@ -926,8 +1143,8 @@ func (b *InMemoryBackend) DescribeDBClusterSnapshots(snapshotID, clusterID strin
 
 		return []DBClusterSnapshot{cp}, nil
 	}
-	result := make([]DBClusterSnapshot, 0, len(b.clusterSnapshots))
-	for _, snap := range b.clusterSnapshots {
+	result := make([]DBClusterSnapshot, 0, len(snapshots))
+	for _, snap := range snapshots {
 		if clusterID != "" && snap.DBClusterIdentifier != clusterID {
 			continue
 		}
@@ -938,23 +1155,25 @@ func (b *InMemoryBackend) DescribeDBClusterSnapshots(snapshotID, clusterID strin
 }
 
 // DeleteDBClusterSnapshot deletes a Neptune DB cluster snapshot.
-func (b *InMemoryBackend) DeleteDBClusterSnapshot(snapshotID string) (*DBClusterSnapshot, error) {
+func (b *InMemoryBackend) DeleteDBClusterSnapshot(ctx context.Context, snapshotID string) (*DBClusterSnapshot, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBClusterSnapshot")
 	defer b.mu.Unlock()
-	snap, exists := b.clusterSnapshots[snapshotID]
+	snapshots := b.clusterSnapshotsStore(region)
+	snap, exists := snapshots[snapshotID]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster snapshot %s not found", ErrClusterSnapshotNotFound, snapshotID)
 	}
 	cp := *snap
-	delete(b.clusterSnapshots, snapshotID)
-	delete(b.tags, b.clusterSnapshotARN(snapshotID))
+	delete(snapshots, snapshotID)
+	delete(b.tagsStore(region), b.clusterSnapshotARN(region, snapshotID))
 
 	return &cp, nil
 }
 
-// validateResourceARN checks whether an ARN refers to a known Neptune resource.
+// validateResourceARN checks whether an ARN refers to a known Neptune resource in the given region.
 // Must be called while holding at least a read lock.
-func (b *InMemoryBackend) validateResourceARN(arnStr string) error {
+func (b *InMemoryBackend) validateResourceARN(region, arnStr string) error {
 	// ARN format: arn:partition:service:region:account:type:id
 	parts := strings.SplitN(arnStr, ":", arnPartCount)
 	if len(parts) < arnPartCount {
@@ -963,23 +1182,23 @@ func (b *InMemoryBackend) validateResourceARN(arnStr string) error {
 	resType, resID := parts[5], parts[6]
 	switch resType {
 	case "cluster":
-		if _, ok := b.clusters[resID]; !ok {
+		if _, ok := b.clustersStore(region)[resID]; !ok {
 			return fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, resID)
 		}
 	case "db":
-		if _, ok := b.instances[resID]; !ok {
+		if _, ok := b.instancesStore(region)[resID]; !ok {
 			return fmt.Errorf("%w: instance %s not found", ErrInstanceNotFound, resID)
 		}
 	case "cluster-snapshot":
-		if _, ok := b.clusterSnapshots[resID]; !ok {
+		if _, ok := b.clusterSnapshotsStore(region)[resID]; !ok {
 			return fmt.Errorf("%w: cluster snapshot %s not found", ErrClusterSnapshotNotFound, resID)
 		}
 	case "subgrp":
-		if _, ok := b.subnetGroups[resID]; !ok {
+		if _, ok := b.subnetGroupsStore(region)[resID]; !ok {
 			return fmt.Errorf("%w: subnet group %s not found", ErrSubnetGroupNotFound, resID)
 		}
 	case "cluster-pg":
-		if _, ok := b.clusterParameterGroups[resID]; !ok {
+		if _, ok := b.clusterParameterGroupsStore(region)[resID]; !ok {
 			return fmt.Errorf("%w: cluster parameter group %s not found", ErrClusterParameterGroupNotFound, resID)
 		}
 	default:
@@ -990,10 +1209,12 @@ func (b *InMemoryBackend) validateResourceARN(arnStr string) error {
 }
 
 // AddTagsToResource adds or updates tags on a Neptune resource.
-func (b *InMemoryBackend) AddTagsToResource(arnStr string, tags []Tag) error {
+// The resource's region is resolved from the ARN, falling back to the ctx region.
+func (b *InMemoryBackend) AddTagsToResource(ctx context.Context, arnStr string, tags []Tag) error {
+	region := regionFromARN(arnStr, getRegion(ctx, b.region))
 	b.mu.Lock("AddTagsToResource")
 	defer b.mu.Unlock()
-	if err := b.validateResourceARN(arnStr); err != nil {
+	if err := b.validateResourceARN(region, arnStr); err != nil {
 		return err
 	}
 	for _, t := range tags {
@@ -1004,7 +1225,8 @@ func (b *InMemoryBackend) AddTagsToResource(arnStr string, tags []Tag) error {
 			return fmt.Errorf("%w: tag value must be 0-%d characters", ErrInvalidParameter, maxTagValueLen)
 		}
 	}
-	current := b.tags[arnStr]
+	tagStore := b.tagsStore(region)
+	current := tagStore[arnStr]
 	idx := make(map[string]int, len(current))
 	for i, t := range current {
 		idx[t.Key] = i
@@ -1026,42 +1248,45 @@ func (b *InMemoryBackend) AddTagsToResource(arnStr string, tags []Tag) error {
 			current = append(current, t)
 		}
 	}
-	b.tags[arnStr] = current
+	tagStore[arnStr] = current
 
 	return nil
 }
 
 // RemoveTagsFromResource removes tags from a Neptune resource.
-func (b *InMemoryBackend) RemoveTagsFromResource(arnStr string, keys []string) error {
+func (b *InMemoryBackend) RemoveTagsFromResource(ctx context.Context, arnStr string, keys []string) error {
+	region := regionFromARN(arnStr, getRegion(ctx, b.region))
 	b.mu.Lock("RemoveTagsFromResource")
 	defer b.mu.Unlock()
-	if err := b.validateResourceARN(arnStr); err != nil {
+	if err := b.validateResourceARN(region, arnStr); err != nil {
 		return err
 	}
 	remove := make(map[string]bool, len(keys))
 	for _, k := range keys {
 		remove[k] = true
 	}
-	current := b.tags[arnStr]
+	tagStore := b.tagsStore(region)
+	current := tagStore[arnStr]
 	kept := make([]Tag, 0, len(current))
 	for _, t := range current {
 		if !remove[t.Key] {
 			kept = append(kept, t)
 		}
 	}
-	b.tags[arnStr] = kept
+	tagStore[arnStr] = kept
 
 	return nil
 }
 
 // ListTagsForResource returns the tags for a Neptune resource.
-func (b *InMemoryBackend) ListTagsForResource(arnStr string) ([]Tag, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, arnStr string) ([]Tag, error) {
+	region := regionFromARN(arnStr, getRegion(ctx, b.region))
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
-	if err := b.validateResourceARN(arnStr); err != nil {
+	if err := b.validateResourceARN(region, arnStr); err != nil {
 		return nil, err
 	}
-	src := b.tags[arnStr]
+	src := b.tagsStore(region)[arnStr]
 	cp := make([]Tag, len(src))
 	copy(cp, src)
 
@@ -1069,37 +1294,42 @@ func (b *InMemoryBackend) ListTagsForResource(arnStr string) ([]Tag, error) {
 }
 
 // AddRoleToDBCluster associates an IAM role with a Neptune DB cluster.
-func (b *InMemoryBackend) AddRoleToDBCluster(clusterID, roleARN string) error {
+func (b *InMemoryBackend) AddRoleToDBCluster(ctx context.Context, clusterID, roleARN string) error {
 	if clusterID == "" {
 		return fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
 	if roleARN == "" {
 		return fmt.Errorf("%w: RoleArn is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AddRoleToDBCluster")
 	defer b.mu.Unlock()
-	if _, exists := b.clusters[clusterID]; !exists {
+	if _, exists := b.clustersStore(region)[clusterID]; !exists {
 		return fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, clusterID)
 	}
-	if slices.Contains(b.clusterRoles[clusterID], roleARN) {
+	roles := b.clusterRolesStore(region)
+	if slices.Contains(roles[clusterID], roleARN) {
 		return nil
 	}
-	b.clusterRoles[clusterID] = append(b.clusterRoles[clusterID], roleARN)
+	roles[clusterID] = append(roles[clusterID], roleARN)
 
 	return nil
 }
 
 // AddSourceIdentifierToSubscription adds a source identifier to an event subscription.
-func (b *InMemoryBackend) AddSourceIdentifierToSubscription(name, sourceID string) (*EventSubscription, error) {
+func (b *InMemoryBackend) AddSourceIdentifierToSubscription(
+	ctx context.Context, name, sourceID string,
+) (*EventSubscription, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: SubscriptionName is required", ErrInvalidParameter)
 	}
 	if sourceID == "" {
 		return nil, fmt.Errorf("%w: SourceIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("AddSourceIdentifierToSubscription")
 	defer b.mu.Unlock()
-	sub, exists := b.eventSubscriptions[name]
+	sub, exists := b.eventSubscriptionsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: subscription %s not found", ErrSubscriptionNotFound, name)
 	}
@@ -1114,7 +1344,9 @@ func (b *InMemoryBackend) AddSourceIdentifierToSubscription(name, sourceID strin
 }
 
 // ApplyPendingMaintenanceAction applies a pending maintenance action to a resource.
-func (b *InMemoryBackend) ApplyPendingMaintenanceAction(resourceID, applyAction, optInType string) error {
+func (b *InMemoryBackend) ApplyPendingMaintenanceAction(
+	_ context.Context, resourceID, applyAction, optInType string,
+) error {
 	if resourceID == "" {
 		return fmt.Errorf("%w: ResourceIdentifier is required", ErrInvalidParameter)
 	}
@@ -1130,58 +1362,52 @@ func (b *InMemoryBackend) ApplyPendingMaintenanceAction(resourceID, applyAction,
 
 // CopyDBClusterParameterGroup copies a Neptune DB cluster parameter group.
 func (b *InMemoryBackend) CopyDBClusterParameterGroup(
+	ctx context.Context,
 	sourceName, targetName, targetDescription string,
 ) (*DBClusterParameterGroup, error) {
-	if sourceName == "" {
-		return nil, fmt.Errorf("%w: SourceDBClusterParameterGroupIdentifier is required", ErrInvalidParameter)
-	}
-	if targetName == "" {
-		return nil, fmt.Errorf("%w: TargetDBClusterParameterGroupIdentifier is required", ErrInvalidParameter)
-	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CopyDBClusterParameterGroup")
 	defer b.mu.Unlock()
-	src, exists := b.clusterParameterGroups[sourceName]
-	if !exists {
-		return nil, fmt.Errorf("%w: cluster parameter group %s not found", ErrClusterParameterGroupNotFound, sourceName)
-	}
-	_, targetExists := b.clusterParameterGroups[targetName]
-	if targetExists {
-		return nil, fmt.Errorf(
-			"%w: cluster parameter group %s already exists",
-			ErrClusterParameterGroupAlreadyExists,
-			targetName,
-		)
-	}
-	description := targetDescription
-	if description == "" {
-		description = src.Description
+	groups := b.clusterParameterGroupsStore(region)
+	src, err := copyPreconditions(
+		groups, sourceName, targetName,
+		"SourceDBClusterParameterGroupIdentifier is required",
+		"TargetDBClusterParameterGroupIdentifier is required",
+		ErrClusterParameterGroupNotFound, ErrClusterParameterGroupAlreadyExists,
+	)
+	if err != nil {
+		return nil, err
 	}
 	pg := &DBClusterParameterGroup{
 		DBClusterParameterGroupName: targetName,
 		DBParameterGroupFamily:      src.DBParameterGroupFamily,
-		Description:                 description,
+		Description:                 resolveCopyDescription(targetDescription, src.Description),
 	}
-	b.clusterParameterGroups[targetName] = pg
+	groups[targetName] = pg
 	cp := *pg
 
 	return &cp, nil
 }
 
 // CopyDBClusterSnapshot copies a Neptune DB cluster snapshot.
-func (b *InMemoryBackend) CopyDBClusterSnapshot(sourceSnapshotID, targetSnapshotID string) (*DBClusterSnapshot, error) {
+func (b *InMemoryBackend) CopyDBClusterSnapshot(
+	ctx context.Context, sourceSnapshotID, targetSnapshotID string,
+) (*DBClusterSnapshot, error) {
 	if sourceSnapshotID == "" {
 		return nil, fmt.Errorf("%w: SourceDBClusterSnapshotIdentifier is required", ErrInvalidParameter)
 	}
 	if targetSnapshotID == "" {
 		return nil, fmt.Errorf("%w: TargetDBClusterSnapshotIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CopyDBClusterSnapshot")
 	defer b.mu.Unlock()
-	src, exists := b.clusterSnapshots[sourceSnapshotID]
+	snapshots := b.clusterSnapshotsStore(region)
+	src, exists := snapshots[sourceSnapshotID]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster snapshot %s not found", ErrClusterSnapshotNotFound, sourceSnapshotID)
 	}
-	_, targetExists := b.clusterSnapshots[targetSnapshotID]
+	_, targetExists := snapshots[targetSnapshotID]
 	if targetExists {
 		return nil, fmt.Errorf(
 			"%w: cluster snapshot %s already exists",
@@ -1191,7 +1417,7 @@ func (b *InMemoryBackend) CopyDBClusterSnapshot(sourceSnapshotID, targetSnapshot
 	}
 	snap := &DBClusterSnapshot{
 		DBClusterSnapshotIdentifier: targetSnapshotID,
-		DBClusterSnapshotArn:        b.clusterSnapshotARN(targetSnapshotID),
+		DBClusterSnapshotArn:        b.clusterSnapshotARN(region, targetSnapshotID),
 		DBClusterIdentifier:         src.DBClusterIdentifier,
 		Engine:                      src.Engine,
 		EngineVersion:               src.EngineVersion,
@@ -1199,7 +1425,7 @@ func (b *InMemoryBackend) CopyDBClusterSnapshot(sourceSnapshotID, targetSnapshot
 		StorageEncrypted:            src.StorageEncrypted,
 		SnapshotType:                snapshotSourceManual,
 	}
-	b.clusterSnapshots[targetSnapshotID] = snap
+	snapshots[targetSnapshotID] = snap
 	cp := *snap
 
 	return &cp, nil
@@ -1207,34 +1433,28 @@ func (b *InMemoryBackend) CopyDBClusterSnapshot(sourceSnapshotID, targetSnapshot
 
 // CopyDBParameterGroup copies a Neptune DB parameter group.
 func (b *InMemoryBackend) CopyDBParameterGroup(
+	ctx context.Context,
 	sourceName, targetName, targetDescription string,
 ) (*DBParameterGroup, error) {
-	if sourceName == "" {
-		return nil, fmt.Errorf("%w: SourceDBParameterGroupIdentifier is required", ErrInvalidParameter)
-	}
-	if targetName == "" {
-		return nil, fmt.Errorf("%w: TargetDBParameterGroupIdentifier is required", ErrInvalidParameter)
-	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CopyDBParameterGroup")
 	defer b.mu.Unlock()
-	src, exists := b.parameterGroups[sourceName]
-	if !exists {
-		return nil, fmt.Errorf("%w: parameter group %s not found", ErrParameterGroupNotFound, sourceName)
-	}
-	_, targetExists := b.parameterGroups[targetName]
-	if targetExists {
-		return nil, fmt.Errorf("%w: parameter group %s already exists", ErrParameterGroupAlreadyExists, targetName)
-	}
-	description := targetDescription
-	if description == "" {
-		description = src.Description
+	groups := b.parameterGroupsStore(region)
+	src, err := copyPreconditions(
+		groups, sourceName, targetName,
+		"SourceDBParameterGroupIdentifier is required",
+		"TargetDBParameterGroupIdentifier is required",
+		ErrParameterGroupNotFound, ErrParameterGroupAlreadyExists,
+	)
+	if err != nil {
+		return nil, err
 	}
 	pg := &DBParameterGroup{
 		DBParameterGroupName:   targetName,
 		DBParameterGroupFamily: src.DBParameterGroupFamily,
-		Description:            description,
+		Description:            resolveCopyDescription(targetDescription, src.Description),
 	}
-	b.parameterGroups[targetName] = pg
+	groups[targetName] = pg
 	cp := *pg
 
 	return &cp, nil
@@ -1242,6 +1462,7 @@ func (b *InMemoryBackend) CopyDBParameterGroup(
 
 // CreateDBClusterEndpoint creates a Neptune DB cluster custom endpoint.
 func (b *InMemoryBackend) CreateDBClusterEndpoint(
+	ctx context.Context,
 	endpointID, clusterID, endpointType string,
 ) (*DBClusterEndpoint, error) {
 	if endpointID == "" {
@@ -1250,12 +1471,14 @@ func (b *InMemoryBackend) CreateDBClusterEndpoint(
 	if clusterID == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBClusterEndpoint")
 	defer b.mu.Unlock()
-	if _, exists := b.clusterEndpoints[endpointID]; exists {
+	endpoints := b.clusterEndpointsStore(region)
+	if _, exists := endpoints[endpointID]; exists {
 		return nil, fmt.Errorf("%w: cluster endpoint %s already exists", ErrClusterEndpointAlreadyExists, endpointID)
 	}
-	if _, exists := b.clusters[clusterID]; !exists {
+	if _, exists := b.clustersStore(region)[clusterID]; !exists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, clusterID)
 	}
 	if endpointType == "" {
@@ -1271,16 +1494,18 @@ func (b *InMemoryBackend) CreateDBClusterEndpoint(
 		DBClusterIdentifier:         clusterID,
 		EndpointType:                endpointType,
 		Status:                      clusterStatusAvailable,
-		Endpoint:                    fmt.Sprintf("%s.cluster-custom.neptune.%s.amazonaws.com", endpointID, b.region),
+		Endpoint:                    fmt.Sprintf("%s.cluster-custom.neptune.%s.amazonaws.com", endpointID, region),
 	}
-	b.clusterEndpoints[endpointID] = ep
+	endpoints[endpointID] = ep
 	cp := *ep
 
 	return &cp, nil
 }
 
 // CreateDBParameterGroup creates a Neptune DB parameter group.
-func (b *InMemoryBackend) CreateDBParameterGroup(name, family, description string) (*DBParameterGroup, error) {
+func (b *InMemoryBackend) CreateDBParameterGroup(
+	ctx context.Context, name, family, description string,
+) (*DBParameterGroup, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: DBParameterGroupName is required", ErrInvalidParameter)
 	}
@@ -1291,9 +1516,11 @@ func (b *InMemoryBackend) CreateDBParameterGroup(name, family, description strin
 			family,
 		)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateDBParameterGroup")
 	defer b.mu.Unlock()
-	if _, exists := b.parameterGroups[name]; exists {
+	pgs := b.parameterGroupsStore(region)
+	if _, exists := pgs[name]; exists {
 		return nil, fmt.Errorf("%w: parameter group %s already exists", ErrParameterGroupAlreadyExists, name)
 	}
 	pg := &DBParameterGroup{
@@ -1301,7 +1528,7 @@ func (b *InMemoryBackend) CreateDBParameterGroup(name, family, description strin
 		DBParameterGroupFamily: family,
 		Description:            description,
 	}
-	b.parameterGroups[name] = pg
+	pgs[name] = pg
 	cp := *pg
 
 	return &cp, nil
@@ -1309,6 +1536,7 @@ func (b *InMemoryBackend) CreateDBParameterGroup(name, family, description strin
 
 // CreateEventSubscription creates a Neptune event notification subscription.
 func (b *InMemoryBackend) CreateEventSubscription(
+	ctx context.Context,
 	name, snsTopicARN string,
 	sourceIDs []string,
 ) (*EventSubscription, error) {
@@ -1318,9 +1546,11 @@ func (b *InMemoryBackend) CreateEventSubscription(
 	if snsTopicARN == "" {
 		return nil, fmt.Errorf("%w: SnsTopicArn is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateEventSubscription")
 	defer b.mu.Unlock()
-	if _, exists := b.eventSubscriptions[name]; exists {
+	subs := b.eventSubscriptionsStore(region)
+	if _, exists := subs[name]; exists {
 		return nil, fmt.Errorf("%w: subscription %s already exists", ErrSubscriptionAlreadyExists, name)
 	}
 	ids := make([]string, len(sourceIDs))
@@ -1331,7 +1561,7 @@ func (b *InMemoryBackend) CreateEventSubscription(
 		Status:             subscriptionStatusActive,
 		SourceIDs:          ids,
 	}
-	b.eventSubscriptions[name] = sub
+	subs[name] = sub
 	cp := *sub
 	cp.SourceIDs = make([]string, len(ids))
 	copy(cp.SourceIDs, ids)
@@ -1340,10 +1570,15 @@ func (b *InMemoryBackend) CreateEventSubscription(
 }
 
 // CreateGlobalCluster creates a Neptune global cluster.
-func (b *InMemoryBackend) CreateGlobalCluster(globalClusterID, sourceDBClusterID string) (*GlobalCluster, error) {
+// Global clusters are partition-scoped (not region-isolated), but the optional
+// source DB cluster is looked up in the ctx region where it resides.
+func (b *InMemoryBackend) CreateGlobalCluster(
+	ctx context.Context, globalClusterID, sourceDBClusterID string,
+) (*GlobalCluster, error) {
 	if globalClusterID == "" {
 		return nil, fmt.Errorf("%w: GlobalClusterIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("CreateGlobalCluster")
 	defer b.mu.Unlock()
 	if _, exists := b.globalClusters[globalClusterID]; exists {
@@ -1354,10 +1589,10 @@ func (b *InMemoryBackend) CreateGlobalCluster(globalClusterID, sourceDBClusterID
 		Status:                  clusterStatusAvailable,
 	}
 	if sourceDBClusterID != "" {
-		if cl, exists := b.clusters[sourceDBClusterID]; exists {
+		if cl, exists := b.clustersStore(region)[sourceDBClusterID]; exists {
 			gc.GlobalClusterMembers = []GlobalClusterMember{
 				{
-					DBClusterARN: b.clusterARN(cl.DBClusterIdentifier),
+					DBClusterARN: b.clusterARN(region, cl.DBClusterIdentifier),
 					IsWriter:     true,
 				},
 			}
@@ -1372,7 +1607,8 @@ func (b *InMemoryBackend) CreateGlobalCluster(globalClusterID, sourceDBClusterID
 }
 
 // DescribeGlobalClusters returns all Neptune global clusters.
-func (b *InMemoryBackend) DescribeGlobalClusters() []GlobalCluster {
+// Global clusters are partition-scoped, so all are returned regardless of region.
+func (b *InMemoryBackend) DescribeGlobalClusters(_ context.Context) []GlobalCluster {
 	b.mu.RLock("DescribeGlobalClusters")
 	defer b.mu.RUnlock()
 	result := make([]GlobalCluster, 0, len(b.globalClusters))
@@ -1387,23 +1623,29 @@ func (b *InMemoryBackend) DescribeGlobalClusters() []GlobalCluster {
 }
 
 // DeleteDBClusterEndpoint deletes a Neptune DB cluster custom endpoint.
-func (b *InMemoryBackend) DeleteDBClusterEndpoint(endpointID string) error {
+func (b *InMemoryBackend) DeleteDBClusterEndpoint(ctx context.Context, endpointID string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBClusterEndpoint")
 	defer b.mu.Unlock()
-	if _, exists := b.clusterEndpoints[endpointID]; !exists {
+	endpoints := b.clusterEndpointsStore(region)
+	if _, exists := endpoints[endpointID]; !exists {
 		return fmt.Errorf("%w: cluster endpoint %s not found", ErrClusterEndpointNotFound, endpointID)
 	}
-	delete(b.clusterEndpoints, endpointID)
+	delete(endpoints, endpointID)
 
 	return nil
 }
 
 // DescribeDBClusterEndpoints returns all Neptune DB cluster endpoints or a specific one.
-func (b *InMemoryBackend) DescribeDBClusterEndpoints(endpointID, clusterID string) ([]DBClusterEndpoint, error) {
+func (b *InMemoryBackend) DescribeDBClusterEndpoints(
+	ctx context.Context, endpointID, clusterID string,
+) ([]DBClusterEndpoint, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBClusterEndpoints")
 	defer b.mu.RUnlock()
+	clusterEndpoints := b.clusterEndpointsStore(region)
 	if endpointID != "" {
-		ep, exists := b.clusterEndpoints[endpointID]
+		ep, exists := clusterEndpoints[endpointID]
 		if !exists {
 			return nil, fmt.Errorf("%w: cluster endpoint %s not found", ErrClusterEndpointNotFound, endpointID)
 		}
@@ -1411,8 +1653,8 @@ func (b *InMemoryBackend) DescribeDBClusterEndpoints(endpointID, clusterID strin
 
 		return []DBClusterEndpoint{cp}, nil
 	}
-	result := make([]DBClusterEndpoint, 0, len(b.clusterEndpoints))
-	for _, ep := range b.clusterEndpoints {
+	result := make([]DBClusterEndpoint, 0, len(clusterEndpoints))
+	for _, ep := range clusterEndpoints {
 		if clusterID != "" && ep.DBClusterIdentifier != clusterID {
 			continue
 		}
@@ -1423,10 +1665,13 @@ func (b *InMemoryBackend) DescribeDBClusterEndpoints(endpointID, clusterID strin
 }
 
 // ModifyDBClusterEndpoint modifies a Neptune DB cluster custom endpoint.
-func (b *InMemoryBackend) ModifyDBClusterEndpoint(endpointID, endpointType string) (*DBClusterEndpoint, error) {
+func (b *InMemoryBackend) ModifyDBClusterEndpoint(
+	ctx context.Context, endpointID, endpointType string,
+) (*DBClusterEndpoint, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyDBClusterEndpoint")
 	defer b.mu.Unlock()
-	ep, exists := b.clusterEndpoints[endpointID]
+	ep, exists := b.clusterEndpointsStore(region)[endpointID]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster endpoint %s not found", ErrClusterEndpointNotFound, endpointID)
 	}
@@ -1439,23 +1684,27 @@ func (b *InMemoryBackend) ModifyDBClusterEndpoint(endpointID, endpointType strin
 }
 
 // DeleteDBParameterGroup deletes a Neptune DB parameter group.
-func (b *InMemoryBackend) DeleteDBParameterGroup(name string) error {
+func (b *InMemoryBackend) DeleteDBParameterGroup(ctx context.Context, name string) error {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteDBParameterGroup")
 	defer b.mu.Unlock()
-	if _, exists := b.parameterGroups[name]; !exists {
+	groups := b.parameterGroupsStore(region)
+	if _, exists := groups[name]; !exists {
 		return fmt.Errorf("%w: parameter group %s not found", ErrParameterGroupNotFound, name)
 	}
-	delete(b.parameterGroups, name)
+	delete(groups, name)
 
 	return nil
 }
 
 // DescribeDBParameterGroups returns all Neptune DB parameter groups or a specific one.
-func (b *InMemoryBackend) DescribeDBParameterGroups(name string) ([]DBParameterGroup, error) {
+func (b *InMemoryBackend) DescribeDBParameterGroups(ctx context.Context, name string) ([]DBParameterGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeDBParameterGroups")
 	defer b.mu.RUnlock()
+	groups := b.parameterGroupsStore(region)
 	if name != "" {
-		pg, exists := b.parameterGroups[name]
+		pg, exists := groups[name]
 		if !exists {
 			return nil, fmt.Errorf("%w: parameter group %s not found", ErrParameterGroupNotFound, name)
 		}
@@ -1463,8 +1712,8 @@ func (b *InMemoryBackend) DescribeDBParameterGroups(name string) ([]DBParameterG
 
 		return []DBParameterGroup{cp}, nil
 	}
-	result := make([]DBParameterGroup, 0, len(b.parameterGroups))
-	for _, pg := range b.parameterGroups {
+	result := make([]DBParameterGroup, 0, len(groups))
+	for _, pg := range groups {
 		result = append(result, *pg)
 	}
 
@@ -1472,10 +1721,11 @@ func (b *InMemoryBackend) DescribeDBParameterGroups(name string) ([]DBParameterG
 }
 
 // ModifyDBParameterGroup modifies a Neptune DB parameter group.
-func (b *InMemoryBackend) ModifyDBParameterGroup(name string) (*DBParameterGroup, error) {
+func (b *InMemoryBackend) ModifyDBParameterGroup(ctx context.Context, name string) (*DBParameterGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyDBParameterGroup")
 	defer b.mu.Unlock()
-	pg, exists := b.parameterGroups[name]
+	pg, exists := b.parameterGroupsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: parameter group %s not found", ErrParameterGroupNotFound, name)
 	}
@@ -1485,10 +1735,11 @@ func (b *InMemoryBackend) ModifyDBParameterGroup(name string) (*DBParameterGroup
 }
 
 // ResetDBParameterGroup resets a Neptune DB parameter group to its default values.
-func (b *InMemoryBackend) ResetDBParameterGroup(name string) (*DBParameterGroup, error) {
+func (b *InMemoryBackend) ResetDBParameterGroup(ctx context.Context, name string) (*DBParameterGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ResetDBParameterGroup")
 	defer b.mu.Unlock()
-	pg, exists := b.parameterGroups[name]
+	pg, exists := b.parameterGroupsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: parameter group %s not found", ErrParameterGroupNotFound, name)
 	}
@@ -1498,10 +1749,13 @@ func (b *InMemoryBackend) ResetDBParameterGroup(name string) (*DBParameterGroup,
 }
 
 // ResetDBClusterParameterGroup resets a Neptune DB cluster parameter group to its default values.
-func (b *InMemoryBackend) ResetDBClusterParameterGroup(name string) (*DBClusterParameterGroup, error) {
+func (b *InMemoryBackend) ResetDBClusterParameterGroup(
+	ctx context.Context, name string,
+) (*DBClusterParameterGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ResetDBClusterParameterGroup")
 	defer b.mu.Unlock()
-	pg, exists := b.clusterParameterGroups[name]
+	pg, exists := b.clusterParameterGroupsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: cluster parameter group %s not found", ErrClusterParameterGroupNotFound, name)
 	}
@@ -1511,52 +1765,53 @@ func (b *InMemoryBackend) ResetDBClusterParameterGroup(name string) (*DBClusterP
 }
 
 // DeleteEventSubscription deletes a Neptune event subscription.
-func (b *InMemoryBackend) DeleteEventSubscription(name string) (*EventSubscription, error) {
+func (b *InMemoryBackend) DeleteEventSubscription(ctx context.Context, name string) (*EventSubscription, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("DeleteEventSubscription")
 	defer b.mu.Unlock()
-	sub, exists := b.eventSubscriptions[name]
+	subs := b.eventSubscriptionsStore(region)
+	sub, exists := subs[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: subscription %s not found", ErrSubscriptionNotFound, name)
 	}
 	cp := *sub
 	cp.SourceIDs = make([]string, len(sub.SourceIDs))
 	copy(cp.SourceIDs, sub.SourceIDs)
-	delete(b.eventSubscriptions, name)
+	delete(subs, name)
 
 	return &cp, nil
 }
 
 // DescribeEventSubscriptions returns all event subscriptions or a specific one.
-func (b *InMemoryBackend) DescribeEventSubscriptions(name string) ([]EventSubscription, error) {
+func (b *InMemoryBackend) DescribeEventSubscriptions(ctx context.Context, name string) ([]EventSubscription, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.RLock("DescribeEventSubscriptions")
 	defer b.mu.RUnlock()
+	subs := b.eventSubscriptionsStore(region)
 	if name != "" {
-		sub, exists := b.eventSubscriptions[name]
+		sub, exists := subs[name]
 		if !exists {
 			return nil, fmt.Errorf("%w: subscription %s not found", ErrSubscriptionNotFound, name)
 		}
-		cp := *sub
-		cp.SourceIDs = make([]string, len(sub.SourceIDs))
-		copy(cp.SourceIDs, sub.SourceIDs)
 
-		return []EventSubscription{cp}, nil
+		return []EventSubscription{cloneEventSubscription(sub)}, nil
 	}
-	result := make([]EventSubscription, 0, len(b.eventSubscriptions))
-	for _, sub := range b.eventSubscriptions {
-		cp := *sub
-		cp.SourceIDs = make([]string, len(sub.SourceIDs))
-		copy(cp.SourceIDs, sub.SourceIDs)
-		result = append(result, cp)
+	result := make([]EventSubscription, 0, len(subs))
+	for _, sub := range subs {
+		result = append(result, cloneEventSubscription(sub))
 	}
 
 	return result, nil
 }
 
 // ModifyEventSubscription modifies a Neptune event subscription.
-func (b *InMemoryBackend) ModifyEventSubscription(name, snsTopicARN string) (*EventSubscription, error) {
+func (b *InMemoryBackend) ModifyEventSubscription(
+	ctx context.Context, name, snsTopicARN string,
+) (*EventSubscription, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyEventSubscription")
 	defer b.mu.Unlock()
-	sub, exists := b.eventSubscriptions[name]
+	sub, exists := b.eventSubscriptionsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: subscription %s not found", ErrSubscriptionNotFound, name)
 	}
@@ -1571,16 +1826,19 @@ func (b *InMemoryBackend) ModifyEventSubscription(name, snsTopicARN string) (*Ev
 }
 
 // RemoveSourceIdentifierFromSubscription removes a source identifier from a Neptune event subscription.
-func (b *InMemoryBackend) RemoveSourceIdentifierFromSubscription(name, sourceID string) (*EventSubscription, error) {
+func (b *InMemoryBackend) RemoveSourceIdentifierFromSubscription(
+	ctx context.Context, name, sourceID string,
+) (*EventSubscription, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%w: SubscriptionName is required", ErrInvalidParameter)
 	}
 	if sourceID == "" {
 		return nil, fmt.Errorf("%w: SourceIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RemoveSourceIdentifierFromSubscription")
 	defer b.mu.Unlock()
-	sub, exists := b.eventSubscriptions[name]
+	sub, exists := b.eventSubscriptionsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: subscription %s not found", ErrSubscriptionNotFound, name)
 	}
@@ -1598,8 +1856,8 @@ func (b *InMemoryBackend) RemoveSourceIdentifierFromSubscription(name, sourceID 
 	return &cp, nil
 }
 
-// DeleteGlobalCluster deletes a Neptune global cluster.
-func (b *InMemoryBackend) DeleteGlobalCluster(globalClusterID string) (*GlobalCluster, error) {
+// DeleteGlobalCluster deletes a Neptune global cluster (partition-scoped).
+func (b *InMemoryBackend) DeleteGlobalCluster(_ context.Context, globalClusterID string) (*GlobalCluster, error) {
 	b.mu.Lock("DeleteGlobalCluster")
 	defer b.mu.Unlock()
 	gc, exists := b.globalClusters[globalClusterID]
@@ -1614,9 +1872,11 @@ func (b *InMemoryBackend) DeleteGlobalCluster(globalClusterID string) (*GlobalCl
 	return &cp, nil
 }
 
-// FailoverGlobalCluster performs a failover for a Neptune global cluster.
+// FailoverGlobalCluster performs a failover for a Neptune global cluster (partition-scoped).
 // targetDBClusterID is accepted for API compatibility but not used in the in-memory backend.
-func (b *InMemoryBackend) FailoverGlobalCluster(globalClusterID, _ string) (*GlobalCluster, error) {
+func (b *InMemoryBackend) FailoverGlobalCluster(
+	_ context.Context, globalClusterID, _ string,
+) (*GlobalCluster, error) {
 	b.mu.Lock("FailoverGlobalCluster")
 	defer b.mu.Unlock()
 	gc, exists := b.globalClusters[globalClusterID]
@@ -1630,8 +1890,8 @@ func (b *InMemoryBackend) FailoverGlobalCluster(globalClusterID, _ string) (*Glo
 	return &cp, nil
 }
 
-// ModifyGlobalCluster modifies a Neptune global cluster.
-func (b *InMemoryBackend) ModifyGlobalCluster(globalClusterID string) (*GlobalCluster, error) {
+// ModifyGlobalCluster modifies a Neptune global cluster (partition-scoped).
+func (b *InMemoryBackend) ModifyGlobalCluster(_ context.Context, globalClusterID string) (*GlobalCluster, error) {
 	b.mu.Lock("ModifyGlobalCluster")
 	defer b.mu.Unlock()
 	gc, exists := b.globalClusters[globalClusterID]
@@ -1645,8 +1905,10 @@ func (b *InMemoryBackend) ModifyGlobalCluster(globalClusterID string) (*GlobalCl
 	return &cp, nil
 }
 
-// RemoveFromGlobalCluster removes a DB cluster from a Neptune global cluster.
-func (b *InMemoryBackend) RemoveFromGlobalCluster(globalClusterID, dbClusterARN string) (*GlobalCluster, error) {
+// RemoveFromGlobalCluster removes a DB cluster from a Neptune global cluster (partition-scoped).
+func (b *InMemoryBackend) RemoveFromGlobalCluster(
+	_ context.Context, globalClusterID, dbClusterARN string,
+) (*GlobalCluster, error) {
 	b.mu.Lock("RemoveFromGlobalCluster")
 	defer b.mu.Unlock()
 	gc, exists := b.globalClusters[globalClusterID]
@@ -1667,9 +1929,11 @@ func (b *InMemoryBackend) RemoveFromGlobalCluster(globalClusterID, dbClusterARN 
 	return &cp, nil
 }
 
-// SwitchoverGlobalCluster switches over a Neptune global cluster to a new primary.
+// SwitchoverGlobalCluster switches over a Neptune global cluster to a new primary (partition-scoped).
 // targetDBClusterID is accepted for API compatibility but not used in the in-memory backend.
-func (b *InMemoryBackend) SwitchoverGlobalCluster(globalClusterID, _ string) (*GlobalCluster, error) {
+func (b *InMemoryBackend) SwitchoverGlobalCluster(
+	_ context.Context, globalClusterID, _ string,
+) (*GlobalCluster, error) {
 	b.mu.Lock("SwitchoverGlobalCluster")
 	defer b.mu.Unlock()
 	gc, exists := b.globalClusters[globalClusterID]
@@ -1684,57 +1948,63 @@ func (b *InMemoryBackend) SwitchoverGlobalCluster(globalClusterID, _ string) (*G
 }
 
 // RemoveRoleFromDBCluster removes an IAM role association from a Neptune DB cluster.
-func (b *InMemoryBackend) RemoveRoleFromDBCluster(clusterID, roleARN string) error {
+func (b *InMemoryBackend) RemoveRoleFromDBCluster(ctx context.Context, clusterID, roleARN string) error {
 	if clusterID == "" {
 		return fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
 	if roleARN == "" {
 		return fmt.Errorf("%w: RoleArn is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RemoveRoleFromDBCluster")
 	defer b.mu.Unlock()
-	if _, exists := b.clusters[clusterID]; !exists {
+	if _, exists := b.clustersStore(region)[clusterID]; !exists {
 		return fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, clusterID)
 	}
-	roles := b.clusterRoles[clusterID]
+	rolesStore := b.clusterRolesStore(region)
+	roles := rolesStore[clusterID]
 	kept := make([]string, 0, len(roles))
 	for _, r := range roles {
 		if r != roleARN {
 			kept = append(kept, r)
 		}
 	}
-	b.clusterRoles[clusterID] = kept
+	rolesStore[clusterID] = kept
 
 	return nil
 }
 
 // RestoreDBClusterFromSnapshot restores a Neptune DB cluster from a snapshot.
-func (b *InMemoryBackend) RestoreDBClusterFromSnapshot(snapshotID, clusterID string) (*DBCluster, error) {
+func (b *InMemoryBackend) RestoreDBClusterFromSnapshot(
+	ctx context.Context, snapshotID, clusterID string,
+) (*DBCluster, error) {
 	if snapshotID == "" {
 		return nil, fmt.Errorf("%w: DBClusterSnapshotIdentifier is required", ErrInvalidParameter)
 	}
 	if clusterID == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RestoreDBClusterFromSnapshot")
 	defer b.mu.Unlock()
-	snap, snapExists := b.clusterSnapshots[snapshotID]
+	clusters := b.clustersStore(region)
+	snap, snapExists := b.clusterSnapshotsStore(region)[snapshotID]
 	if !snapExists {
 		return nil, fmt.Errorf("%w: cluster snapshot %s not found", ErrClusterSnapshotNotFound, snapshotID)
 	}
-	if _, clExists := b.clusters[clusterID]; clExists {
+	if _, clExists := clusters[clusterID]; clExists {
 		return nil, fmt.Errorf("%w: cluster %s already exists", ErrClusterAlreadyExists, clusterID)
 	}
 	// Derive parameter group from the source cluster if available.
 	paramGroupName := pgFamilyDefaultNeptune13
-	if srcCluster, ok := b.clusters[snap.DBClusterIdentifier]; ok {
+	if srcCluster, ok := clusters[snap.DBClusterIdentifier]; ok {
 		paramGroupName = srcCluster.DBClusterParameterGroupName
 	}
-	endpoint := fmt.Sprintf("%s.cluster.%s.neptune.amazonaws.com", clusterID, b.region)
-	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", clusterID, b.region)
+	endpoint := fmt.Sprintf("%s.cluster.%s.neptune.amazonaws.com", clusterID, region)
+	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", clusterID, region)
 	cluster := &DBCluster{
 		DBClusterIdentifier:         clusterID,
-		DBClusterArn:                b.clusterARN(clusterID),
+		DBClusterArn:                b.clusterARN(region, clusterID),
 		Engine:                      snap.Engine,
 		EngineVersion:               snap.EngineVersion,
 		EngineMode:                  engineModeProvisioned,
@@ -1747,34 +2017,38 @@ func (b *InMemoryBackend) RestoreDBClusterFromSnapshot(snapshotID, clusterID str
 		DBClusterMembers:            []DBClusterMember{},
 		BackupRetentionPeriod:       defaultBackupRetentionPeriod,
 	}
-	b.clusters[clusterID] = cluster
+	clusters[clusterID] = cluster
 	cp := cloneCluster(cluster)
 
 	return &cp, nil
 }
 
 // RestoreDBClusterToPointInTime restores a Neptune DB cluster to a point in time.
-func (b *InMemoryBackend) RestoreDBClusterToPointInTime(srcClusterID, targetClusterID string) (*DBCluster, error) {
+func (b *InMemoryBackend) RestoreDBClusterToPointInTime(
+	ctx context.Context, srcClusterID, targetClusterID string,
+) (*DBCluster, error) {
 	if srcClusterID == "" {
 		return nil, fmt.Errorf("%w: SourceDBClusterIdentifier is required", ErrInvalidParameter)
 	}
 	if targetClusterID == "" {
 		return nil, fmt.Errorf("%w: DBClusterIdentifier is required", ErrInvalidParameter)
 	}
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("RestoreDBClusterToPointInTime")
 	defer b.mu.Unlock()
-	src, srcExists := b.clusters[srcClusterID]
+	clusters := b.clustersStore(region)
+	src, srcExists := clusters[srcClusterID]
 	if !srcExists {
 		return nil, fmt.Errorf("%w: cluster %s not found", ErrClusterNotFound, srcClusterID)
 	}
-	if _, tgtExists := b.clusters[targetClusterID]; tgtExists {
+	if _, tgtExists := clusters[targetClusterID]; tgtExists {
 		return nil, fmt.Errorf("%w: cluster %s already exists", ErrClusterAlreadyExists, targetClusterID)
 	}
-	endpoint := fmt.Sprintf("%s.cluster.%s.neptune.amazonaws.com", targetClusterID, b.region)
-	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", targetClusterID, b.region)
+	endpoint := fmt.Sprintf("%s.cluster.%s.neptune.amazonaws.com", targetClusterID, region)
+	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", targetClusterID, region)
 	cluster := &DBCluster{
 		DBClusterIdentifier:             targetClusterID,
-		DBClusterArn:                    b.clusterARN(targetClusterID),
+		DBClusterArn:                    b.clusterARN(region, targetClusterID),
 		Engine:                          src.Engine,
 		EngineVersion:                   src.EngineVersion,
 		EngineMode:                      src.EngineMode,
@@ -1789,17 +2063,18 @@ func (b *InMemoryBackend) RestoreDBClusterToPointInTime(srcClusterID, targetClus
 		DBClusterMembers:                []DBClusterMember{},
 		BackupRetentionPeriod:           src.BackupRetentionPeriod,
 	}
-	b.clusters[targetClusterID] = cluster
+	clusters[targetClusterID] = cluster
 	cp := cloneCluster(cluster)
 
 	return &cp, nil
 }
 
 // ModifyDBSubnetGroup modifies a Neptune DB subnet group.
-func (b *InMemoryBackend) ModifyDBSubnetGroup(name, description string) (*DBSubnetGroup, error) {
+func (b *InMemoryBackend) ModifyDBSubnetGroup(ctx context.Context, name, description string) (*DBSubnetGroup, error) {
+	region := getRegion(ctx, b.region)
 	b.mu.Lock("ModifyDBSubnetGroup")
 	defer b.mu.Unlock()
-	sg, exists := b.subnetGroups[name]
+	sg, exists := b.subnetGroupsStore(region)[name]
 	if !exists {
 		return nil, fmt.Errorf("%w: subnet group %s not found", ErrSubnetGroupNotFound, name)
 	}
@@ -1820,17 +2095,17 @@ func (b *InMemoryBackend) AccountID() string { return b.accountID }
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
-	b.clusters = make(map[string]*DBCluster)
-	b.instances = make(map[string]*DBInstance)
-	b.subnetGroups = make(map[string]*DBSubnetGroup)
-	b.clusterParameterGroups = make(map[string]*DBClusterParameterGroup)
-	b.clusterSnapshots = make(map[string]*DBClusterSnapshot)
-	b.parameterGroups = make(map[string]*DBParameterGroup)
-	b.clusterEndpoints = make(map[string]*DBClusterEndpoint)
-	b.eventSubscriptions = make(map[string]*EventSubscription)
+	b.clusters = make(map[string]map[string]*DBCluster)
+	b.instances = make(map[string]map[string]*DBInstance)
+	b.subnetGroups = make(map[string]map[string]*DBSubnetGroup)
+	b.clusterParameterGroups = make(map[string]map[string]*DBClusterParameterGroup)
+	b.clusterSnapshots = make(map[string]map[string]*DBClusterSnapshot)
+	b.parameterGroups = make(map[string]map[string]*DBParameterGroup)
+	b.clusterEndpoints = make(map[string]map[string]*DBClusterEndpoint)
+	b.eventSubscriptions = make(map[string]map[string]*EventSubscription)
+	b.clusterRoles = make(map[string]map[string][]string)
+	b.tags = make(map[string]map[string][]Tag)
 	b.globalClusters = make(map[string]*GlobalCluster)
-	b.clusterRoles = make(map[string][]string)
-	b.tags = make(map[string][]Tag)
 }
 
 // AddClusterInternal creates a cluster directly, bypassing normal validation. Used for seeding tests.
@@ -1841,7 +2116,7 @@ func (b *InMemoryBackend) AddClusterInternal(id string) *DBCluster {
 	readerEndpoint := fmt.Sprintf("%s.cluster-ro.%s.neptune.amazonaws.com", id, b.region)
 	c := &DBCluster{
 		DBClusterIdentifier:         id,
-		DBClusterArn:                b.clusterARN(id),
+		DBClusterArn:                b.clusterARN(b.region, id),
 		Engine:                      neptuneEngine,
 		EngineVersion:               defaultEngineVersion,
 		EngineMode:                  engineModeProvisioned,
@@ -1852,7 +2127,7 @@ func (b *InMemoryBackend) AddClusterInternal(id string) *DBCluster {
 		Port:                        defaultNeptunePort,
 		BackupRetentionPeriod:       defaultBackupRetentionPeriod,
 	}
-	b.clusters[id] = c
+	b.clustersStore(b.region)[id] = c
 	cp := cloneCluster(c)
 
 	return &cp
@@ -1864,14 +2139,14 @@ func (b *InMemoryBackend) AddSnapshotInternal(snapshotID, clusterID string) *DBC
 	defer b.mu.Unlock()
 	snap := &DBClusterSnapshot{
 		DBClusterSnapshotIdentifier: snapshotID,
-		DBClusterSnapshotArn:        b.clusterSnapshotARN(snapshotID),
+		DBClusterSnapshotArn:        b.clusterSnapshotARN(b.region, snapshotID),
 		DBClusterIdentifier:         clusterID,
 		Engine:                      neptuneEngine,
 		EngineVersion:               defaultEngineVersion,
 		Status:                      clusterStatusAvailable,
 		SnapshotType:                snapshotSourceManual,
 	}
-	b.clusterSnapshots[snapshotID] = snap
+	b.clusterSnapshotsStore(b.region)[snapshotID] = snap
 	cp := *snap
 
 	return &cp
@@ -1886,7 +2161,7 @@ func (b *InMemoryBackend) AddClusterParameterGroupInternal(name, family string) 
 		DBParameterGroupFamily:      family,
 		Description:                 "seeded for tests",
 	}
-	b.clusterParameterGroups[name] = pg
+	b.clusterParameterGroupsStore(b.region)[name] = pg
 	cp := *pg
 
 	return &cp
@@ -1901,7 +2176,7 @@ func (b *InMemoryBackend) AddParameterGroupInternal(name, family string) *DBPara
 		DBParameterGroupFamily: family,
 		Description:            "seeded for tests",
 	}
-	b.parameterGroups[name] = pg
+	b.parameterGroupsStore(b.region)[name] = pg
 	cp := *pg
 
 	return &cp
@@ -1916,7 +2191,7 @@ func (b *InMemoryBackend) AddEventSubscriptionInternal(name, snsTopicARN string)
 		SnsTopicARN:        snsTopicARN,
 		Status:             subscriptionStatusActive,
 	}
-	b.eventSubscriptions[name] = sub
+	b.eventSubscriptionsStore(b.region)[name] = sub
 	cp := *sub
 
 	return &cp

--- a/services/neptune/export_test.go
+++ b/services/neptune/export_test.go
@@ -1,70 +1,80 @@
 package neptune
 
-// ClusterCount returns the number of clusters in the backend.
+// sumNested returns the total element count across all region maps.
+func sumNested[V any](m map[string]map[string]V) int {
+	total := 0
+	for _, region := range m {
+		total += len(region)
+	}
+
+	return total
+}
+
+// ClusterCount returns the number of clusters in the backend across all regions.
 func ClusterCount(b *InMemoryBackend) int {
 	b.mu.RLock("ClusterCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusters)
+	return sumNested(b.clusters)
 }
 
-// InstanceCount returns the number of DB instances in the backend.
+// InstanceCount returns the number of DB instances in the backend across all regions.
 func InstanceCount(b *InMemoryBackend) int {
 	b.mu.RLock("InstanceCount")
 	defer b.mu.RUnlock()
 
-	return len(b.instances)
+	return sumNested(b.instances)
 }
 
-// SubnetGroupCount returns the number of subnet groups in the backend.
+// SubnetGroupCount returns the number of subnet groups in the backend across all regions.
 func SubnetGroupCount(b *InMemoryBackend) int {
 	b.mu.RLock("SubnetGroupCount")
 	defer b.mu.RUnlock()
 
-	return len(b.subnetGroups)
+	return sumNested(b.subnetGroups)
 }
 
-// ClusterParameterGroupCount returns the number of cluster parameter groups in the backend.
+// ClusterParameterGroupCount returns the number of cluster parameter groups across all regions.
 func ClusterParameterGroupCount(b *InMemoryBackend) int {
 	b.mu.RLock("ClusterParameterGroupCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusterParameterGroups)
+	return sumNested(b.clusterParameterGroups)
 }
 
-// ClusterSnapshotCount returns the number of cluster snapshots in the backend.
+// ClusterSnapshotCount returns the number of cluster snapshots in the backend across all regions.
 func ClusterSnapshotCount(b *InMemoryBackend) int {
 	b.mu.RLock("ClusterSnapshotCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusterSnapshots)
+	return sumNested(b.clusterSnapshots)
 }
 
-// ParameterGroupCount returns the number of DB parameter groups in the backend.
+// ParameterGroupCount returns the number of DB parameter groups across all regions.
 func ParameterGroupCount(b *InMemoryBackend) int {
 	b.mu.RLock("ParameterGroupCount")
 	defer b.mu.RUnlock()
 
-	return len(b.parameterGroups)
+	return sumNested(b.parameterGroups)
 }
 
-// ClusterEndpointCount returns the number of cluster endpoints in the backend.
+// ClusterEndpointCount returns the number of cluster endpoints across all regions.
 func ClusterEndpointCount(b *InMemoryBackend) int {
 	b.mu.RLock("ClusterEndpointCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusterEndpoints)
+	return sumNested(b.clusterEndpoints)
 }
 
-// EventSubscriptionCount returns the number of event subscriptions in the backend.
+// EventSubscriptionCount returns the number of event subscriptions across all regions.
 func EventSubscriptionCount(b *InMemoryBackend) int {
 	b.mu.RLock("EventSubscriptionCount")
 	defer b.mu.RUnlock()
 
-	return len(b.eventSubscriptions)
+	return sumNested(b.eventSubscriptions)
 }
 
-// GlobalClusterCount returns the number of global clusters in the backend.
+// GlobalClusterCount returns the number of global clusters (partition-scoped).
 func GlobalClusterCount(b *InMemoryBackend) int {
 	b.mu.RLock("GlobalClusterCount")
 	defer b.mu.RUnlock()
@@ -72,25 +82,27 @@ func GlobalClusterCount(b *InMemoryBackend) int {
 	return len(b.globalClusters)
 }
 
-// TagCount returns the total number of tag entries across all resources.
+// TagCount returns the total number of tag entries across all resources and regions.
 func TagCount(b *InMemoryBackend) int {
 	b.mu.RLock("TagCount")
 	defer b.mu.RUnlock()
 
 	total := 0
-	for _, tags := range b.tags {
-		total += len(tags)
+	for _, regionTags := range b.tags {
+		for _, tags := range regionTags {
+			total += len(tags)
+		}
 	}
 
 	return total
 }
 
-// ClusterRoleCount returns the number of IAM roles associated with a cluster.
+// ClusterRoleCount returns the number of IAM roles associated with a cluster in the default region.
 func ClusterRoleCount(b *InMemoryBackend, clusterID string) int {
 	b.mu.RLock("ClusterRoleCount")
 	defer b.mu.RUnlock()
 
-	return len(b.clusterRoles[clusterID])
+	return len(b.clusterRoles[b.region][clusterID])
 }
 
 // HandlerOpsLen returns the number of operations listed in GetSupportedOperations.

--- a/services/neptune/handler.go
+++ b/services/neptune/handler.go
@@ -1,6 +1,7 @@
 package neptune
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -51,9 +52,15 @@ func (h *Handler) Reset() {
 	h.Backend.Reset()
 }
 
-// clusterARN builds a Neptune cluster ARN using the backend's region and account.
-func (h *Handler) clusterARN(id string) string {
-	return arn.Build("neptune", h.Backend.Region(), h.Backend.AccountID(), "cluster:"+id)
+// clusterARN builds a Neptune cluster ARN using the request region and account.
+func (h *Handler) clusterARN(region, id string) string {
+	return arn.Build("neptune", region, h.Backend.AccountID(), "cluster:"+id)
+}
+
+// regionFromRequest resolves the AWS region for a request from its SigV4
+// credential scope, falling back to the backend's default region.
+func (h *Handler) regionFromRequest(c *echo.Context) string {
+	return httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
 }
 
 // GetSupportedOperations returns supported Neptune operations (sorted).
@@ -211,7 +218,9 @@ func (h *Handler) Handler() echo.HandlerFunc {
 		if action == "" {
 			return h.writeError(c, http.StatusBadRequest, "MissingAction", "missing Action parameter")
 		}
-		resp, opErr := h.dispatch(action, vals)
+		// Attach the SigV4-derived region so backend ops route to the correct region store.
+		ctx := context.WithValue(r.Context(), regionContextKey{}, h.regionFromRequest(c))
+		resp, opErr := h.dispatch(ctx, action, vals)
 		if opErr != nil {
 			return h.handleOpError(c, action, opErr)
 		}
@@ -224,196 +233,196 @@ func (h *Handler) Handler() echo.HandlerFunc {
 	}
 }
 
-func (h *Handler) dispatch(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatch(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "CreateDBCluster":
-		return h.handleCreateDBCluster(vals)
+		return h.handleCreateDBCluster(ctx, vals)
 	case "DescribeDBClusters":
-		return h.handleDescribeDBClusters(vals)
+		return h.handleDescribeDBClusters(ctx, vals)
 	case "DeleteDBCluster":
-		return h.handleDeleteDBCluster(vals)
+		return h.handleDeleteDBCluster(ctx, vals)
 	case "ModifyDBCluster":
-		return h.handleModifyDBCluster(vals)
+		return h.handleModifyDBCluster(ctx, vals)
 	case "StopDBCluster":
-		return h.handleStopDBCluster(vals)
+		return h.handleStopDBCluster(ctx, vals)
 	case "StartDBCluster":
-		return h.handleStartDBCluster(vals)
+		return h.handleStartDBCluster(ctx, vals)
 	case "FailoverDBCluster":
-		return h.handleFailoverDBCluster(vals)
+		return h.handleFailoverDBCluster(ctx, vals)
 	case "CreateDBInstance":
-		return h.handleCreateDBInstance(vals)
+		return h.handleCreateDBInstance(ctx, vals)
 	case "DescribeDBInstances":
-		return h.handleDescribeDBInstances(vals)
+		return h.handleDescribeDBInstances(ctx, vals)
 	case "DeleteDBInstance":
-		return h.handleDeleteDBInstance(vals)
+		return h.handleDeleteDBInstance(ctx, vals)
 	case "ModifyDBInstance":
-		return h.handleModifyDBInstance(vals)
+		return h.handleModifyDBInstance(ctx, vals)
 	case "RebootDBInstance":
-		return h.handleRebootDBInstance(vals)
+		return h.handleRebootDBInstance(ctx, vals)
 	default:
-		return h.dispatchExtended(action, vals)
+		return h.dispatchExtended(ctx, action, vals)
 	}
 }
 
-func (h *Handler) dispatchExtended(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatchExtended(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "CreateDBSubnetGroup":
-		return h.handleCreateDBSubnetGroup(vals)
+		return h.handleCreateDBSubnetGroup(ctx, vals)
 	case "DescribeDBSubnetGroups":
-		return h.handleDescribeDBSubnetGroups(vals)
+		return h.handleDescribeDBSubnetGroups(ctx, vals)
 	case "DeleteDBSubnetGroup":
-		return h.handleDeleteDBSubnetGroup(vals)
+		return h.handleDeleteDBSubnetGroup(ctx, vals)
 	case "CreateDBClusterParameterGroup":
-		return h.handleCreateDBClusterParameterGroup(vals)
+		return h.handleCreateDBClusterParameterGroup(ctx, vals)
 	case "DescribeDBClusterParameterGroups":
-		return h.handleDescribeDBClusterParameterGroups(vals)
+		return h.handleDescribeDBClusterParameterGroups(ctx, vals)
 	case "DeleteDBClusterParameterGroup":
-		return h.handleDeleteDBClusterParameterGroup(vals)
+		return h.handleDeleteDBClusterParameterGroup(ctx, vals)
 	case "ModifyDBClusterParameterGroup":
-		return h.handleModifyDBClusterParameterGroup(vals)
+		return h.handleModifyDBClusterParameterGroup(ctx, vals)
 	default:
-		return h.dispatchExtended2(action, vals)
+		return h.dispatchExtended2(ctx, action, vals)
 	}
 }
 
-func (h *Handler) dispatchExtended2(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatchExtended2(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "CreateDBClusterSnapshot":
-		return h.handleCreateDBClusterSnapshot(vals)
+		return h.handleCreateDBClusterSnapshot(ctx, vals)
 	case "DescribeDBClusterSnapshots":
-		return h.handleDescribeDBClusterSnapshots(vals)
+		return h.handleDescribeDBClusterSnapshots(ctx, vals)
 	case "DeleteDBClusterSnapshot":
-		return h.handleDeleteDBClusterSnapshot(vals)
+		return h.handleDeleteDBClusterSnapshot(ctx, vals)
 	case "ListTagsForResource":
-		return h.handleListTagsForResource(vals)
+		return h.handleListTagsForResource(ctx, vals)
 	case "AddTagsToResource":
-		return h.handleAddTagsToResource(vals)
+		return h.handleAddTagsToResource(ctx, vals)
 	case "RemoveTagsFromResource":
-		return h.handleRemoveTagsFromResource(vals)
+		return h.handleRemoveTagsFromResource(ctx, vals)
 	case "DescribeDBEngineVersions":
-		return h.handleDescribeDBEngineVersions(vals)
+		return h.handleDescribeDBEngineVersions(ctx, vals)
 	case "DescribeOrderableDBInstanceOptions":
-		return h.handleDescribeOrderableDBInstanceOptions(vals)
+		return h.handleDescribeOrderableDBInstanceOptions(ctx, vals)
 	case "DescribeGlobalClusters":
-		return h.handleDescribeGlobalClusters(vals)
+		return h.handleDescribeGlobalClusters(ctx, vals)
 	default:
-		return h.dispatchNewOps(action, vals)
+		return h.dispatchNewOps(ctx, action, vals)
 	}
 }
 
-func (h *Handler) dispatchNewOps(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatchNewOps(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "AddRoleToDBCluster":
-		return h.handleAddRoleToDBCluster(vals)
+		return h.handleAddRoleToDBCluster(ctx, vals)
 	case "AddSourceIdentifierToSubscription":
-		return h.handleAddSourceIdentifierToSubscription(vals)
+		return h.handleAddSourceIdentifierToSubscription(ctx, vals)
 	case "ApplyPendingMaintenanceAction":
-		return h.handleApplyPendingMaintenanceAction(vals)
+		return h.handleApplyPendingMaintenanceAction(ctx, vals)
 	case "CopyDBClusterParameterGroup":
-		return h.handleCopyDBClusterParameterGroup(vals)
+		return h.handleCopyDBClusterParameterGroup(ctx, vals)
 	case "CopyDBClusterSnapshot":
-		return h.handleCopyDBClusterSnapshot(vals)
+		return h.handleCopyDBClusterSnapshot(ctx, vals)
 	case "CopyDBParameterGroup":
-		return h.handleCopyDBParameterGroup(vals)
+		return h.handleCopyDBParameterGroup(ctx, vals)
 	case "CreateDBClusterEndpoint":
-		return h.handleCreateDBClusterEndpoint(vals)
+		return h.handleCreateDBClusterEndpoint(ctx, vals)
 	case "CreateDBParameterGroup":
-		return h.handleCreateDBParameterGroup(vals)
+		return h.handleCreateDBParameterGroup(ctx, vals)
 	case "CreateEventSubscription":
-		return h.handleCreateEventSubscription(vals)
+		return h.handleCreateEventSubscription(ctx, vals)
 	case "CreateGlobalCluster":
-		return h.handleCreateGlobalCluster(vals)
+		return h.handleCreateGlobalCluster(ctx, vals)
 	default:
-		return h.dispatchNewOps2(action, vals)
+		return h.dispatchNewOps2(ctx, action, vals)
 	}
 }
 
-func (h *Handler) dispatchNewOps2(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatchNewOps2(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "DeleteDBClusterEndpoint":
-		return h.handleDeleteDBClusterEndpoint(vals)
+		return h.handleDeleteDBClusterEndpoint(ctx, vals)
 	case "DescribeDBClusterEndpoints":
-		return h.handleDescribeDBClusterEndpoints(vals)
+		return h.handleDescribeDBClusterEndpoints(ctx, vals)
 	case "ModifyDBClusterEndpoint":
-		return h.handleModifyDBClusterEndpoint(vals)
+		return h.handleModifyDBClusterEndpoint(ctx, vals)
 	case "DeleteDBParameterGroup":
-		return h.handleDeleteDBParameterGroup(vals)
+		return h.handleDeleteDBParameterGroup(ctx, vals)
 	case "DescribeDBParameterGroups":
-		return h.handleDescribeDBParameterGroups(vals)
+		return h.handleDescribeDBParameterGroups(ctx, vals)
 	case "DescribeDBParameters":
-		return h.handleDescribeDBParameters(vals)
+		return h.handleDescribeDBParameters(ctx, vals)
 	case "ModifyDBParameterGroup":
-		return h.handleModifyDBParameterGroup(vals)
+		return h.handleModifyDBParameterGroup(ctx, vals)
 	case "ResetDBParameterGroup":
-		return h.handleResetDBParameterGroup(vals)
+		return h.handleResetDBParameterGroup(ctx, vals)
 	case "DescribeDBClusterParameters":
-		return h.handleDescribeDBClusterParameters(vals)
+		return h.handleDescribeDBClusterParameters(ctx, vals)
 	case "DescribeDBClusterSnapshotAttributes":
-		return h.handleDescribeDBClusterSnapshotAttributes(vals)
+		return h.handleDescribeDBClusterSnapshotAttributes(ctx, vals)
 	case "ModifyDBClusterSnapshotAttribute":
-		return h.handleModifyDBClusterSnapshotAttribute(vals)
+		return h.handleModifyDBClusterSnapshotAttribute(ctx, vals)
 	case "ResetDBClusterParameterGroup":
-		return h.handleResetDBClusterParameterGroup(vals)
+		return h.handleResetDBClusterParameterGroup(ctx, vals)
 	default:
-		return h.dispatchNewOps3(action, vals)
+		return h.dispatchNewOps3(ctx, action, vals)
 	}
 }
 
-func (h *Handler) dispatchNewOps3(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatchNewOps3(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "DeleteEventSubscription":
-		return h.handleDeleteEventSubscription(vals)
+		return h.handleDeleteEventSubscription(ctx, vals)
 	case "DescribeEventSubscriptions":
-		return h.handleDescribeEventSubscriptions(vals)
+		return h.handleDescribeEventSubscriptions(ctx, vals)
 	case "ModifyEventSubscription":
-		return h.handleModifyEventSubscription(vals)
+		return h.handleModifyEventSubscription(ctx, vals)
 	case "RemoveSourceIdentifierFromSubscription":
-		return h.handleRemoveSourceIdentifierFromSubscription(vals)
+		return h.handleRemoveSourceIdentifierFromSubscription(ctx, vals)
 	case "DescribeEventCategories":
-		return h.handleDescribeEventCategories(vals)
+		return h.handleDescribeEventCategories(ctx, vals)
 	case "DescribeEvents":
-		return h.handleDescribeEvents(vals)
+		return h.handleDescribeEvents(ctx, vals)
 	case "DeleteGlobalCluster":
-		return h.handleDeleteGlobalCluster(vals)
+		return h.handleDeleteGlobalCluster(ctx, vals)
 	case "FailoverGlobalCluster":
-		return h.handleFailoverGlobalCluster(vals)
+		return h.handleFailoverGlobalCluster(ctx, vals)
 	case "ModifyGlobalCluster":
-		return h.handleModifyGlobalCluster(vals)
+		return h.handleModifyGlobalCluster(ctx, vals)
 	case "RemoveFromGlobalCluster":
-		return h.handleRemoveFromGlobalCluster(vals)
+		return h.handleRemoveFromGlobalCluster(ctx, vals)
 	default:
-		return h.dispatchNewOps4(action, vals)
+		return h.dispatchNewOps4(ctx, action, vals)
 	}
 }
 
-func (h *Handler) dispatchNewOps4(action string, vals url.Values) (any, error) {
+func (h *Handler) dispatchNewOps4(ctx context.Context, action string, vals url.Values) (any, error) {
 	switch action {
 	case "SwitchoverGlobalCluster":
-		return h.handleSwitchoverGlobalCluster(vals)
+		return h.handleSwitchoverGlobalCluster(ctx, vals)
 	case "RemoveRoleFromDBCluster":
-		return h.handleRemoveRoleFromDBCluster(vals)
+		return h.handleRemoveRoleFromDBCluster(ctx, vals)
 	case "DescribeEngineDefaultClusterParameters":
-		return h.handleDescribeEngineDefaultClusterParameters(vals)
+		return h.handleDescribeEngineDefaultClusterParameters(ctx, vals)
 	case "DescribeEngineDefaultParameters":
-		return h.handleDescribeEngineDefaultParameters(vals)
+		return h.handleDescribeEngineDefaultParameters(ctx, vals)
 	case "DescribePendingMaintenanceActions":
-		return h.handleDescribePendingMaintenanceActions(vals)
+		return h.handleDescribePendingMaintenanceActions(ctx, vals)
 	case "DescribeValidDBInstanceModifications":
-		return h.handleDescribeValidDBInstanceModifications(vals)
+		return h.handleDescribeValidDBInstanceModifications(ctx, vals)
 	case "PromoteReadReplicaDBCluster":
-		return h.handlePromoteReadReplicaDBCluster(vals)
+		return h.handlePromoteReadReplicaDBCluster(ctx, vals)
 	case "RestoreDBClusterFromSnapshot":
-		return h.handleRestoreDBClusterFromSnapshot(vals)
+		return h.handleRestoreDBClusterFromSnapshot(ctx, vals)
 	case "RestoreDBClusterToPointInTime":
-		return h.handleRestoreDBClusterToPointInTime(vals)
+		return h.handleRestoreDBClusterToPointInTime(ctx, vals)
 	case "ModifyDBSubnetGroup":
-		return h.handleModifyDBSubnetGroup(vals)
+		return h.handleModifyDBSubnetGroup(ctx, vals)
 	default:
 		return nil, fmt.Errorf("%w: %s is not a valid Neptune action", ErrUnknownAction, action)
 	}
 }
 
-func (h *Handler) handleCreateDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
 	paramGroupName := vals.Get("DBClusterParameterGroupName")
 	port := 0
@@ -442,12 +451,16 @@ func (h *Handler) handleCreateDBCluster(vals url.Values) (any, error) {
 	if err := validateTagEntries(tags); err != nil {
 		return nil, err
 	}
-	cluster, err := h.Backend.CreateDBCluster(id, paramGroupName, port, opts)
+	cluster, err := h.Backend.CreateDBCluster(ctx, id, paramGroupName, port, opts)
 	if err != nil {
 		return nil, err
 	}
 	if len(tags) > 0 {
-		_ = h.Backend.AddTagsToResource(h.clusterARN(cluster.DBClusterIdentifier), tags)
+		_ = h.Backend.AddTagsToResource(
+			ctx,
+			h.clusterARN(getRegion(ctx, h.Backend.Region()), cluster.DBClusterIdentifier),
+			tags,
+		)
 	}
 
 	return &createDBClusterResponse{
@@ -456,9 +469,9 @@ func (h *Handler) handleCreateDBCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBClusters(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBClusters(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	clusters, err := h.Backend.DescribeDBClusters(id)
+	clusters, err := h.Backend.DescribeDBClusters(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -479,9 +492,9 @@ func (h *Handler) handleDescribeDBClusters(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.DeleteDBCluster(id)
+	cluster, err := h.Backend.DeleteDBCluster(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +505,7 @@ func (h *Handler) handleDeleteDBCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleModifyDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
 	paramGroupName := vals.Get("DBClusterParameterGroupName")
 	sv2, sv2Err := parseServerlessV2ScalingConfig(vals)
@@ -512,7 +525,7 @@ func (h *Handler) handleModifyDBCluster(vals url.Values) (any, error) {
 		DeletionProtectionSet:           rawDel != "",
 		ServerlessV2ScalingConfig:       sv2,
 	}
-	cluster, err := h.Backend.ModifyDBCluster(id, paramGroupName, opts)
+	cluster, err := h.Backend.ModifyDBCluster(ctx, id, paramGroupName, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -523,9 +536,9 @@ func (h *Handler) handleModifyDBCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleStopDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleStopDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.StopDBCluster(id)
+	cluster, err := h.Backend.StopDBCluster(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -536,9 +549,9 @@ func (h *Handler) handleStopDBCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleStartDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleStartDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.StartDBCluster(id)
+	cluster, err := h.Backend.StartDBCluster(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -549,9 +562,9 @@ func (h *Handler) handleStartDBCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleFailoverDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleFailoverDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.FailoverDBCluster(id)
+	cluster, err := h.Backend.FailoverDBCluster(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +575,7 @@ func (h *Handler) handleFailoverDBCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateDBInstance(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBInstance(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBInstanceIdentifier")
 	clusterID := vals.Get("DBClusterIdentifier")
 	if clusterID == "" {
@@ -592,12 +605,12 @@ func (h *Handler) handleCreateDBInstance(vals url.Values) (any, error) {
 	if err := validateTagEntries(tags); err != nil {
 		return nil, err
 	}
-	inst, err := h.Backend.CreateDBInstance(id, clusterID, instanceClass, opts)
+	inst, err := h.Backend.CreateDBInstance(ctx, id, clusterID, instanceClass, opts)
 	if err != nil {
 		return nil, err
 	}
 	if len(tags) > 0 {
-		_ = h.Backend.AddTagsToResource(inst.DBInstanceArn, tags)
+		_ = h.Backend.AddTagsToResource(ctx, inst.DBInstanceArn, tags)
 	}
 
 	return &createDBInstanceResponse{
@@ -606,9 +619,9 @@ func (h *Handler) handleCreateDBInstance(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBInstances(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBInstances(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBInstanceIdentifier")
-	instances, err := h.Backend.DescribeDBInstances(id)
+	instances, err := h.Backend.DescribeDBInstances(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -629,9 +642,9 @@ func (h *Handler) handleDescribeDBInstances(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBInstance(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBInstance(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBInstanceIdentifier")
-	inst, err := h.Backend.DeleteDBInstance(id)
+	inst, err := h.Backend.DeleteDBInstance(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -642,7 +655,7 @@ func (h *Handler) handleDeleteDBInstance(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleModifyDBInstance(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBInstance(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBInstanceIdentifier")
 	instanceClass := vals.Get("DBInstanceClass")
 	rawAuto := vals.Get("AutoMinorVersionUpgrade")
@@ -671,7 +684,7 @@ func (h *Handler) handleModifyDBInstance(vals url.Values) (any, error) {
 		PromotionTier:                   promotionTier,
 		PromotionTierSet:                promotionTierSet,
 	}
-	inst, err := h.Backend.ModifyDBInstance(id, instanceClass, opts)
+	inst, err := h.Backend.ModifyDBInstance(ctx, id, instanceClass, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -682,9 +695,9 @@ func (h *Handler) handleModifyDBInstance(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleRebootDBInstance(vals url.Values) (any, error) {
+func (h *Handler) handleRebootDBInstance(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBInstanceIdentifier")
-	inst, err := h.Backend.RebootDBInstance(id)
+	inst, err := h.Backend.RebootDBInstance(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -695,12 +708,12 @@ func (h *Handler) handleRebootDBInstance(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateDBSubnetGroup(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBSubnetGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBSubnetGroupName")
 	description := vals.Get("DBSubnetGroupDescription")
 	vpcID := vals.Get("VpcId")
 	subnetIDs := parseSubnetIDMembers(vals)
-	sg, err := h.Backend.CreateDBSubnetGroup(name, description, vpcID, subnetIDs)
+	sg, err := h.Backend.CreateDBSubnetGroup(ctx, name, description, vpcID, subnetIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -711,9 +724,9 @@ func (h *Handler) handleCreateDBSubnetGroup(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBSubnetGroups(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBSubnetGroups(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBSubnetGroupName")
-	sgs, err := h.Backend.DescribeDBSubnetGroups(name)
+	sgs, err := h.Backend.DescribeDBSubnetGroups(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -734,20 +747,20 @@ func (h *Handler) handleDescribeDBSubnetGroups(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBSubnetGroup(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBSubnetGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBSubnetGroupName")
-	if err := h.Backend.DeleteDBSubnetGroup(name); err != nil {
+	if err := h.Backend.DeleteDBSubnetGroup(ctx, name); err != nil {
 		return nil, err
 	}
 
 	return &deleteDBSubnetGroupResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleCreateDBClusterParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBClusterParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBClusterParameterGroupName")
 	family := vals.Get("DBParameterGroupFamily")
 	description := vals.Get("Description")
-	pg, err := h.Backend.CreateDBClusterParameterGroup(name, family, description)
+	pg, err := h.Backend.CreateDBClusterParameterGroup(ctx, name, family, description)
 	if err != nil {
 		return nil, err
 	}
@@ -758,9 +771,9 @@ func (h *Handler) handleCreateDBClusterParameterGroup(vals url.Values) (any, err
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBClusterParameterGroups(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBClusterParameterGroups(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBClusterParameterGroupName")
-	groups, err := h.Backend.DescribeDBClusterParameterGroups(name)
+	groups, err := h.Backend.DescribeDBClusterParameterGroups(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -778,18 +791,18 @@ func (h *Handler) handleDescribeDBClusterParameterGroups(vals url.Values) (any, 
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBClusterParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBClusterParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBClusterParameterGroupName")
-	if err := h.Backend.DeleteDBClusterParameterGroup(name); err != nil {
+	if err := h.Backend.DeleteDBClusterParameterGroup(ctx, name); err != nil {
 		return nil, err
 	}
 
 	return &deleteDBClusterParameterGroupResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleModifyDBClusterParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBClusterParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBClusterParameterGroupName")
-	pg, err := h.Backend.ModifyDBClusterParameterGroup(name)
+	pg, err := h.Backend.ModifyDBClusterParameterGroup(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -800,10 +813,10 @@ func (h *Handler) handleModifyDBClusterParameterGroup(vals url.Values) (any, err
 	}, nil
 }
 
-func (h *Handler) handleCreateDBClusterSnapshot(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBClusterSnapshot(ctx context.Context, vals url.Values) (any, error) {
 	snapshotID := vals.Get("DBClusterSnapshotIdentifier")
 	clusterID := vals.Get("DBClusterIdentifier")
-	snap, err := h.Backend.CreateDBClusterSnapshot(snapshotID, clusterID)
+	snap, err := h.Backend.CreateDBClusterSnapshot(ctx, snapshotID, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -814,10 +827,10 @@ func (h *Handler) handleCreateDBClusterSnapshot(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBClusterSnapshots(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBClusterSnapshots(ctx context.Context, vals url.Values) (any, error) {
 	snapshotID := vals.Get("DBClusterSnapshotIdentifier")
 	clusterID := vals.Get("DBClusterIdentifier")
-	snaps, err := h.Backend.DescribeDBClusterSnapshots(snapshotID, clusterID)
+	snaps, err := h.Backend.DescribeDBClusterSnapshots(ctx, snapshotID, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -838,9 +851,9 @@ func (h *Handler) handleDescribeDBClusterSnapshots(vals url.Values) (any, error)
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBClusterSnapshot(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBClusterSnapshot(ctx context.Context, vals url.Values) (any, error) {
 	snapshotID := vals.Get("DBClusterSnapshotIdentifier")
-	snap, err := h.Backend.DeleteDBClusterSnapshot(snapshotID)
+	snap, err := h.Backend.DeleteDBClusterSnapshot(ctx, snapshotID)
 	if err != nil {
 		return nil, err
 	}
@@ -851,9 +864,9 @@ func (h *Handler) handleDeleteDBClusterSnapshot(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleListTagsForResource(vals url.Values) (any, error) {
+func (h *Handler) handleListTagsForResource(ctx context.Context, vals url.Values) (any, error) {
 	arnStr := vals.Get("ResourceName")
-	tags, err := h.Backend.ListTagsForResource(arnStr)
+	tags, err := h.Backend.ListTagsForResource(ctx, arnStr)
 	if err != nil {
 		return nil, err
 	}
@@ -868,27 +881,27 @@ func (h *Handler) handleListTagsForResource(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleAddTagsToResource(vals url.Values) (any, error) {
+func (h *Handler) handleAddTagsToResource(ctx context.Context, vals url.Values) (any, error) {
 	arnStr := vals.Get("ResourceName")
 	tags := parseTagEntries(vals)
-	if err := h.Backend.AddTagsToResource(arnStr, tags); err != nil {
+	if err := h.Backend.AddTagsToResource(ctx, arnStr, tags); err != nil {
 		return nil, err
 	}
 
 	return &addTagsToResourceResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleRemoveTagsFromResource(vals url.Values) (any, error) {
+func (h *Handler) handleRemoveTagsFromResource(ctx context.Context, vals url.Values) (any, error) {
 	arnStr := vals.Get("ResourceName")
 	keys := parseTagKeyMembers(vals)
-	if err := h.Backend.RemoveTagsFromResource(arnStr, keys); err != nil {
+	if err := h.Backend.RemoveTagsFromResource(ctx, arnStr, keys); err != nil {
 		return nil, err
 	}
 
 	return &removeTagsFromResourceResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleDescribeDBEngineVersions(_ url.Values) (any, error) {
+func (h *Handler) handleDescribeDBEngineVersions(_ context.Context, _ url.Values) (any, error) {
 	members := []xmlDBEngineVersion{
 		{
 			Engine:                 neptuneEngine,
@@ -946,7 +959,7 @@ func (h *Handler) handleDescribeDBEngineVersions(_ url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeOrderableDBInstanceOptions(_ url.Values) (any, error) {
+func (h *Handler) handleDescribeOrderableDBInstanceOptions(_ context.Context, _ url.Values) (any, error) {
 	engineVersions := []string{"1.2.0.0", "1.2.1.0", defaultEngineVersion, "1.3.1.0", "1.4.0.0"}
 	instanceClasses := []string{
 		"db.r5.large", "db.r5.xlarge", "db.r5.2xlarge", "db.r5.4xlarge", "db.r5.8xlarge",
@@ -972,8 +985,8 @@ func (h *Handler) handleDescribeOrderableDBInstanceOptions(_ url.Values) (any, e
 	}, nil
 }
 
-func (h *Handler) handleDescribeGlobalClusters(_ url.Values) (any, error) {
-	gcs := h.Backend.DescribeGlobalClusters()
+func (h *Handler) handleDescribeGlobalClusters(ctx context.Context, _ url.Values) (any, error) {
+	gcs := h.Backend.DescribeGlobalClusters(ctx)
 	members := make([]xmlGlobalCluster, 0, len(gcs))
 	for _, gc := range gcs {
 		cp := gc
@@ -988,20 +1001,20 @@ func (h *Handler) handleDescribeGlobalClusters(_ url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleAddRoleToDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleAddRoleToDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	clusterID := vals.Get("DBClusterIdentifier")
 	roleARN := vals.Get("RoleArn")
-	if err := h.Backend.AddRoleToDBCluster(clusterID, roleARN); err != nil {
+	if err := h.Backend.AddRoleToDBCluster(ctx, clusterID, roleARN); err != nil {
 		return nil, err
 	}
 
 	return &addRoleToDBClusterResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleAddSourceIdentifierToSubscription(vals url.Values) (any, error) {
+func (h *Handler) handleAddSourceIdentifierToSubscription(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("SubscriptionName")
 	sourceID := vals.Get("SourceIdentifier")
-	sub, err := h.Backend.AddSourceIdentifierToSubscription(name, sourceID)
+	sub, err := h.Backend.AddSourceIdentifierToSubscription(ctx, name, sourceID)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,22 +1025,22 @@ func (h *Handler) handleAddSourceIdentifierToSubscription(vals url.Values) (any,
 	}, nil
 }
 
-func (h *Handler) handleApplyPendingMaintenanceAction(vals url.Values) (any, error) {
+func (h *Handler) handleApplyPendingMaintenanceAction(ctx context.Context, vals url.Values) (any, error) {
 	resourceID := vals.Get("ResourceIdentifier")
 	applyAction := vals.Get("ApplyAction")
 	optInType := vals.Get("OptInType")
-	if err := h.Backend.ApplyPendingMaintenanceAction(resourceID, applyAction, optInType); err != nil {
+	if err := h.Backend.ApplyPendingMaintenanceAction(ctx, resourceID, applyAction, optInType); err != nil {
 		return nil, err
 	}
 
 	return &applyPendingMaintenanceActionResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleCopyDBClusterParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleCopyDBClusterParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	sourceName := vals.Get("SourceDBClusterParameterGroupIdentifier")
 	targetName := vals.Get("TargetDBClusterParameterGroupIdentifier")
 	targetDescription := vals.Get("TargetDBClusterParameterGroupDescription")
-	pg, err := h.Backend.CopyDBClusterParameterGroup(sourceName, targetName, targetDescription)
+	pg, err := h.Backend.CopyDBClusterParameterGroup(ctx, sourceName, targetName, targetDescription)
 	if err != nil {
 		return nil, err
 	}
@@ -1038,10 +1051,10 @@ func (h *Handler) handleCopyDBClusterParameterGroup(vals url.Values) (any, error
 	}, nil
 }
 
-func (h *Handler) handleCopyDBClusterSnapshot(vals url.Values) (any, error) {
+func (h *Handler) handleCopyDBClusterSnapshot(ctx context.Context, vals url.Values) (any, error) {
 	sourceSnapshotID := vals.Get("SourceDBClusterSnapshotIdentifier")
 	targetSnapshotID := vals.Get("TargetDBClusterSnapshotIdentifier")
-	snap, err := h.Backend.CopyDBClusterSnapshot(sourceSnapshotID, targetSnapshotID)
+	snap, err := h.Backend.CopyDBClusterSnapshot(ctx, sourceSnapshotID, targetSnapshotID)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,11 +1065,11 @@ func (h *Handler) handleCopyDBClusterSnapshot(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCopyDBParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleCopyDBParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	sourceName := vals.Get("SourceDBParameterGroupIdentifier")
 	targetName := vals.Get("TargetDBParameterGroupIdentifier")
 	targetDescription := vals.Get("TargetDBParameterGroupDescription")
-	pg, err := h.Backend.CopyDBParameterGroup(sourceName, targetName, targetDescription)
+	pg, err := h.Backend.CopyDBParameterGroup(ctx, sourceName, targetName, targetDescription)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,11 +1080,11 @@ func (h *Handler) handleCopyDBParameterGroup(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateDBClusterEndpoint(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBClusterEndpoint(ctx context.Context, vals url.Values) (any, error) {
 	endpointID := vals.Get("DBClusterEndpointIdentifier")
 	clusterID := vals.Get("DBClusterIdentifier")
 	endpointType := vals.Get("EndpointType")
-	ep, err := h.Backend.CreateDBClusterEndpoint(endpointID, clusterID, endpointType)
+	ep, err := h.Backend.CreateDBClusterEndpoint(ctx, endpointID, clusterID, endpointType)
 	if err != nil {
 		return nil, err
 	}
@@ -1082,11 +1095,11 @@ func (h *Handler) handleCreateDBClusterEndpoint(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateDBParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleCreateDBParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBParameterGroupName")
 	family := vals.Get("DBParameterGroupFamily")
 	description := vals.Get("Description")
-	pg, err := h.Backend.CreateDBParameterGroup(name, family, description)
+	pg, err := h.Backend.CreateDBParameterGroup(ctx, name, family, description)
 	if err != nil {
 		return nil, err
 	}
@@ -1097,11 +1110,11 @@ func (h *Handler) handleCreateDBParameterGroup(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateEventSubscription(vals url.Values) (any, error) {
+func (h *Handler) handleCreateEventSubscription(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("SubscriptionName")
 	snsTopicARN := vals.Get("SnsTopicArn")
 	sourceIDs := parseSourceIDMembers(vals)
-	sub, err := h.Backend.CreateEventSubscription(name, snsTopicARN, sourceIDs)
+	sub, err := h.Backend.CreateEventSubscription(ctx, name, snsTopicARN, sourceIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,10 +1125,10 @@ func (h *Handler) handleCreateEventSubscription(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleCreateGlobalCluster(vals url.Values) (any, error) {
+func (h *Handler) handleCreateGlobalCluster(ctx context.Context, vals url.Values) (any, error) {
 	globalClusterID := vals.Get("GlobalClusterIdentifier")
 	sourceDBClusterID := vals.Get("SourceDBClusterIdentifier")
-	gc, err := h.Backend.CreateGlobalCluster(globalClusterID, sourceDBClusterID)
+	gc, err := h.Backend.CreateGlobalCluster(ctx, globalClusterID, sourceDBClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1126,19 +1139,19 @@ func (h *Handler) handleCreateGlobalCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBClusterEndpoint(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBClusterEndpoint(ctx context.Context, vals url.Values) (any, error) {
 	endpointID := vals.Get("DBClusterEndpointIdentifier")
-	if err := h.Backend.DeleteDBClusterEndpoint(endpointID); err != nil {
+	if err := h.Backend.DeleteDBClusterEndpoint(ctx, endpointID); err != nil {
 		return nil, err
 	}
 
 	return &deleteDBClusterEndpointResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleDescribeDBClusterEndpoints(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBClusterEndpoints(ctx context.Context, vals url.Values) (any, error) {
 	endpointID := vals.Get("DBClusterEndpointIdentifier")
 	clusterID := vals.Get("DBClusterIdentifier")
-	endpoints, err := h.Backend.DescribeDBClusterEndpoints(endpointID, clusterID)
+	endpoints, err := h.Backend.DescribeDBClusterEndpoints(ctx, endpointID, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1159,10 +1172,10 @@ func (h *Handler) handleDescribeDBClusterEndpoints(vals url.Values) (any, error)
 	}, nil
 }
 
-func (h *Handler) handleModifyDBClusterEndpoint(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBClusterEndpoint(ctx context.Context, vals url.Values) (any, error) {
 	endpointID := vals.Get("DBClusterEndpointIdentifier")
 	endpointType := vals.Get("EndpointType")
-	ep, err := h.Backend.ModifyDBClusterEndpoint(endpointID, endpointType)
+	ep, err := h.Backend.ModifyDBClusterEndpoint(ctx, endpointID, endpointType)
 	if err != nil {
 		return nil, err
 	}
@@ -1173,18 +1186,18 @@ func (h *Handler) handleModifyDBClusterEndpoint(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteDBParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteDBParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBParameterGroupName")
-	if err := h.Backend.DeleteDBParameterGroup(name); err != nil {
+	if err := h.Backend.DeleteDBParameterGroup(ctx, name); err != nil {
 		return nil, err
 	}
 
 	return &deleteDBParameterGroupResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleDescribeDBParameterGroups(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBParameterGroups(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBParameterGroupName")
-	groups, err := h.Backend.DescribeDBParameterGroups(name)
+	groups, err := h.Backend.DescribeDBParameterGroups(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1205,10 +1218,10 @@ func (h *Handler) handleDescribeDBParameterGroups(vals url.Values) (any, error) 
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBParameters(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBParameters(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBParameterGroupName")
 	if name != "" {
-		if _, err := h.Backend.DescribeDBParameterGroups(name); err != nil {
+		if _, err := h.Backend.DescribeDBParameterGroups(ctx, name); err != nil {
 			return nil, err
 		}
 	}
@@ -1221,9 +1234,9 @@ func (h *Handler) handleDescribeDBParameters(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleModifyDBParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBParameterGroupName")
-	pg, err := h.Backend.ModifyDBParameterGroup(name)
+	pg, err := h.Backend.ModifyDBParameterGroup(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1234,9 +1247,9 @@ func (h *Handler) handleModifyDBParameterGroup(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleResetDBParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleResetDBParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBParameterGroupName")
-	pg, err := h.Backend.ResetDBParameterGroup(name)
+	pg, err := h.Backend.ResetDBParameterGroup(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1247,10 +1260,10 @@ func (h *Handler) handleResetDBParameterGroup(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBClusterParameters(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBClusterParameters(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBClusterParameterGroupName")
 	if name != "" {
-		if _, err := h.Backend.DescribeDBClusterParameterGroups(name); err != nil {
+		if _, err := h.Backend.DescribeDBClusterParameterGroups(ctx, name); err != nil {
 			return nil, err
 		}
 	}
@@ -1263,10 +1276,10 @@ func (h *Handler) handleDescribeDBClusterParameters(vals url.Values) (any, error
 	}, nil
 }
 
-func (h *Handler) handleDescribeDBClusterSnapshotAttributes(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeDBClusterSnapshotAttributes(ctx context.Context, vals url.Values) (any, error) {
 	snapshotID := vals.Get("DBClusterSnapshotIdentifier")
 	if snapshotID != "" {
-		if _, err := h.Backend.DescribeDBClusterSnapshots(snapshotID, ""); err != nil {
+		if _, err := h.Backend.DescribeDBClusterSnapshots(ctx, snapshotID, ""); err != nil {
 			return nil, err
 		}
 	}
@@ -1281,10 +1294,10 @@ func (h *Handler) handleDescribeDBClusterSnapshotAttributes(vals url.Values) (an
 	}, nil
 }
 
-func (h *Handler) handleModifyDBClusterSnapshotAttribute(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBClusterSnapshotAttribute(ctx context.Context, vals url.Values) (any, error) {
 	snapshotID := vals.Get("DBClusterSnapshotIdentifier")
 	if snapshotID != "" {
-		if _, err := h.Backend.DescribeDBClusterSnapshots(snapshotID, ""); err != nil {
+		if _, err := h.Backend.DescribeDBClusterSnapshots(ctx, snapshotID, ""); err != nil {
 			return nil, err
 		}
 	}
@@ -1292,9 +1305,9 @@ func (h *Handler) handleModifyDBClusterSnapshotAttribute(vals url.Values) (any, 
 	return &modifyDBClusterSnapshotAttributeResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleResetDBClusterParameterGroup(vals url.Values) (any, error) {
+func (h *Handler) handleResetDBClusterParameterGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBClusterParameterGroupName")
-	pg, err := h.Backend.ResetDBClusterParameterGroup(name)
+	pg, err := h.Backend.ResetDBClusterParameterGroup(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1305,9 +1318,9 @@ func (h *Handler) handleResetDBClusterParameterGroup(vals url.Values) (any, erro
 	}, nil
 }
 
-func (h *Handler) handleDeleteEventSubscription(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteEventSubscription(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("SubscriptionName")
-	sub, err := h.Backend.DeleteEventSubscription(name)
+	sub, err := h.Backend.DeleteEventSubscription(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1318,9 +1331,9 @@ func (h *Handler) handleDeleteEventSubscription(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeEventSubscriptions(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeEventSubscriptions(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("SubscriptionName")
-	subs, err := h.Backend.DescribeEventSubscriptions(name)
+	subs, err := h.Backend.DescribeEventSubscriptions(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -1341,10 +1354,10 @@ func (h *Handler) handleDescribeEventSubscriptions(vals url.Values) (any, error)
 	}, nil
 }
 
-func (h *Handler) handleModifyEventSubscription(vals url.Values) (any, error) {
+func (h *Handler) handleModifyEventSubscription(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("SubscriptionName")
 	snsTopicARN := vals.Get("SnsTopicArn")
-	sub, err := h.Backend.ModifyEventSubscription(name, snsTopicARN)
+	sub, err := h.Backend.ModifyEventSubscription(ctx, name, snsTopicARN)
 	if err != nil {
 		return nil, err
 	}
@@ -1355,10 +1368,10 @@ func (h *Handler) handleModifyEventSubscription(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleRemoveSourceIdentifierFromSubscription(vals url.Values) (any, error) {
+func (h *Handler) handleRemoveSourceIdentifierFromSubscription(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("SubscriptionName")
 	sourceID := vals.Get("SourceIdentifier")
-	sub, err := h.Backend.RemoveSourceIdentifierFromSubscription(name, sourceID)
+	sub, err := h.Backend.RemoveSourceIdentifierFromSubscription(ctx, name, sourceID)
 	if err != nil {
 		return nil, err
 	}
@@ -1369,7 +1382,7 @@ func (h *Handler) handleRemoveSourceIdentifierFromSubscription(vals url.Values) 
 	}, nil
 }
 
-func (h *Handler) handleDescribeEventCategories(_ url.Values) (any, error) {
+func (h *Handler) handleDescribeEventCategories(_ context.Context, _ url.Values) (any, error) {
 	return &describeEventCategoriesResponse{
 		Xmlns: neptuneXMLNS,
 		EventCategoriesMapList: xmlEventCategoriesMapList{
@@ -1392,7 +1405,7 @@ func (h *Handler) handleDescribeEventCategories(_ url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDescribeEvents(_ url.Values) (any, error) {
+func (h *Handler) handleDescribeEvents(_ context.Context, _ url.Values) (any, error) {
 	return &describeEventsResponse{
 		Xmlns: neptuneXMLNS,
 		Result: describeEventsResult{
@@ -1401,9 +1414,9 @@ func (h *Handler) handleDescribeEvents(_ url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleDeleteGlobalCluster(vals url.Values) (any, error) {
+func (h *Handler) handleDeleteGlobalCluster(ctx context.Context, vals url.Values) (any, error) {
 	globalClusterID := vals.Get("GlobalClusterIdentifier")
-	gc, err := h.Backend.DeleteGlobalCluster(globalClusterID)
+	gc, err := h.Backend.DeleteGlobalCluster(ctx, globalClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1414,10 +1427,10 @@ func (h *Handler) handleDeleteGlobalCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleFailoverGlobalCluster(vals url.Values) (any, error) {
+func (h *Handler) handleFailoverGlobalCluster(ctx context.Context, vals url.Values) (any, error) {
 	globalClusterID := vals.Get("GlobalClusterIdentifier")
 	targetDBClusterID := vals.Get("TargetDbClusterIdentifier")
-	gc, err := h.Backend.FailoverGlobalCluster(globalClusterID, targetDBClusterID)
+	gc, err := h.Backend.FailoverGlobalCluster(ctx, globalClusterID, targetDBClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1428,9 +1441,9 @@ func (h *Handler) handleFailoverGlobalCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleModifyGlobalCluster(vals url.Values) (any, error) {
+func (h *Handler) handleModifyGlobalCluster(ctx context.Context, vals url.Values) (any, error) {
 	globalClusterID := vals.Get("GlobalClusterIdentifier")
-	gc, err := h.Backend.ModifyGlobalCluster(globalClusterID)
+	gc, err := h.Backend.ModifyGlobalCluster(ctx, globalClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1441,10 +1454,10 @@ func (h *Handler) handleModifyGlobalCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleRemoveFromGlobalCluster(vals url.Values) (any, error) {
+func (h *Handler) handleRemoveFromGlobalCluster(ctx context.Context, vals url.Values) (any, error) {
 	globalClusterID := vals.Get("GlobalClusterIdentifier")
 	dbClusterARN := vals.Get("DbClusterIdentifier")
-	gc, err := h.Backend.RemoveFromGlobalCluster(globalClusterID, dbClusterARN)
+	gc, err := h.Backend.RemoveFromGlobalCluster(ctx, globalClusterID, dbClusterARN)
 	if err != nil {
 		return nil, err
 	}
@@ -1455,10 +1468,10 @@ func (h *Handler) handleRemoveFromGlobalCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleSwitchoverGlobalCluster(vals url.Values) (any, error) {
+func (h *Handler) handleSwitchoverGlobalCluster(ctx context.Context, vals url.Values) (any, error) {
 	globalClusterID := vals.Get("GlobalClusterIdentifier")
 	targetDBClusterID := vals.Get("TargetDbClusterIdentifier")
-	gc, err := h.Backend.SwitchoverGlobalCluster(globalClusterID, targetDBClusterID)
+	gc, err := h.Backend.SwitchoverGlobalCluster(ctx, globalClusterID, targetDBClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1469,17 +1482,17 @@ func (h *Handler) handleSwitchoverGlobalCluster(vals url.Values) (any, error) {
 	}, nil
 }
 
-func (h *Handler) handleRemoveRoleFromDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handleRemoveRoleFromDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	clusterID := vals.Get("DBClusterIdentifier")
 	roleARN := vals.Get("RoleArn")
-	if err := h.Backend.RemoveRoleFromDBCluster(clusterID, roleARN); err != nil {
+	if err := h.Backend.RemoveRoleFromDBCluster(ctx, clusterID, roleARN); err != nil {
 		return nil, err
 	}
 
 	return &removeRoleFromDBClusterResponse{Xmlns: neptuneXMLNS}, nil
 }
 
-func (h *Handler) handleDescribeEngineDefaultClusterParameters(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeEngineDefaultClusterParameters(_ context.Context, vals url.Values) (any, error) {
 	family := vals.Get("DBParameterGroupFamily")
 	if family == "" {
 		family = pgFamilyNeptune13
@@ -1496,7 +1509,7 @@ func (h *Handler) handleDescribeEngineDefaultClusterParameters(vals url.Values) 
 	}, nil
 }
 
-func (h *Handler) handleDescribeEngineDefaultParameters(vals url.Values) (any, error) {
+func (h *Handler) handleDescribeEngineDefaultParameters(_ context.Context, vals url.Values) (any, error) {
 	family := vals.Get("DBParameterGroupFamily")
 	if family == "" {
 		family = pgFamilyNeptune13
@@ -1513,7 +1526,7 @@ func (h *Handler) handleDescribeEngineDefaultParameters(vals url.Values) (any, e
 	}, nil
 }
 
-func (h *Handler) handleDescribePendingMaintenanceActions(_ url.Values) (any, error) {
+func (h *Handler) handleDescribePendingMaintenanceActions(_ context.Context, _ url.Values) (any, error) {
 	return &describePendingMaintenanceActionsResponse{
 		Xmlns: neptuneXMLNS,
 		Result: describePendingMaintenanceActionsResult{
@@ -1522,7 +1535,7 @@ func (h *Handler) handleDescribePendingMaintenanceActions(_ url.Values) (any, er
 	}, nil
 }
 
-func (h *Handler) handleDescribeValidDBInstanceModifications(_ url.Values) (any, error) {
+func (h *Handler) handleDescribeValidDBInstanceModifications(_ context.Context, _ url.Values) (any, error) {
 	validClasses := []xmlValidStorageOption{
 		{DBInstanceClass: "db.r5.large"},
 		{DBInstanceClass: "db.r5.xlarge"},
@@ -1546,9 +1559,9 @@ func (h *Handler) handleDescribeValidDBInstanceModifications(_ url.Values) (any,
 	}, nil
 }
 
-func (h *Handler) handlePromoteReadReplicaDBCluster(vals url.Values) (any, error) {
+func (h *Handler) handlePromoteReadReplicaDBCluster(ctx context.Context, vals url.Values) (any, error) {
 	id := vals.Get("DBClusterIdentifier")
-	clusters, err := h.Backend.DescribeDBClusters(id)
+	clusters, err := h.Backend.DescribeDBClusters(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -1563,10 +1576,10 @@ func (h *Handler) handlePromoteReadReplicaDBCluster(vals url.Values) (any, error
 	}, nil
 }
 
-func (h *Handler) handleRestoreDBClusterFromSnapshot(vals url.Values) (any, error) {
+func (h *Handler) handleRestoreDBClusterFromSnapshot(ctx context.Context, vals url.Values) (any, error) {
 	snapshotID := vals.Get("DBClusterSnapshotIdentifier")
 	clusterID := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.RestoreDBClusterFromSnapshot(snapshotID, clusterID)
+	cluster, err := h.Backend.RestoreDBClusterFromSnapshot(ctx, snapshotID, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1577,10 +1590,10 @@ func (h *Handler) handleRestoreDBClusterFromSnapshot(vals url.Values) (any, erro
 	}, nil
 }
 
-func (h *Handler) handleRestoreDBClusterToPointInTime(vals url.Values) (any, error) {
+func (h *Handler) handleRestoreDBClusterToPointInTime(ctx context.Context, vals url.Values) (any, error) {
 	srcClusterID := vals.Get("SourceDBClusterIdentifier")
 	targetClusterID := vals.Get("DBClusterIdentifier")
-	cluster, err := h.Backend.RestoreDBClusterToPointInTime(srcClusterID, targetClusterID)
+	cluster, err := h.Backend.RestoreDBClusterToPointInTime(ctx, srcClusterID, targetClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -1591,10 +1604,10 @@ func (h *Handler) handleRestoreDBClusterToPointInTime(vals url.Values) (any, err
 	}, nil
 }
 
-func (h *Handler) handleModifyDBSubnetGroup(vals url.Values) (any, error) {
+func (h *Handler) handleModifyDBSubnetGroup(ctx context.Context, vals url.Values) (any, error) {
 	name := vals.Get("DBSubnetGroupName")
 	description := vals.Get("DBSubnetGroupDescription")
-	sg, err := h.Backend.ModifyDBSubnetGroup(name, description)
+	sg, err := h.Backend.ModifyDBSubnetGroup(ctx, name, description)
 	if err != nil {
 		return nil, err
 	}

--- a/services/neptune/handler_batch1_ops_test.go
+++ b/services/neptune/handler_batch1_ops_test.go
@@ -1,6 +1,7 @@
 package neptune_test
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/url"
@@ -1231,14 +1232,14 @@ func TestBatch1Ops_Roles_ClearedOnClusterDelete(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("role-del-cluster", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "role-del-cluster", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
-	err = b.AddRoleToDBCluster("role-del-cluster", "arn:aws:iam::000000000000:role/r1")
+	err = b.AddRoleToDBCluster(context.Background(), "role-del-cluster", "arn:aws:iam::000000000000:role/r1")
 	require.NoError(t, err)
-	err = b.AddRoleToDBCluster("role-del-cluster", "arn:aws:iam::000000000000:role/r2")
+	err = b.AddRoleToDBCluster(context.Background(), "role-del-cluster", "arn:aws:iam::000000000000:role/r2")
 	require.NoError(t, err)
 
-	_, err = b.DeleteDBCluster("role-del-cluster")
+	_, err = b.DeleteDBCluster(context.Background(), "role-del-cluster")
 	require.NoError(t, err)
 
 	// Verify roles gone
@@ -1647,7 +1648,7 @@ func TestBatch1Ops_Backend_CreateDBInstance_AllOptions(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("inst-opts-cluster", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "inst-opts-cluster", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
 
 	opts := neptune.DBInstanceCreateOptions{
@@ -1660,7 +1661,7 @@ func TestBatch1Ops_Backend_CreateDBInstance_AllOptions(t *testing.T) {
 		PromotionTier:                   5,
 		StorageEncrypted:                true,
 	}
-	inst, err := b.CreateDBInstance("inst-opts", "inst-opts-cluster", "db.r5.xlarge", opts)
+	inst, err := b.CreateDBInstance(context.Background(), "inst-opts", "inst-opts-cluster", "db.r5.xlarge", opts)
 	require.NoError(t, err)
 	assert.Equal(t, "custom-pg", inst.DBParameterGroupName)
 	assert.Equal(t, "wed:04:00-wed:05:00", inst.PreferredMaintenanceWindow)
@@ -1676,9 +1677,15 @@ func TestBatch1Ops_Backend_ModifyDBInstance_AllOptions(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("mod-opts-cluster", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "mod-opts-cluster", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
-	_, err = b.CreateDBInstance("mod-opts-inst", "mod-opts-cluster", "", neptune.DBInstanceCreateOptions{})
+	_, err = b.CreateDBInstance(
+		context.Background(),
+		"mod-opts-inst",
+		"mod-opts-cluster",
+		"",
+		neptune.DBInstanceCreateOptions{},
+	)
 	require.NoError(t, err)
 
 	opts := neptune.DBInstanceModifyOptions{
@@ -1694,7 +1701,7 @@ func TestBatch1Ops_Backend_ModifyDBInstance_AllOptions(t *testing.T) {
 		PromotionTier:                   7,
 		PromotionTierSet:                true,
 	}
-	inst, err := b.ModifyDBInstance("mod-opts-inst", "db.r6g.4xlarge", opts)
+	inst, err := b.ModifyDBInstance(context.Background(), "mod-opts-inst", "db.r6g.4xlarge", opts)
 	require.NoError(t, err)
 	assert.Equal(t, "db.r6g.4xlarge", inst.DBInstanceClass)
 	assert.Equal(t, "new-pg", inst.DBParameterGroupName)
@@ -1710,15 +1717,21 @@ func TestBatch1Ops_Backend_ModifyDBInstance_IamNotSet_NoChange(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("iam-noset-cluster", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "iam-noset-cluster", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
-	_, err = b.CreateDBInstance("iam-noset-inst", "iam-noset-cluster", "", neptune.DBInstanceCreateOptions{
-		EnableIAMDatabaseAuthentication: true,
-	})
+	_, err = b.CreateDBInstance(
+		context.Background(),
+		"iam-noset-inst",
+		"iam-noset-cluster",
+		"",
+		neptune.DBInstanceCreateOptions{
+			EnableIAMDatabaseAuthentication: true,
+		},
+	)
 	require.NoError(t, err)
 
 	// Modify without IamAuthSet — should not change
-	inst, err := b.ModifyDBInstance("iam-noset-inst", "", neptune.DBInstanceModifyOptions{
+	inst, err := b.ModifyDBInstance(context.Background(), "iam-noset-inst", "", neptune.DBInstanceModifyOptions{
 		EnableIAMDatabaseAuthentication: false,
 		IamAuthSet:                      false,
 	})
@@ -1809,15 +1822,15 @@ func TestBatch1Ops_DeleteCluster_CascadesSnapshots(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("cascade-del-cluster", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "cascade-del-cluster", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
-	_, err = b.CreateDBClusterSnapshot("cascade-snap", "cascade-del-cluster")
+	_, err = b.CreateDBClusterSnapshot(context.Background(), "cascade-snap", "cascade-del-cluster")
 	require.NoError(t, err)
 
 	require.Equal(t, 1, neptune.ClusterSnapshotCount(b))
 
 	// Delete cluster — snapshots should remain (AWS behavior: snapshots not auto-deleted)
-	_, err = b.DeleteDBCluster("cascade-del-cluster")
+	_, err = b.DeleteDBCluster(context.Background(), "cascade-del-cluster")
 	require.NoError(t, err)
 
 	require.Equal(t, 0, neptune.ClusterCount(b))
@@ -1829,16 +1842,28 @@ func TestBatch1Ops_DeleteCluster_CascadesInstances(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("cascade-inst-cluster", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "cascade-inst-cluster", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
-	_, err = b.CreateDBInstance("cascade-inst-1", "cascade-inst-cluster", "", neptune.DBInstanceCreateOptions{})
+	_, err = b.CreateDBInstance(
+		context.Background(),
+		"cascade-inst-1",
+		"cascade-inst-cluster",
+		"",
+		neptune.DBInstanceCreateOptions{},
+	)
 	require.NoError(t, err)
-	_, err = b.CreateDBInstance("cascade-inst-2", "cascade-inst-cluster", "", neptune.DBInstanceCreateOptions{})
+	_, err = b.CreateDBInstance(
+		context.Background(),
+		"cascade-inst-2",
+		"cascade-inst-cluster",
+		"",
+		neptune.DBInstanceCreateOptions{},
+	)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, neptune.InstanceCount(b))
 
-	_, err = b.DeleteDBCluster("cascade-inst-cluster")
+	_, err = b.DeleteDBCluster(context.Background(), "cascade-inst-cluster")
 	require.NoError(t, err)
 
 	require.Equal(t, 0, neptune.InstanceCount(b))

--- a/services/neptune/handler_batch1_test.go
+++ b/services/neptune/handler_batch1_test.go
@@ -1,6 +1,7 @@
 package neptune_test
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -483,7 +484,7 @@ func TestBatch1_Backend_CreateDBCluster_ServerlessV2(t *testing.T) {
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
 	sv2 := &neptune.ServerlessV2ScalingConfiguration{MinCapacity: 1.0, MaxCapacity: 64.0}
-	cluster, err := b.CreateDBCluster("sv2-unit", "", 0, neptune.DBClusterCreateOptions{
+	cluster, err := b.CreateDBCluster(context.Background(), "sv2-unit", "", 0, neptune.DBClusterCreateOptions{
 		ServerlessV2ScalingConfig: sv2,
 		EngineMode:                "serverless",
 	})
@@ -498,7 +499,7 @@ func TestBatch1_Backend_CreateDBCluster_IAMAuth(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	cluster, err := b.CreateDBCluster("iam-unit", "", 0, neptune.DBClusterCreateOptions{
+	cluster, err := b.CreateDBCluster(context.Background(), "iam-unit", "", 0, neptune.DBClusterCreateOptions{
 		EnableIAMDatabaseAuthentication: true,
 	})
 	require.NoError(t, err)
@@ -509,7 +510,7 @@ func TestBatch1_Backend_CreateDBCluster_ManageMasterUserPassword(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	cluster, err := b.CreateDBCluster("mup-unit", "", 0, neptune.DBClusterCreateOptions{
+	cluster, err := b.CreateDBCluster(context.Background(), "mup-unit", "", 0, neptune.DBClusterCreateOptions{
 		ManageMasterUserPassword: true,
 	})
 	require.NoError(t, err)
@@ -522,23 +523,23 @@ func TestBatch1_Backend_ModifyDBCluster_IamAuth_SetAndUnset(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("iam-mod-unit", "", 0, neptune.DBClusterCreateOptions{
+	_, err := b.CreateDBCluster(context.Background(), "iam-mod-unit", "", 0, neptune.DBClusterCreateOptions{
 		EnableIAMDatabaseAuthentication: true,
 	})
 	require.NoError(t, err)
 
 	// Verify enabled
-	clusters, err := b.DescribeDBClusters("iam-mod-unit")
+	clusters, err := b.DescribeDBClusters(context.Background(), "iam-mod-unit")
 	require.NoError(t, err)
 	assert.True(t, clusters[0].EnableIAMDatabaseAuthentication)
 
 	// Disable via modify
-	_, err = b.ModifyDBCluster("iam-mod-unit", "", neptune.DBClusterModifyOptions{
+	_, err = b.ModifyDBCluster(context.Background(), "iam-mod-unit", "", neptune.DBClusterModifyOptions{
 		EnableIAMDatabaseAuthentication: false,
 		IamAuthSet:                      true,
 	})
 	require.NoError(t, err)
-	clusters, err = b.DescribeDBClusters("iam-mod-unit")
+	clusters, err = b.DescribeDBClusters(context.Background(), "iam-mod-unit")
 	require.NoError(t, err)
 	assert.False(t, clusters[0].EnableIAMDatabaseAuthentication)
 }
@@ -547,18 +548,18 @@ func TestBatch1_Backend_ModifyDBCluster_IamAuth_NotSet_NoChange(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("iam-nochange", "", 0, neptune.DBClusterCreateOptions{
+	_, err := b.CreateDBCluster(context.Background(), "iam-nochange", "", 0, neptune.DBClusterCreateOptions{
 		EnableIAMDatabaseAuthentication: true,
 	})
 	require.NoError(t, err)
 
 	// Modify without IamAuthSet - should not change IAM auth
-	_, err = b.ModifyDBCluster("iam-nochange", "", neptune.DBClusterModifyOptions{
+	_, err = b.ModifyDBCluster(context.Background(), "iam-nochange", "", neptune.DBClusterModifyOptions{
 		EnableIAMDatabaseAuthentication: false,
 		IamAuthSet:                      false,
 	})
 	require.NoError(t, err)
-	clusters, err := b.DescribeDBClusters("iam-nochange")
+	clusters, err := b.DescribeDBClusters(context.Background(), "iam-nochange")
 	require.NoError(t, err)
 	assert.True(t, clusters[0].EnableIAMDatabaseAuthentication)
 }
@@ -567,11 +568,11 @@ func TestBatch1_Backend_ModifyDBCluster_ServerlessV2(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("sv2-modify-unit", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "sv2-modify-unit", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
 
 	sv2 := &neptune.ServerlessV2ScalingConfiguration{MinCapacity: 4.0, MaxCapacity: 32.0}
-	cluster, err := b.ModifyDBCluster("sv2-modify-unit", "", neptune.DBClusterModifyOptions{
+	cluster, err := b.ModifyDBCluster(context.Background(), "sv2-modify-unit", "", neptune.DBClusterModifyOptions{
 		ServerlessV2ScalingConfig: sv2,
 	})
 	require.NoError(t, err)
@@ -584,17 +585,17 @@ func TestBatch1_Backend_ModifyDBCluster_DeletionProtection(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("dp-unit", "", 0, neptune.DBClusterCreateOptions{})
+	_, err := b.CreateDBCluster(context.Background(), "dp-unit", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
 
-	cluster, err := b.ModifyDBCluster("dp-unit", "", neptune.DBClusterModifyOptions{
+	cluster, err := b.ModifyDBCluster(context.Background(), "dp-unit", "", neptune.DBClusterModifyOptions{
 		DeletionProtection:    true,
 		DeletionProtectionSet: true,
 	})
 	require.NoError(t, err)
 	assert.True(t, cluster.DeletionProtection)
 
-	cluster, err = b.ModifyDBCluster("dp-unit", "", neptune.DBClusterModifyOptions{
+	cluster, err = b.ModifyDBCluster(context.Background(), "dp-unit", "", neptune.DBClusterModifyOptions{
 		DeletionProtection:    false,
 		DeletionProtectionSet: true,
 	})
@@ -606,13 +607,13 @@ func TestBatch1_Backend_ModifyDBCluster_DeletionProtection_NotSet_NoChange(t *te
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("dp-nochange", "", 0, neptune.DBClusterCreateOptions{
+	_, err := b.CreateDBCluster(context.Background(), "dp-nochange", "", 0, neptune.DBClusterCreateOptions{
 		DeletionProtection: true,
 	})
 	require.NoError(t, err)
 
 	// No DeletionProtectionSet - should not change
-	cluster, err := b.ModifyDBCluster("dp-nochange", "", neptune.DBClusterModifyOptions{
+	cluster, err := b.ModifyDBCluster(context.Background(), "dp-nochange", "", neptune.DBClusterModifyOptions{
 		DeletionProtection:    false,
 		DeletionProtectionSet: false,
 	})
@@ -624,7 +625,7 @@ func TestBatch1_Backend_CreateDBCluster_DefaultEngineMode(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	cluster, err := b.CreateDBCluster("default-mode", "", 0, neptune.DBClusterCreateOptions{})
+	cluster, err := b.CreateDBCluster(context.Background(), "default-mode", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "provisioned", cluster.EngineMode)
 }
@@ -633,7 +634,7 @@ func TestBatch1_Backend_CloneCluster_ServerlessV2_NilSafe(t *testing.T) {
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	cluster, err := b.CreateDBCluster("no-sv2", "", 0, neptune.DBClusterCreateOptions{})
+	cluster, err := b.CreateDBCluster(context.Background(), "no-sv2", "", 0, neptune.DBClusterCreateOptions{})
 	require.NoError(t, err)
 	assert.Nil(t, cluster.ServerlessV2ScalingConfig)
 	assert.Nil(t, cluster.MasterUserManagedSecret)
@@ -643,13 +644,13 @@ func TestBatch1_Backend_ModifyDBCluster_ManageMasterUserPassword_Idempotent(t *t
 	t.Parallel()
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
-	_, err := b.CreateDBCluster("mup-idem", "", 0, neptune.DBClusterCreateOptions{
+	_, err := b.CreateDBCluster(context.Background(), "mup-idem", "", 0, neptune.DBClusterCreateOptions{
 		ManageMasterUserPassword: true,
 	})
 	require.NoError(t, err)
 
 	// Enable again - should not create a second secret
-	cluster, err := b.ModifyDBCluster("mup-idem", "", neptune.DBClusterModifyOptions{
+	cluster, err := b.ModifyDBCluster(context.Background(), "mup-idem", "", neptune.DBClusterModifyOptions{
 		ManageMasterUserPassword: true,
 	})
 	require.NoError(t, err)
@@ -663,7 +664,7 @@ func TestBatch1_Persistence_ServerlessV2(t *testing.T) {
 
 	b := neptune.NewInMemoryBackend("000000000000", "us-east-1")
 	sv2 := &neptune.ServerlessV2ScalingConfiguration{MinCapacity: 2.0, MaxCapacity: 16.0}
-	_, err := b.CreateDBCluster("sv2-persist", "", 0, neptune.DBClusterCreateOptions{
+	_, err := b.CreateDBCluster(context.Background(), "sv2-persist", "", 0, neptune.DBClusterCreateOptions{
 		ServerlessV2ScalingConfig:       sv2,
 		EngineMode:                      "serverless",
 		EnableIAMDatabaseAuthentication: true,
@@ -679,7 +680,7 @@ func TestBatch1_Persistence_ServerlessV2(t *testing.T) {
 	err = b2.Restore(snap)
 	require.NoError(t, err)
 
-	clusters, err := b2.DescribeDBClusters("sv2-persist")
+	clusters, err := b2.DescribeDBClusters(context.Background(), "sv2-persist")
 	require.NoError(t, err)
 	require.Len(t, clusters, 1)
 	c := clusters[0]

--- a/services/neptune/handler_refinement1_test.go
+++ b/services/neptune/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package neptune_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -321,7 +322,7 @@ func TestRefinement1_CloneCluster_NoSharedSlice(t *testing.T) {
 	createCluster(t, h, "member-cluster")
 	createInstance(t, h, "member-inst", "member-cluster")
 
-	clusters, err := backend.DescribeDBClusters("member-cluster")
+	clusters, err := backend.DescribeDBClusters(context.Background(), "member-cluster")
 	require.NoError(t, err)
 	require.Len(t, clusters, 1)
 	require.Len(t, clusters[0].DBClusterMembers, 1)
@@ -329,7 +330,7 @@ func TestRefinement1_CloneCluster_NoSharedSlice(t *testing.T) {
 	// Mutate the returned copy — should not affect stored state.
 	clusters[0].DBClusterMembers[0].DBInstanceIdentifier = "mutated"
 
-	clusters2, err := backend.DescribeDBClusters("member-cluster")
+	clusters2, err := backend.DescribeDBClusters(context.Background(), "member-cluster")
 	require.NoError(t, err)
 	assert.NotEqual(t, "mutated", clusters2[0].DBClusterMembers[0].DBInstanceIdentifier)
 }

--- a/services/neptune/interfaces.go
+++ b/services/neptune/interfaces.go
@@ -1,94 +1,126 @@
 package neptune
 
+import "context"
+
 // StorageBackend defines the interface for Neptune backend implementations.
 // All mutating methods must be safe for concurrent use.
+//
+// Regional operations take a context.Context from which the target AWS region is
+// resolved (see getRegion); same-named resources are isolated per region. Global
+// cluster operations are partition-scoped and ignore the region.
 type StorageBackend interface {
 	// Cluster operations
-	CreateDBCluster(id, paramGroupName string, port int, opts DBClusterCreateOptions) (*DBCluster, error)
-	DescribeDBClusters(id string) ([]DBCluster, error)
-	DeleteDBCluster(id string) (*DBCluster, error)
-	ModifyDBCluster(id, paramGroupName string, opts DBClusterModifyOptions) (*DBCluster, error)
-	StopDBCluster(id string) (*DBCluster, error)
-	StartDBCluster(id string) (*DBCluster, error)
-	FailoverDBCluster(id string) (*DBCluster, error)
+	CreateDBCluster(
+		ctx context.Context,
+		id, paramGroupName string,
+		port int,
+		opts DBClusterCreateOptions,
+	) (*DBCluster, error)
+	DescribeDBClusters(ctx context.Context, id string) ([]DBCluster, error)
+	DeleteDBCluster(ctx context.Context, id string) (*DBCluster, error)
+	ModifyDBCluster(ctx context.Context, id, paramGroupName string, opts DBClusterModifyOptions) (*DBCluster, error)
+	StopDBCluster(ctx context.Context, id string) (*DBCluster, error)
+	StartDBCluster(ctx context.Context, id string) (*DBCluster, error)
+	FailoverDBCluster(ctx context.Context, id string) (*DBCluster, error)
 
 	// Instance operations
-	CreateDBInstance(id, clusterID, instanceClass string, opts DBInstanceCreateOptions) (*DBInstance, error)
-	DescribeDBInstances(id string) ([]DBInstance, error)
-	DeleteDBInstance(id string) (*DBInstance, error)
-	ModifyDBInstance(id, instanceClass string, opts DBInstanceModifyOptions) (*DBInstance, error)
-	RebootDBInstance(id string) (*DBInstance, error)
+	CreateDBInstance(
+		ctx context.Context,
+		id, clusterID, instanceClass string,
+		opts DBInstanceCreateOptions,
+	) (*DBInstance, error)
+	DescribeDBInstances(ctx context.Context, id string) ([]DBInstance, error)
+	DeleteDBInstance(ctx context.Context, id string) (*DBInstance, error)
+	ModifyDBInstance(ctx context.Context, id, instanceClass string, opts DBInstanceModifyOptions) (*DBInstance, error)
+	RebootDBInstance(ctx context.Context, id string) (*DBInstance, error)
 
 	// Subnet group operations
-	CreateDBSubnetGroup(name, description, vpcID string, subnetIDs []string) (*DBSubnetGroup, error)
-	DescribeDBSubnetGroups(name string) ([]DBSubnetGroup, error)
-	DeleteDBSubnetGroup(name string) error
+	CreateDBSubnetGroup(
+		ctx context.Context,
+		name, description, vpcID string,
+		subnetIDs []string,
+	) (*DBSubnetGroup, error)
+	DescribeDBSubnetGroups(ctx context.Context, name string) ([]DBSubnetGroup, error)
+	DeleteDBSubnetGroup(ctx context.Context, name string) error
 
 	// Cluster parameter group operations
-	CreateDBClusterParameterGroup(name, family, description string) (*DBClusterParameterGroup, error)
-	DescribeDBClusterParameterGroups(name string) ([]DBClusterParameterGroup, error)
-	DeleteDBClusterParameterGroup(name string) error
-	ModifyDBClusterParameterGroup(name string) (*DBClusterParameterGroup, error)
+	CreateDBClusterParameterGroup(
+		ctx context.Context,
+		name, family, description string,
+	) (*DBClusterParameterGroup, error)
+	DescribeDBClusterParameterGroups(ctx context.Context, name string) ([]DBClusterParameterGroup, error)
+	DeleteDBClusterParameterGroup(ctx context.Context, name string) error
+	ModifyDBClusterParameterGroup(ctx context.Context, name string) (*DBClusterParameterGroup, error)
 
 	// Cluster snapshot operations
-	CreateDBClusterSnapshot(snapshotID, clusterID string) (*DBClusterSnapshot, error)
-	DescribeDBClusterSnapshots(snapshotID, clusterID string) ([]DBClusterSnapshot, error)
-	DeleteDBClusterSnapshot(snapshotID string) (*DBClusterSnapshot, error)
+	CreateDBClusterSnapshot(ctx context.Context, snapshotID, clusterID string) (*DBClusterSnapshot, error)
+	DescribeDBClusterSnapshots(ctx context.Context, snapshotID, clusterID string) ([]DBClusterSnapshot, error)
+	DeleteDBClusterSnapshot(ctx context.Context, snapshotID string) (*DBClusterSnapshot, error)
 
 	// Tag operations
-	AddTagsToResource(arn string, tags []Tag) error
-	RemoveTagsFromResource(arn string, keys []string) error
-	ListTagsForResource(arn string) ([]Tag, error)
+	AddTagsToResource(ctx context.Context, arn string, tags []Tag) error
+	RemoveTagsFromResource(ctx context.Context, arn string, keys []string) error
+	ListTagsForResource(ctx context.Context, arn string) ([]Tag, error)
 
 	// New operations (Issue #902)
-	AddRoleToDBCluster(clusterID, roleARN string) error
-	AddSourceIdentifierToSubscription(name, sourceID string) (*EventSubscription, error)
-	ApplyPendingMaintenanceAction(resourceID, applyAction, optInType string) error
-	CopyDBClusterParameterGroup(sourceName, targetName, targetDescription string) (*DBClusterParameterGroup, error)
-	CopyDBClusterSnapshot(sourceSnapshotID, targetSnapshotID string) (*DBClusterSnapshot, error)
-	CopyDBParameterGroup(sourceName, targetName, targetDescription string) (*DBParameterGroup, error)
-	CreateDBClusterEndpoint(endpointID, clusterID, endpointType string) (*DBClusterEndpoint, error)
-	CreateDBParameterGroup(name, family, description string) (*DBParameterGroup, error)
-	CreateEventSubscription(name, snsTopicARN string, sourceIDs []string) (*EventSubscription, error)
-	CreateGlobalCluster(globalClusterID, sourceDBClusterID string) (*GlobalCluster, error)
-	DescribeGlobalClusters() []GlobalCluster
+	AddRoleToDBCluster(ctx context.Context, clusterID, roleARN string) error
+	AddSourceIdentifierToSubscription(ctx context.Context, name, sourceID string) (*EventSubscription, error)
+	ApplyPendingMaintenanceAction(ctx context.Context, resourceID, applyAction, optInType string) error
+	CopyDBClusterParameterGroup(
+		ctx context.Context,
+		sourceName, targetName, targetDescription string,
+	) (*DBClusterParameterGroup, error)
+	CopyDBClusterSnapshot(ctx context.Context, sourceSnapshotID, targetSnapshotID string) (*DBClusterSnapshot, error)
+	CopyDBParameterGroup(
+		ctx context.Context,
+		sourceName, targetName, targetDescription string,
+	) (*DBParameterGroup, error)
+	CreateDBClusterEndpoint(ctx context.Context, endpointID, clusterID, endpointType string) (*DBClusterEndpoint, error)
+	CreateDBParameterGroup(ctx context.Context, name, family, description string) (*DBParameterGroup, error)
+	CreateEventSubscription(
+		ctx context.Context,
+		name, snsTopicARN string,
+		sourceIDs []string,
+	) (*EventSubscription, error)
+	CreateGlobalCluster(ctx context.Context, globalClusterID, sourceDBClusterID string) (*GlobalCluster, error)
+	DescribeGlobalClusters(ctx context.Context) []GlobalCluster
 
 	// Cluster endpoint operations
-	DeleteDBClusterEndpoint(endpointID string) error
-	DescribeDBClusterEndpoints(endpointID, clusterID string) ([]DBClusterEndpoint, error)
-	ModifyDBClusterEndpoint(endpointID, endpointType string) (*DBClusterEndpoint, error)
+	DeleteDBClusterEndpoint(ctx context.Context, endpointID string) error
+	DescribeDBClusterEndpoints(ctx context.Context, endpointID, clusterID string) ([]DBClusterEndpoint, error)
+	ModifyDBClusterEndpoint(ctx context.Context, endpointID, endpointType string) (*DBClusterEndpoint, error)
 
 	// DB parameter group operations
-	DeleteDBParameterGroup(name string) error
-	DescribeDBParameterGroups(name string) ([]DBParameterGroup, error)
-	ModifyDBParameterGroup(name string) (*DBParameterGroup, error)
-	ResetDBParameterGroup(name string) (*DBParameterGroup, error)
+	DeleteDBParameterGroup(ctx context.Context, name string) error
+	DescribeDBParameterGroups(ctx context.Context, name string) ([]DBParameterGroup, error)
+	ModifyDBParameterGroup(ctx context.Context, name string) (*DBParameterGroup, error)
+	ResetDBParameterGroup(ctx context.Context, name string) (*DBParameterGroup, error)
 
 	// Cluster parameter group extended operations
-	ResetDBClusterParameterGroup(name string) (*DBClusterParameterGroup, error)
+	ResetDBClusterParameterGroup(ctx context.Context, name string) (*DBClusterParameterGroup, error)
 
 	// Event subscription extended operations
-	DeleteEventSubscription(name string) (*EventSubscription, error)
-	DescribeEventSubscriptions(name string) ([]EventSubscription, error)
-	ModifyEventSubscription(name, snsTopicARN string) (*EventSubscription, error)
-	RemoveSourceIdentifierFromSubscription(name, sourceID string) (*EventSubscription, error)
+	DeleteEventSubscription(ctx context.Context, name string) (*EventSubscription, error)
+	DescribeEventSubscriptions(ctx context.Context, name string) ([]EventSubscription, error)
+	ModifyEventSubscription(ctx context.Context, name, snsTopicARN string) (*EventSubscription, error)
+	RemoveSourceIdentifierFromSubscription(ctx context.Context, name, sourceID string) (*EventSubscription, error)
 
 	// Global cluster extended operations
-	DeleteGlobalCluster(globalClusterID string) (*GlobalCluster, error)
-	FailoverGlobalCluster(globalClusterID, targetDBClusterID string) (*GlobalCluster, error)
-	ModifyGlobalCluster(globalClusterID string) (*GlobalCluster, error)
-	RemoveFromGlobalCluster(globalClusterID, dbClusterID string) (*GlobalCluster, error)
-	SwitchoverGlobalCluster(globalClusterID, targetDBClusterID string) (*GlobalCluster, error)
+	DeleteGlobalCluster(ctx context.Context, globalClusterID string) (*GlobalCluster, error)
+	FailoverGlobalCluster(ctx context.Context, globalClusterID, targetDBClusterID string) (*GlobalCluster, error)
+	ModifyGlobalCluster(ctx context.Context, globalClusterID string) (*GlobalCluster, error)
+	RemoveFromGlobalCluster(ctx context.Context, globalClusterID, dbClusterID string) (*GlobalCluster, error)
+	SwitchoverGlobalCluster(ctx context.Context, globalClusterID, targetDBClusterID string) (*GlobalCluster, error)
 
 	// Role operations
-	RemoveRoleFromDBCluster(clusterID, roleARN string) error
+	RemoveRoleFromDBCluster(ctx context.Context, clusterID, roleARN string) error
 
 	// Restore operations
-	RestoreDBClusterFromSnapshot(snapshotID, clusterID string) (*DBCluster, error)
-	RestoreDBClusterToPointInTime(srcClusterID, targetClusterID string) (*DBCluster, error)
+	RestoreDBClusterFromSnapshot(ctx context.Context, snapshotID, clusterID string) (*DBCluster, error)
+	RestoreDBClusterToPointInTime(ctx context.Context, srcClusterID, targetClusterID string) (*DBCluster, error)
 
 	// Subnet group extended operations
-	ModifyDBSubnetGroup(name, description string) (*DBSubnetGroup, error)
+	ModifyDBSubnetGroup(ctx context.Context, name, description string) (*DBSubnetGroup, error)
 
 	// Lifecycle
 	Reset()

--- a/services/neptune/isolation_test.go
+++ b/services/neptune/isolation_test.go
@@ -1,0 +1,150 @@
+package neptune //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRegion returns a context carrying the given AWS region under regionContextKey.
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestNeptuneClusterRegionIsolation proves that same-named clusters in two regions
+// are fully isolated: each region sees only its own cluster (with its own ARN and
+// engine version), and deleting in one region leaves the other intact.
+func TestNeptuneClusterRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	const (
+		eastVersion = "1.3.1.0"
+		westVersion = "1.2.1.0"
+	)
+
+	// 1. Create a cluster named "graph1" in us-east-1.
+	eastCluster, err := backend.CreateDBCluster(
+		ctxEast, "graph1", "", 0,
+		DBClusterCreateOptions{EngineVersion: eastVersion},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, eastCluster.DBClusterArn, "us-east-1")
+	assert.Equal(t, eastVersion, eastCluster.EngineVersion)
+
+	// 2. Create a cluster with the SAME NAME in us-west-2 with a different version.
+	westCluster, err := backend.CreateDBCluster(
+		ctxWest, "graph1", "", 0,
+		DBClusterCreateOptions{EngineVersion: westVersion},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, westCluster.DBClusterArn, "us-west-2")
+	assert.Equal(t, westVersion, westCluster.EngineVersion)
+
+	// 3. us-east-1 sees only its own cluster with its own ARN and version.
+	eastList, err := backend.DescribeDBClusters(ctxEast, "")
+	require.NoError(t, err)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, "graph1", eastList[0].DBClusterIdentifier)
+	assert.Equal(t, eastVersion, eastList[0].EngineVersion)
+	assert.Contains(t, eastList[0].DBClusterArn, "us-east-1")
+
+	// 4. us-west-2 sees only its own cluster with its own ARN and version.
+	westList, err := backend.DescribeDBClusters(ctxWest, "")
+	require.NoError(t, err)
+	require.Len(t, westList, 1)
+	assert.Equal(t, "graph1", westList[0].DBClusterIdentifier)
+	assert.Equal(t, westVersion, westList[0].EngineVersion)
+	assert.Contains(t, westList[0].DBClusterArn, "us-west-2")
+
+	// 5. Delete in us-east-1; us-west-2 still has its cluster.
+	_, err = backend.DeleteDBCluster(ctxEast, "graph1")
+	require.NoError(t, err)
+
+	_, err = backend.DescribeDBClusters(ctxEast, "graph1")
+	require.ErrorIs(t, err, ErrClusterNotFound)
+
+	westAfter, err := backend.DescribeDBClusters(ctxWest, "graph1")
+	require.NoError(t, err)
+	require.Len(t, westAfter, 1)
+	assert.Contains(t, westAfter[0].DBClusterArn, "us-west-2")
+}
+
+// TestNeptuneInstanceAndTagRegionIsolation proves DB instances and tags are
+// region-isolated, including ARN-addressed tag operations resolving region from ARN.
+func TestNeptuneInstanceAndTagRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// Same-named cluster + instance in both regions.
+	for _, c := range []context.Context{ctxEast, ctxWest} {
+		_, err := backend.CreateDBCluster(c, "c1", "", 0, DBClusterCreateOptions{})
+		require.NoError(t, err)
+		_, err = backend.CreateDBInstance(c, "i1", "c1", "", DBInstanceCreateOptions{})
+		require.NoError(t, err)
+	}
+
+	// Each region sees exactly one instance.
+	eastInsts, err := backend.DescribeDBInstances(ctxEast, "")
+	require.NoError(t, err)
+	require.Len(t, eastInsts, 1)
+	assert.Contains(t, eastInsts[0].DBInstanceArn, "us-east-1")
+
+	westInsts, err := backend.DescribeDBInstances(ctxWest, "")
+	require.NoError(t, err)
+	require.Len(t, westInsts, 1)
+	assert.Contains(t, westInsts[0].DBInstanceArn, "us-west-2")
+
+	// Tag the us-west-2 instance via its ARN; region is resolved from the ARN itself.
+	require.NoError(
+		t,
+		backend.AddTagsToResource(ctxEast, westInsts[0].DBInstanceArn, []Tag{{Key: "env", Value: "west"}}),
+	)
+
+	// The tag must land on the us-west-2 instance, not us-east-1's.
+	westTags, err := backend.ListTagsForResource(ctxEast, westInsts[0].DBInstanceArn)
+	require.NoError(t, err)
+	require.Len(t, westTags, 1)
+	assert.Equal(t, "west", westTags[0].Value)
+
+	eastTags, err := backend.ListTagsForResource(ctxEast, eastInsts[0].DBInstanceArn)
+	require.NoError(t, err)
+	assert.Empty(t, eastTags)
+}
+
+// TestNeptuneGlobalClusterIsNotRegionIsolated proves global clusters are
+// partition-scoped: one created via a us-east-1 context is visible from us-west-2.
+func TestNeptuneGlobalClusterIsNotRegionIsolated(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	_, err := backend.CreateGlobalCluster(ctxEast, "global1", "")
+	require.NoError(t, err)
+
+	// Visible regardless of the request region (global/partition-scoped).
+	eastGlobals := backend.DescribeGlobalClusters(ctxEast)
+	require.Len(t, eastGlobals, 1)
+
+	westGlobals := backend.DescribeGlobalClusters(ctxWest)
+	require.Len(t, westGlobals, 1)
+	assert.Equal(t, "global1", westGlobals[0].GlobalClusterIdentifier)
+
+	// Deleting from a different region context still removes the single global cluster.
+	_, err = backend.DeleteGlobalCluster(ctxWest, "global1")
+	require.NoError(t, err)
+	assert.Empty(t, backend.DescribeGlobalClusters(ctxEast))
+}

--- a/services/neptune/persistence.go
+++ b/services/neptune/persistence.go
@@ -5,20 +5,22 @@ import (
 	"log/slog"
 )
 
+// backendSnapshot persists the backend state. Regional resource maps are nested by
+// region (outer key = region). GlobalClusters are partition-scoped and stay flat.
 type backendSnapshot struct {
-	Clusters               map[string]*DBCluster               `json:"clusters"`
-	Instances              map[string]*DBInstance              `json:"instances"`
-	SubnetGroups           map[string]*DBSubnetGroup           `json:"subnetGroups"`
-	ClusterParameterGroups map[string]*DBClusterParameterGroup `json:"clusterParameterGroups"`
-	ClusterSnapshots       map[string]*DBClusterSnapshot       `json:"clusterSnapshots"`
-	ParameterGroups        map[string]*DBParameterGroup        `json:"parameterGroups"`
-	ClusterEndpoints       map[string]*DBClusterEndpoint       `json:"clusterEndpoints"`
-	EventSubscriptions     map[string]*EventSubscription       `json:"eventSubscriptions"`
-	GlobalClusters         map[string]*GlobalCluster           `json:"globalClusters"`
-	ClusterRoles           map[string][]string                 `json:"clusterRoles"`
-	Tags                   map[string][]Tag                    `json:"tags"`
-	AccountID              string                              `json:"accountID"`
-	Region                 string                              `json:"region"`
+	Clusters               map[string]map[string]*DBCluster               `json:"clusters"`
+	Instances              map[string]map[string]*DBInstance              `json:"instances"`
+	SubnetGroups           map[string]map[string]*DBSubnetGroup           `json:"subnetGroups"`
+	ClusterParameterGroups map[string]map[string]*DBClusterParameterGroup `json:"clusterParameterGroups"`
+	ClusterSnapshots       map[string]map[string]*DBClusterSnapshot       `json:"clusterSnapshots"`
+	ParameterGroups        map[string]map[string]*DBParameterGroup        `json:"parameterGroups"`
+	ClusterEndpoints       map[string]map[string]*DBClusterEndpoint       `json:"clusterEndpoints"`
+	EventSubscriptions     map[string]map[string]*EventSubscription       `json:"eventSubscriptions"`
+	ClusterRoles           map[string]map[string][]string                 `json:"clusterRoles"`
+	Tags                   map[string]map[string][]Tag                    `json:"tags"`
+	GlobalClusters         map[string]*GlobalCluster                      `json:"globalClusters"`
+	AccountID              string                                         `json:"accountID"`
+	Region                 string                                         `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -85,35 +87,35 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 // ensureNonNilMaps initialises nil maps in the snapshot to empty maps.
 func ensureNonNilMaps(snap *backendSnapshot) {
 	if snap.Clusters == nil {
-		snap.Clusters = make(map[string]*DBCluster)
+		snap.Clusters = make(map[string]map[string]*DBCluster)
 	}
 
 	if snap.Instances == nil {
-		snap.Instances = make(map[string]*DBInstance)
+		snap.Instances = make(map[string]map[string]*DBInstance)
 	}
 
 	if snap.SubnetGroups == nil {
-		snap.SubnetGroups = make(map[string]*DBSubnetGroup)
+		snap.SubnetGroups = make(map[string]map[string]*DBSubnetGroup)
 	}
 
 	if snap.ClusterParameterGroups == nil {
-		snap.ClusterParameterGroups = make(map[string]*DBClusterParameterGroup)
+		snap.ClusterParameterGroups = make(map[string]map[string]*DBClusterParameterGroup)
 	}
 
 	if snap.ClusterSnapshots == nil {
-		snap.ClusterSnapshots = make(map[string]*DBClusterSnapshot)
+		snap.ClusterSnapshots = make(map[string]map[string]*DBClusterSnapshot)
 	}
 
 	if snap.ParameterGroups == nil {
-		snap.ParameterGroups = make(map[string]*DBParameterGroup)
+		snap.ParameterGroups = make(map[string]map[string]*DBParameterGroup)
 	}
 
 	if snap.ClusterEndpoints == nil {
-		snap.ClusterEndpoints = make(map[string]*DBClusterEndpoint)
+		snap.ClusterEndpoints = make(map[string]map[string]*DBClusterEndpoint)
 	}
 
 	if snap.EventSubscriptions == nil {
-		snap.EventSubscriptions = make(map[string]*EventSubscription)
+		snap.EventSubscriptions = make(map[string]map[string]*EventSubscription)
 	}
 
 	if snap.GlobalClusters == nil {
@@ -121,11 +123,11 @@ func ensureNonNilMaps(snap *backendSnapshot) {
 	}
 
 	if snap.ClusterRoles == nil {
-		snap.ClusterRoles = make(map[string][]string)
+		snap.ClusterRoles = make(map[string]map[string][]string)
 	}
 
 	if snap.Tags == nil {
-		snap.Tags = make(map[string][]Tag)
+		snap.Tags = make(map[string]map[string][]Tag)
 	}
 }
 

--- a/services/scheduler/backend.go
+++ b/services/scheduler/backend.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sort"
@@ -13,6 +14,18 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
+
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
 
 // ScheduleOption applies an optional field to a schedule during creation or update.
 type ScheduleOption func(*Schedule)
@@ -186,10 +199,12 @@ type ScheduleGroup struct {
 }
 
 type InMemoryBackend struct {
-	schedules             map[string]*Schedule
-	scheduleARNIndex      map[string]string // ARN → schedule name (group/name composite key)
-	scheduleGroups        map[string]*ScheduleGroup
-	scheduleGroupARNIndex map[string]string // ARN → schedule group name
+	// All resource maps are nested by region (outer key = region) so that
+	// same-named resources in different regions are fully isolated.
+	schedules             map[string]map[string]*Schedule // region → group/name key → schedule
+	scheduleARNIndex      map[string]map[string]string    // region → ARN → group/name key
+	scheduleGroups        map[string]map[string]*ScheduleGroup
+	scheduleGroupARNIndex map[string]map[string]string // region → ARN → schedule group name
 	mu                    *lockmetrics.RWMutex
 	accountID             string
 	region                string
@@ -197,24 +212,69 @@ type InMemoryBackend struct {
 
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	b := &InMemoryBackend{
-		schedules:             make(map[string]*Schedule),
-		scheduleARNIndex:      make(map[string]string),
-		scheduleGroups:        make(map[string]*ScheduleGroup),
-		scheduleGroupARNIndex: make(map[string]string),
+		schedules:             make(map[string]map[string]*Schedule),
+		scheduleARNIndex:      make(map[string]map[string]string),
+		scheduleGroups:        make(map[string]map[string]*ScheduleGroup),
+		scheduleGroupARNIndex: make(map[string]map[string]string),
 		accountID:             accountID,
 		region:                region,
 		mu:                    lockmetrics.New("scheduler"),
 	}
-	b.seedDefaultGroup()
+	// Touch the default-region group store so the built-in "default" group is seeded.
+	b.scheduleGroupsStore(region)
 
 	return b
 }
 
-// seedDefaultGroup creates the built-in "default" schedule group.
-// Must be called without the mutex held.
-func (b *InMemoryBackend) seedDefaultGroup() {
+// schedulesStore returns the schedule map for the given region, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) schedulesStore(region string) map[string]*Schedule {
+	if b.schedules[region] == nil {
+		b.schedules[region] = make(map[string]*Schedule)
+	}
+
+	return b.schedules[region]
+}
+
+// scheduleARNStore returns the schedule ARN index for the given region, lazily creating it.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) scheduleARNStore(region string) map[string]string {
+	if b.scheduleARNIndex[region] == nil {
+		b.scheduleARNIndex[region] = make(map[string]string)
+	}
+
+	return b.scheduleARNIndex[region]
+}
+
+// scheduleGroupsStore returns the schedule group map for the given region, lazily creating
+// it and seeding the built-in "default" group (which exists in every AWS region).
+// Callers must hold b.mu.
+func (b *InMemoryBackend) scheduleGroupsStore(region string) map[string]*ScheduleGroup {
+	if b.scheduleGroups[region] == nil {
+		b.scheduleGroups[region] = make(map[string]*ScheduleGroup)
+		b.seedDefaultGroup(region)
+	}
+
+	return b.scheduleGroups[region]
+}
+
+// scheduleGroupARNStore returns the schedule group ARN index for the given region,
+// lazily creating it. Callers must hold b.mu.
+func (b *InMemoryBackend) scheduleGroupARNStore(region string) map[string]string {
+	if b.scheduleGroupARNIndex[region] == nil {
+		b.scheduleGroupARNIndex[region] = make(map[string]string)
+	}
+
+	return b.scheduleGroupARNIndex[region]
+}
+
+// seedDefaultGroup creates the built-in "default" schedule group in the given region.
+// It is invoked from scheduleGroupsStore the first time a region's group map is created
+// (and from Reset/Restore), so it writes directly into the region maps, which the caller
+// has already initialised. Callers must hold b.mu (or be in single-threaded setup).
+func (b *InMemoryBackend) seedDefaultGroup(region string) {
 	now := time.Now().UTC()
-	groupARN := arn.Build("scheduler", b.region, b.accountID, "schedule-group/"+defaultGroupName)
+	groupARN := arn.Build("scheduler", region, b.accountID, "schedule-group/"+defaultGroupName)
 	g := &ScheduleGroup{
 		Name:                 defaultGroupName,
 		ARN:                  groupARN,
@@ -223,8 +283,12 @@ func (b *InMemoryBackend) seedDefaultGroup() {
 		LastModificationDate: now,
 		Tags:                 tags.New("scheduler.schedulegroup." + defaultGroupName + ".tags"),
 	}
-	b.scheduleGroups[defaultGroupName] = g
-	b.scheduleGroupARNIndex[groupARN] = defaultGroupName
+	b.scheduleGroups[region][defaultGroupName] = g
+
+	if b.scheduleGroupARNIndex[region] == nil {
+		b.scheduleGroupARNIndex[region] = make(map[string]string)
+	}
+	b.scheduleGroupARNIndex[region][groupARN] = defaultGroupName
 }
 
 // scheduleKey returns the composite map key for a schedule: "groupName/name".
@@ -240,6 +304,7 @@ func (b *InMemoryBackend) AccountID() string { return b.accountID }
 
 // CreateSchedule creates a new schedule in the named group.
 func (b *InMemoryBackend) CreateSchedule(
+	ctx context.Context,
 	name, groupName, expr, description, timezone string,
 	target Target,
 	state string,
@@ -282,19 +347,22 @@ func (b *InMemoryBackend) CreateSchedule(
 		groupName = defaultGroupName
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateSchedule")
 	defer b.mu.Unlock()
 
-	if _, ok := b.scheduleGroups[groupName]; !ok {
+	if _, ok := b.scheduleGroupsStore(region)[groupName]; !ok {
 		return nil, fmt.Errorf("%w: schedule group %s not found", ErrNotFound, groupName)
 	}
 
+	schedules := b.schedulesStore(region)
 	key := scheduleKey(groupName, name)
-	if _, ok := b.schedules[key]; ok {
+	if _, ok := schedules[key]; ok {
 		return nil, fmt.Errorf("%w: schedule %s already exists in group %s", ErrAlreadyExists, name, groupName)
 	}
 
-	schedARN := arn.Build("scheduler", b.region, b.accountID, "schedule/"+groupName+"/"+name)
+	schedARN := arn.Build("scheduler", region, b.accountID, "schedule/"+groupName+"/"+name)
 	now := time.Now().UTC()
 	s := &Schedule{
 		Name:                       name,
@@ -307,28 +375,30 @@ func (b *InMemoryBackend) CreateSchedule(
 		State:                      state,
 		FlexibleTimeWindow:         ftw,
 		AccountID:                  b.accountID,
-		Region:                     b.region,
+		Region:                     region,
 		CreationDate:               now,
 		LastModificationDate:       now,
 		Tags:                       tags.New("scheduler.schedule." + groupName + "." + name + ".tags"),
 	}
 	applyScheduleOptions(opts, s)
-	b.schedules[key] = s
-	b.scheduleARNIndex[schedARN] = key
+	schedules[key] = s
+	b.scheduleARNStore(region)[schedARN] = key
 
 	return cloneSchedule(s), nil
 }
 
 // GetSchedule returns a schedule by name and group.
-func (b *InMemoryBackend) GetSchedule(name, groupName string) (*Schedule, error) {
+func (b *InMemoryBackend) GetSchedule(ctx context.Context, name, groupName string) (*Schedule, error) {
 	if groupName == "" {
 		groupName = defaultGroupName
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetSchedule")
 	defer b.mu.RUnlock()
 
-	s, ok := b.schedules[scheduleKey(groupName, name)]
+	s, ok := b.schedulesStore(region)[scheduleKey(groupName, name)]
 	if !ok {
 		return nil, fmt.Errorf("%w: schedule %s not found", ErrNotFound, name)
 	}
@@ -340,15 +410,19 @@ func (b *InMemoryBackend) GetSchedule(name, groupName string) (*Schedule, error)
 // When maxResults > 0 and nextToken is non-empty it resumes after the token (last seen name).
 // Returns the page of schedules and the next continuation token (empty when no more results).
 func (b *InMemoryBackend) ListSchedules(
+	ctx context.Context,
 	groupName, namePrefix, state, nextToken string,
 	maxResults int,
 ) ([]*Schedule, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSchedules")
 	defer b.mu.RUnlock()
 
-	list := make([]*Schedule, 0, len(b.schedules))
+	schedules := b.schedulesStore(region)
+	list := make([]*Schedule, 0, len(schedules))
 
-	for _, s := range b.schedules {
+	for _, s := range schedules {
 		if groupName != "" && s.GroupName != groupName {
 			continue
 		}
@@ -370,23 +444,26 @@ func (b *InMemoryBackend) ListSchedules(
 }
 
 // DeleteSchedule removes a schedule by name and group.
-func (b *InMemoryBackend) DeleteSchedule(name, groupName string) error {
+func (b *InMemoryBackend) DeleteSchedule(ctx context.Context, name, groupName string) error {
 	if groupName == "" {
 		groupName = defaultGroupName
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.Lock("DeleteSchedule")
 	defer b.mu.Unlock()
 
 	key := scheduleKey(groupName, name)
 
-	s, ok := b.schedules[key]
+	schedules := b.schedulesStore(region)
+	s, ok := schedules[key]
 	if !ok {
 		return fmt.Errorf("%w: schedule %s not found", ErrNotFound, name)
 	}
 
-	delete(b.scheduleARNIndex, s.ARN)
-	delete(b.schedules, key)
+	delete(b.scheduleARNStore(region), s.ARN)
+	delete(schedules, key)
 	s.Tags.Close()
 
 	return nil
@@ -394,6 +471,7 @@ func (b *InMemoryBackend) DeleteSchedule(name, groupName string) error {
 
 // UpdateSchedule updates an existing schedule.
 func (b *InMemoryBackend) UpdateSchedule(
+	ctx context.Context,
 	name, groupName, expr, description, timezone string,
 	target Target,
 	state string,
@@ -420,10 +498,12 @@ func (b *InMemoryBackend) UpdateSchedule(
 		groupName = defaultGroupName
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateSchedule")
 	defer b.mu.Unlock()
 
-	s, ok := b.schedules[scheduleKey(groupName, name)]
+	s, ok := b.schedulesStore(region)[scheduleKey(groupName, name)]
 	if !ok {
 		return nil, fmt.Errorf("%w: schedule %s not found", ErrNotFound, name)
 	}
@@ -440,18 +520,20 @@ func (b *InMemoryBackend) UpdateSchedule(
 	return cloneSchedule(s), nil
 }
 
-func (b *InMemoryBackend) TagResource(resourceARN string, kv map[string]string) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceARN string, kv map[string]string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
-	if key, ok := b.scheduleARNIndex[resourceARN]; ok {
-		b.schedules[key].Tags.Merge(kv)
+	if key, ok := b.scheduleARNStore(region)[resourceARN]; ok {
+		b.schedulesStore(region)[key].Tags.Merge(kv)
 
 		return nil
 	}
 
-	if name, ok := b.scheduleGroupARNIndex[resourceARN]; ok {
-		b.scheduleGroups[name].Tags.Merge(kv)
+	if name, ok := b.scheduleGroupARNStore(region)[resourceARN]; ok {
+		b.scheduleGroupsStore(region)[name].Tags.Merge(kv)
 
 		return nil
 	}
@@ -459,18 +541,20 @@ func (b *InMemoryBackend) TagResource(resourceARN string, kv map[string]string) 
 	return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
 }
 
-func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
-	if key, ok := b.scheduleARNIndex[resourceARN]; ok {
-		b.schedules[key].Tags.DeleteKeys(tagKeys)
+	if key, ok := b.scheduleARNStore(region)[resourceARN]; ok {
+		b.schedulesStore(region)[key].Tags.DeleteKeys(tagKeys)
 
 		return nil
 	}
 
-	if name, ok := b.scheduleGroupARNIndex[resourceARN]; ok {
-		b.scheduleGroups[name].Tags.DeleteKeys(tagKeys)
+	if name, ok := b.scheduleGroupARNStore(region)[resourceARN]; ok {
+		b.scheduleGroupsStore(region)[name].Tags.DeleteKeys(tagKeys)
 
 		return nil
 	}
@@ -478,47 +562,56 @@ func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) er
 	return fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
 }
 
-func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]string, error) {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListTagsForResource")
 	defer b.mu.RUnlock()
 
-	if key, ok := b.scheduleARNIndex[resourceARN]; ok {
-		return b.schedules[key].Tags.Clone(), nil
+	if key, ok := b.scheduleARNStore(region)[resourceARN]; ok {
+		return b.schedulesStore(region)[key].Tags.Clone(), nil
 	}
 
-	if name, ok := b.scheduleGroupARNIndex[resourceARN]; ok {
-		return b.scheduleGroups[name].Tags.Clone(), nil
+	if name, ok := b.scheduleGroupARNStore(region)[resourceARN]; ok {
+		return b.scheduleGroupsStore(region)[name].Tags.Clone(), nil
 	}
 
 	return nil, fmt.Errorf("%w: resource %s not found", ErrNotFound, resourceARN)
 }
 
-// Reset clears all in-memory state and re-seeds the default schedule group.
+// Reset clears all in-memory state and re-seeds the default schedule group
+// in the backend's default region.
 func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, s := range b.schedules {
-		if s.Tags != nil {
-			s.Tags.Close()
+	for _, regionSchedules := range b.schedules {
+		for _, s := range regionSchedules {
+			if s.Tags != nil {
+				s.Tags.Close()
+			}
 		}
 	}
 
-	for _, g := range b.scheduleGroups {
-		if g.Tags != nil {
-			g.Tags.Close()
+	for _, regionGroups := range b.scheduleGroups {
+		for _, g := range regionGroups {
+			if g.Tags != nil {
+				g.Tags.Close()
+			}
 		}
 	}
 
-	b.schedules = make(map[string]*Schedule)
-	b.scheduleARNIndex = make(map[string]string)
-	b.scheduleGroups = make(map[string]*ScheduleGroup)
-	b.scheduleGroupARNIndex = make(map[string]string)
-	b.seedDefaultGroup()
+	b.schedules = make(map[string]map[string]*Schedule)
+	b.scheduleARNIndex = make(map[string]map[string]string)
+	b.scheduleGroups = make(map[string]map[string]*ScheduleGroup)
+	b.scheduleGroupARNIndex = make(map[string]map[string]string)
+	// Re-seed the built-in "default" group in the default region.
+	b.scheduleGroupsStore(b.region)
 }
 
 // CreateScheduleGroup creates a new schedule group with the given name and optional tags.
 func (b *InMemoryBackend) CreateScheduleGroup(
+	ctx context.Context,
 	name, description string,
 	initialTags map[string]string,
 ) (*ScheduleGroup, error) {
@@ -526,14 +619,17 @@ func (b *InMemoryBackend) CreateScheduleGroup(
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CreateScheduleGroup")
 	defer b.mu.Unlock()
 
-	if _, ok := b.scheduleGroups[name]; ok {
+	groups := b.scheduleGroupsStore(region)
+	if _, ok := groups[name]; ok {
 		return nil, fmt.Errorf("%w: schedule group %s already exists", ErrAlreadyExists, name)
 	}
 
-	groupARN := arn.Build("scheduler", b.region, b.accountID, "schedule-group/"+name)
+	groupARN := arn.Build("scheduler", region, b.accountID, "schedule-group/"+name)
 	now := time.Now().UTC()
 	g := &ScheduleGroup{
 		Name:                 name,
@@ -545,18 +641,20 @@ func (b *InMemoryBackend) CreateScheduleGroup(
 		Tags:                 tags.New("scheduler.schedulegroup." + name + ".tags"),
 	}
 	g.Tags.Merge(initialTags)
-	b.scheduleGroups[name] = g
-	b.scheduleGroupARNIndex[groupARN] = name
+	groups[name] = g
+	b.scheduleGroupARNStore(region)[groupARN] = name
 
 	return cloneScheduleGroup(g), nil
 }
 
 // GetScheduleGroup returns the schedule group with the given name.
-func (b *InMemoryBackend) GetScheduleGroup(name string) (*ScheduleGroup, error) {
+func (b *InMemoryBackend) GetScheduleGroup(ctx context.Context, name string) (*ScheduleGroup, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetScheduleGroup")
 	defer b.mu.RUnlock()
 
-	g, ok := b.scheduleGroups[name]
+	g, ok := b.scheduleGroupsStore(region)[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: schedule group %s not found", ErrNotFound, name)
 	}
@@ -567,32 +665,37 @@ func (b *InMemoryBackend) GetScheduleGroup(name string) (*ScheduleGroup, error) 
 // DeleteScheduleGroup removes the schedule group with the given name.
 // The built-in "default" group cannot be deleted.
 // All schedules within the group are also deleted.
-func (b *InMemoryBackend) DeleteScheduleGroup(name string) error {
+func (b *InMemoryBackend) DeleteScheduleGroup(ctx context.Context, name string) error {
 	if name == defaultGroupName {
 		return fmt.Errorf("%w: cannot delete the default schedule group", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteScheduleGroup")
 	defer b.mu.Unlock()
 
-	g, ok := b.scheduleGroups[name]
+	groups := b.scheduleGroupsStore(region)
+	g, ok := groups[name]
 	if !ok {
 		return fmt.Errorf("%w: schedule group %s not found", ErrNotFound, name)
 	}
 
 	// Cascade-delete all schedules belonging to this group.
-	for key, s := range b.schedules {
+	schedules := b.schedulesStore(region)
+	arnIndex := b.scheduleARNStore(region)
+	for key, s := range schedules {
 		if s.GroupName == name {
-			delete(b.scheduleARNIndex, s.ARN)
-			delete(b.schedules, key)
+			delete(arnIndex, s.ARN)
+			delete(schedules, key)
 			if s.Tags != nil {
 				s.Tags.Close()
 			}
 		}
 	}
 
-	delete(b.scheduleGroupARNIndex, g.ARN)
-	delete(b.scheduleGroups, name)
+	delete(b.scheduleGroupARNStore(region), g.ARN)
+	delete(groups, name)
 	g.Tags.Close()
 
 	return nil
@@ -601,13 +704,18 @@ func (b *InMemoryBackend) DeleteScheduleGroup(name string) error {
 // ListScheduleGroups returns schedule groups optionally filtered by name prefix.
 // When maxResults > 0 and nextToken is non-empty it resumes after the token (last seen name).
 // Returns the page of groups and the next continuation token (empty when no more results).
-func (b *InMemoryBackend) ListScheduleGroups(namePrefix, nextToken string, maxResults int) ([]*ScheduleGroup, string) {
+func (b *InMemoryBackend) ListScheduleGroups(
+	ctx context.Context, namePrefix, nextToken string, maxResults int,
+) ([]*ScheduleGroup, string) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListScheduleGroups")
 	defer b.mu.RUnlock()
 
-	list := make([]*ScheduleGroup, 0, len(b.scheduleGroups))
+	groups := b.scheduleGroupsStore(region)
+	list := make([]*ScheduleGroup, 0, len(groups))
 
-	for _, g := range b.scheduleGroups {
+	for _, g := range groups {
 		if namePrefix != "" && !strings.HasPrefix(g.Name, namePrefix) {
 			continue
 		}
@@ -661,9 +769,15 @@ func (b *InMemoryBackend) AddScheduleInternal(s *Schedule) {
 		s.Tags = tags.New("scheduler.schedule." + s.GroupName + "." + s.Name + ".tags")
 	}
 
+	region := s.Region
+	if region == "" {
+		region = b.region
+		s.Region = region
+	}
+
 	key := scheduleKey(s.GroupName, s.Name)
-	b.schedules[key] = s
-	b.scheduleARNIndex[s.ARN] = key
+	b.schedulesStore(region)[key] = s
+	b.scheduleARNStore(region)[s.ARN] = key
 }
 
 // AddScheduleGroupInternal inserts a schedule group directly for testing purposes.
@@ -676,8 +790,21 @@ func (b *InMemoryBackend) AddScheduleGroupInternal(g *ScheduleGroup) {
 		g.Tags = tags.New("scheduler.schedulegroup." + g.Name + ".tags")
 	}
 
-	b.scheduleGroups[g.Name] = g
-	b.scheduleGroupARNIndex[g.ARN] = g.Name
+	region := regionFromARN(g.ARN, b.region)
+	b.scheduleGroupsStore(region)[g.Name] = g
+	b.scheduleGroupARNStore(region)[g.ARN] = g.Name
+}
+
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
 }
 
 // cloneSchedule returns a deep copy of a schedule (including a snapshot of its Tags).

--- a/services/scheduler/export_test.go
+++ b/services/scheduler/export_test.go
@@ -25,20 +25,30 @@ func LastFiredAtLen(r *Runner) int {
 	return len(r.lastFiredAt)
 }
 
-// ScheduleCount returns the number of schedules in the backend.
+// ScheduleCount returns the total number of schedules in the backend across all regions.
 func ScheduleCount(b *InMemoryBackend) int {
 	b.mu.RLock("ScheduleCount")
 	defer b.mu.RUnlock()
 
-	return len(b.schedules)
+	total := 0
+	for _, regionSchedules := range b.schedules {
+		total += len(regionSchedules)
+	}
+
+	return total
 }
 
-// ScheduleGroupCount returns the number of schedule groups in the backend.
+// ScheduleGroupCount returns the total number of schedule groups across all regions.
 func ScheduleGroupCount(b *InMemoryBackend) int {
 	b.mu.RLock("ScheduleGroupCount")
 	defer b.mu.RUnlock()
 
-	return len(b.scheduleGroups)
+	total := 0
+	for _, regionGroups := range b.scheduleGroups {
+		total += len(regionGroups)
+	}
+
+	return total
 }
 
 // HandlerOpsLen returns the number of operations in the handler's dispatch table.

--- a/services/scheduler/handler.go
+++ b/services/scheduler/handler.go
@@ -411,21 +411,33 @@ func (h *Handler) Handler() echo.HandlerFunc {
 			return h.handleREST(c)
 		}
 
+		ctx := h.contextWithRegion(c)
+
 		return service.HandleTarget(
-			c, logger.Load(c.Request().Context()),
+			c, logger.Load(ctx),
 			"Scheduler", "application/x-amz-json-1.1",
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(_ context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(ctx, action, body)
+			},
 			h.handleError,
 		)
 	}
+}
+
+// contextWithRegion returns the request context with the resolved AWS region attached
+// under regionContextKey so that backend operations are routed to the correct region.
+func (h *Handler) contextWithRegion(c *echo.Context) context.Context {
+	region := httputils.ExtractRegionFromRequest(c.Request(), h.Backend.Region())
+
+	return context.WithValue(c.Request().Context(), regionContextKey{}, region)
 }
 
 // handleREST handles Scheduler REST API calls.
 // It extracts path parameters from the URL, injects them into the request body,
 // and dispatches to the existing handler logic.
 func (h *Handler) handleREST(c *echo.Context) error {
-	ctx := c.Request().Context()
+	ctx := h.contextWithRegion(c)
 
 	action, name := parseSchedulerRESTPath(c.Request().Method, c.Request().URL.Path)
 	if action == restOpUnknown {
@@ -625,7 +637,7 @@ type createScheduleOutput struct {
 	ScheduleArn string `json:"ScheduleArn"`
 }
 
-func (h *Handler) handleCreateSchedule(_ context.Context, in *scheduleInput) (*createScheduleOutput, error) {
+func (h *Handler) handleCreateSchedule(ctx context.Context, in *scheduleInput) (*createScheduleOutput, error) {
 	state := in.State
 	if state == "" {
 		state = scheduleStateEnabled
@@ -649,6 +661,7 @@ func (h *Handler) handleCreateSchedule(_ context.Context, in *scheduleInput) (*c
 	}
 
 	s, err := h.Backend.CreateSchedule(
+		ctx,
 		in.Name,
 		in.GroupName,
 		in.ScheduleExpression,
@@ -921,8 +934,8 @@ type getScheduleOutput struct {
 	CreationDate               float64                  `json:"CreationDate"`
 }
 
-func (h *Handler) handleGetSchedule(_ context.Context, in *scheduleNameInput) (*getScheduleOutput, error) {
-	s, err := h.Backend.GetSchedule(in.Name, in.GroupName)
+func (h *Handler) handleGetSchedule(ctx context.Context, in *scheduleNameInput) (*getScheduleOutput, error) {
+	s, err := h.Backend.GetSchedule(ctx, in.Name, in.GroupName)
 	if err != nil {
 		return nil, err
 	}
@@ -988,9 +1001,16 @@ type listSchedulesOutput struct {
 	Schedules []scheduleSummary `json:"Schedules"`
 }
 
-func (h *Handler) handleListSchedules(_ context.Context, in *listSchedulesInput) (*listSchedulesOutput, error) {
+func (h *Handler) handleListSchedules(ctx context.Context, in *listSchedulesInput) (*listSchedulesOutput, error) {
 	maxResults := parseMaxResults(in.MaxResults)
-	schedules, nextToken := h.Backend.ListSchedules(in.GroupName, in.NamePrefix, in.State, in.NextToken, maxResults)
+	schedules, nextToken := h.Backend.ListSchedules(
+		ctx,
+		in.GroupName,
+		in.NamePrefix,
+		in.State,
+		in.NextToken,
+		maxResults,
+	)
 	items := make([]scheduleSummary, 0, len(schedules))
 
 	for _, s := range schedules {
@@ -1018,15 +1038,15 @@ func voidOp(fn func() error) (*emptyOutput, error) {
 	return &emptyOutput{}, nil
 }
 
-func (h *Handler) handleDeleteSchedule(_ context.Context, in *scheduleNameInput) (*emptyOutput, error) {
-	return voidOp(func() error { return h.Backend.DeleteSchedule(in.Name, in.GroupName) })
+func (h *Handler) handleDeleteSchedule(ctx context.Context, in *scheduleNameInput) (*emptyOutput, error) {
+	return voidOp(func() error { return h.Backend.DeleteSchedule(ctx, in.Name, in.GroupName) })
 }
 
 type updateScheduleOutput struct {
 	ScheduleArn string `json:"ScheduleArn"`
 }
 
-func (h *Handler) handleUpdateSchedule(_ context.Context, in *scheduleInput) (*updateScheduleOutput, error) {
+func (h *Handler) handleUpdateSchedule(ctx context.Context, in *scheduleInput) (*updateScheduleOutput, error) {
 	var opts []ScheduleOption
 	if in.StartDate != nil {
 		opts = append(opts, WithStartDate(epochSecondsToTime(*in.StartDate)))
@@ -1045,6 +1065,7 @@ func (h *Handler) handleUpdateSchedule(_ context.Context, in *scheduleInput) (*u
 	}
 
 	s, err := h.Backend.UpdateSchedule(
+		ctx,
 		in.Name,
 		in.GroupName,
 		in.ScheduleExpression,
@@ -1070,8 +1091,8 @@ type handleTagResourceInput struct {
 	ResourceArn string            `json:"ResourceArn"`
 }
 
-func (h *Handler) handleTagResource(_ context.Context, in *handleTagResourceInput) (*emptyOutput, error) {
-	return voidOp(func() error { return h.Backend.TagResource(in.ResourceArn, in.Tags) })
+func (h *Handler) handleTagResource(ctx context.Context, in *handleTagResourceInput) (*emptyOutput, error) {
+	return voidOp(func() error { return h.Backend.TagResource(ctx, in.ResourceArn, in.Tags) })
 }
 
 type handleListTagsForResourceInput struct {
@@ -1083,10 +1104,10 @@ type listTagsForResourceOutput struct {
 }
 
 func (h *Handler) handleListTagsForResource(
-	_ context.Context,
+	ctx context.Context,
 	in *handleListTagsForResourceInput,
 ) (*listTagsForResourceOutput, error) {
-	kv, err := h.Backend.ListTagsForResource(in.ResourceArn)
+	kv, err := h.Backend.ListTagsForResource(ctx, in.ResourceArn)
 	if err != nil {
 		return nil, err
 	}
@@ -1100,8 +1121,8 @@ type handleUntagResourceInput struct {
 	TagKeys     []string `json:"TagKeys"`
 }
 
-func (h *Handler) handleUntagResource(_ context.Context, in *handleUntagResourceInput) (*emptyOutput, error) {
-	return voidOp(func() error { return h.Backend.UntagResource(in.ResourceArn, in.TagKeys) })
+func (h *Handler) handleUntagResource(ctx context.Context, in *handleUntagResourceInput) (*emptyOutput, error) {
+	return voidOp(func() error { return h.Backend.UntagResource(ctx, in.ResourceArn, in.TagKeys) })
 }
 
 // Schedule group handlers.
@@ -1117,10 +1138,10 @@ type createScheduleGroupOutput struct {
 }
 
 func (h *Handler) handleCreateScheduleGroup(
-	_ context.Context,
+	ctx context.Context,
 	in *createScheduleGroupInput,
 ) (*createScheduleGroupOutput, error) {
-	g, err := h.Backend.CreateScheduleGroup(in.Name, in.Description, in.Tags)
+	g, err := h.Backend.CreateScheduleGroup(ctx, in.Name, in.Description, in.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -1135,10 +1156,10 @@ type scheduleGroupNameInput struct {
 type deleteScheduleGroupOutput struct{}
 
 func (h *Handler) handleDeleteScheduleGroup(
-	_ context.Context,
+	ctx context.Context,
 	in *scheduleGroupNameInput,
 ) (*deleteScheduleGroupOutput, error) {
-	if err := h.Backend.DeleteScheduleGroup(in.Name); err != nil {
+	if err := h.Backend.DeleteScheduleGroup(ctx, in.Name); err != nil {
 		return nil, err
 	}
 
@@ -1156,10 +1177,10 @@ type getScheduleGroupOutput struct {
 }
 
 func (h *Handler) handleGetScheduleGroup(
-	_ context.Context,
+	ctx context.Context,
 	in *scheduleGroupNameInput,
 ) (*getScheduleGroupOutput, error) {
-	g, err := h.Backend.GetScheduleGroup(in.Name)
+	g, err := h.Backend.GetScheduleGroup(ctx, in.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -1201,11 +1222,11 @@ type listScheduleGroupsOutput struct {
 }
 
 func (h *Handler) handleListScheduleGroups(
-	_ context.Context,
+	ctx context.Context,
 	in *listScheduleGroupsInput,
 ) (*listScheduleGroupsOutput, error) {
 	maxResults := parseMaxResults(in.MaxResults)
-	groups, nextToken := h.Backend.ListScheduleGroups(in.NamePrefix, in.NextToken, maxResults)
+	groups, nextToken := h.Backend.ListScheduleGroups(ctx, in.NamePrefix, in.NextToken, maxResults)
 	items := make([]scheduleGroupSummary, 0, len(groups))
 
 	for _, g := range groups {

--- a/services/scheduler/handler_audit1_test.go
+++ b/services/scheduler/handler_audit1_test.go
@@ -712,13 +712,14 @@ func TestAudit1_CompositeKey_SameNameDifferentGroups_BothFire(t *testing.T) {
 	lambdaARN := "arn:aws:lambda:us-east-1:000000000000:function:fn"
 	backend := newAuditBackend(t)
 
-	_, err := backend.CreateScheduleGroup("g1", "", nil)
+	_, err := backend.CreateScheduleGroup(context.Background(), "g1", "", nil)
 	require.NoError(t, err)
 
-	_, err = backend.CreateScheduleGroup("g2", "", nil)
+	_, err = backend.CreateScheduleGroup(context.Background(), "g2", "", nil)
 	require.NoError(t, err)
 
 	_, err = backend.CreateSchedule(
+		context.Background(),
 		"same-name", "g1", "rate(1 second)", "", "",
 		scheduler.Target{ARN: lambdaARN, RoleARN: "arn:aws:iam::0:role/r"},
 		"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"},
@@ -726,6 +727,7 @@ func TestAudit1_CompositeKey_SameNameDifferentGroups_BothFire(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = backend.CreateSchedule(
+		context.Background(),
 		"same-name", "g2", "rate(1 second)", "", "",
 		scheduler.Target{ARN: lambdaARN, RoleARN: "arn:aws:iam::0:role/r"},
 		"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"},
@@ -788,6 +790,7 @@ func TestAudit1_ActionAfterCompletion_Delete_RemovesSchedule(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"one-shot", "", "rate(1 second)", "", "",
 		scheduler.Target{ARN: lambdaARN, RoleARN: "arn:aws:iam::0:role/r"},
 		"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"},
@@ -804,7 +807,7 @@ func TestAudit1_ActionAfterCompletion_Delete_RemovesSchedule(t *testing.T) {
 	// Schedule should have fired and been deleted.
 	require.Len(t, invoker.Called(), 1)
 
-	_, err = backend.GetSchedule("one-shot", "")
+	_, err = backend.GetSchedule(context.Background(), "one-shot", "")
 	assert.Error(t, err, "schedule should be deleted after ActionAfterCompletion=DELETE")
 }
 
@@ -815,6 +818,7 @@ func TestAudit1_ActionAfterCompletion_None_DoesNotRemove(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"keep-me", "", "rate(1 second)", "", "",
 		scheduler.Target{ARN: lambdaARN, RoleARN: "arn:aws:iam::0:role/r"},
 		"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"},
@@ -829,7 +833,7 @@ func TestAudit1_ActionAfterCompletion_None_DoesNotRemove(t *testing.T) {
 	scheduler.CheckAndFireSchedules(t.Context(), runner, time.Now())
 	require.Len(t, invoker.Called(), 1)
 
-	_, err = backend.GetSchedule("keep-me", "")
+	_, err = backend.GetSchedule(context.Background(), "keep-me", "")
 	assert.NoError(t, err, "schedule with ActionAfterCompletion=NONE should remain")
 }
 
@@ -865,6 +869,7 @@ func TestAudit1_Runner_EventBridgeTarget_Invoked(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"eb-sched", "", "rate(1 second)", "", "",
 		scheduler.Target{
 			ARN:     busARN,
@@ -915,6 +920,7 @@ func TestAudit1_Runner_KinesisTarget_Invoked(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"kinesis-sched", "", "rate(1 second)", "", "",
 		scheduler.Target{
 			ARN:               streamARN,
@@ -964,6 +970,7 @@ func TestAudit1_Runner_SageMakerTarget_Invoked(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"sm-sched", "", "rate(1 second)", "", "",
 		scheduler.Target{
 			ARN:     pipelineARN,
@@ -1019,6 +1026,7 @@ func TestAudit1_Runner_ECSTarget_Invoked(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"ecs-sched", "", "rate(1 second)", "", "",
 		scheduler.Target{
 			ARN:     clusterARN,
@@ -1080,6 +1088,7 @@ func TestAudit1_Runner_DLQ_SentOnExhaustion(t *testing.T) {
 	backend := newAuditBackend(t)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"dlq-test", "", "rate(1 second)", "", "",
 		scheduler.Target{
 			ARN:     lambdaARN,

--- a/services/scheduler/handler_refinement1_test.go
+++ b/services/scheduler/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -85,7 +86,7 @@ func TestRefinement1_ScheduleGroupCount(t *testing.T) {
 	// Seeded with "default" group.
 	assert.Equal(t, 1, scheduler.ScheduleGroupCount(b))
 
-	_, err := b.CreateScheduleGroup("prod", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "prod", "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, scheduler.ScheduleGroupCount(b))
 }
@@ -104,7 +105,7 @@ func TestRefinement1_AddScheduleInternal(t *testing.T) {
 
 	assert.Equal(t, 1, scheduler.ScheduleCount(b))
 
-	s, err := b.GetSchedule("injected", "default")
+	s, err := b.GetSchedule(context.Background(), "injected", "default")
 	require.NoError(t, err)
 	assert.Equal(t, "injected", s.Name)
 }
@@ -121,7 +122,7 @@ func TestRefinement1_AddScheduleGroupInternal(t *testing.T) {
 
 	assert.Equal(t, 2, scheduler.ScheduleGroupCount(b))
 
-	g, err := b.GetScheduleGroup("injected-group")
+	g, err := b.GetScheduleGroup(context.Background(), "injected-group")
 	require.NoError(t, err)
 	assert.Equal(t, "injected-group", g.Name)
 }
@@ -289,9 +290,9 @@ func TestRefinement1_ListSchedulesFilterByGroupName(t *testing.T) {
 	h := newTestSchedulerHandler(t)
 	b := h.Backend.(*scheduler.InMemoryBackend)
 
-	_, err := b.CreateScheduleGroup("g1", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "g1", "", nil)
 	require.NoError(t, err)
-	_, err = b.CreateScheduleGroup("g2", "", nil)
+	_, err = b.CreateScheduleGroup(context.Background(), "g2", "", nil)
 	require.NoError(t, err)
 
 	createScheduleViaHandler(t, h, "in-g1", "g1", "rate(1 minute)")
@@ -380,9 +381,9 @@ func TestRefinement1_ListScheduleGroupsFilterByNamePrefix(t *testing.T) {
 	h := newTestSchedulerHandler(t)
 	b := h.Backend.(*scheduler.InMemoryBackend)
 
-	_, err := b.CreateScheduleGroup("prod-group", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "prod-group", "", nil)
 	require.NoError(t, err)
-	_, err = b.CreateScheduleGroup("dev-group", "", nil)
+	_, err = b.CreateScheduleGroup(context.Background(), "dev-group", "", nil)
 	require.NoError(t, err)
 
 	rec := doSchedulerRequest(t, h, "ListScheduleGroups", map[string]any{"NamePrefix": "prod-"})
@@ -402,9 +403,9 @@ func TestRefinement1_ListScheduleGroupsSorted(t *testing.T) {
 	h := newTestSchedulerHandler(t)
 	b := h.Backend.(*scheduler.InMemoryBackend)
 
-	_, err := b.CreateScheduleGroup("zoo", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "zoo", "", nil)
 	require.NoError(t, err)
-	_, err = b.CreateScheduleGroup("aardvark", "", nil)
+	_, err = b.CreateScheduleGroup(context.Background(), "aardvark", "", nil)
 	require.NoError(t, err)
 
 	rec := doSchedulerRequest(t, h, "ListScheduleGroups", map[string]any{})
@@ -433,7 +434,7 @@ func TestRefinement1_UpdateScheduleUpdatesLastModificationDate(t *testing.T) {
 
 	createScheduleViaHandler(t, h, "upd-sched", "", "rate(1 minute)")
 
-	s1, err := b.GetSchedule("upd-sched", "")
+	s1, err := b.GetSchedule(context.Background(), "upd-sched", "")
 	require.NoError(t, err)
 
 	// Advance time enough to guarantee LastModificationDate changes.
@@ -447,7 +448,7 @@ func TestRefinement1_UpdateScheduleUpdatesLastModificationDate(t *testing.T) {
 		"State":              "ENABLED",
 	})
 
-	s2, err := b.GetSchedule("upd-sched", "")
+	s2, err := b.GetSchedule(context.Background(), "upd-sched", "")
 	require.NoError(t, err)
 
 	assert.True(t, s2.LastModificationDate.After(s1.LastModificationDate),
@@ -508,7 +509,7 @@ func TestRefinement1_UntagResource(t *testing.T) {
 	h := newTestSchedulerHandler(t)
 	b := h.Backend.(*scheduler.InMemoryBackend)
 
-	grp, err := b.CreateScheduleGroup("tag-grp", "", map[string]string{"k1": "v1", "k2": "v2"})
+	grp, err := b.CreateScheduleGroup(context.Background(), "tag-grp", "", map[string]string{"k1": "v1", "k2": "v2"})
 	require.NoError(t, err)
 
 	untagRec := doSchedulerRequest(t, h, "UntagResource", map[string]any{
@@ -533,7 +534,7 @@ func TestRefinement1_DeleteScheduleInCustomGroup(t *testing.T) {
 	h := newTestSchedulerHandler(t)
 	b := h.Backend.(*scheduler.InMemoryBackend)
 
-	_, err := b.CreateScheduleGroup("custom", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "custom", "", nil)
 	require.NoError(t, err)
 
 	createScheduleViaHandler(t, h, "del-sched", "custom", "rate(1 minute)")
@@ -610,10 +611,11 @@ func TestRefinement1_PersistenceRoundTripWithGroupName(t *testing.T) {
 
 	b := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.CreateScheduleGroup("mygrp", "a description", map[string]string{"env": "test"})
+	_, err := b.CreateScheduleGroup(context.Background(), "mygrp", "a description", map[string]string{"env": "test"})
 	require.NoError(t, err)
 
 	_, err = b.CreateSchedule(
+		context.Background(),
 		"grp-sched", "mygrp", "rate(5 minutes)", "desc", "UTC",
 		scheduler.Target{ARN: "arn:a", RoleARN: "arn:r"},
 		"ENABLED",
@@ -627,18 +629,18 @@ func TestRefinement1_PersistenceRoundTripWithGroupName(t *testing.T) {
 	fresh := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 	require.NoError(t, fresh.Restore(snap))
 
-	s, err := fresh.GetSchedule("grp-sched", "mygrp")
+	s, err := fresh.GetSchedule(context.Background(), "grp-sched", "mygrp")
 	require.NoError(t, err)
 	assert.Equal(t, "mygrp", s.GroupName)
 	assert.Equal(t, "UTC", s.ScheduleExpressionTimezone)
 	assert.Equal(t, "desc", s.Description)
 
-	g, err := fresh.GetScheduleGroup("mygrp")
+	g, err := fresh.GetScheduleGroup(context.Background(), "mygrp")
 	require.NoError(t, err)
 	assert.Equal(t, "a description", g.Description)
 
 	// Verify tags were persisted for the group.
-	kv, err := fresh.ListTagsForResource(g.ARN)
+	kv, err := fresh.ListTagsForResource(context.Background(), g.ARN)
 	require.NoError(t, err)
 	assert.Equal(t, "test", kv["env"])
 }
@@ -648,9 +650,9 @@ func TestRefinement1_BackendReset(t *testing.T) {
 
 	b := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.CreateScheduleGroup("grp", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "grp", "", nil)
 	require.NoError(t, err)
-	_, err = b.CreateSchedule("s1", "grp", "rate(1 minute)", "", "",
+	_, err = b.CreateSchedule(context.Background(), "s1", "grp", "rate(1 minute)", "", "",
 		scheduler.Target{ARN: "arn:a", RoleARN: "arn:r"}, "ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"})
 	require.NoError(t, err)
 
@@ -782,7 +784,7 @@ func TestRefinement1_ListSchedulesIncludesGroupNameAndDates(t *testing.T) {
 	h := newTestSchedulerHandler(t)
 	b := h.Backend.(*scheduler.InMemoryBackend)
 
-	_, err := b.CreateScheduleGroup("custom-g", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "custom-g", "", nil)
 	require.NoError(t, err)
 
 	createScheduleViaHandler(t, h, "dated-sched", "custom-g", "rate(1 minute)")

--- a/services/scheduler/handler_refinement2_test.go
+++ b/services/scheduler/handler_refinement2_test.go
@@ -2,6 +2,7 @@ package scheduler_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -477,7 +478,7 @@ func TestRefinement2_DeleteScheduleGroupCascade(t *testing.T) {
 	h := scheduler.NewHandler(b)
 
 	// Create a group and schedules within it.
-	_, err := b.CreateScheduleGroup("grp-cascade", "", nil)
+	_, err := b.CreateScheduleGroup(context.Background(), "grp-cascade", "", nil)
 	require.NoError(t, err)
 
 	createScheduleViaHandler(t, h, "s1", "grp-cascade", "rate(1 minute)")
@@ -590,6 +591,7 @@ func TestRefinement2_Persistence_NewFields(t *testing.T) {
 	kmsARN := "arn:aws:kms:us-east-1:000000000000:key/abc"
 
 	_, err := b.CreateSchedule(
+		context.Background(),
 		"persist-sched", "", "rate(1 minute)", "desc", "",
 		scheduler.Target{ARN: "arn:aws:sqs:us-east-1:0:q", RoleARN: "arn:aws:iam::0:role/r"},
 		"ENABLED",
@@ -605,7 +607,7 @@ func TestRefinement2_Persistence_NewFields(t *testing.T) {
 	b2 := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 	require.NoError(t, b2.Restore(snap))
 
-	s, err := b2.GetSchedule("persist-sched", "default")
+	s, err := b2.GetSchedule(context.Background(), "persist-sched", "default")
 	require.NoError(t, err)
 	assert.Equal(t, "DELETE", s.ActionAfterCompletion)
 	assert.Equal(t, kmsARN, s.KmsKeyArn)

--- a/services/scheduler/handler_schedulegroup_test.go
+++ b/services/scheduler/handler_schedulegroup_test.go
@@ -1,6 +1,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -444,7 +445,7 @@ func TestSchedulerBackend_Reset(t *testing.T) {
 
 	b := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.CreateSchedule("s1", "",
+	_, err := b.CreateSchedule(context.Background(), "s1", "",
 		"rate(1 minute)",
 		"",
 		"",
@@ -452,14 +453,14 @@ func TestSchedulerBackend_Reset(t *testing.T) {
 		"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"})
 	require.NoError(t, err)
 
-	_, err = b.CreateScheduleGroup("g1", "", nil)
+	_, err = b.CreateScheduleGroup(context.Background(), "g1", "", nil)
 	require.NoError(t, err)
 
 	b.Reset()
 
-	schedules, _ := b.ListSchedules("", "", "", "", 0)
+	schedules, _ := b.ListSchedules(context.Background(), "", "", "", "", 0)
 	assert.Empty(t, schedules)
-	groups, _ := b.ListScheduleGroups("", "", 0)
+	groups, _ := b.ListScheduleGroups(context.Background(), "", "", 0)
 	require.Len(t, groups, 1)
 	assert.Equal(t, "default", groups[0].Name)
 }
@@ -469,7 +470,7 @@ func TestSchedulerBackend_SnapshotRestore_ScheduleGroups(t *testing.T) {
 
 	b := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 
-	_, err := b.CreateScheduleGroup("production", "", map[string]string{"env": "prod"})
+	_, err := b.CreateScheduleGroup(context.Background(), "production", "", map[string]string{"env": "prod"})
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
@@ -478,12 +479,12 @@ func TestSchedulerBackend_SnapshotRestore_ScheduleGroups(t *testing.T) {
 	fresh := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 	require.NoError(t, fresh.Restore(snap))
 
-	g, err := fresh.GetScheduleGroup("production")
+	g, err := fresh.GetScheduleGroup(context.Background(), "production")
 	require.NoError(t, err)
 	assert.Equal(t, "production", g.Name)
 	assert.Equal(t, "ACTIVE", g.State)
 
-	def, err := fresh.GetScheduleGroup("default")
+	def, err := fresh.GetScheduleGroup(context.Background(), "default")
 	require.NoError(t, err)
 	assert.Equal(t, "default", def.Name)
 }

--- a/services/scheduler/interfaces.go
+++ b/services/scheduler/interfaces.go
@@ -1,20 +1,29 @@
 package scheduler
 
+import "context"
+
 // StorageBackend defines the interface for EventBridge Scheduler backend implementations.
-// All mutating methods must be safe for concurrent use.
+// All mutating methods must be safe for concurrent use. The region for each operation is
+// resolved from the supplied context (falling back to the backend's default region).
 type StorageBackend interface {
 	// Schedule operations
 	CreateSchedule(
+		ctx context.Context,
 		name, groupName, expr, description, timezone string,
 		target Target,
 		state string,
 		ftw FlexibleTimeWindow,
 		opts ...ScheduleOption,
 	) (*Schedule, error)
-	GetSchedule(name, groupName string) (*Schedule, error)
-	ListSchedules(groupName, namePrefix, state, nextToken string, maxResults int) ([]*Schedule, string)
-	DeleteSchedule(name, groupName string) error
+	GetSchedule(ctx context.Context, name, groupName string) (*Schedule, error)
+	ListSchedules(
+		ctx context.Context,
+		groupName, namePrefix, state, nextToken string,
+		maxResults int,
+	) ([]*Schedule, string)
+	DeleteSchedule(ctx context.Context, name, groupName string) error
 	UpdateSchedule(
+		ctx context.Context,
 		name, groupName, expr, description, timezone string,
 		target Target,
 		state string,
@@ -23,15 +32,19 @@ type StorageBackend interface {
 	) (*Schedule, error)
 
 	// Schedule group operations
-	CreateScheduleGroup(name, description string, initialTags map[string]string) (*ScheduleGroup, error)
-	GetScheduleGroup(name string) (*ScheduleGroup, error)
-	DeleteScheduleGroup(name string) error
-	ListScheduleGroups(namePrefix, nextToken string, maxResults int) ([]*ScheduleGroup, string)
+	CreateScheduleGroup(
+		ctx context.Context,
+		name, description string,
+		initialTags map[string]string,
+	) (*ScheduleGroup, error)
+	GetScheduleGroup(ctx context.Context, name string) (*ScheduleGroup, error)
+	DeleteScheduleGroup(ctx context.Context, name string) error
+	ListScheduleGroups(ctx context.Context, namePrefix, nextToken string, maxResults int) ([]*ScheduleGroup, string)
 
 	// Tag operations
-	TagResource(resourceARN string, kv map[string]string) error
-	UntagResource(resourceARN string, tagKeys []string) error
-	ListTagsForResource(resourceARN string) (map[string]string, error)
+	TagResource(ctx context.Context, resourceARN string, kv map[string]string) error
+	UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error
+	ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error)
 
 	// Lifecycle
 	Reset()

--- a/services/scheduler/isolation_test.go
+++ b/services/scheduler/isolation_test.go
@@ -1,0 +1,107 @@
+package scheduler //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ctxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func newSchedTarget() Target {
+	return Target{
+		ARN:     "arn:aws:lambda:us-east-1:000000000000:function:fn",
+		RoleARN: "arn:aws:iam::000000000000:role/r",
+	}
+}
+
+func newSchedFTW() FlexibleTimeWindow {
+	return FlexibleTimeWindow{Mode: "OFF"}
+}
+
+func TestSchedulerRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	// 1. Create a schedule named "sched1" in us-east-1.
+	eastSched, err := backend.CreateSchedule(
+		ctxEast, "sched1", "", "rate(1 minute)", "", "",
+		newSchedTarget(), "ENABLED", newSchedFTW(),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, eastSched.ARN, "us-east-1")
+	assert.Equal(t, "us-east-1", eastSched.Region)
+
+	// 2. Create a schedule with the SAME NAME in us-west-2.
+	westSched, err := backend.CreateSchedule(
+		ctxWest, "sched1", "", "rate(5 minutes)", "", "",
+		newSchedTarget(), "ENABLED", newSchedFTW(),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, westSched.ARN, "us-west-2")
+	assert.Equal(t, "us-west-2", westSched.Region)
+
+	// 3. us-east-1 sees only its own schedule with its own expression.
+	eastList, _ := backend.ListSchedules(ctxEast, "", "", "", "", 0)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, "sched1", eastList[0].Name)
+	assert.Equal(t, "rate(1 minute)", eastList[0].ScheduleExpression)
+	assert.Contains(t, eastList[0].ARN, "us-east-1")
+
+	// 4. us-west-2 sees only its own schedule with its own expression.
+	westList, _ := backend.ListSchedules(ctxWest, "", "", "", "", 0)
+	require.Len(t, westList, 1)
+	assert.Equal(t, "sched1", westList[0].Name)
+	assert.Equal(t, "rate(5 minutes)", westList[0].ScheduleExpression)
+	assert.Contains(t, westList[0].ARN, "us-west-2")
+
+	// 5. Delete in us-east-1; us-west-2 still has its schedule.
+	require.NoError(t, backend.DeleteSchedule(ctxEast, "sched1", ""))
+
+	eastAfter, _ := backend.ListSchedules(ctxEast, "", "", "", "", 0)
+	assert.Empty(t, eastAfter)
+
+	westAfter, _ := backend.ListSchedules(ctxWest, "", "", "", "", 0)
+	assert.Len(t, westAfter, 1)
+}
+
+func TestSchedulerScheduleGroupRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackend("000000000000", "us-east-1")
+
+	ctxEast := ctxRegion("us-east-1")
+	ctxWest := ctxRegion("us-west-2")
+
+	_, err := backend.CreateScheduleGroup(ctxEast, "grp1", "", nil)
+	require.NoError(t, err)
+
+	_, err = backend.CreateScheduleGroup(ctxWest, "grp1", "", nil)
+	require.NoError(t, err)
+
+	// Each region sees its own "default" group plus "grp1".
+	eastGroups, _ := backend.ListScheduleGroups(ctxEast, "", "", 0)
+	assert.Len(t, eastGroups, 2)
+
+	westGroups, _ := backend.ListScheduleGroups(ctxWest, "", "", 0)
+	assert.Len(t, westGroups, 2)
+
+	// Deleting grp1 in us-east-1 leaves us-west-2's grp1 intact.
+	require.NoError(t, backend.DeleteScheduleGroup(ctxEast, "grp1"))
+
+	_, err = backend.GetScheduleGroup(ctxEast, "grp1")
+	require.Error(t, err)
+
+	g, err := backend.GetScheduleGroup(ctxWest, "grp1")
+	require.NoError(t, err)
+	assert.Equal(t, "grp1", g.Name)
+	assert.Contains(t, g.ARN, "us-west-2")
+}

--- a/services/scheduler/persistence.go
+++ b/services/scheduler/persistence.go
@@ -47,20 +47,21 @@ type persistedScheduleGroup struct {
 }
 
 type backendSnapshot struct {
-	Schedules      map[string]*persistedSchedule      `json:"schedules"`
-	ScheduleGroups map[string]*persistedScheduleGroup `json:"scheduleGroups"`
-	AccountID      string                             `json:"accountID"`
-	Region         string                             `json:"region"`
+	// Schedules and ScheduleGroups are nested by region (outer key = region).
+	Schedules      map[string]map[string]*persistedSchedule      `json:"schedules"`
+	ScheduleGroups map[string]map[string]*persistedScheduleGroup `json:"scheduleGroups"`
+	AccountID      string                                        `json:"accountID"`
+	Region         string                                        `json:"region"`
 }
 
 // ensureNonNilMaps guarantees the snapshot maps are always non-nil after decoding.
 func ensureNonNilMaps(snap *backendSnapshot) {
 	if snap.Schedules == nil {
-		snap.Schedules = make(map[string]*persistedSchedule)
+		snap.Schedules = make(map[string]map[string]*persistedSchedule)
 	}
 
 	if snap.ScheduleGroups == nil {
-		snap.ScheduleGroups = make(map[string]*persistedScheduleGroup)
+		snap.ScheduleGroups = make(map[string]map[string]*persistedScheduleGroup)
 	}
 }
 
@@ -86,57 +87,66 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	defer b.mu.RUnlock()
 
 	// Build persisted copies that do not carry live Prometheus state.
-	schedules := make(map[string]*persistedSchedule, len(b.schedules))
-	for key, s := range b.schedules {
-		var tagMap map[string]string
-		if s.Tags != nil {
-			tagMap = s.Tags.Clone()
-		}
+	schedules := make(map[string]map[string]*persistedSchedule, len(b.schedules))
+	for region, regionSchedules := range b.schedules {
+		regionMap := make(map[string]*persistedSchedule, len(regionSchedules))
+		for key, s := range regionSchedules {
+			var tagMap map[string]string
+			if s.Tags != nil {
+				tagMap = s.Tags.Clone()
+			}
 
-		schedules[key] = &persistedSchedule{
-			Name:                       s.Name,
-			ARN:                        s.ARN,
-			GroupName:                  s.GroupName,
-			ScheduleExpression:         s.ScheduleExpression,
-			ScheduleExpressionTimezone: s.ScheduleExpressionTimezone,
-			Description:                s.Description,
-			Target:                     s.Target,
-			State:                      s.State,
-			FlexibleTimeWindow:         s.FlexibleTimeWindow,
-			ActionAfterCompletion:      s.ActionAfterCompletion,
-			KmsKeyArn:                  s.KmsKeyArn,
-			AccountID:                  s.AccountID,
-			Region:                     s.Region,
-			CreationDate:               s.CreationDate.Format(snapshotTimeLayout),
-			LastModificationDate:       s.LastModificationDate.Format(snapshotTimeLayout),
-			Tags:                       tagMap,
-		}
+			ps := &persistedSchedule{
+				Name:                       s.Name,
+				ARN:                        s.ARN,
+				GroupName:                  s.GroupName,
+				ScheduleExpression:         s.ScheduleExpression,
+				ScheduleExpressionTimezone: s.ScheduleExpressionTimezone,
+				Description:                s.Description,
+				Target:                     s.Target,
+				State:                      s.State,
+				FlexibleTimeWindow:         s.FlexibleTimeWindow,
+				ActionAfterCompletion:      s.ActionAfterCompletion,
+				KmsKeyArn:                  s.KmsKeyArn,
+				AccountID:                  s.AccountID,
+				Region:                     s.Region,
+				CreationDate:               s.CreationDate.Format(snapshotTimeLayout),
+				LastModificationDate:       s.LastModificationDate.Format(snapshotTimeLayout),
+				Tags:                       tagMap,
+			}
 
-		if s.StartDate != nil {
-			schedules[key].StartDate = s.StartDate.Format(snapshotTimeLayout)
-		}
+			if s.StartDate != nil {
+				ps.StartDate = s.StartDate.Format(snapshotTimeLayout)
+			}
 
-		if s.EndDate != nil {
-			schedules[key].EndDate = s.EndDate.Format(snapshotTimeLayout)
+			if s.EndDate != nil {
+				ps.EndDate = s.EndDate.Format(snapshotTimeLayout)
+			}
+			regionMap[key] = ps
 		}
+		schedules[region] = regionMap
 	}
 
-	groups := make(map[string]*persistedScheduleGroup, len(b.scheduleGroups))
-	for name, g := range b.scheduleGroups {
-		var tagMap map[string]string
-		if g.Tags != nil {
-			tagMap = g.Tags.Clone()
-		}
+	groups := make(map[string]map[string]*persistedScheduleGroup, len(b.scheduleGroups))
+	for region, regionGroups := range b.scheduleGroups {
+		regionMap := make(map[string]*persistedScheduleGroup, len(regionGroups))
+		for name, g := range regionGroups {
+			var tagMap map[string]string
+			if g.Tags != nil {
+				tagMap = g.Tags.Clone()
+			}
 
-		groups[name] = &persistedScheduleGroup{
-			Name:                 g.Name,
-			ARN:                  g.ARN,
-			Description:          g.Description,
-			State:                g.State,
-			CreationDate:         g.CreationDate.Format(snapshotTimeLayout),
-			LastModificationDate: g.LastModificationDate.Format(snapshotTimeLayout),
-			Tags:                 tagMap,
+			regionMap[name] = &persistedScheduleGroup{
+				Name:                 g.Name,
+				ARN:                  g.ARN,
+				Description:          g.Description,
+				State:                g.State,
+				CreationDate:         g.CreationDate.Format(snapshotTimeLayout),
+				LastModificationDate: g.LastModificationDate.Format(snapshotTimeLayout),
+				Tags:                 tagMap,
+			}
 		}
+		groups[region] = regionMap
 	}
 
 	snap := backendSnapshot{
@@ -170,91 +180,124 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.mu.Lock("Restore")
 	defer b.mu.Unlock()
 
-	// Release Prometheus metrics held by the current state.
-	for _, s := range b.schedules {
-		if s.Tags != nil {
-			s.Tags.Close()
-		}
-	}
-
-	for _, g := range b.scheduleGroups {
-		if g.Tags != nil {
-			g.Tags.Close()
-		}
-	}
+	b.closeAllTagMetrics()
 
 	// Rebuild live Schedule objects from their persisted counterparts.
-	b.schedules = make(map[string]*Schedule, len(snap.Schedules))
-	b.scheduleARNIndex = make(map[string]string, len(snap.Schedules))
+	b.schedules = make(map[string]map[string]*Schedule, len(snap.Schedules))
+	b.scheduleARNIndex = make(map[string]map[string]string, len(snap.Schedules))
 
-	for key, ps := range snap.Schedules {
-		groupName := ps.GroupName
-		if groupName == "" {
-			groupName = defaultGroupName
+	for region, regionSchedules := range snap.Schedules {
+		for key, ps := range regionSchedules {
+			s := scheduleFromPersisted(ps)
+			b.schedulesStore(region)[key] = s
+			b.scheduleARNStore(region)[s.ARN] = key
 		}
-
-		s := &Schedule{
-			Name:                       ps.Name,
-			ARN:                        ps.ARN,
-			GroupName:                  groupName,
-			ScheduleExpression:         ps.ScheduleExpression,
-			ScheduleExpressionTimezone: ps.ScheduleExpressionTimezone,
-			Description:                ps.Description,
-			Target:                     ps.Target,
-			State:                      ps.State,
-			FlexibleTimeWindow:         ps.FlexibleTimeWindow,
-			ActionAfterCompletion:      ps.ActionAfterCompletion,
-			KmsKeyArn:                  ps.KmsKeyArn,
-			AccountID:                  ps.AccountID,
-			Region:                     ps.Region,
-			CreationDate:               parseSnapshotTime(ps.CreationDate),
-			LastModificationDate:       parseSnapshotTime(ps.LastModificationDate),
-			Tags: tags.FromMap(
-				"scheduler.schedule."+groupName+"."+ps.Name+".tags",
-				ps.Tags,
-			),
-		}
-
-		if ps.StartDate != "" {
-			t := parseSnapshotTime(ps.StartDate)
-			s.StartDate = &t
-		}
-
-		if ps.EndDate != "" {
-			t := parseSnapshotTime(ps.EndDate)
-			s.EndDate = &t
-		}
-		b.schedules[key] = s
-		b.scheduleARNIndex[s.ARN] = key
 	}
 
 	// Rebuild live ScheduleGroup objects from their persisted counterparts.
-	b.scheduleGroups = make(map[string]*ScheduleGroup, len(snap.ScheduleGroups))
-	b.scheduleGroupARNIndex = make(map[string]string, len(snap.ScheduleGroups))
+	b.scheduleGroups = make(map[string]map[string]*ScheduleGroup, len(snap.ScheduleGroups))
+	b.scheduleGroupARNIndex = make(map[string]map[string]string, len(snap.ScheduleGroups))
 
-	for name, pg := range snap.ScheduleGroups {
-		g := &ScheduleGroup{
-			Name:                 pg.Name,
-			ARN:                  pg.ARN,
-			Description:          pg.Description,
-			State:                pg.State,
-			CreationDate:         parseSnapshotTime(pg.CreationDate),
-			LastModificationDate: parseSnapshotTime(pg.LastModificationDate),
-			Tags:                 tags.FromMap("scheduler.schedulegroup."+name+".tags", pg.Tags),
+	for region, regionGroups := range snap.ScheduleGroups {
+		// Initialise the region maps directly (without seeding a default group) so the
+		// restored snapshot's own "default" group is used as-is.
+		if b.scheduleGroups[region] == nil {
+			b.scheduleGroups[region] = make(map[string]*ScheduleGroup)
 		}
-		b.scheduleGroups[name] = g
-		b.scheduleGroupARNIndex[g.ARN] = name
+
+		for name, pg := range regionGroups {
+			g := scheduleGroupFromPersisted(name, pg)
+			b.scheduleGroups[region][name] = g
+			b.scheduleGroupARNStore(region)[g.ARN] = name
+		}
 	}
 
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 
-	// Ensure the default group always exists after restore.
-	if _, ok := b.scheduleGroups[defaultGroupName]; !ok {
-		b.seedDefaultGroup()
+	// Ensure the default group always exists after restore in the default region.
+	// scheduleGroupsStore seeds the built-in "default" group when the region map is
+	// first created; if the region already existed we add it explicitly.
+	if _, ok := b.scheduleGroupsStore(b.region)[defaultGroupName]; !ok {
+		b.seedDefaultGroup(b.region)
 	}
 
 	return nil
+}
+
+// closeAllTagMetrics releases the Prometheus metrics held by all live schedules and
+// schedule groups across every region. Callers must hold b.mu.
+func (b *InMemoryBackend) closeAllTagMetrics() {
+	for _, regionSchedules := range b.schedules {
+		for _, s := range regionSchedules {
+			if s.Tags != nil {
+				s.Tags.Close()
+			}
+		}
+	}
+
+	for _, regionGroups := range b.scheduleGroups {
+		for _, g := range regionGroups {
+			if g.Tags != nil {
+				g.Tags.Close()
+			}
+		}
+	}
+}
+
+// scheduleFromPersisted rebuilds a live Schedule from its persisted representation.
+func scheduleFromPersisted(ps *persistedSchedule) *Schedule {
+	groupName := ps.GroupName
+	if groupName == "" {
+		groupName = defaultGroupName
+	}
+
+	s := &Schedule{
+		Name:                       ps.Name,
+		ARN:                        ps.ARN,
+		GroupName:                  groupName,
+		ScheduleExpression:         ps.ScheduleExpression,
+		ScheduleExpressionTimezone: ps.ScheduleExpressionTimezone,
+		Description:                ps.Description,
+		Target:                     ps.Target,
+		State:                      ps.State,
+		FlexibleTimeWindow:         ps.FlexibleTimeWindow,
+		ActionAfterCompletion:      ps.ActionAfterCompletion,
+		KmsKeyArn:                  ps.KmsKeyArn,
+		AccountID:                  ps.AccountID,
+		Region:                     ps.Region,
+		CreationDate:               parseSnapshotTime(ps.CreationDate),
+		LastModificationDate:       parseSnapshotTime(ps.LastModificationDate),
+		Tags: tags.FromMap(
+			"scheduler.schedule."+groupName+"."+ps.Name+".tags",
+			ps.Tags,
+		),
+	}
+
+	if ps.StartDate != "" {
+		t := parseSnapshotTime(ps.StartDate)
+		s.StartDate = &t
+	}
+
+	if ps.EndDate != "" {
+		t := parseSnapshotTime(ps.EndDate)
+		s.EndDate = &t
+	}
+
+	return s
+}
+
+// scheduleGroupFromPersisted rebuilds a live ScheduleGroup from its persisted representation.
+func scheduleGroupFromPersisted(name string, pg *persistedScheduleGroup) *ScheduleGroup {
+	return &ScheduleGroup{
+		Name:                 pg.Name,
+		ARN:                  pg.ARN,
+		Description:          pg.Description,
+		State:                pg.State,
+		CreationDate:         parseSnapshotTime(pg.CreationDate),
+		LastModificationDate: parseSnapshotTime(pg.LastModificationDate),
+		Tags:                 tags.FromMap("scheduler.schedulegroup."+name+".tags", pg.Tags),
+	}
 }
 
 // Snapshot implements persistence.Persistable by delegating to the backend.

--- a/services/scheduler/persistence_test.go
+++ b/services/scheduler/persistence_test.go
@@ -1,6 +1,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,6 +26,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			name: "round_trip_preserves_state",
 			setup: func(b *scheduler.InMemoryBackend) string {
 				sched, err := b.CreateSchedule(
+					context.Background(),
 					"test-schedule",
 					"",
 					"rate(1 minute)",
@@ -46,7 +48,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *scheduler.InMemoryBackend, id string) {
 				t.Helper()
 
-				sched, err := b.GetSchedule(id, "")
+				sched, err := b.GetSchedule(context.Background(), id, "")
 				require.NoError(t, err)
 				assert.Equal(t, id, sched.Name)
 				assert.Equal(t, "rate(1 minute)", sched.ScheduleExpression)
@@ -56,6 +58,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			name: "restore_rebuilds_arn_index",
 			setup: func(b *scheduler.InMemoryBackend) string {
 				sched, err := b.CreateSchedule(
+					context.Background(),
 					"idx-schedule",
 					"",
 					"rate(5 minutes)",
@@ -78,10 +81,10 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 				t.Helper()
 
 				// TagResource uses the scheduleARNIndex; must succeed after restore.
-				err := b.TagResource(resourceARN, map[string]string{"env": "test"})
+				err := b.TagResource(context.Background(), resourceARN, map[string]string{"env": "test"})
 				require.NoError(t, err)
 
-				kv, err := b.ListTagsForResource(resourceARN)
+				kv, err := b.ListTagsForResource(context.Background(), resourceARN)
 				require.NoError(t, err)
 				assert.Equal(t, "test", kv["env"])
 			},
@@ -92,7 +95,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *scheduler.InMemoryBackend, _ string) {
 				t.Helper()
 
-				schedules, _ := b.ListSchedules("", "", "", "", 0)
+				schedules, _ := b.ListSchedules(context.Background(), "", "", "", "", 0)
 				assert.Empty(t, schedules)
 			},
 		},
@@ -131,6 +134,7 @@ func TestSchedulerHandler_Persistence(t *testing.T) {
 	h := scheduler.NewHandler(backend)
 
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		"snap-schedule",
 		"",
 		"rate(5 minutes)",
@@ -152,7 +156,7 @@ func TestSchedulerHandler_Persistence(t *testing.T) {
 	freshH := scheduler.NewHandler(fresh)
 	require.NoError(t, freshH.Restore(snap))
 
-	schedules, _ := fresh.ListSchedules("", "", "", "", 0)
+	schedules, _ := fresh.ListSchedules(context.Background(), "", "", "", "", 0)
 	assert.Len(t, schedules, 1)
 }
 

--- a/services/scheduler/runner.go
+++ b/services/scheduler/runner.go
@@ -153,7 +153,7 @@ func (r *Runner) run(ctx context.Context) {
 }
 
 func (r *Runner) checkAndFireSchedules(ctx context.Context, now time.Time) {
-	schedules, _ := r.backend.ListSchedules("", "", "", "", 0)
+	schedules, _ := r.backend.ListSchedules(ctx, "", "", "", "", 0)
 
 	activeKeys := make(map[string]struct{}, len(schedules))
 	activeExprs := make(map[string]struct{}, len(schedules))
@@ -430,7 +430,11 @@ func (r *Runner) handleActionAfterCompletion(ctx context.Context, s *Schedule, l
 
 	switch strings.ToUpper(action) {
 	case "DELETE":
-		if err := r.backend.DeleteSchedule(s.Name, s.GroupName); err != nil {
+		delCtx := ctx
+		if s.Region != "" {
+			delCtx = context.WithValue(ctx, regionContextKey{}, s.Region)
+		}
+		if err := r.backend.DeleteSchedule(delCtx, s.Name, s.GroupName); err != nil {
 			log.WarnContext(ctx, "scheduler: ActionAfterCompletion=DELETE failed", "schedule", s.Name, "error", err)
 		} else {
 			log.DebugContext(ctx, "scheduler: deleted schedule after completion", "schedule", s.Name)

--- a/services/scheduler/runner_test.go
+++ b/services/scheduler/runner_test.go
@@ -87,6 +87,7 @@ func newTestBackendWithSchedule(t *testing.T, name, expr, targetARN, state strin
 
 	backend := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 	_, err := backend.CreateSchedule(
+		context.Background(),
 		name,
 		"",
 		expr,
@@ -419,6 +420,7 @@ func TestScheduler_Runner_TargetInput(t *testing.T) {
 
 			backend := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 			_, err := backend.CreateSchedule(
+				context.Background(),
 				"custom-input-sched",
 				"",
 				"rate(1 second)",
@@ -489,6 +491,7 @@ func TestScheduler_Runner_CronRangeAndStep(t *testing.T) {
 
 			backend := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 			_, err := backend.CreateSchedule(
+				context.Background(),
 				tt.scheduleName,
 				"",
 				tt.cronExpr,
@@ -535,7 +538,7 @@ func TestScheduler_Runner_LastFiredAtCleanup(t *testing.T) {
 	assert.Equal(t, 1, scheduler.LastFiredAtLen(runner), "lastFiredAt should have one entry")
 
 	// Delete the schedule.
-	require.NoError(t, backend.DeleteSchedule("sweep-sched", ""))
+	require.NoError(t, backend.DeleteSchedule(context.Background(), "sweep-sched", ""))
 
 	// Fire again: the stale entry should be swept.
 	scheduler.CheckAndFireSchedules(t.Context(), runner, now.Add(2*time.Second))
@@ -662,7 +665,7 @@ func TestScheduler_Runner_CronCacheEviction(t *testing.T) {
 			name: "delete schedule removes cache entry",
 			setup: func(t *testing.T, b *scheduler.InMemoryBackend) {
 				t.Helper()
-				require.NoError(t, b.DeleteSchedule("evict-sched", ""))
+				require.NoError(t, b.DeleteSchedule(context.Background(), "evict-sched", ""))
 			},
 			wantSize: 0,
 		},
@@ -670,9 +673,10 @@ func TestScheduler_Runner_CronCacheEviction(t *testing.T) {
 			name: "update schedule to different expression removes old entry",
 			setup: func(t *testing.T, b *scheduler.InMemoryBackend) {
 				t.Helper()
-				require.NoError(t, b.DeleteSchedule("evict-sched", ""))
+				require.NoError(t, b.DeleteSchedule(context.Background(), "evict-sched", ""))
 
 				_, err := b.CreateSchedule(
+					context.Background(),
 					"evict-sched", "", "cron(0 6 * * ? *)", "", "",
 					scheduler.Target{ARN: lambdaARN, RoleARN: role},
 					"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"},
@@ -690,6 +694,7 @@ func TestScheduler_Runner_CronCacheEviction(t *testing.T) {
 
 			backend := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 			_, err := backend.CreateSchedule(
+				context.Background(),
 				"evict-sched", "", "cron(0 12 * * ? *)", "", "",
 				scheduler.Target{ARN: lambdaARN, RoleARN: role},
 				"ENABLED", scheduler.FlexibleTimeWindow{Mode: "OFF"},
@@ -744,6 +749,7 @@ func TestScheduler_Runner_CronMonthAliases(t *testing.T) {
 
 			backend := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 			_, err := backend.CreateSchedule(
+				context.Background(),
 				tt.name+"-sched",
 				"",
 				tt.cronExpr,
@@ -796,6 +802,7 @@ func TestScheduler_Runner_CronDOWAliases(t *testing.T) {
 
 			backend := scheduler.NewInMemoryBackend("000000000000", "us-east-1")
 			_, err := backend.CreateSchedule(
+				context.Background(),
 				tt.name+"-sched",
 				"",
 				tt.cronExpr,

--- a/services/secretsmanager/accuracy_audit_test.go
+++ b/services/secretsmanager/accuracy_audit_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"slices"
@@ -25,7 +26,7 @@ func TestGetSecretValue_MismatchReturnsResourceNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "mismatch-error-type",
 		SecretString:       "value",
 		ClientRequestToken: "ver-001",
@@ -33,7 +34,7 @@ func TestGetSecretValue_MismatchReturnsResourceNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	// ver-001 carries AWSCURRENT — requesting AWSPREVIOUS must return ErrVersionNotFound.
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:     "mismatch-error-type",
 		VersionID:    "ver-001",
 		VersionStage: sm.StagingLabelPrevious,
@@ -75,14 +76,14 @@ func TestGetSecretValue_BothSuppliedAndMatch(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "match-both",
 		SecretString:       "value",
 		ClientRequestToken: "ver-aaa",
 	})
 	require.NoError(t, err)
 
-	out, err := b.GetSecretValue(&sm.GetSecretValueInput{
+	out, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:     "match-both",
 		VersionID:    "ver-aaa",
 		VersionStage: sm.StagingLabelCurrent,
@@ -101,7 +102,7 @@ func TestCreateSecret_AddReplicaRegionsCreatesReplication(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "create-with-replicas",
 		SecretString: "value",
 		AddReplicaRegions: []sm.ReplicaRegion{
@@ -122,7 +123,7 @@ func TestCreateSecret_AddReplicaRegionsCreatesReplication(t *testing.T) {
 	assert.Equal(t, "alias/my-key", regions["ap-southeast-1"].KmsKeyID)
 
 	// DescribeSecret should also show the replication status.
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "create-with-replicas"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "create-with-replicas"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 2)
 }
@@ -133,7 +134,7 @@ func TestCreateSecret_AddReplicaRegionsWithValueSyncsInSync(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "replica-insync",
 		SecretString: "secret-value",
 		AddReplicaRegions: []sm.ReplicaRegion{
@@ -142,7 +143,7 @@ func TestCreateSecret_AddReplicaRegionsWithValueSyncsInSync(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "replica-insync"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "replica-insync"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 1)
 	assert.Equal(t, "InSync", desc.ReplicationStatus[0].Status)
@@ -154,7 +155,7 @@ func TestCreateSecret_AddReplicaRegionsNoValue(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name: "replica-no-value",
 		AddReplicaRegions: []sm.ReplicaRegion{
 			{Region: "ca-central-1"},
@@ -172,7 +173,7 @@ func TestCreateSecret_NoReplicaRegionsReturnsEmptyStatus(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "no-replicas",
 		SecretString: "v",
 	})
@@ -217,11 +218,11 @@ func TestListSecrets_OwnedByMeFilterPassesAll(t *testing.T) {
 	b := sm.NewInMemoryBackend()
 
 	for _, name := range []string{"sec-a", "sec-b", "sec-c"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{{Key: "owned-by-me", Values: []string{"true"}}},
 	})
 	require.NoError(t, err)
@@ -233,18 +234,18 @@ func TestListSecrets_OwnedByMeWithOtherFilters(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "alpha-secret",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&sm.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "beta-secret",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{
 			{Key: "owned-by-me", Values: []string{"true"}},
 			{Key: "name", Values: []string{"alpha"}},
@@ -416,17 +417,17 @@ func TestRotateSecret_CronScheduleTriggersRotation(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "cron-sched-secret",
 		SecretString: "initial",
 	})
 	require.NoError(t, err)
 
-	before, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "cron-sched-secret"})
+	before, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "cron-sched-secret"})
 	require.NoError(t, err)
 
 	// Use a cron that fires every minute to trigger fast in tests.
-	_, err = b.RotateSecret(&sm.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 		SecretID: "cron-sched-secret",
 		RotationRules: &sm.RotationRulesType{
 			ScheduleExpression: "cron(* * * * ? *)",
@@ -438,7 +439,10 @@ func TestRotateSecret_CronScheduleTriggersRotation(t *testing.T) {
 	rotated := false
 
 	for time.Now().Before(deadline) {
-		current, currentErr := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "cron-sched-secret"})
+		current, currentErr := b.GetSecretValue(
+			context.Background(),
+			&sm.GetSecretValueInput{SecretID: "cron-sched-secret"},
+		)
 		require.NoError(t, currentErr)
 
 		if current.VersionID != before.VersionID {
@@ -459,13 +463,13 @@ func TestDescribeSecret_CronNextRotationDate(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "cron-next-date",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 		SecretID: "cron-next-date",
 		RotationRules: &sm.RotationRulesType{
 			ScheduleExpression: "cron(0 0 * * ? *)",
@@ -473,7 +477,7 @@ func TestDescribeSecret_CronNextRotationDate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "cron-next-date"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "cron-next-date"})
 	require.NoError(t, err)
 	require.NotNil(t, desc.NextRotationDate, "NextRotationDate must be set for cron schedule")
 
@@ -492,10 +496,10 @@ func TestReplication_KmsKeyStoredAndReturned(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "kms-rep", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "kms-rep", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.ReplicateSecretToRegions(&sm.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &sm.ReplicateSecretToRegionsInput{
 		SecretID: "kms-rep",
 		AddReplicaRegions: []sm.ReplicaRegion{
 			{Region: "eu-west-1", KmsKeyID: "arn:aws:kms:eu-west-1:123456789012:key/abc-123"},
@@ -503,7 +507,7 @@ func TestReplication_KmsKeyStoredAndReturned(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "kms-rep"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "kms-rep"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 1)
 	assert.Equal(t, "arn:aws:kms:eu-west-1:123456789012:key/abc-123",
@@ -516,7 +520,7 @@ func TestReplication_CreateWithKmsKeyPreserved(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	createOut, err := b.CreateSecret(&sm.CreateSecretInput{
+	createOut, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "create-kms-rep",
 		SecretString: "v",
 		AddReplicaRegions: []sm.ReplicaRegion{
@@ -528,7 +532,7 @@ func TestReplication_CreateWithKmsKeyPreserved(t *testing.T) {
 	assert.Equal(t, "alias/replica-key", createOut.ReplicationStatus[0].KmsKeyID)
 
 	// Verify persistence in DescribeSecret.
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "create-kms-rep"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "create-kms-rep"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 1)
 	assert.Equal(t, "alias/replica-key", desc.ReplicationStatus[0].KmsKeyID)
@@ -545,14 +549,14 @@ func TestPutSecretValue_EmptyVersionStagesAppliesAWSCURRENT(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "empty-stages",
 		SecretString: "v1",
 	})
 	require.NoError(t, err)
 
 	// Capture v1's version ID before the second put.
-	desc1, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "empty-stages"})
+	desc1, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "empty-stages"})
 	require.NoError(t, err)
 	var v1ID string
 	for id, labels := range desc1.VersionIDsToStages {
@@ -563,7 +567,7 @@ func TestPutSecretValue_EmptyVersionStagesAppliesAWSCURRENT(t *testing.T) {
 	require.NotEmpty(t, v1ID)
 
 	// Put second value with no explicit VersionStages (nil slice).
-	put2, err := b.PutSecretValue(&sm.PutSecretValueInput{
+	put2, err := b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:     "empty-stages",
 		SecretString: "v2",
 	})
@@ -572,7 +576,7 @@ func TestPutSecretValue_EmptyVersionStagesAppliesAWSCURRENT(t *testing.T) {
 		"new version must carry AWSCURRENT when VersionStages is empty")
 
 	// v1 must now carry AWSPREVIOUS.
-	desc2, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "empty-stages"})
+	desc2, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "empty-stages"})
 	require.NoError(t, err)
 	assert.Contains(t, desc2.VersionIDsToStages[v1ID], sm.StagingLabelPrevious,
 		"old AWSCURRENT version must be promoted to AWSPREVIOUS")
@@ -641,11 +645,11 @@ func TestListSecrets_PrimaryRegionFilter(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"pr-a", "pr-b"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{{Key: "primary-region", Values: []string{"us-east-1"}}},
 	})
 	require.NoError(t, err)
@@ -686,14 +690,14 @@ func TestGetSecretValue_VersionIdOnlySucceeds(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "ver-only",
 		SecretString:       "secret",
 		ClientRequestToken: "tok-123",
 	})
 	require.NoError(t, err)
 
-	out, err := b.GetSecretValue(&sm.GetSecretValueInput{
+	out, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:  "ver-only",
 		VersionID: "tok-123",
 	})
@@ -707,13 +711,13 @@ func TestGetSecretValue_VersionStageOnlySucceeds(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "stage-only",
 		SecretString: "value",
 	})
 	require.NoError(t, err)
 
-	out, err := b.GetSecretValue(&sm.GetSecretValueInput{
+	out, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:     "stage-only",
 		VersionStage: sm.StagingLabelCurrent,
 	})
@@ -727,7 +731,7 @@ func TestRotateSecret_ScheduleExpressionPersisted(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "cron-persist",
 		SecretString: "v",
 	})
@@ -735,7 +739,7 @@ func TestRotateSecret_ScheduleExpressionPersisted(t *testing.T) {
 
 	const expr = "cron(0 12 * * ? *)"
 	rotateImmediately := false
-	_, err = b.RotateSecret(&sm.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 		SecretID: "cron-persist",
 		RotationRules: &sm.RotationRulesType{
 			ScheduleExpression: expr,
@@ -744,7 +748,7 @@ func TestRotateSecret_ScheduleExpressionPersisted(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "cron-persist"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "cron-persist"})
 	require.NoError(t, err)
 	require.NotNil(t, desc.RotationRules)
 	assert.Equal(t, expr, desc.RotationRules.ScheduleExpression)
@@ -834,20 +838,20 @@ func TestCreateSecret_AddReplicaRegionsThenMoreReplicas(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:              "grow-replicas",
 		SecretString:      "v",
 		AddReplicaRegions: []sm.ReplicaRegion{{Region: "us-west-2"}},
 	})
 	require.NoError(t, err)
 
-	_, err = b.ReplicateSecretToRegions(&sm.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &sm.ReplicateSecretToRegionsInput{
 		SecretID:          "grow-replicas",
 		AddReplicaRegions: []sm.ReplicaRegion{{Region: "eu-west-1"}},
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "grow-replicas"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "grow-replicas"})
 	require.NoError(t, err)
 	assert.Len(t, desc.ReplicationStatus, 2)
 
@@ -865,17 +869,17 @@ func TestGetSecretValue_MismatchAfterRotation(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "rot-mismatch",
 		SecretString:       "v1",
 		ClientRequestToken: "v1-id",
 	})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{SecretID: "rot-mismatch"})
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "rot-mismatch"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rot-mismatch"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rot-mismatch"})
 	require.NoError(t, err)
 
 	// Find the AWSCURRENT version and try to get it with AWSPREVIOUS — must fail.
@@ -889,7 +893,7 @@ func TestGetSecretValue_MismatchAfterRotation(t *testing.T) {
 	}
 	require.NotEmpty(t, currentID)
 
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:     "rot-mismatch",
 		VersionID:    currentID,
 		VersionStage: sm.StagingLabelPrevious,

--- a/services/secretsmanager/accuracy_batch2_ops_test.go
+++ b/services/secretsmanager/accuracy_batch2_ops_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -30,9 +31,12 @@ func TestBatch2Ops_GetResourcePolicy_DeletedSecret(t *testing.T) {
 			name: "backend_deleted_returns_error",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "grp-del", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "grp-del", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "grp-del"})
+				_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "grp-del"})
 				require.NoError(t, err)
 			},
 			wantFn: func(t *testing.T, err error) {
@@ -44,7 +48,10 @@ func TestBatch2Ops_GetResourcePolicy_DeletedSecret(t *testing.T) {
 			name: "backend_active_no_policy_returns_empty",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "grp-active", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "grp-active", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			wantFn: func(t *testing.T, err error) {
@@ -77,7 +84,7 @@ func TestBatch2Ops_GetResourcePolicy_DeletedSecret(t *testing.T) {
 				"backend_not_found_returns_error":        "nonexistent",
 			}[tt.name]
 
-			_, err := b.GetResourcePolicy(&sm.GetResourcePolicyInput{SecretID: secretID})
+			_, err := b.GetResourcePolicy(context.Background(), &sm.GetResourcePolicyInput{SecretID: secretID})
 			tt.wantFn(t, err)
 		})
 	}
@@ -99,9 +106,12 @@ func TestBatch2Ops_GetResourcePolicy_DeletedSecret_HTTP(t *testing.T) {
 			name: "deleted_returns_400_InvalidRequestException",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "grp-http-del", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "grp-http-del", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "grp-http-del"})
+				_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "grp-http-del"})
 				require.NoError(t, err)
 			},
 			body:           `{"SecretId":"grp-http-del"}`,
@@ -156,7 +166,10 @@ func TestBatch2Ops_DescribeSecret_VersionIDsToStages_ExcludesUnlabeled(t *testin
 			name: "only_current_version_appears",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) string {
 				t.Helper()
-				out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "desc-stg-1", SecretString: "v1"})
+				out, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "desc-stg-1", SecretString: "v1"},
+				)
 				require.NoError(t, err)
 
 				return out.VersionID
@@ -172,14 +185,23 @@ func TestBatch2Ops_DescribeSecret_VersionIDsToStages_ExcludesUnlabeled(t *testin
 			name: "unlabeled_version_excluded",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) string {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "desc-stg-2", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "desc-stg-2", SecretString: "v1"},
+				)
 				require.NoError(t, err)
 				// Second PutSecretValue promotes v1 to AWSPREVIOUS, v2 to AWSCURRENT.
-				_, err = b.PutSecretValue(&sm.PutSecretValueInput{SecretID: "desc-stg-2", SecretString: "v2"})
+				_, err = b.PutSecretValue(
+					context.Background(),
+					&sm.PutSecretValueInput{SecretID: "desc-stg-2", SecretString: "v2"},
+				)
 				require.NoError(t, err)
 				// Third PutSecretValue: v1 loses AWSPREVIOUS (it had it from the prior rotate),
 				// v2 becomes AWSPREVIOUS, v3 becomes AWSCURRENT. v1 is now unlabeled.
-				out, err := b.PutSecretValue(&sm.PutSecretValueInput{SecretID: "desc-stg-2", SecretString: "v3"})
+				out, err := b.PutSecretValue(
+					context.Background(),
+					&sm.PutSecretValueInput{SecretID: "desc-stg-2", SecretString: "v3"},
+				)
 				require.NoError(t, err)
 
 				return out.VersionID
@@ -205,7 +227,7 @@ func TestBatch2Ops_DescribeSecret_VersionIDsToStages_ExcludesUnlabeled(t *testin
 			b := sm.NewInMemoryBackend()
 			versionID := tt.setup(t, b)
 
-			out, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: func() string {
+			out, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: func() string {
 				if tt.name == "only_current_version_appears" {
 					return "desc-stg-1"
 				}
@@ -238,10 +260,10 @@ func TestBatch2Ops_ListSecrets_IncludesRotationRules(t *testing.T) {
 			name: "rotation_rules_returned_in_list",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "ls-rot", SecretString: "v"})
+				_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "ls-rot", SecretString: "v"})
 				require.NoError(t, err)
 				days := int64(30)
-				_, err = b.RotateSecret(&sm.RotateSecretInput{
+				_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 					SecretID: "ls-rot",
 					RotationRules: &sm.RotationRulesType{
 						AutomaticallyAfterDays: &days,
@@ -263,7 +285,10 @@ func TestBatch2Ops_ListSecrets_IncludesRotationRules(t *testing.T) {
 			name: "no_rotation_rules_when_not_configured",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "ls-norot", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "ls-norot", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			checkFn: func(t *testing.T, out *sm.ListSecretsOutput) {
@@ -278,10 +303,13 @@ func TestBatch2Ops_ListSecrets_IncludesRotationRules(t *testing.T) {
 			name: "rotation_rules_in_http_response",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "ls-http-rot", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "ls-http-rot", SecretString: "v"},
+				)
 				require.NoError(t, err)
 				days := int64(7)
-				_, err = b.RotateSecret(&sm.RotateSecretInput{
+				_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 					SecretID: "ls-http-rot",
 					RotationRules: &sm.RotationRulesType{
 						AutomaticallyAfterDays: &days,
@@ -306,7 +334,7 @@ func TestBatch2Ops_ListSecrets_IncludesRotationRules(t *testing.T) {
 			b := sm.NewInMemoryBackend()
 			tt.setup(t, b)
 
-			out, err := b.ListSecrets(&sm.ListSecretsInput{})
+			out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{})
 			require.NoError(t, err)
 
 			tt.checkFn(t, out)
@@ -334,7 +362,10 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			name: "by_id_list_updates_accessed_date",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "bgv-acc-1", SecretString: "val"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "bgv-acc-1", SecretString: "val"},
+				)
 				require.NoError(t, err)
 			},
 			inputFn: func() *sm.BatchGetSecretValueInput {
@@ -342,7 +373,7 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			},
 			checkFn: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "bgv-acc-1"})
+				desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "bgv-acc-1"})
 				require.NoError(t, err)
 				assert.NotNil(t, desc.LastAccessedDate, "LastAccessedDate must be set after BatchGetSecretValue")
 			},
@@ -351,7 +382,10 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			name: "by_filter_updates_accessed_date",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "bgv-filt-1", SecretString: "val"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "bgv-filt-1", SecretString: "val"},
+				)
 				require.NoError(t, err)
 			},
 			inputFn: func() *sm.BatchGetSecretValueInput {
@@ -359,7 +393,7 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			},
 			checkFn: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "bgv-filt-1"})
+				desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "bgv-filt-1"})
 				require.NoError(t, err)
 				assert.NotNil(
 					t,
@@ -372,9 +406,12 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			name: "deleted_secret_in_id_list_does_not_update",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "bgv-del-1", SecretString: "val"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "bgv-del-1", SecretString: "val"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "bgv-del-1"})
+				_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "bgv-del-1"})
 				require.NoError(t, err)
 			},
 			inputFn: func() *sm.BatchGetSecretValueInput {
@@ -382,7 +419,7 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			},
 			checkFn: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "bgv-del-1"})
+				desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "bgv-del-1"})
 				require.NoError(t, err)
 				assert.Nil(t, desc.LastAccessedDate, "deleted secret must not have LastAccessedDate updated")
 			},
@@ -396,7 +433,7 @@ func TestBatch2Ops_BatchGetSecretValue_UpdatesLastAccessedDate(t *testing.T) {
 			b := sm.NewInMemoryBackend()
 			tt.setup(t, b)
 
-			out, err := b.BatchGetSecretValue(tt.inputFn())
+			out, err := b.BatchGetSecretValue(context.Background(), tt.inputFn())
 			require.NoError(t, err)
 
 			// For the non-deleted cases, verify we got a successful result.

--- a/services/secretsmanager/accuracy_batch2b_ops_test.go
+++ b/services/secretsmanager/accuracy_batch2b_ops_test.go
@@ -14,6 +14,7 @@ package secretsmanager_test
 //     staging label without moving it to another version.
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,9 +49,12 @@ func TestBatch2B_CreateSecret_DeletedNameCollision(t *testing.T) {
 			newName: "cs-del-collision",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cs-del-collision", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "cs-del-collision", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "cs-del-collision"})
+				_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "cs-del-collision"})
 				require.NoError(t, err)
 			},
 			wantFn: func(t *testing.T, err error) {
@@ -66,7 +70,10 @@ func TestBatch2B_CreateSecret_DeletedNameCollision(t *testing.T) {
 			newName: "cs-active-collision",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cs-active-collision", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "cs-active-collision", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			wantFn: func(t *testing.T, err error) {
@@ -80,9 +87,12 @@ func TestBatch2B_CreateSecret_DeletedNameCollision(t *testing.T) {
 			newName: "cs-force-del",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cs-force-del", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "cs-force-del", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&sm.DeleteSecretInput{
+				_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{
 					SecretID:                   "cs-force-del",
 					ForceDeleteWithoutRecovery: true,
 				})
@@ -102,7 +112,7 @@ func TestBatch2B_CreateSecret_DeletedNameCollision(t *testing.T) {
 			b := sm.NewInMemoryBackend()
 			tt.setup(t, b)
 
-			_, err := b.CreateSecret(&sm.CreateSecretInput{Name: tt.newName, SecretString: "new"})
+			_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: tt.newName, SecretString: "new"})
 			tt.wantFn(t, err)
 		})
 	}
@@ -124,9 +134,12 @@ func TestBatch2B_CreateSecret_DeletedNameCollision_HTTP(t *testing.T) {
 			name: "deleted_name_returns_400_InvalidRequestException",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cs-http-del", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "cs-http-del", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "cs-http-del"})
+				_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "cs-http-del"})
 				require.NoError(t, err)
 			},
 			body:        `{"Name":"cs-http-del","SecretString":"new"}`,
@@ -137,7 +150,10 @@ func TestBatch2B_CreateSecret_DeletedNameCollision_HTTP(t *testing.T) {
 			name: "active_name_returns_400_ResourceExistsException",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cs-http-active", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "cs-http-active", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			body:        `{"Name":"cs-http-active","SecretString":"new"}`,
@@ -216,7 +232,7 @@ func TestBatch2B_BatchGetSecretValue_SecretIDListTooLong(t *testing.T) {
 			t.Parallel()
 
 			b := sm.NewInMemoryBackend()
-			_, err := b.BatchGetSecretValue(&sm.BatchGetSecretValueInput{SecretIDList: tt.ids})
+			_, err := b.BatchGetSecretValue(context.Background(), &sm.BatchGetSecretValueInput{SecretIDList: tt.ids})
 
 			if tt.wantErr {
 				require.ErrorIs(t, err, sm.ErrInvalidParameter,
@@ -301,7 +317,10 @@ func TestBatch2B_UpdateSecretVersionStage_CannotRemoveAWSCURRENT(t *testing.T) {
 			name: "remove_awscurrent_without_move_rejected",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) string {
 				t.Helper()
-				out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "usvs-cur-1", SecretString: "v"})
+				out, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "usvs-cur-1", SecretString: "v"},
+				)
 				require.NoError(t, err)
 
 				return out.VersionID
@@ -316,10 +335,13 @@ func TestBatch2B_UpdateSecretVersionStage_CannotRemoveAWSCURRENT(t *testing.T) {
 			name: "remove_non_current_label_allowed",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) string {
 				t.Helper()
-				out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "usvs-noncur-1", SecretString: "v"})
+				out, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "usvs-noncur-1", SecretString: "v"},
+				)
 				require.NoError(t, err)
 				// Add a custom label to the version.
-				_, err = b.UpdateSecretVersionStage(&sm.UpdateSecretVersionStageInput{
+				_, err = b.UpdateSecretVersionStage(context.Background(), &sm.UpdateSecretVersionStageInput{
 					SecretID:        "usvs-noncur-1",
 					VersionStage:    "CUSTOM-LABEL",
 					MoveToVersionID: out.VersionID,
@@ -337,9 +359,15 @@ func TestBatch2B_UpdateSecretVersionStage_CannotRemoveAWSCURRENT(t *testing.T) {
 			name: "move_awscurrent_to_new_version_allowed",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) string {
 				t.Helper()
-				_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "usvs-move-1", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "usvs-move-1", SecretString: "v1"},
+				)
 				require.NoError(t, err)
-				out2, err := b.PutSecretValue(&sm.PutSecretValueInput{SecretID: "usvs-move-1", SecretString: "v2"})
+				out2, err := b.PutSecretValue(
+					context.Background(),
+					&sm.PutSecretValueInput{SecretID: "usvs-move-1", SecretString: "v2"},
+				)
 				require.NoError(t, err)
 
 				return out2.VersionID
@@ -381,7 +409,7 @@ func TestBatch2B_UpdateSecretVersionStage_CannotRemoveAWSCURRENT(t *testing.T) {
 				}
 			}
 
-			_, err := b.UpdateSecretVersionStage(input)
+			_, err := b.UpdateSecretVersionStage(context.Background(), input)
 			tt.wantFn(t, err)
 		})
 	}
@@ -402,7 +430,10 @@ func TestBatch2B_UpdateSecretVersionStage_CannotRemoveAWSCURRENT_HTTP(t *testing
 			name: "remove_awscurrent_returns_400",
 			setup: func(t *testing.T, b *sm.InMemoryBackend) string {
 				t.Helper()
-				out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "usvs-http-cur", SecretString: "v"})
+				out, err := b.CreateSecret(
+					context.Background(),
+					&sm.CreateSecretInput{Name: "usvs-http-cur", SecretString: "v"},
+				)
 				require.NoError(t, err)
 
 				return out.VersionID

--- a/services/secretsmanager/backend.go
+++ b/services/secretsmanager/backend.go
@@ -29,6 +29,18 @@ const (
 	errResourceNotFoundException = "ResourceNotFoundException"
 )
 
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
 var (
 	// ErrSecretNotFound is returned when the specified secret does not exist.
 	ErrSecretNotFound = errors.New(errResourceNotFoundException)
@@ -100,11 +112,13 @@ const (
 )
 
 // InMemoryBackend is a concurrency-safe in-memory Secrets Manager backend.
+// InMemoryBackend stores Secrets Manager state. All resource maps are nested by
+// region (outer key = region) so that secrets are isolated per region.
 type InMemoryBackend struct {
 	lambdaInvoker      LambdaInvoker
-	secrets            map[string]*Secret
-	resourcePolicies   map[string]string
-	replicationConfigs map[string][]ReplicationStatusType
+	secrets            map[string]map[string]*Secret
+	resourcePolicies   map[string]map[string]string
+	replicationConfigs map[string]map[string][]ReplicationStatusType
 	mu                 *lockmetrics.RWMutex
 	now                func() time.Time
 	schedulerStop      chan struct{}
@@ -128,15 +142,42 @@ func NewInMemoryBackend() *InMemoryBackend {
 // NewInMemoryBackendWithConfig creates a new Secrets Manager backend with the given account ID and region.
 func NewInMemoryBackendWithConfig(accountID, region string) *InMemoryBackend {
 	return &InMemoryBackend{
-		secrets:            make(map[string]*Secret),
-		resourcePolicies:   make(map[string]string),
-		replicationConfigs: make(map[string][]ReplicationStatusType),
+		secrets:            make(map[string]map[string]*Secret),
+		resourcePolicies:   make(map[string]map[string]string),
+		replicationConfigs: make(map[string]map[string][]ReplicationStatusType),
 		accountID:          accountID,
 		region:             region,
 		mu:                 lockmetrics.New("secretsmanager"),
 		now:                time.Now,
 		schedulerStop:      make(chan struct{}),
 	}
+}
+
+// The *Store helpers return the per-region inner map, lazily creating it.
+// Callers must hold b.mu.
+
+func (b *InMemoryBackend) secretsStore(region string) map[string]*Secret {
+	if b.secrets[region] == nil {
+		b.secrets[region] = make(map[string]*Secret)
+	}
+
+	return b.secrets[region]
+}
+
+func (b *InMemoryBackend) resourcePoliciesStore(region string) map[string]string {
+	if b.resourcePolicies[region] == nil {
+		b.resourcePolicies[region] = make(map[string]string)
+	}
+
+	return b.resourcePolicies[region]
+}
+
+func (b *InMemoryBackend) replicationConfigsStore(region string) map[string][]ReplicationStatusType {
+	if b.replicationConfigs[region] == nil {
+		b.replicationConfigs[region] = make(map[string][]ReplicationStatusType)
+	}
+
+	return b.replicationConfigs[region]
 }
 
 // resolveSecretID resolves a name or ARN to the internal key (name).
@@ -236,7 +277,7 @@ func validateTagCount(existing int, adding int) error {
 }
 
 // CreateSecret creates a new secret with an optional initial value.
-func (b *InMemoryBackend) CreateSecret(input *CreateSecretInput) (*CreateSecretOutput, error) {
+func (b *InMemoryBackend) CreateSecret(ctx context.Context, input *CreateSecretInput) (*CreateSecretOutput, error) {
 	if err := validateSecretName(input.Name); err != nil {
 		return nil, err
 	}
@@ -249,10 +290,16 @@ func (b *InMemoryBackend) CreateSecret(input *CreateSecretInput) (*CreateSecretO
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+	if input.Region != "" {
+		region = input.Region
+	}
+
 	b.mu.Lock("CreateSecret")
 	defer b.mu.Unlock()
 
-	if existing, exists := b.secrets[input.Name]; exists {
+	secrets := b.secretsStore(region)
+	if existing, exists := secrets[input.Name]; exists {
 		if existing.DeletedDate != nil {
 			return nil, fmt.Errorf(
 				"%w: a secret with this name is already scheduled for deletion; restore or force-delete it first",
@@ -268,10 +315,6 @@ func (b *InMemoryBackend) CreateSecret(input *CreateSecretInput) (*CreateSecretO
 		return nil, err
 	}
 
-	region := b.region
-	if input.Region != "" {
-		region = input.Region
-	}
 	arn := b.buildARNWithRegion(region, input.Name, suffix)
 
 	secret := &Secret{
@@ -293,29 +336,9 @@ func (b *InMemoryBackend) CreateSecret(input *CreateSecretInput) (*CreateSecretO
 		}
 	}
 
-	var versionID string
+	versionID := seedInitialVersion(secret, input)
 
-	if input.SecretString != "" || len(input.SecretBinary) > 0 {
-		// Use ClientRequestToken as initial version ID for idempotency.
-		versionID = input.ClientRequestToken
-		if versionID == "" {
-			versionID = uuid.New().String()
-		}
-
-		now := UnixTimeFloat(time.Now())
-		version := &SecretVersion{
-			VersionID:     versionID,
-			SecretString:  input.SecretString,
-			SecretBinary:  input.SecretBinary,
-			StagingLabels: []string{StagingLabelCurrent},
-			CreatedDate:   now,
-		}
-		secret.Versions[versionID] = version
-		secret.CurrentVersionID = versionID
-		secret.LastChangedDate = &now
-	}
-
-	b.secrets[input.Name] = secret
+	secrets[input.Name] = secret
 
 	if len(input.AddReplicaRegions) > 0 {
 		replicas := make([]ReplicationStatusType, 0, len(input.AddReplicaRegions))
@@ -327,27 +350,58 @@ func (b *InMemoryBackend) CreateSecret(input *CreateSecretInput) (*CreateSecretO
 				StatusMessage: "replication queued",
 			})
 		}
-		b.replicationConfigs[input.Name] = replicas
+		b.replicationConfigsStore(region)[input.Name] = replicas
 	}
 
-	b.syncReplicationStatusLocked(secret)
+	b.syncReplicationStatusLocked(region, secret)
 
 	return &CreateSecretOutput{
 		ARN:               arn,
 		Name:              input.Name,
 		VersionID:         versionID,
-		ReplicationStatus: b.replicationConfigs[input.Name],
+		ReplicationStatus: b.replicationConfigsStore(region)[input.Name],
 	}, nil
 }
 
+// seedInitialVersion creates the initial AWSCURRENT version on a freshly created secret
+// when the create request carries a value, and returns the version ID (empty if none).
+func seedInitialVersion(secret *Secret, input *CreateSecretInput) string {
+	if input.SecretString == "" && len(input.SecretBinary) == 0 {
+		return ""
+	}
+
+	// Use ClientRequestToken as initial version ID for idempotency.
+	versionID := input.ClientRequestToken
+	if versionID == "" {
+		versionID = uuid.New().String()
+	}
+
+	now := UnixTimeFloat(time.Now())
+	secret.Versions[versionID] = &SecretVersion{
+		VersionID:     versionID,
+		SecretString:  input.SecretString,
+		SecretBinary:  input.SecretBinary,
+		StagingLabels: []string{StagingLabelCurrent},
+		CreatedDate:   now,
+	}
+	secret.CurrentVersionID = versionID
+	secret.LastChangedDate = &now
+
+	return versionID
+}
+
 // GetSecretValue retrieves the value of a secret version.
-func (b *InMemoryBackend) GetSecretValue(input *GetSecretValueInput) (*GetSecretValueOutput, error) {
+func (b *InMemoryBackend) GetSecretValue(
+	ctx context.Context, input *GetSecretValueInput,
+) (*GetSecretValueOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("GetSecretValue")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secret, exists := b.secretsStore(region)[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -412,7 +466,9 @@ func (b *InMemoryBackend) findVersion(secret *Secret, versionID, versionStage st
 }
 
 // PutSecretValue adds a new version to an existing secret.
-func (b *InMemoryBackend) PutSecretValue(input *PutSecretValueInput) (*PutSecretValueOutput, error) {
+func (b *InMemoryBackend) PutSecretValue(
+	ctx context.Context, input *PutSecretValueInput,
+) (*PutSecretValueOutput, error) {
 	if input.SecretString == "" && len(input.SecretBinary) == 0 {
 		return nil, fmt.Errorf(
 			"%w: you must provide either SecretString or SecretBinary",
@@ -424,12 +480,14 @@ func (b *InMemoryBackend) PutSecretValue(input *PutSecretValueInput) (*PutSecret
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("PutSecretValue")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secret, exists := b.secretsStore(region)[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -479,7 +537,7 @@ func (b *InMemoryBackend) PutSecretValue(input *PutSecretValueInput) (*PutSecret
 	secret.Versions[versionID] = version
 	secret.CurrentVersionID = versionID
 	secret.LastChangedDate = &now
-	b.syncReplicationStatusLocked(secret)
+	b.syncReplicationStatusLocked(region, secret)
 
 	pruneVersions(secret)
 
@@ -572,13 +630,16 @@ func validateSecretSize(secretString string, secretBinary []byte) error {
 }
 
 // DeleteSecret marks a secret as deleted, or permanently removes it when ForceDeleteWithoutRecovery is set.
-func (b *InMemoryBackend) DeleteSecret(input *DeleteSecretInput) (*DeleteSecretOutput, error) {
+func (b *InMemoryBackend) DeleteSecret(ctx context.Context, input *DeleteSecretInput) (*DeleteSecretOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteSecret")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secrets := b.secretsStore(region)
+	secret, exists := secrets[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -590,9 +651,9 @@ func (b *InMemoryBackend) DeleteSecret(input *DeleteSecretInput) (*DeleteSecretO
 			secret.Tags.Close()
 		}
 
-		delete(b.secrets, name)
-		delete(b.resourcePolicies, name)
-		delete(b.replicationConfigs, name)
+		delete(secrets, name)
+		delete(b.resourcePoliciesStore(region), name)
+		delete(b.replicationConfigsStore(region), name)
 
 		return &DeleteSecretOutput{
 			ARN:          secret.ARN,
@@ -634,17 +695,20 @@ func (b *InMemoryBackend) DeleteSecret(input *DeleteSecretInput) (*DeleteSecretO
 }
 
 // ListSecrets returns a paginated list of secrets.
-func (b *InMemoryBackend) ListSecrets(input *ListSecretsInput) (*ListSecretsOutput, error) {
+func (b *InMemoryBackend) ListSecrets(ctx context.Context, input *ListSecretsInput) (*ListSecretsOutput, error) {
 	if err := validateMaxResults(input.MaxResults, maxResultsListSecrets); err != nil {
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("ListSecrets")
 	defer b.mu.RUnlock()
 
-	entries := make([]SecretListEntry, 0, len(b.secrets))
+	secrets := b.secretsStore(region)
+	entries := make([]SecretListEntry, 0, len(secrets))
 
-	for _, s := range b.secrets {
+	for _, s := range secrets {
 		if s.DeletedDate != nil && !input.IncludeDeleted {
 			continue
 		}
@@ -776,17 +840,21 @@ func secretHasTagValue(s *Secret, values []string) bool {
 }
 
 // ListSecretVersionIDs returns the list of versions for a secret with optional pagination.
-func (b *InMemoryBackend) ListSecretVersionIDs(input *ListSecretVersionIDsInput) (*ListSecretVersionIDsOutput, error) {
+func (b *InMemoryBackend) ListSecretVersionIDs(
+	ctx context.Context, input *ListSecretVersionIDsInput,
+) (*ListSecretVersionIDsOutput, error) {
 	if err := validateMaxResults(input.MaxResults, maxResultsListSecrets); err != nil {
 		return nil, err
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.RLock("ListSecretVersionIDs")
 	defer b.mu.RUnlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secret, exists := b.secretsStore(region)[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -849,13 +917,18 @@ func (b *InMemoryBackend) ListSecretVersionIDs(input *ListSecretVersionIDsInput)
 }
 
 // DescribeSecret returns metadata about a secret.
-func (b *InMemoryBackend) DescribeSecret(input *DescribeSecretInput) (*DescribeSecretOutput, error) {
+func (b *InMemoryBackend) DescribeSecret(
+	ctx context.Context,
+	input *DescribeSecretInput,
+) (*DescribeSecretOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("DescribeSecret")
 	defer b.mu.RUnlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secret, exists := b.secretsStore(region)[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -883,9 +956,9 @@ func (b *InMemoryBackend) DescribeSecret(input *DescribeSecretInput) (*DescribeS
 		LastAccessedDate:   secret.LastAccessedDate,
 		VersionIDsToStages: versionIDsToStages,
 		RotationEnabled:    secret.RotationEnabled,
-		ReplicationStatus:  b.replicationConfigs[name],
+		ReplicationStatus:  b.replicationConfigsStore(region)[name],
 		OwnerAccountID:     b.accountID,
-		PrimaryRegion:      b.region,
+		PrimaryRegion:      region,
 	}
 
 	// Compute NextRotationDate from the last rotation base + interval.
@@ -934,17 +1007,19 @@ func computeNextRotationDate(secret *Secret) *float64 {
 }
 
 // UpdateSecret updates the description of a secret and optionally creates a new version.
-func (b *InMemoryBackend) UpdateSecret(input *UpdateSecretInput) (*UpdateSecretOutput, error) {
+func (b *InMemoryBackend) UpdateSecret(ctx context.Context, input *UpdateSecretInput) (*UpdateSecretOutput, error) {
 	if err := validateSecretSize(input.SecretString, input.SecretBinary); err != nil {
 		return nil, err
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.Lock("UpdateSecret")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secret, exists := b.secretsStore(region)[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -995,7 +1070,7 @@ func (b *InMemoryBackend) UpdateSecret(input *UpdateSecretInput) (*UpdateSecretO
 		secret.Versions[versionID] = version
 		secret.CurrentVersionID = versionID
 		secret.LastChangedDate = &now
-		b.syncReplicationStatusLocked(secret)
+		b.syncReplicationStatusLocked(region, secret)
 
 		pruneVersions(secret)
 	}
@@ -1008,13 +1083,15 @@ func (b *InMemoryBackend) UpdateSecret(input *UpdateSecretInput) (*UpdateSecretO
 }
 
 // RestoreSecret clears the deletion mark from a secret.
-func (b *InMemoryBackend) RestoreSecret(input *RestoreSecretInput) (*RestoreSecretOutput, error) {
+func (b *InMemoryBackend) RestoreSecret(ctx context.Context, input *RestoreSecretInput) (*RestoreSecretOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RestoreSecret")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, exists := b.secrets[name]
+	secret, exists := b.secretsStore(region)[name]
 	if !exists {
 		return nil, ErrSecretNotFound
 	}
@@ -1037,15 +1114,18 @@ func (b *InMemoryBackend) RestoreSecret(input *RestoreSecretInput) (*RestoreSecr
 	}, nil
 }
 
-// ListAll returns all secrets as list entries, sorted by name (for dashboard use).
+// ListAll returns all secrets across all regions as list entries, sorted by name
+// (for dashboard use).
 func (b *InMemoryBackend) ListAll() []SecretListEntry {
 	b.mu.RLock("ListAll")
 	defer b.mu.RUnlock()
 
-	entries := make([]SecretListEntry, 0, len(b.secrets))
+	var entries []SecretListEntry
 
-	for _, s := range b.secrets {
-		entries = append(entries, secretToListEntry(s))
+	for _, regionSecrets := range b.secrets {
+		for _, s := range regionSecrets {
+			entries = append(entries, secretToListEntry(s))
+		}
 	}
 
 	sort.Slice(entries, func(i, j int) bool {
@@ -1108,12 +1188,14 @@ func generateVersionID() string {
 }
 
 // TagResource adds or updates tags on a secret.
-func (b *InMemoryBackend) TagResource(input *TagResourceInput) error {
+func (b *InMemoryBackend) TagResource(ctx context.Context, input *TagResourceInput) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("TagResource")
 	defer b.mu.Unlock()
 
 	id := resolveSecretID(input.SecretID)
-	secret, ok := b.secrets[id]
+	secret, ok := b.secretsStore(region)[id]
 	if !ok {
 		return ErrSecretNotFound
 	}
@@ -1141,12 +1223,14 @@ func (b *InMemoryBackend) TagResource(input *TagResourceInput) error {
 }
 
 // UntagResource removes tags from a secret.
-func (b *InMemoryBackend) UntagResource(input *UntagResourceInput) error {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, input *UntagResourceInput) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UntagResource")
 	defer b.mu.Unlock()
 
 	id := resolveSecretID(input.SecretID)
-	secret, ok := b.secrets[id]
+	secret, ok := b.secretsStore(region)[id]
 	if !ok {
 		return ErrSecretNotFound
 	}
@@ -1161,12 +1245,14 @@ func (b *InMemoryBackend) UntagResource(input *UntagResourceInput) error {
 }
 
 // RotateSecret creates a new version of the secret (rotation stub).
-func (b *InMemoryBackend) RotateSecret(input *RotateSecretInput) (*RotateSecretOutput, error) {
+func (b *InMemoryBackend) RotateSecret(ctx context.Context, input *RotateSecretInput) (*RotateSecretOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RotateSecret")
 	defer b.mu.Unlock()
 
 	id := resolveSecretID(input.SecretID)
-	secret, ok := b.secrets[id]
+	secret, ok := b.secretsStore(region)[id]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -1209,7 +1295,7 @@ func (b *InMemoryBackend) RotateSecret(input *RotateSecretInput) (*RotateSecretO
 	// When a Lambda ARN is set AND a Lambda invoker is configured, the handler or
 	// scheduler will call FinishRotation after invoking the four rotation steps.
 	if input.RotationLambdaARN == "" || b.lambdaInvoker == nil {
-		b.finishRotationLocked(secret, versionID)
+		b.finishRotationLocked(region, secret, versionID)
 	}
 
 	return &RotateSecretOutput{
@@ -1257,7 +1343,7 @@ func (b *InMemoryBackend) rotateSecretLocked(secret *Secret, token string) (stri
 
 // finishRotationLocked promotes the AWSPENDING version identified by versionID to
 // AWSCURRENT, moving the old AWSCURRENT to AWSPREVIOUS. Must be called with b.mu held.
-func (b *InMemoryBackend) finishRotationLocked(secret *Secret, versionID string) {
+func (b *InMemoryBackend) finishRotationLocked(region string, secret *Secret, versionID string) {
 	newVer, ok := secret.Versions[versionID]
 	if !ok {
 		return
@@ -1271,7 +1357,7 @@ func (b *InMemoryBackend) finishRotationLocked(secret *Secret, versionID string)
 	secret.LastChangedDate = &now
 	secret.LastRotatedDate = &now
 	pruneVersions(secret)
-	b.syncReplicationStatusLocked(secret)
+	b.syncReplicationStatusLocked(region, secret)
 }
 
 // abortRotationLocked removes the AWSPENDING version, cancelling an in-progress rotation.
@@ -1282,30 +1368,34 @@ func (b *InMemoryBackend) abortRotationLocked(secret *Secret, versionID string) 
 
 // FinishRotation promotes the AWSPENDING version to AWSCURRENT. Called by the
 // handler after all Lambda rotation steps succeed.
-func (b *InMemoryBackend) FinishRotation(secretID, versionID string) error {
+func (b *InMemoryBackend) FinishRotation(ctx context.Context, secretID, versionID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("FinishRotation")
 	defer b.mu.Unlock()
 
 	id := resolveSecretID(secretID)
-	secret, ok := b.secrets[id]
+	secret, ok := b.secretsStore(region)[id]
 
 	if !ok || secret.DeletedDate != nil {
 		return ErrSecretNotFound
 	}
 
-	b.finishRotationLocked(secret, versionID)
+	b.finishRotationLocked(region, secret, versionID)
 
 	return nil
 }
 
 // AbortRotation removes the AWSPENDING version, aborting an in-progress rotation.
 // Called by the handler when a Lambda rotation step fails.
-func (b *InMemoryBackend) AbortRotation(secretID, versionID string) error {
+func (b *InMemoryBackend) AbortRotation(ctx context.Context, secretID, versionID string) error {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("AbortRotation")
 	defer b.mu.Unlock()
 
 	id := resolveSecretID(secretID)
-	secret, ok := b.secrets[id]
+	secret, ok := b.secretsStore(region)[id]
 
 	if !ok || secret.DeletedDate != nil {
 		return ErrSecretNotFound
@@ -1636,32 +1726,49 @@ func (b *InMemoryBackend) TaggedSecrets() []TaggedSecretInfo {
 	b.mu.RLock("TaggedSecrets")
 	defer b.mu.RUnlock()
 
-	result := make([]TaggedSecretInfo, 0, len(b.secrets))
+	var result []TaggedSecretInfo
 
-	for _, secret := range b.secrets {
-		if secret.DeletedDate != nil {
-			continue
+	for _, regionSecrets := range b.secrets {
+		for _, secret := range regionSecrets {
+			if secret.DeletedDate != nil {
+				continue
+			}
+
+			var tagMap map[string]string
+			if secret.Tags != nil {
+				tagMap = secret.Tags.Clone()
+			}
+
+			result = append(result, TaggedSecretInfo{ARN: secret.ARN, Tags: tagMap})
 		}
-
-		var tagMap map[string]string
-		if secret.Tags != nil {
-			tagMap = secret.Tags.Clone()
-		}
-
-		result = append(result, TaggedSecretInfo{ARN: secret.ARN, Tags: tagMap})
 	}
 
 	return result
 }
 
-// TagSecretByARN applies tags to the secret identified by its ARN.
+// regionFromARN extracts the region component (index 3) from an AWS ARN
+// (arn:partition:service:region:account:resource), falling back to defaultRegion.
+func regionFromARN(resourceARN, defaultRegion string) string {
+	parts := strings.Split(resourceARN, ":")
+	const regionIndex = 3
+	if len(parts) > regionIndex && parts[regionIndex] != "" {
+		return parts[regionIndex]
+	}
+
+	return defaultRegion
+}
+
+// TagSecretByARN applies tags to the secret identified by its ARN. The region is taken
+// from the ARN so cross-service callers (Resource Groups Tagging API) reach the right region.
 func (b *InMemoryBackend) TagSecretByARN(secretARN string, newTags map[string]string) error {
+	region := regionFromARN(secretARN, b.region)
+
 	b.mu.Lock("TagSecretByARN")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(secretARN)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrSecretNotFound, secretARN)
 	}
@@ -1677,12 +1784,14 @@ func (b *InMemoryBackend) TagSecretByARN(secretARN string, newTags map[string]st
 
 // UntagSecretByARN removes the specified tag keys from the secret identified by its ARN.
 func (b *InMemoryBackend) UntagSecretByARN(secretARN string, tagKeys []string) error {
+	region := regionFromARN(secretARN, b.region)
+
 	b.mu.Lock("UntagSecretByARN")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(secretARN)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrSecretNotFound, secretARN)
 	}
@@ -1695,7 +1804,9 @@ func (b *InMemoryBackend) UntagSecretByARN(secretARN string, tagKeys []string) e
 }
 
 // BatchGetSecretValue retrieves the values of multiple secrets in a single call.
-func (b *InMemoryBackend) BatchGetSecretValue(input *BatchGetSecretValueInput) (*BatchGetSecretValueOutput, error) {
+func (b *InMemoryBackend) BatchGetSecretValue(
+	ctx context.Context, input *BatchGetSecretValueInput,
+) (*BatchGetSecretValueOutput, error) {
 	if input.MaxResults != nil {
 		mr := int64(*input.MaxResults)
 		if err := validateMaxResults(&mr, maxResultsBatchGet); err != nil {
@@ -1711,6 +1822,8 @@ func (b *InMemoryBackend) BatchGetSecretValue(input *BatchGetSecretValueInput) (
 		)
 	}
 
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("BatchGetSecretValue")
 	defer b.mu.Unlock()
 
@@ -1720,23 +1833,24 @@ func (b *InMemoryBackend) BatchGetSecretValue(input *BatchGetSecretValueInput) (
 	}
 
 	if len(input.SecretIDList) > 0 {
-		b.batchGetByIDList(input.SecretIDList, out)
+		b.batchGetByIDList(region, input.SecretIDList, out)
 
 		return out, nil
 	}
 
-	return b.batchGetByFilter(input, out), nil
+	return b.batchGetByFilter(region, input, out), nil
 }
 
 // batchGetByIDList populates out with values and errors for each explicit secret ID.
 // Must be called with write lock held.
-func (b *InMemoryBackend) batchGetByIDList(ids []string, out *BatchGetSecretValueOutput) {
+func (b *InMemoryBackend) batchGetByIDList(region string, ids []string, out *BatchGetSecretValueOutput) {
 	accessDay := UnixTimeFloat(time.Now().UTC().Truncate(hoursPerDay * time.Hour))
+	secrets := b.secretsStore(region)
 
 	for _, id := range ids {
 		name := resolveSecretID(id)
 
-		secret, ok := b.secrets[name]
+		secret, ok := secrets[name]
 		if !ok {
 			out.Errors = append(out.Errors, APIErrorType{
 				ErrorCode: errResourceNotFoundException,
@@ -1777,13 +1891,15 @@ func (b *InMemoryBackend) batchGetByIDList(ids []string, out *BatchGetSecretValu
 // batchGetByFilter collects and paginates secrets matching filters.
 // Must be called with write lock held.
 func (b *InMemoryBackend) batchGetByFilter(
+	region string,
 	input *BatchGetSecretValueInput,
 	out *BatchGetSecretValueOutput,
 ) *BatchGetSecretValueOutput {
-	allValues := make([]SecretValueEntry, 0, len(b.secrets))
+	secrets := b.secretsStore(region)
+	allValues := make([]SecretValueEntry, 0, len(secrets))
 	accessDay := UnixTimeFloat(time.Now().UTC().Truncate(hoursPerDay * time.Hour))
 
-	for _, secret := range b.secrets {
+	for _, secret := range secrets {
 		if secret.DeletedDate != nil || !batchMatchesFilters(secret, input.Filters) {
 			continue
 		}
@@ -1871,13 +1987,17 @@ func anyMatch(values []string, target string) bool {
 }
 
 // CancelRotateSecret cancels an in-progress rotation by removing the AWSPENDING staging label.
-func (b *InMemoryBackend) CancelRotateSecret(input *CancelRotateSecretInput) (*CancelRotateSecretOutput, error) {
+func (b *InMemoryBackend) CancelRotateSecret(
+	ctx context.Context, input *CancelRotateSecretInput,
+) (*CancelRotateSecretOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("CancelRotateSecret")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -1916,13 +2036,17 @@ func (b *InMemoryBackend) CancelRotateSecret(input *CancelRotateSecretInput) (*C
 }
 
 // GetResourcePolicy retrieves the resource-based policy for a secret.
-func (b *InMemoryBackend) GetResourcePolicy(input *GetResourcePolicyInput) (*GetResourcePolicyOutput, error) {
+func (b *InMemoryBackend) GetResourcePolicy(
+	ctx context.Context, input *GetResourcePolicyInput,
+) (*GetResourcePolicyOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.RLock("GetResourcePolicy")
 	defer b.mu.RUnlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -1931,7 +2055,7 @@ func (b *InMemoryBackend) GetResourcePolicy(input *GetResourcePolicyInput) (*Get
 		return nil, fmt.Errorf("%w: secret %s is deleted", ErrSecretDeleted, input.SecretID)
 	}
 
-	policy := b.resourcePolicies[name]
+	policy := b.resourcePoliciesStore(region)[name]
 
 	return &GetResourcePolicyOutput{
 		ARN:            secret.ARN,
@@ -1941,17 +2065,21 @@ func (b *InMemoryBackend) GetResourcePolicy(input *GetResourcePolicyInput) (*Get
 }
 
 // PutResourcePolicy stores a resource-based policy for a secret.
-func (b *InMemoryBackend) PutResourcePolicy(input *PutResourcePolicyInput) (*PutResourcePolicyOutput, error) {
+func (b *InMemoryBackend) PutResourcePolicy(
+	ctx context.Context, input *PutResourcePolicyInput,
+) (*PutResourcePolicyOutput, error) {
 	if input.ResourcePolicy == "" {
 		return nil, fmt.Errorf("%w: ResourcePolicy must not be empty", ErrInvalidParameter)
 	}
+
+	region := getRegion(ctx, b.region)
 
 	b.mu.Lock("PutResourcePolicy")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -1960,7 +2088,7 @@ func (b *InMemoryBackend) PutResourcePolicy(input *PutResourcePolicyInput) (*Put
 		return nil, fmt.Errorf("%w: secret %s is deleted", ErrSecretDeleted, input.SecretID)
 	}
 
-	b.resourcePolicies[name] = input.ResourcePolicy
+	b.resourcePoliciesStore(region)[name] = input.ResourcePolicy
 
 	return &PutResourcePolicyOutput{
 		ARN:  secret.ARN,
@@ -1969,13 +2097,17 @@ func (b *InMemoryBackend) PutResourcePolicy(input *PutResourcePolicyInput) (*Put
 }
 
 // DeleteResourcePolicy removes the resource-based policy from a secret.
-func (b *InMemoryBackend) DeleteResourcePolicy(input *DeleteResourcePolicyInput) (*DeleteResourcePolicyOutput, error) {
+func (b *InMemoryBackend) DeleteResourcePolicy(
+	ctx context.Context, input *DeleteResourcePolicyInput,
+) (*DeleteResourcePolicyOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("DeleteResourcePolicy")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -1984,7 +2116,7 @@ func (b *InMemoryBackend) DeleteResourcePolicy(input *DeleteResourcePolicyInput)
 		return nil, fmt.Errorf("%w: secret %s is deleted", ErrSecretDeleted, input.SecretID)
 	}
 
-	delete(b.resourcePolicies, name)
+	delete(b.resourcePoliciesStore(region), name)
 
 	return &DeleteResourcePolicyOutput{
 		ARN:  secret.ARN,
@@ -2001,14 +2133,17 @@ const (
 
 // ReplicateSecretToRegions adds replication configuration for the specified regions.
 func (b *InMemoryBackend) ReplicateSecretToRegions(
+	ctx context.Context,
 	input *ReplicateSecretToRegionsInput,
 ) (*ReplicateSecretToRegionsOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("ReplicateSecretToRegions")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -2017,7 +2152,8 @@ func (b *InMemoryBackend) ReplicateSecretToRegions(
 		return nil, fmt.Errorf("%w: secret %s is deleted", ErrSecretDeleted, input.SecretID)
 	}
 
-	existing := b.replicationConfigs[name]
+	configs := b.replicationConfigsStore(region)
+	existing := configs[name]
 	existingByRegion := make(map[string]int, len(existing))
 
 	for i, r := range existing {
@@ -2039,25 +2175,28 @@ func (b *InMemoryBackend) ReplicateSecretToRegions(
 		}
 	}
 
-	b.replicationConfigs[name] = existing
-	b.syncReplicationStatusLocked(secret)
+	configs[name] = existing
+	b.syncReplicationStatusLocked(region, secret)
 
 	return &ReplicateSecretToRegionsOutput{
 		ARN:               secret.ARN,
-		ReplicationStatus: b.replicationConfigs[name],
+		ReplicationStatus: configs[name],
 	}, nil
 }
 
 // RemoveRegionsFromReplication removes replication configuration for the specified regions.
 func (b *InMemoryBackend) RemoveRegionsFromReplication(
+	ctx context.Context,
 	input *RemoveRegionsFromReplicationInput,
 ) (*RemoveRegionsFromReplicationOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("RemoveRegionsFromReplication")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -2072,7 +2211,8 @@ func (b *InMemoryBackend) RemoveRegionsFromReplication(
 		toRemove[r] = struct{}{}
 	}
 
-	existing := b.replicationConfigs[name]
+	configs := b.replicationConfigsStore(region)
+	existing := configs[name]
 	remaining := make([]ReplicationStatusType, 0, len(existing))
 
 	for _, r := range existing {
@@ -2081,7 +2221,7 @@ func (b *InMemoryBackend) RemoveRegionsFromReplication(
 		}
 	}
 
-	b.replicationConfigs[name] = remaining
+	configs[name] = remaining
 
 	return &RemoveRegionsFromReplicationOutput{
 		ARN:               secret.ARN,
@@ -2091,14 +2231,17 @@ func (b *InMemoryBackend) RemoveRegionsFromReplication(
 
 // StopReplicationToReplica promotes a replica secret to a standalone secret.
 func (b *InMemoryBackend) StopReplicationToReplica(
+	ctx context.Context,
 	input *StopReplicationToReplicaInput,
 ) (*StopReplicationToReplicaOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("StopReplicationToReplica")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -2108,7 +2251,7 @@ func (b *InMemoryBackend) StopReplicationToReplica(
 	}
 
 	// In the in-memory backend, we simply remove any replication config for this secret.
-	delete(b.replicationConfigs, name)
+	delete(b.replicationConfigsStore(region), name)
 
 	return &StopReplicationToReplicaOutput{
 		ARN: secret.ARN,
@@ -2117,14 +2260,17 @@ func (b *InMemoryBackend) StopReplicationToReplica(
 
 // UpdateSecretVersionStage moves or adds a staging label to a specific secret version.
 func (b *InMemoryBackend) UpdateSecretVersionStage(
+	ctx context.Context,
 	input *UpdateSecretVersionStageInput,
 ) (*UpdateSecretVersionStageOutput, error) {
+	region := getRegion(ctx, b.region)
+
 	b.mu.Lock("UpdateSecretVersionStage")
 	defer b.mu.Unlock()
 
 	name := resolveSecretID(input.SecretID)
 
-	secret, ok := b.secrets[name]
+	secret, ok := b.secretsStore(region)[name]
 	if !ok {
 		return nil, ErrSecretNotFound
 	}
@@ -2216,15 +2362,17 @@ func (b *InMemoryBackend) Reset() {
 	b.mu.Lock("Reset")
 	defer b.mu.Unlock()
 
-	for _, secret := range b.secrets {
-		if secret.Tags != nil {
-			secret.Tags.Close()
+	for _, regionSecrets := range b.secrets {
+		for _, secret := range regionSecrets {
+			if secret.Tags != nil {
+				secret.Tags.Close()
+			}
 		}
 	}
 
-	b.secrets = make(map[string]*Secret)
-	b.resourcePolicies = make(map[string]string)
-	b.replicationConfigs = make(map[string][]ReplicationStatusType)
+	b.secrets = make(map[string]map[string]*Secret)
+	b.resourcePolicies = make(map[string]map[string]string)
+	b.replicationConfigs = make(map[string]map[string][]ReplicationStatusType)
 }
 
 func (b *InMemoryBackend) ensureRotationScheduler() {
@@ -2258,58 +2406,75 @@ func (b *InMemoryBackend) StopRotationScheduler() {
 	b.schedulerStopOnce.Do(func() { close(b.schedulerStop) })
 }
 
-func (b *InMemoryBackend) runScheduledRotations(now time.Time) {
-	type pendingRotation struct {
-		secretID  string
-		versionID string
-		lambdaARN string
-	}
+// pendingRotation describes a Lambda-backed rotation awaiting its step invocations.
+type pendingRotation struct {
+	region    string
+	secretID  string
+	versionID string
+	lambdaARN string
+}
 
+func (b *InMemoryBackend) runScheduledRotations(now time.Time) {
 	// Phase 1: create AWSPENDING versions while holding the lock.
 	b.mu.Lock("rotationScheduler")
 	var pending []pendingRotation
 
-	for id, secret := range b.secrets {
-		if secret.DeletedDate != nil || !secret.RotationEnabled || secret.RotationRules == nil {
-			continue
+	for region, regionSecrets := range b.secrets {
+		for id, secret := range regionSecrets {
+			if p, ok := b.scheduleRotationLocked(region, id, secret, now); ok {
+				pending = append(pending, p)
+			}
 		}
-
-		base := secret.LastRotatedDate
-		if base == nil {
-			base = secret.LastChangedDate
-		}
-
-		if !rotationDue(secret.RotationRules, now, base) {
-			continue
-		}
-
-		versionID, err := b.rotateSecretLocked(secret, "")
-		if err != nil {
-			continue
-		}
-
-		lambdaARN := secret.RotationLambdaARN
-		if b.lambdaInvoker == nil || lambdaARN == "" {
-			// No Lambda configured — promote immediately while still locked.
-			b.finishRotationLocked(secret, versionID)
-
-			continue
-		}
-
-		pending = append(pending, pendingRotation{secretID: id, versionID: versionID, lambdaARN: lambdaARN})
 	}
 
 	b.mu.Unlock()
 
 	// Phase 2: invoke Lambda WITHOUT holding the lock, then promote or abort.
 	for _, p := range pending {
-		lambdaErr := b.runLambdaRotationSteps(context.Background(), p.lambdaARN, p.secretID, p.versionID)
+		ctx := context.WithValue(context.Background(), regionContextKey{}, p.region)
+		lambdaErr := b.runLambdaRotationSteps(ctx, p.lambdaARN, p.secretID, p.versionID)
 		if lambdaErr != nil {
-			_ = b.AbortRotation(p.secretID, p.versionID)
+			_ = b.AbortRotation(ctx, p.secretID, p.versionID)
 		} else {
-			_ = b.FinishRotation(p.secretID, p.versionID)
+			_ = b.FinishRotation(ctx, p.secretID, p.versionID)
 		}
 	}
+}
+
+// scheduleRotationLocked evaluates a single secret for a due rotation. When rotation is due
+// it creates the AWSPENDING version; if no Lambda is configured it promotes immediately and
+// returns ok=false, otherwise it returns the pendingRotation to invoke without the lock held.
+// Callers must hold b.mu.
+func (b *InMemoryBackend) scheduleRotationLocked(
+	region, id string, secret *Secret, now time.Time,
+) (pendingRotation, bool) {
+	if secret.DeletedDate != nil || !secret.RotationEnabled || secret.RotationRules == nil {
+		return pendingRotation{}, false
+	}
+
+	base := secret.LastRotatedDate
+	if base == nil {
+		base = secret.LastChangedDate
+	}
+
+	if !rotationDue(secret.RotationRules, now, base) {
+		return pendingRotation{}, false
+	}
+
+	versionID, err := b.rotateSecretLocked(secret, "")
+	if err != nil {
+		return pendingRotation{}, false
+	}
+
+	lambdaARN := secret.RotationLambdaARN
+	if b.lambdaInvoker == nil || lambdaARN == "" {
+		// No Lambda configured — promote immediately while still locked.
+		b.finishRotationLocked(region, secret, versionID)
+
+		return pendingRotation{}, false
+	}
+
+	return pendingRotation{region: region, secretID: id, versionID: versionID, lambdaARN: lambdaARN}, true
 }
 
 // rotationDue reports whether a rotation should fire at `now` given the rotation rules and
@@ -2386,8 +2551,9 @@ func rotationInterval(rules *RotationRulesType) (time.Duration, bool) {
 	}
 }
 
-func (b *InMemoryBackend) syncReplicationStatusLocked(secret *Secret) {
-	statuses, exists := b.replicationConfigs[secret.Name]
+func (b *InMemoryBackend) syncReplicationStatusLocked(region string, secret *Secret) {
+	configs := b.replicationConfigsStore(region)
+	statuses, exists := configs[secret.Name]
 	if !exists || len(statuses) == 0 {
 		return
 	}
@@ -2398,7 +2564,7 @@ func (b *InMemoryBackend) syncReplicationStatusLocked(secret *Secret) {
 			statuses[i].Status = replicationStatusFailed
 			statuses[i].StatusMessage = "no current secret version to replicate"
 		}
-		b.replicationConfigs[secret.Name] = statuses
+		configs[secret.Name] = statuses
 
 		return
 	}
@@ -2408,7 +2574,7 @@ func (b *InMemoryBackend) syncReplicationStatusLocked(secret *Secret) {
 		statuses[i].StatusMessage = "replicated version " + currentVer.VersionID
 	}
 
-	b.replicationConfigs[secret.Name] = statuses
+	configs[secret.Name] = statuses
 }
 
 // AccountID returns the AWS account ID configured for this backend.
@@ -2418,14 +2584,17 @@ func (b *InMemoryBackend) AccountID() string { return b.accountID }
 func (b *InMemoryBackend) Region() string { return b.region }
 
 // AddSecretInternal seeds the backend with a pre-built Secret for testing.
-// Must not be called concurrently with other operations.
+// The secret is placed in the region encoded in its ARN (falling back to the
+// backend's default region). Must not be called concurrently with other operations.
 func (b *InMemoryBackend) AddSecretInternal(s *Secret) {
-	b.secrets[s.Name] = s
+	region := regionFromARN(s.ARN, b.region)
+	b.secretsStore(region)[s.Name] = s
 }
 
 // ValidateResourcePolicy validates a resource-based policy document for a secret.
 // It performs basic structural validation and returns any detected issues.
 func (b *InMemoryBackend) ValidateResourcePolicy(
+	ctx context.Context,
 	input *ValidateResourcePolicyInput,
 ) (*ValidateResourcePolicyOutput, error) {
 	if input.ResourcePolicy == "" {
@@ -2434,11 +2603,13 @@ func (b *InMemoryBackend) ValidateResourcePolicy(
 
 	// If a secret ID is provided, verify the secret exists.
 	if input.SecretID != "" {
+		region := getRegion(ctx, b.region)
+
 		b.mu.RLock("ValidateResourcePolicy")
 		defer b.mu.RUnlock()
 
 		name := resolveSecretID(input.SecretID)
-		if _, ok := b.secrets[name]; !ok {
+		if _, ok := b.secretsStore(region)[name]; !ok {
 			return nil, ErrSecretNotFound
 		}
 	}

--- a/services/secretsmanager/batch1_audit_test.go
+++ b/services/secretsmanager/batch1_audit_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,7 +24,7 @@ func TestAudit_SecretName_Empty(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: ""})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: ""})
 	require.Error(t, err)
 	require.ErrorIs(t, err, sm.ErrInvalidSecretName)
 }
@@ -32,7 +33,7 @@ func TestAudit_SecretName_TooLong(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: strings.Repeat("a", 513)})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: strings.Repeat("a", 513)})
 	require.ErrorIs(t, err, sm.ErrInvalidSecretName)
 }
 
@@ -40,7 +41,7 @@ func TestAudit_SecretName_ExactMaxLength(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: strings.Repeat("a", 512)})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: strings.Repeat("a", 512)})
 	require.NoError(t, err)
 }
 
@@ -50,7 +51,7 @@ func TestAudit_SecretName_InvalidChars(t *testing.T) {
 	b := sm.NewInMemoryBackend()
 
 	for _, name := range []string{"has space", "has\ttab", "has\nnewline", "has$dollar"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name})
 		require.ErrorIs(t, err, sm.ErrInvalidSecretName, "expected error for %q", name)
 	}
 }
@@ -60,7 +61,7 @@ func TestAudit_SecretName_ValidSpecialChars(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	// All allowed special characters: /_+=.@-
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "valid/_+=.@-name",
 		SecretString: "v",
 	})
@@ -71,7 +72,7 @@ func TestAudit_SecretName_AWSPrefixRejected(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "aws/my-secret",
 		SecretString: "v",
 	})
@@ -97,7 +98,7 @@ func TestAudit_SecretName_SlashInMiddleAllowed(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "prod/db/password",
 		SecretString: "v",
 	})
@@ -112,14 +113,14 @@ func TestAudit_CreateSecret_WithKmsKeyID(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "kms-secret",
 		SecretString: "v",
 		KmsKeyID:     "arn:aws:kms:us-east-1:123456789012:key/abc-123",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "kms-secret"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "kms-secret"})
 	require.NoError(t, err)
 	assert.Equal(t, "arn:aws:kms:us-east-1:123456789012:key/abc-123", desc.KmsKeyID)
 }
@@ -128,13 +129,13 @@ func TestAudit_CreateSecret_WithBinary(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "binary-secret",
 		SecretBinary: []byte{0x01, 0x02, 0x03},
 	})
 	require.NoError(t, err)
 
-	val, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "binary-secret"})
+	val, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "binary-secret"})
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0x01, 0x02, 0x03}, val.SecretBinary)
 	assert.Empty(t, val.SecretString)
@@ -144,7 +145,7 @@ func TestAudit_CreateSecret_ClientRequestTokenBecomesVersionID(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "token-version",
 		SecretString:       "v",
 		ClientRequestToken: "my-token-abc",
@@ -152,7 +153,7 @@ func TestAudit_CreateSecret_ClientRequestTokenBecomesVersionID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-token-abc", out.VersionID)
 
-	val, err := b.GetSecretValue(&sm.GetSecretValueInput{
+	val, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:  "token-version",
 		VersionID: "my-token-abc",
 	})
@@ -164,7 +165,7 @@ func TestAudit_CreateSecret_WithoutValue_NoVersionID(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "no-value"})
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "no-value"})
 	require.NoError(t, err)
 	assert.Empty(t, out.VersionID, "no version is created when no value is provided")
 }
@@ -173,7 +174,7 @@ func TestAudit_CreateSecret_ARNFormat(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "arn-check",
 		SecretString: "v",
 	})
@@ -186,10 +187,10 @@ func TestAudit_CreateSecret_DuplicateNameReturnsResourceExistsException(t *testi
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "dup", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "dup", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.CreateSecret(&sm.CreateSecretInput{Name: "dup", SecretString: "v"})
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "dup", SecretString: "v"})
 	require.ErrorIs(t, err, sm.ErrSecretAlreadyExists)
 }
 
@@ -221,7 +222,7 @@ func TestAudit_CreateSecret_TagCountLimit(t *testing.T) {
 		tags[i] = sm.Tag{Key: fmt.Sprintf("key%d", i), Value: "v"}
 	}
 
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "too-many-tags",
 		SecretString: "v",
 		Tags:         tags,
@@ -238,7 +239,7 @@ func TestAudit_CreateSecret_Exactly50TagsAllowed(t *testing.T) {
 		tags[i] = sm.Tag{Key: fmt.Sprintf("key%d", i), Value: "v"}
 	}
 
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "max-tags",
 		SecretString: "v",
 		Tags:         tags,
@@ -251,10 +252,10 @@ func TestAudit_CreateSecret_CreatedDateSet(t *testing.T) {
 
 	before := time.Now()
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "ts-check", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "ts-check", SecretString: "v"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "ts-check"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "ts-check"})
 	require.NoError(t, err)
 	require.NotNil(t, desc.CreatedDate)
 	// UnixTimeFloat stores nanoseconds/1e9; recover with int64(f*1e9) nanoseconds.
@@ -271,7 +272,7 @@ func TestAudit_GetSecretValue_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "missing"})
+	_, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -294,13 +295,13 @@ func TestAudit_GetSecretValue_DeletedReturnsInvalidRequest(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "to-delete", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "to-delete", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "to-delete"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "to-delete"})
 	require.NoError(t, err)
 
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "to-delete"})
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "to-delete"})
 	require.ErrorIs(t, err, sm.ErrSecretDeleted)
 }
 
@@ -325,14 +326,14 @@ func TestAudit_GetSecretValue_AWSCURRENTDefault(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "curr-default",
 		SecretString:       "hello",
 		ClientRequestToken: "v1",
 	})
 	require.NoError(t, err)
 
-	out, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "curr-default"})
+	out, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "curr-default"})
 	require.NoError(t, err)
 	assert.Equal(t, "hello", out.SecretString)
 	assert.Contains(t, out.VersionStages, sm.StagingLabelCurrent)
@@ -342,14 +343,14 @@ func TestAudit_GetSecretValue_AWSPREVIOUSAfterPut(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "prev-test",
 		SecretString:       "v1",
 		ClientRequestToken: "ver-1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "prev-test",
 		SecretString:       "v2",
 		ClientRequestToken: "ver-2",
@@ -357,7 +358,7 @@ func TestAudit_GetSecretValue_AWSPREVIOUSAfterPut(t *testing.T) {
 	require.NoError(t, err)
 
 	// v1 should now be AWSPREVIOUS
-	out, err := b.GetSecretValue(&sm.GetSecretValueInput{
+	out, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:     "prev-test",
 		VersionStage: sm.StagingLabelPrevious,
 	})
@@ -370,10 +371,10 @@ func TestAudit_GetSecretValue_VersionIDNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "ver-missing", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "ver-missing", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{
 		SecretID:  "ver-missing",
 		VersionID: "nonexistent-id",
 	})
@@ -384,17 +385,17 @@ func TestAudit_GetSecretValue_SetsLastAccessedDate(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "access-date", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "access-date", SecretString: "v"})
 	require.NoError(t, err)
 
-	desc1, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "access-date"})
+	desc1, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "access-date"})
 	require.NoError(t, err)
 	assert.Nil(t, desc1.LastAccessedDate, "LastAccessedDate nil before first access")
 
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "access-date"})
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "access-date"})
 	require.NoError(t, err)
 
-	desc2, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "access-date"})
+	desc2, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "access-date"})
 	require.NoError(t, err)
 	assert.NotNil(t, desc2.LastAccessedDate, "LastAccessedDate set after access")
 }
@@ -403,10 +404,10 @@ func TestAudit_GetSecretValue_ARNLookup(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "arn-lookup", SecretString: "secret"})
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "arn-lookup", SecretString: "secret"})
 	require.NoError(t, err)
 
-	val, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: out.ARN})
+	val, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: out.ARN})
 	require.NoError(t, err)
 	assert.Equal(t, "secret", val.SecretString)
 }
@@ -419,10 +420,10 @@ func TestAudit_PutSecretValue_EmptyValueRejected(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "empty-put", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "empty-put", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID: "empty-put",
 	})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter,
@@ -445,14 +446,14 @@ func TestAudit_PutSecretValue_AWSCURRENT_Promoted(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "promote-test",
 		SecretString:       "first",
 		ClientRequestToken: "v1",
 	})
 	require.NoError(t, err)
 
-	out, err := b.PutSecretValue(&sm.PutSecretValueInput{
+	out, err := b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "promote-test",
 		SecretString:       "second",
 		ClientRequestToken: "v2",
@@ -461,7 +462,7 @@ func TestAudit_PutSecretValue_AWSCURRENT_Promoted(t *testing.T) {
 	assert.Contains(t, out.VersionStages, sm.StagingLabelCurrent)
 
 	// v2 should be AWSCURRENT
-	val, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "promote-test"})
+	val, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "promote-test"})
 	require.NoError(t, err)
 	assert.Equal(t, "second", val.SecretString)
 	assert.Equal(t, "v2", val.VersionID)
@@ -471,17 +472,17 @@ func TestAudit_PutSecretValue_Idempotent(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "idem-put", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "idem-put", SecretString: "v"})
 	require.NoError(t, err)
 
-	out1, err := b.PutSecretValue(&sm.PutSecretValueInput{
+	out1, err := b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "idem-put",
 		SecretString:       "new-val",
 		ClientRequestToken: "tok-xyz",
 	})
 	require.NoError(t, err)
 
-	out2, err := b.PutSecretValue(&sm.PutSecretValueInput{
+	out2, err := b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "idem-put",
 		SecretString:       "new-val",
 		ClientRequestToken: "tok-xyz",
@@ -494,10 +495,10 @@ func TestAudit_PutSecretValue_WithAWSPENDING(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "pending-put", SecretString: "v1"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "pending-put", SecretString: "v1"})
 	require.NoError(t, err)
 
-	out, err := b.PutSecretValue(&sm.PutSecretValueInput{
+	out, err := b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:      "pending-put",
 		SecretString:  "v2",
 		VersionStages: []string{"AWSPENDING"},
@@ -512,7 +513,7 @@ func TestAudit_PutSecretValue_SecretNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err := b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:     "missing",
 		SecretString: "v",
 	})
@@ -523,12 +524,12 @@ func TestAudit_PutSecretValue_DeletedSecret(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "del-put", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "del-put", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "del-put"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "del-put"})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:     "del-put",
 		SecretString: "v2",
 	})
@@ -539,10 +540,10 @@ func TestAudit_PutSecretValue_SizeLimit(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "size-put", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "size-put", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:     "size-put",
 		SecretString: strings.Repeat("x", 65537),
 	})
@@ -557,16 +558,16 @@ func TestAudit_DeleteSecret_SoftDelete(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "soft-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "soft-del", SecretString: "v"})
 	require.NoError(t, err)
 
-	out, err := b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "soft-del"})
+	out, err := b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "soft-del"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, out.ARN)
 	assert.NotZero(t, out.DeletionDate)
 
 	// Secret still findable but marked deleted
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "soft-del"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "soft-del"})
 	require.NoError(t, err)
 	assert.NotNil(t, desc.DeletedDate)
 }
@@ -575,17 +576,17 @@ func TestAudit_DeleteSecret_ForceDelete(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "force-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "force-del", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{
 		SecretID:                   "force-del",
 		ForceDeleteWithoutRecovery: true,
 	})
 	require.NoError(t, err)
 
 	// Secret completely gone
-	_, err = b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "force-del"})
+	_, err = b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "force-del"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -593,11 +594,11 @@ func TestAudit_DeleteSecret_RecoveryWindowMin(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "recov-min", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "recov-min", SecretString: "v"})
 	require.NoError(t, err)
 
 	days := int64(7)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{
 		SecretID:             "recov-min",
 		RecoveryWindowInDays: &days,
 	})
@@ -608,11 +609,11 @@ func TestAudit_DeleteSecret_RecoveryWindowMax(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "recov-max", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "recov-max", SecretString: "v"})
 	require.NoError(t, err)
 
 	days := int64(30)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{
 		SecretID:             "recov-max",
 		RecoveryWindowInDays: &days,
 	})
@@ -623,11 +624,11 @@ func TestAudit_DeleteSecret_RecoveryWindowTooShort(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "recov-short", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "recov-short", SecretString: "v"})
 	require.NoError(t, err)
 
 	days := int64(6)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{
 		SecretID:             "recov-short",
 		RecoveryWindowInDays: &days,
 	})
@@ -638,11 +639,11 @@ func TestAudit_DeleteSecret_RecoveryWindowTooLong(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "recov-long", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "recov-long", SecretString: "v"})
 	require.NoError(t, err)
 
 	days := int64(31)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{
 		SecretID:             "recov-long",
 		RecoveryWindowInDays: &days,
 	})
@@ -653,13 +654,13 @@ func TestAudit_DeleteSecret_AlreadyDeleted(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "already-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "already-del", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "already-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "already-del"})
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "already-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "already-del"})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter, "deleting an already-deleted secret must fail")
 }
 
@@ -667,7 +668,7 @@ func TestAudit_DeleteSecret_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "missing"})
+	_, err := b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -679,16 +680,16 @@ func TestAudit_RestoreSecret_ClearsDeletedDate(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "restore-me", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "restore-me", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "restore-me"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "restore-me"})
 	require.NoError(t, err)
 
-	_, err = b.RestoreSecret(&sm.RestoreSecretInput{SecretID: "restore-me"})
+	_, err = b.RestoreSecret(context.Background(), &sm.RestoreSecretInput{SecretID: "restore-me"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "restore-me"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "restore-me"})
 	require.NoError(t, err)
 	assert.Nil(t, desc.DeletedDate, "DeletedDate must be cleared after RestoreSecret")
 }
@@ -697,10 +698,10 @@ func TestAudit_RestoreSecret_ActiveSecretFails(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "active-restore", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "active-restore", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.RestoreSecret(&sm.RestoreSecretInput{SecretID: "active-restore"})
+	_, err = b.RestoreSecret(context.Background(), &sm.RestoreSecretInput{SecretID: "active-restore"})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter,
 		"restoring a non-deleted secret must return InvalidRequestException")
 }
@@ -709,16 +710,19 @@ func TestAudit_RestoreSecret_WritableAfterRestore(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "write-after-restore", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&sm.CreateSecretInput{Name: "write-after-restore", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "write-after-restore"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "write-after-restore"})
 	require.NoError(t, err)
 
-	_, err = b.RestoreSecret(&sm.RestoreSecretInput{SecretID: "write-after-restore"})
+	_, err = b.RestoreSecret(context.Background(), &sm.RestoreSecretInput{SecretID: "write-after-restore"})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:     "write-after-restore",
 		SecretString: "v2",
 	})
@@ -729,7 +733,7 @@ func TestAudit_RestoreSecret_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.RestoreSecret(&sm.RestoreSecretInput{SecretID: "missing"})
+	_, err := b.RestoreSecret(context.Background(), &sm.RestoreSecretInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -741,16 +745,16 @@ func TestAudit_UpdateSecret_Description(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "upd-desc", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "upd-desc", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.UpdateSecret(&sm.UpdateSecretInput{
+	_, err = b.UpdateSecret(context.Background(), &sm.UpdateSecretInput{
 		SecretID:    "upd-desc",
 		Description: "new description",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "upd-desc"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "upd-desc"})
 	require.NoError(t, err)
 	assert.Equal(t, "new description", desc.Description)
 }
@@ -759,16 +763,16 @@ func TestAudit_UpdateSecret_KmsKeyID(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "upd-kms", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "upd-kms", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.UpdateSecret(&sm.UpdateSecretInput{
+	_, err = b.UpdateSecret(context.Background(), &sm.UpdateSecretInput{
 		SecretID: "upd-kms",
 		KmsKeyID: "alias/new-key",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "upd-kms"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "upd-kms"})
 	require.NoError(t, err)
 	assert.Equal(t, "alias/new-key", desc.KmsKeyID)
 }
@@ -777,14 +781,14 @@ func TestAudit_UpdateSecret_ValueCreatesNewVersion(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "upd-val",
 		SecretString:       "v1",
 		ClientRequestToken: "v1-id",
 	})
 	require.NoError(t, err)
 
-	out, err := b.UpdateSecret(&sm.UpdateSecretInput{
+	out, err := b.UpdateSecret(context.Background(), &sm.UpdateSecretInput{
 		SecretID:           "upd-val",
 		SecretString:       "v2",
 		ClientRequestToken: "v2-id",
@@ -792,7 +796,7 @@ func TestAudit_UpdateSecret_ValueCreatesNewVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "v2-id", out.VersionID)
 
-	val, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "upd-val"})
+	val, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "upd-val"})
 	require.NoError(t, err)
 	assert.Equal(t, "v2", val.SecretString)
 }
@@ -801,12 +805,12 @@ func TestAudit_UpdateSecret_DeletedFails(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "upd-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "upd-del", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "upd-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "upd-del"})
 	require.NoError(t, err)
 
-	_, err = b.UpdateSecret(&sm.UpdateSecretInput{
+	_, err = b.UpdateSecret(context.Background(), &sm.UpdateSecretInput{
 		SecretID:    "upd-del",
 		Description: "new desc",
 	})
@@ -817,7 +821,7 @@ func TestAudit_UpdateSecret_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.UpdateSecret(&sm.UpdateSecretInput{
+	_, err := b.UpdateSecret(context.Background(), &sm.UpdateSecretInput{
 		SecretID:    "missing",
 		Description: "d",
 	})
@@ -832,7 +836,7 @@ func TestAudit_DescribeSecret_AllMetadataFields(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackendWithConfig("123456789012", "us-west-2")
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "full-desc",
 		Description:  "my description",
 		SecretString: "v",
@@ -841,7 +845,7 @@ func TestAudit_DescribeSecret_AllMetadataFields(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "full-desc"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "full-desc"})
 	require.NoError(t, err)
 	assert.Equal(t, "full-desc", desc.Name)
 	assert.Equal(t, "my description", desc.Description)
@@ -857,12 +861,12 @@ func TestAudit_DescribeSecret_DeletedSecretStillReturnsMetadata(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "desc-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "desc-del", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "desc-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "desc-del"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "desc-del"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "desc-del"})
 	require.NoError(t, err)
 	assert.NotNil(t, desc.DeletedDate, "DeletedDate must be present for deleted secrets")
 	assert.Equal(t, "desc-del", desc.Name)
@@ -872,7 +876,7 @@ func TestAudit_DescribeSecret_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "missing"})
+	_, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -880,21 +884,21 @@ func TestAudit_DescribeSecret_VersionIDsToStages(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "versions-check",
 		SecretString:       "v1",
 		ClientRequestToken: "ver-1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "versions-check",
 		SecretString:       "v2",
 		ClientRequestToken: "ver-2",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "versions-check"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "versions-check"})
 	require.NoError(t, err)
 	require.NotNil(t, desc.VersionIDsToStages)
 
@@ -906,10 +910,10 @@ func TestAudit_DescribeSecret_ARN(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	created, err := b.CreateSecret(&sm.CreateSecretInput{Name: "arn-desc", SecretString: "v"})
+	created, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "arn-desc", SecretString: "v"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "arn-desc"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "arn-desc"})
 	require.NoError(t, err)
 	assert.Equal(t, created.ARN, desc.ARN)
 }
@@ -922,7 +926,7 @@ func TestAudit_ListSecrets_Empty(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.ListSecrets(&sm.ListSecretsInput{})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{})
 	require.NoError(t, err)
 	assert.Empty(t, out.SecretList)
 }
@@ -932,11 +936,11 @@ func TestAudit_ListSecrets_Basic(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"a-secret", "b-secret", "c-secret"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{})
 	require.NoError(t, err)
 	assert.Len(t, out.SecretList, 3)
 }
@@ -946,7 +950,7 @@ func TestAudit_ListSecrets_MaxResultsZeroReturnsError(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	mr := int64(0)
-	_, err := b.ListSecrets(&sm.ListSecretsInput{MaxResults: &mr})
+	_, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{MaxResults: &mr})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter, "MaxResults=0 must be rejected")
 }
 
@@ -955,7 +959,7 @@ func TestAudit_ListSecrets_MaxResults101ReturnsError(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	mr := int64(101)
-	_, err := b.ListSecrets(&sm.ListSecretsInput{MaxResults: &mr})
+	_, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{MaxResults: &mr})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter, "MaxResults=101 must be rejected")
 }
 
@@ -974,7 +978,7 @@ func TestAudit_ListSecrets_Pagination(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for i := range 10 {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 			Name:         fmt.Sprintf("page-secret-%02d", i),
 			SecretString: "v",
 		})
@@ -982,12 +986,12 @@ func TestAudit_ListSecrets_Pagination(t *testing.T) {
 	}
 
 	mr := int64(3)
-	page1, err := b.ListSecrets(&sm.ListSecretsInput{MaxResults: &mr})
+	page1, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{MaxResults: &mr})
 	require.NoError(t, err)
 	assert.Len(t, page1.SecretList, 3)
 	assert.NotEmpty(t, page1.NextToken)
 
-	page2, err := b.ListSecrets(&sm.ListSecretsInput{
+	page2, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		MaxResults: &mr,
 		NextToken:  page1.NextToken,
 	})
@@ -1002,7 +1006,7 @@ func TestAudit_ListSecrets_Pagination(t *testing.T) {
 	for token != "" {
 		var pageErr error
 		var page *sm.ListSecretsOutput
-		page, pageErr = b.ListSecrets(&sm.ListSecretsInput{MaxResults: &mr, NextToken: token})
+		page, pageErr = b.ListSecrets(context.Background(), &sm.ListSecretsInput{MaxResults: &mr, NextToken: token})
 		require.NoError(t, pageErr)
 		all = append(all, page.SecretList...)
 		token = page.NextToken
@@ -1015,11 +1019,11 @@ func TestAudit_ListSecrets_SortAsc(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"charlie", "alpha", "bravo"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{SortOrder: "asc"})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{SortOrder: "asc"})
 	require.NoError(t, err)
 	require.Len(t, out.SecretList, 3)
 	assert.Equal(t, "alpha", out.SecretList[0].Name)
@@ -1031,11 +1035,11 @@ func TestAudit_ListSecrets_SortDesc(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"charlie", "alpha", "bravo"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{SortOrder: "desc"})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{SortOrder: "desc"})
 	require.NoError(t, err)
 	require.Len(t, out.SecretList, 3)
 	assert.Equal(t, "charlie", out.SecretList[0].Name)
@@ -1047,11 +1051,11 @@ func TestAudit_ListSecrets_FilterByNamePrefix(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"prod/db", "prod/api", "dev/db"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{{Key: "name", Values: []string{"prod/"}}},
 	})
 	require.NoError(t, err)
@@ -1062,20 +1066,20 @@ func TestAudit_ListSecrets_FilterByDescription(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "desc-match",
 		SecretString: "v",
 		Description:  "database credentials",
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&sm.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "no-match",
 		SecretString: "v",
 		Description:  "api key",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{{Key: "description", Values: []string{"database"}}},
 	})
 	require.NoError(t, err)
@@ -1087,19 +1091,19 @@ func TestAudit_ListSecrets_FilterByTagKey(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "tagged-secret",
 		SecretString: "v",
 		Tags:         []sm.Tag{{Key: "environment", Value: "prod"}},
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&sm.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "untagged",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{{Key: "tag-key", Values: []string{"environment"}}},
 	})
 	require.NoError(t, err)
@@ -1111,20 +1115,20 @@ func TestAudit_ListSecrets_FilterByTagValue(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "prod-secret",
 		SecretString: "v",
 		Tags:         []sm.Tag{{Key: "env", Value: "prod"}},
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&sm.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "dev-secret",
 		SecretString: "v",
 		Tags:         []sm.Tag{{Key: "env", Value: "dev"}},
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{
 		Filters: []sm.SecretFilter{{Key: "tag-value", Values: []string{"prod"}}},
 	})
 	require.NoError(t, err)
@@ -1136,18 +1140,18 @@ func TestAudit_ListSecrets_IncludeDeleted(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "alive", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "alive", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&sm.CreateSecretInput{Name: "dead", SecretString: "v"})
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "dead", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "dead"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "dead"})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{IncludeDeleted: true})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{IncludeDeleted: true})
 	require.NoError(t, err)
 	assert.Len(t, out.SecretList, 2)
 
-	out2, err := b.ListSecrets(&sm.ListSecretsInput{IncludeDeleted: false})
+	out2, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{IncludeDeleted: false})
 	require.NoError(t, err)
 	assert.Len(t, out2.SecretList, 1)
 }
@@ -1156,14 +1160,14 @@ func TestAudit_ListSecrets_SecretVersionsToStages(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "stages-list",
 		SecretString:       "v1",
 		ClientRequestToken: "ver-1",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{})
 	require.NoError(t, err)
 	require.Len(t, out.SecretList, 1)
 
@@ -1180,21 +1184,21 @@ func TestAudit_ListSecretVersionIds_Basic(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "lvid-basic",
 		SecretString:       "v1",
 		ClientRequestToken: "v1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "lvid-basic",
 		SecretString:       "v2",
 		ClientRequestToken: "v2",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{SecretID: "lvid-basic"})
+	out, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{SecretID: "lvid-basic"})
 	require.NoError(t, err)
 	// Only labeled versions by default (v1=AWSPREVIOUS, v2=AWSCURRENT)
 	assert.Len(t, out.Versions, 2)
@@ -1204,11 +1208,11 @@ func TestAudit_ListSecretVersionIds_MaxResultsInvalid(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "lvid-mr", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "lvid-mr", SecretString: "v"})
 	require.NoError(t, err)
 
 	mr := int64(0)
-	_, err = b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{
+	_, err = b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{
 		SecretID:   "lvid-mr",
 		MaxResults: &mr,
 	})
@@ -1219,7 +1223,7 @@ func TestAudit_ListSecretVersionIds_IncludeDeprecated(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "lvid-depr",
 		SecretString:       "v1",
 		ClientRequestToken: "v1",
@@ -1228,7 +1232,7 @@ func TestAudit_ListSecretVersionIds_IncludeDeprecated(t *testing.T) {
 
 	// Rotate 3 times to create unlabeled versions
 	for i := 2; i <= 4; i++ {
-		_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+		_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 			SecretID:           "lvid-depr",
 			SecretString:       fmt.Sprintf("v%d", i),
 			ClientRequestToken: fmt.Sprintf("v%d", i),
@@ -1236,10 +1240,10 @@ func TestAudit_ListSecretVersionIds_IncludeDeprecated(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	outNormal, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{SecretID: "lvid-depr"})
+	outNormal, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{SecretID: "lvid-depr"})
 	require.NoError(t, err)
 
-	outAll, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{
+	outAll, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{
 		SecretID:          "lvid-depr",
 		IncludeDeprecated: true,
 	})
@@ -1252,7 +1256,7 @@ func TestAudit_ListSecretVersionIds_SortedNewestFirst(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "lvid-sort",
 		SecretString:       "v1",
 		ClientRequestToken: "v1",
@@ -1261,14 +1265,14 @@ func TestAudit_ListSecretVersionIds_SortedNewestFirst(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "lvid-sort",
 		SecretString:       "v2",
 		ClientRequestToken: "v2",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{SecretID: "lvid-sort"})
+	out, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{SecretID: "lvid-sort"})
 	require.NoError(t, err)
 	require.Len(t, out.Versions, 2)
 	// Newest (v2 = AWSCURRENT) should be first
@@ -1279,7 +1283,7 @@ func TestAudit_ListSecretVersionIds_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{SecretID: "missing"})
+	_, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -1287,7 +1291,7 @@ func TestAudit_ListSecretVersionIds_Pagination(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "lvid-pages",
 		SecretString:       "v1",
 		ClientRequestToken: "v1",
@@ -1295,7 +1299,7 @@ func TestAudit_ListSecretVersionIds_Pagination(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 2; i <= 5; i++ {
-		_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+		_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 			SecretID:           "lvid-pages",
 			SecretString:       fmt.Sprintf("v%d", i),
 			ClientRequestToken: fmt.Sprintf("v%d", i),
@@ -1305,7 +1309,7 @@ func TestAudit_ListSecretVersionIds_Pagination(t *testing.T) {
 
 	// Use IncludeDeprecated to surface all 5 versions (v1-v3 are unlabeled/deprecated).
 	mr := int64(2)
-	page1, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{
+	page1, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{
 		SecretID:          "lvid-pages",
 		MaxResults:        &mr,
 		IncludeDeprecated: true,
@@ -1323,16 +1327,16 @@ func TestAudit_TagResource_AddTags(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "tag-add", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "tag-add", SecretString: "v"})
 	require.NoError(t, err)
 
-	err = b.TagResource(&sm.TagResourceInput{
+	err = b.TagResource(context.Background(), &sm.TagResourceInput{
 		SecretID: "tag-add",
 		Tags:     []sm.Tag{{Key: "team", Value: "platform"}, {Key: "env", Value: "prod"}},
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "tag-add"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "tag-add"})
 	require.NoError(t, err)
 	require.NotNil(t, desc.Tags)
 	tagMap := desc.Tags.Clone()
@@ -1344,20 +1348,20 @@ func TestAudit_TagResource_UpdateExistingTag(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "tag-upd",
 		SecretString: "v",
 		Tags:         []sm.Tag{{Key: "env", Value: "staging"}},
 	})
 	require.NoError(t, err)
 
-	err = b.TagResource(&sm.TagResourceInput{
+	err = b.TagResource(context.Background(), &sm.TagResourceInput{
 		SecretID: "tag-upd",
 		Tags:     []sm.Tag{{Key: "env", Value: "prod"}},
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "tag-upd"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "tag-upd"})
 	require.NoError(t, err)
 	tagMap := desc.Tags.Clone()
 	assert.Equal(t, "prod", tagMap["env"])
@@ -1372,7 +1376,7 @@ func TestAudit_TagResource_LimitEnforced(t *testing.T) {
 	for i := range initial {
 		initial[i] = sm.Tag{Key: fmt.Sprintf("k%d", i), Value: "v"}
 	}
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "tag-limit",
 		SecretString: "v",
 		Tags:         initial,
@@ -1381,7 +1385,7 @@ func TestAudit_TagResource_LimitEnforced(t *testing.T) {
 
 	// Add 3 more (would be 51 total)
 	extra := []sm.Tag{{Key: "e1", Value: "v"}, {Key: "e2", Value: "v"}, {Key: "e3", Value: "v"}}
-	err = b.TagResource(&sm.TagResourceInput{SecretID: "tag-limit", Tags: extra})
+	err = b.TagResource(context.Background(), &sm.TagResourceInput{SecretID: "tag-limit", Tags: extra})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter, "must reject tags that exceed the 50-tag limit")
 }
 
@@ -1389,20 +1393,20 @@ func TestAudit_UntagResource_RemoveTag(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "tag-rm",
 		SecretString: "v",
 		Tags:         []sm.Tag{{Key: "env", Value: "prod"}, {Key: "team", Value: "platform"}},
 	})
 	require.NoError(t, err)
 
-	err = b.UntagResource(&sm.UntagResourceInput{
+	err = b.UntagResource(context.Background(), &sm.UntagResourceInput{
 		SecretID: "tag-rm",
 		TagKeys:  []string{"env"},
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "tag-rm"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "tag-rm"})
 	require.NoError(t, err)
 	tagMap := desc.Tags.Clone()
 	_, hasEnv := tagMap["env"]
@@ -1415,12 +1419,12 @@ func TestAudit_TagResource_DeletedSecret(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "tag-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "tag-del", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "tag-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "tag-del"})
 	require.NoError(t, err)
 
-	err = b.TagResource(&sm.TagResourceInput{
+	err = b.TagResource(context.Background(), &sm.TagResourceInput{
 		SecretID: "tag-del",
 		Tags:     []sm.Tag{{Key: "k", Value: "v"}},
 	})
@@ -1431,7 +1435,7 @@ func TestAudit_TagResource_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	err := b.TagResource(&sm.TagResourceInput{
+	err := b.TagResource(context.Background(), &sm.TagResourceInput{
 		SecretID: "missing",
 		Tags:     []sm.Tag{{Key: "k", Value: "v"}},
 	})
@@ -1446,14 +1450,14 @@ func TestAudit_RotateSecret_CreatesNewVersion(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "rot-new-ver",
 		SecretString:       "original",
 		ClientRequestToken: "ver-orig",
 	})
 	require.NoError(t, err)
 
-	out, err := b.RotateSecret(&sm.RotateSecretInput{SecretID: "rot-new-ver"})
+	out, err := b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "rot-new-ver"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, out.VersionID)
 	assert.NotEqual(t, "ver-orig", out.VersionID)
@@ -1463,17 +1467,17 @@ func TestAudit_RotateSecret_AWSCURRENTPromotedAWSPREVIOUS(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "rot-stages",
 		SecretString:       "v1",
 		ClientRequestToken: "v1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{SecretID: "rot-stages"})
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "rot-stages"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rot-stages"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rot-stages"})
 	require.NoError(t, err)
 
 	var hasCurrent, hasPrevious bool
@@ -1498,13 +1502,13 @@ func TestAudit_RotateSecret_LastRotatedDateUpdated(t *testing.T) {
 
 	before := time.Now()
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "rot-date", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "rot-date", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{SecretID: "rot-date"})
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "rot-date"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rot-date"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rot-date"})
 	require.NoError(t, err)
 	require.NotNil(t, desc.LastRotatedDate)
 	// UnixTimeFloat stores nanoseconds/1e9; recover with int64(f*1e9) nanoseconds.
@@ -1517,13 +1521,13 @@ func TestAudit_RotateSecret_RotationEnabledAfterRotate(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "rot-enabled", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "rot-enabled", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{SecretID: "rot-enabled"})
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "rot-enabled"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rot-enabled"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rot-enabled"})
 	require.NoError(t, err)
 	assert.True(t, desc.RotationEnabled)
 }
@@ -1532,7 +1536,7 @@ func TestAudit_RotateSecret_RotateImmediatelyFalse(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "rot-no-imm",
 		SecretString:       "v1",
 		ClientRequestToken: "v1",
@@ -1541,7 +1545,7 @@ func TestAudit_RotateSecret_RotateImmediatelyFalse(t *testing.T) {
 
 	noImm := false
 	days := int64(30)
-	_, err = b.RotateSecret(&sm.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 		SecretID:          "rot-no-imm",
 		RotateImmediately: &noImm,
 		RotationRules: &sm.RotationRulesType{
@@ -1551,7 +1555,7 @@ func TestAudit_RotateSecret_RotateImmediatelyFalse(t *testing.T) {
 	require.NoError(t, err)
 
 	// Value must still be v1 (no immediate rotation)
-	val, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "rot-no-imm"})
+	val, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "rot-no-imm"})
 	require.NoError(t, err)
 	assert.Equal(t, "v1", val.SecretString)
 }
@@ -1560,16 +1564,16 @@ func TestAudit_RotateSecret_LambdaARNStored(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "rot-lambda", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "rot-lambda", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{
 		SecretID:          "rot-lambda",
 		RotationLambdaARN: "arn:aws:lambda:us-east-1:123456789012:function:MyRotator",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rot-lambda"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rot-lambda"})
 	require.NoError(t, err)
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:MyRotator", desc.RotationLambdaARN)
 }
@@ -1578,7 +1582,7 @@ func TestAudit_RotateSecret_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.RotateSecret(&sm.RotateSecretInput{SecretID: "missing"})
+	_, err := b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -1586,12 +1590,12 @@ func TestAudit_RotateSecret_DeletedFails(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "rot-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "rot-del", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "rot-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "rot-del"})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{SecretID: "rot-del"})
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "rot-del"})
 	require.ErrorIs(t, err, sm.ErrSecretDeleted)
 }
 
@@ -1603,11 +1607,11 @@ func TestAudit_CancelRotateSecret_RemovesAWSPENDING(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cancel-rot", SecretString: "v1"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "cancel-rot", SecretString: "v1"})
 	require.NoError(t, err)
 
 	// Put a version with AWSPENDING
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "cancel-rot",
 		SecretString:       "v2",
 		ClientRequestToken: "v2-pending",
@@ -1615,11 +1619,11 @@ func TestAudit_CancelRotateSecret_RemovesAWSPENDING(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = b.CancelRotateSecret(&sm.CancelRotateSecretInput{SecretID: "cancel-rot"})
+	_, err = b.CancelRotateSecret(context.Background(), &sm.CancelRotateSecretInput{SecretID: "cancel-rot"})
 	require.NoError(t, err)
 
 	// Confirm AWSPENDING is gone
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "cancel-rot"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "cancel-rot"})
 	require.NoError(t, err)
 
 	for _, labels := range desc.VersionIDsToStages {
@@ -1633,16 +1637,16 @@ func TestAudit_CancelRotateSecret_SetsRotationDisabled(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "cancel-enabled", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "cancel-enabled", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&sm.RotateSecretInput{SecretID: "cancel-enabled"})
+	_, err = b.RotateSecret(context.Background(), &sm.RotateSecretInput{SecretID: "cancel-enabled"})
 	require.NoError(t, err)
 
-	_, err = b.CancelRotateSecret(&sm.CancelRotateSecretInput{SecretID: "cancel-enabled"})
+	_, err = b.CancelRotateSecret(context.Background(), &sm.CancelRotateSecretInput{SecretID: "cancel-enabled"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "cancel-enabled"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "cancel-enabled"})
 	require.NoError(t, err)
 	assert.False(t, desc.RotationEnabled)
 }
@@ -1651,7 +1655,7 @@ func TestAudit_CancelRotateSecret_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CancelRotateSecret(&sm.CancelRotateSecretInput{SecretID: "missing"})
+	_, err := b.CancelRotateSecret(context.Background(), &sm.CancelRotateSecretInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -1667,27 +1671,27 @@ func TestAudit_ResourcePolicy_PutGetDelete(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "policy-secret", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "policy-secret", SecretString: "v"})
 	require.NoError(t, err)
 
 	// Put
-	_, err = b.PutResourcePolicy(&sm.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &sm.PutResourcePolicyInput{
 		SecretID:       "policy-secret",
 		ResourcePolicy: validPolicy,
 	})
 	require.NoError(t, err)
 
 	// Get
-	out, err := b.GetResourcePolicy(&sm.GetResourcePolicyInput{SecretID: "policy-secret"})
+	out, err := b.GetResourcePolicy(context.Background(), &sm.GetResourcePolicyInput{SecretID: "policy-secret"})
 	require.NoError(t, err)
 	assert.JSONEq(t, validPolicy, out.ResourcePolicy)
 
 	// Delete
-	_, err = b.DeleteResourcePolicy(&sm.DeleteResourcePolicyInput{SecretID: "policy-secret"})
+	_, err = b.DeleteResourcePolicy(context.Background(), &sm.DeleteResourcePolicyInput{SecretID: "policy-secret"})
 	require.NoError(t, err)
 
 	// Get after delete returns empty
-	out2, err := b.GetResourcePolicy(&sm.GetResourcePolicyInput{SecretID: "policy-secret"})
+	out2, err := b.GetResourcePolicy(context.Background(), &sm.GetResourcePolicyInput{SecretID: "policy-secret"})
 	require.NoError(t, err)
 	assert.Empty(t, out2.ResourcePolicy)
 }
@@ -1696,10 +1700,10 @@ func TestAudit_ResourcePolicy_EmptyPolicyRejected(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "policy-empty", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "policy-empty", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.PutResourcePolicy(&sm.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &sm.PutResourcePolicyInput{
 		SecretID:       "policy-empty",
 		ResourcePolicy: "",
 	})
@@ -1710,16 +1714,16 @@ func TestAudit_ResourcePolicy_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.GetResourcePolicy(&sm.GetResourcePolicyInput{SecretID: "missing"})
+	_, err := b.GetResourcePolicy(context.Background(), &sm.GetResourcePolicyInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 
-	_, err = b.PutResourcePolicy(&sm.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &sm.PutResourcePolicyInput{
 		SecretID:       "missing",
 		ResourcePolicy: validPolicy,
 	})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 
-	_, err = b.DeleteResourcePolicy(&sm.DeleteResourcePolicyInput{SecretID: "missing"})
+	_, err = b.DeleteResourcePolicy(context.Background(), &sm.DeleteResourcePolicyInput{SecretID: "missing"})
 	require.ErrorIs(t, err, sm.ErrSecretNotFound)
 }
 
@@ -1727,12 +1731,12 @@ func TestAudit_ResourcePolicy_DeletedSecretRejected(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "policy-del", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "policy-del", SecretString: "v"})
 	require.NoError(t, err)
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: "policy-del"})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: "policy-del"})
 	require.NoError(t, err)
 
-	_, err = b.PutResourcePolicy(&sm.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &sm.PutResourcePolicyInput{
 		SecretID:       "policy-del",
 		ResourcePolicy: validPolicy,
 	})
@@ -1747,7 +1751,7 @@ func TestAudit_ValidateResourcePolicy_ValidPasses(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	out, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		ResourcePolicy: validPolicy,
 	})
 	require.NoError(t, err)
@@ -1759,7 +1763,7 @@ func TestAudit_ValidateResourcePolicy_MissingVersion(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	out, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		ResourcePolicy: `{"Statement":[]}`,
 	})
 	require.NoError(t, err)
@@ -1771,7 +1775,7 @@ func TestAudit_ValidateResourcePolicy_MissingStatement(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	out, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		ResourcePolicy: `{"Version":"2012-10-17"}`,
 	})
 	require.NoError(t, err)
@@ -1782,7 +1786,7 @@ func TestAudit_ValidateResourcePolicy_InvalidJSON(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	out, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		ResourcePolicy: `not-json`,
 	})
 	require.NoError(t, err)
@@ -1793,7 +1797,7 @@ func TestAudit_ValidateResourcePolicy_Empty(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	_, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		ResourcePolicy: "",
 	})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter)
@@ -1803,10 +1807,10 @@ func TestAudit_ValidateResourcePolicy_WithSecretID(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "val-pol-secret", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "val-pol-secret", SecretString: "v"})
 	require.NoError(t, err)
 
-	out, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	out, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		SecretID:       "val-pol-secret",
 		ResourcePolicy: validPolicy,
 	})
@@ -1818,7 +1822,7 @@ func TestAudit_ValidateResourcePolicy_SecretIDNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.ValidateResourcePolicy(&sm.ValidateResourcePolicyInput{
+	_, err := b.ValidateResourcePolicy(context.Background(), &sm.ValidateResourcePolicyInput{
 		SecretID:       "missing",
 		ResourcePolicy: validPolicy,
 	})
@@ -1833,26 +1837,26 @@ func TestAudit_Replication_AddThenRemove(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "rep-add-rm", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "rep-add-rm", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.ReplicateSecretToRegions(&sm.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &sm.ReplicateSecretToRegionsInput{
 		SecretID:          "rep-add-rm",
 		AddReplicaRegions: []sm.ReplicaRegion{{Region: "eu-west-1"}},
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-add-rm"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-add-rm"})
 	require.NoError(t, err)
 	assert.Len(t, desc.ReplicationStatus, 1)
 
-	_, err = b.RemoveRegionsFromReplication(&sm.RemoveRegionsFromReplicationInput{
+	_, err = b.RemoveRegionsFromReplication(context.Background(), &sm.RemoveRegionsFromReplicationInput{
 		SecretID:             "rep-add-rm",
 		RemoveReplicaRegions: []string{"eu-west-1"},
 	})
 	require.NoError(t, err)
 
-	desc2, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-add-rm"})
+	desc2, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-add-rm"})
 	require.NoError(t, err)
 	assert.Empty(t, desc2.ReplicationStatus)
 }
@@ -1861,7 +1865,7 @@ func TestAudit_Replication_InSyncWithValue(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "rep-insync",
 		SecretString: "v",
 		AddReplicaRegions: []sm.ReplicaRegion{
@@ -1870,7 +1874,7 @@ func TestAudit_Replication_InSyncWithValue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-insync"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-insync"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 1)
 	assert.Equal(t, "InSync", desc.ReplicationStatus[0].Status)
@@ -1880,7 +1884,7 @@ func TestAudit_Replication_FailedWithoutValue(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name: "rep-failed",
 		AddReplicaRegions: []sm.ReplicaRegion{
 			{Region: "us-west-1"},
@@ -1888,7 +1892,7 @@ func TestAudit_Replication_FailedWithoutValue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-failed"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-failed"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 1)
 	assert.NotEqual(t, "InSync", desc.ReplicationStatus[0].Status)
@@ -1898,17 +1902,17 @@ func TestAudit_Replication_StopReplication(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:              "rep-stop",
 		SecretString:      "v",
 		AddReplicaRegions: []sm.ReplicaRegion{{Region: "ca-central-1"}},
 	})
 	require.NoError(t, err)
 
-	_, err = b.StopReplicationToReplica(&sm.StopReplicationToReplicaInput{SecretID: "rep-stop"})
+	_, err = b.StopReplicationToReplica(context.Background(), &sm.StopReplicationToReplicaInput{SecretID: "rep-stop"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-stop"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-stop"})
 	require.NoError(t, err)
 	assert.Empty(t, desc.ReplicationStatus, "StopReplicationToReplica must clear replication config")
 }
@@ -1918,25 +1922,25 @@ func TestAudit_Replication_UpdatedAfterPutSecretValue(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	// Create without value but with replica
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:              "rep-update",
 		AddReplicaRegions: []sm.ReplicaRegion{{Region: "sa-east-1"}},
 	})
 	require.NoError(t, err)
 
-	desc1, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-update"})
+	desc1, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-update"})
 	require.NoError(t, err)
 	require.Len(t, desc1.ReplicationStatus, 1)
 	assert.NotEqual(t, "InSync", desc1.ReplicationStatus[0].Status, "should not be InSync without value")
 
 	// Now add a value
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:     "rep-update",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
 
-	desc2, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "rep-update"})
+	desc2, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "rep-update"})
 	require.NoError(t, err)
 	require.Len(t, desc2.ReplicationStatus, 1)
 	assert.Equal(t, "InSync", desc2.ReplicationStatus[0].Status, "should be InSync after value added")
@@ -1946,7 +1950,7 @@ func TestAudit_Replication_NotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.ReplicateSecretToRegions(&sm.ReplicateSecretToRegionsInput{
+	_, err := b.ReplicateSecretToRegions(context.Background(), &sm.ReplicateSecretToRegionsInput{
 		SecretID:          "missing",
 		AddReplicaRegions: []sm.ReplicaRegion{{Region: "eu-west-1"}},
 	})
@@ -1961,14 +1965,14 @@ func TestAudit_UpdateSecretVersionStage_MoveCustomLabel(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "usvs-move",
 		SecretString:       "v1",
 		ClientRequestToken: "ver-1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "usvs-move",
 		SecretString:       "v2",
 		ClientRequestToken: "ver-2",
@@ -1976,7 +1980,7 @@ func TestAudit_UpdateSecretVersionStage_MoveCustomLabel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Move AWSPREVIOUS from ver-1 to ver-2
-	_, err = b.UpdateSecretVersionStage(&sm.UpdateSecretVersionStageInput{
+	_, err = b.UpdateSecretVersionStage(context.Background(), &sm.UpdateSecretVersionStageInput{
 		SecretID:            "usvs-move",
 		VersionStage:        "AWSPREVIOUS",
 		MoveToVersionID:     "ver-2",
@@ -1984,7 +1988,7 @@ func TestAudit_UpdateSecretVersionStage_MoveCustomLabel(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "usvs-move"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "usvs-move"})
 	require.NoError(t, err)
 	assert.Contains(t, desc.VersionIDsToStages["ver-2"], "AWSPREVIOUS")
 }
@@ -1993,14 +1997,14 @@ func TestAudit_UpdateSecretVersionStage_RemoveLabel(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "usvs-rm",
 		SecretString:       "v1",
 		ClientRequestToken: "ver-1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+	_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 		SecretID:           "usvs-rm",
 		SecretString:       "v2",
 		ClientRequestToken: "ver-2",
@@ -2008,14 +2012,14 @@ func TestAudit_UpdateSecretVersionStage_RemoveLabel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove AWSPREVIOUS from ver-1
-	_, err = b.UpdateSecretVersionStage(&sm.UpdateSecretVersionStageInput{
+	_, err = b.UpdateSecretVersionStage(context.Background(), &sm.UpdateSecretVersionStageInput{
 		SecretID:            "usvs-rm",
 		VersionStage:        "AWSPREVIOUS",
 		RemoveFromVersionID: "ver-1",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "usvs-rm"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "usvs-rm"})
 	require.NoError(t, err)
 	for _, l := range desc.VersionIDsToStages["ver-1"] {
 		assert.NotEqual(t, "AWSPREVIOUS", l, "AWSPREVIOUS must be removed from ver-1")
@@ -2026,10 +2030,10 @@ func TestAudit_UpdateSecretVersionStage_TargetNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "usvs-miss", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "usvs-miss", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.UpdateSecretVersionStage(&sm.UpdateSecretVersionStageInput{
+	_, err = b.UpdateSecretVersionStage(context.Background(), &sm.UpdateSecretVersionStageInput{
 		SecretID:        "usvs-miss",
 		VersionStage:    "AWSPENDING",
 		MoveToVersionID: "nonexistent",
@@ -2041,7 +2045,7 @@ func TestAudit_UpdateSecretVersionStage_SecretNotFound(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.UpdateSecretVersionStage(&sm.UpdateSecretVersionStageInput{
+	_, err := b.UpdateSecretVersionStage(context.Background(), &sm.UpdateSecretVersionStageInput{
 		SecretID:        "missing",
 		VersionStage:    "AWSPENDING",
 		MoveToVersionID: "ver-1",
@@ -2058,7 +2062,7 @@ func TestAudit_BatchGetSecretValue_MaxResultsTooHigh(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	mr := int32(21)
-	_, err := b.BatchGetSecretValue(&sm.BatchGetSecretValueInput{MaxResults: &mr})
+	_, err := b.BatchGetSecretValue(context.Background(), &sm.BatchGetSecretValueInput{MaxResults: &mr})
 	require.ErrorIs(t, err, sm.ErrInvalidParameter, "BatchGetSecretValue MaxResults>20 must fail")
 }
 
@@ -2077,11 +2081,11 @@ func TestAudit_BatchGetSecretValue_ByIDList(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"bg-s1", "bg-s2"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: name + "-val"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: name + "-val"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.BatchGetSecretValue(&sm.BatchGetSecretValueInput{
+	out, err := b.BatchGetSecretValue(context.Background(), &sm.BatchGetSecretValueInput{
 		SecretIDList: []string{"bg-s1", "bg-s2"},
 	})
 	require.NoError(t, err)
@@ -2093,10 +2097,10 @@ func TestAudit_BatchGetSecretValue_MissingInErrors(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "bg-good", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "bg-good", SecretString: "v"})
 	require.NoError(t, err)
 
-	out, err := b.BatchGetSecretValue(&sm.BatchGetSecretValueInput{
+	out, err := b.BatchGetSecretValue(context.Background(), &sm.BatchGetSecretValueInput{
 		SecretIDList: []string{"bg-good", "bg-missing"},
 	})
 	require.NoError(t, err)
@@ -2109,18 +2113,18 @@ func TestAudit_BatchGetSecretValue_ByFilter(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "bg-filter-match",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&sm.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "other-name",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
 
-	out, err := b.BatchGetSecretValue(&sm.BatchGetSecretValueInput{
+	out, err := b.BatchGetSecretValue(context.Background(), &sm.BatchGetSecretValueInput{
 		Filters: []sm.BatchGetSecretValueFilter{
 			{Key: "name", Values: []string{"bg-filter-match"}},
 		},
@@ -2292,13 +2296,13 @@ func TestAudit_ARN_GetByARN(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	created, err := b.CreateSecret(&sm.CreateSecretInput{
+	created, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "arn-get",
 		SecretString: "secret-value",
 	})
 	require.NoError(t, err)
 
-	out, err := b.GetSecretValue(&sm.GetSecretValueInput{SecretID: created.ARN})
+	out, err := b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: created.ARN})
 	require.NoError(t, err)
 	assert.Equal(t, "secret-value", out.SecretString)
 	assert.Equal(t, "arn-get", out.Name)
@@ -2308,10 +2312,10 @@ func TestAudit_ARN_DescribeByARN(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	created, err := b.CreateSecret(&sm.CreateSecretInput{Name: "arn-describe", SecretString: "v"})
+	created, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "arn-describe", SecretString: "v"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: created.ARN})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: created.ARN})
 	require.NoError(t, err)
 	assert.Equal(t, "arn-describe", desc.Name)
 }
@@ -2320,13 +2324,13 @@ func TestAudit_ARN_DeleteByARN(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	created, err := b.CreateSecret(&sm.CreateSecretInput{Name: "arn-delete", SecretString: "v"})
+	created, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "arn-delete", SecretString: "v"})
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&sm.DeleteSecretInput{SecretID: created.ARN})
+	_, err = b.DeleteSecret(context.Background(), &sm.DeleteSecretInput{SecretID: created.ARN})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "arn-delete"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "arn-delete"})
 	require.NoError(t, err)
 	assert.NotNil(t, desc.DeletedDate)
 }
@@ -2335,7 +2339,7 @@ func TestAudit_ARN_ContainsNameAndSuffix(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	out, err := b.CreateSecret(&sm.CreateSecretInput{Name: "my-secret-name", SecretString: "v"})
+	out, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "my-secret-name", SecretString: "v"})
 	require.NoError(t, err)
 	assert.Contains(t, out.ARN, "my-secret-name")
 	assert.Contains(t, out.ARN, "arn:aws:secretsmanager:")
@@ -2349,7 +2353,7 @@ func TestAudit_VersionPruning_MaxVersionsRetained(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:               "prune-test",
 		SecretString:       "v0",
 		ClientRequestToken: "v0",
@@ -2358,7 +2362,7 @@ func TestAudit_VersionPruning_MaxVersionsRetained(t *testing.T) {
 
 	// Add 105 more versions (total 106 — well over the 100 limit)
 	for i := 1; i <= 105; i++ {
-		_, err = b.PutSecretValue(&sm.PutSecretValueInput{
+		_, err = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 			SecretID:           "prune-test",
 			SecretString:       fmt.Sprintf("v%d", i),
 			ClientRequestToken: fmt.Sprintf("v%d", i),
@@ -2366,7 +2370,7 @@ func TestAudit_VersionPruning_MaxVersionsRetained(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{
+	out, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{
 		SecretID:          "prune-test",
 		IncludeDeprecated: true,
 	})
@@ -2384,26 +2388,26 @@ func TestAudit_KmsKeyID_RoundTrip(t *testing.T) {
 	b := sm.NewInMemoryBackend()
 	const kmsKey = "arn:aws:kms:us-east-1:123456789012:key/my-key-id"
 
-	_, err := b.CreateSecret(&sm.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{
 		Name:         "kms-rt",
 		SecretString: "v",
 		KmsKeyID:     kmsKey,
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "kms-rt"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "kms-rt"})
 	require.NoError(t, err)
 	assert.Equal(t, kmsKey, desc.KmsKeyID)
 
 	// Update KmsKeyId
 	const newKmsKey = "alias/new-key"
-	_, err = b.UpdateSecret(&sm.UpdateSecretInput{
+	_, err = b.UpdateSecret(context.Background(), &sm.UpdateSecretInput{
 		SecretID: "kms-rt",
 		KmsKeyID: newKmsKey,
 	})
 	require.NoError(t, err)
 
-	desc2, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "kms-rt"})
+	desc2, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "kms-rt"})
 	require.NoError(t, err)
 	assert.Equal(t, newKmsKey, desc2.KmsKeyID)
 }
@@ -2425,17 +2429,17 @@ func TestAudit_Concurrent_CreateAndRead(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			name := fmt.Sprintf("concurrent-%d", i)
-			_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+			_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 			if err != nil {
 				return
 			}
-			_, _ = b.GetSecretValue(&sm.GetSecretValueInput{SecretID: name})
+			_, _ = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: name})
 		}(i)
 	}
 
 	wg.Wait()
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{})
 	require.NoError(t, err)
 	assert.Len(t, out.SecretList, workers)
 }
@@ -2444,7 +2448,7 @@ func TestAudit_Concurrent_PutSecretValue(t *testing.T) {
 	t.Parallel()
 
 	b := sm.NewInMemoryBackend()
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "concurrent-put", SecretString: "v0"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "concurrent-put", SecretString: "v0"})
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -2454,7 +2458,7 @@ func TestAudit_Concurrent_PutSecretValue(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, _ = b.PutSecretValue(&sm.PutSecretValueInput{
+			_, _ = b.PutSecretValue(context.Background(), &sm.PutSecretValueInput{
 				SecretID:           "concurrent-put",
 				SecretString:       fmt.Sprintf("v%d", i),
 				ClientRequestToken: fmt.Sprintf("tok-%d", i),
@@ -2465,7 +2469,7 @@ func TestAudit_Concurrent_PutSecretValue(t *testing.T) {
 	wg.Wait()
 
 	// Must still be accessible
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "concurrent-put"})
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "concurrent-put"})
 	require.NoError(t, err)
 }
 
@@ -2596,7 +2600,7 @@ func TestAudit_HTTP_TagAndUntag(t *testing.T) {
 		`{"SecretId":"http-tags","TagKeys":["env"]}`)
 	require.Equal(t, http.StatusOK, rec2.Code)
 
-	desc, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "http-tags"})
+	desc, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "http-tags"})
 	require.NoError(t, err)
 	if desc.Tags != nil {
 		tagMap := desc.Tags.Clone()
@@ -2649,14 +2653,14 @@ func TestAudit_Reset_ClearsAll(t *testing.T) {
 
 	b := sm.NewInMemoryBackend()
 	for _, name := range []string{"r1", "r2", "r3"} {
-		_, err := b.CreateSecret(&sm.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
 	h := sm.NewHandler(b)
 	h.Reset()
 
-	out, err := b.ListSecrets(&sm.ListSecretsInput{})
+	out, err := b.ListSecrets(context.Background(), &sm.ListSecretsInput{})
 	require.NoError(t, err)
 	assert.Empty(t, out.SecretList)
 }

--- a/services/secretsmanager/export_test.go
+++ b/services/secretsmanager/export_test.go
@@ -2,28 +2,43 @@ package secretsmanager
 
 import "time"
 
-// SecretCount returns the number of secrets in the backend.
+// SecretCount returns the total number of secrets in the backend across all regions.
 func SecretCount(b *InMemoryBackend) int {
 	b.mu.RLock("SecretCount")
 	defer b.mu.RUnlock()
 
-	return len(b.secrets)
+	total := 0
+	for _, regionSecrets := range b.secrets {
+		total += len(regionSecrets)
+	}
+
+	return total
 }
 
-// ResourcePolicyCount returns the number of resource policies in the backend.
+// ResourcePolicyCount returns the total number of resource policies across all regions.
 func ResourcePolicyCount(b *InMemoryBackend) int {
 	b.mu.RLock("ResourcePolicyCount")
 	defer b.mu.RUnlock()
 
-	return len(b.resourcePolicies)
+	total := 0
+	for _, regionPolicies := range b.resourcePolicies {
+		total += len(regionPolicies)
+	}
+
+	return total
 }
 
-// ReplicationConfigCount returns the number of replication configs in the backend.
+// ReplicationConfigCount returns the total number of replication configs across all regions.
 func ReplicationConfigCount(b *InMemoryBackend) int {
 	b.mu.RLock("ReplicationConfigCount")
 	defer b.mu.RUnlock()
 
-	return len(b.replicationConfigs)
+	total := 0
+	for _, regionConfigs := range b.replicationConfigs {
+		total += len(regionConfigs)
+	}
+
+	return total
 }
 
 // HandlerOpsLen returns the number of operations registered in the handler dispatch table.

--- a/services/secretsmanager/handler.go
+++ b/services/secretsmanager/handler.go
@@ -250,147 +250,147 @@ type smActionFn func(ctx context.Context, region string, body []byte) (any, erro
 
 func (h *Handler) smExtendedActions() map[string]smActionFn {
 	return map[string]smActionFn{
-		"GetResourcePolicy": func(_ context.Context, _ string, b []byte) (any, error) {
+		"GetResourcePolicy": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input GetResourcePolicyInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.GetResourcePolicy(&input)
+			return h.Backend.GetResourcePolicy(ctx, &input)
 		},
-		"PutResourcePolicy": func(_ context.Context, _ string, b []byte) (any, error) {
+		"PutResourcePolicy": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input PutResourcePolicyInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.PutResourcePolicy(&input)
+			return h.Backend.PutResourcePolicy(ctx, &input)
 		},
-		"DeleteResourcePolicy": func(_ context.Context, _ string, b []byte) (any, error) {
+		"DeleteResourcePolicy": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input DeleteResourcePolicyInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.DeleteResourcePolicy(&input)
+			return h.Backend.DeleteResourcePolicy(ctx, &input)
 		},
-		"BatchGetSecretValue": func(_ context.Context, _ string, b []byte) (any, error) {
+		"BatchGetSecretValue": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input BatchGetSecretValueInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.BatchGetSecretValue(&input)
+			return h.Backend.BatchGetSecretValue(ctx, &input)
 		},
-		"CancelRotateSecret": func(_ context.Context, _ string, b []byte) (any, error) {
+		"CancelRotateSecret": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input CancelRotateSecretInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.CancelRotateSecret(&input)
+			return h.Backend.CancelRotateSecret(ctx, &input)
 		},
-		"ReplicateSecretToRegions": func(_ context.Context, _ string, b []byte) (any, error) {
+		"ReplicateSecretToRegions": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input ReplicateSecretToRegionsInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.ReplicateSecretToRegions(&input)
+			return h.Backend.ReplicateSecretToRegions(ctx, &input)
 		},
-		"RemoveRegionsFromReplication": func(_ context.Context, _ string, b []byte) (any, error) {
+		"RemoveRegionsFromReplication": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input RemoveRegionsFromReplicationInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.RemoveRegionsFromReplication(&input)
+			return h.Backend.RemoveRegionsFromReplication(ctx, &input)
 		},
-		"StopReplicationToReplica": func(_ context.Context, _ string, b []byte) (any, error) {
+		"StopReplicationToReplica": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input StopReplicationToReplicaInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.StopReplicationToReplica(&input)
+			return h.Backend.StopReplicationToReplica(ctx, &input)
 		},
-		"ValidateResourcePolicy": func(_ context.Context, _ string, b []byte) (any, error) {
+		"ValidateResourcePolicy": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input ValidateResourcePolicyInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.ValidateResourcePolicy(&input)
+			return h.Backend.ValidateResourcePolicy(ctx, &input)
 		},
 	}
 }
 
 func (h *Handler) smCRUDActions() map[string]smActionFn {
 	return map[string]smActionFn{
-		"CreateSecret": func(_ context.Context, region string, b []byte) (any, error) {
+		"CreateSecret": func(ctx context.Context, region string, b []byte) (any, error) {
 			var input CreateSecretInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 			input.Region = region
 
-			return h.Backend.CreateSecret(&input)
+			return h.Backend.CreateSecret(ctx, &input)
 		},
-		"GetSecretValue": func(_ context.Context, _ string, b []byte) (any, error) {
+		"GetSecretValue": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input GetSecretValueInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.GetSecretValue(&input)
+			return h.Backend.GetSecretValue(ctx, &input)
 		},
-		"PutSecretValue": func(_ context.Context, _ string, b []byte) (any, error) {
+		"PutSecretValue": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input PutSecretValueInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.PutSecretValue(&input)
+			return h.Backend.PutSecretValue(ctx, &input)
 		},
-		"DeleteSecret": func(_ context.Context, _ string, b []byte) (any, error) {
+		"DeleteSecret": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input DeleteSecretInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.DeleteSecret(&input)
+			return h.Backend.DeleteSecret(ctx, &input)
 		},
-		"ListSecrets": func(_ context.Context, _ string, b []byte) (any, error) {
+		"ListSecrets": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input ListSecretsInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.ListSecrets(&input)
+			return h.Backend.ListSecrets(ctx, &input)
 		},
-		"DescribeSecret": func(_ context.Context, _ string, b []byte) (any, error) {
+		"DescribeSecret": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input DescribeSecretInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.DescribeSecret(&input)
+			return h.Backend.DescribeSecret(ctx, &input)
 		},
-		"UpdateSecret": func(_ context.Context, _ string, b []byte) (any, error) {
+		"UpdateSecret": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input UpdateSecretInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.UpdateSecret(&input)
+			return h.Backend.UpdateSecret(ctx, &input)
 		},
-		"RestoreSecret": func(_ context.Context, _ string, b []byte) (any, error) {
+		"RestoreSecret": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input RestoreSecretInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.RestoreSecret(&input)
+			return h.Backend.RestoreSecret(ctx, &input)
 		},
 		"RotateSecret": func(ctx context.Context, region string, b []byte) (any, error) {
 			var input RotateSecretInput
@@ -413,42 +413,42 @@ func (h *Handler) smCRUDActions() map[string]smActionFn {
 
 func (h *Handler) smTagActions() map[string]smActionFn {
 	return map[string]smActionFn{
-		"TagResource": func(_ context.Context, _ string, b []byte) (any, error) {
+		"TagResource": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input TagResourceInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return struct{}{}, h.Backend.TagResource(&input)
+			return struct{}{}, h.Backend.TagResource(ctx, &input)
 		},
-		"UntagResource": func(_ context.Context, _ string, b []byte) (any, error) {
+		"UntagResource": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input UntagResourceInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return struct{}{}, h.Backend.UntagResource(&input)
+			return struct{}{}, h.Backend.UntagResource(ctx, &input)
 		},
 	}
 }
 
 func (h *Handler) smVersionActions() map[string]smActionFn {
 	return map[string]smActionFn{
-		"ListSecretVersionIds": func(_ context.Context, _ string, b []byte) (any, error) {
+		"ListSecretVersionIds": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input ListSecretVersionIDsInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.ListSecretVersionIDs(&input)
+			return h.Backend.ListSecretVersionIDs(ctx, &input)
 		},
-		"UpdateSecretVersionStage": func(_ context.Context, _ string, b []byte) (any, error) {
+		"UpdateSecretVersionStage": func(ctx context.Context, _ string, b []byte) (any, error) {
 			var input UpdateSecretVersionStageInput
 			if err := json.Unmarshal(b, &input); err != nil {
 				return nil, err
 			}
 
-			return h.Backend.UpdateSecretVersionStage(&input)
+			return h.Backend.UpdateSecretVersionStage(ctx, &input)
 		},
 	}
 }
@@ -456,6 +456,8 @@ func (h *Handler) smVersionActions() map[string]smActionFn {
 // dispatch routes the operation to the appropriate backend method.
 func (h *Handler) dispatch(ctx context.Context, r *http.Request, action string, body []byte) ([]byte, error) {
 	region := httputils.ExtractRegionFromRequest(r, h.DefaultRegion)
+	// Attach the resolved region to the context so backend operations are region-scoped.
+	ctx = context.WithValue(ctx, regionContextKey{}, region)
 
 	fn, ok := h.ops[action]
 	if !ok {
@@ -541,7 +543,7 @@ func extractFunctionNameFromARN(arn string) string {
 // The backend creates a new AWSPENDING version; this function promotes it to AWSCURRENT
 // after all Lambda steps succeed (or immediately if no Lambda ARN is configured).
 func (h *Handler) rotateSecret(ctx context.Context, _ string, input *RotateSecretInput) (*RotateSecretOutput, error) {
-	out, err := h.Backend.RotateSecret(input)
+	out, err := h.Backend.RotateSecret(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +560,7 @@ func (h *Handler) rotateSecret(ctx context.Context, _ string, input *RotateSecre
 
 	// Promote AWSPENDING → AWSCURRENT after all Lambda steps succeed.
 	if b, ok := h.Backend.(*InMemoryBackend); ok {
-		if finishErr := b.FinishRotation(input.SecretID, out.VersionID); finishErr != nil {
+		if finishErr := b.FinishRotation(ctx, input.SecretID, out.VersionID); finishErr != nil {
 			return nil, finishErr
 		}
 	}
@@ -594,7 +596,7 @@ func (h *Handler) invokeLambdaRotationSteps(
 		)
 		if invokeErr != nil {
 			if b, ok := h.Backend.(*InMemoryBackend); ok {
-				_ = b.AbortRotation(input.SecretID, out.VersionID)
+				_ = b.AbortRotation(ctx, input.SecretID, out.VersionID)
 			}
 
 			return fmt.Errorf("rotation Lambda step %q failed: %w", step, invokeErr)

--- a/services/secretsmanager/handler_new_ops_test.go
+++ b/services/secretsmanager/handler_new_ops_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -43,9 +44,15 @@ func TestBatchGetSecretValue(t *testing.T) {
 			name: "by_secret_id_list",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "batch-s1", SecretString: "val1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "batch-s1", SecretString: "val1"},
+				)
 				require.NoError(t, err)
-				_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "batch-s2", SecretString: "val2"})
+				_, err = b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "batch-s2", SecretString: "val2"},
+				)
 				require.NoError(t, err)
 			},
 			body:           `{"SecretIdList":["batch-s1","batch-s2"]}`,
@@ -62,7 +69,10 @@ func TestBatchGetSecretValue(t *testing.T) {
 			name: "partial_errors",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "batch-ok", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "batch-ok", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			body:           `{"SecretIdList":["batch-ok","batch-missing"]}`,
@@ -81,9 +91,15 @@ func TestBatchGetSecretValue(t *testing.T) {
 			name: "all_secrets_when_no_id_list",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "batch-all-1", SecretString: "a"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "batch-all-1", SecretString: "a"},
+				)
 				require.NoError(t, err)
-				_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "batch-all-2", SecretString: "b"})
+				_, err = b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "batch-all-2", SecretString: "b"},
+				)
 				require.NoError(t, err)
 			},
 			body:           `{}`,
@@ -138,10 +154,13 @@ func TestCancelRotateSecret(t *testing.T) {
 			name: "cancels_rotation",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "cancel-rot", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "cancel-rot", SecretString: "v1"},
+				)
 				require.NoError(t, err)
 				// Rotate to create a pending version.
-				_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{SecretID: "cancel-rot"})
+				_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{SecretID: "cancel-rot"})
 				require.NoError(t, err)
 			},
 			body:           `{"SecretId":"cancel-rot"}`,
@@ -163,9 +182,12 @@ func TestCancelRotateSecret(t *testing.T) {
 			name: "deleted_secret",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "cancel-del", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "cancel-del", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "cancel-del"})
+				_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "cancel-del"})
 				require.NoError(t, err)
 			},
 			body:           `{"SecretId":"cancel-del"}`,
@@ -215,7 +237,10 @@ func TestResourcePolicyCycle(t *testing.T) {
 			name: "put_resource_policy",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "policy-secret", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "policy-secret", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			target:         "secretsmanager.PutResourcePolicy",
@@ -233,9 +258,12 @@ func TestResourcePolicyCycle(t *testing.T) {
 			name: "get_resource_policy_after_put",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "get-policy", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "get-policy", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+				_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 					SecretID:       "get-policy",
 					ResourcePolicy: `{"Version":"2012-10-17"}`,
 				})
@@ -256,9 +284,12 @@ func TestResourcePolicyCycle(t *testing.T) {
 			name: "delete_resource_policy",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "del-policy", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "del-policy", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+				_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 					SecretID:       "del-policy",
 					ResourcePolicy: `{"Version":"2012-10-17"}`,
 				})
@@ -350,7 +381,10 @@ func TestReplicationOperations(t *testing.T) {
 			name: "replicate_to_regions",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rep-secret", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "rep-secret", SecretString: "v"},
+				)
 				require.NoError(t, err)
 			},
 			target:         "secretsmanager.ReplicateSecretToRegions",
@@ -370,9 +404,12 @@ func TestReplicationOperations(t *testing.T) {
 			name: "remove_regions_from_replication",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rem-rep", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "rem-rep", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+				_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 					SecretID:          "rem-rep",
 					AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "eu-west-1"}, {Region: "ap-east-1"}},
 				})
@@ -393,9 +430,12 @@ func TestReplicationOperations(t *testing.T) {
 			name: "stop_replication_to_replica",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "stop-rep", SecretString: "v"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "stop-rep", SecretString: "v"},
+				)
 				require.NoError(t, err)
-				_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+				_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 					SecretID:          "stop-rep",
 					AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "eu-west-1"}},
 				})
@@ -485,9 +525,12 @@ func TestUpdateSecretVersionStage(t *testing.T) {
 			name: "move_label_to_new_version",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) string {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "stage-secret", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "stage-secret", SecretString: "v1"},
+				)
 				require.NoError(t, err)
-				out, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+				out, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 					SecretID:     "stage-secret",
 					SecretString: "v2",
 				})
@@ -511,11 +554,14 @@ func TestUpdateSecretVersionStage(t *testing.T) {
 			name: "remove_label_from_version",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) string {
 				t.Helper()
-				out, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "stage-remove", SecretString: "v1"})
+				out, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "stage-remove", SecretString: "v1"},
+				)
 				require.NoError(t, err)
 				// Add a custom label first so we can remove it.
 				// AWSCURRENT cannot be removed without MoveToVersionId (AWS constraint).
-				_, err = b.UpdateSecretVersionStage(&secretsmanager.UpdateSecretVersionStageInput{
+				_, err = b.UpdateSecretVersionStage(context.Background(), &secretsmanager.UpdateSecretVersionStageInput{
 					SecretID:        "stage-remove",
 					VersionStage:    "AWSCUSTOM",
 					MoveToVersionID: out.VersionID,
@@ -599,9 +645,12 @@ func TestListSecretVersionIds(t *testing.T) {
 			name: "lists_versions",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "lsvi-secret", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "lsvi-secret", SecretString: "v1"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+				_, err = b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 					SecretID:     "lsvi-secret",
 					SecretString: "v2",
 				})
@@ -658,12 +707,15 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "del-batch", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "del-batch", SecretString: "v"},
+		)
 		require.NoError(t, err)
-		_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "del-batch"})
+		_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "del-batch"})
 		require.NoError(t, err)
 
-		out, err := b.BatchGetSecretValue(&secretsmanager.BatchGetSecretValueInput{
+		out, err := b.BatchGetSecretValue(context.Background(), &secretsmanager.BatchGetSecretValueInput{
 			SecretIDList: []string{"del-batch"},
 		})
 		require.NoError(t, err)
@@ -676,16 +728,22 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rot-cancel", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "rot-cancel", SecretString: "v"},
+		)
 		require.NoError(t, err)
-		_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{SecretID: "rot-cancel"})
+		_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{SecretID: "rot-cancel"})
 		require.NoError(t, err)
 
-		out, err := b.CancelRotateSecret(&secretsmanager.CancelRotateSecretInput{SecretID: "rot-cancel"})
+		out, err := b.CancelRotateSecret(
+			context.Background(),
+			&secretsmanager.CancelRotateSecretInput{SecretID: "rot-cancel"},
+		)
 		require.NoError(t, err)
 		assert.Equal(t, "rot-cancel", out.Name)
 
-		desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "rot-cancel"})
+		desc, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "rot-cancel"})
 		require.NoError(t, err)
 		assert.False(t, desc.RotationEnabled)
 	})
@@ -694,7 +752,10 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CancelRotateSecret(&secretsmanager.CancelRotateSecretInput{SecretID: "nonexistent"})
+		_, err := b.CancelRotateSecret(
+			context.Background(),
+			&secretsmanager.CancelRotateSecretInput{SecretID: "nonexistent"},
+		)
 		require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
 	})
 
@@ -702,10 +763,16 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "no-policy", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "no-policy", SecretString: "v"},
+		)
 		require.NoError(t, err)
 
-		out, err := b.GetResourcePolicy(&secretsmanager.GetResourcePolicyInput{SecretID: "no-policy"})
+		out, err := b.GetResourcePolicy(
+			context.Background(),
+			&secretsmanager.GetResourcePolicyInput{SecretID: "no-policy"},
+		)
 		require.NoError(t, err)
 		assert.Empty(t, out.ResourcePolicy)
 		assert.Equal(t, "no-policy", out.Name)
@@ -715,12 +782,15 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "put-del-policy", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "put-del-policy", SecretString: "v"},
+		)
 		require.NoError(t, err)
-		_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "put-del-policy"})
+		_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "put-del-policy"})
 		require.NoError(t, err)
 
-		_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+		_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 			SecretID:       "put-del-policy",
 			ResourcePolicy: "{}",
 		})
@@ -731,12 +801,18 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "del-del-policy", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "del-del-policy", SecretString: "v"},
+		)
 		require.NoError(t, err)
-		_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "del-del-policy"})
+		_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "del-del-policy"})
 		require.NoError(t, err)
 
-		_, err = b.DeleteResourcePolicy(&secretsmanager.DeleteResourcePolicyInput{SecretID: "del-del-policy"})
+		_, err = b.DeleteResourcePolicy(
+			context.Background(),
+			&secretsmanager.DeleteResourcePolicyInput{SecretID: "del-del-policy"},
+		)
 		require.ErrorIs(t, err, secretsmanager.ErrSecretDeleted)
 	})
 
@@ -744,18 +820,21 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rep-idem", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "rep-idem", SecretString: "v"},
+		)
 		require.NoError(t, err)
 
 		// Add us-east-2.
-		_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+		_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 			SecretID:          "rep-idem",
 			AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-east-2"}},
 		})
 		require.NoError(t, err)
 
 		// Add us-east-2 again (should update, not duplicate).
-		out, err := b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+		out, err := b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 			SecretID:          "rep-idem",
 			AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-east-2", KmsKeyID: "key-123"}},
 		})
@@ -768,10 +847,13 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "stage-ver-nf", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "stage-ver-nf", SecretString: "v"},
+		)
 		require.NoError(t, err)
 
-		_, err = b.UpdateSecretVersionStage(&secretsmanager.UpdateSecretVersionStageInput{
+		_, err = b.UpdateSecretVersionStage(context.Background(), &secretsmanager.UpdateSecretVersionStageInput{
 			SecretID:            "stage-ver-nf",
 			VersionStage:        "AWSCUSTOM",
 			RemoveFromVersionID: "no-such-version",
@@ -783,10 +865,13 @@ func TestNewOpsBackend(t *testing.T) {
 		t.Parallel()
 
 		b := secretsmanager.NewInMemoryBackend()
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "stage-mov-nf", SecretString: "v"})
+		_, err := b.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "stage-mov-nf", SecretString: "v"},
+		)
 		require.NoError(t, err)
 
-		_, err = b.UpdateSecretVersionStage(&secretsmanager.UpdateSecretVersionStageInput{
+		_, err = b.UpdateSecretVersionStage(context.Background(), &secretsmanager.UpdateSecretVersionStageInput{
 			SecretID:        "stage-mov-nf",
 			VersionStage:    "AWSCUSTOM",
 			MoveToVersionID: "no-such-version",

--- a/services/secretsmanager/handler_refinement1_test.go
+++ b/services/secretsmanager/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -67,11 +68,11 @@ func TestRefinement1_SecretCount(t *testing.T) {
 	b := secretsmanager.NewInMemoryBackend()
 	require.Equal(t, 0, secretsmanager.SecretCount(b))
 
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "a", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "a", SecretString: "v"})
 	require.NoError(t, err)
 	assert.Equal(t, 1, secretsmanager.SecretCount(b))
 
-	_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "b", SecretString: "v"})
+	_, err = b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "b", SecretString: "v"})
 	require.NoError(t, err)
 	assert.Equal(t, 2, secretsmanager.SecretCount(b))
 }
@@ -81,18 +82,24 @@ func TestRefinement1_ResourcePolicyCount(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "pol-secret", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "pol-secret", SecretString: "v"},
+	)
 	require.NoError(t, err)
 	require.Equal(t, 0, secretsmanager.ResourcePolicyCount(b))
 
-	_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 		SecretID:       "pol-secret",
 		ResourcePolicy: `{"Version":"2012-10-17"}`,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, secretsmanager.ResourcePolicyCount(b))
 
-	_, err = b.DeleteResourcePolicy(&secretsmanager.DeleteResourcePolicyInput{SecretID: "pol-secret"})
+	_, err = b.DeleteResourcePolicy(
+		context.Background(),
+		&secretsmanager.DeleteResourcePolicyInput{SecretID: "pol-secret"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 0, secretsmanager.ResourcePolicyCount(b))
 }
@@ -102,18 +109,24 @@ func TestRefinement1_ReplicationConfigCount(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rep-cnt", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "rep-cnt", SecretString: "v"},
+	)
 	require.NoError(t, err)
 	require.Equal(t, 0, secretsmanager.ReplicationConfigCount(b))
 
-	_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 		SecretID:          "rep-cnt",
 		AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-west-2"}},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, secretsmanager.ReplicationConfigCount(b))
 
-	_, err = b.StopReplicationToReplica(&secretsmanager.StopReplicationToReplicaInput{SecretID: "rep-cnt"})
+	_, err = b.StopReplicationToReplica(
+		context.Background(),
+		&secretsmanager.StopReplicationToReplicaInput{SecretID: "rep-cnt"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 0, secretsmanager.ReplicationConfigCount(b))
 }
@@ -129,7 +142,7 @@ func TestRefinement1_AddSecretInternal(t *testing.T) {
 	})
 	assert.Equal(t, 1, secretsmanager.SecretCount(b))
 
-	got, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "my-seed"})
+	got, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "my-seed"})
 	require.NoError(t, err)
 	assert.Equal(t, "my-seed", got.Name)
 }
@@ -140,10 +153,13 @@ func TestRefinement1_UpdateSecretVersionStageAutoStrip(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "vs-strip", SecretString: "v1"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "vs-strip", SecretString: "v1"},
+	)
 	require.NoError(t, err)
 
-	desc1, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "vs-strip"})
+	desc1, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "vs-strip"})
 	require.NoError(t, err)
 	v1ID := desc1.VersionIDsToStages
 	var v1 string
@@ -152,7 +168,7 @@ func TestRefinement1_UpdateSecretVersionStageAutoStrip(t *testing.T) {
 	}
 
 	// Create second version.
-	put, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+	put, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 		SecretID:     "vs-strip",
 		SecretString: "v2",
 	})
@@ -160,7 +176,7 @@ func TestRefinement1_UpdateSecretVersionStageAutoStrip(t *testing.T) {
 	v2 := put.VersionID
 
 	// Move AWSPREVIOUS label to v2 (stripping from v1 where it may be).
-	_, err = b.UpdateSecretVersionStage(&secretsmanager.UpdateSecretVersionStageInput{
+	_, err = b.UpdateSecretVersionStage(context.Background(), &secretsmanager.UpdateSecretVersionStageInput{
 		SecretID:        "vs-strip",
 		VersionStage:    secretsmanager.StagingLabelPrevious,
 		MoveToVersionID: v2,
@@ -168,7 +184,7 @@ func TestRefinement1_UpdateSecretVersionStageAutoStrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify v1 no longer has AWSPREVIOUS.
-	desc2, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "vs-strip"})
+	desc2, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "vs-strip"})
 	require.NoError(t, err)
 
 	for _, lbl := range desc2.VersionIDsToStages[v1] {
@@ -184,10 +200,13 @@ func TestRefinement1_UpdateSecretVersionStageAWSCURRENT(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "vs-curr", SecretString: "v1"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "vs-curr", SecretString: "v1"},
+	)
 	require.NoError(t, err)
 
-	put, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+	put, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 		SecretID:     "vs-curr",
 		SecretString: "v2",
 	})
@@ -195,7 +214,7 @@ func TestRefinement1_UpdateSecretVersionStageAWSCURRENT(t *testing.T) {
 	v2 := put.VersionID
 
 	// Move AWSCURRENT back to the original v1.
-	desc1, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "vs-curr"})
+	desc1, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "vs-curr"})
 	require.NoError(t, err)
 	var v1 string
 	for id, labels := range desc1.VersionIDsToStages {
@@ -207,7 +226,7 @@ func TestRefinement1_UpdateSecretVersionStageAWSCURRENT(t *testing.T) {
 	}
 	require.NotEmpty(t, v1)
 
-	_, err = b.UpdateSecretVersionStage(&secretsmanager.UpdateSecretVersionStageInput{
+	_, err = b.UpdateSecretVersionStage(context.Background(), &secretsmanager.UpdateSecretVersionStageInput{
 		SecretID:            "vs-curr",
 		VersionStage:        secretsmanager.StagingLabelCurrent,
 		MoveToVersionID:     v1,
@@ -216,7 +235,7 @@ func TestRefinement1_UpdateSecretVersionStageAWSCURRENT(t *testing.T) {
 	require.NoError(t, err)
 
 	// v1 should now be AWSCURRENT.
-	got, err := b.GetSecretValue(&secretsmanager.GetSecretValueInput{
+	got, err := b.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 		SecretID:     "vs-curr",
 		VersionStage: secretsmanager.StagingLabelCurrent,
 	})
@@ -229,16 +248,19 @@ func TestRefinement1_DeleteSecretCascade(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "cascade", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "cascade", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 		SecretID:       "cascade",
 		ResourcePolicy: `{"Version":"2012-10-17"}`,
 	})
 	require.NoError(t, err)
 
-	_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 		SecretID:          "cascade",
 		AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-west-2"}},
 	})
@@ -247,7 +269,7 @@ func TestRefinement1_DeleteSecretCascade(t *testing.T) {
 	require.Equal(t, 1, secretsmanager.ResourcePolicyCount(b))
 	require.Equal(t, 1, secretsmanager.ReplicationConfigCount(b))
 
-	_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{
+	_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{
 		SecretID:                   "cascade",
 		ForceDeleteWithoutRecovery: true,
 	})
@@ -263,10 +285,13 @@ func TestRefinement1_PutResourcePolicyEmptyRejects(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "ep-secret", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "ep-secret", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 		SecretID:       "ep-secret",
 		ResourcePolicy: "",
 	})
@@ -278,7 +303,10 @@ func TestRefinement1_PutResourcePolicyEmptyHTTP(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "ep-http", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "ep-http", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
 	h := secretsmanager.NewHandler(b)
@@ -292,14 +320,14 @@ func TestRefinement1_KmsKeyIdRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "kms-test",
 		SecretString: "v",
 		KmsKeyID:     "alias/my-key",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "kms-test"})
+	desc, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "kms-test"})
 	require.NoError(t, err)
 	assert.Equal(t, "alias/my-key", desc.KmsKeyID)
 }
@@ -309,16 +337,19 @@ func TestRefinement1_RotationLambdaARNStored(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rla-test", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "rla-test", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{
 		SecretID:          "rla-test",
 		RotationLambdaARN: "arn:aws:lambda:us-east-1:123:function:my-rotator",
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "rla-test"})
+	desc, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "rla-test"})
 	require.NoError(t, err)
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123:function:my-rotator", desc.RotationLambdaARN)
 }
@@ -328,17 +359,20 @@ func TestRefinement1_LastRotatedDate(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "lrd-test", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "lrd-test", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	desc0, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "lrd-test"})
+	desc0, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "lrd-test"})
 	require.NoError(t, err)
 	assert.Nil(t, desc0.LastRotatedDate)
 
-	_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{SecretID: "lrd-test"})
+	_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{SecretID: "lrd-test"})
 	require.NoError(t, err)
 
-	desc1, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "lrd-test"})
+	desc1, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "lrd-test"})
 	require.NoError(t, err)
 	require.NotNil(t, desc1.LastRotatedDate)
 	assert.Greater(t, *desc1.LastRotatedDate, float64(0))
@@ -349,16 +383,19 @@ func TestRefinement1_DescribeSecretReplicationStatus(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "rep-desc", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "rep-desc", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 		SecretID:          "rep-desc",
 		AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "ap-northeast-1"}},
 	})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "rep-desc"})
+	desc, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "rep-desc"})
 	require.NoError(t, err)
 	require.Len(t, desc.ReplicationStatus, 1)
 	assert.Equal(t, "ap-northeast-1", desc.ReplicationStatus[0].Region)
@@ -371,11 +408,11 @@ func TestRefinement1_ListSecretsFilterByName(t *testing.T) {
 	b := secretsmanager.NewInMemoryBackend()
 
 	for _, name := range []string{"alpha-1", "alpha-2", "beta-1"} {
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&secretsmanager.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{
 		Filters: []secretsmanager.SecretFilter{{Key: "name", Values: []string{"alpha"}}},
 	})
 	require.NoError(t, err)
@@ -389,20 +426,20 @@ func TestRefinement1_ListSecretsFilterByDescription(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "desc-a",
 		SecretString: "v",
 		Description:  "production secret",
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "desc-b",
 		SecretString: "v",
 		Description:  "staging secret",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&secretsmanager.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{
 		Filters: []secretsmanager.SecretFilter{{Key: "description", Values: []string{"prod"}}},
 	})
 	require.NoError(t, err)
@@ -415,19 +452,19 @@ func TestRefinement1_ListSecretsFilterByTagKey(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "tagged",
 		SecretString: "v",
 		Tags:         []secretsmanager.Tag{{Key: "env", Value: "prod"}},
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "untagged",
 		SecretString: "v",
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&secretsmanager.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{
 		Filters: []secretsmanager.SecretFilter{{Key: "tag-key", Values: []string{"env"}}},
 	})
 	require.NoError(t, err)
@@ -440,20 +477,20 @@ func TestRefinement1_ListSecretsFilterByTagValue(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "tv-a",
 		SecretString: "v",
 		Tags:         []secretsmanager.Tag{{Key: "env", Value: "prod"}},
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err = b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "tv-b",
 		SecretString: "v",
 		Tags:         []secretsmanager.Tag{{Key: "env", Value: "dev"}},
 	})
 	require.NoError(t, err)
 
-	out, err := b.ListSecrets(&secretsmanager.ListSecretsInput{
+	out, err := b.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{
 		Filters: []secretsmanager.SecretFilter{{Key: "tag-value", Values: []string{"prod"}}},
 	})
 	require.NoError(t, err)
@@ -466,16 +503,19 @@ func TestRefinement1_BatchGetFilterTagKey(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "batch-tag",
 		SecretString: "v",
 		Tags:         []secretsmanager.Tag{{Key: "class", Value: "database"}},
 	})
 	require.NoError(t, err)
-	_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "batch-notag", SecretString: "v"})
+	_, err = b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "batch-notag", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	out, err := b.BatchGetSecretValue(&secretsmanager.BatchGetSecretValueInput{
+	out, err := b.BatchGetSecretValue(context.Background(), &secretsmanager.BatchGetSecretValueInput{
 		Filters: []secretsmanager.BatchGetSecretValueFilter{{Key: "tag-key", Values: []string{"class"}}},
 	})
 	require.NoError(t, err)
@@ -490,7 +530,7 @@ func TestRefinement1_BatchGetPagination(t *testing.T) {
 	b := secretsmanager.NewInMemoryBackend()
 
 	for i := range 5 {
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         fmt.Sprintf("pag-%02d", i),
 			SecretString: "v",
 		})
@@ -498,14 +538,14 @@ func TestRefinement1_BatchGetPagination(t *testing.T) {
 	}
 
 	maxResults := int32(2)
-	out1, err := b.BatchGetSecretValue(&secretsmanager.BatchGetSecretValueInput{
+	out1, err := b.BatchGetSecretValue(context.Background(), &secretsmanager.BatchGetSecretValueInput{
 		MaxResults: &maxResults,
 	})
 	require.NoError(t, err)
 	require.Len(t, out1.SecretValues, 2)
 	assert.NotEmpty(t, out1.NextToken)
 
-	out2, err := b.BatchGetSecretValue(&secretsmanager.BatchGetSecretValueInput{
+	out2, err := b.BatchGetSecretValue(context.Background(), &secretsmanager.BatchGetSecretValueInput{
 		MaxResults: &maxResults,
 		NextToken:  out1.NextToken,
 	})
@@ -513,7 +553,7 @@ func TestRefinement1_BatchGetPagination(t *testing.T) {
 	require.Len(t, out2.SecretValues, 2)
 	assert.NotEmpty(t, out2.NextToken)
 
-	out3, err := b.BatchGetSecretValue(&secretsmanager.BatchGetSecretValueInput{
+	out3, err := b.BatchGetSecretValue(context.Background(), &secretsmanager.BatchGetSecretValueInput{
 		MaxResults: &maxResults,
 		NextToken:  out2.NextToken,
 	})
@@ -527,13 +567,19 @@ func TestRefinement1_ListSecretVersionsDeleted(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "del-ver", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "del-ver", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "del-ver"})
+	_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "del-ver"})
 	require.NoError(t, err)
 
-	out, err := b.ListSecretVersionIDs(&secretsmanager.ListSecretVersionIDsInput{SecretID: "del-ver"})
+	out, err := b.ListSecretVersionIDs(
+		context.Background(),
+		&secretsmanager.ListSecretVersionIDsInput{SecretID: "del-ver"},
+	)
 	require.NoError(t, err)
 	assert.Len(t, out.Versions, 1)
 }
@@ -545,7 +591,7 @@ func TestRefinement1_CreateSecretClientRequestToken(t *testing.T) {
 	b := secretsmanager.NewInMemoryBackend()
 	token := "11111111-2222-3333-4444-555555555555"
 
-	out, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	out, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:               "crt-test",
 		SecretString:       "v",
 		ClientRequestToken: token,
@@ -559,13 +605,16 @@ func TestRefinement1_GenerateVersionID(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "uuid-ver", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "uuid-ver", SecretString: "v"},
+	)
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{SecretID: "uuid-ver"})
+	_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{SecretID: "uuid-ver"})
 	require.NoError(t, err)
 
-	desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "uuid-ver"})
+	desc, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "uuid-ver"})
 	require.NoError(t, err)
 
 	uuidRE := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
@@ -579,14 +628,14 @@ func TestRefinement1_Snapshot_Restore(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "snap-test",
 		SecretString: "v",
 		KmsKeyID:     "alias/snap-key",
 	})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{
+	_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{
 		SecretID:          "snap-test",
 		RotationLambdaARN: "arn:aws:lambda:us-east-1:123:function:rotator",
 	})
@@ -598,7 +647,7 @@ func TestRefinement1_Snapshot_Restore(t *testing.T) {
 	b2 := secretsmanager.NewInMemoryBackend()
 	require.NoError(t, b2.Restore(snap))
 
-	desc, err := b2.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "snap-test"})
+	desc, err := b2.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "snap-test"})
 	require.NoError(t, err)
 	assert.Equal(t, "alias/snap-key", desc.KmsKeyID)
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123:function:rotator", desc.RotationLambdaARN)
@@ -610,14 +659,17 @@ func TestRefinement1_ResetCleansAllMaps(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "reset-s", SecretString: "v"})
+	_, err := b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "reset-s", SecretString: "v"},
+	)
 	require.NoError(t, err)
-	_, err = b.PutResourcePolicy(&secretsmanager.PutResourcePolicyInput{
+	_, err = b.PutResourcePolicy(context.Background(), &secretsmanager.PutResourcePolicyInput{
 		SecretID:       "reset-s",
 		ResourcePolicy: `{}`,
 	})
 	require.NoError(t, err)
-	_, err = b.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
+	_, err = b.ReplicateSecretToRegions(context.Background(), &secretsmanager.ReplicateSecretToRegionsInput{
 		SecretID:          "reset-s",
 		AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-west-2"}},
 	})
@@ -636,11 +688,11 @@ func TestRefinement1_CancelRotateSecretNoRotation(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "norot", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "norot", SecretString: "v"})
 	require.NoError(t, err)
 
 	// CancelRotate on a non-rotating secret should succeed (idempotent).
-	out, err := b.CancelRotateSecret(&secretsmanager.CancelRotateSecretInput{SecretID: "norot"})
+	out, err := b.CancelRotateSecret(context.Background(), &secretsmanager.CancelRotateSecretInput{SecretID: "norot"})
 	require.NoError(t, err)
 	assert.Equal(t, "norot", out.Name)
 }
@@ -654,7 +706,10 @@ func TestRefinement1_RestoreEnsuresNonNilMaps(t *testing.T) {
 	err := b.Restore([]byte(`{"accountID":"acct","region":"us-east-1"}`))
 	require.NoError(t, err)
 	// Should be able to create secrets without panics.
-	_, err = b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "post-restore", SecretString: "v"})
+	_, err = b.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "post-restore", SecretString: "v"},
+	)
 	require.NoError(t, err)
 }
 
@@ -665,11 +720,11 @@ func TestRefinement1_ListSecretsNoFilter(t *testing.T) {
 	b := secretsmanager.NewInMemoryBackend()
 
 	for _, name := range []string{"x", "y", "z"} {
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 
-	out, err := b.ListSecrets(&secretsmanager.ListSecretsInput{})
+	out, err := b.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{})
 	require.NoError(t, err)
 	assert.Len(t, out.SecretList, 3)
 }
@@ -679,7 +734,7 @@ func TestRefinement1_DescribeSecretHTTP(t *testing.T) {
 	t.Parallel()
 
 	b := secretsmanager.NewInMemoryBackend()
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "http-kms",
 		SecretString: "v",
 		KmsKeyID:     "alias/http-key",
@@ -703,7 +758,7 @@ func TestRefinement1_ListSecretsHTTPFilter(t *testing.T) {
 	b := secretsmanager.NewInMemoryBackend()
 
 	for _, name := range []string{"http-flt-a", "http-flt-b", "other"} {
-		_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: name, SecretString: "v"})
+		_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: name, SecretString: "v"})
 		require.NoError(t, err)
 	}
 

--- a/services/secretsmanager/handler_test.go
+++ b/services/secretsmanager/handler_test.go
@@ -27,7 +27,7 @@ func TestSecretsManagerBackendCreateSecret(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		out, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		out, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         "my-secret",
 			Description:  "a test secret",
 			SecretString: "mysecretvalue",
@@ -44,7 +44,7 @@ func TestSecretsManagerBackendCreateSecret(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		out, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		out, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name: "empty-secret",
 		})
 
@@ -57,9 +57,9 @@ func TestSecretsManagerBackendCreateSecret(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "dup-secret"})
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "dup-secret"})
 
-		_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "dup-secret"})
+		_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "dup-secret"})
 		require.ErrorIs(t, err, secretsmanager.ErrSecretAlreadyExists)
 	})
 
@@ -68,7 +68,7 @@ func TestSecretsManagerBackendCreateSecret(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		out, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		out, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name: "tagged-secret",
 			Tags: []secretsmanager.Tag{
 				{Key: "env", Value: "test"},
@@ -89,12 +89,12 @@ func TestSecretsManagerBackendGetSecretValue(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         "db-password",
 			SecretString: "secretpassword",
 		})
 
-		out, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		out, err := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 			SecretID: "db-password",
 		})
 
@@ -108,7 +108,7 @@ func TestSecretsManagerBackendGetSecretValue(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		_, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "missing"})
+		_, err := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{SecretID: "missing"})
 		require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
 	})
 
@@ -116,13 +116,16 @@ func TestSecretsManagerBackendGetSecretValue(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         "deleted-secret",
 			SecretString: "value",
 		})
-		_, _ = backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "deleted-secret"})
+		_, _ = backend.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "deleted-secret"})
 
-		_, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "deleted-secret"})
+		_, err := backend.GetSecretValue(
+			context.Background(),
+			&secretsmanager.GetSecretValueInput{SecretID: "deleted-secret"},
+		)
 		require.ErrorIs(t, err, secretsmanager.ErrSecretDeleted)
 	})
 }
@@ -135,12 +138,12 @@ func TestSecretsManagerBackendPutSecretValue(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         "versioned-secret",
 			SecretString: "v1",
 		})
 
-		out, err := backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+		out, err := backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 			SecretID:     "versioned-secret",
 			SecretString: "v2",
 		})
@@ -150,11 +153,14 @@ func TestSecretsManagerBackendPutSecretValue(t *testing.T) {
 		assert.Contains(t, out.VersionStages, secretsmanager.StagingLabelCurrent)
 
 		// New current value
-		curr, _ := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "versioned-secret"})
+		curr, _ := backend.GetSecretValue(
+			context.Background(),
+			&secretsmanager.GetSecretValueInput{SecretID: "versioned-secret"},
+		)
 		assert.Equal(t, "v2", curr.SecretString)
 
 		// Previous value accessible via AWSPREVIOUS
-		prev, prevErr := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		prev, prevErr := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 			SecretID:     "versioned-secret",
 			VersionStage: secretsmanager.StagingLabelPrevious,
 		})
@@ -167,7 +173,7 @@ func TestSecretsManagerBackendPutSecretValue(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		_, err := backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+		_, err := backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 			SecretID:     "missing",
 			SecretString: "value",
 		})
@@ -183,22 +189,31 @@ func TestSecretsManagerBackendDeleteAndRestore(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         "restorable",
 			SecretString: "data",
 		})
 
-		delOut, err := backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "restorable"})
+		delOut, err := backend.DeleteSecret(
+			context.Background(),
+			&secretsmanager.DeleteSecretInput{SecretID: "restorable"},
+		)
 		require.NoError(t, err)
 		assert.NotZero(t, delOut.DeletionDate)
 
 		// Restore
-		restOut, err := backend.RestoreSecret(&secretsmanager.RestoreSecretInput{SecretID: "restorable"})
+		restOut, err := backend.RestoreSecret(
+			context.Background(),
+			&secretsmanager.RestoreSecretInput{SecretID: "restorable"},
+		)
 		require.NoError(t, err)
 		assert.Equal(t, "restorable", restOut.Name)
 
 		// Can get value again
-		_, err = backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "restorable"})
+		_, err = backend.GetSecretValue(
+			context.Background(),
+			&secretsmanager.GetSecretValueInput{SecretID: "restorable"},
+		)
 		require.NoError(t, err)
 	})
 
@@ -207,7 +222,7 @@ func TestSecretsManagerBackendDeleteAndRestore(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		_, err := backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "missing"})
+		_, err := backend.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "missing"})
 		require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
 	})
 
@@ -216,7 +231,7 @@ func TestSecretsManagerBackendDeleteAndRestore(t *testing.T) {
 
 		backend := secretsmanager.NewInMemoryBackend()
 
-		_, err := backend.RestoreSecret(&secretsmanager.RestoreSecretInput{SecretID: "missing"})
+		_, err := backend.RestoreSecret(context.Background(), &secretsmanager.RestoreSecretInput{SecretID: "missing"})
 		require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
 	})
 }
@@ -231,10 +246,10 @@ func TestSecretsManagerBackendListSecrets(t *testing.T) {
 		backend := secretsmanager.NewInMemoryBackend()
 
 		for _, name := range []string{"alpha", "beta", "gamma"} {
-			_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: name})
+			_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: name})
 		}
 
-		out, err := backend.ListSecrets(&secretsmanager.ListSecretsInput{})
+		out, err := backend.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{})
 		require.NoError(t, err)
 		assert.Len(t, out.SecretList, 3)
 	})
@@ -243,11 +258,11 @@ func TestSecretsManagerBackendListSecrets(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "active"})
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "deleted"})
-		_, _ = backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "deleted"})
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "active"})
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "deleted"})
+		_, _ = backend.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "deleted"})
 
-		out, err := backend.ListSecrets(&secretsmanager.ListSecretsInput{})
+		out, err := backend.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{})
 		require.NoError(t, err)
 		assert.Len(t, out.SecretList, 1)
 		assert.Equal(t, "active", out.SecretList[0].Name)
@@ -257,11 +272,11 @@ func TestSecretsManagerBackendListSecrets(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "active"})
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "deleted"})
-		_, _ = backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "deleted"})
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "active"})
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "deleted"})
+		_, _ = backend.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "deleted"})
 
-		out, err := backend.ListSecrets(&secretsmanager.ListSecretsInput{IncludeDeleted: true})
+		out, err := backend.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{IncludeDeleted: true})
 		require.NoError(t, err)
 		assert.Len(t, out.SecretList, 2)
 	})
@@ -272,16 +287,16 @@ func TestSecretsManagerBackendListSecrets(t *testing.T) {
 		backend := secretsmanager.NewInMemoryBackend()
 
 		for _, name := range []string{"a", "b", "c", "d", "e"} {
-			_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: name})
+			_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: name})
 		}
 
 		limit := int64(2)
-		out, err := backend.ListSecrets(&secretsmanager.ListSecretsInput{MaxResults: &limit})
+		out, err := backend.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{MaxResults: &limit})
 		require.NoError(t, err)
 		assert.Len(t, out.SecretList, 2)
 		assert.NotEmpty(t, out.NextToken)
 
-		out2, err := backend.ListSecrets(&secretsmanager.ListSecretsInput{
+		out2, err := backend.ListSecrets(context.Background(), &secretsmanager.ListSecretsInput{
 			MaxResults: &limit,
 			NextToken:  out.NextToken,
 		})
@@ -298,7 +313,7 @@ func TestSecretsManagerBackendDescribeSecret(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 			Name:         "described",
 			Description:  "my description",
 			SecretString: "value",
@@ -307,7 +322,10 @@ func TestSecretsManagerBackendDescribeSecret(t *testing.T) {
 			},
 		})
 
-		out, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "described"})
+		out, err := backend.DescribeSecret(
+			context.Background(),
+			&secretsmanager.DescribeSecretInput{SecretID: "described"},
+		)
 		require.NoError(t, err)
 		assert.Equal(t, "described", out.Name)
 		assert.Equal(t, "my description", out.Description)
@@ -318,7 +336,7 @@ func TestSecretsManagerBackendDescribeSecret(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "missing"})
+		_, err := backend.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "missing"})
 		require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
 	})
 }
@@ -331,9 +349,12 @@ func TestSecretsManagerBackendUpdateSecret(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "updatable", SecretString: "original"})
+		_, _ = backend.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "updatable", SecretString: "original"},
+		)
 
-		out, err := backend.UpdateSecret(&secretsmanager.UpdateSecretInput{
+		out, err := backend.UpdateSecret(context.Background(), &secretsmanager.UpdateSecretInput{
 			SecretID:    "updatable",
 			Description: "new description",
 		})
@@ -341,7 +362,10 @@ func TestSecretsManagerBackendUpdateSecret(t *testing.T) {
 		assert.Equal(t, "updatable", out.Name)
 		assert.Empty(t, out.VersionID) // no new version for description-only update
 
-		desc, _ := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "updatable"})
+		desc, _ := backend.DescribeSecret(
+			context.Background(),
+			&secretsmanager.DescribeSecretInput{SecretID: "updatable"},
+		)
 		assert.Equal(t, "new description", desc.Description)
 	})
 
@@ -349,9 +373,12 @@ func TestSecretsManagerBackendUpdateSecret(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "with-value", SecretString: "v1"})
+		_, _ = backend.CreateSecret(
+			context.Background(),
+			&secretsmanager.CreateSecretInput{Name: "with-value", SecretString: "v1"},
+		)
 
-		out, err := backend.UpdateSecret(&secretsmanager.UpdateSecretInput{
+		out, err := backend.UpdateSecret(context.Background(), &secretsmanager.UpdateSecretInput{
 			SecretID:     "with-value",
 			SecretString: "v2",
 		})
@@ -363,7 +390,7 @@ func TestSecretsManagerBackendUpdateSecret(t *testing.T) {
 		t.Parallel()
 
 		backend := secretsmanager.NewInMemoryBackend()
-		_, err := backend.UpdateSecret(&secretsmanager.UpdateSecretInput{SecretID: "missing"})
+		_, err := backend.UpdateSecret(context.Background(), &secretsmanager.UpdateSecretInput{SecretID: "missing"})
 		require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
 	})
 }
@@ -375,7 +402,7 @@ func TestSecretsManagerBackendListAll(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackend()
 
 	for _, name := range []string{"z-secret", "a-secret", "m-secret"} {
-		_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: name})
+		_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: name})
 	}
 
 	all := backend.ListAll()
@@ -416,7 +443,7 @@ func TestSecretsManagerHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			setupFn: func(t *testing.T, backend secretsmanager.StorageBackend) {
 				t.Helper()
-				_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "pre-created",
 					SecretString: "the-value",
 				})
@@ -641,13 +668,16 @@ func TestSecretsManagerBinarySecret(t *testing.T) {
 
 	binaryData := []byte{0x01, 0x02, 0x03, 0xFF}
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "binary-secret",
 		SecretBinary: binaryData,
 	})
 	require.NoError(t, err)
 
-	out, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "binary-secret"})
+	out, err := backend.GetSecretValue(
+		context.Background(),
+		&secretsmanager.GetSecretValueInput{SecretID: "binary-secret"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, binaryData, out.SecretBinary)
 	assert.Empty(t, out.SecretString)
@@ -659,23 +689,26 @@ func TestSecretsManagerVersionByID(t *testing.T) {
 
 	backend := secretsmanager.NewInMemoryBackend()
 
-	_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "versioned",
 		SecretString: "v1-value",
 	})
 
 	// Get the initial version ID
-	current, _ := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "versioned"})
+	current, _ := backend.GetSecretValue(
+		context.Background(),
+		&secretsmanager.GetSecretValueInput{SecretID: "versioned"},
+	)
 	v1ID := current.VersionID
 
 	// Add v2
-	_, _ = backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+	_, _ = backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 		SecretID:     "versioned",
 		SecretString: "v2-value",
 	})
 
 	// Retrieve v1 by ID
-	out, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+	out, err := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 		SecretID:  "versioned",
 		VersionID: v1ID,
 	})
@@ -782,14 +815,17 @@ func TestSecretsManagerHandlerErrorCases(t *testing.T) {
 			h := secretsmanager.NewHandler(backend)
 
 			if tt.name == "SecretAlreadyExists" {
-				_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "dup-secret"})
+				_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "dup-secret"})
 			}
 			if tt.name == "SecretDeleted" {
-				_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "deleted-secret",
 					SecretString: "value",
 				})
-				_, _ = backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "deleted-secret"})
+				_, _ = backend.DeleteSecret(
+					context.Background(),
+					&secretsmanager.DeleteSecretInput{SecretID: "deleted-secret"},
+				)
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
@@ -813,7 +849,7 @@ func TestSecretsManagerResolveSecretIDARN(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackend()
 
 	// Create a secret and retrieve its ARN
-	out, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	out, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "arn-test-secret",
 		SecretString: "arn-value",
 	})
@@ -821,7 +857,7 @@ func TestSecretsManagerResolveSecretIDARN(t *testing.T) {
 	arn := out.ARN
 
 	// Get by ARN
-	valOut, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+	valOut, err := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 		SecretID: arn,
 	})
 	require.NoError(t, err)
@@ -833,17 +869,17 @@ func TestSecretsManagerGetSecretValueVersionLabel(t *testing.T) {
 	t.Parallel()
 
 	backend := secretsmanager.NewInMemoryBackend()
-	_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "labeled-secret",
 		SecretString: "v1",
 	})
-	_, _ = backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+	_, _ = backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 		SecretID:     "labeled-secret",
 		SecretString: "v2",
 	})
 
 	// Retrieve AWSPREVIOUS
-	out, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+	out, err := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 		SecretID:     "labeled-secret",
 		VersionStage: secretsmanager.StagingLabelPrevious,
 	})
@@ -861,7 +897,7 @@ func TestSecretsManagerPutSecretValueLabelRotation(t *testing.T) {
 	h := secretsmanager.NewHandler(backend)
 
 	// Create initial secret
-	_, _ = backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, _ = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "rotate-test",
 		SecretString: "v1",
 	})
@@ -882,7 +918,10 @@ func TestSecretsManagerPutSecretValueLabelRotation(t *testing.T) {
 	assert.Contains(t, putOut.VersionStages, secretsmanager.StagingLabelCurrent)
 
 	// Current should be v2
-	curr, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "rotate-test"})
+	curr, err := backend.GetSecretValue(
+		context.Background(),
+		&secretsmanager.GetSecretValueInput{SecretID: "rotate-test"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, "v2", curr.SecretString)
 }
@@ -896,7 +935,7 @@ func TestSecretsManagerTagResource(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackend()
 	h := secretsmanager.NewHandler(backend)
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "tag-secret",
 		SecretString: "value",
 	})
@@ -911,7 +950,10 @@ func TestSecretsManagerTagResource(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// DescribeSecret should show tags
-	desc, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "tag-secret"})
+	desc, err := backend.DescribeSecret(
+		context.Background(),
+		&secretsmanager.DescribeSecretInput{SecretID: "tag-secret"},
+	)
 	require.NoError(t, err)
 	envVal, _ := desc.Tags.Get("env")
 	assert.Equal(t, "test", envVal)
@@ -926,7 +968,10 @@ func TestSecretsManagerTagResource(t *testing.T) {
 	require.NoError(t, h.Handler()(e.NewContext(req2, rec2)))
 	assert.Equal(t, http.StatusOK, rec2.Code)
 
-	desc2, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "tag-secret"})
+	desc2, err := backend.DescribeSecret(
+		context.Background(),
+		&secretsmanager.DescribeSecretInput{SecretID: "tag-secret"},
+	)
 	require.NoError(t, err)
 	assert.False(t, desc2.Tags.HasTag("env"))
 	team2Val, _ := desc2.Tags.Get("team")
@@ -942,7 +987,7 @@ func TestSecretsManagerRotateSecret(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackend()
 	h := secretsmanager.NewHandler(backend)
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "rotate-secret",
 		SecretString: "original-value",
 	})
@@ -961,7 +1006,10 @@ func TestSecretsManagerRotateSecret(t *testing.T) {
 	assert.NotEmpty(t, out.VersionID)
 
 	// New version should be AWSCURRENT
-	curr, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "rotate-secret"})
+	curr, err := backend.GetSecretValue(
+		context.Background(),
+		&secretsmanager.GetSecretValueInput{SecretID: "rotate-secret"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, out.VersionID, curr.VersionID)
 	assert.Equal(t, "original-value", curr.SecretString)
@@ -1008,7 +1056,7 @@ func TestSecretsManagerRotateSecret_WithLambda(t *testing.T) {
 	mock := &mockLambdaInvoker{}
 	h.SetLambdaInvoker(mock)
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "lambda-rotate-secret",
 		SecretString: "initial-value",
 	})
@@ -1050,7 +1098,7 @@ func TestSecretsManagerRotateSecret_NoLambdaInvoker(t *testing.T) {
 	h := secretsmanager.NewHandler(backend)
 	// No lambda invoker set
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "no-lambda-rotate",
 		SecretString: "value",
 	})
@@ -1368,21 +1416,24 @@ func TestSecretsManagerVersionPruning(t *testing.T) {
 
 			backend := secretsmanager.NewInMemoryBackend()
 
-			_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "prune-test",
 				SecretString: "initial",
 			})
 			require.NoError(t, err)
 
 			for i := range tt.putCount {
-				_, putErr := backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+				_, putErr := backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 					SecretID:     "prune-test",
 					SecretString: fmt.Sprintf("value-%d", i),
 				})
 				require.NoError(t, putErr)
 			}
 
-			out, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "prune-test"})
+			out, err := backend.DescribeSecret(
+				context.Background(),
+				&secretsmanager.DescribeSecretInput{SecretID: "prune-test"},
+			)
 			require.NoError(t, err)
 			assert.LessOrEqual(t, len(out.VersionIDsToStages), tt.wantMaxVers)
 		})
@@ -1395,21 +1446,24 @@ func TestSecretsManagerVersionPruning_LabeledVersionsPreserved(t *testing.T) {
 
 	backend := secretsmanager.NewInMemoryBackend()
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "prune-labeled",
 		SecretString: "initial",
 	})
 	require.NoError(t, err)
 
 	for i := range 150 {
-		_, putErr := backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+		_, putErr := backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 			SecretID:     "prune-labeled",
 			SecretString: fmt.Sprintf("value-%d", i),
 		})
 		require.NoError(t, putErr)
 	}
 
-	out, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "prune-labeled"})
+	out, err := backend.DescribeSecret(
+		context.Background(),
+		&secretsmanager.DescribeSecretInput{SecretID: "prune-labeled"},
+	)
 	require.NoError(t, err)
 
 	var foundCurrent, foundPrevious bool
@@ -1448,7 +1502,7 @@ func TestSecretsManagerSecretSizeValidation(t *testing.T) {
 		{
 			name: "create_secret_string_too_large",
 			op: func(b *secretsmanager.InMemoryBackend) error {
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "big-string",
 					SecretString: bigString,
 				})
@@ -1460,7 +1514,7 @@ func TestSecretsManagerSecretSizeValidation(t *testing.T) {
 		{
 			name: "create_secret_binary_too_large",
 			op: func(b *secretsmanager.InMemoryBackend) error {
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "big-binary",
 					SecretBinary: bigBinary,
 				})
@@ -1473,12 +1527,13 @@ func TestSecretsManagerSecretSizeValidation(t *testing.T) {
 			name: "put_secret_value_string_too_large",
 			op: func(b *secretsmanager.InMemoryBackend) error {
 				if _, err := b.CreateSecret(
+					context.Background(),
 					&secretsmanager.CreateSecretInput{Name: "existing", SecretString: "ok"},
 				); err != nil {
 					return err
 				}
 
-				_, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+				_, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 					SecretID:     "existing",
 					SecretString: bigString,
 				})
@@ -1491,12 +1546,13 @@ func TestSecretsManagerSecretSizeValidation(t *testing.T) {
 			name: "put_secret_value_binary_too_large",
 			op: func(b *secretsmanager.InMemoryBackend) error {
 				if _, err := b.CreateSecret(
+					context.Background(),
 					&secretsmanager.CreateSecretInput{Name: "existing-bin", SecretString: "ok"},
 				); err != nil {
 					return err
 				}
 
-				_, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+				_, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 					SecretID:     "existing-bin",
 					SecretBinary: bigBinary,
 				})
@@ -1509,12 +1565,13 @@ func TestSecretsManagerSecretSizeValidation(t *testing.T) {
 			name: "update_secret_string_too_large",
 			op: func(b *secretsmanager.InMemoryBackend) error {
 				if _, err := b.CreateSecret(
+					context.Background(),
 					&secretsmanager.CreateSecretInput{Name: "update-big", SecretString: "ok"},
 				); err != nil {
 					return err
 				}
 
-				_, err := b.UpdateSecret(&secretsmanager.UpdateSecretInput{
+				_, err := b.UpdateSecret(context.Background(), &secretsmanager.UpdateSecretInput{
 					SecretID:     "update-big",
 					SecretString: bigString,
 				})
@@ -1526,7 +1583,7 @@ func TestSecretsManagerSecretSizeValidation(t *testing.T) {
 		{
 			name: "create_secret_max_size_accepted",
 			op: func(b *secretsmanager.InMemoryBackend) error {
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "max-size",
 					SecretString: strings.Repeat("x", maxBytes),
 				})
@@ -1570,9 +1627,15 @@ func TestSecretsManagerListSecretVersionIDs(t *testing.T) {
 			name: "returns_labeled_versions",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "lsv-test", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "lsv-test", SecretString: "v1"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutSecretValue(&secretsmanager.PutSecretValueInput{SecretID: "lsv-test", SecretString: "v2"})
+				_, err = b.PutSecretValue(
+					context.Background(),
+					&secretsmanager.PutSecretValueInput{SecretID: "lsv-test", SecretString: "v2"},
+				)
 				require.NoError(t, err)
 			},
 			input: secretsmanager.ListSecretVersionIDsInput{SecretID: "lsv-test"},
@@ -1586,11 +1649,20 @@ func TestSecretsManagerListSecretVersionIDs(t *testing.T) {
 			name: "include_deprecated_returns_all",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "lsv-depr", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "lsv-depr", SecretString: "v1"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutSecretValue(&secretsmanager.PutSecretValueInput{SecretID: "lsv-depr", SecretString: "v2"})
+				_, err = b.PutSecretValue(
+					context.Background(),
+					&secretsmanager.PutSecretValueInput{SecretID: "lsv-depr", SecretString: "v2"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutSecretValue(&secretsmanager.PutSecretValueInput{SecretID: "lsv-depr", SecretString: "v3"})
+				_, err = b.PutSecretValue(
+					context.Background(),
+					&secretsmanager.PutSecretValueInput{SecretID: "lsv-depr", SecretString: "v3"},
+				)
 				require.NoError(t, err)
 			},
 			input: secretsmanager.ListSecretVersionIDsInput{SecretID: "lsv-depr", IncludeDeprecated: true},
@@ -1610,9 +1682,15 @@ func TestSecretsManagerListSecretVersionIDs(t *testing.T) {
 			name: "pagination",
 			setup: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: "lsv-page", SecretString: "v1"})
+				_, err := b.CreateSecret(
+					context.Background(),
+					&secretsmanager.CreateSecretInput{Name: "lsv-page", SecretString: "v1"},
+				)
 				require.NoError(t, err)
-				_, err = b.PutSecretValue(&secretsmanager.PutSecretValueInput{SecretID: "lsv-page", SecretString: "v2"})
+				_, err = b.PutSecretValue(
+					context.Background(),
+					&secretsmanager.PutSecretValueInput{SecretID: "lsv-page", SecretString: "v2"},
+				)
 				require.NoError(t, err)
 			},
 			input: secretsmanager.ListSecretVersionIDsInput{
@@ -1639,7 +1717,7 @@ func TestSecretsManagerListSecretVersionIDs(t *testing.T) {
 			b := secretsmanager.NewInMemoryBackend()
 			tt.setup(t, b)
 
-			out, err := b.ListSecretVersionIDs(&tt.input)
+			out, err := b.ListSecretVersionIDs(context.Background(), &tt.input)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1668,9 +1746,15 @@ func TestSecretsManagerListSecretVersionIDs_Handler(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackend()
 	h := secretsmanager.NewHandler(backend)
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "handler-lsv", SecretString: "v1"})
+	_, err := backend.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "handler-lsv", SecretString: "v1"},
+	)
 	require.NoError(t, err)
-	_, err = backend.PutSecretValue(&secretsmanager.PutSecretValueInput{SecretID: "handler-lsv", SecretString: "v2"})
+	_, err = backend.PutSecretValue(
+		context.Background(),
+		&secretsmanager.PutSecretValueInput{SecretID: "handler-lsv", SecretString: "v2"},
+	)
 	require.NoError(t, err)
 
 	body := `{"SecretId":"handler-lsv"}`
@@ -1716,7 +1800,10 @@ func TestSecretsManagerReset(t *testing.T) {
 
 	backend := secretsmanager.NewInMemoryBackend()
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "to-be-reset", SecretString: "val"})
+	_, err := backend.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "to-be-reset", SecretString: "val"},
+	)
 	require.NoError(t, err)
 	assert.Len(t, backend.ListAll(), 1)
 
@@ -1730,17 +1817,17 @@ func TestSecretsManagerTaggedSecrets(t *testing.T) {
 
 	backend := secretsmanager.NewInMemoryBackend()
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name: "tagged-arn",
 		Tags: []secretsmanager.Tag{{Key: "env", Value: "prod"}},
 	})
 	require.NoError(t, err)
 
-	_, err = backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "no-tags"})
+	_, err = backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: "no-tags"})
 	require.NoError(t, err)
 
 	// Delete one to confirm it's excluded.
-	_, err = backend.DeleteSecret(&secretsmanager.DeleteSecretInput{SecretID: "no-tags"})
+	_, err = backend.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{SecretID: "no-tags"})
 	require.NoError(t, err)
 
 	infos := backend.TaggedSecrets()
@@ -1782,7 +1869,7 @@ func TestSecretsManagerTagSecretByARN(t *testing.T) {
 			b := secretsmanager.NewInMemoryBackend()
 
 			if tt.setupName != "" {
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{Name: tt.setupName})
+				_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{Name: tt.setupName})
 				require.NoError(t, err)
 			}
 
@@ -1830,7 +1917,7 @@ func TestSecretsManagerUntagSecretByARN(t *testing.T) {
 			b := secretsmanager.NewInMemoryBackend()
 
 			if tt.setupName != "" {
-				_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+				_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name: tt.setupName,
 					Tags: []secretsmanager.Tag{{Key: "env", Value: "test"}},
 				})
@@ -1868,7 +1955,10 @@ func TestSecretsManagerHandlerReset(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackend()
 	h := secretsmanager.NewHandler(backend)
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "handler-reset", SecretString: "val"})
+	_, err := backend.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "handler-reset", SecretString: "val"},
+	)
 	require.NoError(t, err)
 	assert.Len(t, backend.ListAll(), 1)
 
@@ -1903,19 +1993,22 @@ func TestSecretsManagerDeleteSecret_ForceDelete(t *testing.T) {
 
 			b := secretsmanager.NewInMemoryBackend()
 
-			_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "force-del-test",
 				SecretString: "val",
 			})
 			require.NoError(t, err)
 
-			_, err = b.DeleteSecret(&secretsmanager.DeleteSecretInput{
+			_, err = b.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{
 				SecretID:                   "force-del-test",
 				ForceDeleteWithoutRecovery: tt.forceDeleteWithoutRecovery,
 			})
 			require.NoError(t, err)
 
-			_, err = b.RestoreSecret(&secretsmanager.RestoreSecretInput{SecretID: "force-del-test"})
+			_, err = b.RestoreSecret(
+				context.Background(),
+				&secretsmanager.RestoreSecretInput{SecretID: "force-del-test"},
+			)
 
 			if tt.wantRestoreErr {
 				require.ErrorIs(t, err, secretsmanager.ErrSecretNotFound)
@@ -1932,22 +2025,22 @@ func TestSecretsManagerRotationEnabled(t *testing.T) {
 
 	b := secretsmanager.NewInMemoryBackend()
 
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "rot-flag-test",
 		SecretString: "initial",
 	})
 	require.NoError(t, err)
 
 	// Before rotation: RotationEnabled should be false.
-	desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "rot-flag-test"})
+	desc, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "rot-flag-test"})
 	require.NoError(t, err)
 	assert.False(t, desc.RotationEnabled)
 
-	_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{SecretID: "rot-flag-test"})
+	_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{SecretID: "rot-flag-test"})
 	require.NoError(t, err)
 
 	// After rotation: RotationEnabled should be true and LastChangedDate set.
-	desc, err = b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "rot-flag-test"})
+	desc, err = b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "rot-flag-test"})
 	require.NoError(t, err)
 	assert.True(t, desc.RotationEnabled)
 	assert.NotNil(t, desc.LastChangedDate)
@@ -1969,7 +2062,7 @@ func TestSecretsManagerLastChangedDate(t *testing.T) {
 			name: "updated_by_put_secret_value",
 			after: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+				_, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 					SecretID:     "lcd-test",
 					SecretString: "v2",
 				})
@@ -1980,7 +2073,7 @@ func TestSecretsManagerLastChangedDate(t *testing.T) {
 			name: "updated_by_update_secret",
 			after: func(t *testing.T, b *secretsmanager.InMemoryBackend) {
 				t.Helper()
-				_, err := b.UpdateSecret(&secretsmanager.UpdateSecretInput{
+				_, err := b.UpdateSecret(context.Background(), &secretsmanager.UpdateSecretInput{
 					SecretID:     "lcd-test",
 					SecretString: "v2-updated",
 				})
@@ -1995,7 +2088,7 @@ func TestSecretsManagerLastChangedDate(t *testing.T) {
 
 			b := secretsmanager.NewInMemoryBackend()
 
-			_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "lcd-test",
 				SecretString: "initial",
 			})
@@ -2003,7 +2096,10 @@ func TestSecretsManagerLastChangedDate(t *testing.T) {
 
 			tt.after(t, b)
 
-			desc, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "lcd-test"})
+			desc, err := b.DescribeSecret(
+				context.Background(),
+				&secretsmanager.DescribeSecretInput{SecretID: "lcd-test"},
+			)
 			require.NoError(t, err)
 			assert.NotNil(t, desc.LastChangedDate)
 			assert.Greater(t, *desc.LastChangedDate, float64(0))
@@ -2043,13 +2139,13 @@ func TestSecretsManagerPutSecretValue_VersionStages(t *testing.T) {
 
 			b := secretsmanager.NewInMemoryBackend()
 
-			_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "vs-test",
 				SecretString: "v1",
 			})
 			require.NoError(t, err)
 
-			out, err := b.PutSecretValue(&secretsmanager.PutSecretValueInput{
+			out, err := b.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 				SecretID:      "vs-test",
 				SecretString:  "v2",
 				VersionStages: tt.versionStages,
@@ -2066,13 +2162,13 @@ func TestSecretsManagerPersistence_RotationEnabled(t *testing.T) {
 
 	b := secretsmanager.NewInMemoryBackend()
 
-	_, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+	_, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 		Name:         "persist-rot",
 		SecretString: "v1",
 	})
 	require.NoError(t, err)
 
-	_, err = b.RotateSecret(&secretsmanager.RotateSecretInput{SecretID: "persist-rot"})
+	_, err = b.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{SecretID: "persist-rot"})
 	require.NoError(t, err)
 
 	snap := b.Snapshot()
@@ -2081,7 +2177,7 @@ func TestSecretsManagerPersistence_RotationEnabled(t *testing.T) {
 	b2 := secretsmanager.NewInMemoryBackend()
 	require.NoError(t, b2.Restore(snap))
 
-	desc, err := b2.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "persist-rot"})
+	desc, err := b2.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "persist-rot"})
 	require.NoError(t, err)
 	assert.True(t, desc.RotationEnabled)
 	assert.NotNil(t, desc.LastChangedDate)

--- a/services/secretsmanager/interfaces.go
+++ b/services/secretsmanager/interfaces.go
@@ -1,31 +1,45 @@
 package secretsmanager
 
+import "context"
+
 // StorageBackend defines the interface for the Secrets Manager in-memory backend.
+// The region for each operation is resolved from the supplied context (falling back
+// to the backend's default region).
 type StorageBackend interface {
-	CreateSecret(input *CreateSecretInput) (*CreateSecretOutput, error)
-	GetSecretValue(input *GetSecretValueInput) (*GetSecretValueOutput, error)
-	PutSecretValue(input *PutSecretValueInput) (*PutSecretValueOutput, error)
-	DeleteSecret(input *DeleteSecretInput) (*DeleteSecretOutput, error)
-	ListSecrets(input *ListSecretsInput) (*ListSecretsOutput, error)
-	ListSecretVersionIDs(input *ListSecretVersionIDsInput) (*ListSecretVersionIDsOutput, error)
-	DescribeSecret(input *DescribeSecretInput) (*DescribeSecretOutput, error)
-	UpdateSecret(input *UpdateSecretInput) (*UpdateSecretOutput, error)
-	RestoreSecret(input *RestoreSecretInput) (*RestoreSecretOutput, error)
-	TagResource(input *TagResourceInput) error
-	UntagResource(input *UntagResourceInput) error
-	RotateSecret(input *RotateSecretInput) (*RotateSecretOutput, error)
+	CreateSecret(ctx context.Context, input *CreateSecretInput) (*CreateSecretOutput, error)
+	GetSecretValue(ctx context.Context, input *GetSecretValueInput) (*GetSecretValueOutput, error)
+	PutSecretValue(ctx context.Context, input *PutSecretValueInput) (*PutSecretValueOutput, error)
+	DeleteSecret(ctx context.Context, input *DeleteSecretInput) (*DeleteSecretOutput, error)
+	ListSecrets(ctx context.Context, input *ListSecretsInput) (*ListSecretsOutput, error)
+	ListSecretVersionIDs(ctx context.Context, input *ListSecretVersionIDsInput) (*ListSecretVersionIDsOutput, error)
+	DescribeSecret(ctx context.Context, input *DescribeSecretInput) (*DescribeSecretOutput, error)
+	UpdateSecret(ctx context.Context, input *UpdateSecretInput) (*UpdateSecretOutput, error)
+	RestoreSecret(ctx context.Context, input *RestoreSecretInput) (*RestoreSecretOutput, error)
+	TagResource(ctx context.Context, input *TagResourceInput) error
+	UntagResource(ctx context.Context, input *UntagResourceInput) error
+	RotateSecret(ctx context.Context, input *RotateSecretInput) (*RotateSecretOutput, error)
 	GetRandomPassword(input *GetRandomPasswordInput) (*GetRandomPasswordOutput, error)
 	ListAll() []SecretListEntry
-	BatchGetSecretValue(input *BatchGetSecretValueInput) (*BatchGetSecretValueOutput, error)
-	CancelRotateSecret(input *CancelRotateSecretInput) (*CancelRotateSecretOutput, error)
-	GetResourcePolicy(input *GetResourcePolicyInput) (*GetResourcePolicyOutput, error)
-	PutResourcePolicy(input *PutResourcePolicyInput) (*PutResourcePolicyOutput, error)
-	DeleteResourcePolicy(input *DeleteResourcePolicyInput) (*DeleteResourcePolicyOutput, error)
-	ReplicateSecretToRegions(input *ReplicateSecretToRegionsInput) (*ReplicateSecretToRegionsOutput, error)
-	RemoveRegionsFromReplication(input *RemoveRegionsFromReplicationInput) (*RemoveRegionsFromReplicationOutput, error)
-	StopReplicationToReplica(input *StopReplicationToReplicaInput) (*StopReplicationToReplicaOutput, error)
-	UpdateSecretVersionStage(input *UpdateSecretVersionStageInput) (*UpdateSecretVersionStageOutput, error)
-	ValidateResourcePolicy(input *ValidateResourcePolicyInput) (*ValidateResourcePolicyOutput, error)
+	BatchGetSecretValue(ctx context.Context, input *BatchGetSecretValueInput) (*BatchGetSecretValueOutput, error)
+	CancelRotateSecret(ctx context.Context, input *CancelRotateSecretInput) (*CancelRotateSecretOutput, error)
+	GetResourcePolicy(ctx context.Context, input *GetResourcePolicyInput) (*GetResourcePolicyOutput, error)
+	PutResourcePolicy(ctx context.Context, input *PutResourcePolicyInput) (*PutResourcePolicyOutput, error)
+	DeleteResourcePolicy(ctx context.Context, input *DeleteResourcePolicyInput) (*DeleteResourcePolicyOutput, error)
+	ReplicateSecretToRegions(
+		ctx context.Context, input *ReplicateSecretToRegionsInput,
+	) (*ReplicateSecretToRegionsOutput, error)
+	RemoveRegionsFromReplication(
+		ctx context.Context, input *RemoveRegionsFromReplicationInput,
+	) (*RemoveRegionsFromReplicationOutput, error)
+	StopReplicationToReplica(
+		ctx context.Context, input *StopReplicationToReplicaInput,
+	) (*StopReplicationToReplicaOutput, error)
+	UpdateSecretVersionStage(
+		ctx context.Context, input *UpdateSecretVersionStageInput,
+	) (*UpdateSecretVersionStageOutput, error)
+	ValidateResourcePolicy(
+		ctx context.Context, input *ValidateResourcePolicyInput,
+	) (*ValidateResourcePolicyOutput, error)
 }
 
 // ensure InMemoryBackend satisfies StorageBackend at compile time.

--- a/services/secretsmanager/isolation_test.go
+++ b/services/secretsmanager/isolation_test.go
@@ -1,0 +1,96 @@
+package secretsmanager //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func smCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+func TestSecretsManagerRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+
+	ctxEast := smCtxRegion("us-east-1")
+	ctxWest := smCtxRegion("us-west-2")
+
+	// 1. Create a secret with the same name in us-east-1.
+	eastOut, err := backend.CreateSecret(ctxEast, &CreateSecretInput{Name: "shared", SecretString: "east-value"})
+	require.NoError(t, err)
+	assert.Contains(t, eastOut.ARN, "us-east-1")
+
+	// 2. Create a secret with the SAME NAME in us-west-2.
+	westOut, err := backend.CreateSecret(ctxWest, &CreateSecretInput{Name: "shared", SecretString: "west-value"})
+	require.NoError(t, err)
+	assert.Contains(t, westOut.ARN, "us-west-2")
+
+	// 3. us-east-1 reads its own value.
+	eastVal, err := backend.GetSecretValue(ctxEast, &GetSecretValueInput{SecretID: "shared"})
+	require.NoError(t, err)
+	assert.Equal(t, "east-value", eastVal.SecretString)
+	assert.Contains(t, eastVal.ARN, "us-east-1")
+
+	// 4. us-west-2 reads its own value.
+	westVal, err := backend.GetSecretValue(ctxWest, &GetSecretValueInput{SecretID: "shared"})
+	require.NoError(t, err)
+	assert.Equal(t, "west-value", westVal.SecretString)
+	assert.Contains(t, westVal.ARN, "us-west-2")
+
+	// Each region lists exactly one secret.
+	eastList, err := backend.ListSecrets(ctxEast, &ListSecretsInput{})
+	require.NoError(t, err)
+	require.Len(t, eastList.SecretList, 1)
+
+	westList, err := backend.ListSecrets(ctxWest, &ListSecretsInput{})
+	require.NoError(t, err)
+	require.Len(t, westList.SecretList, 1)
+
+	// 5. Force-delete in us-east-1; us-west-2's secret remains.
+	_, err = backend.DeleteSecret(ctxEast, &DeleteSecretInput{
+		SecretID:                   "shared",
+		ForceDeleteWithoutRecovery: true,
+	})
+	require.NoError(t, err)
+
+	_, err = backend.GetSecretValue(ctxEast, &GetSecretValueInput{SecretID: "shared"})
+	require.Error(t, err)
+
+	stillThere, err := backend.GetSecretValue(ctxWest, &GetSecretValueInput{SecretID: "shared"})
+	require.NoError(t, err)
+	assert.Equal(t, "west-value", stillThere.SecretString)
+}
+
+func TestSecretsManagerResourcePolicyRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backend := NewInMemoryBackendWithConfig("000000000000", "us-east-1")
+
+	ctxEast := smCtxRegion("us-east-1")
+	ctxWest := smCtxRegion("us-west-2")
+
+	_, err := backend.CreateSecret(ctxEast, &CreateSecretInput{Name: "p", SecretString: "v"})
+	require.NoError(t, err)
+	_, err = backend.CreateSecret(ctxWest, &CreateSecretInput{Name: "p", SecretString: "v"})
+	require.NoError(t, err)
+
+	_, err = backend.PutResourcePolicy(ctxEast, &PutResourcePolicyInput{
+		SecretID:       "p",
+		ResourcePolicy: `{"east":true}`,
+	})
+	require.NoError(t, err)
+
+	// us-east-1 has the policy; us-west-2 does not.
+	eastPol, err := backend.GetResourcePolicy(ctxEast, &GetResourcePolicyInput{SecretID: "p"})
+	require.NoError(t, err)
+	assert.Equal(t, `{"east":true}`, eastPol.ResourcePolicy)
+
+	westPol, err := backend.GetResourcePolicy(ctxWest, &GetResourcePolicyInput{SecretID: "p"})
+	require.NoError(t, err)
+	assert.Empty(t, westPol.ResourcePolicy)
+}

--- a/services/secretsmanager/janitor.go
+++ b/services/secretsmanager/janitor.go
@@ -74,17 +74,20 @@ func (j *Janitor) sweepExpiredSecrets(ctx context.Context) {
 	j.Backend.mu.Lock("sweepExpiredSecrets")
 	purged := 0
 
-	for name, secret := range j.Backend.secrets {
-		if secret.DeletedDate != nil {
+	for region, regionSecrets := range j.Backend.secrets {
+		for name, secret := range regionSecrets {
+			if secret.DeletedDate == nil {
+				continue
+			}
 			// By default recovery window is 30 days. If the secret was deleted more than 30 days ago, purge it.
 			deletionTime := *secret.DeletedDate + float64(defaultRecoveryWindowDays*secondsPerDay)
 			if nowFloat >= deletionTime {
 				if secret.Tags != nil {
 					secret.Tags.Close()
 				}
-				delete(j.Backend.secrets, name)
-				delete(j.Backend.resourcePolicies, name)
-				delete(j.Backend.replicationConfigs, name)
+				delete(regionSecrets, name)
+				delete(j.Backend.resourcePoliciesStore(region), name)
+				delete(j.Backend.replicationConfigsStore(region), name)
 				purged++
 			}
 		}

--- a/services/secretsmanager/parity_extras_test.go
+++ b/services/secretsmanager/parity_extras_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,10 +15,10 @@ func TestDescribeSecret_OwnerAccountAndPrimaryRegion(t *testing.T) {
 
 	b := sm.NewInMemoryBackendWithConfig("000000000001", "eu-west-2")
 
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "owned", SecretString: "v"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "owned", SecretString: "v"})
 	require.NoError(t, err)
 
-	out, err := b.DescribeSecret(&sm.DescribeSecretInput{SecretID: "owned"})
+	out, err := b.DescribeSecret(context.Background(), &sm.DescribeSecretInput{SecretID: "owned"})
 	require.NoError(t, err)
 	assert.Equal(t, "000000000001", out.OwnerAccountID)
 	assert.Equal(t, "eu-west-2", out.PrimaryRegion)
@@ -28,13 +29,13 @@ func TestListSecretVersionIDs_IncludesLastAccessedDate(t *testing.T) {
 
 	b := sm.NewInMemoryBackendWithConfig("000000000001", "us-east-1")
 
-	_, err := b.CreateSecret(&sm.CreateSecretInput{Name: "with-access", SecretString: "value"})
+	_, err := b.CreateSecret(context.Background(), &sm.CreateSecretInput{Name: "with-access", SecretString: "value"})
 	require.NoError(t, err)
 
-	_, err = b.GetSecretValue(&sm.GetSecretValueInput{SecretID: "with-access"})
+	_, err = b.GetSecretValue(context.Background(), &sm.GetSecretValueInput{SecretID: "with-access"})
 	require.NoError(t, err)
 
-	out, err := b.ListSecretVersionIDs(&sm.ListSecretVersionIDsInput{SecretID: "with-access"})
+	out, err := b.ListSecretVersionIDs(context.Background(), &sm.ListSecretVersionIDsInput{SecretID: "with-access"})
 	require.NoError(t, err)
 	require.Len(t, out.Versions, 1)
 	require.NotNil(t, out.Versions[0].LastAccessedDate)

--- a/services/secretsmanager/persistence.go
+++ b/services/secretsmanager/persistence.go
@@ -26,12 +26,13 @@ type secretSnapshot struct {
 	RotationEnabled   bool                      `json:"rotationEnabled,omitempty"`
 }
 
+// backendSnapshot mirrors the region-nested backend maps (outer key = region).
 type backendSnapshot struct {
-	Secrets            map[string]*secretSnapshot         `json:"secrets"`
-	ResourcePolicies   map[string]string                  `json:"resourcePolicies,omitempty"`
-	ReplicationConfigs map[string][]ReplicationStatusType `json:"replicationConfigs,omitempty"`
-	AccountID          string                             `json:"accountID"`
-	Region             string                             `json:"region"`
+	Secrets            map[string]map[string]*secretSnapshot         `json:"secrets"`
+	ResourcePolicies   map[string]map[string]string                  `json:"resourcePolicies,omitempty"`
+	ReplicationConfigs map[string]map[string][]ReplicationStatusType `json:"replicationConfigs,omitempty"`
+	AccountID          string                                        `json:"accountID"`
+	Region             string                                        `json:"region"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -40,25 +41,29 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock("Snapshot")
 	defer b.mu.RUnlock()
 
-	secrets := make(map[string]*secretSnapshot, len(b.secrets))
-	for k, s := range b.secrets {
-		secrets[k] = &secretSnapshot{
-			ARN:               s.ARN,
-			Name:              s.Name,
-			Description:       s.Description,
-			KmsKeyID:          s.KmsKeyID,
-			RotationLambdaARN: s.RotationLambdaARN,
-			RotationRules:     cloneRotationRules(s.RotationRules),
-			Tags:              s.Tags,
-			DeletedDate:       s.DeletedDate,
-			LastChangedDate:   s.LastChangedDate,
-			LastRotatedDate:   s.LastRotatedDate,
-			LastAccessedDate:  s.LastAccessedDate,
-			CreatedDate:       s.CreatedDate,
-			Versions:          s.Versions,
-			CurrentVersionID:  s.CurrentVersionID,
-			RotationEnabled:   s.RotationEnabled,
+	secrets := make(map[string]map[string]*secretSnapshot, len(b.secrets))
+	for region, regionSecrets := range b.secrets {
+		regionMap := make(map[string]*secretSnapshot, len(regionSecrets))
+		for k, s := range regionSecrets {
+			regionMap[k] = &secretSnapshot{
+				ARN:               s.ARN,
+				Name:              s.Name,
+				Description:       s.Description,
+				KmsKeyID:          s.KmsKeyID,
+				RotationLambdaARN: s.RotationLambdaARN,
+				RotationRules:     cloneRotationRules(s.RotationRules),
+				Tags:              s.Tags,
+				DeletedDate:       s.DeletedDate,
+				LastChangedDate:   s.LastChangedDate,
+				LastRotatedDate:   s.LastRotatedDate,
+				LastAccessedDate:  s.LastAccessedDate,
+				CreatedDate:       s.CreatedDate,
+				Versions:          s.Versions,
+				CurrentVersionID:  s.CurrentVersionID,
+				RotationEnabled:   s.RotationEnabled,
+			}
 		}
+		secrets[region] = regionMap
 	}
 
 	snap := backendSnapshot{
@@ -93,81 +98,94 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 
 	// Close Tags on any secrets that are being replaced to prevent
 	// Prometheus registry leaks.
-	for _, secret := range b.secrets {
-		if secret.Tags != nil {
-			secret.Tags.Close()
+	for _, regionSecrets := range b.secrets {
+		for _, secret := range regionSecrets {
+			if secret.Tags != nil {
+				secret.Tags.Close()
+			}
 		}
 	}
 
 	if snap.Secrets == nil {
-		snap.Secrets = make(map[string]*secretSnapshot)
+		snap.Secrets = make(map[string]map[string]*secretSnapshot)
 	}
 
-	b.secrets = make(map[string]*Secret, len(snap.Secrets))
+	b.secrets = make(map[string]map[string]*Secret, len(snap.Secrets))
 
-	for k, ss := range snap.Secrets {
-		if ss.Versions == nil {
-			ss.Versions = make(map[string]*SecretVersion)
+	for region, regionSecrets := range snap.Secrets {
+		regionMap := make(map[string]*Secret, len(regionSecrets))
+		for k, ss := range regionSecrets {
+			regionMap[k] = secretFromSnapshot(ss)
 		}
-
-		b.secrets[k] = &Secret{
-			ARN:               ss.ARN,
-			Name:              ss.Name,
-			Description:       ss.Description,
-			KmsKeyID:          ss.KmsKeyID,
-			RotationLambdaARN: ss.RotationLambdaARN,
-			RotationRules:     cloneRotationRules(ss.RotationRules),
-			Tags:              ss.Tags,
-			DeletedDate:       ss.DeletedDate,
-			LastChangedDate:   ss.LastChangedDate,
-			LastRotatedDate:   ss.LastRotatedDate,
-			LastAccessedDate:  ss.LastAccessedDate,
-			CreatedDate:       ss.CreatedDate,
-			Versions:          ss.Versions,
-			CurrentVersionID:  ss.CurrentVersionID,
-			RotationEnabled:   ss.RotationEnabled,
-		}
+		b.secrets[region] = regionMap
 	}
 
 	b.accountID = snap.AccountID
 	b.region = snap.Region
 
 	if snap.ResourcePolicies == nil {
-		snap.ResourcePolicies = make(map[string]string)
+		snap.ResourcePolicies = make(map[string]map[string]string)
 	}
 
 	b.resourcePolicies = snap.ResourcePolicies
 
 	if snap.ReplicationConfigs == nil {
-		snap.ReplicationConfigs = make(map[string][]ReplicationStatusType)
+		snap.ReplicationConfigs = make(map[string]map[string][]ReplicationStatusType)
 	}
 
 	b.replicationConfigs = snap.ReplicationConfigs
 
 	b.ensureNonNilMaps()
-	for _, secret := range b.secrets {
-		if secret.RotationRules != nil && secret.RotationEnabled {
-			b.ensureRotationScheduler()
+	for _, regionSecrets := range b.secrets {
+		for _, secret := range regionSecrets {
+			if secret.RotationRules != nil && secret.RotationEnabled {
+				b.ensureRotationScheduler()
 
-			break
+				return nil
+			}
 		}
 	}
 
 	return nil
 }
 
+// secretFromSnapshot rebuilds a live Secret from its persisted representation.
+func secretFromSnapshot(ss *secretSnapshot) *Secret {
+	if ss.Versions == nil {
+		ss.Versions = make(map[string]*SecretVersion)
+	}
+
+	return &Secret{
+		ARN:               ss.ARN,
+		Name:              ss.Name,
+		Description:       ss.Description,
+		KmsKeyID:          ss.KmsKeyID,
+		RotationLambdaARN: ss.RotationLambdaARN,
+		RotationRules:     cloneRotationRules(ss.RotationRules),
+		Tags:              ss.Tags,
+		DeletedDate:       ss.DeletedDate,
+		LastChangedDate:   ss.LastChangedDate,
+		LastRotatedDate:   ss.LastRotatedDate,
+		LastAccessedDate:  ss.LastAccessedDate,
+		CreatedDate:       ss.CreatedDate,
+		Versions:          ss.Versions,
+		CurrentVersionID:  ss.CurrentVersionID,
+		RotationEnabled:   ss.RotationEnabled,
+	}
+}
+
 // ensureNonNilMaps initialises any nil maps to avoid nil-map panics.
 func (b *InMemoryBackend) ensureNonNilMaps() {
 	if b.secrets == nil {
-		b.secrets = make(map[string]*Secret)
+		b.secrets = make(map[string]map[string]*Secret)
 	}
 
 	if b.resourcePolicies == nil {
-		b.resourcePolicies = make(map[string]string)
+		b.resourcePolicies = make(map[string]map[string]string)
 	}
 
 	if b.replicationConfigs == nil {
-		b.replicationConfigs = make(map[string][]ReplicationStatusType)
+		b.replicationConfigs = make(map[string]map[string][]ReplicationStatusType)
 	}
 }
 

--- a/services/secretsmanager/persistence_test.go
+++ b/services/secretsmanager/persistence_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 		{
 			name: "round_trip_preserves_state",
 			setup: func(b *secretsmanager.InMemoryBackend) string {
-				out, err := b.CreateSecret(&secretsmanager.CreateSecretInput{
+				out, err := b.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 					Name:         "test-secret",
 					Description:  "test description",
 					SecretString: "my-secret-value",
@@ -34,7 +35,7 @@ func TestInMemoryBackend_SnapshotRestore(t *testing.T) {
 			verify: func(t *testing.T, b *secretsmanager.InMemoryBackend, id string) {
 				t.Helper()
 
-				out, err := b.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: id})
+				out, err := b.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: id})
 				require.NoError(t, err)
 				assert.Equal(t, id, out.Name)
 				assert.Equal(t, "test description", out.Description)
@@ -84,7 +85,10 @@ func TestSecretsManagerHandler_Persistence(t *testing.T) {
 	backend := secretsmanager.NewInMemoryBackendWithConfig("000000000000", "us-east-1")
 	h := secretsmanager.NewHandler(backend)
 
-	_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{Name: "snap-secret", SecretString: "snap-value"})
+	_, err := backend.CreateSecret(
+		context.Background(),
+		&secretsmanager.CreateSecretInput{Name: "snap-secret", SecretString: "snap-value"},
+	)
 	require.NoError(t, err)
 
 	snap := h.Snapshot()
@@ -94,7 +98,7 @@ func TestSecretsManagerHandler_Persistence(t *testing.T) {
 	freshH := secretsmanager.NewHandler(fresh)
 	require.NoError(t, freshH.Restore(snap))
 
-	out, err := fresh.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "snap-secret"})
+	out, err := fresh.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{SecretID: "snap-secret"})
 	require.NoError(t, err)
 	assert.Equal(t, "snap-secret", out.Name)
 }

--- a/services/secretsmanager/rotation_lambda_test.go
+++ b/services/secretsmanager/rotation_lambda_test.go
@@ -56,7 +56,7 @@ func TestRotation_StagingLabels_PendingBeforeFinish(t *testing.T) {
 			}
 			h.SetLambdaInvoker(mock)
 
-			_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "pending-test",
 				SecretString: "v1",
 			})
@@ -75,7 +75,10 @@ func TestRotation_StagingLabels_PendingBeforeFinish(t *testing.T) {
 
 			// New version must be AWSCURRENT after all steps succeed.
 			if tt.wantCurrent {
-				curr, getErr := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "pending-test"})
+				curr, getErr := backend.GetSecretValue(
+					context.Background(),
+					&secretsmanager.GetSecretValueInput{SecretID: "pending-test"},
+				)
 				require.NoError(t, getErr)
 				assert.Contains(t, curr.VersionStages, "AWSCURRENT")
 				assert.NotContains(t, curr.VersionStages, "AWSPENDING",
@@ -132,7 +135,7 @@ func TestRotation_LambdaFailure_AbortsRotation(t *testing.T) {
 			}
 			h.SetLambdaInvoker(mock)
 
-			out0, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+			out0, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "abort-test",
 				SecretString: "original",
 			})
@@ -150,7 +153,10 @@ func TestRotation_LambdaFailure_AbortsRotation(t *testing.T) {
 			assert.NotEqual(t, 200, rec.Code, "Lambda failure must cause non-200 response")
 
 			// Original AWSCURRENT must be unchanged.
-			curr, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "abort-test"})
+			curr, err := backend.GetSecretValue(
+				context.Background(),
+				&secretsmanager.GetSecretValueInput{SecretID: "abort-test"},
+			)
 			require.NoError(t, err)
 			assert.Equal(t, originalVersion, curr.VersionID,
 				"original AWSCURRENT version must be intact after Lambda failure")
@@ -197,7 +203,7 @@ func TestRotation_ScheduledRotation_InvokesLambda(t *testing.T) {
 			}
 			h.SetLambdaInvoker(mock)
 
-			_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "sched-lambda",
 				SecretString: "v0",
 			})
@@ -205,7 +211,7 @@ func TestRotation_ScheduledRotation_InvokesLambda(t *testing.T) {
 
 			days := int64(1)
 			rotateImmediately := false
-			_, err = backend.RotateSecret(&secretsmanager.RotateSecretInput{
+			_, err = backend.RotateSecret(context.Background(), &secretsmanager.RotateSecretInput{
 				SecretID:          "sched-lambda",
 				RotationLambdaARN: testLambdaARN,
 				RotationRules: &secretsmanager.RotationRulesType{
@@ -225,7 +231,10 @@ func TestRotation_ScheduledRotation_InvokesLambda(t *testing.T) {
 				"scheduler must invoke Lambda rotation steps in order")
 
 			// New version must be AWSCURRENT.
-			curr, getErr := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "sched-lambda"})
+			curr, getErr := backend.GetSecretValue(
+				context.Background(),
+				&secretsmanager.GetSecretValueInput{SecretID: "sched-lambda"},
+			)
 			require.NoError(t, getErr)
 			assert.Contains(t, curr.VersionStages, "AWSCURRENT")
 		})

--- a/services/secretsmanager/rotation_replication_test.go
+++ b/services/secretsmanager/rotation_replication_test.go
@@ -1,6 +1,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -52,25 +53,32 @@ func TestRotateSecretRulesAndScheduler(t *testing.T) {
 			t.Parallel()
 
 			backend := secretsmanager.NewInMemoryBackend()
-			_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "sched-secret",
 				SecretString: "initial",
 			})
 			require.NoError(t, err)
 
-			before, err := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretID: "sched-secret"})
+			before, err := backend.GetSecretValue(
+				context.Background(),
+				&secretsmanager.GetSecretValueInput{SecretID: "sched-secret"},
+			)
 			require.NoError(t, err)
 
-			out, err := backend.RotateSecret(&tt.rotateInput)
+			out, err := backend.RotateSecret(context.Background(), &tt.rotateInput)
 			require.NoError(t, err)
 
-			desc, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{SecretID: "sched-secret"})
+			desc, err := backend.DescribeSecret(
+				context.Background(),
+				&secretsmanager.DescribeSecretInput{SecretID: "sched-secret"},
+			)
 			require.NoError(t, err)
 			require.NotNil(t, desc.RotationRules)
 
 			if tt.wantImmediateEmpty {
 				assert.Empty(t, out.VersionID)
 				current, currentErr := backend.GetSecretValue(
+					context.Background(),
 					&secretsmanager.GetSecretValueInput{SecretID: "sched-secret"},
 				)
 				require.NoError(t, currentErr)
@@ -92,6 +100,7 @@ func TestRotateSecretRulesAndScheduler(t *testing.T) {
 
 			for time.Now().Before(deadline) {
 				current, currentErr := backend.GetSecretValue(
+					context.Background(),
 					&secretsmanager.GetSecretValueInput{SecretID: "sched-secret"},
 				)
 				require.NoError(t, currentErr)
@@ -134,19 +143,22 @@ func TestReplicationStatusSync(t *testing.T) {
 			t.Parallel()
 
 			backend := secretsmanager.NewInMemoryBackend()
-			_, err := backend.CreateSecret(&secretsmanager.CreateSecretInput{
+			_, err := backend.CreateSecret(context.Background(), &secretsmanager.CreateSecretInput{
 				Name:         "replication-secret",
 				SecretString: tt.initialSecretString,
 			})
 			require.NoError(t, err)
 
-			_, err = backend.ReplicateSecretToRegions(&secretsmanager.ReplicateSecretToRegionsInput{
-				SecretID:          "replication-secret",
-				AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-west-2"}},
-			})
+			_, err = backend.ReplicateSecretToRegions(
+				context.Background(),
+				&secretsmanager.ReplicateSecretToRegionsInput{
+					SecretID:          "replication-secret",
+					AddReplicaRegions: []secretsmanager.ReplicaRegion{{Region: "us-west-2"}},
+				},
+			)
 			require.NoError(t, err)
 
-			desc, err := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{
+			desc, err := backend.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{
 				SecretID: "replication-secret",
 			})
 			require.NoError(t, err)
@@ -159,27 +171,33 @@ func TestReplicationStatusSync(t *testing.T) {
 				return
 			}
 
-			initialCurrent, currentErr := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
-				SecretID: "replication-secret",
-			})
+			initialCurrent, currentErr := backend.GetSecretValue(
+				context.Background(),
+				&secretsmanager.GetSecretValueInput{
+					SecretID: "replication-secret",
+				},
+			)
 			require.NoError(t, currentErr)
 			assert.Contains(t, desc.ReplicationStatus[0].StatusMessage, initialCurrent.VersionID)
 
-			_, err = backend.PutSecretValue(&secretsmanager.PutSecretValueInput{
+			_, err = backend.PutSecretValue(context.Background(), &secretsmanager.PutSecretValueInput{
 				SecretID:     "replication-secret",
 				SecretString: "v2",
 			})
 			require.NoError(t, err)
 
-			nextCurrent, nextErr := backend.GetSecretValue(&secretsmanager.GetSecretValueInput{
+			nextCurrent, nextErr := backend.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 				SecretID: "replication-secret",
 			})
 			require.NoError(t, nextErr)
 			assert.NotEqual(t, initialCurrent.VersionID, nextCurrent.VersionID)
 
-			descAfterPut, describeErr := backend.DescribeSecret(&secretsmanager.DescribeSecretInput{
-				SecretID: "replication-secret",
-			})
+			descAfterPut, describeErr := backend.DescribeSecret(
+				context.Background(),
+				&secretsmanager.DescribeSecretInput{
+					SecretID: "replication-secret",
+				},
+			)
 			require.NoError(t, describeErr)
 			require.Len(t, descAfterPut.ReplicationStatus, 1)
 			assert.Equal(t, "InSync", descAfterPut.ReplicationStatus[0].Status)

--- a/services/sqs/isolation_test.go
+++ b/services/sqs/isolation_test.go
@@ -1,0 +1,81 @@
+package sqs_test
+
+import (
+	"testing"
+
+	"github.com/blackbirdworks/gopherstack/services/sqs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQSRegionIsolation proves that a same-named queue created in two different
+// regions stays fully isolated: each region lists only its own queue, GetQueueURL
+// is region-scoped, and deleting the queue in one region leaves the other region's
+// queue intact.
+//
+// SQS isolates by a region-qualified map key (region + queue name) and stores the
+// region on every queue; ListQueues/GetQueueURL filter by the request region
+// threaded from SigV4. This test locks that behaviour in.
+func TestSQSRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		east  = "us-east-1"
+		west  = "us-west-2"
+		queue = "shared-name"
+	)
+
+	b := sqs.NewInMemoryBackendWithConfig("000000000000", east)
+	t.Cleanup(b.Close)
+
+	// 1. Create a queue named "shared-name" in us-east-1.
+	_, err := b.CreateQueue(&sqs.CreateQueueInput{
+		QueueName: queue,
+		Endpoint:  "localhost:4566",
+		Region:    east,
+	})
+	require.NoError(t, err)
+
+	// 2. Create a queue with the SAME NAME in us-west-2 — must NOT collide.
+	_, err = b.CreateQueue(&sqs.CreateQueueInput{
+		QueueName: queue,
+		Endpoint:  "localhost:4566",
+		Region:    west,
+	})
+	require.NoError(t, err)
+
+	// 3. Each region lists exactly its own queue.
+	eastList, err := b.ListQueues(&sqs.ListQueuesInput{Region: east})
+	require.NoError(t, err)
+	require.Len(t, eastList.QueueURLs, 1)
+
+	westList, err := b.ListQueues(&sqs.ListQueuesInput{Region: west})
+	require.NoError(t, err)
+	require.Len(t, westList.QueueURLs, 1)
+
+	// 4. GetQueueURL resolves within the requested region.
+	gotEast, err := b.GetQueueURL(&sqs.GetQueueURLInput{QueueName: queue, Region: east})
+	require.NoError(t, err)
+	assert.NotEmpty(t, gotEast.QueueURL)
+
+	gotWest, err := b.GetQueueURL(&sqs.GetQueueURLInput{QueueName: queue, Region: west})
+	require.NoError(t, err)
+	assert.NotEmpty(t, gotWest.QueueURL)
+
+	// 5. Deleting the us-east-1 queue leaves the us-west-2 queue intact.
+	require.NoError(t, b.DeleteQueue(&sqs.DeleteQueueInput{QueueURL: gotEast.QueueURL, Region: east}))
+
+	_, err = b.GetQueueURL(&sqs.GetQueueURLInput{QueueName: queue, Region: east})
+	require.Error(t, err)
+
+	_, err = b.GetQueueURL(&sqs.GetQueueURLInput{QueueName: queue, Region: west})
+	require.NoError(t, err)
+
+	eastAfter, err := b.ListQueues(&sqs.ListQueuesInput{Region: east})
+	require.NoError(t, err)
+	assert.Empty(t, eastAfter.QueueURLs)
+
+	westAfter, err := b.ListQueues(&sqs.ListQueuesInput{Region: west})
+	require.NoError(t, err)
+	assert.Len(t, westAfter.QueueURLs, 1)
+}

--- a/test/e2e/acm_test.go
+++ b/test/e2e/acm_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -17,6 +18,7 @@ func TestACMDashboard(t *testing.T) {
 	stack := newStack(t)
 
 	_, err := stack.ACMHandler.Backend.RequestCertificate(
+		context.Background(),
 		"e2e-test.example.com",
 		"AMAZON_ISSUED",
 		"",

--- a/test/e2e/codeartifact_test.go
+++ b/test/e2e/codeartifact_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -16,7 +17,7 @@ import (
 func TestCodeArtifactDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	_, err := stack.CodeArtifactHandler.Backend.CreateDomain("e2e-test-domain", "", nil)
+	_, err := stack.CodeArtifactHandler.Backend.CreateDomain(context.Background(), "e2e-test-domain", "", nil)
 	require.NoError(t, err)
 
 	server := httptest.NewServer(stack.Echo)

--- a/test/e2e/codepipeline_test.go
+++ b/test/e2e/codepipeline_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -19,6 +20,7 @@ func TestCodePipelineDashboard(t *testing.T) {
 	stack := newStack(t)
 
 	_, err := stack.CodePipelineHandler.Backend.CreatePipeline(
+		context.Background(),
 		codepipelinebackend.PipelineDeclaration{
 			Name:    "e2e-test-pipeline",
 			RoleArn: "arn:aws:iam::000000000000:role/pipeline-role",

--- a/test/e2e/dms_test.go
+++ b/test/e2e/dms_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -17,7 +18,7 @@ func TestDMSDashboard(t *testing.T) {
 	stack := newStack(t)
 
 	_, err := stack.DMSHandler.Backend.CreateReplicationInstance(
-		"e2e-rep-inst", "dms.t3.medium", "", "", 50, false, true, false, nil,
+		context.Background(), "e2e-rep-inst", "dms.t3.medium", "", "", 50, false, true, false, nil,
 	)
 	require.NoError(t, err)
 

--- a/test/e2e/efs_test.go
+++ b/test/e2e/efs_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 func TestEFSDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	_, err := stack.EFSHandler.Backend.CreateFileSystem(efsbackend.CreateFileSystemRequest{
+	_, err := stack.EFSHandler.Backend.CreateFileSystem(context.Background(), efsbackend.CreateFileSystemRequest{
 		CreationToken:   "e2e-test-token",
 		PerformanceMode: "generalPurpose",
 		ThroughputMode:  "bursting",

--- a/test/e2e/elb_test.go
+++ b/test/e2e/elb_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 func TestELBDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	_, err := stack.ELBHandler.Backend.CreateLoadBalancer(elbbackend.CreateLoadBalancerInput{
+	_, err := stack.ELBHandler.Backend.CreateLoadBalancer(context.Background(), elbbackend.CreateLoadBalancerInput{
 		LoadBalancerName:  "e2e-test-lb",
 		Scheme:            "internet-facing",
 		AvailabilityZones: []string{"us-east-1a"},

--- a/test/e2e/emr_test.go
+++ b/test/e2e/emr_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 func TestEMRDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	_, err := stack.EMRHandler.Backend.RunJobFlow(emr.RunJobFlowParams{
+	_, err := stack.EMRHandler.Backend.RunJobFlow(context.Background(), emr.RunJobFlowParams{
 		Name:         "e2e-test-cluster",
 		ReleaseLabel: "emr-6.0.0",
 	})

--- a/test/e2e/kafka_test.go
+++ b/test/e2e/kafka_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -20,6 +21,7 @@ func TestKafkaDashboard(t *testing.T) {
 
 	// Seed a cluster via the backend.
 	_, err := stack.KafkaHandler.Backend.CreateCluster(
+		context.Background(),
 		"my-test-cluster",
 		"3.5.1",
 		1,

--- a/test/e2e/kinesis_test.go
+++ b/test/e2e/kinesis_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 func TestKinesisDashboard(t *testing.T) {
 	stack := newStack(t)
 
-	err := stack.KinesisHandler.Backend.CreateStream(&kinesisbackend.CreateStreamInput{
+	err := stack.KinesisHandler.Backend.CreateStream(context.Background(), &kinesisbackend.CreateStreamInput{
 		StreamName: "test-stream",
 		ShardCount: 1,
 	})

--- a/test/e2e/kinesisanalyticsv2_test.go
+++ b/test/e2e/kinesisanalyticsv2_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestKinesisAnalyticsV2Dashboard(t *testing.T) {
 	stack := newStack(t)
 
 	// Seed an application via the backend.
-	err := stack.KinesisHandler.Backend.CreateStream(&kinesisbackend.CreateStreamInput{
+	err := stack.KinesisHandler.Backend.CreateStream(context.Background(), &kinesisbackend.CreateStreamInput{
 		StreamName: "my-test-stream",
 		ShardCount: 1,
 	})

--- a/test/e2e/scheduler_test.go
+++ b/test/e2e/scheduler_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -19,6 +20,7 @@ func TestSchedulerDashboard(t *testing.T) {
 	stack := newStack(t)
 
 	_, err := stack.SchedulerHandler.Backend.CreateSchedule(
+		context.Background(),
 		"test-schedule",
 		"",
 		"rate(5 minutes)",
@@ -36,11 +38,11 @@ func TestSchedulerDashboard(t *testing.T) {
 	server := httptest.NewServer(stack.Echo)
 	defer server.Close()
 
-	context, err := browser.NewContext()
+	bctx, err := browser.NewContext()
 	require.NoError(t, err)
-	defer context.Close()
+	defer bctx.Close()
 
-	page, err := context.NewPage()
+	page, err := bctx.NewPage()
 	require.NoError(t, err)
 	defer page.Close()
 
@@ -71,11 +73,11 @@ func TestSchedulerDashboard_Empty(t *testing.T) {
 	server := httptest.NewServer(stack.Echo)
 	defer server.Close()
 
-	context, err := browser.NewContext()
+	bctx, err := browser.NewContext()
 	require.NoError(t, err)
-	defer context.Close()
+	defer bctx.Close()
 
-	page, err := context.NewPage()
+	page, err := bctx.NewPage()
 	require.NoError(t, err)
 	defer page.Close()
 
@@ -105,11 +107,11 @@ func TestSchedulerDashboard_CreateAndDelete(t *testing.T) {
 	server := httptest.NewServer(stack.Echo)
 	defer server.Close()
 
-	context, err := browser.NewContext()
+	bctx, err := browser.NewContext()
 	require.NoError(t, err)
-	defer context.Close()
+	defer bctx.Close()
 
-	page, err := context.NewPage()
+	page, err := bctx.NewPage()
 	require.NoError(t, err)
 	defer page.Close()
 


### PR DESCRIPTION
Region-isolate service backends so resources are partitioned by AWS region (context-based pattern, matching ssm/eventbridge/cloudwatchlogs). Currently only 6/147 services were isolated; this closes the gap for ~43 non-global services (global services iam/sts/route53/cloudfront/s3/organizations/account/shield/support excluded by design).

**Batch 1 (done):** scheduler, codeartifact, acmpca, acm, secretsmanager — region-nested maps + getRegion(ctx) + isolation_test each. Build/test/lint clean.

**Deferred to dedicated batches (high complexity):** KMS (multi-region replication + cross-service crypto dep), RDS (81 maps), cognitoidp (41), lambda (34).

Subsequent batches stack on this branch (serialized — they share cross-package ctx call-site updates in cloudformation/bench). DO NOT MERGE until complete. No stubs, no //nolint.