### PR TITLE
parity §A: Lambda ListFunctionVersionsByCapacityProvider real impl (recovered)

### DIFF
--- a/services/lambda/handler.go
+++ b/services/lambda/handler.go
@@ -3390,7 +3390,9 @@ func (h *Handler) handleCapacityProviderRoute(c *echo.Context, path, method stri
 
 	// /2025-11-30/capacity-providers/{name}/function-versions → ListFunctionVersionsByCapacityProvider
 	if strings.HasSuffix(rest, "/function-versions") && method == http.MethodGet {
-		return h.handleListFunctionVersionsByCapacityProvider(c)
+		cpName := strings.TrimSuffix(rest, "/function-versions")
+
+		return h.handleListFunctionVersionsByCapacityProvider(c, lambdaBk, cpName)
 	}
 
 	// /2025-11-30/capacity-providers/{name} → Get / Delete / Update

--- a/services/lambda/handler_stubs.go
+++ b/services/lambda/handler_stubs.go
@@ -193,15 +193,24 @@ func (h *Handler) handleStopDurableExecution(c *echo.Context) error {
 	return c.JSON(http.StatusOK, ex)
 }
 
-// --- ListFunctionVersionsByCapacityProvider stub ---
+// --- ListFunctionVersionsByCapacityProvider ---
 
 type listFunctionVersionsByCapacityProviderOutput struct {
 	NextMarker       string `json:"NextMarker,omitempty"`
 	FunctionVersions []any  `json:"FunctionVersions"`
 }
 
-// handleListFunctionVersionsByCapacityProvider returns an empty list stub.
-func (h *Handler) handleListFunctionVersionsByCapacityProvider(c *echo.Context) error {
+// handleListFunctionVersionsByCapacityProvider returns function versions assigned to the
+// named capacity provider. Since there is currently no API to assign function versions
+// to a capacity provider, this always returns an empty list for a valid provider.
+func (h *Handler) handleListFunctionVersionsByCapacityProvider(
+	c *echo.Context, bk *InMemoryBackend, name string,
+) error {
+	if _, err := bk.GetCapacityProvider(name); err != nil {
+		return h.writeError(c, http.StatusNotFound, "ResourceNotFoundException",
+			"Capacity provider not found: "+name)
+	}
+
 	return c.JSON(http.StatusOK, &listFunctionVersionsByCapacityProviderOutput{
 		FunctionVersions: []any{},
 	})

--- a/services/lambda/new_ops_test.go
+++ b/services/lambda/new_ops_test.go
@@ -470,6 +470,60 @@ func TestNewOps_CapacityProvider_GetDeleteUpdateList(t *testing.T) {
 	assert.Empty(t, listOut2.CapacityProviders)
 }
 
+// --- ListFunctionVersionsByCapacityProvider tests ---
+
+func TestNewOps_ListFunctionVersionsByCapacityProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cpName     string
+		wantStatus int
+		setup      bool // create the CP before the list call
+		wantEmpty  bool
+	}{
+		{
+			name:       "exists_returns_empty_list",
+			cpName:     "my-cp",
+			setup:      true,
+			wantStatus: http.StatusOK,
+			wantEmpty:  true,
+		},
+		{
+			name:       "not_found_returns_404",
+			cpName:     "nonexistent-cp",
+			setup:      false,
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, _ := newInMemoryHandler(t)
+
+			if tt.setup {
+				rec := callInMemoryHandler(t, h, http.MethodPost, "/2025-11-30/capacity-providers",
+					`{"Name":"`+tt.cpName+`","TargetOnDemandConcurrency":100}`)
+				require.Equal(t, http.StatusCreated, rec.Code)
+			}
+
+			rec := callInMemoryHandler(t, h, http.MethodGet,
+				"/2025-11-30/capacity-providers/"+tt.cpName+"/function-versions", "")
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantEmpty {
+				var out struct {
+					FunctionVersions []any `json:"FunctionVersions"`
+				}
+				require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+				assert.Empty(t, out.FunctionVersions)
+			}
+		})
+	}
+}
+
 // --- CheckpointDurableExecution tests ---
 
 func TestNewOps_CheckpointDurableExecution(t *testing.T) {
@@ -691,6 +745,7 @@ func TestNewOps_GetSupportedOperations(t *testing.T) {
 		"ListCodeSigningConfigs",
 		"ListFunctionsByCodeSigningConfig",
 		"ListFunctionUrlConfigs",
+		"ListFunctionVersionsByCapacityProvider",
 		"PutFunctionCodeSigningConfig",
 		"UpdateCapacityProvider",
 		"UpdateCodeSigningConfig",


### PR DESCRIPTION
parity.md §A — Lambda capacity-provider op with real validation + tests. Recovered from orphaned jasper branch (4f07bcde). 🤖 mayor