### PR TITLE
parity: high-severity stub elimination (audit remediation)

### DIFF
--- a/services/inspector2/backend.go
+++ b/services/inspector2/backend.go
@@ -812,6 +812,7 @@ func (b *InMemoryBackend) Reset() {
 	b.filters = make(map[string]*Filter)
 	b.findings = make(map[string]*storedFinding)
 	b.tags = make(map[string]map[string]string)
+	b.ax = newAppendixAState()
 	b.config = Configuration{
 		Ec2ScanMode:       ec2ScanModeEC2SSMAgentBased,
 		EcrRescanDuration: ecrRescanDurationLifetime,
@@ -823,6 +824,7 @@ type backendSnapshot struct {
 	Filters   map[string]*Filter           `json:"filters"`
 	Findings  map[string]*storedFinding    `json:"findings"`
 	Tags      map[string]map[string]string `json:"tags"`
+	Appendix  *appendixAState              `json:"appendix"`
 	Config    Configuration                `json:"config"`
 	AccountID string                       `json:"accountId"`
 	Region    string                       `json:"region"`
@@ -838,6 +840,7 @@ func (b *InMemoryBackend) Snapshot() []byte {
 		Filters:   b.filters,
 		Findings:  b.findings,
 		Tags:      b.tags,
+		Appendix:  b.ax,
 		Config:    b.config,
 		Enabled:   b.enabled,
 		AccountID: b.accountID,
@@ -869,6 +872,10 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 
 	if b.findings == nil {
 		b.findings = make(map[string]*storedFinding)
+	}
+
+	if snap.Appendix != nil {
+		b.ax = snap.Appendix
 	}
 
 	return nil

--- a/services/inspector2/backend_appendixa.go
+++ b/services/inspector2/backend_appendixa.go
@@ -36,6 +36,21 @@ var (
 	ErrCisSessionNotFound = awserr.New(errResourceNotFound, awserr.ErrNotFound)
 )
 
+// CIS scan and check status values (AWS Inspector2 CIS API).
+const (
+	cisScanStatusCompleted = "COMPLETED"
+
+	cisCheckStatusPassed = "PASSED"
+	cisCheckStatusFailed = "FAILED"
+
+	cisLevel1        = "LEVEL_1"
+	cisPlatform      = "AMAZON_LINUX_2"
+	cisReportSuccess = "SUCCEEDED"
+
+	keyScanArn  = "scanArn"
+	keyPlatform = "platform"
+)
+
 // --- domain types ---
 
 // Member represents an Inspector2 member account.
@@ -102,6 +117,35 @@ type CisSession struct {
 	ScanJobID    string    `json:"scanJobId"`
 	SessionToken string    `json:"sessionToken"`
 	Status       string    `json:"status"`
+}
+
+// CisCheckResult is a single CIS benchmark check outcome for one target resource.
+type CisCheckResult struct {
+	CheckID      string `json:"checkId"`
+	CheckDescr   string `json:"checkDescription"`
+	Level        string `json:"level"`
+	Platform     string `json:"platform"`
+	Status       string `json:"status"`
+	TargetID     string `json:"targetResourceId"`
+	AccountID    string `json:"accountId"`
+	StatusReason string `json:"statusReason,omitempty"`
+}
+
+// CisScan is a completed CIS scan run produced from a scan configuration. It
+// carries the per-check results so the report, result-detail and aggregation
+// operations all derive from the same stored state rather than canned data.
+type CisScan struct {
+	ScheduledAt          time.Time         `json:"scheduledBy"`
+	FinishedAt           time.Time         `json:"finishedAt"`
+	ScanArn              string            `json:"scanArn"`
+	ScanConfigurationArn string            `json:"scanConfigurationArn"`
+	ScanName             string            `json:"scanName"`
+	Status               string            `json:"status"`
+	SecurityLevel        string            `json:"securityLevel"`
+	TargetAccountID      string            `json:"targetAccountId"`
+	Results              []*CisCheckResult `json:"results"`
+	TotalChecks          int               `json:"totalChecks"`
+	FailedChecks         int               `json:"failedChecks"`
 }
 
 // CodeSecurityIntegration represents a code security integration.
@@ -184,21 +228,22 @@ type AccountPermission struct {
 
 // appendixAState holds all appendix A data.
 type appendixAState struct {
-	CodeSecurityIntegrations map[string]*CodeSecurityIntegration
-	CisScanConfigs           map[string]*CisScanConfiguration
-	SbomExports              map[string]*SbomExport
-	FindingsReports          map[string]*FindingsReport
-	CodeSecurityScans        map[string]map[string]any
-	MemberEc2Status          map[string]*MemberEc2DeepInspectionStatus
-	DelegatedAdmins          map[string]*DelegatedAdminAccount
-	CodeSecurityScanConfigs  map[string]*CodeSecurityScanConfiguration
-	EncryptionKeys           map[string]*EncryptionKey
-	Members                  map[string]*Member
-	CisSessions              map[string]*CisSession
-	ScanConfigAssociations   map[string][]*CodeSecurityScanConfigurationAssociation
-	Ec2DeepConfig            Ec2DeepInspectionConfig
-	OrgEc2Config             OrgEc2DeepInspectionConfig
-	OrgConfig                OrgConfiguration
+	CodeSecurityIntegrations map[string]*CodeSecurityIntegration                    `json:"codeSecurityIntegrations"`
+	CisScanConfigs           map[string]*CisScanConfiguration                       `json:"cisScanConfigs"`
+	CisScans                 map[string]*CisScan                                    `json:"cisScans"`
+	SbomExports              map[string]*SbomExport                                 `json:"sbomExports"`
+	FindingsReports          map[string]*FindingsReport                             `json:"findingsReports"`
+	CodeSecurityScans        map[string]map[string]any                              `json:"codeSecurityScans"`
+	MemberEc2Status          map[string]*MemberEc2DeepInspectionStatus              `json:"memberEc2Status"`
+	DelegatedAdmins          map[string]*DelegatedAdminAccount                      `json:"delegatedAdmins"`
+	CodeSecurityScanConfigs  map[string]*CodeSecurityScanConfiguration              `json:"codeSecurityScanConfigs"`
+	EncryptionKeys           map[string]*EncryptionKey                              `json:"encryptionKeys"`
+	Members                  map[string]*Member                                     `json:"members"`
+	CisSessions              map[string]*CisSession                                 `json:"cisSessions"`
+	ScanConfigAssociations   map[string][]*CodeSecurityScanConfigurationAssociation `json:"scanConfigAssociations"`
+	Ec2DeepConfig            Ec2DeepInspectionConfig                                `json:"ec2DeepConfig"`
+	OrgEc2Config             OrgEc2DeepInspectionConfig                             `json:"orgEc2Config"`
+	OrgConfig                OrgConfiguration                                       `json:"orgConfig"`
 }
 
 func newAppendixAState() *appendixAState {
@@ -208,6 +253,7 @@ func newAppendixAState() *appendixAState {
 		MemberEc2Status:          make(map[string]*MemberEc2DeepInspectionStatus),
 		EncryptionKeys:           make(map[string]*EncryptionKey),
 		CisScanConfigs:           make(map[string]*CisScanConfiguration),
+		CisScans:                 make(map[string]*CisScan),
 		CisSessions:              make(map[string]*CisSession),
 		CodeSecurityIntegrations: make(map[string]*CodeSecurityIntegration),
 		CodeSecurityScanConfigs:  make(map[string]*CodeSecurityScanConfiguration),
@@ -226,6 +272,10 @@ func newAppendixAState() *appendixAState {
 
 func (b *InMemoryBackend) buildCisScanConfigARN() string {
 	return arn.Build(inspector2Service, b.region, b.accountID, "cis-scan-configuration/"+uuid.New().String())
+}
+
+func (b *InMemoryBackend) buildCisScanARN() string {
+	return arn.Build(inspector2Service, b.region, b.accountID, "cis-scan/"+uuid.New().String())
 }
 
 func (b *InMemoryBackend) buildCodeSecurityIntegrationARN() string {
@@ -574,7 +624,106 @@ func (b *InMemoryBackend) CreateCisScanConfiguration(
 	}
 	b.ax.CisScanConfigs[cfgARN] = cfg
 
+	// Materialize a completed scan run for the config so the result/report/
+	// aggregation operations reflect real configuration state instead of canned
+	// data. Real AWS runs scans asynchronously on the configured schedule; we
+	// model the steady-state outcome at creation time.
+	scan := b.buildCisScanForConfig(cfg)
+	b.ax.CisScans[scan.ScanArn] = scan
+
 	return cfg, nil
+}
+
+// cisCheckCatalog is a small representative slice of the CIS benchmark checks
+// that a scan evaluates per target. Results are derived deterministically from
+// these so report/detail/aggregation operations stay internally consistent.
+func cisCheckCatalog() []CisCheckResult {
+	return []CisCheckResult{
+		{
+			CheckID:    "1.1.1",
+			CheckDescr: "Ensure mounting of cramfs filesystems is disabled",
+			Level:      cisLevel1,
+			Platform:   cisPlatform,
+			Status:     cisCheckStatusPassed,
+		},
+		{
+			CheckID:    "1.3.1",
+			CheckDescr: "Ensure AIDE is installed",
+			Level:      cisLevel1,
+			Platform:   cisPlatform,
+			Status:     cisCheckStatusFailed,
+		},
+		{
+			CheckID:    "5.2.1",
+			CheckDescr: "Ensure permissions on /etc/ssh/sshd_config are configured",
+			Level:      cisLevel1,
+			Platform:   cisPlatform,
+			Status:     cisCheckStatusPassed,
+		},
+	}
+}
+
+// cisTargetAccounts extracts the account IDs a scan targets, defaulting to the
+// backend account when the configuration does not name any.
+func (b *InMemoryBackend) cisTargetAccounts(targets map[string]any) []string {
+	var accounts []string
+
+	if raw, ok := targets["accountIds"].([]any); ok {
+		for _, v := range raw {
+			if id, isStr := v.(string); isStr && id != "" {
+				accounts = append(accounts, id)
+			}
+		}
+	}
+
+	if len(accounts) == 0 {
+		accounts = []string{b.accountID}
+	}
+
+	return accounts
+}
+
+// buildCisScanForConfig constructs a completed scan, including per-target check
+// results, from a scan configuration. Caller must hold the write lock.
+func (b *InMemoryBackend) buildCisScanForConfig(cfg *CisScanConfiguration) *CisScan {
+	now := time.Now().UTC()
+	accounts := b.cisTargetAccounts(cfg.Targets)
+	catalog := cisCheckCatalog()
+
+	results := make([]*CisCheckResult, 0, len(accounts)*len(catalog))
+	failed := 0
+
+	for _, acct := range accounts {
+		targetID := "i-" + uuid.New().String()[:17]
+
+		for i := range catalog {
+			res := catalog[i]
+			res.AccountID = acct
+			res.TargetID = targetID
+
+			if res.Status == cisCheckStatusFailed {
+				failed++
+				res.StatusReason = "remediation required"
+			}
+
+			rc := res
+			results = append(results, &rc)
+		}
+	}
+
+	return &CisScan{
+		ScanArn:              b.buildCisScanARN(),
+		ScanConfigurationArn: cfg.Arn,
+		ScanName:             cfg.Name,
+		Status:               cisScanStatusCompleted,
+		SecurityLevel:        cisLevel1,
+		ScheduledAt:          now,
+		FinishedAt:           now,
+		TargetAccountID:      accounts[0],
+		TotalChecks:          len(results),
+		FailedChecks:         failed,
+		Results:              results,
+	}
 }
 
 // DeleteCisScanConfiguration deletes a CIS scan configuration.
@@ -587,6 +736,14 @@ func (b *InMemoryBackend) DeleteCisScanConfiguration(configARN string) error {
 	}
 
 	delete(b.ax.CisScanConfigs, configARN)
+
+	// Drop any scans materialized from this configuration so list/result
+	// operations stop reporting them.
+	for scanARN, s := range b.ax.CisScans {
+		if s.ScanConfigurationArn == configARN {
+			delete(b.ax.CisScans, scanARN)
+		}
+	}
 
 	return nil
 }
@@ -690,34 +847,242 @@ func (b *InMemoryBackend) SendCisSessionTelemetry(_ string, _ map[string]any) er
 	return nil
 }
 
-// GetCisScanReport returns a stub CIS scan report.
-func (b *InMemoryBackend) GetCisScanReport(_ string) (map[string]any, error) {
+// findCisScan returns the stored scan for either its scan ARN or the ARN of the
+// configuration that produced it. Caller must hold at least an RLock.
+func (b *InMemoryBackend) findCisScan(scanOrConfigARN string) *CisScan {
+	if s, ok := b.ax.CisScans[scanOrConfigARN]; ok {
+		return s
+	}
+
+	for _, s := range b.ax.CisScans {
+		if s.ScanConfigurationArn == scanOrConfigARN {
+			return s
+		}
+	}
+
+	return nil
+}
+
+// GetCisScanReport returns the report for a completed CIS scan. The status and
+// counts are drawn from the stored scan produced by its configuration. For an
+// unrecognized scan ARN it returns a benign SUCCEEDED report with no findings,
+// matching AWS, which does not error on missing report targets.
+func (b *InMemoryBackend) GetCisScanReport(scanArn string) (map[string]any, error) {
+	b.mu.RLock("GetCisScanReport")
+	defer b.mu.RUnlock()
+
+	scan := b.findCisScan(scanArn)
+	if scan == nil {
+		return map[string]any{
+			keyStatus: cisReportSuccess,
+			"url":     "",
+		}, nil
+	}
+
 	return map[string]any{
-		"status": "SUCCEEDED", //nolint:goconst // existing issue.
-		"url":    "",
+		keyStatus:      cisReportSuccess,
+		"url":          "",
+		keyScanArn:     scan.ScanArn,
+		"totalChecks":  scan.TotalChecks,
+		"failedChecks": scan.FailedChecks,
 	}, nil
 }
 
-// GetCisScanResultDetails returns stub CIS scan result details.
-func (b *InMemoryBackend) GetCisScanResultDetails(_ string) (map[string]any, error) {
-	return map[string]any{
-		"checkResults": []any{},
-	}, nil
+// GetCisScanResultDetails returns the per-check results for a CIS scan. Results
+// reflect the scan generated for the configuration; an unknown scan ARN yields
+// an empty result set rather than an error (AWS behavior for absent scans).
+func (b *InMemoryBackend) GetCisScanResultDetails(scanArn string) (map[string]any, error) {
+	b.mu.RLock("GetCisScanResultDetails")
+	defer b.mu.RUnlock()
+
+	scan := b.findCisScan(scanArn)
+	if scan == nil {
+		return map[string]any{"checkResults": []any{}}, nil
+	}
+
+	checkResults := make([]map[string]any, 0, len(scan.Results))
+	for _, r := range scan.Results {
+		entry := map[string]any{
+			keyScanArn:         scan.ScanArn,
+			"checkId":          r.CheckID,
+			"checkDescription": r.CheckDescr,
+			"level":            r.Level,
+			keyPlatform:        r.Platform,
+			keyStatus:          r.Status,
+			keyAccountID:       r.AccountID,
+			"targetResourceId": r.TargetID,
+		}
+		if r.StatusReason != "" {
+			entry["statusReason"] = r.StatusReason
+		}
+
+		checkResults = append(checkResults, entry)
+	}
+
+	return map[string]any{"checkResults": checkResults}, nil
 }
 
-// ListCisScans returns stub CIS scans.
+// ListCisScans returns all completed CIS scans, sorted by scan ARN for stable
+// pagination-free ordering. Each entry summarizes the scan produced from a
+// configuration.
 func (b *InMemoryBackend) ListCisScans() ([]map[string]any, error) {
-	return []map[string]any{}, nil
+	b.mu.RLock("ListCisScans")
+	defer b.mu.RUnlock()
+
+	arns := make([]string, 0, len(b.ax.CisScans))
+	for a := range b.ax.CisScans {
+		arns = append(arns, a)
+	}
+
+	sort.Strings(arns)
+
+	result := make([]map[string]any, 0, len(arns))
+
+	for _, a := range arns {
+		s := b.ax.CisScans[a]
+		result = append(result, map[string]any{
+			keyScanArn:              s.ScanArn,
+			keyScanConfigurationArn: s.ScanConfigurationArn,
+			"scanName":              s.ScanName,
+			keyStatus:               s.Status,
+			"securityLevel":         s.SecurityLevel,
+			"scheduledBy":           s.ScheduledAt.Format(time.RFC3339),
+			"failedChecks":          s.FailedChecks,
+			"totalChecks":           s.TotalChecks,
+			"targetAccountId":       s.TargetAccountID,
+		})
+	}
+
+	return result, nil
 }
 
-// ListCisScanResultsAggregatedByChecks returns stub results.
-func (b *InMemoryBackend) ListCisScanResultsAggregatedByChecks(_ string) ([]map[string]any, error) {
-	return []map[string]any{}, nil
+// ListCisScanResultsAggregatedByChecks groups a scan's results by check ID,
+// reporting passed/failed/skipped counts per check. An unknown scan ARN yields
+// an empty aggregation list.
+func (b *InMemoryBackend) ListCisScanResultsAggregatedByChecks(scanArn string) ([]map[string]any, error) {
+	b.mu.RLock("ListCisScanResultsAggregatedByChecks")
+	defer b.mu.RUnlock()
+
+	scan := b.findCisScan(scanArn)
+	if scan == nil {
+		return []map[string]any{}, nil
+	}
+
+	type checkAgg struct {
+		descr        string
+		level        string
+		platform     string
+		passed       int64
+		failed       int64
+		skipped      int64
+		firstSeenIdx int
+	}
+
+	aggs := make(map[string]*checkAgg)
+	order := make([]string, 0)
+
+	for i, r := range scan.Results {
+		a, ok := aggs[r.CheckID]
+		if !ok {
+			a = &checkAgg{descr: r.CheckDescr, level: r.Level, platform: r.Platform, firstSeenIdx: i}
+			aggs[r.CheckID] = a
+			order = append(order, r.CheckID)
+		}
+
+		switch r.Status {
+		case cisCheckStatusPassed:
+			a.passed++
+		case cisCheckStatusFailed:
+			a.failed++
+		default:
+			a.skipped++
+		}
+	}
+
+	sort.Strings(order)
+
+	result := make([]map[string]any, 0, len(order))
+	for _, id := range order {
+		a := aggs[id]
+		result = append(result, map[string]any{
+			keyScanArn:         scan.ScanArn,
+			"checkId":          id,
+			"checkDescription": a.descr,
+			"level":            a.level,
+			keyPlatform:        a.platform,
+			"statusCounts": map[string]any{
+				"passed":  a.passed,
+				"failed":  a.failed,
+				"skipped": a.skipped,
+			},
+		})
+	}
+
+	return result, nil
 }
 
-// ListCisScanResultsAggregatedByTargetResource returns stub results.
-func (b *InMemoryBackend) ListCisScanResultsAggregatedByTargetResource(_ string) ([]map[string]any, error) {
-	return []map[string]any{}, nil
+// ListCisScanResultsAggregatedByTargetResource groups a scan's results by target
+// resource, reporting passed/failed/skipped counts per resource. An unknown scan
+// ARN yields an empty aggregation list.
+func (b *InMemoryBackend) ListCisScanResultsAggregatedByTargetResource(
+	scanArn string,
+) ([]map[string]any, error) {
+	b.mu.RLock("ListCisScanResultsAggregatedByTargetResource")
+	defer b.mu.RUnlock()
+
+	scan := b.findCisScan(scanArn)
+	if scan == nil {
+		return []map[string]any{}, nil
+	}
+
+	type targetAgg struct {
+		accountID string
+		platform  string
+		passed    int64
+		failed    int64
+		skipped   int64
+	}
+
+	aggs := make(map[string]*targetAgg)
+	order := make([]string, 0)
+
+	for _, r := range scan.Results {
+		a, ok := aggs[r.TargetID]
+		if !ok {
+			a = &targetAgg{accountID: r.AccountID, platform: r.Platform}
+			aggs[r.TargetID] = a
+			order = append(order, r.TargetID)
+		}
+
+		switch r.Status {
+		case cisCheckStatusPassed:
+			a.passed++
+		case cisCheckStatusFailed:
+			a.failed++
+		default:
+			a.skipped++
+		}
+	}
+
+	sort.Strings(order)
+
+	result := make([]map[string]any, 0, len(order))
+	for _, tid := range order {
+		a := aggs[tid]
+		result = append(result, map[string]any{
+			keyScanArn:         scan.ScanArn,
+			"targetResourceId": tid,
+			keyAccountID:       a.accountID,
+			keyPlatform:        a.platform,
+			"statusCounts": map[string]any{
+				"passed":  a.passed,
+				"failed":  a.failed,
+				"skipped": a.skipped,
+			},
+		})
+	}
+
+	return result, nil
 }
 
 // --- Code Security Integration ---
@@ -1030,7 +1395,7 @@ func (b *InMemoryBackend) StartCodeSecurityScan(resourceID string) (map[string]a
 	scan := map[string]any{
 		"scanId":     scanID,
 		"resourceId": resourceID,
-		"status":     "IN_PROGRESS",
+		keyStatus:    "IN_PROGRESS",
 	}
 	b.ax.CodeSecurityScans[scanID] = scan
 
@@ -1232,7 +1597,7 @@ func (b *InMemoryBackend) ListUsageTotals(_ []string) ([]map[string]any, error) 
 	return []map[string]any{
 		{
 			keyAccountID: b.accountID,
-			"status":     "ACTIVE",
+			keyStatus:    "ACTIVE",
 			"usage":      []any{},
 		},
 	}, nil
@@ -1281,10 +1646,10 @@ func (b *InMemoryBackend) BatchGetFreeTrialInfo(accountIDs []string) (map[string
 			"accountId": id,
 			"freeTrialInfo": []map[string]any{
 				{
-					"end":    time.Now().UTC().AddDate(0, 0, 30).Format(time.RFC3339), //nolint:mnd // existing issue.
-					"start":  time.Now().UTC().Format(time.RFC3339),
-					"status": "ACTIVE",
-					"type":   "EC2",
+					"end":     time.Now().UTC().AddDate(0, 0, 30).Format(time.RFC3339), //nolint:mnd // existing issue.
+					"start":   time.Now().UTC().Format(time.RFC3339),
+					keyStatus: "ACTIVE",
+					"type":    "EC2",
 				},
 			},
 		})

--- a/services/inspector2/handler_cis_scans_test.go
+++ b/services/inspector2/handler_cis_scans_test.go
@@ -1,0 +1,290 @@
+package inspector2_test
+
+// Stateful CIS scan tests: prove that scan result/report/aggregation operations
+// reflect the configuration that produced them (real stored state) rather than
+// canned data, and that unknown scan ARNs degrade benignly.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/inspector2"
+)
+
+// createCisConfig creates a CIS scan configuration over the given target account
+// IDs and returns the resulting configuration ARN.
+func createCisConfig(t *testing.T, h *inspector2.Handler, name string, accountIDs []string) string {
+	t.Helper()
+
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan-configuration/create", map[string]any{
+		"scanName": name,
+		"targets":  map[string]any{"accountIds": accountIDs},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	arn, ok := resp["scanConfigurationArn"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, arn)
+
+	return arn
+}
+
+// firstScanArn returns the scan ARN of the single scan materialized for cfgARN.
+func firstScanArn(t *testing.T, h *inspector2.Handler, cfgARN string) string {
+	t.Helper()
+
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan/list", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	scans, _ := resp["cisScans"].([]any)
+
+	for _, raw := range scans {
+		s, _ := raw.(map[string]any)
+		if s["scanConfigurationArn"] == cfgARN {
+			arn, _ := s["scanArn"].(string)
+			require.NotEmpty(t, arn)
+
+			return arn
+		}
+	}
+
+	t.Fatalf("no scan found for config %q", cfgARN)
+
+	return ""
+}
+
+func TestCisScans_CreatedConfigMaterializesScan(t *testing.T) {
+	t.Parallel()
+
+	h := axHandler(t)
+
+	// No configs yet => no scans.
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan/list", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var empty map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &empty))
+	scans, _ := empty["cisScans"].([]any)
+	assert.Empty(t, scans)
+
+	// Creating a config materializes exactly one scan referencing it.
+	cfgARN := createCisConfig(t, h, "scan-a", []string{"111111111111"})
+
+	rec = auditDo(t, h, http.MethodPost, "/cis/scan/list", map[string]any{})
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &empty))
+	scans, _ = empty["cisScans"].([]any)
+	require.Len(t, scans, 1)
+
+	entry, _ := scans[0].(map[string]any)
+	assert.Equal(t, cfgARN, entry["scanConfigurationArn"])
+	assert.Equal(t, "scan-a", entry["scanName"])
+	assert.Equal(t, "COMPLETED", entry["status"])
+}
+
+func TestCisScans_ResultDetailsReflectConfig(t *testing.T) {
+	t.Parallel()
+
+	h := axHandler(t)
+	cfgARN := createCisConfig(t, h, "scan-detail", []string{"111111111111", "222222222222"})
+	scanARN := firstScanArn(t, h, cfgARN)
+
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan-result/details/get", map[string]any{
+		"scanArn": scanARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	results, _ := resp["checkResults"].([]any)
+
+	// Two target accounts x catalog checks => non-empty, and every result is
+	// tagged with one of the configured accounts.
+	require.NotEmpty(t, results)
+
+	accounts := map[string]bool{}
+
+	for _, raw := range results {
+		r, _ := raw.(map[string]any)
+		assert.Equal(t, scanARN, r["scanArn"])
+		acct, _ := r["accountId"].(string)
+		accounts[acct] = true
+		assert.NotEmpty(t, r["checkId"])
+		assert.Contains(t, []any{"PASSED", "FAILED"}, r["status"])
+	}
+
+	assert.True(t, accounts["111111111111"])
+	assert.True(t, accounts["222222222222"])
+}
+
+func TestCisScans_ReportReflectsScan(t *testing.T) {
+	t.Parallel()
+
+	h := axHandler(t)
+	cfgARN := createCisConfig(t, h, "scan-report", []string{"111111111111"})
+	scanARN := firstScanArn(t, h, cfgARN)
+
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan/report/get", map[string]any{
+		"scanArn": scanARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "SUCCEEDED", resp["status"])
+	assert.Equal(t, scanARN, resp["scanArn"])
+	// totalChecks reported as a JSON number.
+	total, ok := resp["totalChecks"].(float64)
+	require.True(t, ok)
+	assert.Positive(t, total)
+}
+
+func TestCisScans_AggregationsConsistent(t *testing.T) {
+	t.Parallel()
+
+	h := axHandler(t)
+	cfgARN := createCisConfig(t, h, "scan-agg", []string{"111111111111", "222222222222"})
+	scanARN := firstScanArn(t, h, cfgARN)
+
+	// By checks: one aggregation per distinct check ID.
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan-result/check/list", map[string]any{
+		"scanArn": scanARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var byCheck map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &byCheck))
+	checks, _ := byCheck["checkAggregations"].([]any)
+	require.NotEmpty(t, checks)
+
+	for _, raw := range checks {
+		c, _ := raw.(map[string]any)
+		assert.NotEmpty(t, c["checkId"])
+		_, ok := c["statusCounts"].(map[string]any)
+		assert.True(t, ok)
+	}
+
+	// By target resource: one aggregation per target (2 accounts => 2 targets).
+	rec = auditDo(t, h, http.MethodPost, "/cis/scan-result/resource/list", map[string]any{
+		"scanArn": scanARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var byTarget map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &byTarget))
+	targets, _ := byTarget["targetResourceAggregations"].([]any)
+	assert.Len(t, targets, 2)
+}
+
+func TestCisScans_DeleteConfigRemovesScans(t *testing.T) {
+	t.Parallel()
+
+	h := axHandler(t)
+	cfgARN := createCisConfig(t, h, "scan-del", []string{"111111111111"})
+
+	rec := auditDo(t, h, http.MethodPost, "/cis/scan-configuration/delete", map[string]any{
+		"scanConfigurationArn": cfgARN,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = auditDo(t, h, http.MethodPost, "/cis/scan/list", map[string]any{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	scans, _ := resp["cisScans"].([]any)
+	assert.Empty(t, scans)
+}
+
+func TestCisScans_UnknownScanArnDegradesBenignly(t *testing.T) {
+	t.Parallel()
+
+	h := axHandler(t)
+	unknown := "arn:aws:inspector2:us-east-1:123456789012:cis-scan/does-not-exist"
+
+	cases := []struct {
+		path string
+		key  string
+	}{
+		{"/cis/scan/report/get", "status"},
+		{"/cis/scan-result/details/get", "checkResults"},
+		{"/cis/scan-result/check/list", "checkAggregations"},
+		{"/cis/scan-result/resource/list", "targetResourceAggregations"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+
+			rec := auditDo(t, h, http.MethodPost, tc.path, map[string]any{"scanArn": unknown})
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			_, ok := resp[tc.key]
+			assert.True(t, ok)
+		})
+	}
+}
+
+// TestCisScans_SnapshotRestoreRoundTrip proves the appendix state (including CIS
+// scans) survives a Snapshot/Restore cycle.
+func TestCisScans_SnapshotRestoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	src := inspector2.NewInMemoryBackend("123456789012", "us-east-1")
+	cfg, err := src.CreateCisScanConfiguration("rt", nil, map[string]any{
+		"accountIds": []any{"333333333333"},
+	}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.Arn)
+
+	scansBefore, err := src.ListCisScans()
+	require.NoError(t, err)
+	require.Len(t, scansBefore, 1)
+
+	data := src.Snapshot()
+
+	dst := inspector2.NewInMemoryBackend("000000000000", "us-east-2")
+	require.NoError(t, dst.Restore(data))
+
+	scansAfter, err := dst.ListCisScans()
+	require.NoError(t, err)
+	require.Len(t, scansAfter, 1)
+	assert.Equal(t, scansBefore[0]["scanArn"], scansAfter[0]["scanArn"])
+
+	cfgsAfter, err := dst.ListCisScanConfigurations()
+	require.NoError(t, err)
+	require.Len(t, cfgsAfter, 1)
+	assert.Equal(t, cfg.Arn, cfgsAfter[0].Arn)
+}
+
+// TestCisScans_ResetClearsState proves Reset clears appendix CIS state.
+func TestCisScans_ResetClearsState(t *testing.T) {
+	t.Parallel()
+
+	b := inspector2.NewInMemoryBackend("123456789012", "us-east-1")
+	_, err := b.CreateCisScanConfiguration("r", nil, nil, nil)
+	require.NoError(t, err)
+
+	scans, err := b.ListCisScans()
+	require.NoError(t, err)
+	require.Len(t, scans, 1)
+
+	b.Reset()
+
+	scans, err = b.ListCisScans()
+	require.NoError(t, err)
+	assert.Empty(t, scans)
+
+	cfgs, err := b.ListCisScanConfigurations()
+	require.NoError(t, err)
+	assert.Empty(t, cfgs)
+}

--- a/services/quicksight/backend.go
+++ b/services/quicksight/backend.go
@@ -242,16 +242,21 @@ func (a *storedAnalysis) toAnalysis() *Analysis {
 
 // state is the serializable snapshot of the backend.
 type state struct {
-	Namespaces   map[string]*storedNamespace  `json:"namespaces"`
-	Groups       map[string]*storedGroup      `json:"groups"`
-	GroupMembers map[string]bool              `json:"groupMembers"`
-	Users        map[string]*storedUser       `json:"users"`
-	DataSources  map[string]*storedDataSource `json:"dataSources"`
-	DataSets     map[string]*storedDataSet    `json:"dataSets"`
-	Ingestions   map[string]*storedIngestion  `json:"ingestions"`
-	Dashboards   map[string]*storedDashboard  `json:"dashboards"`
-	Analyses     map[string]*storedAnalysis   `json:"analyses"`
-	Tags         map[string]map[string]string `json:"tags"`
+	Namespaces     map[string]*storedNamespace     `json:"namespaces"`
+	Groups         map[string]*storedGroup         `json:"groups"`
+	GroupMembers   map[string]bool                 `json:"groupMembers"`
+	Users          map[string]*storedUser          `json:"users"`
+	DataSources    map[string]*storedDataSource    `json:"dataSources"`
+	DataSets       map[string]*storedDataSet       `json:"dataSets"`
+	Ingestions     map[string]*storedIngestion     `json:"ingestions"`
+	Dashboards     map[string]*storedDashboard     `json:"dashboards"`
+	Analyses       map[string]*storedAnalysis      `json:"analyses"`
+	Folders        map[string]*storedFolder        `json:"folders"`
+	Templates      map[string]*storedTemplate      `json:"templates"`
+	Themes         map[string]*storedTheme         `json:"themes"`
+	VPCConnections map[string]*storedVPCConnection `json:"vpcConnections"`
+	Brands         map[string]*storedBrand         `json:"brands"`
+	Tags           map[string]map[string]string    `json:"tags"`
 }
 
 // InMemoryBackend is the in-memory implementation of StorageBackend.
@@ -266,26 +271,37 @@ type InMemoryBackend struct {
 	ingestions   map[string]*storedIngestion
 	dashboards   map[string]*storedDashboard
 	analyses     map[string]*storedAnalysis
-	tags         map[string]map[string]string
-	accountID    string
-	region       string
+	folders      map[string]*storedFolder
+	templates    map[string]*storedTemplate
+	themes       map[string]*storedTheme
+	// vpcConnections and brands round out the stateful Appendix-A families.
+	vpcConnections map[string]*storedVPCConnection
+	brands         map[string]*storedBrand
+	tags           map[string]map[string]string
+	accountID      string
+	region         string
 }
 
 // NewInMemoryBackend creates a new InMemoryBackend.
 func NewInMemoryBackend(accountID, region string) *InMemoryBackend {
 	b := &InMemoryBackend{
-		accountID:    accountID,
-		region:       region,
-		namespaces:   make(map[string]*storedNamespace),
-		groups:       make(map[string]*storedGroup),
-		groupMembers: make(map[string]bool),
-		users:        make(map[string]*storedUser),
-		dataSources:  make(map[string]*storedDataSource),
-		dataSets:     make(map[string]*storedDataSet),
-		ingestions:   make(map[string]*storedIngestion),
-		dashboards:   make(map[string]*storedDashboard),
-		analyses:     make(map[string]*storedAnalysis),
-		tags:         make(map[string]map[string]string),
+		accountID:      accountID,
+		region:         region,
+		namespaces:     make(map[string]*storedNamespace),
+		groups:         make(map[string]*storedGroup),
+		groupMembers:   make(map[string]bool),
+		users:          make(map[string]*storedUser),
+		dataSources:    make(map[string]*storedDataSource),
+		dataSets:       make(map[string]*storedDataSet),
+		ingestions:     make(map[string]*storedIngestion),
+		dashboards:     make(map[string]*storedDashboard),
+		analyses:       make(map[string]*storedAnalysis),
+		folders:        make(map[string]*storedFolder),
+		templates:      make(map[string]*storedTemplate),
+		themes:         make(map[string]*storedTheme),
+		vpcConnections: make(map[string]*storedVPCConnection),
+		brands:         make(map[string]*storedBrand),
+		tags:           make(map[string]map[string]string),
 	}
 	b.mu = lockmetrics.New("quicksight")
 
@@ -321,6 +337,11 @@ func (b *InMemoryBackend) Reset() {
 	b.ingestions = make(map[string]*storedIngestion)
 	b.dashboards = make(map[string]*storedDashboard)
 	b.analyses = make(map[string]*storedAnalysis)
+	b.folders = make(map[string]*storedFolder)
+	b.templates = make(map[string]*storedTemplate)
+	b.themes = make(map[string]*storedTheme)
+	b.vpcConnections = make(map[string]*storedVPCConnection)
+	b.brands = make(map[string]*storedBrand)
 	b.tags = make(map[string]map[string]string)
 
 	b.namespaces[nsKey(b.accountID, defaultNamespace)] = &storedNamespace{
@@ -338,16 +359,21 @@ func (b *InMemoryBackend) Snapshot() []byte {
 	defer b.mu.RUnlock()
 
 	s := state{
-		Namespaces:   b.namespaces,
-		Groups:       b.groups,
-		GroupMembers: b.groupMembers,
-		Users:        b.users,
-		DataSources:  b.dataSources,
-		DataSets:     b.dataSets,
-		Ingestions:   b.ingestions,
-		Dashboards:   b.dashboards,
-		Analyses:     b.analyses,
-		Tags:         b.tags,
+		Namespaces:     b.namespaces,
+		Groups:         b.groups,
+		GroupMembers:   b.groupMembers,
+		Users:          b.users,
+		DataSources:    b.dataSources,
+		DataSets:       b.dataSets,
+		Ingestions:     b.ingestions,
+		Dashboards:     b.dashboards,
+		Analyses:       b.analyses,
+		Folders:        b.folders,
+		Templates:      b.templates,
+		Themes:         b.themes,
+		VPCConnections: b.vpcConnections,
+		Brands:         b.brands,
+		Tags:           b.tags,
 	}
 
 	data, _ := json.Marshal(s)
@@ -374,9 +400,36 @@ func (b *InMemoryBackend) Restore(data []byte) error {
 	b.ingestions = s.Ingestions
 	b.dashboards = s.Dashboards
 	b.analyses = s.Analyses
+	b.folders = s.Folders
+	b.templates = s.Templates
+	b.themes = s.Themes
+	b.vpcConnections = s.VPCConnections
+	b.brands = s.Brands
 	b.tags = s.Tags
 
+	b.ensureAppendixMaps()
+
 	return nil
+}
+
+// ensureAppendixMaps initializes any Appendix-A maps that were nil in a restored
+// snapshot (e.g. snapshots taken before these families were added).
+func (b *InMemoryBackend) ensureAppendixMaps() {
+	if b.folders == nil {
+		b.folders = make(map[string]*storedFolder)
+	}
+	if b.templates == nil {
+		b.templates = make(map[string]*storedTemplate)
+	}
+	if b.themes == nil {
+		b.themes = make(map[string]*storedTheme)
+	}
+	if b.vpcConnections == nil {
+		b.vpcConnections = make(map[string]*storedVPCConnection)
+	}
+	if b.brands == nil {
+		b.brands = make(map[string]*storedBrand)
+	}
 }
 
 // ---- key helpers ----

--- a/services/quicksight/backend_appendixa.go
+++ b/services/quicksight/backend_appendixa.go
@@ -1,0 +1,608 @@
+package quicksight
+
+import (
+	"strings"
+	"time"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/awserr"
+)
+
+// Errors for Appendix-A resource families. They reuse the same AWS error codes
+// as the rest of the service so httpErr maps them to the correct HTTP status.
+var (
+	// ErrFolderNotFound is returned when a folder does not exist.
+	ErrFolderNotFound = awserr.New(errResourceNotFound, awserr.ErrNotFound)
+	// ErrFolderAlreadyExists is returned when a folder already exists.
+	ErrFolderAlreadyExists = awserr.New(errConflictException, awserr.ErrAlreadyExists)
+	// ErrTemplateNotFound is returned when a template does not exist.
+	ErrTemplateNotFound = awserr.New(errResourceNotFound, awserr.ErrNotFound)
+	// ErrTemplateAlreadyExists is returned when a template already exists.
+	ErrTemplateAlreadyExists = awserr.New(errConflictException, awserr.ErrAlreadyExists)
+	// ErrThemeNotFound is returned when a theme does not exist.
+	ErrThemeNotFound = awserr.New(errResourceNotFound, awserr.ErrNotFound)
+	// ErrThemeAlreadyExists is returned when a theme already exists.
+	ErrThemeAlreadyExists = awserr.New(errConflictException, awserr.ErrAlreadyExists)
+	// ErrVPCConnectionNotFound is returned when a VPC connection does not exist.
+	ErrVPCConnectionNotFound = awserr.New(errResourceNotFound, awserr.ErrNotFound)
+	// ErrVPCConnectionAlreadyExists is returned when a VPC connection already exists.
+	ErrVPCConnectionAlreadyExists = awserr.New(errConflictException, awserr.ErrAlreadyExists)
+	// ErrBrandNotFound is returned when a brand does not exist.
+	ErrBrandNotFound = awserr.New(errResourceNotFound, awserr.ErrNotFound)
+	// ErrBrandAlreadyExists is returned when a brand already exists.
+	ErrBrandAlreadyExists = awserr.New(errConflictException, awserr.ErrAlreadyExists)
+)
+
+// ---- stored types ----
+
+type storedFolder struct {
+	CreatedTime     time.Time `json:"createdTime"`
+	LastUpdatedTime time.Time `json:"lastUpdatedTime"`
+	FolderID        string    `json:"folderId"`
+	Arn             string    `json:"arn"`
+	Name            string    `json:"name"`
+	FolderType      string    `json:"folderType"`
+}
+
+func (f *storedFolder) toFolder() *Folder {
+	return &Folder{
+		CreatedTime:     f.CreatedTime,
+		LastUpdatedTime: f.LastUpdatedTime,
+		FolderID:        f.FolderID,
+		Arn:             f.Arn,
+		Name:            f.Name,
+		FolderType:      f.FolderType,
+	}
+}
+
+type storedTemplate struct {
+	CreatedTime     time.Time `json:"createdTime"`
+	LastUpdatedTime time.Time `json:"lastUpdatedTime"`
+	TemplateID      string    `json:"templateId"`
+	Arn             string    `json:"arn"`
+	Name            string    `json:"name"`
+	Status          string    `json:"status"`
+	VersionNumber   int64     `json:"versionNumber"`
+}
+
+func (t *storedTemplate) toTemplate() *Template {
+	return &Template{
+		CreatedTime:     t.CreatedTime,
+		LastUpdatedTime: t.LastUpdatedTime,
+		TemplateID:      t.TemplateID,
+		Arn:             t.Arn,
+		Name:            t.Name,
+		Status:          t.Status,
+		VersionNumber:   t.VersionNumber,
+	}
+}
+
+type storedTheme struct {
+	CreatedTime     time.Time `json:"createdTime"`
+	LastUpdatedTime time.Time `json:"lastUpdatedTime"`
+	ThemeID         string    `json:"themeId"`
+	Arn             string    `json:"arn"`
+	Name            string    `json:"name"`
+	Status          string    `json:"status"`
+	VersionNumber   int64     `json:"versionNumber"`
+}
+
+func (t *storedTheme) toTheme() *Theme {
+	return &Theme{
+		CreatedTime:     t.CreatedTime,
+		LastUpdatedTime: t.LastUpdatedTime,
+		ThemeID:         t.ThemeID,
+		Arn:             t.Arn,
+		Name:            t.Name,
+		Status:          t.Status,
+		VersionNumber:   t.VersionNumber,
+	}
+}
+
+type storedVPCConnection struct {
+	CreatedTime       time.Time `json:"createdTime"`
+	LastUpdatedTime   time.Time `json:"lastUpdatedTime"`
+	VPCConnectionID   string    `json:"vpcConnectionId"`
+	Arn               string    `json:"arn"`
+	Name              string    `json:"name"`
+	Status            string    `json:"status"`
+	AvailabilityState string    `json:"availabilityState"`
+}
+
+func (v *storedVPCConnection) toVPCConnection() *VPCConnection {
+	return &VPCConnection{
+		CreatedTime:       v.CreatedTime,
+		LastUpdatedTime:   v.LastUpdatedTime,
+		VPCConnectionID:   v.VPCConnectionID,
+		Arn:               v.Arn,
+		Name:              v.Name,
+		Status:            v.Status,
+		AvailabilityState: v.AvailabilityState,
+	}
+}
+
+type storedBrand struct {
+	CreatedTime     time.Time `json:"createdTime"`
+	LastUpdatedTime time.Time `json:"lastUpdatedTime"`
+	BrandID         string    `json:"brandId"`
+	Arn             string    `json:"arn"`
+	Name            string    `json:"name"`
+	Status          string    `json:"status"`
+}
+
+func (b *storedBrand) toBrand() *Brand {
+	return &Brand{
+		CreatedTime:     b.CreatedTime,
+		LastUpdatedTime: b.LastUpdatedTime,
+		BrandID:         b.BrandID,
+		Arn:             b.Arn,
+		Name:            b.Name,
+		Status:          b.Status,
+	}
+}
+
+// ---- key helpers ----
+
+func appendixKey(accountID, resID string) string {
+	return accountID + "/" + resID
+}
+
+// ---- Folders ----
+
+func (b *InMemoryBackend) CreateFolder(accountID, folderID, name, folderType string) (*Folder, error) {
+	if folderID == "" {
+		return nil, ErrValidation
+	}
+
+	b.mu.Lock("CreateFolder")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, folderID)
+	if _, exists := b.folders[key]; exists {
+		return nil, ErrFolderAlreadyExists
+	}
+
+	if folderType == "" {
+		folderType = "SHARED"
+	}
+
+	now := time.Now().UTC()
+	f := &storedFolder{
+		CreatedTime:     now,
+		LastUpdatedTime: now,
+		FolderID:        folderID,
+		Arn:             b.buildARN("folder", folderID),
+		Name:            name,
+		FolderType:      folderType,
+	}
+	b.folders[key] = f
+
+	return f.toFolder(), nil
+}
+
+func (b *InMemoryBackend) DescribeFolder(accountID, folderID string) (*Folder, error) {
+	b.mu.RLock("DescribeFolder")
+	defer b.mu.RUnlock()
+
+	f, ok := b.folders[appendixKey(accountID, folderID)]
+	if !ok {
+		return nil, ErrFolderNotFound
+	}
+
+	return f.toFolder(), nil
+}
+
+func (b *InMemoryBackend) UpdateFolder(accountID, folderID, name string) (*Folder, error) {
+	b.mu.Lock("UpdateFolder")
+	defer b.mu.Unlock()
+
+	f, ok := b.folders[appendixKey(accountID, folderID)]
+	if !ok {
+		return nil, ErrFolderNotFound
+	}
+
+	if name != "" {
+		f.Name = name
+	}
+	f.LastUpdatedTime = time.Now().UTC()
+
+	return f.toFolder(), nil
+}
+
+func (b *InMemoryBackend) DeleteFolder(accountID, folderID string) error {
+	b.mu.Lock("DeleteFolder")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, folderID)
+	f, ok := b.folders[key]
+	if !ok {
+		return ErrFolderNotFound
+	}
+
+	delete(b.tags, f.Arn)
+	delete(b.folders, key)
+
+	return nil
+}
+
+func (b *InMemoryBackend) ListFolders(accountID string) ([]*Folder, error) {
+	b.mu.RLock("ListFolders")
+	defer b.mu.RUnlock()
+
+	prefix := accountID + "/"
+	result := make([]*Folder, 0, len(b.folders))
+	for k, f := range b.folders {
+		if strings.HasPrefix(k, prefix) {
+			result = append(result, f.toFolder())
+		}
+	}
+
+	return result, nil
+}
+
+// ---- Templates ----
+
+func (b *InMemoryBackend) CreateTemplate(accountID, templateID, name string) (*Template, error) {
+	if templateID == "" {
+		return nil, ErrValidation
+	}
+
+	b.mu.Lock("CreateTemplate")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, templateID)
+	if _, exists := b.templates[key]; exists {
+		return nil, ErrTemplateAlreadyExists
+	}
+
+	now := time.Now().UTC()
+	t := &storedTemplate{
+		CreatedTime:     now,
+		LastUpdatedTime: now,
+		TemplateID:      templateID,
+		Arn:             b.buildARN("template", templateID),
+		Name:            name,
+		Status:          statusCreationSuccessful,
+		VersionNumber:   1,
+	}
+	b.templates[key] = t
+
+	return t.toTemplate(), nil
+}
+
+func (b *InMemoryBackend) DescribeTemplate(accountID, templateID string) (*Template, error) {
+	b.mu.RLock("DescribeTemplate")
+	defer b.mu.RUnlock()
+
+	t, ok := b.templates[appendixKey(accountID, templateID)]
+	if !ok {
+		return nil, ErrTemplateNotFound
+	}
+
+	return t.toTemplate(), nil
+}
+
+func (b *InMemoryBackend) UpdateTemplate(accountID, templateID, name string) (*Template, error) {
+	b.mu.Lock("UpdateTemplate")
+	defer b.mu.Unlock()
+
+	t, ok := b.templates[appendixKey(accountID, templateID)]
+	if !ok {
+		return nil, ErrTemplateNotFound
+	}
+
+	if name != "" {
+		t.Name = name
+	}
+	t.LastUpdatedTime = time.Now().UTC()
+	t.VersionNumber++
+	t.Status = statusUpdateSuccessful
+
+	return t.toTemplate(), nil
+}
+
+func (b *InMemoryBackend) DeleteTemplate(accountID, templateID string) error {
+	b.mu.Lock("DeleteTemplate")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, templateID)
+	t, ok := b.templates[key]
+	if !ok {
+		return ErrTemplateNotFound
+	}
+
+	delete(b.tags, t.Arn)
+	delete(b.templates, key)
+
+	return nil
+}
+
+func (b *InMemoryBackend) ListTemplates(accountID string) ([]*Template, error) {
+	b.mu.RLock("ListTemplates")
+	defer b.mu.RUnlock()
+
+	prefix := accountID + "/"
+	result := make([]*Template, 0, len(b.templates))
+	for k, t := range b.templates {
+		if strings.HasPrefix(k, prefix) {
+			result = append(result, t.toTemplate())
+		}
+	}
+
+	return result, nil
+}
+
+// ---- Themes ----
+
+func (b *InMemoryBackend) CreateTheme(accountID, themeID, name string) (*Theme, error) {
+	if themeID == "" {
+		return nil, ErrValidation
+	}
+
+	b.mu.Lock("CreateTheme")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, themeID)
+	if _, exists := b.themes[key]; exists {
+		return nil, ErrThemeAlreadyExists
+	}
+
+	now := time.Now().UTC()
+	t := &storedTheme{
+		CreatedTime:     now,
+		LastUpdatedTime: now,
+		ThemeID:         themeID,
+		Arn:             b.buildARN("theme", themeID),
+		Name:            name,
+		Status:          statusCreationSuccessful,
+		VersionNumber:   1,
+	}
+	b.themes[key] = t
+
+	return t.toTheme(), nil
+}
+
+func (b *InMemoryBackend) DescribeTheme(accountID, themeID string) (*Theme, error) {
+	b.mu.RLock("DescribeTheme")
+	defer b.mu.RUnlock()
+
+	t, ok := b.themes[appendixKey(accountID, themeID)]
+	if !ok {
+		return nil, ErrThemeNotFound
+	}
+
+	return t.toTheme(), nil
+}
+
+func (b *InMemoryBackend) UpdateTheme(accountID, themeID, name string) (*Theme, error) {
+	b.mu.Lock("UpdateTheme")
+	defer b.mu.Unlock()
+
+	t, ok := b.themes[appendixKey(accountID, themeID)]
+	if !ok {
+		return nil, ErrThemeNotFound
+	}
+
+	if name != "" {
+		t.Name = name
+	}
+	t.LastUpdatedTime = time.Now().UTC()
+	t.VersionNumber++
+	t.Status = statusUpdateSuccessful
+
+	return t.toTheme(), nil
+}
+
+func (b *InMemoryBackend) DeleteTheme(accountID, themeID string) error {
+	b.mu.Lock("DeleteTheme")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, themeID)
+	t, ok := b.themes[key]
+	if !ok {
+		return ErrThemeNotFound
+	}
+
+	delete(b.tags, t.Arn)
+	delete(b.themes, key)
+
+	return nil
+}
+
+func (b *InMemoryBackend) ListThemes(accountID string) ([]*Theme, error) {
+	b.mu.RLock("ListThemes")
+	defer b.mu.RUnlock()
+
+	prefix := accountID + "/"
+	result := make([]*Theme, 0, len(b.themes))
+	for k, t := range b.themes {
+		if strings.HasPrefix(k, prefix) {
+			result = append(result, t.toTheme())
+		}
+	}
+
+	return result, nil
+}
+
+// ---- VPC Connections ----
+
+func (b *InMemoryBackend) CreateVPCConnection(accountID, vpcConnectionID, name string) (*VPCConnection, error) {
+	if vpcConnectionID == "" {
+		return nil, ErrValidation
+	}
+
+	b.mu.Lock("CreateVPCConnection")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, vpcConnectionID)
+	if _, exists := b.vpcConnections[key]; exists {
+		return nil, ErrVPCConnectionAlreadyExists
+	}
+
+	now := time.Now().UTC()
+	v := &storedVPCConnection{
+		CreatedTime:       now,
+		LastUpdatedTime:   now,
+		VPCConnectionID:   vpcConnectionID,
+		Arn:               b.buildARN("vpcConnection", vpcConnectionID),
+		Name:              name,
+		Status:            statusCreationInProgress,
+		AvailabilityState: "UNAVAILABLE",
+	}
+	b.vpcConnections[key] = v
+
+	return v.toVPCConnection(), nil
+}
+
+func (b *InMemoryBackend) DescribeVPCConnection(accountID, vpcConnectionID string) (*VPCConnection, error) {
+	b.mu.RLock("DescribeVPCConnection")
+	defer b.mu.RUnlock()
+
+	v, ok := b.vpcConnections[appendixKey(accountID, vpcConnectionID)]
+	if !ok {
+		return nil, ErrVPCConnectionNotFound
+	}
+
+	return v.toVPCConnection(), nil
+}
+
+func (b *InMemoryBackend) UpdateVPCConnection(accountID, vpcConnectionID, name string) (*VPCConnection, error) {
+	b.mu.Lock("UpdateVPCConnection")
+	defer b.mu.Unlock()
+
+	v, ok := b.vpcConnections[appendixKey(accountID, vpcConnectionID)]
+	if !ok {
+		return nil, ErrVPCConnectionNotFound
+	}
+
+	if name != "" {
+		v.Name = name
+	}
+	v.LastUpdatedTime = time.Now().UTC()
+	v.Status = statusUpdateSuccessful
+	v.AvailabilityState = "AVAILABLE"
+
+	return v.toVPCConnection(), nil
+}
+
+func (b *InMemoryBackend) DeleteVPCConnection(accountID, vpcConnectionID string) (*VPCConnection, error) {
+	b.mu.Lock("DeleteVPCConnection")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, vpcConnectionID)
+	v, ok := b.vpcConnections[key]
+	if !ok {
+		return nil, ErrVPCConnectionNotFound
+	}
+
+	v.Status = statusDeleted
+	deleted := v.toVPCConnection()
+	delete(b.tags, v.Arn)
+	delete(b.vpcConnections, key)
+
+	return deleted, nil
+}
+
+func (b *InMemoryBackend) ListVPCConnections(accountID string) ([]*VPCConnection, error) {
+	b.mu.RLock("ListVPCConnections")
+	defer b.mu.RUnlock()
+
+	prefix := accountID + "/"
+	result := make([]*VPCConnection, 0, len(b.vpcConnections))
+	for k, v := range b.vpcConnections {
+		if strings.HasPrefix(k, prefix) {
+			result = append(result, v.toVPCConnection())
+		}
+	}
+
+	return result, nil
+}
+
+// ---- Brands ----
+
+func (b *InMemoryBackend) CreateBrand(accountID, brandID, name string) (*Brand, error) {
+	if brandID == "" {
+		return nil, ErrValidation
+	}
+
+	b.mu.Lock("CreateBrand")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, brandID)
+	if _, exists := b.brands[key]; exists {
+		return nil, ErrBrandAlreadyExists
+	}
+
+	now := time.Now().UTC()
+	br := &storedBrand{
+		CreatedTime:     now,
+		LastUpdatedTime: now,
+		BrandID:         brandID,
+		Arn:             b.buildARN("brand", brandID),
+		Name:            name,
+		Status:          statusCreationSuccessful,
+	}
+	b.brands[key] = br
+
+	return br.toBrand(), nil
+}
+
+func (b *InMemoryBackend) DescribeBrand(accountID, brandID string) (*Brand, error) {
+	b.mu.RLock("DescribeBrand")
+	defer b.mu.RUnlock()
+
+	br, ok := b.brands[appendixKey(accountID, brandID)]
+	if !ok {
+		return nil, ErrBrandNotFound
+	}
+
+	return br.toBrand(), nil
+}
+
+func (b *InMemoryBackend) UpdateBrand(accountID, brandID, name string) (*Brand, error) {
+	b.mu.Lock("UpdateBrand")
+	defer b.mu.Unlock()
+
+	br, ok := b.brands[appendixKey(accountID, brandID)]
+	if !ok {
+		return nil, ErrBrandNotFound
+	}
+
+	if name != "" {
+		br.Name = name
+	}
+	br.LastUpdatedTime = time.Now().UTC()
+	br.Status = statusUpdateSuccessful
+
+	return br.toBrand(), nil
+}
+
+func (b *InMemoryBackend) DeleteBrand(accountID, brandID string) error {
+	b.mu.Lock("DeleteBrand")
+	defer b.mu.Unlock()
+
+	key := appendixKey(accountID, brandID)
+	br, ok := b.brands[key]
+	if !ok {
+		return ErrBrandNotFound
+	}
+
+	delete(b.tags, br.Arn)
+	delete(b.brands, key)
+
+	return nil
+}
+
+func (b *InMemoryBackend) ListBrands(accountID string) ([]*Brand, error) {
+	b.mu.RLock("ListBrands")
+	defer b.mu.RUnlock()
+
+	prefix := accountID + "/"
+	result := make([]*Brand, 0, len(b.brands))
+	for k, br := range b.brands {
+		if strings.HasPrefix(k, prefix) {
+			result = append(result, br.toBrand())
+		}
+	}
+
+	return result, nil
+}

--- a/services/quicksight/export_test.go
+++ b/services/quicksight/export_test.go
@@ -56,6 +56,46 @@ func AnalysisCount(b *InMemoryBackend) int {
 	return len(b.analyses)
 }
 
+// FolderCount returns the number of stored folders.
+func FolderCount(b *InMemoryBackend) int {
+	b.mu.RLock("FolderCount")
+	defer b.mu.RUnlock()
+
+	return len(b.folders)
+}
+
+// TemplateCount returns the number of stored templates.
+func TemplateCount(b *InMemoryBackend) int {
+	b.mu.RLock("TemplateCount")
+	defer b.mu.RUnlock()
+
+	return len(b.templates)
+}
+
+// ThemeCount returns the number of stored themes.
+func ThemeCount(b *InMemoryBackend) int {
+	b.mu.RLock("ThemeCount")
+	defer b.mu.RUnlock()
+
+	return len(b.themes)
+}
+
+// VPCConnectionCount returns the number of stored VPC connections.
+func VPCConnectionCount(b *InMemoryBackend) int {
+	b.mu.RLock("VPCConnectionCount")
+	defer b.mu.RUnlock()
+
+	return len(b.vpcConnections)
+}
+
+// BrandCount returns the number of stored brands.
+func BrandCount(b *InMemoryBackend) int {
+	b.mu.RLock("BrandCount")
+	defer b.mu.RUnlock()
+
+	return len(b.brands)
+}
+
 // HandlerOpsLen returns the count of GetSupportedOperations.
 func HandlerOpsLen(h *Handler) int {
 	return len(h.GetSupportedOperations())

--- a/services/quicksight/handler.go
+++ b/services/quicksight/handler.go
@@ -463,18 +463,22 @@ const (
 type Handler struct {
 	Backend     StorageBackend
 	appendixOps map[string]appendixHandlerFn
+	statefulOps map[string]echo.HandlerFunc
 	accountID   string
 	region      string
 }
 
 // NewHandler creates a new QuickSight handler.
 func NewHandler(b StorageBackend) *Handler {
-	return &Handler{
+	h := &Handler{
 		Backend:     b,
 		appendixOps: buildAppendixOps(),
 		accountID:   b.AccountID(),
 		region:      b.Region(),
 	}
+	h.statefulOps = h.buildStatefulAppendixOps()
+
+	return h
 }
 
 // Name returns the service name.
@@ -2476,7 +2480,7 @@ func (h *Handler) handleUpdateDataSource(c *echo.Context) error {
 		keyDataSourceID: ds.DataSourceID,
 		keyRequestID:    reqIDPlaceholder,
 		keyStatus:       http.StatusOK,
-		"UpdateStatus":  ds.Status,
+		keyUpdateStatus: ds.Status,
 	})
 }
 

--- a/services/quicksight/handler_appendixa.go
+++ b/services/quicksight/handler_appendixa.go
@@ -9,9 +9,54 @@ import (
 // appendixHandlerFn is a function that builds the response body for one Appendix-A op.
 type appendixHandlerFn func(resID, subID string) map[string]any
 
+// buildStatefulAppendixOps returns the op→handler map for Appendix-A operations
+// backed by real backend state (Create persists, Describe/List reflect state,
+// Update mutates, Delete removes). It is a flat map literal, so its cyclomatic
+// complexity is 1.
+func (h *Handler) buildStatefulAppendixOps() map[string]echo.HandlerFunc {
+	return map[string]echo.HandlerFunc{
+		// ---- Folders ----
+		opCreateFolder:   h.handleCreateFolder,
+		opDescribeFolder: h.handleDescribeFolder,
+		opUpdateFolder:   h.handleUpdateFolder,
+		opDeleteFolder:   h.handleDeleteFolder,
+		opListFolders:    h.handleListFolders,
+		// ---- Templates ----
+		opCreateTemplate:   h.handleCreateTemplate,
+		opDescribeTemplate: h.handleDescribeTemplate,
+		opUpdateTemplate:   h.handleUpdateTemplate,
+		opDeleteTemplate:   h.handleDeleteTemplate,
+		opListTemplates:    h.handleListTemplates,
+		// ---- Themes ----
+		opCreateTheme:   h.handleCreateTheme,
+		opDescribeTheme: h.handleDescribeTheme,
+		opUpdateTheme:   h.handleUpdateTheme,
+		opDeleteTheme:   h.handleDeleteTheme,
+		opListThemes:    h.handleListThemes,
+		// ---- VPC Connections ----
+		opCreateVPCConnection:   h.handleCreateVPCConnection,
+		opDescribeVPCConnection: h.handleDescribeVPCConnection,
+		opUpdateVPCConnection:   h.handleUpdateVPCConnection,
+		opDeleteVPCConnection:   h.handleDeleteVPCConnection,
+		opListVPCConnections:    h.handleListVPCConnections,
+		// ---- Brands ----
+		opCreateBrand:   h.handleCreateBrand,
+		opDescribeBrand: h.handleDescribeBrand,
+		opUpdateBrand:   h.handleUpdateBrand,
+		opDeleteBrand:   h.handleDeleteBrand,
+		opListBrands:    h.handleListBrands,
+	}
+}
+
 // dispatchNew handles all Appendix-A operations that are not dispatched by the
 // legacy type-specific helpers (namespace/group/user/datasource/dataset/dashboard/analysis/tag).
+// Stateful resource families (folders/templates/themes/vpc-connections/brands) are
+// served from real backend state; the remaining ops fall back to the canned-map.
 func (h *Handler) dispatchNew(c *echo.Context, op string) error {
+	if fn, ok := h.statefulOps[op]; ok {
+		return fn(c)
+	}
+
 	segs := pathSegsFromCtx(c)
 	resID := seg(segs, segResID)
 	subID := seg(segs, segSubResID)
@@ -39,11 +84,6 @@ func buildAppendixOps() map[string]appendixHandlerFn { //nolint:funlen // existi
 	withList := func(key string) appendixHandlerFn {
 		return func(_, _ string) map[string]any { return reqID(map[string]any{key: []any{}}) }
 	}
-	withNested := func(outerKey, innerKey string) appendixHandlerFn {
-		return func(resID, _ string) map[string]any {
-			return reqID(map[string]any{outerKey: map[string]any{innerKey: resID}})
-		}
-	}
 	withIDAndPerms := func(key string) appendixHandlerFn {
 		return func(resID, _ string) map[string]any {
 			return reqID(map[string]any{key: resID, "Permissions": []any{}})
@@ -63,12 +103,7 @@ func buildAppendixOps() map[string]appendixHandlerFn { //nolint:funlen // existi
 	}
 
 	return map[string]appendixHandlerFn{
-		// ---- Folders ----
-		opCreateFolder:                withID("FolderId"),
-		opDescribeFolder:              withNested("Folder", "FolderId"),
-		opUpdateFolder:                withID("FolderId"),
-		opDeleteFolder:                withID("FolderId"),
-		opListFolders:                 withList("FolderSummaryList"),
+		// ---- Folders (core CRUD is stateful; sub-resources canned) ----
 		opSearchFolders:               withList("FolderSummaryList"),
 		opDescribeFolderPermissions:   withIDAndPerms("FolderId"),
 		opUpdateFolderPermissions:     withIDAndPerms("FolderId"),
@@ -80,12 +115,7 @@ func buildAppendixOps() map[string]appendixHandlerFn { //nolint:funlen // existi
 		opListFolderMembers:      withList("FolderMemberList"),
 		opListFoldersForResource: withList("Folders"),
 
-		// ---- Templates ----
-		opCreateTemplate:             withID("TemplateId"),
-		opDescribeTemplate:           withNested("Template", "TemplateId"),
-		opUpdateTemplate:             withID("TemplateId"),
-		opDeleteTemplate:             withID("TemplateId"),
-		opListTemplates:              withList("TemplateSummaryList"),
+		// ---- Templates (core CRUD is stateful; sub-resources canned) ----
 		opListTemplateVersions:       withList("TemplateVersionSummaryList"),
 		opDescribeTemplateDefinition: withID("TemplateId"),
 		opDescribeTemplatePerms:      withIDAndPerms("TemplateId"),
@@ -96,12 +126,7 @@ func buildAppendixOps() map[string]appendixHandlerFn { //nolint:funlen // existi
 		opDeleteTemplateAlias:        withID("TemplateId"),
 		opListTemplateAliases:        withList("TemplateAliasList"),
 
-		// ---- Themes ----
-		opCreateTheme:        withID("ThemeId"),
-		opDescribeTheme:      withNested("Theme", "ThemeId"),
-		opUpdateTheme:        withID("ThemeId"),
-		opDeleteTheme:        withID("ThemeId"),
-		opListThemes:         withList("ThemeSummaryList"),
+		// ---- Themes (core CRUD is stateful; sub-resources canned) ----
 		opListThemeVersions:  withList("ThemeVersionSummaryList"),
 		opDescribeThemePerms: withIDAndPerms("ThemeId"),
 		opUpdateThemePerms:   withIDAndPerms("ThemeId"),
@@ -132,16 +157,7 @@ func buildAppendixOps() map[string]appendixHandlerFn { //nolint:funlen // existi
 		opBatchDeleteTopicAnswers:      withID("TopicId"),
 		opListTopicReviewedAnswers:     withID("TopicId"),
 
-		// ---- VPC Connections ----
-		opCreateVPCConnection: func(_, _ string) map[string]any {
-			return reqID(map[string]any{"VPCConnectionId": "new-vpc"})
-		},
-		opDescribeVPCConnection: func(resID, _ string) map[string]any {
-			return reqID(map[string]any{"VPCConnection": map[string]any{"VPCConnectionId": resID}})
-		},
-		opUpdateVPCConnection: withID("VPCConnectionId"),
-		opDeleteVPCConnection: withID("VPCConnectionId"),
-		opListVPCConnections:  withList("VPCConnectionSummaries"),
+		// ---- VPC Connections: core CRUD is stateful (see statefulAppendixHandler) ----
 
 		// ---- IAM Policy Assignments ----
 		opCreateIAMPolicyAssignment: func(_, _ string) map[string]any {
@@ -235,12 +251,7 @@ func buildAppendixOps() map[string]appendixHandlerFn { //nolint:funlen // existi
 		opDescribeDataSourcePerms: withIDAndPerms("DataSourceId"),
 		opUpdateDataSourcePerms:   withIDAndPerms("DataSourceId"),
 
-		// ---- Brands ----
-		opCreateBrand:   withID("BrandId"),
-		opDescribeBrand: withNested("Brand", "BrandId"),
-		opUpdateBrand:   withID("BrandId"),
-		opDeleteBrand:   withID("BrandId"),
-		opListBrands:    withList("Brands"),
+		// ---- Brands (core CRUD is stateful; assignment/published-version canned) ----
 		opDescribeBrandAssignment: func(_, _ string) map[string]any {
 			return reqID(map[string]any{"BrandAssignment": map[string]any{}})
 		},

--- a/services/quicksight/handler_appendixa_state.go
+++ b/services/quicksight/handler_appendixa_state.go
@@ -1,0 +1,617 @@
+package quicksight
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+)
+
+// Response keys for the stateful Appendix-A resource families. Declared as
+// constants to keep the handlers DRY and satisfy goconst.
+const (
+	keyFolderID        = "FolderId"
+	keyFolder          = "Folder"
+	keyFolderSummaries = "FolderSummaryList"
+
+	keyTemplateID        = "TemplateId"
+	keyTemplate          = "Template"
+	keyTemplateSummaries = "TemplateSummaryList"
+
+	keyThemeID        = "ThemeId"
+	keyTheme          = "Theme"
+	keyThemeSummaries = "ThemeSummaryList"
+
+	keyVPCConnectionID  = "VPCConnectionId"
+	keyVPCConnection    = "VPCConnection"
+	keyVPCConnSummaries = "VPCConnectionSummaries"
+
+	keyBrandID  = "BrandId"
+	keyBrand    = "Brand"
+	keyBrands   = "Brands"
+	keyBrandArn = "BrandArn"
+
+	keyUpdateStatus = "UpdateStatus"
+)
+
+// ---- Folder handlers ----
+
+func (h *Handler) handleCreateFolder(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	folderID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	f, err := h.Backend.CreateFolder(accountID, folderID, strField(body, "Name"), strField(body, "FolderType"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:       f.Arn,
+		keyFolderID:  f.FolderID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDescribeFolder(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	folderID := seg(segs, segResID)
+
+	f, err := h.Backend.DescribeFolder(accountID, folderID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyFolder:    folderToMap(f),
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleUpdateFolder(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	folderID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	f, err := h.Backend.UpdateFolder(accountID, folderID, strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:       f.Arn,
+		keyFolderID:  f.FolderID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDeleteFolder(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	folderID := seg(segs, segResID)
+
+	if err := h.Backend.DeleteFolder(accountID, folderID); err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:       h.buildResourceARN("folder", folderID),
+		keyFolderID:  folderID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleListFolders(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+
+	folders, err := h.Backend.ListFolders(accountID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	items := make([]map[string]any, 0, len(folders))
+	for _, f := range folders {
+		items = append(items, folderToMap(f))
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyFolderSummaries: items,
+		keyRequestID:       reqIDPlaceholder,
+		keyStatus:          http.StatusOK,
+	})
+}
+
+func folderToMap(f *Folder) map[string]any {
+	return map[string]any{
+		keyArn:             f.Arn,
+		keyCreatedTime:     f.CreatedTime.Format(timeFormat),
+		keyFolderID:        f.FolderID,
+		keyLastUpdatedTime: f.LastUpdatedTime.Format(timeFormat),
+		keyName:            f.Name,
+		"FolderType":       f.FolderType,
+	}
+}
+
+// ---- Template handlers ----
+
+func (h *Handler) handleCreateTemplate(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	templateID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	t, err := h.Backend.CreateTemplate(accountID, templateID, strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:            t.Arn,
+		keyTemplateID:     t.TemplateID,
+		keyCreationStatus: t.Status,
+		keyRequestID:      reqIDPlaceholder,
+		keyStatus:         http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDescribeTemplate(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	templateID := seg(segs, segResID)
+
+	t, err := h.Backend.DescribeTemplate(accountID, templateID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyTemplate:  templateToMap(t),
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleUpdateTemplate(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	templateID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	t, err := h.Backend.UpdateTemplate(accountID, templateID, strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:            t.Arn,
+		keyTemplateID:     t.TemplateID,
+		keyCreationStatus: t.Status,
+		keyRequestID:      reqIDPlaceholder,
+		keyStatus:         http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDeleteTemplate(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	templateID := seg(segs, segResID)
+
+	if err := h.Backend.DeleteTemplate(accountID, templateID); err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:        h.buildResourceARN("template", templateID),
+		keyTemplateID: templateID,
+		keyRequestID:  reqIDPlaceholder,
+		keyStatus:     http.StatusOK,
+	})
+}
+
+func (h *Handler) handleListTemplates(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+
+	templates, err := h.Backend.ListTemplates(accountID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	items := make([]map[string]any, 0, len(templates))
+	for _, t := range templates {
+		items = append(items, templateToMap(t))
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyTemplateSummaries: items,
+		keyRequestID:         reqIDPlaceholder,
+		keyStatus:            http.StatusOK,
+	})
+}
+
+func templateToMap(t *Template) map[string]any {
+	return map[string]any{
+		keyArn:                t.Arn,
+		keyCreatedTime:        t.CreatedTime.Format(timeFormat),
+		keyTemplateID:         t.TemplateID,
+		keyLastUpdatedTime:    t.LastUpdatedTime.Format(timeFormat),
+		keyName:               t.Name,
+		"LatestVersionNumber": t.VersionNumber,
+	}
+}
+
+// ---- Theme handlers ----
+
+func (h *Handler) handleCreateTheme(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	themeID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	t, err := h.Backend.CreateTheme(accountID, themeID, strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:            t.Arn,
+		keyThemeID:        t.ThemeID,
+		keyCreationStatus: t.Status,
+		keyRequestID:      reqIDPlaceholder,
+		keyStatus:         http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDescribeTheme(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	themeID := seg(segs, segResID)
+
+	t, err := h.Backend.DescribeTheme(accountID, themeID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyTheme:     themeToMap(t),
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleUpdateTheme(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	themeID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	t, err := h.Backend.UpdateTheme(accountID, themeID, strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:            t.Arn,
+		keyThemeID:        t.ThemeID,
+		keyCreationStatus: t.Status,
+		keyRequestID:      reqIDPlaceholder,
+		keyStatus:         http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDeleteTheme(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	themeID := seg(segs, segResID)
+
+	if err := h.Backend.DeleteTheme(accountID, themeID); err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:       h.buildResourceARN("theme", themeID),
+		keyThemeID:   themeID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleListThemes(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+
+	themes, err := h.Backend.ListThemes(accountID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	items := make([]map[string]any, 0, len(themes))
+	for _, t := range themes {
+		items = append(items, themeToMap(t))
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyThemeSummaries: items,
+		keyRequestID:      reqIDPlaceholder,
+		keyStatus:         http.StatusOK,
+	})
+}
+
+func themeToMap(t *Theme) map[string]any {
+	return map[string]any{
+		keyArn:                t.Arn,
+		keyCreatedTime:        t.CreatedTime.Format(timeFormat),
+		keyThemeID:            t.ThemeID,
+		keyLastUpdatedTime:    t.LastUpdatedTime.Format(timeFormat),
+		keyName:               t.Name,
+		"LatestVersionNumber": t.VersionNumber,
+	}
+}
+
+// ---- VPC Connection handlers ----
+
+func (h *Handler) handleCreateVPCConnection(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	v, err := h.Backend.CreateVPCConnection(accountID, strField(body, keyVPCConnectionID), strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:               v.Arn,
+		keyVPCConnectionID:   v.VPCConnectionID,
+		keyCreationStatus:    v.Status,
+		"AvailabilityStatus": v.AvailabilityState,
+		keyRequestID:         reqIDPlaceholder,
+		keyStatus:            http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDescribeVPCConnection(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	vpcID := seg(segs, segResID)
+
+	v, err := h.Backend.DescribeVPCConnection(accountID, vpcID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyVPCConnection: vpcConnectionToMap(v),
+		keyRequestID:     reqIDPlaceholder,
+		keyStatus:        http.StatusOK,
+	})
+}
+
+func (h *Handler) handleUpdateVPCConnection(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	vpcID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	v, err := h.Backend.UpdateVPCConnection(accountID, vpcID, strField(body, "Name"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:             v.Arn,
+		keyVPCConnectionID: v.VPCConnectionID,
+		keyUpdateStatus:    v.Status,
+		keyRequestID:       reqIDPlaceholder,
+		keyStatus:          http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDeleteVPCConnection(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	vpcID := seg(segs, segResID)
+
+	v, err := h.Backend.DeleteVPCConnection(accountID, vpcID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyArn:             v.Arn,
+		keyVPCConnectionID: v.VPCConnectionID,
+		"DeletionStatus":   v.Status,
+		keyRequestID:       reqIDPlaceholder,
+		keyStatus:          http.StatusOK,
+	})
+}
+
+func (h *Handler) handleListVPCConnections(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+
+	conns, err := h.Backend.ListVPCConnections(accountID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	items := make([]map[string]any, 0, len(conns))
+	for _, v := range conns {
+		items = append(items, vpcConnectionToMap(v))
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyVPCConnSummaries: items,
+		keyRequestID:        reqIDPlaceholder,
+		keyStatus:           http.StatusOK,
+	})
+}
+
+func vpcConnectionToMap(v *VPCConnection) map[string]any {
+	return map[string]any{
+		keyArn:               v.Arn,
+		keyCreatedTime:       v.CreatedTime.Format(timeFormat),
+		keyVPCConnectionID:   v.VPCConnectionID,
+		keyLastUpdatedTime:   v.LastUpdatedTime.Format(timeFormat),
+		keyName:              v.Name,
+		keyStatus:            v.Status,
+		"AvailabilityStatus": v.AvailabilityState,
+	}
+}
+
+// ---- Brand handlers ----
+
+func (h *Handler) handleCreateBrand(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	brandID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	br, err := h.Backend.CreateBrand(accountID, brandID, strField(body, "BrandName"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyBrandArn:  br.Arn,
+		keyBrandID:   br.BrandID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDescribeBrand(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	brandID := seg(segs, segResID)
+
+	br, err := h.Backend.DescribeBrand(accountID, brandID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyBrand:     brandToMap(br),
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleUpdateBrand(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	brandID := seg(segs, segResID)
+
+	body, err := readBody(c)
+	if err != nil {
+		return writeError(c, http.StatusBadRequest, errInvalidParam, errInvalidBody)
+	}
+
+	br, err := h.Backend.UpdateBrand(accountID, brandID, strField(body, "BrandName"))
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyBrandArn:  br.Arn,
+		keyBrandID:   br.BrandID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleDeleteBrand(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+	brandID := seg(segs, segResID)
+
+	if err := h.Backend.DeleteBrand(accountID, brandID); err != nil {
+		return httpErr(c, err)
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyBrandID:   brandID,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func (h *Handler) handleListBrands(c *echo.Context) error {
+	segs := pathSegsFromCtx(c)
+	accountID := seg(segs, segAccountID)
+
+	brands, err := h.Backend.ListBrands(accountID)
+	if err != nil {
+		return httpErr(c, err)
+	}
+
+	items := make([]map[string]any, 0, len(brands))
+	for _, br := range brands {
+		items = append(items, brandToMap(br))
+	}
+
+	return writeJSON(c, http.StatusOK, map[string]any{
+		keyBrands:    items,
+		keyRequestID: reqIDPlaceholder,
+		keyStatus:    http.StatusOK,
+	})
+}
+
+func brandToMap(br *Brand) map[string]any {
+	return map[string]any{
+		keyBrandArn:        br.Arn,
+		keyBrandID:         br.BrandID,
+		keyCreatedTime:     br.CreatedTime.Format(timeFormat),
+		keyLastUpdatedTime: br.LastUpdatedTime.Format(timeFormat),
+		keyName:            br.Name,
+		keyStatus:          br.Status,
+	}
+}
+
+// buildResourceARN builds an ARN for a resource using the handler's region/account.
+func (h *Handler) buildResourceARN(resourceType, resourceID string) string {
+	return "arn:aws:quicksight:" + h.region + ":" + h.accountID + ":" + resourceType + "/" + resourceID
+}

--- a/services/quicksight/handler_appendixa_state_test.go
+++ b/services/quicksight/handler_appendixa_state_test.go
@@ -1,0 +1,375 @@
+package quicksight_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/quicksight"
+)
+
+// roundTripStep is one HTTP call in a stateful round-trip scenario.
+type roundTripStep struct {
+	body         any
+	name         string
+	method       string
+	path         string
+	wantContains string // top-level key expected in the response body
+	wantStatus   int
+}
+
+func runRoundTrip(t *testing.T, h *quicksight.Handler, steps []roundTripStep) {
+	t.Helper()
+
+	for _, st := range steps {
+		t.Run(st.name, func(t *testing.T) {
+			rec := doRequest(t, h, st.method, st.path, st.body)
+			assert.Equal(t, st.wantStatus, rec.Code, "status for %s", st.name)
+			if st.wantContains != "" {
+				body := parseBody(t, rec)
+				assert.Contains(t, body, st.wantContains, "key for %s", st.name)
+			}
+		})
+	}
+}
+
+func TestQuickSight_FolderRoundTrip(t *testing.T) { //nolint:paralleltest // shared handler state.
+	b := newTestBackend(t)
+	h := quicksight.NewHandler(b)
+
+	steps := []roundTripStep{
+		{
+			name:         "describe missing folder returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/folders/rtf1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+		{
+			name:         "create folder",
+			method:       http.MethodPost,
+			path:         accountPath("/folders/rtf1"),
+			body:         map[string]any{"Name": "RT Folder"},
+			wantStatus:   http.StatusOK,
+			wantContains: "FolderId",
+		},
+		{
+			name:         "describe reflects created folder",
+			method:       http.MethodGet,
+			path:         accountPath("/folders/rtf1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "Folder",
+		},
+		{
+			name:         "update folder",
+			method:       http.MethodPut,
+			path:         accountPath("/folders/rtf1"),
+			body:         map[string]any{"Name": "RT Renamed"},
+			wantStatus:   http.StatusOK,
+			wantContains: "FolderId",
+		},
+		{
+			name:         "list folders includes folder",
+			method:       http.MethodGet,
+			path:         accountPath("/folders"),
+			wantStatus:   http.StatusOK,
+			wantContains: "FolderSummaryList",
+		},
+		{
+			name:         "delete folder",
+			method:       http.MethodDelete,
+			path:         accountPath("/folders/rtf1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "FolderId",
+		},
+		{
+			name:         "describe after delete returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/folders/rtf1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+	}
+
+	runRoundTrip(t, h, steps)
+
+	// describe reflects renamed value before delete is verified separately below.
+	assert.Equal(t, 0, quicksight.FolderCount(b), "folder removed after delete")
+}
+
+func TestQuickSight_FolderDescribeReflectsUpdate(t *testing.T) { //nolint:paralleltest // shared handler state.
+	h := newTestHandler(t)
+
+	rec := doRequest(t, h, http.MethodPost, accountPath("/folders/upd1"), map[string]any{"Name": "Original"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doRequest(t, h, http.MethodPut, accountPath("/folders/upd1"), map[string]any{"Name": "Updated"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = doRequest(t, h, http.MethodGet, accountPath("/folders/upd1"), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := parseBody(t, rec)
+	folder, ok := body["Folder"].(map[string]any)
+	require.True(t, ok, "Folder object present")
+	assert.Equal(t, "Updated", folder["Name"], "describe reflects updated name")
+}
+
+func TestQuickSight_TemplateRoundTrip(t *testing.T) { //nolint:paralleltest // shared handler state.
+	b := newTestBackend(t)
+	h := quicksight.NewHandler(b)
+
+	steps := []roundTripStep{
+		{
+			name:         "describe missing template returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/templates/rtt1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+		{
+			name:         "create template",
+			method:       http.MethodPost,
+			path:         accountPath("/templates/rtt1"),
+			body:         map[string]any{"Name": "RT Tpl"},
+			wantStatus:   http.StatusOK,
+			wantContains: "TemplateId",
+		},
+		{
+			name:         "describe reflects created template",
+			method:       http.MethodGet,
+			path:         accountPath("/templates/rtt1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "Template",
+		},
+		{
+			name:         "list templates includes template",
+			method:       http.MethodGet,
+			path:         accountPath("/templates"),
+			wantStatus:   http.StatusOK,
+			wantContains: "TemplateSummaryList",
+		},
+		{
+			name:         "delete template",
+			method:       http.MethodDelete,
+			path:         accountPath("/templates/rtt1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "TemplateId",
+		},
+		{
+			name:         "describe after delete returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/templates/rtt1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+	}
+
+	runRoundTrip(t, h, steps)
+	assert.Equal(t, 0, quicksight.TemplateCount(b), "template removed after delete")
+}
+
+func TestQuickSight_ThemeRoundTrip(t *testing.T) { //nolint:paralleltest // shared handler state.
+	b := newTestBackend(t)
+	h := quicksight.NewHandler(b)
+
+	steps := []roundTripStep{
+		{
+			name:         "describe missing theme returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/themes/rtth1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+		{
+			name:         "create theme",
+			method:       http.MethodPost,
+			path:         accountPath("/themes/rtth1"),
+			body:         map[string]any{"Name": "RT Theme"},
+			wantStatus:   http.StatusOK,
+			wantContains: "ThemeId",
+		},
+		{
+			name:         "describe reflects created theme",
+			method:       http.MethodGet,
+			path:         accountPath("/themes/rtth1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "Theme",
+		},
+		{
+			name:         "list themes includes theme",
+			method:       http.MethodGet,
+			path:         accountPath("/themes"),
+			wantStatus:   http.StatusOK,
+			wantContains: "ThemeSummaryList",
+		},
+		{
+			name:         "delete theme",
+			method:       http.MethodDelete,
+			path:         accountPath("/themes/rtth1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "ThemeId",
+		},
+		{
+			name:         "describe after delete returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/themes/rtth1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+	}
+
+	runRoundTrip(t, h, steps)
+	assert.Equal(t, 0, quicksight.ThemeCount(b), "theme removed after delete")
+}
+
+func TestQuickSight_VPCConnectionRoundTrip(t *testing.T) { //nolint:paralleltest // shared handler state.
+	b := newTestBackend(t)
+	h := quicksight.NewHandler(b)
+
+	steps := []roundTripStep{
+		{
+			name:         "describe missing vpc returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/vpc-connections/rtv1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+		{
+			name:         "create vpc connection",
+			method:       http.MethodPost,
+			path:         accountPath("/vpc-connections"),
+			body:         map[string]any{"VPCConnectionId": "rtv1", "Name": "RT VPC"},
+			wantStatus:   http.StatusOK,
+			wantContains: "VPCConnectionId",
+		},
+		{
+			name:         "describe reflects created vpc connection",
+			method:       http.MethodGet,
+			path:         accountPath("/vpc-connections/rtv1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "VPCConnection",
+		},
+		{
+			name:         "list vpc connections includes connection",
+			method:       http.MethodGet,
+			path:         accountPath("/vpc-connections"),
+			wantStatus:   http.StatusOK,
+			wantContains: "VPCConnectionSummaries",
+		},
+		{
+			name:         "update vpc connection",
+			method:       http.MethodPut,
+			path:         accountPath("/vpc-connections/rtv1"),
+			body:         map[string]any{"Name": "RT VPC Renamed"},
+			wantStatus:   http.StatusOK,
+			wantContains: "VPCConnectionId",
+		},
+		{
+			name:         "delete vpc connection",
+			method:       http.MethodDelete,
+			path:         accountPath("/vpc-connections/rtv1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "VPCConnectionId",
+		},
+		{
+			name:         "describe after delete returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/vpc-connections/rtv1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+	}
+
+	runRoundTrip(t, h, steps)
+	assert.Equal(t, 0, quicksight.VPCConnectionCount(b), "vpc connection removed after delete")
+}
+
+func TestQuickSight_BrandRoundTrip(t *testing.T) { //nolint:paralleltest // shared handler state.
+	b := newTestBackend(t)
+	h := quicksight.NewHandler(b)
+
+	steps := []roundTripStep{
+		{
+			name:         "describe missing brand returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/brands/rtb1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+		{
+			name:         "create brand",
+			method:       http.MethodPost,
+			path:         accountPath("/brands/rtb1"),
+			body:         map[string]any{"BrandName": "RT Brand"},
+			wantStatus:   http.StatusOK,
+			wantContains: "BrandId",
+		},
+		{
+			name:         "describe reflects created brand",
+			method:       http.MethodGet,
+			path:         accountPath("/brands/rtb1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "Brand",
+		},
+		{
+			name:         "list brands includes brand",
+			method:       http.MethodGet,
+			path:         accountPath("/brands"),
+			wantStatus:   http.StatusOK,
+			wantContains: "Brands",
+		},
+		{
+			name:         "delete brand",
+			method:       http.MethodDelete,
+			path:         accountPath("/brands/rtb1"),
+			wantStatus:   http.StatusOK,
+			wantContains: "BrandId",
+		},
+		{
+			name:         "describe after delete returns not found",
+			method:       http.MethodGet,
+			path:         accountPath("/brands/rtb1"),
+			wantStatus:   http.StatusNotFound,
+			wantContains: "Message",
+		},
+	}
+
+	runRoundTrip(t, h, steps)
+	assert.Equal(t, 0, quicksight.BrandCount(b), "brand removed after delete")
+}
+
+func TestQuickSight_DuplicateCreateConflicts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body any
+		name string
+		path string
+	}{
+		{name: "folder", path: accountPath("/folders/dup1"), body: map[string]any{"Name": "Dup"}},
+		{name: "template", path: accountPath("/templates/dup1"), body: map[string]any{"Name": "Dup"}},
+		{name: "theme", path: accountPath("/themes/dup1"), body: map[string]any{"Name": "Dup"}},
+		{name: "brand", path: accountPath("/brands/dup1"), body: map[string]any{"BrandName": "Dup"}},
+		{
+			name: "vpc",
+			path: accountPath("/vpc-connections"),
+			body: map[string]any{"VPCConnectionId": "dup1", "Name": "Dup"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+
+			rec := doRequest(t, h, http.MethodPost, tc.path, tc.body)
+			require.Equal(t, http.StatusOK, rec.Code, "first create")
+
+			rec = doRequest(t, h, http.MethodPost, tc.path, tc.body)
+			assert.Equal(t, http.StatusConflict, rec.Code, "duplicate create conflicts")
+		})
+	}
+}

--- a/services/quicksight/interfaces.go
+++ b/services/quicksight/interfaces.go
@@ -77,6 +77,41 @@ type StorageBackend interface {
 	ListAnalyses(accountID string, maxResults int32, nextToken string) ([]*Analysis, string, error)
 	RestoreAnalysis(accountID, analysisID string) (*Analysis, error)
 
+	// Folders
+	CreateFolder(accountID, folderID, name, folderType string) (*Folder, error)
+	DescribeFolder(accountID, folderID string) (*Folder, error)
+	UpdateFolder(accountID, folderID, name string) (*Folder, error)
+	DeleteFolder(accountID, folderID string) error
+	ListFolders(accountID string) ([]*Folder, error)
+
+	// Templates
+	CreateTemplate(accountID, templateID, name string) (*Template, error)
+	DescribeTemplate(accountID, templateID string) (*Template, error)
+	UpdateTemplate(accountID, templateID, name string) (*Template, error)
+	DeleteTemplate(accountID, templateID string) error
+	ListTemplates(accountID string) ([]*Template, error)
+
+	// Themes
+	CreateTheme(accountID, themeID, name string) (*Theme, error)
+	DescribeTheme(accountID, themeID string) (*Theme, error)
+	UpdateTheme(accountID, themeID, name string) (*Theme, error)
+	DeleteTheme(accountID, themeID string) error
+	ListThemes(accountID string) ([]*Theme, error)
+
+	// VPC Connections
+	CreateVPCConnection(accountID, vpcConnectionID, name string) (*VPCConnection, error)
+	DescribeVPCConnection(accountID, vpcConnectionID string) (*VPCConnection, error)
+	UpdateVPCConnection(accountID, vpcConnectionID, name string) (*VPCConnection, error)
+	DeleteVPCConnection(accountID, vpcConnectionID string) (*VPCConnection, error)
+	ListVPCConnections(accountID string) ([]*VPCConnection, error)
+
+	// Brands
+	CreateBrand(accountID, brandID, name string) (*Brand, error)
+	DescribeBrand(accountID, brandID string) (*Brand, error)
+	UpdateBrand(accountID, brandID, name string) (*Brand, error)
+	DeleteBrand(accountID, brandID string) error
+	ListBrands(accountID string) ([]*Brand, error)
+
 	// Tags
 	TagResource(resourceARN string, tags map[string]string) error
 	UntagResource(resourceARN string, tagKeys []string) error
@@ -85,6 +120,59 @@ type StorageBackend interface {
 	AccountID() string
 	Region() string
 	Reset()
+}
+
+// Folder represents a QuickSight folder.
+type Folder struct {
+	CreatedTime     time.Time
+	LastUpdatedTime time.Time
+	FolderID        string
+	Arn             string
+	Name            string
+	FolderType      string
+}
+
+// Template represents a QuickSight template.
+type Template struct {
+	CreatedTime     time.Time
+	LastUpdatedTime time.Time
+	TemplateID      string
+	Arn             string
+	Name            string
+	Status          string
+	VersionNumber   int64
+}
+
+// Theme represents a QuickSight theme.
+type Theme struct {
+	CreatedTime     time.Time
+	LastUpdatedTime time.Time
+	ThemeID         string
+	Arn             string
+	Name            string
+	Status          string
+	VersionNumber   int64
+}
+
+// VPCConnection represents a QuickSight VPC connection.
+type VPCConnection struct {
+	CreatedTime       time.Time
+	LastUpdatedTime   time.Time
+	VPCConnectionID   string
+	Arn               string
+	Name              string
+	Status            string
+	AvailabilityState string
+}
+
+// Brand represents a QuickSight brand.
+type Brand struct {
+	CreatedTime     time.Time
+	LastUpdatedTime time.Time
+	BrandID         string
+	Arn             string
+	Name            string
+	Status          string
 }
 
 // Namespace represents a QuickSight namespace.

--- a/services/rekognition/backend.go
+++ b/services/rekognition/backend.go
@@ -27,14 +27,24 @@ const (
 	maxFacesPerPage            = 4096
 	maxStreamProcessorsPerPage = 1000
 
-	defaultFaceConfidence = 99.9
-	defaultFaceSimilarity = 90.0
-
 	// SearchFacesByImage synthetic similarity tuning.
 	defaultSearchMaxFaces = 5
 	minSearchSimilarity   = 75.0 // similarity range floor
 	searchSimilaritySpan  = 24   // similarity range width: yields [75.0, 99.0]
 	seedStride            = 7    // per-face seed multiplier for score variation
+
+	// Deterministic similarity tuning for face/user matching. Scores are derived
+	// from stored face/user state (IDs + ExternalImageId), never canned constants.
+	// A perfect identity match (same ExternalImageId) yields 100.0; otherwise the
+	// score is spread across [minSearchSimilarity, exactMatchSimilarity).
+	exactMatchSimilarity = 100.0
+	// Indexed-face confidence is derived per-face from its identity so distinct
+	// faces carry distinct (but stable) detection confidence values.
+	minFaceConfidence  = 90.0
+	faceConfidenceSpan = 1000 // confidence range width in milli-percent: [90.000, 99.999]
+	// milliScale expresses scores to 3 decimal places (milli-percent precision)
+	// so deterministic hashing spreads values smoothly across the range.
+	milliScale = 1000.0
 
 	maxTagCount        = 200
 	maxTagKeyLen       = 128
@@ -370,8 +380,10 @@ func (b *InMemoryBackend) IndexFaces(collectionID, externalImageID string) ([]*F
 		ImageID:         uuid.NewString(),
 		ExternalImageID: externalImageID,
 		CollectionID:    collectionID,
-		Confidence:      defaultFaceConfidence,
 	}
+	// Detection confidence is derived deterministically from the face's own
+	// identity so distinct faces carry distinct (but stable) values.
+	face.Confidence = faceConfidence(face)
 	b.faces[collectionID] = append(b.faces[collectionID], face)
 
 	return []*Face{face.toFace()}, nil
@@ -458,23 +470,23 @@ func (b *InMemoryBackend) SearchFaces(collectionID, faceID string, maxFaces int3
 		return nil, ErrCollectionNotFound
 	}
 
-	var found bool
+	var query *storedFace
 
 	for _, f := range b.faces[collectionID] {
 		if f.FaceID == faceID {
-			found = true
+			query = f
 
 			break
 		}
 	}
 
-	if !found {
+	if query == nil {
 		return nil, ErrFaceNotFound
 	}
 
 	limit := int(maxFaces)
 	if limit <= 0 {
-		limit = 5
+		limit = defaultSearchMaxFaces
 	}
 
 	var matches []*FaceMatch
@@ -484,8 +496,10 @@ func (b *InMemoryBackend) SearchFaces(collectionID, faceID string, maxFaces int3
 			continue
 		}
 
+		// Similarity is derived from the stored query/candidate identities,
+		// not a canned constant: same ExternalImageId scores 100.0.
 		matches = append(matches, &FaceMatch{
-			Similarity: defaultFaceSimilarity,
+			Similarity: faceSimilarity(query, f),
 			Face:       f.toFace(),
 		})
 
@@ -537,7 +551,7 @@ func (b *InMemoryBackend) SearchFacesByImage(
 	return matches, nil
 }
 
-// imageKeySeed converts an image key string to a uint32 for deterministic variation.
+// imageKeySeed converts an image key string to a uint32 (FNV-1a) for deterministic variation.
 func imageKeySeed(key string) uint32 {
 	var h uint32 = 2166136261
 	for i := range len(key) {
@@ -546,6 +560,41 @@ func imageKeySeed(key string) uint32 {
 	}
 
 	return h
+}
+
+// faceConfidence derives a stable detection confidence in
+// [minFaceConfidence, 99.999] from a stored face's identity. Distinct faces
+// get distinct (but reproducible) confidence values rather than a flat constant.
+func faceConfidence(f *storedFace) float64 {
+	seed := imageKeySeed(f.FaceID + "|" + f.ExternalImageID)
+
+	return minFaceConfidence + float64(seed%faceConfidenceSpan)/milliScale
+}
+
+// faceSimilarity derives a deterministic similarity score for a candidate face
+// relative to a query face. Faces sharing a non-empty ExternalImageId are
+// treated as the same subject and score exactly exactMatchSimilarity; otherwise
+// the score is a stable value in [minSearchSimilarity, exactMatchSimilarity)
+// derived from both face identities.
+func faceSimilarity(query, candidate *storedFace) float64 {
+	if query.ExternalImageID != "" && query.ExternalImageID == candidate.ExternalImageID {
+		return exactMatchSimilarity
+	}
+
+	seed := imageKeySeed(query.FaceID + "|" + candidate.FaceID)
+	span := uint32((exactMatchSimilarity - minSearchSimilarity) * milliScale)
+
+	return minSearchSimilarity + float64(seed%span)/milliScale
+}
+
+// userSimilarity derives a deterministic similarity score for a candidate user
+// relative to a query identity (a user ID or image key), in
+// [minSearchSimilarity, exactMatchSimilarity).
+func userSimilarity(queryKey string, candidate *storedUser) float64 {
+	seed := imageKeySeed(queryKey + "|" + candidate.UserID)
+	span := uint32((exactMatchSimilarity - minSearchSimilarity) * milliScale)
+
+	return minSearchSimilarity + float64(seed%span)/milliScale
 }
 
 // CreateStreamProcessor creates a new stream processor.

--- a/services/rekognition/backend_appendixa.go
+++ b/services/rekognition/backend_appendixa.go
@@ -908,7 +908,7 @@ func (b *InMemoryBackend) SearchUsers(collectionID, userID string, maxUsers int3
 
 		matches = append(matches, &UserMatch{
 			User:       u.toUser(),
-			Similarity: defaultFaceSimilarity,
+			Similarity: userSimilarity(userID, u),
 		})
 
 		if len(matches) >= limit {
@@ -919,8 +919,13 @@ func (b *InMemoryBackend) SearchUsers(collectionID, userID string, maxUsers int3
 	return matches, nil
 }
 
-// SearchUsersByImage returns up to maxUsers users with a simulated similarity score.
-func (b *InMemoryBackend) SearchUsersByImage(collectionID string, maxUsers int32) ([]*UserMatch, error) {
+// SearchUsersByImage returns up to maxUsers users with a deterministic similarity
+// score derived from the image reference and each candidate user's identity.
+func (b *InMemoryBackend) SearchUsersByImage(
+	collectionID string,
+	maxUsers int32,
+	imageKey string,
+) ([]*UserMatch, error) {
 	b.mu.RLock("SearchUsersByImage")
 	defer b.mu.RUnlock()
 
@@ -942,7 +947,7 @@ func (b *InMemoryBackend) SearchUsersByImage(collectionID string, maxUsers int32
 	for _, u := range userMap {
 		matches = append(matches, &UserMatch{
 			User:       u.toUser(),
-			Similarity: defaultFaceSimilarity,
+			Similarity: userSimilarity(imageKey, u),
 		})
 
 		if len(matches) >= limit {

--- a/services/rekognition/handler_appendixa.go
+++ b/services/rekognition/handler_appendixa.go
@@ -900,8 +900,9 @@ func (h *Handler) handleSearchUsers(_ context.Context, req *searchUsersReq) (*se
 }
 
 type searchUsersByImageReq struct {
-	CollectionId string `json:"CollectionId"` //nolint:revive,staticcheck // existing issue.
-	MaxUsers     int32  `json:"MaxUsers"`
+	CollectionId string   `json:"CollectionId"` //nolint:revive,staticcheck // existing issue.
+	Image        imageRef `json:"Image"`
+	MaxUsers     int32    `json:"MaxUsers"`
 }
 
 type searchUsersByImageResp struct {
@@ -916,7 +917,7 @@ func (h *Handler) handleSearchUsersByImage(
 		return nil, fmt.Errorf("%w: CollectionId is required", ErrValidation)
 	}
 
-	matches, err := h.Backend.SearchUsersByImage(req.CollectionId, req.MaxUsers)
+	matches, err := h.Backend.SearchUsersByImage(req.CollectionId, req.MaxUsers, imageRefKey(req.Image))
 	if err != nil {
 		return nil, err
 	}

--- a/services/rekognition/handler_audit4_test.go
+++ b/services/rekognition/handler_audit4_test.go
@@ -1,0 +1,243 @@
+package rekognition_test
+
+// handler_audit4_test.go — AWS-accuracy audit batch-4 for Rekognition (parity §A/§B).
+//
+// Proves similarity/confidence are derived deterministically from stored face
+// state rather than canned constants:
+//   - IndexFaces confidence is in a plausible range, stable, and varies per face
+//   - SearchFaces similarity is deterministic and reproducible across calls
+//   - SearchFaces returns exactly 100.0 for faces sharing an ExternalImageId
+//   - SearchFacesByImage similarity depends on the supplied image
+//   - Full round-trip: index → search → list → delete → search-not-found
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeFaceIDs pulls FaceId values out of an IndexFaces response.
+func decodeFaceIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+
+	var resp struct {
+		FaceRecords []struct {
+			Face struct {
+				FaceID string `json:"FaceId"`
+			} `json:"Face"`
+		} `json:"FaceRecords"`
+	}
+	require.NoError(t, json.Unmarshal(body, &resp))
+
+	ids := make([]string, 0, len(resp.FaceRecords))
+	for _, r := range resp.FaceRecords {
+		ids = append(ids, r.Face.FaceID)
+	}
+
+	return ids
+}
+
+func TestAudit4_IndexFaces_ConfidenceDeterministicAndPlausible(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	require.Equal(t, http.StatusOK,
+		doRequest(t, h, "CreateCollection", map[string]any{"CollectionId": "conf-coll"}).Code)
+
+	confidences := make([]float64, 0, 5)
+
+	for i := range 5 {
+		rec := doRequest(t, h, "IndexFaces", map[string]any{
+			"CollectionId":    "conf-coll",
+			"ExternalImageId": map[bool]string{true: "", false: "subject"}[i%2 == 0],
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp struct {
+			FaceRecords []struct {
+				Face struct {
+					Confidence float64 `json:"Confidence"`
+				} `json:"Face"`
+			} `json:"FaceRecords"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Len(t, resp.FaceRecords, 1)
+
+		conf := resp.FaceRecords[0].Face.Confidence
+		assert.GreaterOrEqual(t, conf, 90.0, "confidence must be a plausible detection value")
+		assert.Less(t, conf, 100.0, "confidence must stay below 100")
+		confidences = append(confidences, conf)
+	}
+
+	// Distinct faces should not all collapse to a single canned constant.
+	distinct := map[float64]struct{}{}
+	for _, c := range confidences {
+		distinct[c] = struct{}{}
+	}
+
+	assert.Greater(t, len(distinct), 1, "confidence must vary per face, not be a canned constant")
+}
+
+func TestAudit4_SearchFaces_SimilarityDeterministic(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	require.Equal(t, http.StatusOK,
+		doRequest(t, h, "CreateCollection", map[string]any{"CollectionId": "sim-coll"}).Code)
+
+	// Two faces with distinct external image IDs (different subjects).
+	rec1 := doRequest(t, h, "IndexFaces", map[string]any{"CollectionId": "sim-coll", "ExternalImageId": "alice"})
+	rec2 := doRequest(t, h, "IndexFaces", map[string]any{"CollectionId": "sim-coll", "ExternalImageId": "bob"})
+	queryID := decodeFaceIDs(t, rec1.Body.Bytes())[0]
+	require.NotEmpty(t, queryID)
+	require.NotEmpty(t, decodeFaceIDs(t, rec2.Body.Bytes())[0])
+
+	getSim := func() float64 {
+		rec := doRequest(t, h, "SearchFaces", map[string]any{"CollectionId": "sim-coll", "FaceId": queryID})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp struct {
+			FaceMatches []struct {
+				Similarity float64 `json:"Similarity"`
+			} `json:"FaceMatches"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Len(t, resp.FaceMatches, 1)
+
+		return resp.FaceMatches[0].Similarity
+	}
+
+	first := getSim()
+	second := getSim()
+
+	assert.InDelta(t, first, second, 1e-9, "similarity must be deterministic across calls")
+	assert.GreaterOrEqual(t, first, 75.0)
+	assert.Less(t, first, 100.0, "different subjects must score below an exact match")
+}
+
+func TestAudit4_SearchFaces_SameExternalImageId_ScoresExactMatch(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	require.Equal(t, http.StatusOK,
+		doRequest(t, h, "CreateCollection", map[string]any{"CollectionId": "exact-coll"}).Code)
+
+	// Two faces sharing the same ExternalImageId model the same subject.
+	same := map[string]any{"CollectionId": "exact-coll", "ExternalImageId": "same-person"}
+	rec1 := doRequest(t, h, "IndexFaces", same)
+	doRequest(t, h, "IndexFaces", same)
+	queryID := decodeFaceIDs(t, rec1.Body.Bytes())[0]
+
+	rec := doRequest(t, h, "SearchFaces", map[string]any{"CollectionId": "exact-coll", "FaceId": queryID})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		FaceMatches []struct {
+			Similarity float64 `json:"Similarity"`
+		} `json:"FaceMatches"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.FaceMatches, 1)
+	assert.InDelta(t, 100.0, resp.FaceMatches[0].Similarity, 1e-9,
+		"faces sharing an ExternalImageId must score an exact match")
+}
+
+func TestAudit4_SearchFacesByImage_SimilarityDependsOnImage(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	require.Equal(t, http.StatusOK,
+		doRequest(t, h, "CreateCollection", map[string]any{"CollectionId": "img-coll"}).Code)
+	require.Equal(t, http.StatusOK,
+		doRequest(t, h, "IndexFaces", map[string]any{"CollectionId": "img-coll", "ExternalImageId": "x"}).Code)
+
+	search := func(bucket, key string) float64 {
+		rec := doRequest(t, h, "SearchFacesByImage", map[string]any{
+			"CollectionId": "img-coll",
+			"Image":        map[string]any{"S3Object": map[string]any{"Bucket": bucket, "Name": key}},
+		})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp struct {
+			FaceMatches []struct {
+				Similarity float64 `json:"Similarity"`
+			} `json:"FaceMatches"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Len(t, resp.FaceMatches, 1)
+
+		return resp.FaceMatches[0].Similarity
+	}
+
+	a := search("b1", "img-a.jpg")
+	aAgain := search("b1", "img-a.jpg")
+	b := search("b1", "img-b.jpg")
+
+	assert.InDelta(t, a, aAgain, 1e-9, "same image must yield the same similarity")
+	assert.NotEqual(t, a, b, "different images must yield different similarities (not canned)")
+}
+
+func TestAudit4_FaceRoundTrip_IndexSearchListDelete(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t)
+	require.Equal(t, http.StatusOK,
+		doRequest(t, h, "CreateCollection", map[string]any{"CollectionId": "rt-coll"}).Code)
+
+	// Index two faces.
+	rec1 := doRequest(t, h, "IndexFaces", map[string]any{"CollectionId": "rt-coll", "ExternalImageId": "a"})
+	rec2 := doRequest(t, h, "IndexFaces", map[string]any{"CollectionId": "rt-coll", "ExternalImageId": "b"})
+	id1 := decodeFaceIDs(t, rec1.Body.Bytes())[0]
+	id2 := decodeFaceIDs(t, rec2.Body.Bytes())[0]
+	require.NotEmpty(t, id1)
+	require.NotEmpty(t, id2)
+
+	// ListFaces reflects both.
+	listRec := doRequest(t, h, "ListFaces", map[string]any{"CollectionId": "rt-coll"})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var list struct {
+		Faces []struct {
+			FaceID string `json:"FaceId"`
+		} `json:"Faces"`
+	}
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &list))
+	require.Len(t, list.Faces, 2)
+
+	// SearchFaces from id1 finds id2.
+	searchRec := doRequest(t, h, "SearchFaces", map[string]any{"CollectionId": "rt-coll", "FaceId": id1})
+	require.Equal(t, http.StatusOK, searchRec.Code)
+
+	var search struct {
+		FaceMatches []struct {
+			Face struct {
+				FaceID string `json:"FaceId"`
+			} `json:"Face"`
+		} `json:"FaceMatches"`
+	}
+	require.NoError(t, json.Unmarshal(searchRec.Body.Bytes(), &search))
+	require.Len(t, search.FaceMatches, 1)
+	assert.Equal(t, id2, search.FaceMatches[0].Face.FaceID)
+
+	// Delete id2.
+	delRec := doRequest(t, h, "DeleteFaces", map[string]any{"CollectionId": "rt-coll", "FaceIds": []string{id2}})
+	require.Equal(t, http.StatusOK, delRec.Code)
+
+	// SearchFaces from id1 now finds nothing.
+	searchRec2 := doRequest(t, h, "SearchFaces", map[string]any{"CollectionId": "rt-coll", "FaceId": id1})
+	require.Equal(t, http.StatusOK, searchRec2.Code)
+
+	var search2 struct {
+		FaceMatches []json.RawMessage `json:"FaceMatches"`
+	}
+	require.NoError(t, json.Unmarshal(searchRec2.Body.Bytes(), &search2))
+	assert.Empty(t, search2.FaceMatches)
+
+	// SearchFaces for the deleted id returns ResourceNotFoundException.
+	nfRec := doRequest(t, h, "SearchFaces", map[string]any{"CollectionId": "rt-coll", "FaceId": id2})
+	require.Equal(t, http.StatusBadRequest, nfRec.Code)
+	assert.Contains(t, nfRec.Body.String(), "ResourceNotFoundException")
+}

--- a/services/rekognition/interfaces.go
+++ b/services/rekognition/interfaces.go
@@ -64,7 +64,7 @@ type StorageBackend interface {
 		faceIDs []string,
 	) ([]*DisassociatedFace, []*UnsuccessfulFaceDisassociation, error)
 	SearchUsers(collectionID, userID string, maxUsers int32) ([]*UserMatch, error)
-	SearchUsersByImage(collectionID string, maxUsers int32) ([]*UserMatch, error)
+	SearchUsersByImage(collectionID string, maxUsers int32, imageKey string) ([]*UserMatch, error)
 
 	// Face Liveness
 	CreateFaceLivenessSession() (string, error)


### PR DESCRIPTION
Single accumulating PR for the high-severity stub services from the 2026-06-19 154-service audit (parity.md §A). Mayor-driven; real stateful emulation replacing canned/stub responses. Each commit verified: go build + golangci 0 issues + tests pass.

- [x] **quicksight** (`4b9b341e`) — 25 Appendix-A ops stateful (folders/templates/themes/VPC-connections/brands): Create persists, Describe/List reflect state, Update mutates, Delete removes; ResourceNotFoundException/ConflictException
- [x] **rekognition** (`7e94bd14`) — deterministic similarity/confidence derived from stored faces (eliminated canned 90.0/99.9 constants); image-dependent SearchFacesByImage/SearchUsersByImage
- [x] **inspector2** (`3f01b4e9`) — real CIS scan state (config materializes scans; report/details/aggregations round-trip) + snapshot/restore durability fix
- [n/a] **kms** — done by swarm (`fc8755b2` GetKeyLastUsage)
- [n/a] **omics** — done by swarm (`a2c0d469` read-set/reference binary upload+streaming)

The other ~149 audit services are handled by the polecat swarm (executor fixed: stale origin/temp branch was silently rejecting gt-done pushes; reset to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)