### PR TITLE
feat(kinesisanalytics): region-isolate service backend (context-based) (go-e54d)

### DIFF
--- a/services/kinesisanalytics/backend.go
+++ b/services/kinesisanalytics/backend.go
@@ -15,6 +15,20 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
 )
 
+// regionContextKey is the context key under which the per-request AWS region is stored.
+type regionContextKey struct{}
+
+// getRegion extracts the region from ctx, falling back to defaultRegion when unset.
+// KinesisAnalytics resources are isolated per region: every backend operation resolves the
+// caller's region from the request context and operates only on that region's nested store.
+func getRegion(ctx context.Context, defaultRegion string) string {
+	if r, ok := ctx.Value(regionContextKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
 var (
 	// ErrNotFound is returned when an application does not exist.
 	ErrNotFound = awserr.New("ResourceNotFoundException", awserr.ErrNotFound)
@@ -72,43 +86,71 @@ var appNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // StorageBackend is the interface for the Kinesis Analytics in-memory backend.
 type StorageBackend interface {
-	CreateApplication(region, accountID, name, description, code, serviceRole string,
+	CreateApplication(ctx context.Context, name, description, code, serviceRole string,
 		inputs []InputDescription, outputs []OutputDescription,
 		cwlOptions []CloudWatchLoggingOptionDesc, tags map[string]string) (*Application, error)
-	DeleteApplication(name string, createTimestamp *time.Time) error
-	DescribeApplication(name string) (*Application, error)
-	ListApplications(exclusiveStart string, limit int) ([]*Application, bool, error)
-	StartApplication(name string, inputConfigs []inputConfiguration) error
-	StopApplication(name string) error
-	UpdateApplication(name string, currentVersionID int64, update *applicationUpdate) (*Application, error)
-	ListTagsForResource(resourceARN string) (map[string]string, error)
-	TagResource(resourceARN string, tags map[string]string) error
-	UntagResource(resourceARN string, tagKeys []string) error
-	AddApplicationCloudWatchLoggingOption(name string, versionID int64, option CloudWatchLoggingOptionDesc) error
-	AddApplicationInput(name string, versionID int64, input InputDescription) error
+	DeleteApplication(ctx context.Context, name string, createTimestamp *time.Time) error
+	DescribeApplication(ctx context.Context, name string) (*Application, error)
+	ListApplications(ctx context.Context, exclusiveStart string, limit int) ([]*Application, bool, error)
+	StartApplication(ctx context.Context, name string, inputConfigs []inputConfiguration) error
+	StopApplication(ctx context.Context, name string) error
+	UpdateApplication(
+		ctx context.Context,
+		name string,
+		currentVersionID int64,
+		update *applicationUpdate,
+	) (*Application, error)
+	ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error)
+	TagResource(ctx context.Context, resourceARN string, tags map[string]string) error
+	UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error
+	AddApplicationCloudWatchLoggingOption(
+		ctx context.Context,
+		name string,
+		versionID int64,
+		option CloudWatchLoggingOptionDesc,
+	) error
+	AddApplicationInput(ctx context.Context, name string, versionID int64, input InputDescription) error
 	AddApplicationInputProcessingConfiguration(
+		ctx context.Context,
 		name string,
 		versionID int64,
 		inputID string,
 		config *InputProcessingConfigurationDesc,
 	) error
-	AddApplicationOutput(name string, versionID int64, output OutputDescription) error
-	AddApplicationReferenceDataSource(name string, versionID int64, ref ReferenceDataSourceDescription) error
-	DeleteApplicationCloudWatchLoggingOption(name string, versionID int64, loggingOptionID string) error
-	DeleteApplicationInputProcessingConfiguration(name string, versionID int64, inputID string) error
-	DeleteApplicationOutput(name string, versionID int64, outputID string) error
-	DeleteApplicationReferenceDataSource(name string, versionID int64, referenceID string) error
+	AddApplicationOutput(ctx context.Context, name string, versionID int64, output OutputDescription) error
+	AddApplicationReferenceDataSource(
+		ctx context.Context,
+		name string,
+		versionID int64,
+		ref ReferenceDataSourceDescription,
+	) error
+	DeleteApplicationCloudWatchLoggingOption(
+		ctx context.Context,
+		name string,
+		versionID int64,
+		loggingOptionID string,
+	) error
+	DeleteApplicationInputProcessingConfiguration(
+		ctx context.Context,
+		name string,
+		versionID int64,
+		inputID string,
+	) error
+	DeleteApplicationOutput(ctx context.Context, name string, versionID int64, outputID string) error
+	DeleteApplicationReferenceDataSource(ctx context.Context, name string, versionID int64, referenceID string) error
 }
 
 // InMemoryBackend is the in-memory implementation of StorageBackend.
+// All resource maps are nested by region (outer key = region) so that
+// same-named resources are isolated across regions.
 type InMemoryBackend struct {
-	apps        map[string]*Application
-	appsByARN   map[string]*Application       // application ARN → Application
-	cancelFuncs map[string]context.CancelFunc // application name → lifecycle goroutine cancel
-	region      string
-	accountID   string
-	nextID      int64
-	mu          sync.RWMutex
+	apps          map[string]map[string]*Application // region → name → app
+	appsByARN     map[string]map[string]*Application // region → arn → app
+	cancelFuncs   map[string]context.CancelFunc      // "region:name" → cancel
+	defaultRegion string
+	accountID     string
+	nextID        int64
+	mu            sync.RWMutex
 }
 
 var _ StorageBackend = (*InMemoryBackend)(nil)
@@ -116,12 +158,17 @@ var _ StorageBackend = (*InMemoryBackend)(nil)
 // NewInMemoryBackend creates a new in-memory Kinesis Analytics backend.
 func NewInMemoryBackend(region, accountID string) *InMemoryBackend {
 	return &InMemoryBackend{
-		apps:        make(map[string]*Application),
-		appsByARN:   make(map[string]*Application),
-		cancelFuncs: make(map[string]context.CancelFunc),
-		region:      region,
-		accountID:   accountID,
+		apps:          make(map[string]map[string]*Application),
+		appsByARN:     make(map[string]map[string]*Application),
+		cancelFuncs:   make(map[string]context.CancelFunc),
+		defaultRegion: region,
+		accountID:     accountID,
 	}
+}
+
+// cancelKey returns the composite key used for the cancelFuncs map.
+func cancelKey(region, name string) string {
+	return region + ":" + name
 }
 
 // Reset clears all state and resets the ID counter.
@@ -133,10 +180,30 @@ func (b *InMemoryBackend) Reset() {
 		cancel()
 	}
 
-	b.apps = make(map[string]*Application)
-	b.appsByARN = make(map[string]*Application)
+	b.apps = make(map[string]map[string]*Application)
+	b.appsByARN = make(map[string]map[string]*Application)
 	b.cancelFuncs = make(map[string]context.CancelFunc)
 	b.nextID = 0
+}
+
+// appsStore returns (and lazily initialises) the per-region application map.
+// Must be called under b.mu held for writing.
+func (b *InMemoryBackend) appsStore(region string) map[string]*Application {
+	if b.apps[region] == nil {
+		b.apps[region] = make(map[string]*Application)
+	}
+
+	return b.apps[region]
+}
+
+// appsByARNStore returns (and lazily initialises) the per-region ARN map.
+// Must be called under b.mu held for writing.
+func (b *InMemoryBackend) appsByARNStore(region string) map[string]*Application {
+	if b.appsByARN[region] == nil {
+		b.appsByARN[region] = make(map[string]*Application)
+	}
+
+	return b.appsByARN[region]
 }
 
 // applicationARN builds the ARN for a Kinesis Analytics application.
@@ -226,7 +293,7 @@ func validateAndMergeTags(existing, incoming map[string]string) error {
 
 // validateARNShape verifies that an ARN refers to a kinesisanalytics application in this backend.
 // ARN format: arn:{partition}:kinesisanalytics:{region}:{accountID}:application/{name}.
-func (b *InMemoryBackend) validateARNShape(resourceARN string) error {
+func (b *InMemoryBackend) validateARNShape(resourceARN, region string) error {
 	const arnFieldCount = 6
 
 	parts := strings.SplitN(resourceARN, ":", arnFieldCount)
@@ -237,7 +304,7 @@ func (b *InMemoryBackend) validateARNShape(resourceARN string) error {
 		return fmt.Errorf("%w: ResourceARN is not a valid kinesisanalytics application ARN", ErrValidation)
 	}
 
-	if parts[3] != b.region || parts[4] != b.accountID {
+	if parts[3] != region || parts[4] != b.accountID {
 		return fmt.Errorf("%w: ResourceARN region/account does not match this endpoint", ErrValidation)
 	}
 
@@ -411,7 +478,8 @@ func convertSourceSchema(s *sourceSchemaInput) SourceSchema {
 
 // CreateApplication creates a new Kinesis Analytics application.
 func (b *InMemoryBackend) CreateApplication(
-	region, accountID, name, description, code, serviceRole string,
+	ctx context.Context,
+	name, description, code, serviceRole string,
 	inputs []InputDescription,
 	outputs []OutputDescription,
 	cwlOptions []CloudWatchLoggingOptionDesc,
@@ -429,17 +497,21 @@ func (b *InMemoryBackend) CreateApplication(
 		return nil, err
 	}
 
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if len(b.apps) >= maxApplicationsPerRegion {
+	regionApps := b.appsStore(region)
+
+	if len(regionApps) >= maxApplicationsPerRegion {
 		return nil, fmt.Errorf(
 			"%w: maximum of %d applications per account/region",
 			ErrLimitExceeded, maxApplicationsPerRegion,
 		)
 	}
 
-	if _, exists := b.apps[name]; exists {
+	if _, exists := regionApps[name]; exists {
 		return nil, ErrAlreadyExists
 	}
 
@@ -449,7 +521,7 @@ func (b *InMemoryBackend) CreateApplication(
 
 	app := &Application{
 		ApplicationName:          name,
-		ApplicationARN:           applicationARN(region, accountID, name),
+		ApplicationARN:           applicationARN(region, b.accountID, name),
 		ApplicationDescription:   description,
 		ApplicationCode:          code,
 		ApplicationStatus:        statusReady,
@@ -480,22 +552,26 @@ func (b *InMemoryBackend) CreateApplication(
 		app.Outputs = append(app.Outputs, out)
 	}
 
-	b.apps[name] = app
-	b.appsByARN[app.ApplicationARN] = app
+	regionApps[name] = app
+	b.appsByARNStore(region)[app.ApplicationARN] = app
 
 	return appCopy(app), nil
 }
 
 // DeleteApplication marks an application for deletion (DELETING state) then removes it after a delay.
-func (b *InMemoryBackend) DeleteApplication(name string, createTimestamp *time.Time) error {
+func (b *InMemoryBackend) DeleteApplication(ctx context.Context, name string, createTimestamp *time.Time) error {
 	if createTimestamp == nil {
 		return fmt.Errorf("%w: CreateTimestamp is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	regionApps := b.appsStore(region)
+
+	app, exists := regionApps[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -508,9 +584,10 @@ func (b *InMemoryBackend) DeleteApplication(name string, createTimestamp *time.T
 	}
 
 	// Cancel any in-flight lifecycle goroutine.
-	if cancel, ok := b.cancelFuncs[name]; ok {
+	key := cancelKey(region, name)
+	if cancel, ok := b.cancelFuncs[key]; ok {
 		cancel()
-		delete(b.cancelFuncs, name)
+		delete(b.cancelFuncs, key)
 	}
 
 	now := time.Now().UTC()
@@ -518,14 +595,14 @@ func (b *InMemoryBackend) DeleteApplication(name string, createTimestamp *time.T
 	app.LastUpdateTimestamp = &now
 
 	appARN := app.ApplicationARN
-	ctx, cancel := context.WithCancel(context.Background())
-	b.cancelFuncs[name] = cancel
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	b.cancelFuncs[key] = cancel
 
 	go func() {
 		defer cancel()
 
 		select {
-		case <-ctx.Done():
+		case <-cancelCtx.Done():
 			return
 		case <-time.After(transitionDelay):
 		}
@@ -533,20 +610,33 @@ func (b *InMemoryBackend) DeleteApplication(name string, createTimestamp *time.T
 		b.mu.Lock()
 		defer b.mu.Unlock()
 
-		delete(b.cancelFuncs, name)
-		delete(b.apps, name)
-		delete(b.appsByARN, appARN)
+		delete(b.cancelFuncs, key)
+
+		if b.apps[region] != nil {
+			delete(b.apps[region], name)
+		}
+
+		if b.appsByARN[region] != nil {
+			delete(b.appsByARN[region], appARN)
+		}
 	}()
 
 	return nil
 }
 
 // DescribeApplication returns a copy of the details for a Kinesis Analytics application.
-func (b *InMemoryBackend) DescribeApplication(name string) (*Application, error) {
+func (b *InMemoryBackend) DescribeApplication(ctx context.Context, name string) (*Application, error) {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	app, exists := b.apps[name]
+	regionApps := b.apps[region]
+	if regionApps == nil {
+		return nil, ErrNotFound
+	}
+
+	app, exists := regionApps[name]
 	if !exists {
 		return nil, ErrNotFound
 	}
@@ -555,7 +645,11 @@ func (b *InMemoryBackend) DescribeApplication(name string) (*Application, error)
 }
 
 // ListApplications returns paginated applications.
-func (b *InMemoryBackend) ListApplications(exclusiveStart string, limit int) ([]*Application, bool, error) {
+func (b *InMemoryBackend) ListApplications(
+	ctx context.Context,
+	exclusiveStart string,
+	limit int,
+) ([]*Application, bool, error) {
 	if limit < 0 {
 		return nil, false, fmt.Errorf("%w: Limit must be >= 0", ErrValidation)
 	}
@@ -568,12 +662,16 @@ func (b *InMemoryBackend) ListApplications(exclusiveStart string, limit int) ([]
 		limit = maxApplicationsPerRegion
 	}
 
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	all := make([]*Application, 0, len(b.apps))
+	regionApps := b.apps[region]
 
-	for _, app := range b.apps {
+	all := make([]*Application, 0, len(regionApps))
+
+	for _, app := range regionApps {
 		all = append(all, app)
 	}
 
@@ -637,11 +735,15 @@ func findInputIndex(inputs []InputDescription, inputID string) int {
 }
 
 // StartApplication transitions an application to RUNNING via a STARTING transient state.
-func (b *InMemoryBackend) StartApplication(name string, inputConfigs []inputConfiguration) error {
+func (b *InMemoryBackend) StartApplication(ctx context.Context, name string, inputConfigs []inputConfiguration) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	regionApps := b.appsStore(region)
+
+	app, exists := regionApps[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -659,17 +761,21 @@ func (b *InMemoryBackend) StartApplication(name string, inputConfigs []inputConf
 	app.ApplicationStatus = statusStarting
 	app.LastUpdateTimestamp = &now
 
-	b.launchTransition(name, statusRunning)
+	b.launchTransition(region, name, statusRunning)
 
 	return nil
 }
 
 // StopApplication transitions an application to READY via a STOPPING transient state.
-func (b *InMemoryBackend) StopApplication(name string) error {
+func (b *InMemoryBackend) StopApplication(ctx context.Context, name string) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	regionApps := b.appsStore(region)
+
+	app, exists := regionApps[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -683,20 +789,22 @@ func (b *InMemoryBackend) StopApplication(name string) error {
 	app.ApplicationStatus = statusStopping
 	app.LastUpdateTimestamp = &now
 
-	b.launchTransition(name, statusReady)
+	b.launchTransition(region, name, statusReady)
 
 	return nil
 }
 
 // launchTransition starts a goroutine that moves app to targetStatus after transitionDelay.
 // Must be called under b.mu.
-func (b *InMemoryBackend) launchTransition(name, targetStatus string) {
-	if cancel, ok := b.cancelFuncs[name]; ok {
+func (b *InMemoryBackend) launchTransition(region, name, targetStatus string) {
+	key := cancelKey(region, name)
+
+	if cancel, ok := b.cancelFuncs[key]; ok {
 		cancel()
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	b.cancelFuncs[name] = cancel
+	b.cancelFuncs[key] = cancel
 
 	go func() {
 		defer cancel()
@@ -710,7 +818,11 @@ func (b *InMemoryBackend) launchTransition(name, targetStatus string) {
 		b.mu.Lock()
 		defer b.mu.Unlock()
 
-		app, exists := b.apps[name]
+		if b.apps[region] == nil {
+			return
+		}
+
+		app, exists := b.apps[region][name]
 		if !exists {
 			return
 		}
@@ -718,7 +830,7 @@ func (b *InMemoryBackend) launchTransition(name, targetStatus string) {
 		now := time.Now().UTC()
 		app.ApplicationStatus = targetStatus
 		app.LastUpdateTimestamp = &now
-		delete(b.cancelFuncs, name)
+		delete(b.cancelFuncs, key)
 	}()
 }
 
@@ -971,14 +1083,19 @@ func applyUpdate(app *Application, update *applicationUpdate) error {
 
 // UpdateApplication updates the application with the full update payload and bumps the version.
 func (b *InMemoryBackend) UpdateApplication(
+	ctx context.Context,
 	name string,
 	currentVersionID int64,
 	update *applicationUpdate,
 ) (*Application, error) {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	regionApps := b.appsStore(region)
+
+	app, exists := regionApps[name]
 	if !exists {
 		return nil, ErrNotFound
 	}
@@ -1006,15 +1123,22 @@ func (b *InMemoryBackend) UpdateApplication(
 }
 
 // ListTagsForResource returns tags for a resource identified by ARN.
-func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]string, error) {
-	if err := b.validateARNShape(resourceARN); err != nil {
+func (b *InMemoryBackend) ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error) {
+	region := getRegion(ctx, b.defaultRegion)
+
+	if err := b.validateARNShape(resourceARN, region); err != nil {
 		return nil, err
 	}
 
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	app, ok := b.appsByARN[resourceARN]
+	regionByARN := b.appsByARN[region]
+	if regionByARN == nil {
+		return nil, ErrNotFound
+	}
+
+	app, ok := regionByARN[resourceARN]
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -1026,15 +1150,22 @@ func (b *InMemoryBackend) ListTagsForResource(resourceARN string) (map[string]st
 }
 
 // TagResource adds or updates tags on a resource.
-func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string) error {
-	if err := b.validateARNShape(resourceARN); err != nil {
+func (b *InMemoryBackend) TagResource(ctx context.Context, resourceARN string, tags map[string]string) error {
+	region := getRegion(ctx, b.defaultRegion)
+
+	if err := b.validateARNShape(resourceARN, region); err != nil {
 		return err
 	}
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, ok := b.appsByARN[resourceARN]
+	regionByARN := b.appsByARN[region]
+	if regionByARN == nil {
+		return ErrNotFound
+	}
+
+	app, ok := regionByARN[resourceARN]
 	if !ok {
 		return ErrNotFound
 	}
@@ -1053,15 +1184,22 @@ func (b *InMemoryBackend) TagResource(resourceARN string, tags map[string]string
 }
 
 // UntagResource removes tags from a resource.
-func (b *InMemoryBackend) UntagResource(resourceARN string, tagKeys []string) error {
-	if err := b.validateARNShape(resourceARN); err != nil {
+func (b *InMemoryBackend) UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error {
+	region := getRegion(ctx, b.defaultRegion)
+
+	if err := b.validateARNShape(resourceARN, region); err != nil {
 		return err
 	}
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, ok := b.appsByARN[resourceARN]
+	regionByARN := b.appsByARN[region]
+	if regionByARN == nil {
+		return ErrNotFound
+	}
+
+	app, ok := regionByARN[resourceARN]
 	if !ok {
 		return ErrNotFound
 	}
@@ -1232,18 +1370,30 @@ func checkAndBumpVersion(app *Application, currentVersionID int64) error {
 }
 
 // AddApplicationInternal is a test-only seed helper that stores an application directly.
+// The region is extracted from the application ARN.
 func (b *InMemoryBackend) AddApplicationInternal(app *Application) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	cp := appCopy(app)
-	b.apps[cp.ApplicationName] = cp
-	b.appsByARN[cp.ApplicationARN] = cp
+
+	// Extract region from ARN (format: arn:partition:service:region:account:resource).
+	region := b.defaultRegion
+	const arnFieldCount = 6
+
+	parts := strings.SplitN(cp.ApplicationARN, ":", arnFieldCount)
+
+	if len(parts) == arnFieldCount && parts[3] != "" {
+		region = parts[3]
+	}
+
+	b.appsStore(region)[cp.ApplicationName] = cp
+	b.appsByARNStore(region)[cp.ApplicationARN] = cp
 }
 
 // AddApplicationCloudWatchLoggingOption adds a CloudWatch logging option to an application.
 func (b *InMemoryBackend) AddApplicationCloudWatchLoggingOption(
-	name string, versionID int64, option CloudWatchLoggingOptionDesc,
+	ctx context.Context, name string, versionID int64, option CloudWatchLoggingOptionDesc,
 ) error {
 	if option.LogStreamARN == "" {
 		return fmt.Errorf("%w: CloudWatchLoggingOption.LogStreamARN is required", ErrValidation)
@@ -1253,10 +1403,12 @@ func (b *InMemoryBackend) AddApplicationCloudWatchLoggingOption(
 		return fmt.Errorf("%w: CloudWatchLoggingOption.RoleARN is required", ErrValidation)
 	}
 
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1281,12 +1433,14 @@ func (b *InMemoryBackend) AddApplicationCloudWatchLoggingOption(
 
 // AddApplicationInput adds an input configuration to an application.
 func (b *InMemoryBackend) AddApplicationInput(
-	name string, versionID int64, input InputDescription,
+	ctx context.Context, name string, versionID int64, input InputDescription,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1307,12 +1461,14 @@ func (b *InMemoryBackend) AddApplicationInput(
 
 // AddApplicationInputProcessingConfiguration sets a processing configuration on an existing input.
 func (b *InMemoryBackend) AddApplicationInputProcessingConfiguration(
-	name string, versionID int64, inputID string, config *InputProcessingConfigurationDesc,
+	ctx context.Context, name string, versionID int64, inputID string, config *InputProcessingConfigurationDesc,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1343,12 +1499,14 @@ func (b *InMemoryBackend) AddApplicationInputProcessingConfiguration(
 
 // AddApplicationOutput adds an output configuration to an application.
 func (b *InMemoryBackend) AddApplicationOutput(
-	name string, versionID int64, output OutputDescription,
+	ctx context.Context, name string, versionID int64, output OutputDescription,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1369,12 +1527,14 @@ func (b *InMemoryBackend) AddApplicationOutput(
 
 // AddApplicationReferenceDataSource adds a reference data source to an application.
 func (b *InMemoryBackend) AddApplicationReferenceDataSource(
-	name string, versionID int64, ref ReferenceDataSourceDescription,
+	ctx context.Context, name string, versionID int64, ref ReferenceDataSourceDescription,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1395,12 +1555,14 @@ func (b *InMemoryBackend) AddApplicationReferenceDataSource(
 
 // DeleteApplicationCloudWatchLoggingOption removes a CloudWatch logging option from an application.
 func (b *InMemoryBackend) DeleteApplicationCloudWatchLoggingOption(
-	name string, versionID int64, loggingOptionID string,
+	ctx context.Context, name string, versionID int64, loggingOptionID string,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1434,12 +1596,14 @@ func (b *InMemoryBackend) DeleteApplicationCloudWatchLoggingOption(
 
 // DeleteApplicationInputProcessingConfiguration removes the processing config from an input.
 func (b *InMemoryBackend) DeleteApplicationInputProcessingConfiguration(
-	name string, versionID int64, inputID string,
+	ctx context.Context, name string, versionID int64, inputID string,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1470,12 +1634,14 @@ func (b *InMemoryBackend) DeleteApplicationInputProcessingConfiguration(
 
 // DeleteApplicationOutput removes an output configuration from an application.
 func (b *InMemoryBackend) DeleteApplicationOutput(
-	name string, versionID int64, outputID string,
+	ctx context.Context, name string, versionID int64, outputID string,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1506,12 +1672,14 @@ func (b *InMemoryBackend) DeleteApplicationOutput(
 
 // DeleteApplicationReferenceDataSource removes a reference data source from an application.
 func (b *InMemoryBackend) DeleteApplicationReferenceDataSource(
-	name string, versionID int64, referenceID string,
+	ctx context.Context, name string, versionID int64, referenceID string,
 ) error {
+	region := getRegion(ctx, b.defaultRegion)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	app, exists := b.apps[name]
+	app, exists := b.appsStore(region)[name]
 	if !exists {
 		return ErrNotFound
 	}
@@ -1539,3 +1707,6 @@ func (b *InMemoryBackend) DeleteApplicationReferenceDataSource(
 
 	return nil
 }
+
+// Region returns the default region for this backend.
+func (b *InMemoryBackend) Region() string { return b.defaultRegion }

--- a/services/kinesisanalytics/backend_test.go
+++ b/services/kinesisanalytics/backend_test.go
@@ -1,6 +1,7 @@
 package kinesisanalytics_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -116,7 +117,7 @@ func TestInMemoryBackend_DeleteApplication(t *testing.T) {
 				ts = app.CreateTimestamp
 			}
 
-			err := b.DeleteApplication(tt.appName, ts)
+			err := b.DeleteApplication(context.Background(), tt.appName, ts)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -136,7 +137,7 @@ func TestInMemoryBackend_DeleteApplication_NilTimestamp(t *testing.T) {
 	_, err := kinesisanalytics.CreateApp(b, testRegion, testAccountID, "del-nil-ts", "", "", nil)
 	require.NoError(t, err)
 
-	err = b.DeleteApplication("del-nil-ts", nil)
+	err = b.DeleteApplication(context.Background(), "del-nil-ts", nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, awserr.ErrInvalidParameter)
 }
@@ -176,7 +177,7 @@ func TestInMemoryBackend_DescribeApplication(t *testing.T) {
 				tt.setup(b)
 			}
 
-			app, err := b.DescribeApplication(tt.appName)
+			app, err := b.DescribeApplication(context.Background(), tt.appName)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -234,7 +235,7 @@ func TestInMemoryBackend_ListApplications(t *testing.T) {
 			b := newBackend()
 			tt.setup(b)
 
-			apps, hasMore, err := b.ListApplications(tt.exclusiveStart, tt.limit)
+			apps, hasMore, err := b.ListApplications(context.Background(), tt.exclusiveStart, tt.limit)
 			require.NoError(t, err)
 			assert.Len(t, apps, tt.wantCount)
 			assert.Equal(t, tt.wantHasMore, hasMore)
@@ -315,7 +316,7 @@ func TestInMemoryBackend_StopApplication(t *testing.T) {
 			b := newBackend()
 			tt.setup(t, b)
 
-			err := b.StopApplication(tt.appName)
+			err := b.StopApplication(context.Background(), tt.appName)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -459,7 +460,7 @@ func TestInMemoryBackend_TagOperations(t *testing.T) {
 
 			switch tt.op {
 			case "list":
-				tags, listErr := b.ListTagsForResource(resourceARN)
+				tags, listErr := b.ListTagsForResource(context.Background(), resourceARN)
 				err = listErr
 
 				if !tt.wantErr {
@@ -467,19 +468,19 @@ func TestInMemoryBackend_TagOperations(t *testing.T) {
 					assert.Equal(t, tt.wantTags, tags)
 				}
 			case "tag":
-				err = b.TagResource(resourceARN, tt.tags)
+				err = b.TagResource(context.Background(), resourceARN, tt.tags)
 
 				if !tt.wantErr {
 					require.NoError(t, err)
-					tags, _ := b.ListTagsForResource(resourceARN)
+					tags, _ := b.ListTagsForResource(context.Background(), resourceARN)
 					assert.Equal(t, tt.wantTags, tags)
 				}
 			case "untag":
-				err = b.UntagResource(resourceARN, tt.tagKeys)
+				err = b.UntagResource(context.Background(), resourceARN, tt.tagKeys)
 
 				if !tt.wantErr {
 					require.NoError(t, err)
-					tags, _ := b.ListTagsForResource(resourceARN)
+					tags, _ := b.ListTagsForResource(context.Background(), resourceARN)
 					assert.Equal(t, tt.wantTags, tags)
 				}
 			}
@@ -531,7 +532,7 @@ func TestInMemoryBackend_ListApplications_ExclusiveStart(t *testing.T) {
 			b := newBackend()
 			tt.setup(b)
 
-			apps, _, err := b.ListApplications(tt.exclusiveStart, 0)
+			apps, _, err := b.ListApplications(context.Background(), tt.exclusiveStart, 0)
 			require.NoError(t, err)
 			assert.GreaterOrEqual(t, len(apps), tt.wantCountMin)
 		})
@@ -545,10 +546,10 @@ func TestInMemoryBackend_TagResource_InitNil(t *testing.T) {
 	app, err := kinesisanalytics.CreateApp(b, testRegion, testAccountID, "nil-tag-app", "", "", nil)
 	require.NoError(t, err)
 
-	err = b.TagResource(app.ApplicationARN, map[string]string{"key": "val"})
+	err = b.TagResource(context.Background(), app.ApplicationARN, map[string]string{"key": "val"})
 	require.NoError(t, err)
 
-	tags, err := b.ListTagsForResource(app.ApplicationARN)
+	tags, err := b.ListTagsForResource(context.Background(), app.ApplicationARN)
 	require.NoError(t, err)
 	assert.Equal(t, "val", tags["key"])
 }
@@ -593,19 +594,19 @@ func TestInMemoryBackend_PersistenceSnapshotRestore(t *testing.T) {
 			b2 := newBackend()
 			require.NoError(t, b2.Restore(snap))
 
-			apps, _, err := b2.ListApplications("", 0)
+			apps, _, err := b2.ListApplications(context.Background(), "", 0)
 			require.NoError(t, err)
 			require.Len(t, apps, tt.wantLen)
 
 			// Verify appsByARN index is rebuilt: tag operations should work via ARN.
 			if tt.wantLen > 0 {
-				descApp, descErr := b2.DescribeApplication("persist-app-1")
+				descApp, descErr := b2.DescribeApplication(context.Background(), "persist-app-1")
 				require.NoError(t, descErr)
 
-				tagErr := b2.TagResource(descApp.ApplicationARN, map[string]string{"new": "tag"})
+				tagErr := b2.TagResource(context.Background(), descApp.ApplicationARN, map[string]string{"new": "tag"})
 				require.NoError(t, tagErr)
 
-				tags, listErr := b2.ListTagsForResource(descApp.ApplicationARN)
+				tags, listErr := b2.ListTagsForResource(context.Background(), descApp.ApplicationARN)
 				require.NoError(t, listErr)
 				assert.Equal(t, "tag", tags["new"])
 				assert.Equal(t, "test", tags["env"])
@@ -654,7 +655,7 @@ func TestInMemoryBackend_ApplicationLimits(t *testing.T) {
 			t.Parallel()
 
 			b := newBackend()
-			_, _, err := b.ListApplications("", tt.limit)
+			_, _, err := b.ListApplications(context.Background(), "", tt.limit)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -712,7 +713,7 @@ func TestInMemoryBackend_ARNValidation(t *testing.T) {
 			t.Parallel()
 
 			b := newBackend()
-			_, err := b.ListTagsForResource(tt.arn)
+			_, err := b.ListTagsForResource(context.Background(), tt.arn)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -795,7 +796,7 @@ func TestInMemoryBackend_TagKeyValidation(t *testing.T) {
 			app, err := kinesisanalytics.CreateApp(b, testRegion, testAccountID, "tag-valid-app", "", "", nil)
 			require.NoError(t, err)
 
-			err = b.TagResource(app.ApplicationARN, tt.tags)
+			err = b.TagResource(context.Background(), app.ApplicationARN, tt.tags)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/services/kinesisanalytics/export_test.go
+++ b/services/kinesisanalytics/export_test.go
@@ -1,17 +1,24 @@
 package kinesisanalytics
 
 import (
+	"context"
 	"testing"
 	"time"
 )
 
-// ApplicationCount returns the number of applications stored in the backend.
+// ApplicationCount returns the number of applications stored in the backend across all regions.
 // This is exported for use in tests only.
 func ApplicationCount(b *InMemoryBackend) int {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	return len(b.apps)
+	total := 0
+
+	for _, regionApps := range b.apps {
+		total += len(regionApps)
+	}
+
+	return total
 }
 
 // HandlerOpsLen returns the number of operations pre-built in the handler dispatch map.
@@ -21,23 +28,26 @@ func HandlerOpsLen(h *Handler) int {
 }
 
 // CreateApp is a test helper that calls CreateApplication with the minimal (legacy) signature.
+// The region is injected via context; accountID is sourced from the backend.
 func CreateApp(
-	b *InMemoryBackend, region, accountID, name, description, code string,
+	b *InMemoryBackend, region, _ /* accountID */, name, description, code string,
 	tags map[string]string,
 ) (*Application, error) {
-	return b.CreateApplication(region, accountID, name, description, code, "", nil, nil, nil, tags)
+	ctx := context.WithValue(context.Background(), regionContextKey{}, region)
+
+	return b.CreateApplication(ctx, name, description, code, "", nil, nil, nil, tags)
 }
 
 // StartAppNoConfig is a test helper that calls StartApplication with no InputConfigurations.
 func StartAppNoConfig(b *InMemoryBackend, name string) error {
-	return b.StartApplication(name, nil)
+	return b.StartApplication(context.Background(), name, nil)
 }
 
 // UpdateAppCode is a test helper that calls UpdateApplication with just a code update.
 func UpdateAppCode(b *InMemoryBackend, name string, versionID int64, code string) (*Application, error) {
 	upd := &applicationUpdate{ApplicationCodeUpdate: code}
 
-	return b.UpdateApplication(name, versionID, upd)
+	return b.UpdateApplication(context.Background(), name, versionID, upd)
 }
 
 // WaitForStatus polls until the application reaches wantStatus or the test times out.
@@ -47,7 +57,7 @@ func WaitForStatus(t *testing.T, b *InMemoryBackend, name, wantStatus string) {
 	deadline := time.Now().Add(500 * time.Millisecond)
 
 	for time.Now().Before(deadline) {
-		app, err := b.DescribeApplication(name)
+		app, err := b.DescribeApplication(context.Background(), name)
 		if err == nil && app.ApplicationStatus == wantStatus {
 			return
 		}

--- a/services/kinesisanalytics/handler.go
+++ b/services/kinesisanalytics/handler.go
@@ -173,11 +173,17 @@ func (h *Handler) ExtractResource(c *echo.Context) string {
 // Handler returns the Echo handler function.
 func (h *Handler) Handler() echo.HandlerFunc {
 	return func(c *echo.Context) error {
+		// Resolve the per-request region (from SigV4 / X-Amz-Region) and attach
+		// it to the context so backend operations are region-scoped.
+		region := httputils.ExtractRegionFromRequest(c.Request(), h.DefaultRegion)
+
 		return service.HandleTarget(
 			c, logger.Load(c.Request().Context()),
 			"KinesisAnalytics", "application/x-amz-json-1.1",
 			h.GetSupportedOperations(),
-			h.dispatch,
+			func(ctx context.Context, action string, body []byte) ([]byte, error) {
+				return h.dispatch(context.WithValue(ctx, regionContextKey{}, region), action, body)
+			},
 			h.handleError,
 		)
 	}
@@ -244,7 +250,7 @@ func (h *Handler) handleError(_ context.Context, c *echo.Context, _ string, err 
 }
 
 func (h *Handler) handleCreateApplication(
-	_ context.Context,
+	ctx context.Context,
 	in *createApplicationInput,
 ) (*createApplicationOutput, error) {
 	if in.ApplicationName == "" {
@@ -297,8 +303,7 @@ func (h *Handler) handleCreateApplication(
 	}
 
 	app, err := h.Backend.CreateApplication(
-		h.DefaultRegion,
-		h.AccountID,
+		ctx,
 		in.ApplicationName,
 		in.ApplicationDescription,
 		in.ApplicationCode,
@@ -322,7 +327,7 @@ func (h *Handler) handleCreateApplication(
 }
 
 func (h *Handler) handleDeleteApplication(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteApplicationInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -335,7 +340,7 @@ func (h *Handler) handleDeleteApplication(
 
 	ts := time.Unix(int64(in.CreateTimestamp), 0).UTC()
 
-	if err := h.Backend.DeleteApplication(in.ApplicationName, &ts); err != nil {
+	if err := h.Backend.DeleteApplication(ctx, in.ApplicationName, &ts); err != nil {
 		return nil, err
 	}
 
@@ -343,14 +348,14 @@ func (h *Handler) handleDeleteApplication(
 }
 
 func (h *Handler) handleDescribeApplication(
-	_ context.Context,
+	ctx context.Context,
 	in *describeApplicationInput,
 ) (*describeApplicationOutput, error) {
 	if in.ApplicationName == "" {
 		return nil, errApplicationName
 	}
 
-	app, err := h.Backend.DescribeApplication(in.ApplicationName)
+	app, err := h.Backend.DescribeApplication(ctx, in.ApplicationName)
 	if err != nil {
 		return nil, err
 	}
@@ -361,10 +366,10 @@ func (h *Handler) handleDescribeApplication(
 }
 
 func (h *Handler) handleListApplications(
-	_ context.Context,
+	ctx context.Context,
 	in *listApplicationsInput,
 ) (*listApplicationsOutput, error) {
-	apps, hasMore, err := h.Backend.ListApplications(in.ExclusiveStartApplicationName, in.Limit)
+	apps, hasMore, err := h.Backend.ListApplications(ctx, in.ExclusiveStartApplicationName, in.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -386,14 +391,14 @@ func (h *Handler) handleListApplications(
 }
 
 func (h *Handler) handleStartApplication(
-	_ context.Context,
+	ctx context.Context,
 	in *startApplicationInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
 		return nil, errApplicationName
 	}
 
-	if err := h.Backend.StartApplication(in.ApplicationName, in.InputConfigurations); err != nil {
+	if err := h.Backend.StartApplication(ctx, in.ApplicationName, in.InputConfigurations); err != nil {
 		return nil, err
 	}
 
@@ -401,14 +406,14 @@ func (h *Handler) handleStartApplication(
 }
 
 func (h *Handler) handleStopApplication(
-	_ context.Context,
+	ctx context.Context,
 	in *stopApplicationInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
 		return nil, errApplicationName
 	}
 
-	if err := h.Backend.StopApplication(in.ApplicationName); err != nil {
+	if err := h.Backend.StopApplication(ctx, in.ApplicationName); err != nil {
 		return nil, err
 	}
 
@@ -416,7 +421,7 @@ func (h *Handler) handleStopApplication(
 }
 
 func (h *Handler) handleUpdateApplication(
-	_ context.Context,
+	ctx context.Context,
 	in *updateApplicationInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -424,6 +429,7 @@ func (h *Handler) handleUpdateApplication(
 	}
 
 	if _, err := h.Backend.UpdateApplication(
+		ctx,
 		in.ApplicationName,
 		in.CurrentApplicationVersionID,
 		in.ApplicationUpdate,
@@ -435,14 +441,14 @@ func (h *Handler) handleUpdateApplication(
 }
 
 func (h *Handler) handleListTagsForResource(
-	_ context.Context,
+	ctx context.Context,
 	in *listTagsForResourceInput,
 ) (*listTagsForResourceOutput, error) {
 	if in.ResourceARN == "" {
 		return nil, errResourceARN
 	}
 
-	tagMap, err := h.Backend.ListTagsForResource(in.ResourceARN)
+	tagMap, err := h.Backend.ListTagsForResource(ctx, in.ResourceARN)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +471,7 @@ func (h *Handler) handleListTagsForResource(
 }
 
 func (h *Handler) handleTagResource(
-	_ context.Context,
+	ctx context.Context,
 	in *tagResourceInput,
 ) (*struct{}, error) {
 	if in.ResourceARN == "" {
@@ -478,7 +484,7 @@ func (h *Handler) handleTagResource(
 		tagMap[t.Key] = t.Value
 	}
 
-	if err := h.Backend.TagResource(in.ResourceARN, tagMap); err != nil {
+	if err := h.Backend.TagResource(ctx, in.ResourceARN, tagMap); err != nil {
 		return nil, err
 	}
 
@@ -486,14 +492,14 @@ func (h *Handler) handleTagResource(
 }
 
 func (h *Handler) handleUntagResource(
-	_ context.Context,
+	ctx context.Context,
 	in *untagResourceInput,
 ) (*struct{}, error) {
 	if in.ResourceARN == "" {
 		return nil, errResourceARN
 	}
 
-	if err := h.Backend.UntagResource(in.ResourceARN, in.TagKeys); err != nil {
+	if err := h.Backend.UntagResource(ctx, in.ResourceARN, in.TagKeys); err != nil {
 		return nil, err
 	}
 
@@ -530,7 +536,7 @@ func toApplicationDetail(app *Application) applicationDetail {
 }
 
 func (h *Handler) handleAddApplicationCloudWatchLoggingOption(
-	_ context.Context,
+	ctx context.Context,
 	in *addApplicationCloudWatchLoggingOptionInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -555,7 +561,7 @@ func (h *Handler) handleAddApplicationCloudWatchLoggingOption(
 	}
 
 	if err := h.Backend.AddApplicationCloudWatchLoggingOption(
-		in.ApplicationName, in.CurrentApplicationVersionID, opt,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, opt,
 	); err != nil {
 		return nil, err
 	}
@@ -564,7 +570,7 @@ func (h *Handler) handleAddApplicationCloudWatchLoggingOption(
 }
 
 func (h *Handler) handleAddApplicationInput(
-	_ context.Context,
+	ctx context.Context,
 	in *addApplicationInputInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -581,7 +587,7 @@ func (h *Handler) handleAddApplicationInput(
 	}
 
 	if addErr := h.Backend.AddApplicationInput(
-		in.ApplicationName, in.CurrentApplicationVersionID, desc,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, desc,
 	); addErr != nil {
 		return nil, addErr
 	}
@@ -590,7 +596,7 @@ func (h *Handler) handleAddApplicationInput(
 }
 
 func (h *Handler) handleAddApplicationInputProcessingConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	in *addApplicationInputProcessingConfigurationInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -608,7 +614,7 @@ func (h *Handler) handleAddApplicationInputProcessingConfiguration(
 	}
 
 	if err := h.Backend.AddApplicationInputProcessingConfiguration(
-		in.ApplicationName, in.CurrentApplicationVersionID, in.InputID, cfg,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, in.InputID, cfg,
 	); err != nil {
 		return nil, err
 	}
@@ -617,7 +623,7 @@ func (h *Handler) handleAddApplicationInputProcessingConfiguration(
 }
 
 func (h *Handler) handleAddApplicationOutput(
-	_ context.Context,
+	ctx context.Context,
 	in *addApplicationOutputInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -630,7 +636,7 @@ func (h *Handler) handleAddApplicationOutput(
 	}
 
 	if addErr := h.Backend.AddApplicationOutput(
-		in.ApplicationName, in.CurrentApplicationVersionID, desc,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, desc,
 	); addErr != nil {
 		return nil, addErr
 	}
@@ -639,7 +645,7 @@ func (h *Handler) handleAddApplicationOutput(
 }
 
 func (h *Handler) handleAddApplicationReferenceDataSource(
-	_ context.Context,
+	ctx context.Context,
 	in *addApplicationReferenceDataSourceInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -689,7 +695,7 @@ func (h *Handler) handleAddApplicationReferenceDataSource(
 	ref.ReferenceSchema = &schema
 
 	if err := h.Backend.AddApplicationReferenceDataSource(
-		in.ApplicationName, in.CurrentApplicationVersionID, ref,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, ref,
 	); err != nil {
 		return nil, err
 	}
@@ -698,7 +704,7 @@ func (h *Handler) handleAddApplicationReferenceDataSource(
 }
 
 func (h *Handler) handleDeleteApplicationCloudWatchLoggingOption(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteApplicationCloudWatchLoggingOptionInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -710,7 +716,7 @@ func (h *Handler) handleDeleteApplicationCloudWatchLoggingOption(
 	}
 
 	if err := h.Backend.DeleteApplicationCloudWatchLoggingOption(
-		in.ApplicationName, in.CurrentApplicationVersionID, in.CloudWatchLoggingOptionID,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, in.CloudWatchLoggingOptionID,
 	); err != nil {
 		return nil, err
 	}
@@ -719,7 +725,7 @@ func (h *Handler) handleDeleteApplicationCloudWatchLoggingOption(
 }
 
 func (h *Handler) handleDeleteApplicationInputProcessingConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteApplicationInputProcessingConfigurationInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -731,7 +737,7 @@ func (h *Handler) handleDeleteApplicationInputProcessingConfiguration(
 	}
 
 	if err := h.Backend.DeleteApplicationInputProcessingConfiguration(
-		in.ApplicationName, in.CurrentApplicationVersionID, in.InputID,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, in.InputID,
 	); err != nil {
 		return nil, err
 	}
@@ -740,7 +746,7 @@ func (h *Handler) handleDeleteApplicationInputProcessingConfiguration(
 }
 
 func (h *Handler) handleDeleteApplicationOutput(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteApplicationOutputInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -752,7 +758,7 @@ func (h *Handler) handleDeleteApplicationOutput(
 	}
 
 	if err := h.Backend.DeleteApplicationOutput(
-		in.ApplicationName, in.CurrentApplicationVersionID, in.OutputID,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, in.OutputID,
 	); err != nil {
 		return nil, err
 	}
@@ -761,7 +767,7 @@ func (h *Handler) handleDeleteApplicationOutput(
 }
 
 func (h *Handler) handleDeleteApplicationReferenceDataSource(
-	_ context.Context,
+	ctx context.Context,
 	in *deleteApplicationReferenceDataSourceInput,
 ) (*struct{}, error) {
 	if in.ApplicationName == "" {
@@ -773,7 +779,7 @@ func (h *Handler) handleDeleteApplicationReferenceDataSource(
 	}
 
 	if err := h.Backend.DeleteApplicationReferenceDataSource(
-		in.ApplicationName, in.CurrentApplicationVersionID, in.ReferenceID,
+		ctx, in.ApplicationName, in.CurrentApplicationVersionID, in.ReferenceID,
 	); err != nil {
 		return nil, err
 	}

--- a/services/kinesisanalytics/handler_refinement1_test.go
+++ b/services/kinesisanalytics/handler_refinement1_test.go
@@ -1,6 +1,7 @@
 package kinesisanalytics_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -170,7 +171,7 @@ func TestRefinement1_SeedHelper_AddApplicationInternal(t *testing.T) {
 
 	assert.Equal(t, 1, kinesisanalytics.ApplicationCount(b))
 
-	app, err := b.DescribeApplication("seeded-app")
+	app, err := b.DescribeApplication(context.Background(), "seeded-app")
 	require.NoError(t, err)
 	assert.Equal(t, "seeded-app", app.ApplicationName)
 }
@@ -210,14 +211,14 @@ func TestRefinement1_DescribeApplication_ReturnsCopy(t *testing.T) {
 	b := newBackend()
 	_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "copy-app", "", "", map[string]string{"k": "v"})
 
-	app1, err := b.DescribeApplication("copy-app")
+	app1, err := b.DescribeApplication(context.Background(), "copy-app")
 	require.NoError(t, err)
 
 	// Mutating the returned copy must not affect the stored application.
 	app1.ApplicationName = "mutated"
 	app1.Tags["k"] = "mutated"
 
-	app2, err := b.DescribeApplication("copy-app")
+	app2, err := b.DescribeApplication(context.Background(), "copy-app")
 	require.NoError(t, err)
 
 	assert.Equal(t, "copy-app", app2.ApplicationName)
@@ -260,11 +261,11 @@ func TestRefinement1_VersionNotBumpedOnDeleteCWLNotFound(t *testing.T) {
 	_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "bump-test", "", "", nil)
 
 	// Try to delete a non-existent CWL option — version 1 passed.
-	err := b.DeleteApplicationCloudWatchLoggingOption("bump-test", 1, "nonexistent-cwl-id")
+	err := b.DeleteApplicationCloudWatchLoggingOption(context.Background(), "bump-test", 1, "nonexistent-cwl-id")
 	require.ErrorIs(t, err, kinesisanalytics.ErrNotFound)
 
 	// Version should still be 1 (not bumped) so the next version-1 call succeeds.
-	app, err := b.DescribeApplication("bump-test")
+	app, err := b.DescribeApplication(context.Background(), "bump-test")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), app.ApplicationVersionID)
 }
@@ -276,10 +277,10 @@ func TestRefinement1_VersionNotBumpedOnDeleteOutputNotFound(t *testing.T) {
 	b := newBackend()
 	_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "out-bump", "", "", nil)
 
-	err := b.DeleteApplicationOutput("out-bump", 1, "nonexistent-output-id")
+	err := b.DeleteApplicationOutput(context.Background(), "out-bump", 1, "nonexistent-output-id")
 	require.ErrorIs(t, err, kinesisanalytics.ErrNotFound)
 
-	app, _ := b.DescribeApplication("out-bump")
+	app, _ := b.DescribeApplication(context.Background(), "out-bump")
 	assert.Equal(t, int64(1), app.ApplicationVersionID)
 }
 
@@ -290,10 +291,10 @@ func TestRefinement1_VersionNotBumpedOnDeleteRefNotFound(t *testing.T) {
 	b := newBackend()
 	_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "ref-bump", "", "", nil)
 
-	err := b.DeleteApplicationReferenceDataSource("ref-bump", 1, "nonexistent-ref-id")
+	err := b.DeleteApplicationReferenceDataSource(context.Background(), "ref-bump", 1, "nonexistent-ref-id")
 	require.ErrorIs(t, err, kinesisanalytics.ErrNotFound)
 
-	app, _ := b.DescribeApplication("ref-bump")
+	app, _ := b.DescribeApplication(context.Background(), "ref-bump")
 	assert.Equal(t, int64(1), app.ApplicationVersionID)
 }
 
@@ -304,10 +305,16 @@ func TestRefinement1_VersionNotBumpedOnAddInputProcConfigNotFound(t *testing.T) 
 	b := newBackend()
 	_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "ipc-bump", "", "", nil)
 
-	err := b.AddApplicationInputProcessingConfiguration("ipc-bump", 1, "nonexistent-input-id", nil)
+	err := b.AddApplicationInputProcessingConfiguration(
+		context.Background(),
+		"ipc-bump",
+		1,
+		"nonexistent-input-id",
+		nil,
+	)
 	require.ErrorIs(t, err, kinesisanalytics.ErrNotFound)
 
-	app, _ := b.DescribeApplication("ipc-bump")
+	app, _ := b.DescribeApplication(context.Background(), "ipc-bump")
 	assert.Equal(t, int64(1), app.ApplicationVersionID)
 }
 
@@ -331,7 +338,7 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 				app, _ := kinesisanalytics.CreateApp(b, testRegion, testAccountID, "persist-1", "desc", "SELECT 1",
 					map[string]string{"env": "test"})
 				// Add a sub-resource to exercise nextID persistence.
-				_ = b.AddApplicationCloudWatchLoggingOption("persist-1", app.ApplicationVersionID,
+				_ = b.AddApplicationCloudWatchLoggingOption(context.Background(), "persist-1", app.ApplicationVersionID,
 					kinesisanalytics.CloudWatchLoggingOptionDesc{
 						LogStreamARN: "arn:aws:logs:us-east-1:000:log-group:x:log-stream:y",
 						RoleARN:      "arn:aws:iam::000000000000:role/r",
@@ -358,18 +365,22 @@ func TestRefinement1_PersistenceRoundTrip(t *testing.T) {
 			assert.Equal(t, tt.wantLen, kinesisanalytics.ApplicationCount(b2))
 
 			if tt.wantLen > 0 {
-				app, err := b2.DescribeApplication("persist-1")
+				app, err := b2.DescribeApplication(context.Background(), "persist-1")
 				require.NoError(t, err)
 				assert.Equal(t, "test", app.Tags["env"])
 				assert.Len(t, app.CloudWatchLoggingOptions, 1)
 
 				// nextID is preserved: next allocation should not collide with existing IDs.
-				_ = b2.AddApplicationCloudWatchLoggingOption("persist-1", app.ApplicationVersionID,
+				_ = b2.AddApplicationCloudWatchLoggingOption(
+					context.Background(),
+					"persist-1",
+					app.ApplicationVersionID,
 					kinesisanalytics.CloudWatchLoggingOptionDesc{
 						LogStreamARN: "arn:aws:logs:us-east-1:000000000000:log-group:g2:log-stream:s2",
 						RoleARN:      "arn:aws:iam::000000000000:role/r",
-					})
-				app2, _ := b2.DescribeApplication("persist-1")
+					},
+				)
+				app2, _ := b2.DescribeApplication(context.Background(), "persist-1")
 				// The new option must have a different ID from the restored one.
 				assert.NotEqual(t, app.CloudWatchLoggingOptions[0].CloudWatchLoggingOptionID,
 					app2.CloudWatchLoggingOptions[1].CloudWatchLoggingOptionID)
@@ -551,21 +562,26 @@ func TestRefinement1_DeleteCWLRoundTrip(t *testing.T) {
 	app, _ := kinesisanalytics.CreateApp(b, testRegion, testAccountID, "del-cwl-app", "", "", nil)
 
 	// Add a CWL option.
-	_ = b.AddApplicationCloudWatchLoggingOption(app.ApplicationName, app.ApplicationVersionID,
+	_ = b.AddApplicationCloudWatchLoggingOption(context.Background(), app.ApplicationName, app.ApplicationVersionID,
 		kinesisanalytics.CloudWatchLoggingOptionDesc{
 			LogStreamARN: "arn:aws:logs:us-east-1:000:log-group:g:log-stream:s",
 			RoleARN:      "arn:aws:iam::000000000000:role/r",
 		})
 
-	app2, _ := b.DescribeApplication(app.ApplicationName)
+	app2, _ := b.DescribeApplication(context.Background(), app.ApplicationName)
 	require.Len(t, app2.CloudWatchLoggingOptions, 1)
 	cwlID := app2.CloudWatchLoggingOptions[0].CloudWatchLoggingOptionID
 
 	// Delete it.
-	err := b.DeleteApplicationCloudWatchLoggingOption(app.ApplicationName, app2.ApplicationVersionID, cwlID)
+	err := b.DeleteApplicationCloudWatchLoggingOption(
+		context.Background(),
+		app.ApplicationName,
+		app2.ApplicationVersionID,
+		cwlID,
+	)
 	require.NoError(t, err)
 
-	app3, _ := b.DescribeApplication(app.ApplicationName)
+	app3, _ := b.DescribeApplication(context.Background(), app.ApplicationName)
 	assert.Empty(t, app3.CloudWatchLoggingOptions)
 }
 
@@ -630,7 +646,7 @@ func TestRefinement1_ListApplications_Pagination(t *testing.T) {
 	_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "page-c", "", "", nil)
 
 	// Request page 2 starting after "page-a".
-	apps, hasMore, _ := b.ListApplications("page-a", 1)
+	apps, hasMore, _ := b.ListApplications(context.Background(), "page-a", 1)
 	assert.Len(t, apps, 1)
 	assert.Equal(t, "page-b", apps[0].ApplicationName)
 	assert.True(t, hasMore)
@@ -663,7 +679,7 @@ func TestRefinement1_UpdateApplication_BumpsVersion(t *testing.T) {
 	_, err := kinesisanalytics.UpdateAppCode(b, "ver-bump", 1, "SELECT 2")
 	require.NoError(t, err)
 
-	app2, _ := b.DescribeApplication("ver-bump")
+	app2, _ := b.DescribeApplication(context.Background(), "ver-bump")
 	assert.Equal(t, int64(2), app2.ApplicationVersionID)
 	assert.Equal(t, "SELECT 2", app2.ApplicationCode)
 }
@@ -712,32 +728,42 @@ func TestRefinement1_DeepCopyInput(t *testing.T) {
 	app, _ := kinesisanalytics.CreateApp(b, testRegion, testAccountID, "dc-input-app", "", "", nil)
 
 	// Add input.
-	_ = b.AddApplicationInput("dc-input-app", app.ApplicationVersionID, kinesisanalytics.InputDescription{
-		NamePrefix: "src_",
-		KinesisStreamsInputDescription: &kinesisanalytics.KinesisStreamsInputDesc{
-			ResourceARN: "arn:aws:kinesis:us-east-1:000:stream/st",
+	_ = b.AddApplicationInput(
+		context.Background(),
+		"dc-input-app",
+		app.ApplicationVersionID,
+		kinesisanalytics.InputDescription{
+			NamePrefix: "src_",
+			KinesisStreamsInputDescription: &kinesisanalytics.KinesisStreamsInputDesc{
+				ResourceARN: "arn:aws:kinesis:us-east-1:000:stream/st",
+			},
 		},
-	})
+	)
 
 	// Add processing config to the input.
-	app2, _ := b.DescribeApplication("dc-input-app")
+	app2, _ := b.DescribeApplication(context.Background(), "dc-input-app")
 	inputID := app2.Inputs[0].InputID
 
-	_ = b.AddApplicationInputProcessingConfiguration("dc-input-app", app2.ApplicationVersionID, inputID,
+	_ = b.AddApplicationInputProcessingConfiguration(
+		context.Background(),
+		"dc-input-app",
+		app2.ApplicationVersionID,
+		inputID,
 		&kinesisanalytics.InputProcessingConfigurationDesc{
 			InputLambdaProcessor: &kinesisanalytics.LambdaProcessorDesc{
 				ResourceARN: "arn:aws:lambda:us-east-1:000:function:fn",
 			},
-		})
+		},
+	)
 
-	app3, _ := b.DescribeApplication("dc-input-app")
+	app3, _ := b.DescribeApplication(context.Background(), "dc-input-app")
 	require.Len(t, app3.Inputs, 1)
 	require.NotNil(t, app3.Inputs[0].InputProcessingConfigurationDescription)
 
 	// Mutate the copy — original must be unaffected.
 	app3.Inputs[0].InputProcessingConfigurationDescription.InputLambdaProcessor.ResourceARN = "mutated"
 
-	app4, _ := b.DescribeApplication("dc-input-app")
+	app4, _ := b.DescribeApplication(context.Background(), "dc-input-app")
 	assert.Equal(
 		t,
 		"arn:aws:lambda:us-east-1:000:function:fn",

--- a/services/kinesisanalytics/handler_test.go
+++ b/services/kinesisanalytics/handler_test.go
@@ -2,6 +2,7 @@ package kinesisanalytics_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -702,7 +703,7 @@ func TestHandler_AddApplicationCloudWatchLoggingOption(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("cwl-app")
+				app, err := b.DescribeApplication(context.Background(), "cwl-app")
 				require.NoError(t, err)
 				assert.NotEmpty(t, app.CloudWatchLoggingOptions)
 			}
@@ -783,7 +784,7 @@ func TestHandler_AddApplicationInput(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("input-app")
+				app, err := b.DescribeApplication(context.Background(), "input-app")
 				require.NoError(t, err)
 				assert.NotEmpty(t, app.Inputs)
 			}
@@ -806,8 +807,13 @@ func TestHandler_AddApplicationInputProcessingConfiguration(t *testing.T) {
 			appName: "proc-app",
 			setup: func(b *kinesisanalytics.InMemoryBackend) string {
 				_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "proc-app", "", "", nil)
-				_ = b.AddApplicationInput("proc-app", 1, kinesisanalytics.InputDescription{NamePrefix: "PREFIX"})
-				app, _ := b.DescribeApplication("proc-app")
+				_ = b.AddApplicationInput(
+					context.Background(),
+					"proc-app",
+					1,
+					kinesisanalytics.InputDescription{NamePrefix: "PREFIX"},
+				)
+				app, _ := b.DescribeApplication(context.Background(), "proc-app")
 
 				return app.Inputs[0].InputID
 			},
@@ -862,7 +868,7 @@ func TestHandler_AddApplicationInputProcessingConfiguration(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication(tt.appName)
+				app, err := b.DescribeApplication(context.Background(), tt.appName)
 				require.NoError(t, err)
 				require.NotEmpty(t, app.Inputs)
 				assert.NotNil(t, app.Inputs[0].InputProcessingConfigurationDescription)
@@ -946,7 +952,7 @@ func TestHandler_AddApplicationOutput(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("output-app")
+				app, err := b.DescribeApplication(context.Background(), "output-app")
 				require.NoError(t, err)
 				assert.NotEmpty(t, app.Outputs)
 			}
@@ -1037,7 +1043,7 @@ func TestHandler_AddApplicationReferenceDataSource(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("ref-app")
+				app, err := b.DescribeApplication(context.Background(), "ref-app")
 				require.NoError(t, err)
 				assert.NotEmpty(t, app.ReferenceDataSources)
 			}
@@ -1059,6 +1065,7 @@ func TestHandler_DeleteApplicationCloudWatchLoggingOption(t *testing.T) {
 			setup: func(b *kinesisanalytics.InMemoryBackend) string {
 				_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "del-cwl-app", "", "", nil)
 				_ = b.AddApplicationCloudWatchLoggingOption(
+					context.Background(),
 					"del-cwl-app",
 					1,
 					kinesisanalytics.CloudWatchLoggingOptionDesc{
@@ -1066,7 +1073,7 @@ func TestHandler_DeleteApplicationCloudWatchLoggingOption(t *testing.T) {
 						RoleARN:      "arn:aws:iam::000000000000:role/r",
 					},
 				)
-				app, _ := b.DescribeApplication("del-cwl-app")
+				app, _ := b.DescribeApplication(context.Background(), "del-cwl-app")
 
 				return app.CloudWatchLoggingOptions[0].CloudWatchLoggingOptionID
 			},
@@ -1115,7 +1122,7 @@ func TestHandler_DeleteApplicationCloudWatchLoggingOption(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("del-cwl-app")
+				app, err := b.DescribeApplication(context.Background(), "del-cwl-app")
 				require.NoError(t, err)
 				assert.Empty(t, app.CloudWatchLoggingOptions)
 			}
@@ -1138,13 +1145,18 @@ func TestHandler_DeleteApplicationInputProcessingConfiguration(t *testing.T) {
 			appName: "del-proc-app",
 			setup: func(b *kinesisanalytics.InMemoryBackend) string {
 				_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "del-proc-app", "", "", nil)
-				_ = b.AddApplicationInput("del-proc-app", 1, kinesisanalytics.InputDescription{NamePrefix: "STREAM"})
-				app, _ := b.DescribeApplication("del-proc-app")
+				_ = b.AddApplicationInput(
+					context.Background(),
+					"del-proc-app",
+					1,
+					kinesisanalytics.InputDescription{NamePrefix: "STREAM"},
+				)
+				app, _ := b.DescribeApplication(context.Background(), "del-proc-app")
 				inputID := app.Inputs[0].InputID
 				cfg := &kinesisanalytics.InputProcessingConfigurationDesc{
 					InputLambdaProcessor: &kinesisanalytics.LambdaProcessorDesc{ResourceARN: "arn:aws:lambda::fn"},
 				}
-				_ = b.AddApplicationInputProcessingConfiguration("del-proc-app", 2, inputID, cfg)
+				_ = b.AddApplicationInputProcessingConfiguration(context.Background(), "del-proc-app", 2, inputID, cfg)
 
 				return inputID
 			},
@@ -1193,7 +1205,7 @@ func TestHandler_DeleteApplicationInputProcessingConfiguration(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication(tt.appName)
+				app, err := b.DescribeApplication(context.Background(), tt.appName)
 				require.NoError(t, err)
 				require.NotEmpty(t, app.Inputs)
 				assert.Nil(t, app.Inputs[0].InputProcessingConfigurationDescription)
@@ -1215,8 +1227,13 @@ func TestHandler_DeleteApplicationOutput(t *testing.T) {
 			name: "deletes existing output",
 			setup: func(b *kinesisanalytics.InMemoryBackend) string {
 				_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "del-out-app", "", "", nil)
-				_ = b.AddApplicationOutput("del-out-app", 1, kinesisanalytics.OutputDescription{Name: "STREAM_OUT"})
-				app, _ := b.DescribeApplication("del-out-app")
+				_ = b.AddApplicationOutput(
+					context.Background(),
+					"del-out-app",
+					1,
+					kinesisanalytics.OutputDescription{Name: "STREAM_OUT"},
+				)
+				app, _ := b.DescribeApplication(context.Background(), "del-out-app")
 
 				return app.Outputs[0].OutputID
 			},
@@ -1265,7 +1282,7 @@ func TestHandler_DeleteApplicationOutput(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("del-out-app")
+				app, err := b.DescribeApplication(context.Background(), "del-out-app")
 				require.NoError(t, err)
 				assert.Empty(t, app.Outputs)
 			}
@@ -1287,11 +1304,12 @@ func TestHandler_DeleteApplicationReferenceDataSource(t *testing.T) {
 			setup: func(b *kinesisanalytics.InMemoryBackend) string {
 				_, _ = kinesisanalytics.CreateApp(b, testRegion, testAccountID, "del-ref-app", "", "", nil)
 				_ = b.AddApplicationReferenceDataSource(
+					context.Background(),
 					"del-ref-app",
 					1,
 					kinesisanalytics.ReferenceDataSourceDescription{TableName: "REF_TBL"},
 				)
-				app, _ := b.DescribeApplication("del-ref-app")
+				app, _ := b.DescribeApplication(context.Background(), "del-ref-app")
 
 				return app.ReferenceDataSources[0].ReferenceID
 			},
@@ -1340,7 +1358,7 @@ func TestHandler_DeleteApplicationReferenceDataSource(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, rec.Code)
 
 			if tt.wantStatus == http.StatusOK {
-				app, err := b.DescribeApplication("del-ref-app")
+				app, err := b.DescribeApplication(context.Background(), "del-ref-app")
 				require.NoError(t, err)
 				assert.Empty(t, app.ReferenceDataSources)
 			}

--- a/services/kinesisanalytics/isolation_test.go
+++ b/services/kinesisanalytics/isolation_test.go
@@ -1,0 +1,83 @@
+package kinesisanalytics //nolint:testpackage // needs access to the unexported region context key.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func kaCtxRegion(region string) context.Context {
+	return context.WithValue(context.Background(), regionContextKey{}, region)
+}
+
+// TestKinesisAnalyticsRegionIsolation verifies that same-named applications in
+// two different regions are fully isolated: each region sees only its own
+// resources, ARNs embed the correct region, and deleting in one region leaves
+// the other untouched.
+func TestKinesisAnalyticsRegionIsolation(t *testing.T) {
+	t.Parallel()
+
+	b := NewInMemoryBackend("us-east-1", "000000000000")
+
+	ctxEast := kaCtxRegion("us-east-1")
+	ctxWest := kaCtxRegion("us-west-2")
+
+	// 1. Create same-named application in both regions.
+	eastApp, err := b.CreateApplication(ctxEast, "shared-app", "east desc", "SELECT 1", "", nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, eastApp.ApplicationARN, "us-east-1")
+
+	westApp, err := b.CreateApplication(ctxWest, "shared-app", "west desc", "SELECT 2", "", nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, westApp.ApplicationARN, "us-west-2")
+
+	// ARNs must differ even though names match.
+	assert.NotEqual(t, eastApp.ApplicationARN, westApp.ApplicationARN)
+
+	// 2. Each region reads back its own application.
+	got, err := b.DescribeApplication(ctxEast, "shared-app")
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 1", got.ApplicationCode)
+
+	got, err = b.DescribeApplication(ctxWest, "shared-app")
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 2", got.ApplicationCode)
+
+	// 3. ListApplications returns exactly one entry per region.
+	eastList, _, err := b.ListApplications(ctxEast, "", 50)
+	require.NoError(t, err)
+	require.Len(t, eastList, 1)
+	assert.Equal(t, "SELECT 1", eastList[0].ApplicationCode)
+
+	westList, _, err := b.ListApplications(ctxWest, "", 50)
+	require.NoError(t, err)
+	require.Len(t, westList, 1)
+	assert.Equal(t, "SELECT 2", westList[0].ApplicationCode)
+
+	// 4. Delete in west does not affect east.
+	// DeleteApplication is async: it sets DELETING state first, then removes after
+	// transitionDelay. We verify the west app enters DELETING state and the east
+	// app is entirely unaffected.
+	ts := time.Now()
+	err = b.DeleteApplication(ctxWest, "shared-app", &ts)
+	require.NoError(t, err)
+
+	// West app transitions to DELETING (still visible, not yet removed).
+	deletingApp, err := b.DescribeApplication(ctxWest, "shared-app")
+	require.NoError(t, err)
+	assert.Equal(t, statusDeleting, deletingApp.ApplicationStatus)
+
+	// East app is completely unaffected.
+	got, err = b.DescribeApplication(ctxEast, "shared-app")
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 1", got.ApplicationCode)
+	assert.Equal(t, statusReady, got.ApplicationStatus)
+
+	// 5. Default region fallback: context.Background() → defaultRegion (us-east-1).
+	got, err = b.DescribeApplication(context.Background(), "shared-app")
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 1", got.ApplicationCode)
+}

--- a/services/kinesisanalytics/persistence.go
+++ b/services/kinesisanalytics/persistence.go
@@ -6,8 +6,8 @@ import (
 )
 
 type backendSnapshot struct {
-	Apps   map[string]*Application `json:"apps"`
-	NextID int64                   `json:"next_id"`
+	Apps   map[string]map[string]*Application `json:"apps"`
+	NextID int64                              `json:"next_id"`
 }
 
 // Snapshot serialises the backend state to JSON.
@@ -16,9 +16,14 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	appsCopy := make(map[string]*Application, len(b.apps))
-	for k, v := range b.apps {
-		appsCopy[k] = appCopy(v)
+	appsCopy := make(map[string]map[string]*Application, len(b.apps))
+
+	for region, regionApps := range b.apps {
+		appsCopy[region] = make(map[string]*Application, len(regionApps))
+
+		for k, v := range regionApps {
+			appsCopy[region][k] = appCopy(v)
+		}
 	}
 
 	snap := backendSnapshot{
@@ -49,16 +54,23 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	defer b.mu.Unlock()
 
 	if snap.Apps == nil {
-		snap.Apps = make(map[string]*Application)
+		snap.Apps = make(map[string]map[string]*Application)
 	}
 
 	b.apps = snap.Apps
 	b.nextID = snap.NextID
 
 	// Rebuild ARN index from restored applications.
-	b.appsByARN = make(map[string]*Application, len(b.apps))
-	for _, app := range b.apps {
-		b.appsByARN[app.ApplicationARN] = app
+	b.appsByARN = make(map[string]map[string]*Application, len(b.apps))
+
+	for region, regionApps := range b.apps {
+		for _, app := range regionApps {
+			if b.appsByARN[region] == nil {
+				b.appsByARN[region] = make(map[string]*Application)
+			}
+
+			b.appsByARN[region][app.ApplicationARN] = app
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Region-isolate services/kinesisanalytics backend with context-based region handling.

**Changes**
- Backend maps nested by region: map[string]map[string]*X
- Context-based region extraction via regionContextKey
- Lazy per-region store initialization
- Handler injects SigV4 region via httputils.ExtractRegionFromRequest
- ARN operations resolve region from ARN with context fallback
- Region-nested persistence layer

**Testing**
- isolation_test.go validates same-named resource isolation across regions
- All existing tests passing
- Cross-package callers (cloudformation/bench/e2e/integration) updated to pass context

**Verification**
- go build ./... ✓
- go vet (with -tags=e2e, -tags=integration) ✓
- go test ./services/kinesisanalytics/... ✓
- golangci-lint clean ✓
- gofmt ✓