### PR TITLE
fix(opsworks): add internal sdk_completeness_test without SDK v2 import (go-5uju)

### DIFF
--- a/services/opsworks/export_test.go
+++ b/services/opsworks/export_test.go
@@ -1,5 +1,18 @@
 package opsworks
 
+import "sort"
+
+// HandlerDispatchKeys returns the sorted operation keys from the handler's dispatch table.
+func HandlerDispatchKeys(h *Handler) []string {
+	keys := make([]string, 0, len(h.ops))
+	for k := range h.ops {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
 // StackCount returns the number of stored stacks.
 func StackCount(b *InMemoryBackend) int {
 	b.mu.RLock("StackCount")

--- a/services/opsworks/sdk_completeness_test.go
+++ b/services/opsworks/sdk_completeness_test.go
@@ -1,0 +1,47 @@
+package opsworks_test
+
+// OpsWorks was not migrated to AWS SDK v2 — it was deprecated and removed from
+// the SDK. There is no aws-sdk-go-v2/service/opsworks package to compare against.
+// Instead, this file verifies internal consistency between GetSupportedOperations()
+// and the handler dispatch table.
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/blackbirdworks/gopherstack/services/opsworks"
+)
+
+// TestSDKCompleteness verifies that GetSupportedOperations() has no duplicates
+// and matches the handler's internal dispatch table exactly. Because OpsWorks is
+// not present in aws-sdk-go-v2, no SDK client comparison is performed.
+func TestSDKCompleteness(t *testing.T) {
+	t.Parallel()
+
+	backend := opsworks.NewInMemoryBackend("000000000000", "us-east-1")
+	h := opsworks.NewHandler(backend)
+
+	supportedOps := h.GetSupportedOperations()
+
+	seen := make(map[string]bool, len(supportedOps))
+	var dups []string
+
+	for _, op := range supportedOps {
+		if seen[op] {
+			dups = append(dups, op)
+		}
+		seen[op] = true
+	}
+
+	assert.Empty(t, dups, "GetSupportedOperations() contains duplicate entries — remove the duplicates.")
+
+	dispatchKeys := opsworks.HandlerDispatchKeys(h)
+	supported := make([]string, len(supportedOps))
+	copy(supported, supportedOps)
+	sort.Strings(supported)
+
+	assert.Equal(t, dispatchKeys, supported,
+		"GetSupportedOperations() and the dispatch table must contain exactly the same operations.")
+}


### PR DESCRIPTION
Fix OpsWorks SDK completeness test for deprecated service.

**Problem**
- aws-sdk-go-v2/service/opsworks does not exist (OpsWorks deprecated)
- sdk_completeness_test.go references non-existent package
- Build/test failures due to import

**Solution**
- Add internal sdk_completeness_test.go for opsworks
- Validates internal consistency without SDK v2 import
- Tests work with internal implementation only

**Testing**
- go build ./services/opsworks/... ✓
- go test ./services/opsworks/... ✓