### PR TITLE
parity §K: CFN resource types — core (ApiGateway/EC2/Cognito/KMS/ELBv2/Events/Lambda) + ssm race fix (go-x4dr/go-s7hy)

### DIFF
--- a/services/ssm/backend_ops.go
+++ b/services/ssm/backend_ops.go
@@ -467,7 +467,7 @@ func (b *InMemoryBackend) ListComplianceItems(
 
 	var all []ComplianceItem
 
-	for _, items := range b.complianceStore(region) {
+	for _, items := range b.compliance[region] {
 		for _, item := range items {
 			if input.ResourceID != "" && item.ResourceID != input.ResourceID {
 				continue
@@ -558,7 +558,7 @@ func (b *InMemoryBackend) ListComplianceSummaries(
 	b.mu.RLock("ListComplianceSummaries")
 	defer b.mu.RUnlock()
 
-	tallies := buildComplianceTallies(b.complianceStore(region))
+	tallies := buildComplianceTallies(b.compliance[region])
 
 	summaries := make([]any, 0, len(tallies))
 	for ct, t := range tallies {
@@ -622,7 +622,7 @@ func (b *InMemoryBackend) ListResourceComplianceSummaries(
 	b.mu.RLock("ListResourceComplianceSummaries")
 	defer b.mu.RUnlock()
 
-	store := b.complianceStore(region)
+	store := b.compliance[region]
 	summaries := make([]any, 0, len(store))
 
 	for resourceID, items := range store {


### PR DESCRIPTION
Parity §K core CFN resource types + fix for the services/ssm data race (compliance read ops). Supersedes #2251 (go-x4dr, became DIRTY after rebase). Rebased clean on current main. 🤖 mayor