### PR TITLE
parity §C+§D: resource-leak fixes + hot-path perf (go-dtth)

### DIFF
--- a/services/pinpoint/backend_ops.go
+++ b/services/pinpoint/backend_ops.go
@@ -35,6 +35,10 @@ const (
 	// maxAppEvents caps the number of ingested events retained per application so
 	// PutEvents cannot grow the appEvents slice without bound on a long-lived app.
 	maxAppEvents = 10000
+
+	// maxTemplateVersions caps the number of stored template versions per
+	// template so Update* calls cannot grow templateVersionHistory without bound.
+	maxTemplateVersions = 100
 )
 
 // ──────────────────────────────────────────────────
@@ -231,6 +235,10 @@ func (b *InMemoryBackend) UpdateVoiceTemplate(
 			TemplateVersion: nextVersion,
 		},
 	)
+
+	if h := b.templateVersionHistory[versionKey]; len(h) > maxTemplateVersions {
+		b.templateVersionHistory[versionKey] = h[len(h)-maxTemplateVersions:]
+	}
 
 	cp := *t
 	cp.Tags = nonNilTagsCopy(t.Tags)
@@ -468,6 +476,7 @@ func (b *InMemoryBackend) DeleteCampaign(appID, campaignID string) (*Campaign, e
 
 	delete(b.campaigns, campaignID)
 	delete(b.arnIndex, c.ARN)
+	delete(b.campaignVersions, appID+"/"+campaignID)
 
 	return cloneCampaign(c), nil
 }
@@ -565,6 +574,7 @@ func (b *InMemoryBackend) DeleteSegment(appID, segmentID string) (*Segment, erro
 
 	delete(b.segments, segmentID)
 	delete(b.arnIndex, s.ARN)
+	delete(b.segmentVersions, appID+"/"+segmentID)
 
 	return cloneSegment(s), nil
 }
@@ -786,6 +796,10 @@ func (b *InMemoryBackend) UpdateEmailTemplate(
 		},
 	)
 
+	if h := b.templateVersionHistory[versionKey]; len(h) > maxTemplateVersions {
+		b.templateVersionHistory[versionKey] = h[len(h)-maxTemplateVersions:]
+	}
+
 	if req.Subject != "" {
 		t.Subject = req.Subject
 	}
@@ -828,6 +842,7 @@ func (b *InMemoryBackend) DeleteEmailTemplate(templateName string) (*EmailTempla
 
 	delete(b.emailTemplates, templateName)
 	delete(b.arnIndex, t.ARN)
+	delete(b.templateVersionHistory, templateName+"/"+ChannelTypeEmail)
 
 	return cloneEmailTemplate(t), nil
 }
@@ -869,6 +884,10 @@ func (b *InMemoryBackend) UpdateInAppTemplate(
 		},
 	)
 
+	if h := b.templateVersionHistory[versionKey]; len(h) > maxTemplateVersions {
+		b.templateVersionHistory[versionKey] = h[len(h)-maxTemplateVersions:]
+	}
+
 	if len(req.Content) > 0 {
 		t.Content = cloneContentSlice(req.Content)
 	}
@@ -899,6 +918,7 @@ func (b *InMemoryBackend) DeleteInAppTemplate(templateName string) (*InAppTempla
 
 	delete(b.inAppTemplates, templateName)
 	delete(b.arnIndex, t.ARN)
+	delete(b.templateVersionHistory, templateName+"/"+templateTypeINAPP)
 
 	return cloneInAppTemplate(t), nil
 }
@@ -939,6 +959,10 @@ func (b *InMemoryBackend) UpdatePushTemplate(
 			TemplateVersion: nextVersion,
 		},
 	)
+
+	if h := b.templateVersionHistory[versionKey]; len(h) > maxTemplateVersions {
+		b.templateVersionHistory[versionKey] = h[len(h)-maxTemplateVersions:]
+	}
 
 	if req.Body != "" {
 		t.Body = req.Body
@@ -982,6 +1006,7 @@ func (b *InMemoryBackend) DeletePushTemplate(templateName string) (*PushTemplate
 
 	delete(b.pushTemplates, templateName)
 	delete(b.arnIndex, t.ARN)
+	delete(b.templateVersionHistory, templateName+"/"+templateTypePUSH)
 
 	return clonePushTemplate(t), nil
 }
@@ -1023,6 +1048,10 @@ func (b *InMemoryBackend) UpdateSmsTemplate(
 		},
 	)
 
+	if h := b.templateVersionHistory[versionKey]; len(h) > maxTemplateVersions {
+		b.templateVersionHistory[versionKey] = h[len(h)-maxTemplateVersions:]
+	}
+
 	if req.Body != "" {
 		t.Body = req.Body
 	}
@@ -1053,6 +1082,7 @@ func (b *InMemoryBackend) DeleteSmsTemplate(templateName string) (*SmsTemplate, 
 
 	delete(b.smsTemplates, templateName)
 	delete(b.arnIndex, t.ARN)
+	delete(b.templateVersionHistory, templateName+"/"+ChannelTypeSMS)
 
 	return cloneSmsTemplate(t), nil
 }

--- a/services/pinpoint/export_test.go
+++ b/services/pinpoint/export_test.go
@@ -5,6 +5,9 @@ import "strconv"
 // MaxAppEvents exposes the per-app event cap for tests.
 const MaxAppEvents = maxAppEvents
 
+// MaxTemplateVersions exposes the template version cap for tests.
+const MaxTemplateVersions = maxTemplateVersions
+
 // TotalPerAppEntries counts every entry across the per-application maps so a
 // leak (an entry surviving DeleteApp) shows up as a non-zero delta from
 // baseline in tests.
@@ -36,6 +39,16 @@ func CreateCampaignForTest(b *InMemoryBackend, region, accountID, appID string) 
 	return err
 }
 
+// CreateCampaignIDForTest creates a campaign and returns its ID.
+func CreateCampaignIDForTest(b *InMemoryBackend, region, accountID, appID string) (string, error) {
+	c, err := b.CreateCampaign(region, accountID, appID, createCampaignRequest{})
+	if err != nil {
+		return "", err
+	}
+
+	return c.ID, nil
+}
+
 // CreateSegmentForTest creates a segment for the app using a minimal request.
 func CreateSegmentForTest(b *InMemoryBackend, region, accountID, appID string) error {
 	_, err := b.CreateSegment(region, accountID, appID, createSegmentRequest{})
@@ -43,9 +56,64 @@ func CreateSegmentForTest(b *InMemoryBackend, region, accountID, appID string) e
 	return err
 }
 
+// CreateSegmentIDForTest creates a segment and returns its ID.
+func CreateSegmentIDForTest(b *InMemoryBackend, region, accountID, appID string) (string, error) {
+	s, err := b.CreateSegment(region, accountID, appID, createSegmentRequest{})
+	if err != nil {
+		return "", err
+	}
+
+	return s.ID, nil
+}
+
 // CreateJourneyForTest creates a journey for the app using a minimal request.
 func CreateJourneyForTest(b *InMemoryBackend, region, accountID, appID string) error {
 	_, err := b.CreateJourney(region, accountID, appID, createJourneyRequest{})
+
+	return err
+}
+
+// TemplateVersionCount returns the number of stored versions for a template.
+func TemplateVersionCount(b *InMemoryBackend, templateName, templateType string) int {
+	b.mu.RLock("TemplateVersionCount")
+	defer b.mu.RUnlock()
+
+	return len(b.templateVersionHistory[templateName+"/"+templateType])
+}
+
+// CampaignVersionCount returns the number of stored version entries for a campaign.
+func CampaignVersionCount(b *InMemoryBackend, appID, campaignID string) int {
+	b.mu.RLock("CampaignVersionCount")
+	defer b.mu.RUnlock()
+
+	return len(b.campaignVersions[appID+"/"+campaignID])
+}
+
+// SegmentVersionCount returns the number of stored version entries for a segment.
+func SegmentVersionCount(b *InMemoryBackend, appID, segmentID string) int {
+	b.mu.RLock("SegmentVersionCount")
+	defer b.mu.RUnlock()
+
+	return len(b.segmentVersions[appID+"/"+segmentID])
+}
+
+// CreateEmailTemplateForTest creates an email template with the given name.
+func CreateEmailTemplateForTest(b *InMemoryBackend, region, accountID, templateName string) error {
+	_, err := b.CreateEmailTemplate(region, accountID, templateName, createEmailTemplateRequest{})
+
+	return err
+}
+
+// DeleteEmailTemplateForTest deletes an email template by name.
+func DeleteEmailTemplateForTest(b *InMemoryBackend, templateName string) error {
+	_, err := b.DeleteEmailTemplate(templateName)
+
+	return err
+}
+
+// UpdateEmailTemplateForTest updates an email template (increments its version).
+func UpdateEmailTemplateForTest(b *InMemoryBackend, templateName string) error {
+	_, err := b.UpdateEmailTemplate(templateName, createEmailTemplateRequest{})
 
 	return err
 }

--- a/services/pinpoint/leak_test.go
+++ b/services/pinpoint/leak_test.go
@@ -82,3 +82,84 @@ func TestPutEvents_CapsAppEvents(t *testing.T) {
 	require.LessOrEqual(t, pinpoint.AppEventCount(b, app.ID), pinpoint.MaxAppEvents,
 		"retained events must not exceed the cap")
 }
+
+// TestDeleteCampaign_ReleasesVersionHistory verifies that deleting a campaign
+// removes its version history entry so the campaignVersions map returns to baseline.
+func TestDeleteCampaign_ReleasesVersionHistory(t *testing.T) {
+	t.Parallel()
+
+	b := pinpoint.NewInMemoryBackend(leakRegion, leakAccountID)
+	app, err := b.CreateApp(leakRegion, leakAccountID, "campaign-leak-app", nil)
+	require.NoError(t, err)
+
+	campaignID, err := pinpoint.CreateCampaignIDForTest(b, leakRegion, leakAccountID, app.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, pinpoint.CampaignVersionCount(b, app.ID, campaignID),
+		"version entry must exist after create")
+
+	_, err = b.DeleteCampaign(app.ID, campaignID)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, pinpoint.CampaignVersionCount(b, app.ID, campaignID),
+		"version entry must be removed after delete")
+}
+
+// TestDeleteSegment_ReleasesVersionHistory verifies that deleting a segment
+// removes its version history entry so the segmentVersions map returns to baseline.
+func TestDeleteSegment_ReleasesVersionHistory(t *testing.T) {
+	t.Parallel()
+
+	b := pinpoint.NewInMemoryBackend(leakRegion, leakAccountID)
+	app, err := b.CreateApp(leakRegion, leakAccountID, "segment-leak-app", nil)
+	require.NoError(t, err)
+
+	segmentID, err := pinpoint.CreateSegmentIDForTest(b, leakRegion, leakAccountID, app.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, pinpoint.SegmentVersionCount(b, app.ID, segmentID),
+		"version entry must exist after create")
+
+	_, err = b.DeleteSegment(app.ID, segmentID)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, pinpoint.SegmentVersionCount(b, app.ID, segmentID),
+		"version entry must be removed after delete")
+}
+
+// TestDeleteEmailTemplate_ReleasesVersionHistory verifies that deleting a template
+// removes its version history from templateVersionHistory.
+func TestDeleteEmailTemplate_ReleasesVersionHistory(t *testing.T) {
+	t.Parallel()
+
+	b := pinpoint.NewInMemoryBackend(leakRegion, leakAccountID)
+
+	require.NoError(t, pinpoint.CreateEmailTemplateForTest(b, leakRegion, leakAccountID, "my-tpl"))
+
+	require.Equal(t, 1, pinpoint.TemplateVersionCount(b, "my-tpl", "EMAIL"),
+		"version entry must exist after create")
+
+	require.NoError(t, pinpoint.DeleteEmailTemplateForTest(b, "my-tpl"))
+
+	require.Equal(t, 0, pinpoint.TemplateVersionCount(b, "my-tpl", "EMAIL"),
+		"version history must be removed after delete")
+}
+
+// TestUpdateEmailTemplate_CapsVersionHistory verifies that repeated updates to a
+// template do not grow templateVersionHistory beyond maxTemplateVersions.
+func TestUpdateEmailTemplate_CapsVersionHistory(t *testing.T) {
+	t.Parallel()
+
+	b := pinpoint.NewInMemoryBackend(leakRegion, leakAccountID)
+
+	require.NoError(t, pinpoint.CreateEmailTemplateForTest(b, leakRegion, leakAccountID, "cap-tpl"))
+
+	const updates = pinpoint.MaxTemplateVersions * 2
+	for range updates {
+		require.NoError(t, pinpoint.UpdateEmailTemplateForTest(b, "cap-tpl"))
+	}
+
+	count := pinpoint.TemplateVersionCount(b, "cap-tpl", "EMAIL")
+	require.LessOrEqual(t, count, pinpoint.MaxTemplateVersions,
+		"template version history must not exceed the cap")
+}


### PR DESCRIPTION
Implements parity.md §C (hot-path perf) + §D (resource leaks). Bead go-dtth. PR auto-creation failed during gt done (bead-store exit 128); opened manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)