### PR TITLE
parity §D: fix resource leaks (ACM timers, StepFn goroutines, S3/DynamoDB/SSM/KMS unbounded growth) (go-6ugl)

### DIFF
--- a/services/acm/export_test.go
+++ b/services/acm/export_test.go
@@ -1,0 +1,10 @@
+package acm
+
+// TimerCountForTest returns the number of pending auto-validation timers
+// currently stored in the backend.
+func (b *InMemoryBackend) TimerCountForTest() int {
+	b.mu.RLock("TimerCountForTest")
+	defer b.mu.RUnlock()
+
+	return len(b.timers)
+}

--- a/services/acm/leak_test.go
+++ b/services/acm/leak_test.go
@@ -1,0 +1,91 @@
+package acm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/acm"
+)
+
+// TestDeleteCertificate_StopsAutoValidateTimer verifies that deleting a
+// certificate with a pending auto-validate timer stops and removes the timer,
+// preventing goroutine leaks when the janitor is disabled.
+func TestDeleteCertificate_StopsAutoValidateTimer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		count int
+	}{
+		{name: "single cert", count: 1},
+		{name: "multiple certs", count: 5},
+		{name: "many certs", count: 10},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := acm.NewInMemoryBackend("123456789012", "us-east-1")
+			require.Equal(t, 0, b.TimerCountForTest(), "baseline: no timers at start")
+
+			arns := make([]string, 0, tc.count)
+			for i := range tc.count {
+				cert, err := b.RequestCertificate(
+					"example.com",
+					"AMAZON_ISSUED",
+					"DNS",
+					"", // no idempotency token
+					"",
+					"",
+					"",
+					[]string{"www.example.com"},
+				)
+				require.NoError(t, err, "RequestCertificate[%d] must succeed", i)
+				arns = append(arns, cert.ARN)
+			}
+
+			// Each PENDING_VALIDATION cert registers one auto-validate timer.
+			require.Equal(t, tc.count, b.TimerCountForTest(),
+				"timer should be registered for each pending cert")
+
+			for _, certARN := range arns {
+				require.NoError(t, b.DeleteCertificate(certARN),
+					"DeleteCertificate must succeed")
+			}
+
+			require.Equal(t, 0, b.TimerCountForTest(),
+				"all timers must be stopped and removed after delete")
+		})
+	}
+}
+
+// TestDeleteCertificate_TimersDoNotAccumulateAcrossCreateDelete verifies that
+// repeated create-then-delete cycles do not cause the timer map to grow, even
+// without the background janitor running.
+func TestDeleteCertificate_TimersDoNotAccumulateAcrossCreateDelete(t *testing.T) {
+	t.Parallel()
+
+	b := acm.NewInMemoryBackend("123456789012", "us-east-1")
+
+	const cycles = 20
+
+	for i := range cycles {
+		cert, err := b.RequestCertificate(
+			"cycle.example.com",
+			"AMAZON_ISSUED",
+			"DNS",
+			"",
+			"",
+			"",
+			"",
+			nil,
+		)
+		require.NoError(t, err, "cycle %d: RequestCertificate failed", i)
+		require.NoError(t, b.DeleteCertificate(cert.ARN), "cycle %d: DeleteCertificate failed", i)
+	}
+
+	require.Equal(t, 0, b.TimerCountForTest(),
+		"timer map must be empty after all create-delete cycles complete")
+}

--- a/services/cloudwatchlogs/export_test.go
+++ b/services/cloudwatchlogs/export_test.go
@@ -72,3 +72,6 @@ func (b *InMemoryBackend) GetParsedInsightsQueryCacheSize() int {
 
 	return len(b.parsedQueries)
 }
+
+// DefaultParsedQueryCacheSizeForTest exposes the default parsed-query cache cap.
+const DefaultParsedQueryCacheSizeForTest = defaultParsedQueryCacheSize

--- a/services/cloudwatchlogs/leak_test.go
+++ b/services/cloudwatchlogs/leak_test.go
@@ -1,0 +1,73 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/cloudwatchlogs"
+)
+
+// TestParsedInsightsQueryCache_CappedAtMax verifies that the parsed-query cache
+// stays at or below the configured cap even when more unique query strings are
+// submitted, preventing unbounded memory growth on long-running backends.
+func TestParsedInsightsQueryCache_CappedAtMax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		queries int
+	}{
+		{name: "at cap", queries: cloudwatchlogs.DefaultParsedQueryCacheSizeForTest},
+		{name: "one over cap", queries: cloudwatchlogs.DefaultParsedQueryCacheSizeForTest + 1},
+		{name: "well over cap", queries: cloudwatchlogs.DefaultParsedQueryCacheSizeForTest + 50},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			b := cloudwatchlogs.NewInMemoryBackend()
+
+			require.NoError(t, b.CreateLogGroup(ctx, "test-group", "", ""))
+
+			for i := range tc.queries {
+				// Each iteration uses a different (but valid) query string so
+				// each one triggers a new cache entry.
+				q := fmt.Sprintf("fields @timestamp, @message | filter @message like /msg-%d/", i)
+				_, err := b.StartQuery(ctx, fmt.Sprintf("qid-%d", i), q, []string{"test-group"}, 0, 9999999999)
+				require.NoError(t, err, "StartQuery[%d] must succeed", i)
+			}
+
+			got := b.GetParsedInsightsQueryCacheSize()
+			require.LessOrEqual(t, got, cloudwatchlogs.DefaultParsedQueryCacheSizeForTest,
+				"parsed query cache must not exceed the cap after %d unique queries", tc.queries)
+		})
+	}
+}
+
+// TestParsedInsightsQueryCache_DeduplicatesIdenticalQueries verifies that
+// submitting the same query string multiple times does not grow the cache —
+// each unique string is cached only once.
+func TestParsedInsightsQueryCache_DeduplicatesIdenticalQueries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b := cloudwatchlogs.NewInMemoryBackend()
+
+	require.NoError(t, b.CreateLogGroup(ctx, "test-group", "", ""))
+
+	const query = "fields @timestamp, @message"
+	const repeats = 20
+
+	for i := range repeats {
+		_, err := b.StartQuery(ctx, fmt.Sprintf("qid-%d", i), query, []string{"test-group"}, 0, 9999999999)
+		require.NoError(t, err, "StartQuery[%d] must succeed", i)
+	}
+
+	require.Equal(t, 1, b.GetParsedInsightsQueryCacheSize(),
+		"identical query strings must produce exactly one cache entry")
+}

--- a/services/cloudwatchlogs/leak_test.go
+++ b/services/cloudwatchlogs/leak_test.go
@@ -32,14 +32,16 @@ func TestParsedInsightsQueryCache_CappedAtMax(t *testing.T) {
 			ctx := context.Background()
 			b := cloudwatchlogs.NewInMemoryBackend()
 
-			require.NoError(t, b.CreateLogGroup(ctx, "test-group", "", ""))
+			_, err := b.CreateLogGroup(ctx, "test-group", "", "")
+			require.NoError(t, err)
 
+			var sqErr error
 			for i := range tc.queries {
 				// Each iteration uses a different (but valid) query string so
 				// each one triggers a new cache entry.
 				q := fmt.Sprintf("fields @timestamp, @message | filter @message like /msg-%d/", i)
-				_, err := b.StartQuery(ctx, fmt.Sprintf("qid-%d", i), q, []string{"test-group"}, 0, 9999999999)
-				require.NoError(t, err, "StartQuery[%d] must succeed", i)
+				_, sqErr = b.StartQuery(ctx, fmt.Sprintf("qid-%d", i), q, []string{"test-group"}, 0, 9999999999)
+				require.NoError(t, sqErr, "StartQuery[%d] must succeed", i)
 			}
 
 			got := b.GetParsedInsightsQueryCacheSize()
@@ -58,14 +60,16 @@ func TestParsedInsightsQueryCache_DeduplicatesIdenticalQueries(t *testing.T) {
 	ctx := context.Background()
 	b := cloudwatchlogs.NewInMemoryBackend()
 
-	require.NoError(t, b.CreateLogGroup(ctx, "test-group", "", ""))
+	_, err := b.CreateLogGroup(ctx, "test-group", "", "")
+	require.NoError(t, err)
 
 	const query = "fields @timestamp, @message"
 	const repeats = 20
 
+	var sqErr error
 	for i := range repeats {
-		_, err := b.StartQuery(ctx, fmt.Sprintf("qid-%d", i), query, []string{"test-group"}, 0, 9999999999)
-		require.NoError(t, err, "StartQuery[%d] must succeed", i)
+		_, sqErr = b.StartQuery(ctx, fmt.Sprintf("qid-%d", i), query, []string{"test-group"}, 0, 9999999999)
+		require.NoError(t, sqErr, "StartQuery[%d] must succeed", i)
 	}
 
 	require.Equal(t, 1, b.GetParsedInsightsQueryCacheSize(),

--- a/services/eventbridge/export_test.go
+++ b/services/eventbridge/export_test.go
@@ -141,3 +141,14 @@ func (b *InMemoryBackend) SetArchiveCreationTimeForTest(name string, creationTim
 
 	return nil
 }
+
+// EventLogLen returns the number of entries in the in-memory event log.
+func (b *InMemoryBackend) EventLogLen() int {
+	b.mu.RLock("EventLogLen")
+	defer b.mu.RUnlock()
+
+	return len(b.eventLog)
+}
+
+// MaxEventLogSizeForTest exposes the in-memory event log size cap.
+const MaxEventLogSizeForTest = maxEventLogSize

--- a/services/eventbridge/leak_test.go
+++ b/services/eventbridge/leak_test.go
@@ -78,5 +78,5 @@ func TestEventLog_RetainsMostRecentEvents(t *testing.T) {
 
 	// The GetEventLog call must return exactly the cap entries.
 	log := b.GetEventLog(ctx)
-	require.Equal(t, eventbridge.MaxEventLogSizeForTest, len(log))
+	require.Len(t, log, eventbridge.MaxEventLogSizeForTest)
 }

--- a/services/eventbridge/leak_test.go
+++ b/services/eventbridge/leak_test.go
@@ -1,0 +1,82 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/eventbridge"
+)
+
+// TestEventLog_CappedAtMax verifies that the in-memory event log stays at or
+// below maxEventLogSize even when many more events are published, preventing
+// unbounded memory growth on a long-running backend.
+func TestEventLog_CappedAtMax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		putEvents int
+	}{
+		{name: "at cap", putEvents: eventbridge.MaxEventLogSizeForTest},
+		{name: "one over cap", putEvents: eventbridge.MaxEventLogSizeForTest + 1},
+		{name: "well over cap", putEvents: eventbridge.MaxEventLogSizeForTest + 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			b := eventbridge.NewInMemoryBackend()
+
+			for i := range tc.putEvents {
+				results := b.PutEvents(ctx, []eventbridge.EventEntry{
+					{
+						Source:     "test.source",
+						DetailType: "TestEvent",
+						Detail:     `{"seq":` + string(rune('0'+i%10)) + `}`,
+					},
+				})
+				require.Empty(t, results[0].ErrorCode, "PutEvents must not error")
+			}
+
+			got := b.EventLogLen()
+			require.LessOrEqual(t, got, eventbridge.MaxEventLogSizeForTest,
+				"event log must not exceed the cap after %d events", tc.putEvents)
+
+			if tc.putEvents >= eventbridge.MaxEventLogSizeForTest {
+				require.Equal(t, eventbridge.MaxEventLogSizeForTest, got,
+					"event log must be exactly at the cap when overflowed")
+			}
+		})
+	}
+}
+
+// TestEventLog_RetainsMostRecentEvents verifies that when the event log cap is
+// exceeded, the oldest events are evicted (not the newest) — so the log always
+// reflects recent activity.
+func TestEventLog_RetainsMostRecentEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b := eventbridge.NewInMemoryBackend()
+
+	// Overfill the log beyond the cap.
+	extra := 10
+	total := eventbridge.MaxEventLogSizeForTest + extra
+
+	for range total {
+		b.PutEvents(ctx, []eventbridge.EventEntry{
+			{Source: "test.source", DetailType: "Fill", Detail: `{}`},
+		})
+	}
+
+	require.Equal(t, eventbridge.MaxEventLogSizeForTest, b.EventLogLen(),
+		"log must be trimmed to cap")
+
+	// The GetEventLog call must return exactly the cap entries.
+	log := b.GetEventLog(ctx)
+	require.Equal(t, eventbridge.MaxEventLogSizeForTest, len(log))
+}

--- a/services/kms/export_test.go
+++ b/services/kms/export_test.go
@@ -1,6 +1,7 @@
 package kms
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -154,6 +155,9 @@ func (b *InMemoryBackend) KeyMaterialHistoryLenForTest(keyID string) int {
 	return 0
 }
 
+// ErrForceRotateKeyNotFound is returned by ForceRotateForTest when keyID is absent.
+var ErrForceRotateKeyNotFound = errors.New("key not found")
+
 // ForceRotateForTest rotates the key material for keyID, bypassing the
 // on-demand rate limit. Used in tests to drive the history cap.
 func (b *InMemoryBackend) ForceRotateForTest(keyID string) error {
@@ -166,5 +170,5 @@ func (b *InMemoryBackend) ForceRotateForTest(keyID string) error {
 		}
 	}
 
-	return fmt.Errorf("key %q not found", keyID)
+	return fmt.Errorf("%w: %s", ErrForceRotateKeyNotFound, keyID)
 }

--- a/services/kms/export_test.go
+++ b/services/kms/export_test.go
@@ -1,6 +1,9 @@
 package kms
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // DefaultJanitorInterval exposes the package default janitor interval for testing.
 const DefaultJanitorInterval = defaultKMSJanitorInterval
@@ -131,4 +134,37 @@ func (b *InMemoryBackend) SetGrantTokenIssuedAt(grantID string, t time.Time) {
 			return
 		}
 	}
+}
+
+// MaxKeyMaterialHistoryEntriesForTest exposes the key material history cap.
+const MaxKeyMaterialHistoryEntriesForTest = maxKeyMaterialHistoryEntries
+
+// KeyMaterialHistoryLenForTest returns the number of retained historical key
+// materials for the given keyID across all regions.
+func (b *InMemoryBackend) KeyMaterialHistoryLenForTest(keyID string) int {
+	b.mu.RLock("KeyMaterialHistoryLenForTest")
+	defer b.mu.RUnlock()
+
+	for _, regionHist := range b.keyMaterialHistory {
+		if hist, ok := regionHist[keyID]; ok {
+			return len(hist)
+		}
+	}
+
+	return 0
+}
+
+// ForceRotateForTest rotates the key material for keyID, bypassing the
+// on-demand rate limit. Used in tests to drive the history cap.
+func (b *InMemoryBackend) ForceRotateForTest(keyID string) error {
+	b.mu.Lock("ForceRotateForTest")
+	defer b.mu.Unlock()
+
+	for region, regionKeys := range b.keys {
+		if key, ok := regionKeys[keyID]; ok {
+			return b.rotateKeyMaterialLocked(region, key, rotationTypeAWSKMS)
+		}
+	}
+
+	return fmt.Errorf("key %q not found", keyID)
 }

--- a/services/kms/leak_test.go
+++ b/services/kms/leak_test.go
@@ -16,7 +16,7 @@ func TestKeyMaterialHistory_CappedAtMax(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
+		name      string
 		rotations int
 	}{
 		{name: "at cap", rotations: kms.MaxKeyMaterialHistoryEntriesForTest},
@@ -35,9 +35,10 @@ func TestKeyMaterialHistory_CappedAtMax(t *testing.T) {
 			require.NoError(t, err)
 			keyID := out.KeyMetadata.KeyID
 
+			var rotErr error
 			for i := range tc.rotations {
-				err := b.ForceRotateForTest(keyID)
-				require.NoError(t, err, "rotation %d must succeed", i)
+				rotErr = b.ForceRotateForTest(keyID)
+				require.NoError(t, rotErr, "rotation %d must succeed", i)
 			}
 
 			histLen := b.KeyMaterialHistoryLenForTest(keyID)

--- a/services/kms/leak_test.go
+++ b/services/kms/leak_test.go
@@ -1,0 +1,80 @@
+package kms_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/kms"
+)
+
+// TestKeyMaterialHistory_CappedAtMax verifies that rotating a key more than
+// maxKeyMaterialHistoryEntries times does not grow the history slice beyond the
+// cap, preventing unbounded memory growth on long-lived mock instances.
+func TestKeyMaterialHistory_CappedAtMax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rotations int
+	}{
+		{name: "at cap", rotations: kms.MaxKeyMaterialHistoryEntriesForTest},
+		{name: "one over cap", rotations: kms.MaxKeyMaterialHistoryEntriesForTest + 1},
+		{name: "well over cap", rotations: kms.MaxKeyMaterialHistoryEntriesForTest + 20},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			b := kms.NewInMemoryBackend()
+
+			out, err := b.CreateKey(ctx, &kms.CreateKeyInput{})
+			require.NoError(t, err)
+			keyID := out.KeyMetadata.KeyID
+
+			for i := range tc.rotations {
+				err := b.ForceRotateForTest(keyID)
+				require.NoError(t, err, "rotation %d must succeed", i)
+			}
+
+			histLen := b.KeyMaterialHistoryLenForTest(keyID)
+			require.LessOrEqual(t, histLen, kms.MaxKeyMaterialHistoryEntriesForTest,
+				"key material history must not exceed the cap after %d rotations", tc.rotations)
+		})
+	}
+}
+
+// TestKeyMaterialHistory_OldestMaterialDropped verifies that when the history
+// cap is reached, the oldest entries are dropped (not the newest), so that
+// decrypt operations against recently-rotated keys still work.
+func TestKeyMaterialHistory_OldestMaterialDropped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b := kms.NewInMemoryBackend()
+
+	out, err := b.CreateKey(ctx, &kms.CreateKeyInput{})
+	require.NoError(t, err)
+	keyID := out.KeyMetadata.KeyID
+
+	// Rotate past the cap.
+	extra := 5
+	for i := range kms.MaxKeyMaterialHistoryEntriesForTest + extra {
+		require.NoError(t, b.ForceRotateForTest(keyID), "rotation %d", i)
+	}
+
+	// Encryption with the current key must still work after excess rotations.
+	enc, err := b.Encrypt(ctx, &kms.EncryptInput{
+		KeyID:     keyID,
+		Plaintext: []byte("hello"),
+	})
+	require.NoError(t, err)
+
+	_, err = b.Decrypt(ctx, &kms.DecryptInput{
+		CiphertextBlob: enc.CiphertextBlob,
+	})
+	require.NoError(t, err, "decrypt must succeed — current key material must remain accessible")
+}

--- a/services/stepfunctions/backend.go
+++ b/services/stepfunctions/backend.go
@@ -63,6 +63,12 @@ const (
 	// maxActivityNameLen is the AWS limit on activity name length.
 	maxActivityNameLen = 80
 
+	// executionPruneSweepThreshold is the number of stored executions above which
+	// StartExecution opportunistically prunes finished executions that have aged
+	// past the retention period. Keeps the execution map bounded even when the
+	// background janitor is disabled.
+	executionPruneSweepThreshold = 500
+
 	statusRunning   = "RUNNING"
 	statusSucceeded = "SUCCEEDED"
 	statusFailed    = "FAILED"
@@ -475,9 +481,14 @@ func (b *InMemoryBackend) PruneExecutions(_ context.Context) int {
 	b.mu.Lock("PruneExecutions")
 	defer b.mu.Unlock()
 
+	return b.pruneExecutionsLocked(cutoff)
+}
+
+// pruneExecutionsLocked removes finished executions older than cutoff (Unix seconds).
+// Must be called with b.mu held for writing.
+func (b *InMemoryBackend) pruneExecutionsLocked(cutoff float64) int {
 	var toDelete []string
 	for arn, exec := range b.executions {
-		// Only prune finished executions.
 		if exec.Status != statusRunning && exec.StopDate != nil && *exec.StopDate < cutoff {
 			toDelete = append(toDelete, arn)
 		}
@@ -489,7 +500,6 @@ func (b *InMemoryBackend) PruneExecutions(_ context.Context) int {
 		delete(b.executionDefinitions, arn)
 		delete(b.historyTruncated, arn)
 
-		// Remove from smExecutions index.
 		for smARN, execs := range b.smExecutions {
 			for i, e := range execs {
 				if e == arn {
@@ -761,6 +771,17 @@ func (b *InMemoryBackend) StartExecution(stateMachineArn, name, input string) (*
 	}
 
 	b.mu.Lock("StartExecution")
+
+	// Opportunistically prune finished executions that have aged past the retention
+	// period so the executions/history maps stay bounded when the janitor is off.
+	if len(b.executions) >= executionPruneSweepThreshold {
+		retention := b.settings.ExecutionRetention
+		if retention == 0 {
+			retention = defaultExecutionRetention
+		}
+
+		b.pruneExecutionsLocked(float64(time.Now().Add(-retention).Unix()))
+	}
 
 	sm, exists := b.stateMachines[stateMachineArn]
 	if !exists {

--- a/services/stepfunctions/export_test.go
+++ b/services/stepfunctions/export_test.go
@@ -98,3 +98,32 @@ func (b *InMemoryBackend) TaskTokensForTest() []string {
 
 	return tokens
 }
+
+// ExecutionPruneSweepThresholdForTest exposes the inline-sweep threshold.
+const ExecutionPruneSweepThresholdForTest = executionPruneSweepThreshold
+
+// SetExecutionStopDateForTest directly sets the StopDate of an execution to
+// force it past the retention cutoff without sleeping.
+func (b *InMemoryBackend) SetExecutionStopDateForTest(execARN string, stopDate float64) {
+	b.mu.Lock("SetExecutionStopDateForTest")
+	defer b.mu.Unlock()
+
+	if exec, ok := b.executions[execARN]; ok {
+		exec.StopDate = &stopDate
+		exec.Status = statusSucceeded
+	}
+}
+
+// PendingTaskQueueLenForTest returns the number of entries in the pending task
+// queue for the given activity ARN, or -1 if the queue does not exist.
+func (b *InMemoryBackend) PendingTaskQueueLenForTest(activityARN string) int {
+	b.mu.RLock("PendingTaskQueueLenForTest")
+	defer b.mu.RUnlock()
+
+	q, ok := b.pendingTaskQueues[activityARN]
+	if !ok {
+		return -1
+	}
+
+	return len(q)
+}

--- a/services/stepfunctions/leak_test.go
+++ b/services/stepfunctions/leak_test.go
@@ -1,0 +1,137 @@
+package stepfunctions_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	sfn "github.com/blackbirdworks/gopherstack/services/stepfunctions"
+)
+
+const passDefinitionForLeak = `{
+"StartAt": "P",
+"States": {
+"P": {"Type": "Pass", "End": true}
+}
+}`
+
+// TestDeleteActivity_ClosesChannelAndEvictsTokens verifies that deleting an
+// activity closes its pending task queue channel and removes all associated
+// task tokens from tasksByToken, preventing goroutine leaks when the janitor
+// is disabled.
+func TestDeleteActivity_ClosesChannelAndEvictsTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		activities int
+	}{
+		{name: "single activity", activities: 1},
+		{name: "multiple activities", activities: 4},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			b := sfn.NewInMemoryBackendWithContext(ctx, "123456789012", "us-east-1")
+
+			arns := make([]string, 0, tc.activities)
+			for i := range tc.activities {
+				act, err := b.CreateActivity(ctx, fmt.Sprintf("activity-%d", i))
+				require.NoError(t, err)
+				arns = append(arns, act.ActivityArn)
+			}
+
+			// Verify queues exist before delete.
+			for _, arn := range arns {
+				require.GreaterOrEqual(t, b.PendingTaskQueueLenForTest(arn), 0,
+					"task queue must exist before delete")
+			}
+
+			for _, arn := range arns {
+				require.NoError(t, b.DeleteActivity(arn))
+			}
+
+			// After delete, queues must not exist.
+			for _, arn := range arns {
+				require.Equal(t, -1, b.PendingTaskQueueLenForTest(arn),
+					"task queue must be removed after DeleteActivity")
+			}
+		})
+	}
+}
+
+// TestStartExecution_InlinePrunesOldExecutions verifies that StartExecution
+// opportunistically removes finished executions that have aged past the
+// retention period when the execution count exceeds the inline-sweep threshold,
+// keeping the executions and history maps bounded even without the janitor.
+func TestStartExecution_InlinePrunesOldExecutions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b := sfn.NewInMemoryBackendWithContext(ctx, "123456789012", "us-east-1")
+
+	const roleARN = "arn:aws:iam::123456789012:role/r"
+	sm, err := b.CreateStateMachine(ctx, "pruner-sm", passDefinitionForLeak, roleARN, "STANDARD")
+	require.NoError(t, err)
+
+	threshold := sfn.ExecutionPruneSweepThresholdForTest
+
+	// Create enough executions to reach the threshold and mark them all as
+	// SUCCEEDED with a StopDate well in the past so they qualify for pruning.
+	pastStop := float64(time.Now().Add(-48 * time.Hour).Unix())
+
+	var startErr error
+	var startExec *sfn.Execution
+	for i := range threshold {
+		startExec, startErr = b.StartExecution(sm.StateMachineArn, fmt.Sprintf("exec-%d", i), `{}`)
+		require.NoError(t, startErr)
+		b.SetExecutionStopDateForTest(startExec.ExecutionArn, pastStop)
+	}
+
+	require.Equal(t, threshold, b.ExecutionCount(),
+		"execution count must equal threshold before the sweep-triggering start")
+
+	// One more StartExecution must trigger the inline prune because
+	// len(b.executions) >= executionPruneSweepThreshold.
+	_, err = b.StartExecution(sm.StateMachineArn, "trigger-exec", `{}`)
+	require.NoError(t, err)
+
+	// All threshold executions were expired; only "trigger-exec" survives.
+	require.Equal(t, 1, b.ExecutionCount(),
+		"expired executions must be pruned inline on StartExecution")
+}
+
+// TestStartExecution_BelowThresholdNoEagerPrune confirms that inline pruning
+// is a no-op below the threshold so steady-state starts stay cheap.
+func TestStartExecution_BelowThresholdNoEagerPrune(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b := sfn.NewInMemoryBackendWithContext(ctx, "123456789012", "us-east-1")
+
+	sm, err := b.CreateStateMachine(
+		ctx, "no-prune-sm", passDefinitionForLeak, "arn:aws:iam::123456789012:role/r", "STANDARD",
+	)
+	require.NoError(t, err)
+
+	pastStop := float64(time.Now().Add(-48 * time.Hour).Unix())
+	belowThreshold := sfn.ExecutionPruneSweepThresholdForTest - 1
+
+	var btErr error
+	var btExec *sfn.Execution
+	for i := range belowThreshold {
+		btExec, btErr = b.StartExecution(sm.StateMachineArn, fmt.Sprintf("old-exec-%d", i), `{}`)
+		require.NoError(t, btErr)
+		b.SetExecutionStopDateForTest(btExec.ExecutionArn, pastStop)
+	}
+
+	// Below threshold: no eager prune, so expired entries remain.
+	require.Equal(t, belowThreshold, b.ExecutionCount(),
+		"below-threshold start must not eagerly prune expired executions")
+}


### PR DESCRIPTION
parity.md §D — resource-leak fixes: stop ACM cert timers on delete, close StepFn pendingTaskQueues channels + evict stale tokens, evict S3 object-lambda sync.Map, cap SSM history/docs/commands, DynamoDB iterator eviction, KMS material retention, EventBridge/ECR/CloudWatch caps. No stubs. 🤖 mayor