### PR TITLE
fix(s3): resolve flaky 'Condition never satisfied' in parity_batch7_test (go-9ayp)

### DIFF
--- a/services/s3/access_log.go
+++ b/services/s3/access_log.go
@@ -56,7 +56,10 @@ func (h *S3Handler) dispatchAccessLog(
 	logKey := buildAccessLogKey(prefix)
 
 	go func() {
-		dispatchCtx, cancel := context.WithTimeout(h.notificationDispatchContext(), accessLogDispatchTimeout)
+		dispatchCtx, cancel := context.WithTimeout(
+			h.notificationDispatchContext(),
+			accessLogDispatchTimeout,
+		)
 		defer cancel()
 
 		if _, putErr := h.Backend.PutObject(dispatchCtx, &awss3.PutObjectInput{

--- a/services/s3/access_log_test.go
+++ b/services/s3/access_log_test.go
@@ -92,9 +92,12 @@ func TestHandler_AccessLogDispatch(t *testing.T) {
 
 			if !tt.wantLog {
 				require.Never(t, func() bool {
-					out, err := backend.ListObjectsV2(context.Background(), &sdk_s3.ListObjectsV2Input{
-						Bucket: aws.String(tt.bucket),
-					})
+					out, err := backend.ListObjectsV2(
+						context.Background(),
+						&sdk_s3.ListObjectsV2Input{
+							Bucket: aws.String(tt.bucket),
+						},
+					)
 
 					return err == nil && len(out.Contents) != tt.wantObjects
 				}, 100*time.Millisecond, 20*time.Millisecond)

--- a/services/s3/accuracy.go
+++ b/services/s3/accuracy.go
@@ -340,9 +340,7 @@ func NewCRC64NVME() hash.Hash {
 // Write implements io.Writer.
 func (h *CRC64NVMEHash) Write(p []byte) (int, error) {
 	for _, b := range p {
-		lsb := byte(
-			h.crc,
-		) //nolint:gosec // lower-byte truncation is intentional for CRC table index
+		lsb := byte(h.crc) //nolint:gosec // lower-byte truncation is intentional for CRC table index
 		h.crc = crc64NVMETable[lsb^b] ^ (h.crc >> crc64ShiftBits)
 	}
 

--- a/services/s3/accuracy.go
+++ b/services/s3/accuracy.go
@@ -340,7 +340,9 @@ func NewCRC64NVME() hash.Hash {
 // Write implements io.Writer.
 func (h *CRC64NVMEHash) Write(p []byte) (int, error) {
 	for _, b := range p {
-		lsb := byte(h.crc) //nolint:gosec // lower-byte truncation is intentional for CRC table index
+		lsb := byte(
+			h.crc,
+		) //nolint:gosec // lower-byte truncation is intentional for CRC table index
 		h.crc = crc64NVMETable[lsb^b] ^ (h.crc >> crc64ShiftBits)
 	}
 

--- a/services/s3/accuracy_batch2_test.go
+++ b/services/s3/accuracy_batch2_test.go
@@ -82,7 +82,10 @@ func TestBatch2_GetBucketLocation_NonDefaultRegion_HasConstraint(t *testing.T) {
 	_ = backend // backend available for future assertions
 
 	req2 := httptest.NewRequest(http.MethodGet, "/"+bucket+"?location", nil)
-	req2.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKID/20240101/eu-west-1/s3/aws4_request")
+	req2.Header.Set(
+		"Authorization",
+		"AWS4-HMAC-SHA256 Credential=AKID/20240101/eu-west-1/s3/aws4_request",
+	)
 	rec2 := httptest.NewRecorder()
 	serveS3Handler(handler, rec2, req2)
 

--- a/services/s3/accuracy_test.go
+++ b/services/s3/accuracy_test.go
@@ -912,7 +912,11 @@ func ssecHeaders(keyB64, keyMD5 string) map[string]string {
 	}
 }
 
-func mustPutSSECObject(t *testing.T, handler *s3.S3Handler, bucket, key, content string) (string, string) {
+func mustPutSSECObject(
+	t *testing.T,
+	handler *s3.S3Handler,
+	bucket, key, content string,
+) (string, string) {
 	t.Helper()
 
 	rawKey := make([]byte, 32)
@@ -974,12 +978,24 @@ func TestSSEC_GetObject_ValidHeaders_Returns200(t *testing.T) {
 	mustCreateBucket(t, backend, "ssec-get-valid")
 	keyB64, keyMD5 := mustPutSSECObject(t, handler, "ssec-get-valid", "obj", "hello")
 
-	rec := doRequest(handler, http.MethodGet, "/ssec-get-valid/obj", nil, ssecHeaders(keyB64, keyMD5))
+	rec := doRequest(
+		handler,
+		http.MethodGet,
+		"/ssec-get-valid/obj",
+		nil,
+		ssecHeaders(keyB64, keyMD5),
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// second object with a distinct key name ensures mustPutSSECObject's key param is exercised.
 	key2B64, key2MD5 := mustPutSSECObject(t, handler, "ssec-get-valid", "obj2", "world")
-	rec2 := doRequest(handler, http.MethodGet, "/ssec-get-valid/obj2", nil, ssecHeaders(key2B64, key2MD5))
+	rec2 := doRequest(
+		handler,
+		http.MethodGet,
+		"/ssec-get-valid/obj2",
+		nil,
+		ssecHeaders(key2B64, key2MD5),
+	)
 	assert.Equal(t, http.StatusOK, rec2.Code)
 }
 
@@ -1025,7 +1041,13 @@ func TestSSEC_HeadObject_ValidHeaders_Returns200(t *testing.T) {
 	mustCreateBucket(t, backend, "ssec-head-valid")
 	keyB64, keyMD5 := mustPutSSECObject(t, handler, "ssec-head-valid", "obj", "hello")
 
-	rec := doRequest(handler, http.MethodHead, "/ssec-head-valid/obj", nil, ssecHeaders(keyB64, keyMD5))
+	rec := doRequest(
+		handler,
+		http.MethodHead,
+		"/ssec-head-valid/obj",
+		nil,
+		ssecHeaders(keyB64, keyMD5),
+	)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 

--- a/services/s3/backend_fixes_test.go
+++ b/services/s3/backend_fixes_test.go
@@ -62,7 +62,12 @@ func TestVersionID_RandomFormat(t *testing.T) {
 					break
 				}
 			}
-			assert.False(t, isNumeric, "version ID should not be a purely numeric Unix timestamp: %s", vid)
+			assert.False(
+				t,
+				isNumeric,
+				"version ID should not be a purely numeric Unix timestamp: %s",
+				vid,
+			)
 
 			// Must be 32 hex chars (16 random bytes encoded as hex).
 			assert.Len(t, vid, 32)
@@ -192,11 +197,14 @@ func TestMultipartUpload_TaggingPropagated(t *testing.T) {
 			backend := newTestBackend(t)
 			mustCreateBucket(t, backend, "bkt")
 
-			createOut, err := backend.CreateMultipartUpload(t.Context(), &sdk_s3.CreateMultipartUploadInput{
-				Bucket:  aws.String("bkt"),
-				Key:     aws.String("key"),
-				Tagging: aws.String(tt.tagging),
-			})
+			createOut, err := backend.CreateMultipartUpload(
+				t.Context(),
+				&sdk_s3.CreateMultipartUploadInput{
+					Bucket:  aws.String("bkt"),
+					Key:     aws.String("key"),
+					Tagging: aws.String(tt.tagging),
+				},
+			)
 			require.NoError(t, err)
 
 			uploadID := createOut.UploadId
@@ -212,22 +220,28 @@ func TestMultipartUpload_TaggingPropagated(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			_, err = backend.CompleteMultipartUpload(t.Context(), &sdk_s3.CompleteMultipartUploadInput{
-				Bucket:   aws.String("bkt"),
-				Key:      aws.String("key"),
-				UploadId: uploadID,
-				MultipartUpload: &types.CompletedMultipartUpload{
-					Parts: []types.CompletedPart{
-						{PartNumber: aws.Int32(1), ETag: p1.ETag},
+			_, err = backend.CompleteMultipartUpload(
+				t.Context(),
+				&sdk_s3.CompleteMultipartUploadInput{
+					Bucket:   aws.String("bkt"),
+					Key:      aws.String("key"),
+					UploadId: uploadID,
+					MultipartUpload: &types.CompletedMultipartUpload{
+						Parts: []types.CompletedPart{
+							{PartNumber: aws.Int32(1), ETag: p1.ETag},
+						},
 					},
 				},
-			})
+			)
 			require.NoError(t, err)
 
-			taggingOut, getErr := backend.GetObjectTagging(t.Context(), &sdk_s3.GetObjectTaggingInput{
-				Bucket: aws.String("bkt"),
-				Key:    aws.String("key"),
-			})
+			taggingOut, getErr := backend.GetObjectTagging(
+				t.Context(),
+				&sdk_s3.GetObjectTaggingInput{
+					Bucket: aws.String("bkt"),
+					Key:    aws.String("key"),
+				},
+			)
 
 			if tt.wantTags == 0 {
 				// No tags set → either NoSuchTagSet or empty tag set.

--- a/services/s3/backend_memory.go
+++ b/services/s3/backend_memory.go
@@ -476,11 +476,9 @@ func (b *InMemoryBackend) PutObject(
 		"versionId", newVersionID)
 
 	// Async replication to configured destination buckets.
-	b.replicationWg.Add(1)
-	go func() {
-		defer b.replicationWg.Done()
+	b.replicationWg.Go(func() {
 		b.triggerReplication(ctx, bucketName, key, finalQuotedETag)
-	}()
+	})
 
 	return &s3.PutObjectOutput{
 		ETag:              aws.String(finalQuotedETag),
@@ -863,11 +861,9 @@ func (b *InMemoryBackend) DeleteObject(
 
 	// Async delete-marker replication when versioning created a delete marker.
 	if out.DeleteMarker != nil && aws.ToBool(out.DeleteMarker) {
-		b.replicationWg.Add(1)
-		go func() {
-			defer b.replicationWg.Done()
+		b.replicationWg.Go(func() {
 			b.triggerDeleteMarkerReplication(ctx, bucketName, *input.Key)
-		}()
+		})
 	}
 
 	return out, nil

--- a/services/s3/backend_memory.go
+++ b/services/s3/backend_memory.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/config"
@@ -117,6 +118,9 @@ type InMemoryBackend struct {
 	compressor          Compressor
 	defaultRegion       string
 	compressionMinBytes int
+	// replicationWg tracks all in-flight replication goroutines.
+	// DrainReplicationGoroutines blocks until they all finish.
+	replicationWg sync.WaitGroup
 	// skipMultipartSizeCheck disables the 5 MiB minimum part size check during
 	// CompleteMultipartUpload. This is intended for use in unit tests only.
 	skipMultipartSizeCheck bool
@@ -128,6 +132,13 @@ func (b *InMemoryBackend) WithSkipMultipartSizeCheck() *InMemoryBackend {
 	b.skipMultipartSizeCheck = true
 
 	return b
+}
+
+// DrainReplicationGoroutines blocks until all in-flight replication goroutines
+// complete. Use in tests to establish a happens-before boundary between
+// operations that spawn replication goroutines and subsequent state assertions.
+func (b *InMemoryBackend) DrainReplicationGoroutines() {
+	b.replicationWg.Wait()
 }
 
 func NewInMemoryBackend(compressor Compressor) *InMemoryBackend {
@@ -465,7 +476,11 @@ func (b *InMemoryBackend) PutObject(
 		"versionId", newVersionID)
 
 	// Async replication to configured destination buckets.
-	go b.triggerReplication(ctx, bucketName, key, finalQuotedETag)
+	b.replicationWg.Add(1)
+	go func() {
+		defer b.replicationWg.Done()
+		b.triggerReplication(ctx, bucketName, key, finalQuotedETag)
+	}()
 
 	return &s3.PutObjectOutput{
 		ETag:              aws.String(finalQuotedETag),
@@ -848,7 +863,11 @@ func (b *InMemoryBackend) DeleteObject(
 
 	// Async delete-marker replication when versioning created a delete marker.
 	if out.DeleteMarker != nil && aws.ToBool(out.DeleteMarker) {
-		go b.triggerDeleteMarkerReplication(ctx, bucketName, *input.Key)
+		b.replicationWg.Add(1)
+		go func() {
+			defer b.replicationWg.Done()
+			b.triggerDeleteMarkerReplication(ctx, bucketName, *input.Key)
+		}()
 	}
 
 	return out, nil

--- a/services/s3/backend_memory_test.go
+++ b/services/s3/backend_memory_test.go
@@ -56,7 +56,10 @@ func TestCreateBucket(t *testing.T) {
 			setup: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
 				mustCreateBucket(t, b, "my-bucket")
-				_, err := b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("my-bucket")})
+				_, err := b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("my-bucket")},
+				)
 				require.NoError(t, err)
 			},
 			wantErr:   s3.ErrBucketAlreadyOwnedByYou,
@@ -241,7 +244,11 @@ func TestListBuckets(t *testing.T) {
 				gotNames[i] = aws.ToString(b.Name)
 			}
 
-			assert.Empty(t, cmp.Diff(tt.wantBuckets, gotNames, cmpopts.EquateEmpty()), "bucket names mismatch")
+			assert.Empty(
+				t,
+				cmp.Diff(tt.wantBuckets, gotNames, cmpopts.EquateEmpty()),
+				"bucket names mismatch",
+			)
 		})
 	}
 }
@@ -745,7 +752,11 @@ func TestObjectTagging(t *testing.T) {
 				func(i, j int) bool { return *wantSorted[i].Key < *wantSorted[j].Key },
 			)
 
-			assert.Empty(t, cmp.Diff(wantSorted, gotTags, cmpopts.IgnoreUnexported(types.Tag{})), "tag set mismatch")
+			assert.Empty(
+				t,
+				cmp.Diff(wantSorted, gotTags, cmpopts.IgnoreUnexported(types.Tag{})),
+				"tag set mismatch",
+			)
 		})
 	}
 }
@@ -978,7 +989,12 @@ func TestCreateBucket_GlobalUniqueness(t *testing.T) {
 	_, err := backend.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{
 		Bucket: aws.String("unique-bucket"),
 	})
-	require.ErrorIs(t, err, s3.ErrBucketAlreadyOwnedByYou, "same bucket name should be rejected globally")
+	require.ErrorIs(
+		t,
+		err,
+		s3.ErrBucketAlreadyOwnedByYou,
+		"same bucket name should be rejected globally",
+	)
 }
 
 func TestPutObject_ContentEncodingDisposition(t *testing.T) {
@@ -1104,7 +1120,11 @@ func TestCreateBucket_NonDefaultRegion_PutObjectSucceeds(t *testing.T) {
 		Key:    aws.String("hello.txt"),
 		Body:   bytes.NewReader([]byte("hello")),
 	})
-	require.NoError(t, err, "PutObject must succeed even when bucket was created with a non-default LocationConstraint")
+	require.NoError(
+		t,
+		err,
+		"PutObject must succeed even when bucket was created with a non-default LocationConstraint",
+	)
 
 	out, err := backend.GetObject(t.Context(), &sdk_s3.GetObjectInput{
 		Bucket: aws.String("west-bucket"),
@@ -1364,7 +1384,11 @@ func TestPutBucketEncryption_NotFound(t *testing.T) {
 	t.Parallel()
 
 	backend := newTestBackend(t)
-	err := backend.PutBucketEncryption(t.Context(), "nonexistent-bucket", "<ServerSideEncryptionConfiguration/>")
+	err := backend.PutBucketEncryption(
+		t.Context(),
+		"nonexistent-bucket",
+		"<ServerSideEncryptionConfiguration/>",
+	)
 	assert.ErrorIs(t, err, s3.ErrNoSuchBucket)
 }
 
@@ -1515,10 +1539,13 @@ func TestCompressionMinBytes_CompleteMultipartUpload(t *testing.T) {
 			mustCreateBucket(t, backend, "bkt")
 
 			// Start multipart upload
-			createOut, err := backend.CreateMultipartUpload(t.Context(), &sdk_s3.CreateMultipartUploadInput{
-				Bucket: aws.String("bkt"),
-				Key:    aws.String("key"),
-			})
+			createOut, err := backend.CreateMultipartUpload(
+				t.Context(),
+				&sdk_s3.CreateMultipartUploadInput{
+					Bucket: aws.String("bkt"),
+					Key:    aws.String("key"),
+				},
+			)
 			require.NoError(t, err)
 			uploadID := createOut.UploadId
 
@@ -1542,15 +1569,18 @@ func TestCompressionMinBytes_CompleteMultipartUpload(t *testing.T) {
 			require.NoError(t, err)
 
 			// Complete
-			_, err = backend.CompleteMultipartUpload(t.Context(), &sdk_s3.CompleteMultipartUploadInput{
-				Bucket:   aws.String("bkt"),
-				Key:      aws.String("key"),
-				UploadId: uploadID,
-				MultipartUpload: &types.CompletedMultipartUpload{Parts: []types.CompletedPart{
-					{PartNumber: aws.Int32(1), ETag: p1.ETag},
-					{PartNumber: aws.Int32(2), ETag: p2.ETag},
-				}},
-			})
+			_, err = backend.CompleteMultipartUpload(
+				t.Context(),
+				&sdk_s3.CompleteMultipartUploadInput{
+					Bucket:   aws.String("bkt"),
+					Key:      aws.String("key"),
+					UploadId: uploadID,
+					MultipartUpload: &types.CompletedMultipartUpload{Parts: []types.CompletedPart{
+						{PartNumber: aws.Int32(1), ETag: p1.ETag},
+						{PartNumber: aws.Int32(2), ETag: p2.ETag},
+					}},
+				},
+			)
 			require.NoError(t, err)
 
 			assert.Equal(
@@ -1703,7 +1733,12 @@ func TestInMemoryBackend_IntelligentTieringConfig(t *testing.T) {
 			ctx := t.Context()
 
 			if tt.configXML != "" {
-				err := b.PutBucketIntelligentTieringConfiguration(ctx, tt.bucket, tt.id, tt.configXML)
+				err := b.PutBucketIntelligentTieringConfiguration(
+					ctx,
+					tt.bucket,
+					tt.id,
+					tt.configXML,
+				)
 				require.NoError(t, err)
 			}
 

--- a/services/s3/bucket_ops.go
+++ b/services/s3/bucket_ops.go
@@ -519,7 +519,8 @@ func (h *S3Handler) createBucket(
 		return
 	}
 
-	logger.Load(ctx).DebugContext(ctx, "S3 createBucket output", "bucket", bucketName, "region", region)
+	logger.Load(ctx).
+		DebugContext(ctx, "S3 createBucket output", "bucket", bucketName, "region", region)
 
 	// Set Location header from output
 	if output.Location != nil {
@@ -905,7 +906,10 @@ func (h *S3Handler) listObjectVersions(
 	}
 
 	for _, cp := range out.CommonPrefixes {
-		resp.CommonPrefixes = append(resp.CommonPrefixes, CommonPrefixXML{Prefix: aws.ToString(cp.Prefix)})
+		resp.CommonPrefixes = append(
+			resp.CommonPrefixes,
+			CommonPrefixXML{Prefix: aws.ToString(cp.Prefix)},
+		)
 	}
 
 	httputils.WriteXML(ctx, w, http.StatusOK, resp)
@@ -995,7 +999,12 @@ func (h *S3Handler) getBucketACL(
 	httputils.WriteXML(ctx, w, http.StatusOK, resp)
 }
 
-func (h *S3Handler) putBucketPolicy(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketPolicy(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketPolicy")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1018,7 +1027,12 @@ func (h *S3Handler) putBucketPolicy(ctx context.Context, w http.ResponseWriter, 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) getBucketPolicy(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketPolicy(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketPolicy")
 	policy, err := h.Backend.GetBucketPolicy(ctx, bucket)
 	if err != nil {
@@ -1031,7 +1045,12 @@ func (h *S3Handler) getBucketPolicy(ctx context.Context, w http.ResponseWriter, 
 	_, _ = w.Write([]byte(policy))
 }
 
-func (h *S3Handler) deleteBucketPolicy(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) deleteBucketPolicy(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "DeleteBucketPolicy")
 	if err := h.Backend.DeleteBucketPolicy(ctx, bucket); err != nil {
 		WriteError(ctx, w, r, err)
@@ -1041,7 +1060,12 @@ func (h *S3Handler) deleteBucketPolicy(ctx context.Context, w http.ResponseWrite
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) putBucketCORS(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketCORS(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketCors")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1070,7 +1094,12 @@ func (h *S3Handler) putBucketCORS(ctx context.Context, w http.ResponseWriter, r 
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *S3Handler) getBucketCORS(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketCORS(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketCors")
 	corsXML, err := h.Backend.GetBucketCORS(ctx, bucket)
 	if err != nil {
@@ -1083,7 +1112,12 @@ func (h *S3Handler) getBucketCORS(ctx context.Context, w http.ResponseWriter, r 
 	_, _ = w.Write([]byte(corsXML))
 }
 
-func (h *S3Handler) deleteBucketCORS(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) deleteBucketCORS(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "DeleteBucketCors")
 	if err := h.Backend.DeleteBucketCORS(ctx, bucket); err != nil {
 		WriteError(ctx, w, r, err)
@@ -1093,7 +1127,12 @@ func (h *S3Handler) deleteBucketCORS(ctx context.Context, w http.ResponseWriter,
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) putBucketWebsite(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketWebsite(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketWebsite")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1121,7 +1160,12 @@ func (h *S3Handler) putBucketWebsite(ctx context.Context, w http.ResponseWriter,
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *S3Handler) getBucketWebsite(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketWebsite(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketWebsite")
 	websiteXML, err := h.Backend.GetBucketWebsite(ctx, bucket)
 	if err != nil {
@@ -1134,7 +1178,12 @@ func (h *S3Handler) getBucketWebsite(ctx context.Context, w http.ResponseWriter,
 	_, _ = w.Write([]byte(websiteXML))
 }
 
-func (h *S3Handler) deleteBucketWebsite(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) deleteBucketWebsite(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "DeleteBucketWebsite")
 	if err := h.Backend.DeleteBucketWebsite(ctx, bucket); err != nil {
 		WriteError(ctx, w, r, err)
@@ -1144,7 +1193,12 @@ func (h *S3Handler) deleteBucketWebsite(ctx context.Context, w http.ResponseWrit
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) putBucketEncryption(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketEncryption(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketEncryption")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1172,7 +1226,12 @@ func (h *S3Handler) putBucketEncryption(ctx context.Context, w http.ResponseWrit
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *S3Handler) getBucketEncryption(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketEncryption(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketEncryption")
 	encryptionXML, err := h.Backend.GetBucketEncryption(ctx, bucket)
 	if err != nil {
@@ -1185,7 +1244,12 @@ func (h *S3Handler) getBucketEncryption(ctx context.Context, w http.ResponseWrit
 	_, _ = w.Write([]byte(encryptionXML))
 }
 
-func (h *S3Handler) deleteBucketEncryption(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) deleteBucketEncryption(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "DeleteBucketEncryption")
 	if err := h.Backend.DeleteBucketEncryption(ctx, bucket); err != nil {
 		WriteError(ctx, w, r, err)
@@ -1195,7 +1259,12 @@ func (h *S3Handler) deleteBucketEncryption(ctx context.Context, w http.ResponseW
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) putPublicAccessBlock(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putPublicAccessBlock(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutPublicAccessBlock")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1223,7 +1292,12 @@ func (h *S3Handler) putPublicAccessBlock(ctx context.Context, w http.ResponseWri
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *S3Handler) getPublicAccessBlock(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getPublicAccessBlock(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetPublicAccessBlock")
 	configXML, err := h.Backend.GetPublicAccessBlock(ctx, bucket)
 	if err != nil {
@@ -1317,7 +1391,12 @@ func (h *S3Handler) deleteBucketOwnershipControls(
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) putBucketLogging(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketLogging(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketLogging")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1345,7 +1424,12 @@ func (h *S3Handler) putBucketLogging(ctx context.Context, w http.ResponseWriter,
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *S3Handler) getBucketLogging(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketLogging(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketLogging")
 	loggingXML, err := h.Backend.GetBucketLogging(ctx, bucket)
 	if err != nil {
@@ -1370,7 +1454,12 @@ func (h *S3Handler) getBucketLogging(ctx context.Context, w http.ResponseWriter,
 	_, _ = w.Write([]byte(loggingXML))
 }
 
-func (h *S3Handler) putBucketReplication(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketReplication(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketReplication")
 	body, err := httputils.ReadBody(r)
 	if err != nil {
@@ -1398,7 +1487,12 @@ func (h *S3Handler) putBucketReplication(ctx context.Context, w http.ResponseWri
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *S3Handler) getBucketReplication(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketReplication(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketReplication")
 	replicationXML, err := h.Backend.GetBucketReplication(ctx, bucket)
 	if err != nil {
@@ -1426,7 +1520,12 @@ func (h *S3Handler) deleteBucketReplication(
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) putBucketTagging(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) putBucketTagging(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "PutBucketTagging")
 
 	body, err := httputils.ReadBody(r)
@@ -1463,7 +1562,12 @@ func (h *S3Handler) putBucketTagging(ctx context.Context, w http.ResponseWriter,
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) getBucketTagging(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) getBucketTagging(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "GetBucketTagging")
 
 	tags, err := h.Backend.GetBucketTagging(ctx, bucket)
@@ -1484,7 +1588,12 @@ func (h *S3Handler) getBucketTagging(ctx context.Context, w http.ResponseWriter,
 	httputils.WriteXML(ctx, w, http.StatusOK, tagging)
 }
 
-func (h *S3Handler) deleteBucketTagging(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) deleteBucketTagging(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "DeleteBucketTagging")
 
 	if err := h.Backend.DeleteBucketTagging(ctx, bucket); err != nil {
@@ -1496,7 +1605,12 @@ func (h *S3Handler) deleteBucketTagging(ctx context.Context, w http.ResponseWrit
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) handleCORSPreflight(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) handleCORSPreflight(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "CORSPreflight")
 	corsXML, err := h.Backend.GetBucketCORS(ctx, bucket)
 	if err != nil {
@@ -1970,7 +2084,12 @@ func (h *S3Handler) deleteBucketMetadataTableConfiguration(
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *S3Handler) createSession(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) {
+func (h *S3Handler) createSession(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	bucket string,
+) {
 	h.setOperation(ctx, "CreateSession")
 	sessionXML, err := h.Backend.CreateSession(ctx, bucket)
 	if err != nil {
@@ -2047,7 +2166,12 @@ func (h *S3Handler) listBucketAnalyticsConfigurations(
 
 		return
 	}
-	writeConfigListXML(w, "ListBucketAnalyticsConfigurationResult", "AnalyticsConfiguration", configs)
+	writeConfigListXML(
+		w,
+		"ListBucketAnalyticsConfigurationResult",
+		"AnalyticsConfiguration",
+		configs,
+	)
 }
 
 func (h *S3Handler) putBucketIntelligentTieringConfiguration(

--- a/services/s3/coverage2_test.go
+++ b/services/s3/coverage2_test.go
@@ -196,8 +196,14 @@ func TestListMultipartUploads_KeyMarkerPlusUploadIDMarker(t *testing.T) {
 	require.Equal(t, http.StatusOK, listRec.Code)
 
 	// Use key-marker + upload-id-marker to skip the first upload for "same-key".
-	req := httptest.NewRequest(http.MethodGet,
-		fmt.Sprintf("/smm2-bucket?uploads&key-marker=same-key&upload-id-marker=%s", uploadIDs[0]), nil)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf(
+			"/smm2-bucket?uploads&key-marker=same-key&upload-id-marker=%s",
+			uploadIDs[0],
+		),
+		nil,
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -255,7 +261,12 @@ func checksumB64SHA256(data []byte) string {
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
 }
 
-func doMultipartUpload(t *testing.T, handler *s3.S3Handler, backend s3.StorageBackend, bucket string) string {
+func doMultipartUpload(
+	t *testing.T,
+	handler *s3.S3Handler,
+	backend s3.StorageBackend,
+	bucket string,
+) string {
 	t.Helper()
 	mustCreateBucket(t, backend, bucket)
 
@@ -577,7 +588,10 @@ func TestSSE_KMS_ResponseHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/sse-kms-hdr/obj",
 		strings.NewReader("hello kms"))
 	req.Header.Set("X-Amz-Server-Side-Encryption", "aws:kms")
-	req.Header.Set("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id", "arn:aws:kms:us-east-1:123456789012:key/test-key")
+	req.Header.Set(
+		"X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id",
+		"arn:aws:kms:us-east-1:123456789012:key/test-key",
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 

--- a/services/s3/coverage_test.go
+++ b/services/s3/coverage_test.go
@@ -142,13 +142,21 @@ func TestHandler_DeleteObjects_BulkOps(t *testing.T) {
 			mustCreateBucket(t, backend, tt.bucket)
 
 			for _, key := range tt.setupObjects {
-				putReq := httptest.NewRequest(http.MethodPut, "/"+tt.bucket+"/"+key, strings.NewReader("data"))
+				putReq := httptest.NewRequest(
+					http.MethodPut,
+					"/"+tt.bucket+"/"+key,
+					strings.NewReader("data"),
+				)
 				putRec := httptest.NewRecorder()
 				serveS3Handler(handler, putRec, putReq)
 				require.Equal(t, http.StatusOK, putRec.Code)
 			}
 
-			req := httptest.NewRequest(http.MethodPost, "/"+tt.bucket+"?delete", strings.NewReader(tt.deleteBody))
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/"+tt.bucket+"?delete",
+				strings.NewReader(tt.deleteBody),
+			)
 			rec := httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 
@@ -186,7 +194,11 @@ func TestHandler_DeleteObjectTagging(t *testing.T) {
 			handler, backend := newTestHandler(t)
 			mustCreateBucket(t, backend, tt.bucket)
 
-			putReq := httptest.NewRequest(http.MethodPut, "/"+tt.bucket+"/"+tt.key, strings.NewReader("data"))
+			putReq := httptest.NewRequest(
+				http.MethodPut,
+				"/"+tt.bucket+"/"+tt.key,
+				strings.NewReader("data"),
+			)
 			putRec := httptest.NewRecorder()
 			serveS3Handler(handler, putRec, putReq)
 			require.Equal(t, http.StatusOK, putRec.Code)
@@ -200,7 +212,11 @@ func TestHandler_DeleteObjectTagging(t *testing.T) {
 			serveS3Handler(handler, tagRec, tagReq)
 			require.Equal(t, http.StatusOK, tagRec.Code)
 
-			delReq := httptest.NewRequest(http.MethodDelete, "/"+tt.bucket+"/"+tt.key+"?tagging", nil)
+			delReq := httptest.NewRequest(
+				http.MethodDelete,
+				"/"+tt.bucket+"/"+tt.key+"?tagging",
+				nil,
+			)
 			delRec := httptest.NewRecorder()
 			serveS3Handler(handler, delRec, delReq)
 
@@ -267,7 +283,11 @@ func TestHandler_GetObject_WithChecksumMode(t *testing.T) {
 			handler, backend := newTestHandler(t)
 			mustCreateBucket(t, backend, tt.bucket)
 
-			putReq := httptest.NewRequest(http.MethodPut, "/"+tt.bucket+"/"+tt.key, strings.NewReader(tt.body))
+			putReq := httptest.NewRequest(
+				http.MethodPut,
+				"/"+tt.bucket+"/"+tt.key,
+				strings.NewReader(tt.body),
+			)
 			putReq.Header.Set("X-Amz-Checksum-Algorithm", "SHA256")
 			putRec := httptest.NewRecorder()
 			serveS3Handler(handler, putRec, putReq)
@@ -359,7 +379,11 @@ func TestHandler_DeleteObject_Versioned(t *testing.T) {
 			handler, backend := newTestHandler(t)
 			mustCreateBucket(t, backend, tt.bucket)
 
-			putReq := httptest.NewRequest(http.MethodPut, "/"+tt.bucket+"/"+tt.key, strings.NewReader("data"))
+			putReq := httptest.NewRequest(
+				http.MethodPut,
+				"/"+tt.bucket+"/"+tt.key,
+				strings.NewReader("data"),
+			)
 			putRec := httptest.NewRecorder()
 			serveS3Handler(handler, putRec, putReq)
 			require.Equal(t, http.StatusOK, putRec.Code)
@@ -428,7 +452,11 @@ func TestHandler_DeleteBucket_NotEmpty(t *testing.T) {
 			handler, backend := newTestHandler(t)
 			mustCreateBucket(t, backend, tt.bucket)
 
-			putReq := httptest.NewRequest(http.MethodPut, "/"+tt.bucket+"/"+tt.objectKey, strings.NewReader("data"))
+			putReq := httptest.NewRequest(
+				http.MethodPut,
+				"/"+tt.bucket+"/"+tt.objectKey,
+				strings.NewReader("data"),
+			)
 			putRec := httptest.NewRecorder()
 			serveS3Handler(handler, putRec, putReq)
 			require.Equal(t, http.StatusOK, putRec.Code)

--- a/services/s3/errors.go
+++ b/services/s3/errors.go
@@ -75,8 +75,18 @@ func errorTable() []s3ErrorEntry {
 
 func coreErrorTable() []s3ErrorEntry {
 	return []s3ErrorEntry{
-		{ErrNoSuchBucket, s3ErrorInfo{"NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound}},
-		{ErrNoSuchKey, s3ErrorInfo{"NoSuchKey", "The specified key does not exist.", http.StatusNotFound}},
+		{
+			ErrNoSuchBucket,
+			s3ErrorInfo{
+				"NoSuchBucket",
+				"The specified bucket does not exist.",
+				http.StatusNotFound,
+			},
+		},
+		{
+			ErrNoSuchKey,
+			s3ErrorInfo{"NoSuchKey", "The specified key does not exist.", http.StatusNotFound},
+		},
 		{ErrBucketAlreadyOwnedByYou, s3ErrorInfo{
 			"BucketAlreadyOwnedByYou",
 			"Your previous request to create the named bucket succeeded and you already own it.",
@@ -117,7 +127,10 @@ func coreErrorTable() []s3ErrorEntry {
 			"You must specify at least one part",
 			http.StatusBadRequest,
 		}},
-		{ErrInvalidArgument, s3ErrorInfo{errInvalidArgument, "Invalid Argument.", http.StatusBadRequest}},
+		{
+			ErrInvalidArgument,
+			s3ErrorInfo{errInvalidArgument, "Invalid Argument.", http.StatusBadRequest},
+		},
 		{ErrMethodNotAllowed, s3ErrorInfo{
 			"MethodNotAllowed",
 			"The specified method is not allowed against this resource.",

--- a/services/s3/errors.go
+++ b/services/s3/errors.go
@@ -74,6 +74,10 @@ func errorTable() []s3ErrorEntry {
 }
 
 func coreErrorTable() []s3ErrorEntry {
+	return append(coreErrorTableBucket(), coreErrorTableObject()...)
+}
+
+func coreErrorTableBucket() []s3ErrorEntry {
 	return []s3ErrorEntry{
 		{
 			ErrNoSuchBucket,
@@ -131,6 +135,11 @@ func coreErrorTable() []s3ErrorEntry {
 			ErrInvalidArgument,
 			s3ErrorInfo{errInvalidArgument, "Invalid Argument.", http.StatusBadRequest},
 		},
+	}
+}
+
+func coreErrorTableObject() []s3ErrorEntry {
+	return []s3ErrorEntry{
 		{ErrMethodNotAllowed, s3ErrorInfo{
 			"MethodNotAllowed",
 			"The specified method is not allowed against this resource.",

--- a/services/s3/export_test.go
+++ b/services/s3/export_test.go
@@ -130,7 +130,10 @@ func BackdateObjectForTest(b *InMemoryBackend, bucketName, key string, t time.Ti
 
 // StorageClassTransitionsForObject returns the StorageClassTransitions history
 // for the latest version of an object. Used in janitor transition tests.
-func StorageClassTransitionsForObject(b *InMemoryBackend, bucketName, key string) []StorageClassTransition {
+func StorageClassTransitionsForObject(
+	b *InMemoryBackend,
+	bucketName, key string,
+) []StorageClassTransition {
 	b.mu.RLock("StorageClassTransitionsForObject")
 	region, ok := b.bucketIndex[bucketName]
 	if !ok {

--- a/services/s3/extra_backend.go
+++ b/services/s3/extra_backend.go
@@ -36,7 +36,10 @@ func newStoredObject(key string) *StoredObject {
 // Reuses ErrNoSuchKey from errors.go via the s3 package.
 
 // PutBucketAccelerateConfiguration stores the accelerate status ("Enabled"/"Suspended") for a bucket.
-func (b *InMemoryBackend) PutBucketAccelerateConfiguration(_ context.Context, bucketName, status string) error {
+func (b *InMemoryBackend) PutBucketAccelerateConfiguration(
+	_ context.Context,
+	bucketName, status string,
+) error {
 	b.mu.RLock("PutBucketAccelerateConfiguration")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -55,7 +58,10 @@ func (b *InMemoryBackend) PutBucketAccelerateConfiguration(_ context.Context, bu
 
 // GetBucketAccelerateConfiguration returns the bucket's accelerate status.
 // When unset the AWS default of "Suspended" is returned.
-func (b *InMemoryBackend) GetBucketAccelerateConfiguration(_ context.Context, bucketName string) (string, error) {
+func (b *InMemoryBackend) GetBucketAccelerateConfiguration(
+	_ context.Context,
+	bucketName string,
+) (string, error) {
 	b.mu.RLock("GetBucketAccelerateConfiguration")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -75,7 +81,10 @@ func (b *InMemoryBackend) GetBucketAccelerateConfiguration(_ context.Context, bu
 }
 
 // PutBucketRequestPayment stores the request-payment payer ("BucketOwner" or "Requester").
-func (b *InMemoryBackend) PutBucketRequestPayment(_ context.Context, bucketName, payer string) error {
+func (b *InMemoryBackend) PutBucketRequestPayment(
+	_ context.Context,
+	bucketName, payer string,
+) error {
 	b.mu.RLock("PutBucketRequestPayment")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -93,7 +102,10 @@ func (b *InMemoryBackend) PutBucketRequestPayment(_ context.Context, bucketName,
 }
 
 // GetBucketRequestPayment returns the request-payment payer; defaults to "BucketOwner".
-func (b *InMemoryBackend) GetBucketRequestPayment(_ context.Context, bucketName string) (string, error) {
+func (b *InMemoryBackend) GetBucketRequestPayment(
+	_ context.Context,
+	bucketName string,
+) (string, error) {
 	b.mu.RLock("GetBucketRequestPayment")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -228,7 +240,10 @@ func (b *InMemoryBackend) RestoreObject(_ context.Context, bucketName, key strin
 
 // UpdateObjectEncryption updates the SSE algorithm (and optional KMS key id)
 // of the latest version of the named object.
-func (b *InMemoryBackend) UpdateObjectEncryption(_ context.Context, bucketName, key, algorithm, kmsKeyID string) error {
+func (b *InMemoryBackend) UpdateObjectEncryption(
+	_ context.Context,
+	bucketName, key, algorithm, kmsKeyID string,
+) error {
 	b.mu.RLock("UpdateObjectEncryption")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -261,7 +276,10 @@ func (b *InMemoryBackend) UpdateObjectEncryption(_ context.Context, bucketName, 
 
 // PutObjectACL stores the ACL XML/canned-ACL header on the latest object version.
 // versionID may be empty to target the latest version.
-func (b *InMemoryBackend) PutObjectACL(_ context.Context, bucketName, key, versionID, acl string) error {
+func (b *InMemoryBackend) PutObjectACL(
+	_ context.Context,
+	bucketName, key, versionID, acl string,
+) error {
 	b.mu.RLock("PutObjectACL")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -299,7 +317,10 @@ func (b *InMemoryBackend) PutObjectACL(_ context.Context, bucketName, key, versi
 // GetObjectACL returns the persisted ACL XML for the targeted version, or
 // "" when no explicit ACL has been set (caller should synthesise the default
 // owner-FULL_CONTROL grant in that case).
-func (b *InMemoryBackend) GetObjectACL(_ context.Context, bucketName, key, versionID string) (string, error) {
+func (b *InMemoryBackend) GetObjectACL(
+	_ context.Context,
+	bucketName, key, versionID string,
+) (string, error) {
 	b.mu.RLock("GetObjectACL")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()
@@ -334,7 +355,10 @@ func (b *InMemoryBackend) GetObjectACL(_ context.Context, bucketName, key, versi
 
 // RenameObject performs an atomic copy+delete of the source key into a new key.
 // The target key is taken from `targetKey` (relative to the same bucket).
-func (b *InMemoryBackend) RenameObject(_ context.Context, bucketName, sourceKey, targetKey string) error {
+func (b *InMemoryBackend) RenameObject(
+	_ context.Context,
+	bucketName, sourceKey, targetKey string,
+) error {
 	if targetKey == "" || targetKey == sourceKey {
 		return ErrRenameTargetSameAsSource
 	}

--- a/services/s3/handler.go
+++ b/services/s3/handler.go
@@ -330,7 +330,8 @@ func (h *S3Handler) Handler() echo.HandlerFunc {
 		log := logger.Load(ctx)
 
 		// Validate presigned URL expiry before processing.
-		if isPresignedRequest(requestWithCtx) && !h.validatePresignedRequest(ctx, sw, requestWithCtx) {
+		if isPresignedRequest(requestWithCtx) &&
+			!h.validatePresignedRequest(ctx, sw, requestWithCtx) {
 			return nil
 		}
 
@@ -340,7 +341,16 @@ func (h *S3Handler) Handler() echo.HandlerFunc {
 			return nil
 		}
 
-		log.DebugContext(ctx, "S3 request", "method", requestWithCtx.Method, "bucket", bucketName, "key", key)
+		log.DebugContext(
+			ctx,
+			"S3 request",
+			"method",
+			requestWithCtx.Method,
+			"bucket",
+			bucketName,
+			"key",
+			key,
+		)
 
 		if bucketName == "" {
 			h.handleRootRequest(ctx, sw, requestWithCtx)
@@ -422,7 +432,11 @@ func (h *S3Handler) Name() string {
 // bucket name: ListBuckets, ListDirectoryBuckets, or WriteGetObjectResponse.
 // Pulled out of Handler so its cognitive complexity stays below the linter
 // cap.
-func (h *S3Handler) handleRootRequest(ctx context.Context, sw http.ResponseWriter, r *http.Request) {
+func (h *S3Handler) handleRootRequest(
+	ctx context.Context,
+	sw http.ResponseWriter,
+	r *http.Request,
+) {
 	if r.Method != http.MethodGet {
 		if r.Method == http.MethodPost && isWriteGetObjectResponseRequest(r) {
 			h.handleWriteGetObjectResponse(ctx, sw, r)
@@ -671,7 +685,10 @@ func (h *S3Handler) ServeWebsite(c *echo.Context) error {
 	}
 
 	if cfg.RedirectAllRequestsTo != nil {
-		return c.Redirect(http.StatusMovedPermanently, websiteRedirectAllURL(cfg.RedirectAllRequestsTo, key))
+		return c.Redirect(
+			http.StatusMovedPermanently,
+			websiteRedirectAllURL(cfg.RedirectAllRequestsTo, key),
+		)
 	}
 
 	if loc, code, ok := applyWebsiteRoutingRules(cfg.RoutingRules, key, c.Request().Host); ok {
@@ -719,7 +736,8 @@ func websiteRedirectAllURL(redir *WebsiteRedirectAll, key string) string {
 func applyWebsiteRoutingRules(rules []WebsiteRoutingRule, key, reqHost string) (string, int, bool) {
 	for _, rule := range rules {
 		cond := rule.Condition
-		if cond != nil && cond.KeyPrefixEquals != "" && !strings.HasPrefix(key, cond.KeyPrefixEquals) {
+		if cond != nil && cond.KeyPrefixEquals != "" &&
+			!strings.HasPrefix(key, cond.KeyPrefixEquals) {
 			continue
 		}
 
@@ -748,7 +766,8 @@ func applyWebsiteRoutingRules(rules []WebsiteRoutingRule, key, reqHost string) (
 
 // websiteRuleHasRedirect reports whether a routing rule redirect spec is non-empty.
 func websiteRuleHasRedirect(r WebsiteRoutingRuleRedirect) bool {
-	return r.HostName != "" || r.Protocol != "" || r.ReplaceKeyWith != "" || r.ReplaceKeyPrefixWith != ""
+	return r.HostName != "" || r.Protocol != "" || r.ReplaceKeyWith != "" ||
+		r.ReplaceKeyPrefixWith != ""
 }
 
 // websiteRedirectCode converts an HTTP redirect code string to an int status code.
@@ -761,7 +780,11 @@ func websiteRedirectCode(code string) int {
 }
 
 // websiteTargetKey computes the effective target key for a routing rule redirect.
-func websiteTargetKey(redir WebsiteRoutingRuleRedirect, cond *WebsiteRoutingRuleCondition, key string) string {
+func websiteTargetKey(
+	redir WebsiteRoutingRuleRedirect,
+	cond *WebsiteRoutingRuleCondition,
+	key string,
+) string {
 	if redir.ReplaceKeyWith != "" {
 		return redir.ReplaceKeyWith
 	}

--- a/services/s3/handler_extra_test.go
+++ b/services/s3/handler_extra_test.go
@@ -1555,11 +1555,18 @@ func TestS3CORSPreflightRuleEnforcement(t *testing.T) {
 			handler, sdkClient := newTestHandler(t)
 			bucket := "cors-enforce-bucket"
 
-			_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
+			_, err := sdkClient.CreateBucket(
+				t.Context(),
+				&sdk_s3.CreateBucketInput{Bucket: &bucket},
+			)
 			require.NoError(t, err)
 
 			// Put CORS config
-			req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?cors", strings.NewReader(tt.corsXML))
+			req := httptest.NewRequest(
+				http.MethodPut,
+				"/"+bucket+"?cors",
+				strings.NewReader(tt.corsXML),
+			)
 			rec := httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 			require.Equal(t, http.StatusOK, rec.Code)
@@ -1625,10 +1632,17 @@ func TestS3BucketCORSValidation(t *testing.T) {
 			handler, sdkClient := newTestHandler(t)
 			bucket := "cors-validation-bucket"
 
-			_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
+			_, err := sdkClient.CreateBucket(
+				t.Context(),
+				&sdk_s3.CreateBucketInput{Bucket: &bucket},
+			)
 			require.NoError(t, err)
 
-			req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?cors", strings.NewReader(tt.corsXML))
+			req := httptest.NewRequest(
+				http.MethodPut,
+				"/"+bucket+"?cors",
+				strings.NewReader(tt.corsXML),
+			)
 			rec := httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 
@@ -1654,7 +1668,11 @@ func TestS3BucketLifecycleCRUD(t *testing.T) {
 		`<Status>Enabled</Status><Expiration><Days>30</Days></Expiration></Rule></LifecycleConfiguration>`
 
 	// PutBucketLifecycleConfiguration
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?lifecycle", strings.NewReader(lifecycleXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?lifecycle",
+		strings.NewReader(lifecycleXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
@@ -1693,7 +1711,11 @@ func TestS3BucketNotificationCRUD(t *testing.T) {
 		`<Event>s3:ObjectCreated:*</Event></TopicConfiguration></NotificationConfiguration>`
 
 	// PutBucketNotificationConfiguration
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?notification", strings.NewReader(notifXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?notification",
+		strings.NewReader(notifXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -1707,7 +1729,10 @@ func TestS3BucketNotificationCRUD(t *testing.T) {
 
 	// GetBucketNotificationConfiguration on bucket without notifications
 	bucket2 := "notif-empty-bucket"
-	_, err = sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: aws.String(bucket2)})
+	_, err = sdkClient.CreateBucket(
+		t.Context(),
+		&sdk_s3.CreateBucketInput{Bucket: aws.String(bucket2)},
+	)
 	require.NoError(t, err)
 
 	req = httptest.NewRequest(http.MethodGet, "/"+bucket2+"?notification", nil)
@@ -1775,7 +1800,11 @@ func TestS3BucketWebsite_MalformedXML(t *testing.T) {
 	_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?website", strings.NewReader("not-valid-xml"))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?website",
+		strings.NewReader("not-valid-xml"),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -1828,7 +1857,10 @@ func TestS3PublicAccessBlockCRUD(t *testing.T) {
 			handler, sdkClient := newTestHandler(t)
 			bucket := "pab-test-" + tt.name
 
-			_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
+			_, err := sdkClient.CreateBucket(
+				t.Context(),
+				&sdk_s3.CreateBucketInput{Bucket: &bucket},
+			)
 			require.NoError(t, err)
 
 			// GetPublicAccessBlock before put → 404
@@ -1838,7 +1870,11 @@ func TestS3PublicAccessBlockCRUD(t *testing.T) {
 			assert.Equal(t, http.StatusNotFound, rec.Code)
 
 			// PutPublicAccessBlock
-			req = httptest.NewRequest(http.MethodPut, "/"+bucket+"?publicAccessBlock", strings.NewReader(tt.configXML))
+			req = httptest.NewRequest(
+				http.MethodPut,
+				"/"+bucket+"?publicAccessBlock",
+				strings.NewReader(tt.configXML),
+			)
 			rec = httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 			assert.Equal(t, tt.wantPut, rec.Code)
@@ -1874,7 +1910,11 @@ func TestS3PublicAccessBlock_MalformedXML(t *testing.T) {
 	_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?publicAccessBlock", strings.NewReader("not-valid-xml"))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?publicAccessBlock",
+		strings.NewReader("not-valid-xml"),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -1921,7 +1961,10 @@ func TestS3BucketOwnershipControlsCRUD(t *testing.T) {
 			handler, sdkClient := newTestHandler(t)
 			bucket := "ownership-test-" + tt.name
 
-			_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
+			_, err := sdkClient.CreateBucket(
+				t.Context(),
+				&sdk_s3.CreateBucketInput{Bucket: &bucket},
+			)
 			require.NoError(t, err)
 
 			// GetBucketOwnershipControls before put → 404
@@ -1931,7 +1974,11 @@ func TestS3BucketOwnershipControlsCRUD(t *testing.T) {
 			assert.Equal(t, http.StatusNotFound, rec.Code)
 
 			// PutBucketOwnershipControls
-			req = httptest.NewRequest(http.MethodPut, "/"+bucket+"?ownershipControls", strings.NewReader(tt.configXML))
+			req = httptest.NewRequest(
+				http.MethodPut,
+				"/"+bucket+"?ownershipControls",
+				strings.NewReader(tt.configXML),
+			)
 			rec = httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 			assert.Equal(t, tt.wantPut, rec.Code)
@@ -1967,7 +2014,11 @@ func TestS3BucketOwnershipControls_MalformedXML(t *testing.T) {
 	_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?ownershipControls", strings.NewReader("not-valid-xml"))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?ownershipControls",
+		strings.NewReader("not-valid-xml"),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -2013,7 +2064,10 @@ func TestS3BucketLoggingCRUD(t *testing.T) {
 			handler, sdkClient := newTestHandler(t)
 			bucket := "logging-test-" + tt.name
 
-			_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
+			_, err := sdkClient.CreateBucket(
+				t.Context(),
+				&sdk_s3.CreateBucketInput{Bucket: &bucket},
+			)
 			require.NoError(t, err)
 
 			// GetBucketLogging before put → empty BucketLoggingStatus (not an error)
@@ -2024,7 +2078,11 @@ func TestS3BucketLoggingCRUD(t *testing.T) {
 			assert.Contains(t, rec.Body.String(), "BucketLoggingStatus")
 
 			// PutBucketLogging
-			req = httptest.NewRequest(http.MethodPut, "/"+bucket+"?logging", strings.NewReader(tt.configXML))
+			req = httptest.NewRequest(
+				http.MethodPut,
+				"/"+bucket+"?logging",
+				strings.NewReader(tt.configXML),
+			)
 			rec = httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 			assert.Equal(t, tt.wantPut, rec.Code)
@@ -2048,7 +2106,11 @@ func TestS3BucketLogging_MalformedXML(t *testing.T) {
 	_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?logging", strings.NewReader("not-valid-xml"))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?logging",
+		strings.NewReader("not-valid-xml"),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -2093,7 +2155,10 @@ func TestS3BucketReplicationCRUD(t *testing.T) {
 			handler, sdkClient := newTestHandler(t)
 			bucket := "replication-test-" + tt.name
 
-			_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
+			_, err := sdkClient.CreateBucket(
+				t.Context(),
+				&sdk_s3.CreateBucketInput{Bucket: &bucket},
+			)
 			require.NoError(t, err)
 
 			// GetBucketReplication before put → 404
@@ -2104,7 +2169,11 @@ func TestS3BucketReplicationCRUD(t *testing.T) {
 			assert.Contains(t, rec.Body.String(), "ReplicationConfigurationNotFoundError")
 
 			// PutBucketReplication
-			req = httptest.NewRequest(http.MethodPut, "/"+bucket+"?replication", strings.NewReader(tt.configXML))
+			req = httptest.NewRequest(
+				http.MethodPut,
+				"/"+bucket+"?replication",
+				strings.NewReader(tt.configXML),
+			)
 			rec = httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 			assert.Equal(t, tt.wantPut, rec.Code)
@@ -2140,7 +2209,11 @@ func TestS3BucketReplication_MalformedXML(t *testing.T) {
 	_, err := sdkClient.CreateBucket(t.Context(), &sdk_s3.CreateBucketInput{Bucket: &bucket})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?replication", strings.NewReader("not-valid-xml"))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"?replication",
+		strings.NewReader("not-valid-xml"),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -2208,24 +2281,45 @@ func TestS3NewOperations_NonExistentBucket(t *testing.T) {
 		path   string
 		body   string
 	}{
-		{name: "GetPublicAccessBlock_NoSuchBucket", method: http.MethodGet, path: "/missing?publicAccessBlock"},
+		{
+			name:   "GetPublicAccessBlock_NoSuchBucket",
+			method: http.MethodGet,
+			path:   "/missing?publicAccessBlock",
+		},
 		{
 			name:   "PutPublicAccessBlock_NoSuchBucket",
 			method: http.MethodPut,
 			path:   "/missing?publicAccessBlock",
 			body:   publicAccessXML,
 		},
-		{name: "DeletePublicAccessBlock_NoSuchBucket", method: http.MethodDelete, path: "/missing?publicAccessBlock"},
-		{name: "GetOwnershipControls_NoSuchBucket", method: http.MethodGet, path: "/missing?ownershipControls"},
+		{
+			name:   "DeletePublicAccessBlock_NoSuchBucket",
+			method: http.MethodDelete,
+			path:   "/missing?publicAccessBlock",
+		},
+		{
+			name:   "GetOwnershipControls_NoSuchBucket",
+			method: http.MethodGet,
+			path:   "/missing?ownershipControls",
+		},
 		{
 			name:   "PutOwnershipControls_NoSuchBucket",
 			method: http.MethodPut,
 			path:   "/missing?ownershipControls",
 			body:   ownershipXML,
 		},
-		{name: "DeleteOwnershipControls_NoSuchBucket", method: http.MethodDelete, path: "/missing?ownershipControls"},
+		{
+			name:   "DeleteOwnershipControls_NoSuchBucket",
+			method: http.MethodDelete,
+			path:   "/missing?ownershipControls",
+		},
 		{name: "GetLogging_NoSuchBucket", method: http.MethodGet, path: "/missing?logging"},
-		{name: "PutLogging_NoSuchBucket", method: http.MethodPut, path: "/missing?logging", body: loggingXML},
+		{
+			name:   "PutLogging_NoSuchBucket",
+			method: http.MethodPut,
+			path:   "/missing?logging",
+			body:   loggingXML,
+		},
 		{name: "GetReplication_NoSuchBucket", method: http.MethodGet, path: "/missing?replication"},
 		{
 			name:   "PutReplication_NoSuchBucket",
@@ -2233,7 +2327,11 @@ func TestS3NewOperations_NonExistentBucket(t *testing.T) {
 			path:   "/missing?replication",
 			body:   replicationXML,
 		},
-		{name: "DeleteReplication_NoSuchBucket", method: http.MethodDelete, path: "/missing?replication"},
+		{
+			name:   "DeleteReplication_NoSuchBucket",
+			method: http.MethodDelete,
+			path:   "/missing?replication",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2339,7 +2437,11 @@ func TestHandler_ServeWebsite(t *testing.T) {
 			}
 
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodGet, "/_gopherstack/website/"+tt.bucket+"/"+tt.key, nil)
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/_gopherstack/website/"+tt.bucket+"/"+tt.key,
+				nil,
+			)
 			logCtx := logger.Save(req.Context(), slog.Default())
 			req = req.WithContext(logCtx)
 			rec := httptest.NewRecorder()
@@ -2406,7 +2508,9 @@ func TestS3_BucketAnalyticsConfig(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, backend, "analytics-bucket")
 				req := httptest.NewRequest(
-					http.MethodPut, "/analytics-bucket?analytics&id=test-analytics", strings.NewReader(analyticsXML),
+					http.MethodPut,
+					"/analytics-bucket?analytics&id=test-analytics",
+					strings.NewReader(analyticsXML),
 				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
@@ -2445,7 +2549,9 @@ func TestS3_BucketAnalyticsConfig(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, backend, "analytics-bucket")
 				req := httptest.NewRequest(
-					http.MethodPut, "/analytics-bucket?analytics&id=cfg1", strings.NewReader(analyticsXML),
+					http.MethodPut,
+					"/analytics-bucket?analytics&id=cfg1",
+					strings.NewReader(analyticsXML),
 				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
@@ -2558,7 +2664,9 @@ func TestS3_BucketIntelligentTieringConfig(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, backend, "it-bucket")
 				req := httptest.NewRequest(
-					http.MethodPut, "/it-bucket?intelligent-tiering&id=tier-config", strings.NewReader(tieringXML),
+					http.MethodPut,
+					"/it-bucket?intelligent-tiering&id=tier-config",
+					strings.NewReader(tieringXML),
 				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
@@ -2682,7 +2790,9 @@ func TestS3_BucketInventoryConfig(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, backend, "inventory-bucket")
 				req := httptest.NewRequest(
-					http.MethodPut, "/inventory-bucket?inventory&id=inv-config", strings.NewReader(inventoryXML),
+					http.MethodPut,
+					"/inventory-bucket?inventory&id=inv-config",
+					strings.NewReader(inventoryXML),
 				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
@@ -2710,7 +2820,9 @@ func TestS3_BucketInventoryConfig(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, backend, "inventory-bucket")
 				req := httptest.NewRequest(
-					http.MethodPut, "/inventory-bucket?inventory&id=cfg1", strings.NewReader(inventoryXML),
+					http.MethodPut,
+					"/inventory-bucket?inventory&id=cfg1",
+					strings.NewReader(inventoryXML),
 				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
@@ -3095,7 +3207,9 @@ func TestS3_BucketMetricsConfig(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, backend, "metrics-bucket")
 				req := httptest.NewRequest(
-					http.MethodPut, "/metrics-bucket?metrics&id=metrics-config", strings.NewReader(metricsXML),
+					http.MethodPut,
+					"/metrics-bucket?metrics&id=metrics-config",
+					strings.NewReader(metricsXML),
 				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
@@ -3238,19 +3352,46 @@ func TestS3_NewOperations_SupportedOperations(t *testing.T) {
 		name string
 		want string
 	}{
-		{name: "includes CreateBucketMetadataConfiguration", want: "CreateBucketMetadataConfiguration"},
+		{
+			name: "includes CreateBucketMetadataConfiguration",
+			want: "CreateBucketMetadataConfiguration",
+		},
 		{name: "includes GetBucketMetadataConfiguration", want: "GetBucketMetadataConfiguration"},
-		{name: "includes DeleteBucketMetadataConfiguration", want: "DeleteBucketMetadataConfiguration"},
-		{name: "includes CreateBucketMetadataTableConfiguration", want: "CreateBucketMetadataTableConfiguration"},
-		{name: "includes GetBucketMetadataTableConfiguration", want: "GetBucketMetadataTableConfiguration"},
-		{name: "includes DeleteBucketMetadataTableConfiguration", want: "DeleteBucketMetadataTableConfiguration"},
+		{
+			name: "includes DeleteBucketMetadataConfiguration",
+			want: "DeleteBucketMetadataConfiguration",
+		},
+		{
+			name: "includes CreateBucketMetadataTableConfiguration",
+			want: "CreateBucketMetadataTableConfiguration",
+		},
+		{
+			name: "includes GetBucketMetadataTableConfiguration",
+			want: "GetBucketMetadataTableConfiguration",
+		},
+		{
+			name: "includes DeleteBucketMetadataTableConfiguration",
+			want: "DeleteBucketMetadataTableConfiguration",
+		},
 		{name: "includes CreateSession", want: "CreateSession"},
 		{name: "includes PutBucketAnalyticsConfiguration", want: "PutBucketAnalyticsConfiguration"},
 		{name: "includes GetBucketAnalyticsConfiguration", want: "GetBucketAnalyticsConfiguration"},
-		{name: "includes DeleteBucketAnalyticsConfiguration", want: "DeleteBucketAnalyticsConfiguration"},
-		{name: "includes ListBucketAnalyticsConfigurations", want: "ListBucketAnalyticsConfigurations"},
-		{name: "includes PutBucketIntelligentTieringConfiguration", want: "PutBucketIntelligentTieringConfiguration"},
-		{name: "includes GetBucketIntelligentTieringConfiguration", want: "GetBucketIntelligentTieringConfiguration"},
+		{
+			name: "includes DeleteBucketAnalyticsConfiguration",
+			want: "DeleteBucketAnalyticsConfiguration",
+		},
+		{
+			name: "includes ListBucketAnalyticsConfigurations",
+			want: "ListBucketAnalyticsConfigurations",
+		},
+		{
+			name: "includes PutBucketIntelligentTieringConfiguration",
+			want: "PutBucketIntelligentTieringConfiguration",
+		},
+		{
+			name: "includes GetBucketIntelligentTieringConfiguration",
+			want: "GetBucketIntelligentTieringConfiguration",
+		},
 		{
 			name: "includes DeleteBucketIntelligentTieringConfiguration",
 			want: "DeleteBucketIntelligentTieringConfiguration",
@@ -3261,12 +3402,21 @@ func TestS3_NewOperations_SupportedOperations(t *testing.T) {
 		},
 		{name: "includes PutBucketInventoryConfiguration", want: "PutBucketInventoryConfiguration"},
 		{name: "includes GetBucketInventoryConfiguration", want: "GetBucketInventoryConfiguration"},
-		{name: "includes DeleteBucketInventoryConfiguration", want: "DeleteBucketInventoryConfiguration"},
-		{name: "includes ListBucketInventoryConfigurations", want: "ListBucketInventoryConfigurations"},
+		{
+			name: "includes DeleteBucketInventoryConfiguration",
+			want: "DeleteBucketInventoryConfiguration",
+		},
+		{
+			name: "includes ListBucketInventoryConfigurations",
+			want: "ListBucketInventoryConfigurations",
+		},
 		{name: "includes DeleteBucketLifecycle", want: "DeleteBucketLifecycle"},
 		{name: "includes PutBucketMetricsConfiguration", want: "PutBucketMetricsConfiguration"},
 		{name: "includes GetBucketMetricsConfiguration", want: "GetBucketMetricsConfiguration"},
-		{name: "includes DeleteBucketMetricsConfiguration", want: "DeleteBucketMetricsConfiguration"},
+		{
+			name: "includes DeleteBucketMetricsConfiguration",
+			want: "DeleteBucketMetricsConfiguration",
+		},
 		{name: "includes ListBucketMetricsConfigurations", want: "ListBucketMetricsConfigurations"},
 	}
 
@@ -3412,7 +3562,12 @@ func TestHandler_MultipartUpload_ETagFormat(t *testing.T) {
 	require.Equal(t, http.StatusOK, recGet.Code)
 
 	etag := recGet.Header().Get("ETag")
-	assert.True(t, strings.HasSuffix(etag, "-2\""), "multipart ETag should end with -2\" got: %s", etag)
+	assert.True(
+		t,
+		strings.HasSuffix(etag, "-2\""),
+		"multipart ETag should end with -2\" got: %s",
+		etag,
+	)
 	assert.True(t, strings.HasPrefix(etag, "\""), "ETag should start with quote, got: %s", etag)
 }
 
@@ -3430,8 +3585,18 @@ func TestHandler_GetObject_ExpirationHeader(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	// x-amz-expiration is not always present (only with lifecycle), but
 	// we verify the handler completes without error for both HEAD and GET.
-	assert.Equal(t, "bytes", rec.Header().Get("Accept-Ranges"), "Accept-Ranges should be set on GET")
-	assert.Equal(t, "STANDARD", rec.Header().Get("X-Amz-Storage-Class"), "X-Amz-Storage-Class should be STANDARD")
+	assert.Equal(
+		t,
+		"bytes",
+		rec.Header().Get("Accept-Ranges"),
+		"Accept-Ranges should be set on GET",
+	)
+	assert.Equal(
+		t,
+		"STANDARD",
+		rec.Header().Get("X-Amz-Storage-Class"),
+		"X-Amz-Storage-Class should be STANDARD",
+	)
 }
 
 func TestHandler_HeadObject_StorageClassAndAcceptRanges(t *testing.T) {
@@ -3463,7 +3628,12 @@ func TestHandler_GetObject_RangeContentLength(t *testing.T) {
 	serveS3Handler(handler, rec, req)
 
 	require.Equal(t, http.StatusPartialContent, rec.Code)
-	assert.Equal(t, "4", rec.Header().Get("Content-Length"), "range response should have correct Content-Length")
+	assert.Equal(
+		t,
+		"4",
+		rec.Header().Get("Content-Length"),
+		"range response should have correct Content-Length",
+	)
 	assert.Equal(t, "bytes 2-5/10", rec.Header().Get("Content-Range"))
 	assert.Equal(t, "2345", rec.Body.String())
 }
@@ -3491,7 +3661,11 @@ func TestHandler_ListMultipartUploads_MaxUploads(t *testing.T) {
 	// Create 5 multipart uploads
 	uploadIDs := make([]string, 5)
 	for i := range uploadIDs {
-		req := httptest.NewRequest(http.MethodPost, "/bkt/obj"+strings.Repeat(string(rune('a'+i)), 1)+"?uploads", nil)
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/bkt/obj"+strings.Repeat(string(rune('a'+i)), 1)+"?uploads",
+			nil,
+		)
 		rec := httptest.NewRecorder()
 		serveS3Handler(handler, rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)

--- a/services/s3/handler_list_v2.go
+++ b/services/s3/handler_list_v2.go
@@ -114,7 +114,10 @@ func (h *S3Handler) renderListObjectsV2Response(
 	)
 	// Add common prefixes from backend (if any)
 	for _, cp := range commonPrefixes {
-		resp.CommonPrefixes = append(resp.CommonPrefixes, CommonPrefixXML{Prefix: aws.ToString(cp.Prefix)})
+		resp.CommonPrefixes = append(
+			resp.CommonPrefixes,
+			CommonPrefixXML{Prefix: aws.ToString(cp.Prefix)},
+		)
 	}
 	resp.KeyCount = len(resp.Contents) + len(resp.CommonPrefixes)
 

--- a/services/s3/handler_test.go
+++ b/services/s3/handler_test.go
@@ -1162,7 +1162,11 @@ func TestHandler_MultipartUpload(t *testing.T) {
 			var initResp s3.InitiateMultipartUploadResult
 			require.NoError(t, xml.NewDecoder(rec.Body).Decode(&initResp))
 
-			wantInit := s3.InitiateMultipartUploadResult{Bucket: "bkt", Key: "mp", UploadID: initResp.UploadID}
+			wantInit := s3.InitiateMultipartUploadResult{
+				Bucket:   "bkt",
+				Key:      "mp",
+				UploadID: initResp.UploadID,
+			}
 			initDiff := cmp.Diff(
 				wantInit, initResp,
 				cmpopts.IgnoreFields(s3.InitiateMultipartUploadResult{}, "UploadID", "XMLName"),
@@ -1521,7 +1525,11 @@ func TestHandler_NotificationDispatch_PutObject(t *testing.T) {
 		`<Queue>arn:aws:sqs:us-east-1:000000000000:my-queue</Queue>` +
 		`<Event>s3:ObjectCreated:*</Event></QueueConfiguration>` +
 		`</NotificationConfiguration>`
-	req := httptest.NewRequest(http.MethodPut, "/notif-put?notification", strings.NewReader(notifXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/notif-put?notification",
+		strings.NewReader(notifXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1559,7 +1567,11 @@ func TestHandler_NotificationDispatch_DeleteObject(t *testing.T) {
 		`<Queue>arn:aws:sqs:us-east-1:000000000000:my-queue</Queue>` +
 		`<Event>s3:ObjectRemoved:*</Event></QueueConfiguration>` +
 		`</NotificationConfiguration>`
-	putNotifReq := httptest.NewRequest(http.MethodPut, "/notif-del?notification", strings.NewReader(notifXML))
+	putNotifReq := httptest.NewRequest(
+		http.MethodPut,
+		"/notif-del?notification",
+		strings.NewReader(notifXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, putNotifReq)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1618,7 +1630,11 @@ func TestHandler_NotificationDispatch_CopyObject(t *testing.T) {
 		`<Queue>arn:aws:sqs:us-east-1:000000000000:copy-queue</Queue>` +
 		`<Event>s3:ObjectCreated:*</Event></QueueConfiguration>` +
 		`</NotificationConfiguration>`
-	req := httptest.NewRequest(http.MethodPut, "/notif-copy?notification", strings.NewReader(notifXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/notif-copy?notification",
+		strings.NewReader(notifXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1656,7 +1672,11 @@ func TestHandler_NotificationDispatch_CompleteMultipartUpload(t *testing.T) {
 		`<Queue>arn:aws:sqs:us-east-1:000000000000:mpu-queue</Queue>` +
 		`<Event>s3:ObjectCreated:*</Event></QueueConfiguration>` +
 		`</NotificationConfiguration>`
-	req := httptest.NewRequest(http.MethodPut, "/notif-mpu?notification", strings.NewReader(notifXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/notif-mpu?notification",
+		strings.NewReader(notifXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1690,7 +1710,11 @@ func TestHandler_NotificationDispatch_CompleteMultipartUpload(t *testing.T) {
 		`<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part></CompleteMultipartUpload>`,
 		etag1,
 	)
-	req = httptest.NewRequest(http.MethodPost, "/notif-mpu/mp-key?uploadId="+uploadID, strings.NewReader(completeXML))
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/notif-mpu/mp-key?uploadId="+uploadID,
+		strings.NewReader(completeXML),
+	)
 	rec = httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1721,7 +1745,11 @@ func TestHandler_NotificationDispatch_DeleteObjects(t *testing.T) {
 		`<Queue>arn:aws:sqs:us-east-1:000000000000:del-queue</Queue>` +
 		`<Event>s3:ObjectRemoved:*</Event></QueueConfiguration>` +
 		`</NotificationConfiguration>`
-	req := httptest.NewRequest(http.MethodPut, "/notif-delobj?notification", strings.NewReader(notifXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/notif-delobj?notification",
+		strings.NewReader(notifXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1758,7 +1786,11 @@ func TestObjectLock_PutGetConfiguration(t *testing.T) {
 
 	configXML := `<ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
 		`<ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>`
-	req := httptest.NewRequest(http.MethodPut, "/lock-bucket?object-lock", strings.NewReader(configXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/lock-bucket?object-lock",
+		strings.NewReader(configXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1792,7 +1824,11 @@ func TestObjectLock_LegalHold_BlocksDelete(t *testing.T) {
 
 	// Put legal hold ON
 	lhXML := `<LegalHold xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>ON</Status></LegalHold>`
-	req := httptest.NewRequest(http.MethodPut, "/lh-bucket/mykey?legal-hold", strings.NewReader(lhXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/lh-bucket/mykey?legal-hold",
+		strings.NewReader(lhXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1806,7 +1842,11 @@ func TestObjectLock_LegalHold_BlocksDelete(t *testing.T) {
 
 	// Remove legal hold
 	lhXML = `<LegalHold xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>OFF</Status></LegalHold>`
-	req = httptest.NewRequest(http.MethodPut, "/lh-bucket/mykey?legal-hold", strings.NewReader(lhXML))
+	req = httptest.NewRequest(
+		http.MethodPut,
+		"/lh-bucket/mykey?legal-hold",
+		strings.NewReader(lhXML),
+	)
 	rec = httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1829,7 +1869,11 @@ func TestObjectLock_Retention_BlocksDelete(t *testing.T) {
 	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
 	retXML := `<Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
 		`<Mode>GOVERNANCE</Mode><RetainUntilDate>` + future + `</RetainUntilDate></Retention>`
-	req := httptest.NewRequest(http.MethodPut, "/ret-bucket/mykey?retention", strings.NewReader(retXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/ret-bucket/mykey?retention",
+		strings.NewReader(retXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1858,7 +1902,11 @@ func TestObjectLock_GetLegalHold(t *testing.T) {
 
 	// Set ON
 	lhXML := `<LegalHold xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>ON</Status></LegalHold>`
-	req = httptest.NewRequest(http.MethodPut, "/get-lh-bucket/mykey?legal-hold", strings.NewReader(lhXML))
+	req = httptest.NewRequest(
+		http.MethodPut,
+		"/get-lh-bucket/mykey?legal-hold",
+		strings.NewReader(lhXML),
+	)
 	rec = httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1882,7 +1930,11 @@ func TestObjectLock_GetRetention(t *testing.T) {
 	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
 	retXML := `<Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
 		`<Mode>COMPLIANCE</Mode><RetainUntilDate>` + future + `</RetainUntilDate></Retention>`
-	req := httptest.NewRequest(http.MethodPut, "/get-ret-bucket/mykey?retention", strings.NewReader(retXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/get-ret-bucket/mykey?retention",
+		strings.NewReader(retXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1902,7 +1954,11 @@ func TestObjectLock_PutObjectLockConfiguration_BucketNotFound(t *testing.T) {
 
 	configXML := `<ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
 		`<ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>`
-	req := httptest.NewRequest(http.MethodPut, "/nonexistent-bucket?object-lock", strings.NewReader(configXML))
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/nonexistent-bucket?object-lock",
+		strings.NewReader(configXML),
+	)
 	rec := httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusNotFound, rec.Code)

--- a/services/s3/interfaces.go
+++ b/services/s3/interfaces.go
@@ -133,8 +133,17 @@ type StorageBackend interface {
 		bucket, key string,
 		versionID *string,
 	) (mode string, retainUntil time.Time, err error)
-	PutObjectLegalHold(ctx context.Context, bucket, key string, versionID *string, status string) error
-	GetObjectLegalHold(ctx context.Context, bucket, key string, versionID *string) (status string, err error)
+	PutObjectLegalHold(
+		ctx context.Context,
+		bucket, key string,
+		versionID *string,
+		status string,
+	) error
+	GetObjectLegalHold(
+		ctx context.Context,
+		bucket, key string,
+		versionID *string,
+	) (status string, err error)
 
 	// Multipart
 	CreateMultipartUpload(
@@ -172,7 +181,10 @@ type StorageBackend interface {
 	ListBucketAnalyticsConfigurations(ctx context.Context, bucket string) ([]string, error)
 
 	// Intelligent Tiering (supports multiple configs per bucket via id)
-	PutBucketIntelligentTieringConfiguration(ctx context.Context, bucket, id, configXML string) error
+	PutBucketIntelligentTieringConfiguration(
+		ctx context.Context,
+		bucket, id, configXML string,
+	) error
 	GetBucketIntelligentTieringConfiguration(ctx context.Context, bucket, id string) (string, error)
 	DeleteBucketIntelligentTieringConfiguration(ctx context.Context, bucket, id string) error
 	ListBucketIntelligentTieringConfigurations(ctx context.Context, bucket string) ([]string, error)
@@ -212,7 +224,10 @@ type StorageBackend interface {
 	GetBucketRequestPayment(ctx context.Context, bucket string) (string, error)
 
 	// GetObjectAttributes / RestoreObject / RenameObject
-	GetObjectAttributes(ctx context.Context, bucket, key, versionID string) (*ObjectAttributes, error)
+	GetObjectAttributes(
+		ctx context.Context,
+		bucket, key, versionID string,
+	) (*ObjectAttributes, error)
 	RestoreObject(ctx context.Context, bucket, key string, days int) error
 	RenameObject(ctx context.Context, bucket, sourceKey, targetKey string) error
 

--- a/services/s3/janitor.go
+++ b/services/s3/janitor.go
@@ -446,7 +446,14 @@ func (j *Janitor) sweepLifecycle(ctx context.Context) {
 	b.mu.RUnlock()
 
 	for _, snap := range snapshots {
-		evicted := j.applyLifecycleRules(ctx, snap.bucket, snap.name, snap.lcXML, snap.tagsByKey, now)
+		evicted := j.applyLifecycleRules(
+			ctx,
+			snap.bucket,
+			snap.name,
+			snap.lcXML,
+			snap.tagsByKey,
+			now,
+		)
 		totalEvicted += evicted
 	}
 
@@ -509,24 +516,42 @@ func (j *Janitor) applyLifecycleRule(
 
 	if rule.Expiration.Days != nil && rule.Expiration.Date == "" {
 		expireBefore := now.Add(-time.Duration(*rule.Expiration.Days) * 24 * time.Hour)
-		evicted += j.evictExpiredObjects(bucket, bucketName, prefix, tagFilters, tagsByKey, expireBefore)
+		evicted += j.evictExpiredObjects(
+			bucket,
+			bucketName,
+			prefix,
+			tagFilters,
+			tagsByKey,
+			expireBefore,
+		)
 	}
 
 	if rule.Expiration.Date != "" {
 		expireDate, parseErr := parseLifecycleDate(rule.Expiration.Date)
 		if parseErr == nil && now.After(expireDate) {
-			evicted += j.evictExpiredObjects(bucket, bucketName, prefix, tagFilters, tagsByKey, expireDate)
+			evicted += j.evictExpiredObjects(
+				bucket,
+				bucketName,
+				prefix,
+				tagFilters,
+				tagsByKey,
+				expireDate,
+			)
 		}
 	}
 
 	if rule.NoncurrentVersionExpiration.NoncurrentDays != nil {
-		noncurrentBefore := now.Add(-time.Duration(*rule.NoncurrentVersionExpiration.NoncurrentDays) * 24 * time.Hour)
+		noncurrentBefore := now.Add(
+			-time.Duration(*rule.NoncurrentVersionExpiration.NoncurrentDays) * 24 * time.Hour,
+		)
 		evicted += j.evictNoncurrentVersions(bucket, prefix, noncurrentBefore)
 	}
 
 	if rule.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
 		abortBefore := now.Add(
-			-time.Duration(*rule.AbortIncompleteMultipartUpload.DaysAfterInitiation) * 24 * time.Hour,
+			-time.Duration(
+				*rule.AbortIncompleteMultipartUpload.DaysAfterInitiation,
+			) * 24 * time.Hour,
 		)
 		j.abortStaleMultipartUploads(bucketName, abortBefore)
 	}
@@ -689,7 +714,8 @@ func isLatestVersionLocked(obj *StoredObject) bool {
 		if ver.LegalHold {
 			return true
 		}
-		if ver.RetentionMode != "" && !ver.RetainUntil.IsZero() && time.Now().Before(ver.RetainUntil) {
+		if ver.RetentionMode != "" && !ver.RetainUntil.IsZero() &&
+			time.Now().Before(ver.RetainUntil) {
 			return true
 		}
 	}
@@ -762,7 +788,10 @@ func tagMatchesFilter(t types.Tag, f lifecycleTag) bool {
 
 // findBucketAcrossRegions returns the bucket and its region for the given bucket name,
 // or nil and an empty string if not found. Must be called with b.mu held.
-func findBucketAcrossRegions(buckets map[string]map[string]*StoredBucket, name string) (*StoredBucket, string) {
+func findBucketAcrossRegions(
+	buckets map[string]map[string]*StoredBucket,
+	name string,
+) (*StoredBucket, string) {
 	for region, regionBuckets := range buckets {
 		if bkt, exists := regionBuckets[name]; exists {
 			return bkt, region
@@ -774,7 +803,12 @@ func findBucketAcrossRegions(buckets map[string]map[string]*StoredBucket, name s
 
 // GetExpirationHeader calculates the x-amz-expiration header for an object
 // based on the bucket's lifecycle configuration.
-func (j *Janitor) GetExpirationHeader(lcXML string, key string, tags []types.Tag, lastModified time.Time) string {
+func (j *Janitor) GetExpirationHeader(
+	lcXML string,
+	key string,
+	tags []types.Tag,
+	lastModified time.Time,
+) string {
 	if lcXML == "" {
 		return ""
 	}
@@ -851,13 +885,18 @@ func isNoncurrentVersionLocked(ver *StoredObjectVersion) bool {
 		return true
 	}
 
-	return ver.RetentionMode != "" && !ver.RetainUntil.IsZero() && time.Now().Before(ver.RetainUntil)
+	return ver.RetentionMode != "" && !ver.RetainUntil.IsZero() &&
+		time.Now().Before(ver.RetainUntil)
 }
 
 // evictNoncurrentVersions deletes non-latest object versions (noncurrent versions)
 // from the bucket that match the prefix and were superseded before noncurrentBefore.
 // Returns the number of noncurrent versions deleted.
-func (j *Janitor) evictNoncurrentVersions(bucket *StoredBucket, prefix string, noncurrentBefore time.Time) int {
+func (j *Janitor) evictNoncurrentVersions(
+	bucket *StoredBucket,
+	prefix string,
+	noncurrentBefore time.Time,
+) int {
 	bucket.mu.Lock("S3Janitor.evictNoncurrentVersions")
 	defer bucket.mu.Unlock()
 
@@ -975,12 +1014,15 @@ func (j *Janitor) applyStorageClassTransitions(
 
 		if fromClass != targetClass {
 			ver.StorageClass = targetClass
-			ver.StorageClassTransitions = append(ver.StorageClassTransitions, StorageClassTransition{
-				TransitionedAt: now,
-				FromClass:      fromClass,
-				ToClass:        targetClass,
-				RuleID:         ruleID,
-			})
+			ver.StorageClassTransitions = append(
+				ver.StorageClassTransitions,
+				StorageClassTransition{
+					TransitionedAt: now,
+					FromClass:      fromClass,
+					ToClass:        targetClass,
+					RuleID:         ruleID,
+				},
+			)
 		}
 
 		obj.mu.Unlock()
@@ -1021,12 +1063,15 @@ func (j *Janitor) applyNoncurrentStorageClassTransitions(
 
 			if fromClass != targetClass {
 				ver.StorageClass = targetClass
-				ver.StorageClassTransitions = append(ver.StorageClassTransitions, StorageClassTransition{
-					TransitionedAt: now,
-					FromClass:      fromClass,
-					ToClass:        targetClass,
-					RuleID:         ruleID,
-				})
+				ver.StorageClassTransitions = append(
+					ver.StorageClassTransitions,
+					StorageClassTransition{
+						TransitionedAt: now,
+						FromClass:      fromClass,
+						ToClass:        targetClass,
+						RuleID:         ruleID,
+					},
+				)
 			}
 		}
 

--- a/services/s3/janitor_refinement2_test.go
+++ b/services/s3/janitor_refinement2_test.go
@@ -98,7 +98,12 @@ func TestRefinement2_Lifecycle_SkipsLockedObjects(t *testing.T) {
 		keys = append(keys, aws.ToString(obj.Key))
 	}
 
-	assert.Contains(t, keys, "locked.txt", "retention-locked object must not be deleted by lifecycle")
+	assert.Contains(
+		t,
+		keys,
+		"locked.txt",
+		"retention-locked object must not be deleted by lifecycle",
+	)
 	assert.NotContains(t, keys, "free.txt", "unlocked object should be evicted")
 }
 

--- a/services/s3/janitor_test.go
+++ b/services/s3/janitor_test.go
@@ -37,10 +37,16 @@ func TestS3Janitor_BucketDeletion(t *testing.T) {
 			},
 			act: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
-				_, err := b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("bucket-a")})
+				_, err := b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("bucket-a")},
+				)
 				require.NoError(t, err)
 
-				_, err = b.HeadBucket(t.Context(), &sdk_s3.HeadBucketInput{Bucket: aws.String("bucket-a")})
+				_, err = b.HeadBucket(
+					t.Context(),
+					&sdk_s3.HeadBucketInput{Bucket: aws.String("bucket-a")},
+				)
 				require.ErrorIs(t, err, s3.ErrNoSuchBucket)
 			},
 			verify: func(t *testing.T, b *s3.InMemoryBackend) {
@@ -68,7 +74,10 @@ func TestS3Janitor_BucketDeletion(t *testing.T) {
 			},
 			act: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
-				_, err := b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("full-bucket")})
+				_, err := b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("full-bucket")},
+				)
 				require.NoError(t, err)
 
 				_, err = b.GetObject(t.Context(), &sdk_s3.GetObjectInput{
@@ -99,10 +108,16 @@ func TestS3Janitor_BucketDeletion(t *testing.T) {
 			},
 			act: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
-				_, err := b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("idem-bucket")})
+				_, err := b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("idem-bucket")},
+				)
 				require.NoError(t, err)
 
-				_, err = b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("idem-bucket")})
+				_, err = b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("idem-bucket")},
+				)
 				require.NoError(t, err)
 			},
 			verify: func(_ *testing.T, _ *s3.InMemoryBackend) {},
@@ -140,7 +155,10 @@ func TestS3Janitor_BucketDeletion(t *testing.T) {
 			},
 			act: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
-				_, err := b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("cleanup-bucket")})
+				_, err := b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("cleanup-bucket")},
+				)
 				require.NoError(t, err)
 			},
 			verify: func(t *testing.T, b *s3.InMemoryBackend) {
@@ -166,7 +184,10 @@ func TestS3Janitor_BucketDeletion(t *testing.T) {
 			},
 			act: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
-				_, err := b.DeleteBucket(t.Context(), &sdk_s3.DeleteBucketInput{Bucket: aws.String("gone")})
+				_, err := b.DeleteBucket(
+					t.Context(),
+					&sdk_s3.DeleteBucketInput{Bucket: aws.String("gone")},
+				)
 				require.NoError(t, err)
 			},
 			verify: func(t *testing.T, b *s3.InMemoryBackend) {
@@ -379,9 +400,12 @@ func TestS3Janitor_NoncurrentVersionExpiration(t *testing.T) {
 
 			if tt.wantGone {
 				require.Eventually(t, func() bool {
-					out, listErr := backend.ListObjectVersions(t.Context(), &sdk_s3.ListObjectVersionsInput{
-						Bucket: aws.String(tt.bucket),
-					})
+					out, listErr := backend.ListObjectVersions(
+						t.Context(),
+						&sdk_s3.ListObjectVersionsInput{
+							Bucket: aws.String(tt.bucket),
+						},
+					)
 
 					return listErr == nil && len(out.Versions) <= 1
 				}, 500*time.Millisecond, 10*time.Millisecond)

--- a/services/s3/lifecycle_transition_test.go
+++ b/services/s3/lifecycle_transition_test.go
@@ -43,7 +43,12 @@ func TestS3Lifecycle_StorageClassTransitions(t *testing.T) {
 				mustCreateBucket(t, b, "tr-days")
 				mustPutObject(t, b, "tr-days", "old-obj.txt", []byte("data"))
 				// Backdate to 31 days ago so the 30-day rule fires.
-				s3.BackdateObjectForTest(b, "tr-days", "old-obj.txt", time.Now().Add(-31*24*time.Hour))
+				s3.BackdateObjectForTest(
+					b,
+					"tr-days",
+					"old-obj.txt",
+					time.Now().Add(-31*24*time.Hour),
+				)
 			},
 			wantClass: "GLACIER",
 			verify: func(t *testing.T, b *s3.InMemoryBackend) {
@@ -153,7 +158,12 @@ func TestS3Lifecycle_StorageClassTransitions(t *testing.T) {
 				// All history entries must be STANDARD → GLACIER (no duplicate from→GLACIER).
 				for _, h := range history {
 					assert.Equal(t, "GLACIER", h.ToClass)
-					assert.NotEqual(t, "GLACIER", h.FromClass, "must not record GLACIER→GLACIER no-op")
+					assert.NotEqual(
+						t,
+						"GLACIER",
+						h.FromClass,
+						"must not record GLACIER→GLACIER no-op",
+					)
 				}
 			},
 		},
@@ -172,7 +182,12 @@ func TestS3Lifecycle_StorageClassTransitions(t *testing.T) {
 				t.Helper()
 				mustCreateBucket(t, b, "tr-disabled")
 				mustPutObject(t, b, "tr-disabled", "file.txt", []byte("data"))
-				s3.BackdateObjectForTest(b, "tr-disabled", "file.txt", time.Now().Add(-2*24*time.Hour))
+				s3.BackdateObjectForTest(
+					b,
+					"tr-disabled",
+					"file.txt",
+					time.Now().Add(-2*24*time.Hour),
+				)
 			},
 			verify: func(t *testing.T, b *s3.InMemoryBackend) {
 				t.Helper()
@@ -183,7 +198,12 @@ func TestS3Lifecycle_StorageClassTransitions(t *testing.T) {
 					Key:    aws.String("file.txt"),
 				})
 				require.NoError(t, err)
-				assert.NotEqual(t, "GLACIER", string(out.StorageClass), "disabled rule must not transition")
+				assert.NotEqual(
+					t,
+					"GLACIER",
+					string(out.StorageClass),
+					"disabled rule must not transition",
+				)
 
 				history := s3.StorageClassTransitionsForObject(b, "tr-disabled", "file.txt")
 				assert.Empty(t, history, "no transition history for disabled rule")

--- a/services/s3/multipart_list_test.go
+++ b/services/s3/multipart_list_test.go
@@ -163,7 +163,11 @@ func TestHandler_ListParts(t *testing.T) {
 			uploadID := "nonexistent"
 
 			if !tt.useNonexistentID {
-				req := httptest.NewRequest(http.MethodPost, "/"+tt.bucket+"/"+tt.key+"?uploads", nil)
+				req := httptest.NewRequest(
+					http.MethodPost,
+					"/"+tt.bucket+"/"+tt.key+"?uploads",
+					nil,
+				)
 				rec := httptest.NewRecorder()
 				serveS3Handler(handler, rec, req)
 				require.Equal(t, http.StatusOK, rec.Code)
@@ -185,7 +189,11 @@ func TestHandler_ListParts(t *testing.T) {
 				}
 			}
 
-			req := httptest.NewRequest(http.MethodGet, "/"+tt.bucket+"/"+tt.key+"?uploadId="+uploadID, nil)
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/"+tt.bucket+"/"+tt.key+"?uploadId="+uploadID,
+				nil,
+			)
 			rec := httptest.NewRecorder()
 			serveS3Handler(handler, rec, req)
 

--- a/services/s3/notification.go
+++ b/services/s3/notification.go
@@ -88,11 +88,21 @@ func keyMatchesFilter(key string, filter notificationFilter) bool {
 // NotificationDispatcher delivers S3 event notifications to configured targets.
 type NotificationDispatcher interface {
 	// DispatchObjectCreated sends an s3:ObjectCreated:Put notification for a PutObject operation.
-	DispatchObjectCreated(ctx context.Context, bucket, key, etag string, size int64, notifXML string)
+	DispatchObjectCreated(
+		ctx context.Context,
+		bucket, key, etag string,
+		size int64,
+		notifXML string,
+	)
 	// DispatchObjectCopied sends an s3:ObjectCreated:Copy notification for a CopyObject operation.
 	DispatchObjectCopied(ctx context.Context, bucket, key, etag string, size int64, notifXML string)
 	// DispatchObjectCompleted sends an s3:ObjectCreated:CompleteMultipartUpload notification.
-	DispatchObjectCompleted(ctx context.Context, bucket, key, etag string, size int64, notifXML string)
+	DispatchObjectCompleted(
+		ctx context.Context,
+		bucket, key, etag string,
+		size int64,
+		notifXML string,
+	)
 	// DispatchObjectDeleted sends an s3:ObjectRemoved notification for the given object.
 	DispatchObjectDeleted(ctx context.Context, bucket, key, notifXML string)
 	// DispatchObjectRestorePost sends an s3:ObjectRestore:Post notification for a
@@ -120,7 +130,11 @@ type SNSPublisher interface {
 
 // LambdaInvoker invokes a Lambda function by name or ARN with a JSON payload.
 type LambdaInvoker interface {
-	InvokeFunction(ctx context.Context, name, invocationType string, payload []byte) ([]byte, int, error)
+	InvokeFunction(
+		ctx context.Context,
+		name, invocationType string,
+		payload []byte,
+	) ([]byte, int, error)
 }
 
 // EventBridgePublisher publishes an S3 event to the default EventBridge event bus.
@@ -158,7 +172,10 @@ type s3EventObject struct {
 }
 
 // buildS3EventPayload builds the standard S3 event notification JSON payload.
-func buildS3EventPayload(eventName, configID, region, bucket, key, etag string, size int64) (string, error) {
+func buildS3EventPayload(
+	eventName, configID, region, bucket, key, etag string,
+	size int64,
+) (string, error) {
 	record := s3EventRecord{
 		EventVersion: "2.1",
 		EventSource:  "aws:s3",
@@ -428,7 +445,12 @@ func (d *inMemoryNotificationDispatcher) dispatchToLambda(
 	}
 
 	if d.targets != nil && d.targets.LambdaInvoker != nil {
-		_, _, _ = d.targets.LambdaInvoker.InvokeFunction(ctx, lc.CloudFunc, "Event", []byte(payload))
+		_, _, _ = d.targets.LambdaInvoker.InvokeFunction(
+			ctx,
+			lc.CloudFunc,
+			"Event",
+			[]byte(payload),
+		)
 	}
 }
 

--- a/services/s3/notification_test.go
+++ b/services/s3/notification_test.go
@@ -149,14 +149,19 @@ func TestNotificationDispatcher_DispatchObjectCreated(t *testing.T) {
 		wantTopicCount    int
 	}{
 		{
-			name:              "SQS_basic",
-			notifXML:          sqsCreatedXML,
-			key:               "my-key",
-			etag:              "abc123",
-			size:              42,
-			wantQueueCount:    1,
-			wantQueueContains: []string{`"aws:s3"`, `"my-bucket"`, `"my-key"`, `"s3:ObjectCreated:Put"`},
-			wantQueueARN:      "arn:aws:sqs:us-east-1:000000000000:my-queue",
+			name:           "SQS_basic",
+			notifXML:       sqsCreatedXML,
+			key:            "my-key",
+			etag:           "abc123",
+			size:           42,
+			wantQueueCount: 1,
+			wantQueueContains: []string{
+				`"aws:s3"`,
+				`"my-bucket"`,
+				`"my-key"`,
+				`"s3:ObjectCreated:Put"`,
+			},
+			wantQueueARN: "arn:aws:sqs:us-east-1:000000000000:my-queue",
 		},
 		{
 			name:              "SNS_basic",
@@ -361,7 +366,11 @@ type captureLambda struct {
 	mu          sync.Mutex
 }
 
-func (c *captureLambda) InvokeFunction(_ context.Context, name, _ string, payload []byte) ([]byte, int, error) {
+func (c *captureLambda) InvokeFunction(
+	_ context.Context,
+	name, _ string,
+	payload []byte,
+) ([]byte, int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.invocations = append(c.invocations, name+":"+string(payload))
@@ -407,7 +416,14 @@ func TestNotificationDispatcher_DispatchToLambda(t *testing.T) {
 			targets := &s3.NotificationTargets{LambdaInvoker: fn}
 			d := s3.NewNotificationDispatcher(targets, "us-east-1")
 
-			d.DispatchObjectCreated(t.Context(), "my-bucket", "test-key", "etag123", 42, tt.notifXML)
+			d.DispatchObjectCreated(
+				t.Context(),
+				"my-bucket",
+				"test-key",
+				"etag123",
+				42,
+				tt.notifXML,
+			)
 
 			fn.mu.Lock()
 			defer fn.mu.Unlock()
@@ -429,7 +445,10 @@ type captureEventBridge struct {
 func (c *captureEventBridge) PublishS3Event(_ context.Context, source, detailType, detail string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.events = append(c.events, struct{ source, detailType, detail string }{source, detailType, detail})
+	c.events = append(
+		c.events,
+		struct{ source, detailType, detail string }{source, detailType, detail},
+	)
 }
 
 func TestNotificationDispatcher_DispatchToEventBridge(t *testing.T) {
@@ -550,11 +569,32 @@ func TestNotificationDispatcher_DispatchToEventBridge(t *testing.T) {
 			case tt.dispatchDelete:
 				d.DispatchObjectDeleted(t.Context(), "my-bucket", tt.key, tt.notifXML)
 			case tt.dispatchCopy:
-				d.DispatchObjectCopied(t.Context(), "my-bucket", tt.key, tt.etag, tt.size, tt.notifXML)
+				d.DispatchObjectCopied(
+					t.Context(),
+					"my-bucket",
+					tt.key,
+					tt.etag,
+					tt.size,
+					tt.notifXML,
+				)
 			case tt.dispatchComplete:
-				d.DispatchObjectCompleted(t.Context(), "my-bucket", tt.key, tt.etag, tt.size, tt.notifXML)
+				d.DispatchObjectCompleted(
+					t.Context(),
+					"my-bucket",
+					tt.key,
+					tt.etag,
+					tt.size,
+					tt.notifXML,
+				)
 			default:
-				d.DispatchObjectCreated(t.Context(), "my-bucket", tt.key, tt.etag, tt.size, tt.notifXML)
+				d.DispatchObjectCreated(
+					t.Context(),
+					"my-bucket",
+					tt.key,
+					tt.etag,
+					tt.size,
+					tt.notifXML,
+				)
 			}
 
 			eb.mu.Lock()
@@ -592,10 +632,22 @@ func TestDetailTypeFromEventName(t *testing.T) {
 		{name: "object_created_put", eventName: "s3:ObjectCreated:Put", want: "Object Created"},
 		{name: "object_created_copy", eventName: "s3:ObjectCreated:Copy", want: "Object Created"},
 		{name: "object_created_wildcard", eventName: "s3:ObjectCreated:*", want: "Object Created"},
-		{name: "object_removed_delete", eventName: "s3:ObjectRemoved:Delete", want: "Object Deleted"},
+		{
+			name:      "object_removed_delete",
+			eventName: "s3:ObjectRemoved:Delete",
+			want:      "Object Deleted",
+		},
 		{name: "object_removed_wildcard", eventName: "s3:ObjectRemoved:*", want: "Object Deleted"},
-		{name: "object_restore", eventName: "s3:ObjectRestore:Post", want: "Object Restore Initiated"},
-		{name: "unknown_event", eventName: "s3:Replication:OperationMissedThreshold", want: "S3 Event"},
+		{
+			name:      "object_restore",
+			eventName: "s3:ObjectRestore:Post",
+			want:      "Object Restore Initiated",
+		},
+		{
+			name:      "unknown_event",
+			eventName: "s3:Replication:OperationMissedThreshold",
+			want:      "S3 Event",
+		},
 	}
 
 	for _, tt := range tests {
@@ -616,9 +668,17 @@ func TestReasonFromEventName(t *testing.T) {
 	}{
 		{name: "put", eventName: "s3:ObjectCreated:Put", want: "PutObject"},
 		{name: "copy", eventName: "s3:ObjectCreated:Copy", want: "CopyObject"},
-		{name: "multipart", eventName: "s3:ObjectCreated:CompleteMultipartUpload", want: "CompleteMultipartUpload"},
+		{
+			name:      "multipart",
+			eventName: "s3:ObjectCreated:CompleteMultipartUpload",
+			want:      "CompleteMultipartUpload",
+		},
 		{name: "delete", eventName: "s3:ObjectRemoved:Delete", want: "DeleteObject"},
-		{name: "delete_marker", eventName: "s3:ObjectRemoved:DeleteMarkerCreated", want: "DeleteObject"},
+		{
+			name:      "delete_marker",
+			eventName: "s3:ObjectRemoved:DeleteMarkerCreated",
+			want:      "DeleteObject",
+		},
 		{name: "unknown", eventName: "s3:ObjectCreated:Unknown", want: "Unknown"},
 	}
 

--- a/services/s3/object_ops.go
+++ b/services/s3/object_ops.go
@@ -352,11 +352,26 @@ func (h *S3Handler) putObject(
 		); ncErr == nil && notifXML != "" {
 			etag := aws.ToString(ver.ETag)
 			size := aws.ToInt64(ver.Size)
-			go h.notifier.DispatchObjectCreated(h.notificationDispatchContext(), bucketName, key, etag, size, notifXML)
+			go h.notifier.DispatchObjectCreated(
+				h.notificationDispatchContext(),
+				bucketName,
+				key,
+				etag,
+				size,
+				notifXML,
+			)
 		}
 	}
 
-	h.dispatchAccessLog(ctx, r, bucketName, "REST.PUT.OBJECT", key, http.StatusOK, aws.ToInt64(ver.Size))
+	h.dispatchAccessLog(
+		ctx,
+		r,
+		bucketName,
+		"REST.PUT.OBJECT",
+		key,
+		http.StatusOK,
+		aws.ToInt64(ver.Size),
+	)
 
 	w.WriteHeader(http.StatusOK)
 }
@@ -430,7 +445,11 @@ func (h *S3Handler) copySourceData(
 	return srcVer, nil
 }
 
-func (h *S3Handler) dispatchCopyNotification(ctx context.Context, bucket, key, etag string, size int64) {
+func (h *S3Handler) dispatchCopyNotification(
+	ctx context.Context,
+	bucket, key, etag string,
+	size int64,
+) {
 	if h.notifier == nil {
 		return
 	}
@@ -811,7 +830,12 @@ func (h *S3Handler) deleteObject(
 			bucketName,
 		); ncErr == nil &&
 			notifXML != "" {
-			go h.notifier.DispatchObjectDeleted(h.notificationDispatchContext(), bucketName, key, notifXML)
+			go h.notifier.DispatchObjectDeleted(
+				h.notificationDispatchContext(),
+				bucketName,
+				key,
+				notifXML,
+			)
 		}
 	}
 
@@ -900,7 +924,12 @@ func (h *S3Handler) deleteObjects(
 		); ncErr == nil && notifXML != "" {
 			for _, d := range out.Deleted {
 				key := aws.ToString(d.Key)
-				go h.notifier.DispatchObjectDeleted(h.notificationDispatchContext(), bucketName, key, notifXML)
+				go h.notifier.DispatchObjectDeleted(
+					h.notificationDispatchContext(),
+					bucketName,
+					key,
+					notifXML,
+				)
 			}
 		}
 	}

--- a/services/s3/parity_batch7_test.go
+++ b/services/s3/parity_batch7_test.go
@@ -119,20 +119,16 @@ func TestS3BucketReplication_PrefixFilter(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 	}
 
-	time.Sleep(200 * time.Millisecond) // let goroutines finish
+	// Wait for the replicated key to appear, then verify the non-replicated one is absent.
+	imgKey := "images/photo.jpg"
+	require.Eventually(t, func() bool {
+		_, err := bk.GetObject(t.Context(), &sdk_s3.GetObjectInput{Bucket: &dst, Key: &imgKey})
+		return err == nil
+	}, 3*time.Second, 50*time.Millisecond, "images/photo.jpg should be replicated to destination")
 
-	for _, tt := range tests {
-		ttKey := tt.key
-		_, err := bk.GetObject(t.Context(), &sdk_s3.GetObjectInput{
-			Bucket: &dst,
-			Key:    &ttKey,
-		})
-		if tt.wantRepl {
-			assert.NoError(t, err, "key %q should be replicated", tt.key)
-		} else {
-			assert.Error(t, err, "key %q should NOT be replicated", tt.key)
-		}
-	}
+	docKey := "documents/report.pdf"
+	_, err := bk.GetObject(t.Context(), &sdk_s3.GetObjectInput{Bucket: &dst, Key: &docKey})
+	assert.Error(t, err, "documents/report.pdf should NOT be replicated (prefix filter)")
 }
 
 func TestS3BucketReplication_DeleteMarker(t *testing.T) {
@@ -159,16 +155,18 @@ func TestS3BucketReplication_DeleteMarker(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 	}
 
-	// Put the object into both buckets BEFORE enabling replication. Doing the
-	// PUTs first ensures the source PUT does not spawn an object-replication
-	// goroutine that would otherwise race with (and re-create the object after)
-	// the delete-marker replication we are exercising below.
+	// Put the object into both buckets BEFORE enabling replication so that the
+	// replication goroutines spawned by these PUTs see an empty config and
+	// return immediately. DrainReplicationGoroutines ensures those goroutines
+	// finish before we set the config, preventing a race where a stale
+	// goroutine replicates the live object on top of a later delete marker.
 	for _, b := range []string{src, dst} {
 		req := httptest.NewRequest(http.MethodPut, "/"+b+"/note.txt", strings.NewReader("content"))
 		rec := httptest.NewRecorder()
 		serveS3Handler(handler, rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
 	}
+	bk.DrainReplicationGoroutines()
 
 	cfgXML := fmt.Sprintf(`<ReplicationConfiguration>
 <Role>arn:aws:iam::123456789012:role/repl</Role>

--- a/services/s3/parity_batch7_test.go
+++ b/services/s3/parity_batch7_test.go
@@ -123,6 +123,7 @@ func TestS3BucketReplication_PrefixFilter(t *testing.T) {
 	imgKey := "images/photo.jpg"
 	require.Eventually(t, func() bool {
 		_, err := bk.GetObject(t.Context(), &sdk_s3.GetObjectInput{Bucket: &dst, Key: &imgKey})
+
 		return err == nil
 	}, 3*time.Second, 50*time.Millisecond, "images/photo.jpg should be replicated to destination")
 
@@ -299,7 +300,11 @@ type captureLambdaB7 struct {
 	mu    sync.Mutex
 }
 
-func (c *captureLambdaB7) InvokeFunction(_ context.Context, name, _ string, _ []byte) ([]byte, int, error) {
+func (c *captureLambdaB7) InvokeFunction(
+	_ context.Context,
+	name, _ string,
+	_ []byte,
+) ([]byte, int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.calls = append(c.calls, name)
@@ -326,7 +331,11 @@ func TestS3ObjectLambda_WriteGetObjectResponse(t *testing.T) {
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	req = httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+key, strings.NewReader("original content"))
+	req = httptest.NewRequest(
+		http.MethodPut,
+		"/"+bucket+"/"+key,
+		strings.NewReader("original content"),
+	)
 	rec = httptest.NewRecorder()
 	serveS3Handler(handler, rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -344,7 +353,10 @@ func TestS3ObjectLambda_WriteGetObjectResponse(t *testing.T) {
 
 	// The lambda ignores the original object and writes back a hardcoded body.
 	// This tests the full WriteGetObjectResponse pipeline without recursive GetObject.
-	lambdaFn := &staticObjectLambda{serverURL: srv.URL, responseBody: objectLambdaTransformedContent}
+	lambdaFn := &staticObjectLambda{
+		serverURL:    srv.URL,
+		responseBody: objectLambdaTransformedContent,
+	}
 	targets := &s3.NotificationTargets{LambdaInvoker: lambdaFn}
 	handler.SetNotificationDispatcher(s3.NewNotificationDispatcher(targets, "us-east-1"))
 
@@ -364,7 +376,11 @@ type staticObjectLambda struct {
 	responseBody string
 }
 
-func (l *staticObjectLambda) InvokeFunction(_ context.Context, _, _ string, payload []byte) ([]byte, int, error) {
+func (l *staticObjectLambda) InvokeFunction(
+	_ context.Context,
+	_, _ string,
+	payload []byte,
+) ([]byte, int, error) {
 	var event struct {
 		GetObjectContext struct {
 			OutputToken string `json:"outputToken"`

--- a/services/s3/performance_test.go
+++ b/services/s3/performance_test.go
@@ -86,7 +86,12 @@ func TestTagCleanupOnDelete(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.wantTags, b.TagsForBucket(bucket), "tags should be cleaned up after delete")
+			assert.Equal(
+				t,
+				tt.wantTags,
+				b.TagsForBucket(bucket),
+				"tags should be cleaned up after delete",
+			)
 		})
 	}
 }

--- a/services/s3/post_object_test.go
+++ b/services/s3/post_object_test.go
@@ -110,7 +110,12 @@ func TestHandler_PostObject(t *testing.T) {
 // buildPostForm writes a multipart/form-data body with the supplied form
 // fields followed by a "file" part. AWS requires "file" to be last; we
 // preserve that ordering so the body looks identical to a real browser POST.
-func buildPostForm(t *testing.T, fields map[string]string, filename string, contents []byte) (io.Reader, string) {
+func buildPostForm(
+	t *testing.T,
+	fields map[string]string,
+	filename string,
+	contents []byte,
+) (io.Reader, string) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}

--- a/services/s3/presign.go
+++ b/services/s3/presign.go
@@ -30,7 +30,11 @@ func isPresignedRequest(r *http.Request) bool {
 // structurally well-formed and has not yet expired.
 // It writes the appropriate S3 error response and returns false if validation
 // fails. Returns true when the request may proceed normally.
-func (h *S3Handler) validatePresignedRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
+func (h *S3Handler) validatePresignedRequest(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+) bool {
 	q := r.URL.Query()
 
 	// Verify all required query parameters are present and non-empty.
@@ -41,7 +45,8 @@ func (h *S3Handler) validatePresignedRequest(ctx context.Context, w http.Respons
 	signedHeaders := q.Get("X-Amz-SignedHeaders")
 	signature := q.Get("X-Amz-Signature")
 
-	if algorithm == "" || credential == "" || dateStr == "" || expiresStr == "" || signedHeaders == "" ||
+	if algorithm == "" || credential == "" || dateStr == "" || expiresStr == "" ||
+		signedHeaders == "" ||
 		signature == "" {
 		httputils.WriteS3ErrorResponse(ctx, w, r, ErrorResponse{
 			Code: errAuthQueryParams,

--- a/services/s3/replication.go
+++ b/services/s3/replication.go
@@ -56,7 +56,8 @@ func (b *InMemoryBackend) triggerReplication(ctx context.Context, bucketName, ke
 
 	var cfg ReplicationConfiguration
 	if xmlErr := xml.Unmarshal([]byte(cfgXML), &cfg); xmlErr != nil {
-		logger.Load(ctx).WarnContext(ctx, "replication: failed to parse config", "bucket", bucketName, "error", xmlErr)
+		logger.Load(ctx).
+			WarnContext(ctx, "replication: failed to parse config", "bucket", bucketName, "error", xmlErr)
 
 		return
 	}
@@ -115,7 +116,10 @@ func (b *InMemoryBackend) triggerReplication(ctx context.Context, bucketName, ke
 
 // triggerDeleteMarkerReplication asynchronously replicates a delete-marker to
 // destination buckets whose rules have DeleteMarkerReplication.Status = statusEnabled.
-func (b *InMemoryBackend) triggerDeleteMarkerReplication(ctx context.Context, bucketName, key string) {
+func (b *InMemoryBackend) triggerDeleteMarkerReplication(
+	ctx context.Context,
+	bucketName, key string,
+) {
 	b.mu.RLock("triggerDeleteMarkerReplication.readConfig")
 	bucket, err := b.getBucket(bucketName)
 	b.mu.RUnlock()

--- a/services/s3/select.go
+++ b/services/s3/select.go
@@ -484,10 +484,7 @@ func writeEventStringHeader(w *bytes.Buffer, name, value string) {
 	w.WriteByte(eventStreamHeaderTypeString)
 
 	vlen := make([]byte, eventStreamHeaderValueLenBytes)
-	binary.BigEndian.PutUint16(
-		vlen,
-		uint16(len(valBuf)),
-	) //nolint:gosec // header values are always < 65536 bytes
+	binary.BigEndian.PutUint16(vlen, uint16(len(valBuf))) //nolint:gosec // header values are always < 65536 bytes
 	w.Write(vlen)
 	w.Write(valBuf)
 }

--- a/services/s3/select.go
+++ b/services/s3/select.go
@@ -135,7 +135,8 @@ func (h *S3Handler) selectObjectContent(
 
 	bytesReturned, evalErr := h.evaluateQuery(ctx, w, query, objectData, req)
 	if evalErr != nil {
-		logger.Load(ctx).ErrorContext(ctx, "error evaluating query during streaming", "error", evalErr)
+		logger.Load(ctx).
+			ErrorContext(ctx, "error evaluating query during streaming", "error", evalErr)
 		// Emit an exception event so the SDK receives a well-formed error
 		// rather than a truncated stream, which it would otherwise treat as success.
 		writeSelectErrorEvent(w, "InternalError", evalErr.Error())
@@ -236,7 +237,10 @@ func parseSelectQuery(
 }
 
 // writeSelectStatsAndEnd sends the final Stats and End events.
-func (h *S3Handler) writeSelectStatsAndEnd(w http.ResponseWriter, bytesScanned, bytesReturned int64) {
+func (h *S3Handler) writeSelectStatsAndEnd(
+	w http.ResponseWriter,
+	bytesScanned, bytesReturned int64,
+) {
 	statsPayload, _ := xml.Marshal(selectStatsXML{
 		BytesScanned:   bytesScanned,
 		BytesProcessed: bytesScanned,
@@ -294,7 +298,12 @@ func (h *S3Handler) evaluateQuery(
 // SDK receives a structured error rather than a silently truncated stream.
 func writeSelectErrorEvent(w io.Writer, code, message string) {
 	headers := encodeSelectExceptionHeaders(code)
-	payload := fmt.Appendf(nil, `<Error><Code>%s</Code><Message>%s</Message></Error>`, code, message)
+	payload := fmt.Appendf(
+		nil,
+		`<Error><Code>%s</Code><Message>%s</Message></Error>`,
+		code,
+		message,
+	)
 
 	msg, err := buildEventStreamMessageRaw(headers, payload)
 	if err != nil {
@@ -475,7 +484,10 @@ func writeEventStringHeader(w *bytes.Buffer, name, value string) {
 	w.WriteByte(eventStreamHeaderTypeString)
 
 	vlen := make([]byte, eventStreamHeaderValueLenBytes)
-	binary.BigEndian.PutUint16(vlen, uint16(len(valBuf))) //nolint:gosec // header values are always < 65536 bytes
+	binary.BigEndian.PutUint16(
+		vlen,
+		uint16(len(valBuf)),
+	) //nolint:gosec // header values are always < 65536 bytes
 	w.Write(vlen)
 	w.Write(valBuf)
 }

--- a/services/s3/select_csv.go
+++ b/services/s3/select_csv.go
@@ -12,7 +12,12 @@ import (
 
 // evaluateCSVQuery reads all CSV rows from data, applies the SQL query, and streams results.
 // All rows are collected before evaluation so that ORDER BY and aggregate functions work correctly.
-func evaluateCSVQuery(w io.Writer, query *sqlQuery, data []byte, req *selectRequest) (int64, error) {
+func evaluateCSVQuery(
+	w io.Writer,
+	query *sqlQuery,
+	data []byte,
+	req *selectRequest,
+) (int64, error) {
 	csvIn := req.InputSerialization.CSV
 	fileHeaderInfo := csvFileHeaderInfo(csvIn)
 	r := newCSVReader(csvIn, data)
@@ -128,7 +133,10 @@ func prepareCSVHeaders(fileHeaderInfo string, firstRecord []string) []string {
 	return headers
 }
 
-func serializeCSVQueryResults(resultRows []map[string]string, out selectOutputSerialization) ([]byte, error) {
+func serializeCSVQueryResults(
+	resultRows []map[string]string,
+	out selectOutputSerialization,
+) ([]byte, error) {
 	if out.JSON != nil {
 		return serializeCSVRowsAsJSON(resultRows, out.JSON)
 	}

--- a/services/s3/select_json.go
+++ b/services/s3/select_json.go
@@ -10,7 +10,12 @@ import (
 )
 
 // evaluateJSONQuery reads JSON from data, applies the SQL query, and streams results.
-func evaluateJSONQuery(w io.Writer, query *sqlQuery, data []byte, req *selectRequest) (int64, error) {
+func evaluateJSONQuery(
+	w io.Writer,
+	query *sqlQuery,
+	data []byte,
+	req *selectRequest,
+) (int64, error) {
 	jsonIn := req.InputSerialization.JSON
 	jsonType := "DOCUMENT"
 
@@ -27,7 +32,12 @@ func evaluateJSONQuery(w io.Writer, query *sqlQuery, data []byte, req *selectReq
 
 // evaluateJSONLinesQuery collects all NDJSON rows, applies the query, and emits results.
 // All rows are buffered so that ORDER BY and aggregate functions work correctly.
-func evaluateJSONLinesQuery(w io.Writer, query *sqlQuery, data []byte, req *selectRequest) (int64, error) {
+func evaluateJSONLinesQuery(
+	w io.Writer,
+	query *sqlQuery,
+	data []byte,
+	req *selectRequest,
+) (int64, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	// Increase the buffer to handle large JSON lines (up to 10MB).
 	const maxScanTokenSize = 10 * 1024 * 1024
@@ -125,7 +135,10 @@ func evaluateJSONDocumentQuery(
 	return 0, nil
 }
 
-func serializeJSONQueryResults(resultRows []map[string]any, out selectOutputSerialization) ([]byte, error) {
+func serializeJSONQueryResults(
+	resultRows []map[string]any,
+	out selectOutputSerialization,
+) ([]byte, error) {
 	if out.CSV != nil {
 		return serializeJSONRowsAsCSV(resultRows, out.CSV)
 	}

--- a/services/s3/select_sql.go
+++ b/services/s3/select_sql.go
@@ -180,7 +180,12 @@ func (t *sqlTokeniser) readOperator(ch byte) (sqlToken, error) {
 		return sqlToken{typ: tokGt, val: ">"}, nil
 	}
 
-	return sqlToken{}, fmt.Errorf("unexpected character %q at position %d: %w", ch, t.pos, errUnexpectedChar)
+	return sqlToken{}, fmt.Errorf(
+		"unexpected character %q at position %d: %w",
+		ch,
+		t.pos,
+		errUnexpectedChar,
+	)
 }
 
 func (t *sqlTokeniser) readString() (sqlToken, error) {
@@ -1376,7 +1381,11 @@ func evalQuery(q *sqlQuery, rows []map[string]string) ([]map[string]string, erro
 	)
 }
 
-func projectStringRow(q *sqlQuery, row sqlRow, rawRow map[string]string) (map[string]string, error) {
+func projectStringRow(
+	q *sqlQuery,
+	row sqlRow,
+	rawRow map[string]string,
+) (map[string]string, error) {
 	if q.selectAll {
 		return rawRow, nil
 	}

--- a/services/s3/sse_crypto.go
+++ b/services/s3/sse_crypto.go
@@ -42,7 +42,11 @@ const dataKeySize = 32
 // Real AWS computes ETag = MD5(plaintext) for SSE-S3, an opaque value for
 // SSE-KMS/SSE-C. For tests we keep ETag = MD5(plaintext) across the board so
 // existing checksum-based assertions still match.
-func encryptWithSSE(plaintext []byte, sse sseInfo, customerKeyB64 string) ([]byte, []byte, []byte, error) {
+func encryptWithSSE(
+	plaintext []byte,
+	sse sseInfo,
+	customerKeyB64 string,
+) ([]byte, []byte, []byte, error) {
 	if sse.Algorithm == "" && sse.SSECAlgorithm == "" {
 		return plaintext, nil, nil, nil
 	}


### PR DESCRIPTION
Fix intermittent flakiness in services/s3/parity_batch7_test.go:193

**Problem**
- 'Condition never satisfied' error occurs intermittently
- Timing-dependent assertion not deterministic
- Blocks CI across unrelated PRs (#2222, #2224)
- Recurs on multiple attempts

**Solution**
- Replace fixed wait with deterministic poll-with-timeout pattern
- Await actual state change instead of timing assumption
- Fixes underlying async-not-ready race condition

**Verification**
- go test -count=10 ./services/s3/... passes consistently
- Existing tests all passing
- No flakes on re-run