### PR TITLE
fix(ec2): stop lifecycle reconciler goroutine in test cleanup (go-um6b)

### DIFF
--- a/services/ec2/handler.go
+++ b/services/ec2/handler.go
@@ -91,6 +91,14 @@ func (h *Handler) StartWorker(ctx context.Context) error {
 	return nil
 }
 
+// Shutdown stops background goroutines started by this handler.
+// Implements service.Shutdowner. Safe to call multiple times.
+func (h *Handler) Shutdown(_ context.Context) {
+	if mem, ok := h.Backend.(*InMemoryBackend); ok {
+		mem.StopLifecycleReconciler()
+	}
+}
+
 // Name returns the service name.
 func (h *Handler) Name() string {
 	return "EC2"

--- a/services/ec2/handler_test.go
+++ b/services/ec2/handler_test.go
@@ -1,6 +1,7 @@
 package ec2_test
 
 import (
+	"context"
 	"encoding/xml"
 	"log/slog"
 	"net/http"
@@ -455,6 +456,7 @@ func TestEC2Provider_Init(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, reg)
 	assert.Equal(t, "EC2", reg.Name())
+	t.Cleanup(func() { reg.(*ec2.Handler).Shutdown(context.Background()) })
 }
 
 func TestEC2Handler_NameAndOperations(t *testing.T) {

--- a/services/ec2/provider_test.go
+++ b/services/ec2/provider_test.go
@@ -1,6 +1,7 @@
 package ec2_test
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 	"time"
@@ -61,6 +62,7 @@ func TestEC2Provider_Init_WithConfigProvider(t *testing.T) {
 
 			h, ok := svc.(*ec2.Handler)
 			require.True(t, ok)
+			t.Cleanup(func() { h.Shutdown(context.Background()) })
 			assert.Equal(t, tt.wantInterval, h.GetJanitorInterval())
 			assert.Equal(t, tt.wantTerminatedTTL, h.GetJanitorTerminatedTTL())
 			assert.Equal(t, tt.wantCancelledSpotTTL, h.GetJanitorCancelledSpotTTL())


### PR DESCRIPTION
Fixes go-um6b: EC2 data race in lifecycle reconciler

**Changes**
- Handler.Shutdown(ctx) implementing service.Shutdowner
- Stops lifecycle reconciler goroutine in tests
- Test cleanup via t.Cleanup(h.Shutdown)

**Verification**
- go test -race ./services/ec2/... passes clean
- All b.instances accesses properly mu-guarded