### PR TITLE
refactor(cli): make getServiceProviders funlen-proof (unblocks new-service PRs)

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2586,7 +2586,14 @@ func initializeServices(appCtx *service.AppContext) ([]service.Registerable, err
 
 // getServiceProviders returns the list of all available service providers.
 func getServiceProviders() []service.Provider {
-	return append([]service.Provider{
+	return append(getCoreServiceProviders(), getRemainingServiceProviders()...)
+}
+
+// getCoreServiceProviders returns the foundational service providers.
+// Extracted from getServiceProviders to satisfy the funlen limit and to
+// give the inline registration list headroom as new services are added.
+func getCoreServiceProviders() []service.Provider {
+	return []service.Provider{
 		&ddbbackend.Provider{},
 		&s3backend.Provider{},
 		&ssmbackend.Provider{},
@@ -2598,6 +2605,14 @@ func getServiceProviders() []service.Provider {
 		&secretsmanagerbackend.Provider{},
 		&lambdabackend.Provider{},
 		&ebbackend.Provider{},
+	}
+}
+
+// getRemainingServiceProviders returns the remaining service providers. New
+// services should be registered in getMostRecentServiceProviders (the tail of
+// the chain), not here, to keep this function under the funlen limit.
+func getRemainingServiceProviders() []service.Provider {
+	return append([]service.Provider{
 		&apigwbackend.Provider{},
 		&cwlogsbackend.Provider{},
 		&sfnbackend.Provider{},


### PR DESCRIPTION
## Problem
Every new-service PR (#2232 #2235 #2236 #2238) fails CI `lint` identically:
```
cli.go: Function 'getServiceProviders' is too long (101 > 100) (funlen)
```
Each new service appends to the inline slice in `getServiceProviders`, overflowing the funlen limit. Polecats kept fixing their service files, missing the real cause in shared `cli.go`.

## Fix
Extract the 11 foundational providers into `getCoreServiceProviders()`; body becomes `getRemainingServiceProviders()`. Tail + chain untouched so in-flight service PRs rebase cleanly.

- getServiceProviders: 6 lines · getRemainingServiceProviders: 93 lines (headroom)
- New services should register in `getMostRecentServiceProviders()` (chain tail)
- `go build ./...` clean, goimports applied

After merge, rebase #2232/#2235/#2236/#2238 — funlen clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)