### PR TITLE
Refinery: batch merge (KMS, omics, workmail fixes)

### DIFF
--- a/services/kms/backend.go
+++ b/services/kms/backend.go
@@ -247,6 +247,7 @@ type StorageBackend interface {
 	GenerateMac(ctx context.Context, input *GenerateMacInput) (*GenerateMacOutput, error)
 	GenerateRandom(ctx context.Context, input *GenerateRandomInput) (*GenerateRandomOutput, error)
 	VerifyMac(ctx context.Context, input *VerifyMacInput) (*VerifyMacOutput, error)
+	GetKeyLastUsage(ctx context.Context, input *GetKeyLastUsageInput) (*GetKeyLastUsageOutput, error)
 }
 
 // ensure InMemoryBackend satisfies StorageBackend at compile time.
@@ -273,6 +274,9 @@ type InMemoryBackend struct {
 	accountID            string
 	defaultRegion        string
 	keyIDResolutionCache sync.Map
+	// lastUsage tracks the last successful cryptographic operation per key.
+	// Key format: "region:keyID" → *KeyLastUsageData.
+	lastUsage sync.Map
 }
 
 // NewInMemoryBackend creates and returns a new empty KMS backend with default account/region.
@@ -819,6 +823,8 @@ func (b *InMemoryBackend) Encrypt(ctx context.Context, input *EncryptInput) (*En
 		return nil, err
 	}
 
+	b.recordLastUsage(region, key.KeyID, "Encrypt")
+
 	return &EncryptOutput{
 		CiphertextBlob:      blob,
 		KeyID:               key.Arn,
@@ -927,6 +933,8 @@ func (b *InMemoryBackend) Decrypt(ctx context.Context, input *DecryptInput) (*De
 		)
 	}
 
+	b.recordLastUsage(region, key.KeyID, "Decrypt")
+
 	return &DecryptOutput{
 		Plaintext:           plaintext,
 		KeyID:               key.Arn,
@@ -1030,6 +1038,8 @@ func (b *InMemoryBackend) GenerateDataKey(
 		return nil, encErr
 	}
 
+	b.recordLastUsage(region, key.KeyID, "GenerateDataKey")
+
 	return &GenerateDataKeyOutput{
 		CiphertextBlob: blob,
 		Plaintext:      plaintextKey,
@@ -1111,6 +1121,9 @@ func (b *InMemoryBackend) ReEncrypt(ctx context.Context, input *ReEncryptInput) 
 		return nil, encErr
 	}
 
+	b.recordLastUsage(region, sourceKey.KeyID, "ReEncrypt")
+	b.recordLastUsage(region, destKey.KeyID, "ReEncrypt")
+
 	return &ReEncryptOutput{
 		CiphertextBlob:                 blob,
 		KeyID:                          destKey.Arn,
@@ -1172,6 +1185,8 @@ func (b *InMemoryBackend) Sign(ctx context.Context, input *SignInput) (*SignOutp
 		return nil, signErr
 	}
 
+	b.recordLastUsage(region, key.KeyID, "Sign")
+
 	return &SignOutput{
 		KeyID:            key.Arn,
 		Signature:        sig,
@@ -1230,6 +1245,8 @@ func (b *InMemoryBackend) Verify(ctx context.Context, input *VerifyInput) (*Veri
 	if verifyErr != nil {
 		return nil, verifyErr
 	}
+
+	b.recordLastUsage(region, key.KeyID, "Verify")
 
 	return &VerifyOutput{
 		KeyID:            key.Arn,
@@ -2478,6 +2495,13 @@ func (b *InMemoryBackend) GenerateDataKeyWithoutPlaintext(
 		return nil, err
 	}
 
+	// Override the operation name recorded by GenerateDataKey to reflect the actual caller.
+	// out.KeyID is the key ARN; the canonical UUID follows the last "/".
+	region := getRegion(ctx, b.defaultRegion)
+	if idx := strings.LastIndexByte(out.KeyID, '/'); idx >= 0 {
+		b.recordLastUsage(region, out.KeyID[idx+1:], "GenerateDataKeyWithoutPlaintext")
+	}
+
 	return &GenerateDataKeyWithoutPlaintextOutput{
 		KeyID:          out.KeyID,
 		CiphertextBlob: out.CiphertextBlob,
@@ -3258,6 +3282,8 @@ func (b *InMemoryBackend) DeriveSharedSecret(
 		algo = algoECDH
 	}
 
+	b.recordLastUsage(region, key.KeyID, "DeriveSharedSecret")
+
 	return &DeriveSharedSecretOutput{
 		KeyID:                 key.Arn,
 		SharedSecret:          sharedSecret,
@@ -3318,6 +3344,8 @@ func (b *InMemoryBackend) GenerateDataKeyPair(
 		return nil, fmt.Errorf("encrypting private key: %w", err)
 	}
 
+	b.recordLastUsage(region, wrapKey.KeyID, "GenerateDataKeyPair")
+
 	return &GenerateDataKeyPairOutput{
 		KeyID:                    wrapKey.Arn,
 		KeyPairSpec:              input.KeyPairSpec,
@@ -3339,6 +3367,12 @@ func (b *InMemoryBackend) GenerateDataKeyPairWithoutPlaintext(
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Override the operation name recorded by GenerateDataKeyPair to reflect the actual caller.
+	region := getRegion(ctx, b.defaultRegion)
+	if idx := strings.LastIndexByte(out.KeyID, '/'); idx >= 0 {
+		b.recordLastUsage(region, out.KeyID[idx+1:], "GenerateDataKeyPairWithoutPlaintext")
 	}
 
 	return &GenerateDataKeyPairWithoutPlaintextOutput{
@@ -3389,6 +3423,8 @@ func (b *InMemoryBackend) GenerateMac(ctx context.Context, input *GenerateMacInp
 	if err != nil {
 		return nil, err
 	}
+
+	b.recordLastUsage(region, key.KeyID, "GenerateMac")
 
 	return &GenerateMacOutput{
 		KeyID:        key.Arn,
@@ -3467,11 +3503,54 @@ func (b *InMemoryBackend) VerifyMac(ctx context.Context, input *VerifyMacInput) 
 		return nil, fmt.Errorf("%w: MAC verification failed", ErrInvalidSignature)
 	}
 
+	b.recordLastUsage(region, key.KeyID, "VerifyMac")
+
 	return &VerifyMacOutput{
 		KeyID:        key.Arn,
 		MacAlgorithm: input.MacAlgorithm,
 		MacValid:     true,
 	}, nil
+}
+
+// recordLastUsage stores the last successful cryptographic operation for the given key.
+// It is safe to call concurrently without holding any lock.
+func (b *InMemoryBackend) recordLastUsage(region, canonicalKeyID, operation string) {
+	b.lastUsage.Store(region+":"+canonicalKeyID, &KeyLastUsageData{
+		Operation:         operation,
+		Timestamp:         UnixTimeFloat(time.Now()),
+		CloudTrailEventID: uuid.New().String(),
+		KmsRequestID:      uuid.New().String(),
+	})
+}
+
+// GetKeyLastUsage returns the last successful cryptographic operation performed with the specified key.
+func (b *InMemoryBackend) GetKeyLastUsage(
+	ctx context.Context,
+	input *GetKeyLastUsageInput,
+) (*GetKeyLastUsageOutput, error) {
+	b.mu.RLock("GetKeyLastUsage")
+	defer b.mu.RUnlock()
+
+	region := getRegion(ctx, b.defaultRegion)
+
+	key, err := b.lookupKey(ctx, input.KeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &GetKeyLastUsageOutput{
+		KeyID:             key.KeyID,
+		KeyCreationDate:   key.CreationDate,
+		TrackingStartDate: key.CreationDate,
+	}
+
+	if v, loaded := b.lastUsage.Load(region + ":" + key.KeyID); loaded {
+		if lu, ok := v.(*KeyLastUsageData); ok {
+			out.KeyLastUsage = lu
+		}
+	}
+
+	return out, nil
 }
 
 // AddKeyInternal inserts a key directly into the backend without going through CreateKey.

--- a/services/kms/get_key_last_usage_test.go
+++ b/services/kms/get_key_last_usage_test.go
@@ -1,0 +1,186 @@
+package kms_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/kms"
+)
+
+func TestGetKeyLastUsage(t *testing.T) {
+	t.Parallel()
+
+	newBackendWithKey := func(t *testing.T) (*kms.InMemoryBackend, string) {
+		t.Helper()
+
+		b := kms.NewInMemoryBackend()
+		out, err := b.CreateKey(context.Background(), &kms.CreateKeyInput{})
+		require.NoError(t, err)
+
+		return b, out.KeyMetadata.KeyID
+	}
+
+	tests := []struct { //nolint:govet // readability: name first
+		name          string
+		wantOperation string
+		keyID         func(keyID string) string
+		setup         func(t *testing.T, b *kms.InMemoryBackend, keyID string)
+		wantErr       bool
+		wantNoUsage   bool
+	}{
+		{
+			name:        "key exists but no usage yet",
+			setup:       func(_ *testing.T, _ *kms.InMemoryBackend, _ string) {},
+			keyID:       func(id string) string { return id },
+			wantNoUsage: true,
+		},
+		{
+			name: "records Encrypt usage",
+			setup: func(t *testing.T, b *kms.InMemoryBackend, keyID string) {
+				t.Helper()
+
+				_, err := b.Encrypt(context.Background(), &kms.EncryptInput{
+					KeyID:     keyID,
+					Plaintext: []byte("hello"),
+				})
+				require.NoError(t, err)
+			},
+			keyID:         func(id string) string { return id },
+			wantOperation: "Encrypt",
+		},
+		{
+			name: "records Decrypt usage",
+			setup: func(t *testing.T, b *kms.InMemoryBackend, keyID string) {
+				t.Helper()
+
+				enc, err := b.Encrypt(context.Background(), &kms.EncryptInput{
+					KeyID:     keyID,
+					Plaintext: []byte("hello"),
+				})
+				require.NoError(t, err)
+
+				_, err = b.Decrypt(context.Background(), &kms.DecryptInput{
+					KeyID:          keyID,
+					CiphertextBlob: enc.CiphertextBlob,
+				})
+				require.NoError(t, err)
+			},
+			keyID:         func(id string) string { return id },
+			wantOperation: "Decrypt",
+		},
+		{
+			name: "records GenerateDataKey usage",
+			setup: func(t *testing.T, b *kms.InMemoryBackend, keyID string) {
+				t.Helper()
+
+				_, err := b.GenerateDataKey(context.Background(), &kms.GenerateDataKeyInput{
+					KeyID:   keyID,
+					KeySpec: "AES_256",
+				})
+				require.NoError(t, err)
+			},
+			keyID:         func(id string) string { return id },
+			wantOperation: "GenerateDataKey",
+		},
+		{
+			name: "records GenerateDataKeyWithoutPlaintext usage",
+			setup: func(t *testing.T, b *kms.InMemoryBackend, keyID string) {
+				t.Helper()
+
+				_, err := b.GenerateDataKeyWithoutPlaintext(
+					context.Background(),
+					&kms.GenerateDataKeyWithoutPlaintextInput{
+						KeyID:   keyID,
+						KeySpec: "AES_256",
+					},
+				)
+				require.NoError(t, err)
+			},
+			keyID:         func(id string) string { return id },
+			wantOperation: "GenerateDataKeyWithoutPlaintext",
+		},
+		{
+			name:    "returns error for unknown key",
+			setup:   func(_ *testing.T, _ *kms.InMemoryBackend, _ string) {},
+			keyID:   func(_ string) string { return "nonexistent-key-id" },
+			wantErr: true,
+		},
+		{
+			name:        "KeyCreationDate and TrackingStartDate are populated",
+			setup:       func(_ *testing.T, _ *kms.InMemoryBackend, _ string) {},
+			keyID:       func(id string) string { return id },
+			wantNoUsage: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, keyID := newBackendWithKey(t)
+			tc.setup(t, b, keyID)
+
+			out, err := b.GetKeyLastUsage(context.Background(), &kms.GetKeyLastUsageInput{
+				KeyID: tc.keyID(keyID),
+			})
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			assert.NotEmpty(t, out.KeyID)
+			assert.Greater(t, out.KeyCreationDate, float64(0))
+			assert.Greater(t, out.TrackingStartDate, float64(0))
+
+			if tc.wantNoUsage {
+				assert.Nil(t, out.KeyLastUsage)
+
+				return
+			}
+
+			require.NotNil(t, out.KeyLastUsage)
+			assert.Equal(t, tc.wantOperation, out.KeyLastUsage.Operation)
+			assert.Greater(t, out.KeyLastUsage.Timestamp, float64(0))
+			assert.NotEmpty(t, out.KeyLastUsage.CloudTrailEventID)
+			assert.NotEmpty(t, out.KeyLastUsage.KmsRequestID)
+		})
+	}
+}
+
+func TestGetKeyLastUsage_Via_Handler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wantStatus int
+	}{
+		{
+			name:       "dispatches GetKeyLastUsage through handler",
+			wantStatus: 200,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := kms.NewInMemoryBackend()
+			h := kms.NewHandler(b)
+
+			createOut, err := b.CreateKey(context.Background(), &kms.CreateKeyInput{})
+			require.NoError(t, err)
+
+			keyID := createOut.KeyMetadata.KeyID
+
+			rec := sendKMSOp(t, h, "GetKeyLastUsage", `{"KeyId":"`+keyID+`"}`)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+		})
+	}
+}

--- a/services/kms/handler.go
+++ b/services/kms/handler.go
@@ -238,6 +238,7 @@ func (h *Handler) GetSupportedOperations() []string {
 		opGenerateDataKeyWithoutPlaintext,
 		opGenerateMac,
 		"GenerateRandom",
+		"GetKeyLastUsage",
 		"GetKeyPolicy",
 		"GetKeyRotationStatus",
 		"GetParametersForImport",
@@ -349,6 +350,9 @@ func (h *Handler) buildDispatchTable() map[string]kmsActionFn {
 	maps.Copy(table, h.buildGrantPolicyActions())
 	maps.Copy(table, h.buildTagActions())
 	maps.Copy(table, h.buildNewOpsActions())
+	table["GetKeyLastUsage"] = unmarshalAction(func(ctx context.Context, i *GetKeyLastUsageInput) (any, error) {
+		return h.Backend.GetKeyLastUsage(ctx, i)
+	})
 
 	return table
 }

--- a/services/kms/models.go
+++ b/services/kms/models.go
@@ -864,3 +864,24 @@ type VerifyMacOutput struct {
 	MacAlgorithm string `json:"MacAlgorithm"`
 	MacValid     bool   `json:"MacValid"`
 }
+
+// KeyLastUsageData contains information about the last successful cryptographic operation on a KMS key.
+type KeyLastUsageData struct {
+	CloudTrailEventID string  `json:"CloudTrailEventId,omitempty"`
+	KmsRequestID      string  `json:"KmsRequestId,omitempty"`
+	Operation         string  `json:"Operation,omitempty"`
+	Timestamp         float64 `json:"Timestamp,omitempty"`
+}
+
+// GetKeyLastUsageInput is the request payload for GetKeyLastUsage.
+type GetKeyLastUsageInput struct {
+	KeyID string `json:"KeyId"` //nolint:tagliatelle // AWS API uses KeyId
+}
+
+// GetKeyLastUsageOutput is the response payload for GetKeyLastUsage.
+type GetKeyLastUsageOutput struct {
+	KeyCreationDate   float64           `json:"KeyCreationDate,omitempty"`
+	KeyID             string            `json:"KeyId,omitempty"` //nolint:tagliatelle // AWS API uses KeyId
+	KeyLastUsage      *KeyLastUsageData `json:"KeyLastUsage,omitempty"`
+	TrackingStartDate float64           `json:"TrackingStartDate,omitempty"`
+}

--- a/services/kms/sdk_completeness_test.go
+++ b/services/kms/sdk_completeness_test.go
@@ -18,7 +18,5 @@ func TestSDKCompleteness(t *testing.T) {
 
 	backend := kms.NewInMemoryBackend()
 	h := kms.NewHandler(backend)
-	sdkcheck.CheckCompleteness(t, &kmssdk.Client{}, h.GetSupportedOperations(), []string{
-		"GetKeyLastUsage",
-	})
+	sdkcheck.CheckCompleteness(t, &kmssdk.Client{}, h.GetSupportedOperations(), []string{})
 }

--- a/services/omics/backend.go
+++ b/services/omics/backend.go
@@ -1325,9 +1325,11 @@ func (b *InMemoryBackend) UploadReadSetPart(
 			p.PartSize = int64(len(data))
 			p.LastUpdatedTime = time.Now().UTC()
 			found = true
+
 			break
 		}
 	}
+
 	if !found {
 		parts = append(parts, &ReadSetUploadPart{
 			PartNumber:      partNumber,
@@ -1339,6 +1341,7 @@ func (b *InMemoryBackend) UploadReadSetPart(
 	}
 
 	sum := sha256.Sum256(data)
+
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/services/omics/backend.go
+++ b/services/omics/backend.go
@@ -2,6 +2,8 @@ package omics
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -67,6 +69,9 @@ type regionState struct {
 	readSetImportJobs     map[string]map[string]*ReadSetImportJob
 	multipartUploads      map[string]map[string]*MultipartReadSetUpload
 	uploadParts           map[string]map[string][]*ReadSetUploadPart
+	uploadPartData        map[string]map[string]map[string]map[int][]byte // storeID→uploadID→source→partNum→bytes
+	readSetBytes          map[string]map[string][]byte                    // storeID→readSetID→bytes
+	referenceBytes        map[string]map[string][]byte                    // storeID→refID→bytes
 	runGroups             map[string]*RunGroup
 	runs                  map[string]*Run
 	runTasks              map[string]map[string]*RunTask
@@ -97,6 +102,9 @@ func newRegionState() *regionState {
 		readSetImportJobs:     make(map[string]map[string]*ReadSetImportJob),
 		multipartUploads:      make(map[string]map[string]*MultipartReadSetUpload),
 		uploadParts:           make(map[string]map[string][]*ReadSetUploadPart),
+		uploadPartData:        make(map[string]map[string]map[string]map[int][]byte),
+		readSetBytes:          make(map[string]map[string][]byte),
+		referenceBytes:        make(map[string]map[string][]byte),
 		runGroups:             make(map[string]*RunGroup),
 		runs:                  make(map[string]*Run),
 		runTasks:              make(map[string]map[string]*RunTask),
@@ -250,6 +258,7 @@ func (b *InMemoryBackend) CreateReferenceStore(
 	st.referenceStores[rs.ID] = rs
 	st.references[rs.ID] = make(map[string]*ReferenceMetadata)
 	st.referenceImportJobs[rs.ID] = make(map[string]*ReferenceImportJob)
+	st.referenceBytes[rs.ID] = make(map[string][]byte)
 
 	if tags != nil {
 		st.tags[rs.Arn] = copyTags(tags)
@@ -276,6 +285,7 @@ func (b *InMemoryBackend) DeleteReferenceStore(id string) error {
 	delete(st.referenceStores, id)
 	delete(st.references, id)
 	delete(st.referenceImportJobs, id)
+	delete(st.referenceBytes, id)
 
 	return nil
 }
@@ -470,6 +480,7 @@ func (b *InMemoryBackend) StartReferenceImportJob(
 			UpdateTime:   time.Now().UTC(),
 		}
 		st.references[referenceStoreID][refID] = ref
+		st.referenceBytes[referenceStoreID][refID] = []byte{}
 	}
 
 	st.referenceImportJobs[referenceStoreID][job.ID] = job
@@ -575,6 +586,8 @@ func (b *InMemoryBackend) CreateSequenceStore(
 	st.readSetImportJobs[ss.ID] = make(map[string]*ReadSetImportJob)
 	st.multipartUploads[ss.ID] = make(map[string]*MultipartReadSetUpload)
 	st.uploadParts[ss.ID] = make(map[string][]*ReadSetUploadPart)
+	st.uploadPartData[ss.ID] = make(map[string]map[string]map[int][]byte)
+	st.readSetBytes[ss.ID] = make(map[string][]byte)
 
 	if tags != nil {
 		st.tags[ss.Arn] = copyTags(tags)
@@ -605,6 +618,8 @@ func (b *InMemoryBackend) DeleteSequenceStore(id string) error {
 	delete(st.readSetImportJobs, id)
 	delete(st.multipartUploads, id)
 	delete(st.uploadParts, id)
+	delete(st.uploadPartData, id)
+	delete(st.readSetBytes, id)
 
 	return nil
 }
@@ -1099,6 +1114,7 @@ func (b *InMemoryBackend) CreateMultipartReadSetUpload(
 	}
 	st.multipartUploads[sequenceStoreID][upload.UploadID] = upload
 	st.uploadParts[sequenceStoreID][upload.UploadID] = nil
+	st.uploadPartData[sequenceStoreID][upload.UploadID] = make(map[string]map[int][]byte)
 
 	result := *upload
 
@@ -1122,6 +1138,7 @@ func (b *InMemoryBackend) AbortMultipartReadSetUpload(sequenceStoreID, uploadID 
 
 	delete(st.multipartUploads[sequenceStoreID], uploadID)
 	delete(st.uploadParts[sequenceStoreID], uploadID)
+	delete(st.uploadPartData[sequenceStoreID], uploadID)
 
 	return nil
 }
@@ -1162,8 +1179,26 @@ func (b *InMemoryBackend) CompleteMultipartReadSetUpload(
 		Tags:         maps.Clone(upload.Tags),
 	}
 	st.readSets[sequenceStoreID][rsID] = rs
+
+	// Concatenate stored part bytes (SOURCE1 then SOURCE2, in part-number order) as the read set body.
+	partData := st.uploadPartData[sequenceStoreID][uploadID]
+	var combined []byte
+	for _, src := range []string{"SOURCE1", "SOURCE2"} {
+		srcParts := partData[src]
+		partNums := make([]int, 0, len(srcParts))
+		for n := range srcParts {
+			partNums = append(partNums, n)
+		}
+		sort.Ints(partNums)
+		for _, n := range partNums {
+			combined = append(combined, srcParts[n]...)
+		}
+	}
+	st.readSetBytes[sequenceStoreID][rsID] = combined
+
 	delete(st.multipartUploads[sequenceStoreID], uploadID)
 	delete(st.uploadParts[sequenceStoreID], uploadID)
+	delete(st.uploadPartData[sequenceStoreID], uploadID)
 
 	result := *rs
 
@@ -1252,6 +1287,87 @@ func (b *InMemoryBackend) ListReadSetUploadParts(
 	}
 
 	return result, outToken, nil
+}
+
+// UploadReadSetPart stores binary data for a single part and returns its SHA256 checksum.
+func (b *InMemoryBackend) UploadReadSetPart(
+	sequenceStoreID, uploadID string,
+	partNumber int,
+	partSource string,
+	data []byte,
+) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	st := b.region(b.defaultRegion)
+
+	if _, ok := st.sequenceStores[sequenceStoreID]; !ok {
+		return "", fmt.Errorf("%w: sequence store %s not found", ErrNotFound, sequenceStoreID)
+	}
+
+	if _, ok := st.multipartUploads[sequenceStoreID][uploadID]; !ok {
+		return "", fmt.Errorf("%w: upload %s not found", ErrNotFound, uploadID)
+	}
+
+	if st.uploadPartData[sequenceStoreID][uploadID] == nil {
+		st.uploadPartData[sequenceStoreID][uploadID] = make(map[string]map[int][]byte)
+	}
+	if st.uploadPartData[sequenceStoreID][uploadID][partSource] == nil {
+		st.uploadPartData[sequenceStoreID][uploadID][partSource] = make(map[int][]byte)
+	}
+	st.uploadPartData[sequenceStoreID][uploadID][partSource][partNumber] = data
+
+	// Update or append the upload part metadata.
+	parts := st.uploadParts[sequenceStoreID][uploadID]
+	found := false
+	for _, p := range parts {
+		if p.PartNumber == partNumber && p.Source == partSource {
+			p.PartSize = int64(len(data))
+			p.LastUpdatedTime = time.Now().UTC()
+			found = true
+			break
+		}
+	}
+	if !found {
+		parts = append(parts, &ReadSetUploadPart{
+			PartNumber:      partNumber,
+			Source:          partSource,
+			PartSize:        int64(len(data)),
+			LastUpdatedTime: time.Now().UTC(),
+		})
+		st.uploadParts[sequenceStoreID][uploadID] = parts
+	}
+
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// GetReadSetBytes returns the stored binary body for a read set.
+func (b *InMemoryBackend) GetReadSetBytes(sequenceStoreID, id string) ([]byte, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	st := b.region(b.defaultRegion)
+
+	if _, ok := st.readSets[sequenceStoreID][id]; !ok {
+		return nil, fmt.Errorf("%w: read set %s not found", ErrNotFound, id)
+	}
+
+	return st.readSetBytes[sequenceStoreID][id], nil
+}
+
+// GetReferenceBytes returns the stored binary body for a reference.
+func (b *InMemoryBackend) GetReferenceBytes(referenceStoreID, id string) ([]byte, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	st := b.region(b.defaultRegion)
+
+	if _, ok := st.references[referenceStoreID][id]; !ok {
+		return nil, fmt.Errorf("%w: reference %s not found", ErrNotFound, id)
+	}
+
+	return st.referenceBytes[referenceStoreID][id], nil
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/services/omics/handler.go
+++ b/services/omics/handler.go
@@ -1703,7 +1703,10 @@ func (h *Handler) handleUploadReadSetPart(c *echo.Context, storeID, uploadID str
 
 	data, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("InternalFailureException", "failed to read request body"))
+		return c.JSON(
+			http.StatusInternalServerError,
+			errResp("InternalFailureException", "failed to read request body"),
+		)
 	}
 
 	checksum, err := h.Backend.UploadReadSetPart(storeID, uploadID, partNumber, partSource, data)

--- a/services/omics/handler.go
+++ b/services/omics/handler.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/labstack/echo/v5"
@@ -1236,12 +1238,12 @@ func (h *Handler) handleDeleteReference(c *echo.Context, storeID, id string) err
 }
 
 func (h *Handler) handleGetReference(c *echo.Context, storeID, id string) error {
-	// GetReference returns binary data; respond with 200 and empty body as stub
-	if _, err := h.Backend.GetReferenceMetadata(storeID, id); err != nil {
+	data, err := h.Backend.GetReferenceBytes(storeID, id)
+	if err != nil {
 		return h.mapError(c, err)
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{})
+	return c.Blob(http.StatusOK, "application/octet-stream", data)
 }
 
 func (h *Handler) handleGetReferenceMetadata(c *echo.Context, storeID, id string) error {
@@ -1417,12 +1419,12 @@ func (h *Handler) handleBatchDeleteReadSet(c *echo.Context, storeID string) erro
 }
 
 func (h *Handler) handleGetReadSet(c *echo.Context, storeID, id string) error {
-	// GetReadSet returns binary streaming data; return 200 empty as stub
-	if _, err := h.Backend.GetReadSetMetadata(storeID, id); err != nil {
+	data, err := h.Backend.GetReadSetBytes(storeID, id)
+	if err != nil {
 		return h.mapError(c, err)
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{})
+	return c.Blob(http.StatusOK, "application/octet-stream", data)
 }
 
 func (h *Handler) handleGetReadSetMetadata(c *echo.Context, storeID, id string) error {
@@ -1688,14 +1690,31 @@ func (h *Handler) handleListReadSetUploadParts(c *echo.Context, storeID, uploadI
 }
 
 func (h *Handler) handleUploadReadSetPart(c *echo.Context, storeID, uploadID string) error {
-	// Binary upload stub - validate the store/upload exist then return 200
-	if _, _, err := h.Backend.ListMultipartReadSetUploads(storeID, 1, ""); err != nil {
+	partNumberStr := c.QueryParam("partNumber")
+	partNumber, err := strconv.Atoi(partNumberStr)
+	if err != nil || partNumber < 1 {
+		return c.JSON(http.StatusBadRequest, errResp("ValidationException", "partNumber must be a positive integer"))
+	}
+
+	partSource := c.QueryParam("partSource")
+	if partSource == "" {
+		partSource = "SOURCE1"
+	}
+
+	data, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errResp("InternalFailureException", "failed to read request body"))
+	}
+
+	checksum, err := h.Backend.UploadReadSetPart(storeID, uploadID, partNumber, partSource, data)
+	if err != nil {
 		return h.mapError(c, err)
 	}
 
-	_ = uploadID
-
-	return c.JSON(http.StatusOK, map[string]any{"checksum": "stub"})
+	return c.JSON(http.StatusOK, map[string]any{
+		"checksum":          checksum,
+		"checksumAlgorithm": "SHA256",
+	})
 }
 
 func (h *Handler) handleCreateRunGroup(c *echo.Context) error {

--- a/services/omics/handler_test.go
+++ b/services/omics/handler_test.go
@@ -2,7 +2,10 @@ package omics_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -641,6 +644,247 @@ func TestOmics_RouteMatcher_TagPaths(t *testing.T) {
 			c := e.NewContext(req, rec)
 			matcher := h.RouteMatcher()
 			assert.Equal(t, tt.wantMatch, matcher(c), "path: %s", tt.path)
+		})
+	}
+}
+
+func doRequestRaw(t *testing.T, h *omics.Handler, method, path string, contentType string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	rec := httptest.NewRecorder()
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Handler()(c))
+
+	return rec
+}
+
+func TestOmics_GetReference_Binary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, h *omics.Handler) string // returns reference path
+		wantCode int
+	}{
+		{
+			name: "GetReference returns 404 for unknown store",
+			setup: func(t *testing.T, h *omics.Handler) string {
+				t.Helper()
+				return "/referencestore/unknownstore/reference/unknownref"
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name: "GetReference returns 404 for unknown reference",
+			setup: func(t *testing.T, h *omics.Handler) string {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/referencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				return fmt.Sprintf("/referencestore/%s/reference/doesnotexist", resp["id"])
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name: "GetReference returns 200 with binary body for imported reference",
+			setup: func(t *testing.T, h *omics.Handler) string {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/referencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var storeResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &storeResp))
+				storeID := storeResp["id"].(string)
+
+				rec2 := doRequest(t, h, http.MethodPost,
+					fmt.Sprintf("/referencestore/%s/importjob", storeID),
+					map[string]any{
+						"roleArn": "arn:aws:iam::000000000000:role/test",
+						"sources": []map[string]any{{"sourceFile": "s3://b/ref.fa", "name": "ref1"}},
+					},
+				)
+				require.Equal(t, http.StatusCreated, rec2.Code)
+
+				// List references to get the created reference ID.
+				rec3 := doRequest(t, h, http.MethodPost,
+					fmt.Sprintf("/referencestore/%s/references", storeID),
+					nil,
+				)
+				require.Equal(t, http.StatusOK, rec3.Code)
+				var listResp map[string]any
+				require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &listResp))
+				refs := listResp["references"].([]any)
+				require.Len(t, refs, 1)
+				refID := refs[0].(map[string]any)["id"].(string)
+
+				return fmt.Sprintf("/referencestore/%s/reference/%s", storeID, refID)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestHandler(t)
+			path := tc.setup(t, h)
+			rec := doRequestRaw(t, h, http.MethodGet, path, "", nil)
+			assert.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+func TestOmics_UploadReadSetPart_And_GetReadSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		run      func(t *testing.T, h *omics.Handler)
+	}{
+		{
+			name: "UploadReadSetPart missing partNumber returns 400",
+			run: func(t *testing.T, h *omics.Handler) {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/sequencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var storeResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &storeResp))
+				storeID := storeResp["id"].(string)
+
+				rec2 := doRequestRaw(t, h, http.MethodPut,
+					fmt.Sprintf("/sequencestore/%s/upload/fakeid/part", storeID),
+					"application/octet-stream",
+					[]byte("data"),
+				)
+				assert.Equal(t, http.StatusBadRequest, rec2.Code)
+			},
+		},
+		{
+			name: "UploadReadSetPart unknown upload returns 404",
+			run: func(t *testing.T, h *omics.Handler) {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/sequencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var storeResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &storeResp))
+				storeID := storeResp["id"].(string)
+
+				rec2 := doRequestRaw(t, h, http.MethodPut,
+					fmt.Sprintf("/sequencestore/%s/upload/fakeid/part?partNumber=1&partSource=SOURCE1", storeID),
+					"application/octet-stream",
+					[]byte("data"),
+				)
+				assert.Equal(t, http.StatusNotFound, rec2.Code)
+			},
+		},
+		{
+			name: "UploadReadSetPart returns real SHA256 checksum",
+			run: func(t *testing.T, h *omics.Handler) {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/sequencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var storeResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &storeResp))
+				storeID := storeResp["id"].(string)
+
+				rec2 := doRequest(t, h, http.MethodPost,
+					fmt.Sprintf("/sequencestore/%s/upload", storeID),
+					map[string]any{"name": "rs", "sequenceType": "GENERIC"},
+				)
+				require.Equal(t, http.StatusCreated, rec2.Code)
+				var uploadResp map[string]any
+				require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &uploadResp))
+				uploadID := uploadResp["uploadId"].(string)
+
+				payload := []byte("ACGT sequence data")
+				expectedSum := sha256.Sum256(payload)
+				expectedChecksum := hex.EncodeToString(expectedSum[:])
+
+				rec3 := doRequestRaw(t, h, http.MethodPut,
+					fmt.Sprintf("/sequencestore/%s/upload/%s/part?partNumber=1&partSource=SOURCE1", storeID, uploadID),
+					"application/octet-stream",
+					payload,
+				)
+				require.Equal(t, http.StatusOK, rec3.Code)
+				var partResp map[string]any
+				require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &partResp))
+				assert.Equal(t, expectedChecksum, partResp["checksum"])
+				assert.Equal(t, "SHA256", partResp["checksumAlgorithm"])
+			},
+		},
+		{
+			name: "GetReadSet streams bytes after complete multipart upload",
+			run: func(t *testing.T, h *omics.Handler) {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/sequencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var storeResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &storeResp))
+				storeID := storeResp["id"].(string)
+
+				rec2 := doRequest(t, h, http.MethodPost,
+					fmt.Sprintf("/sequencestore/%s/upload", storeID),
+					map[string]any{"name": "rs", "sequenceType": "GENERIC"},
+				)
+				require.Equal(t, http.StatusCreated, rec2.Code)
+				var uploadResp map[string]any
+				require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &uploadResp))
+				uploadID := uploadResp["uploadId"].(string)
+
+				payload := []byte("hello omics")
+				rec3 := doRequestRaw(t, h, http.MethodPut,
+					fmt.Sprintf("/sequencestore/%s/upload/%s/part?partNumber=1&partSource=SOURCE1", storeID, uploadID),
+					"application/octet-stream",
+					payload,
+				)
+				require.Equal(t, http.StatusOK, rec3.Code)
+
+				rec4 := doRequest(t, h, http.MethodPost,
+					fmt.Sprintf("/sequencestore/%s/upload/%s/complete", storeID, uploadID),
+					nil,
+				)
+				require.Equal(t, http.StatusOK, rec4.Code)
+				var rsResp map[string]any
+				require.NoError(t, json.Unmarshal(rec4.Body.Bytes(), &rsResp))
+				rsID := rsResp["id"].(string)
+
+				rec5 := doRequestRaw(t, h, http.MethodGet,
+					fmt.Sprintf("/sequencestore/%s/readset/%s", storeID, rsID),
+					"", nil,
+				)
+				require.Equal(t, http.StatusOK, rec5.Code)
+				assert.Equal(t, payload, rec5.Body.Bytes())
+			},
+		},
+		{
+			name: "GetReadSet returns 404 for unknown read set",
+			run: func(t *testing.T, h *omics.Handler) {
+				t.Helper()
+				rec := doRequest(t, h, http.MethodPost, "/sequencestore", map[string]any{"name": "s"})
+				require.Equal(t, http.StatusCreated, rec.Code)
+				var storeResp map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &storeResp))
+				storeID := storeResp["id"].(string)
+
+				rec2 := doRequestRaw(t, h, http.MethodGet,
+					fmt.Sprintf("/sequencestore/%s/readset/doesnotexist", storeID),
+					"", nil,
+				)
+				assert.Equal(t, http.StatusNotFound, rec2.Code)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.run(t, newTestHandler(t))
 		})
 	}
 }

--- a/services/omics/handler_test.go
+++ b/services/omics/handler_test.go
@@ -648,7 +648,9 @@ func TestOmics_RouteMatcher_TagPaths(t *testing.T) {
 	}
 }
 
-func doRequestRaw(t *testing.T, h *omics.Handler, method, path string, contentType string, body []byte) *httptest.ResponseRecorder {
+func doRequestRaw(
+	t *testing.T, h *omics.Handler, method, path, contentType string, body []byte,
+) *httptest.ResponseRecorder {
 	t.Helper()
 
 	req := httptest.NewRequest(method, path, bytes.NewReader(body))
@@ -668,14 +670,15 @@ func TestOmics_GetReference_Binary(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
 		setup    func(t *testing.T, h *omics.Handler) string // returns reference path
+		name     string
 		wantCode int
 	}{
 		{
 			name: "GetReference returns 404 for unknown store",
-			setup: func(t *testing.T, h *omics.Handler) string {
+			setup: func(t *testing.T, _ *omics.Handler) string {
 				t.Helper()
+
 				return "/referencestore/unknownstore/reference/unknownref"
 			},
 			wantCode: http.StatusNotFound,
@@ -684,10 +687,13 @@ func TestOmics_GetReference_Binary(t *testing.T) {
 			name: "GetReference returns 404 for unknown reference",
 			setup: func(t *testing.T, h *omics.Handler) string {
 				t.Helper()
+
 				rec := doRequest(t, h, http.MethodPost, "/referencestore", map[string]any{"name": "s"})
 				require.Equal(t, http.StatusCreated, rec.Code)
+
 				var resp map[string]any
 				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
 				return fmt.Sprintf("/referencestore/%s/reference/doesnotexist", resp["id"])
 			},
 			wantCode: http.StatusNotFound,
@@ -744,8 +750,8 @@ func TestOmics_UploadReadSetPart_And_GetReadSet(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		run      func(t *testing.T, h *omics.Handler)
+		run  func(t *testing.T, h *omics.Handler)
+		name string
 	}{
 		{
 			name: "UploadReadSetPart missing partNumber returns 400",

--- a/services/omics/interfaces.go
+++ b/services/omics/interfaces.go
@@ -102,6 +102,14 @@ type StorageBackend interface {
 		maxResults int,
 		nextToken string,
 	) ([]*ReadSetUploadPart, string, error)
+	UploadReadSetPart(
+		sequenceStoreID, uploadID string,
+		partNumber int,
+		partSource string,
+		data []byte,
+	) (string, error)
+	GetReadSetBytes(sequenceStoreID, id string) ([]byte, error)
+	GetReferenceBytes(referenceStoreID, id string) ([]byte, error)
 
 	// RunGroup
 	CreateRunGroup(

--- a/test/integration/workmail_test.go
+++ b/test/integration/workmail_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	workmailsdk "github.com/aws/aws-sdk-go-v2/service/workmail"
+	worktypes "github.com/aws/aws-sdk-go-v2/service/workmail/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,18 +30,38 @@ func createWorkMailClient(t *testing.T) *workmailsdk.Client {
 	})
 }
 
-// TestIntegration_WorkMail_OrganizationLifecycle drives create→describe→list→delete of an
-// organization, then a nested group create→delete.
+// wmCreateOrg is a helper that creates an organization and registers a cleanup.
+func wmCreateOrg(t *testing.T, client *workmailsdk.Client, alias string) string {
+	t.Helper()
+
+	ctx := t.Context()
+	out, err := client.CreateOrganization(ctx, &workmailsdk.CreateOrganizationInput{
+		Alias: aws.String(alias),
+	})
+	require.NoError(t, err, "CreateOrganization(%q) should succeed", alias)
+	orgID := aws.ToString(out.OrganizationId)
+	require.NotEmpty(t, orgID)
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteOrganization(t.Context(), &workmailsdk.DeleteOrganizationInput{
+			OrganizationId:  aws.String(orgID),
+			DeleteDirectory: true,
+		})
+	})
+
+	return orgID
+}
+
+// TestIntegration_WorkMail_OrganizationLifecycle drives create→describe→list→delete.
 func TestIntegration_WorkMail_OrganizationLifecycle(t *testing.T) {
 	t.Parallel()
 	dumpContainerLogsOnFailure(t)
 
 	tests := []struct {
-		name      string
-		alias     string
-		groupName string
+		name  string
+		alias string
 	}{
-		{name: "full_lifecycle", alias: "integ-org", groupName: "integ-group"},
+		{name: "basic", alias: "integ-org-lifecycle"},
 	}
 
 	for _, tt := range tests {
@@ -50,25 +71,147 @@ func TestIntegration_WorkMail_OrganizationLifecycle(t *testing.T) {
 			ctx := t.Context()
 			client := createWorkMailClient(t)
 
-			createOut, err := client.CreateOrganization(ctx, &workmailsdk.CreateOrganizationInput{
-				Alias: aws.String(tt.alias),
-			})
-			require.NoError(t, err, "CreateOrganization should succeed")
-			orgID := aws.ToString(createOut.OrganizationId)
-			require.NotEmpty(t, orgID, "organization id must be returned")
-
-			t.Cleanup(func() {
-				_, _ = client.DeleteOrganization(ctx, &workmailsdk.DeleteOrganizationInput{
-					OrganizationId:  aws.String(orgID),
-					DeleteDirectory: true,
-				})
-			})
+			orgID := wmCreateOrg(t, client, tt.alias)
 
 			descOut, err := client.DescribeOrganization(ctx, &workmailsdk.DescribeOrganizationInput{
 				OrganizationId: aws.String(orgID),
 			})
 			require.NoError(t, err, "DescribeOrganization should succeed")
 			assert.Equal(t, tt.alias, aws.ToString(descOut.Alias))
+			assert.NotEmpty(t, descOut.OrganizationId)
+
+			listOut, err := client.ListOrganizations(ctx, &workmailsdk.ListOrganizationsInput{})
+			require.NoError(t, err, "ListOrganizations should succeed")
+
+			found := false
+			for _, o := range listOut.OrganizationSummaries {
+				if aws.ToString(o.OrganizationId) == orgID {
+					found = true
+
+					break
+				}
+			}
+			assert.True(t, found, "org should appear in list")
+		})
+	}
+}
+
+// TestIntegration_WorkMail_UserLifecycle drives create→describe→update→list→register→deregister→delete.
+func TestIntegration_WorkMail_UserLifecycle(t *testing.T) {
+	t.Parallel()
+	dumpContainerLogsOnFailure(t)
+
+	tests := []struct {
+		name        string
+		orgAlias    string
+		userName    string
+		displayName string
+	}{
+		{name: "full_lifecycle", orgAlias: "integ-user-org", userName: "alice", displayName: "Alice Smith"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			client := createWorkMailClient(t)
+
+			orgID := wmCreateOrg(t, client, tt.orgAlias)
+
+			createOut, err := client.CreateUser(ctx, &workmailsdk.CreateUserInput{
+				OrganizationId: aws.String(orgID),
+				Name:           aws.String(tt.userName),
+				DisplayName:    aws.String(tt.displayName),
+				Password:       aws.String("TestPass@1234"),
+			})
+			require.NoError(t, err, "CreateUser should succeed")
+			userID := aws.ToString(createOut.UserId)
+			require.NotEmpty(t, userID)
+
+			descOut, err := client.DescribeUser(ctx, &workmailsdk.DescribeUserInput{
+				OrganizationId: aws.String(orgID),
+				UserId:         aws.String(userID),
+			})
+			require.NoError(t, err, "DescribeUser should succeed")
+			assert.Equal(t, tt.userName, aws.ToString(descOut.Name))
+			assert.Equal(t, tt.displayName, aws.ToString(descOut.DisplayName))
+			assert.Equal(t, "DISABLED", string(descOut.State))
+
+			_, err = client.UpdateUser(ctx, &workmailsdk.UpdateUserInput{
+				OrganizationId: aws.String(orgID),
+				UserId:         aws.String(userID),
+				FirstName:      aws.String("Alice"),
+				LastName:       aws.String("Smith"),
+			})
+			require.NoError(t, err, "UpdateUser should succeed")
+
+			listOut, err := client.ListUsers(ctx, &workmailsdk.ListUsersInput{
+				OrganizationId: aws.String(orgID),
+			})
+			require.NoError(t, err, "ListUsers should succeed")
+
+			found := false
+			for _, u := range listOut.Users {
+				if aws.ToString(u.Id) == userID {
+					found = true
+
+					break
+				}
+			}
+			assert.True(t, found, "user should appear in list")
+
+			email := tt.userName + "@example.com"
+			_, err = client.RegisterToWorkMail(ctx, &workmailsdk.RegisterToWorkMailInput{
+				OrganizationId: aws.String(orgID),
+				EntityId:       aws.String(userID),
+				Email:          aws.String(email),
+			})
+			require.NoError(t, err, "RegisterToWorkMail should succeed")
+
+			descEnabled, err := client.DescribeUser(ctx, &workmailsdk.DescribeUserInput{
+				OrganizationId: aws.String(orgID),
+				UserId:         aws.String(userID),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "ENABLED", string(descEnabled.State))
+
+			_, err = client.DeregisterFromWorkMail(ctx, &workmailsdk.DeregisterFromWorkMailInput{
+				OrganizationId: aws.String(orgID),
+				EntityId:       aws.String(userID),
+			})
+			require.NoError(t, err, "DeregisterFromWorkMail should succeed")
+
+			_, err = client.DeleteUser(ctx, &workmailsdk.DeleteUserInput{
+				OrganizationId: aws.String(orgID),
+				UserId:         aws.String(userID),
+			})
+			require.NoError(t, err, "DeleteUser should succeed")
+		})
+	}
+}
+
+// TestIntegration_WorkMail_GroupLifecycle drives create→describe→list→member ops→delete.
+func TestIntegration_WorkMail_GroupLifecycle(t *testing.T) {
+	t.Parallel()
+	dumpContainerLogsOnFailure(t)
+
+	tests := []struct {
+		name      string
+		orgAlias  string
+		groupName string
+	}{
+		{name: "full_lifecycle", orgAlias: "integ-group-org", groupName: "integ-group"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			client := createWorkMailClient(t)
+
+			orgID := wmCreateOrg(t, client, tt.orgAlias)
 
 			grpOut, err := client.CreateGroup(ctx, &workmailsdk.CreateGroupInput{
 				OrganizationId: aws.String(orgID),
@@ -76,7 +219,14 @@ func TestIntegration_WorkMail_OrganizationLifecycle(t *testing.T) {
 			})
 			require.NoError(t, err, "CreateGroup should succeed")
 			groupID := aws.ToString(grpOut.GroupId)
-			require.NotEmpty(t, groupID, "group id must be returned")
+			require.NotEmpty(t, groupID)
+
+			descOut, err := client.DescribeGroup(ctx, &workmailsdk.DescribeGroupInput{
+				OrganizationId: aws.String(orgID),
+				GroupId:        aws.String(groupID),
+			})
+			require.NoError(t, err, "DescribeGroup should succeed")
+			assert.Equal(t, tt.groupName, aws.ToString(descOut.Name))
 
 			listOut, err := client.ListGroups(ctx, &workmailsdk.ListGroupsInput{
 				OrganizationId: aws.String(orgID),
@@ -91,14 +241,243 @@ func TestIntegration_WorkMail_OrganizationLifecycle(t *testing.T) {
 					break
 				}
 			}
-
 			assert.True(t, found, "created group should appear in list")
+
+			// Create a user to add as member.
+			userOut, err := client.CreateUser(ctx, &workmailsdk.CreateUserInput{
+				OrganizationId: aws.String(orgID),
+				Name:           aws.String("member-user"),
+				DisplayName:    aws.String("Member"),
+				Password:       aws.String("TestPass@1234"),
+			})
+			require.NoError(t, err)
+			userID := aws.ToString(userOut.UserId)
+
+			_, err = client.AssociateMemberToGroup(ctx, &workmailsdk.AssociateMemberToGroupInput{
+				OrganizationId: aws.String(orgID),
+				GroupId:        aws.String(groupID),
+				MemberId:       aws.String(userID),
+			})
+			require.NoError(t, err, "AssociateMemberToGroup should succeed")
+
+			membersOut, err := client.ListGroupMembers(ctx, &workmailsdk.ListGroupMembersInput{
+				OrganizationId: aws.String(orgID),
+				GroupId:        aws.String(groupID),
+			})
+			require.NoError(t, err, "ListGroupMembers should succeed")
+			require.Len(t, membersOut.Members, 1)
+			assert.Equal(t, userID, aws.ToString(membersOut.Members[0].Id))
+
+			_, err = client.DisassociateMemberFromGroup(ctx, &workmailsdk.DisassociateMemberFromGroupInput{
+				OrganizationId: aws.String(orgID),
+				GroupId:        aws.String(groupID),
+				MemberId:       aws.String(userID),
+			})
+			require.NoError(t, err, "DisassociateMemberFromGroup should succeed")
 
 			_, err = client.DeleteGroup(ctx, &workmailsdk.DeleteGroupInput{
 				OrganizationId: aws.String(orgID),
 				GroupId:        aws.String(groupID),
 			})
 			require.NoError(t, err, "DeleteGroup should succeed")
+		})
+	}
+}
+
+// TestIntegration_WorkMail_ResourceLifecycle drives create→describe→list→delegate ops→delete.
+func TestIntegration_WorkMail_ResourceLifecycle(t *testing.T) {
+	t.Parallel()
+	dumpContainerLogsOnFailure(t)
+
+	tests := []struct {
+		name         string
+		orgAlias     string
+		resourceName string
+		resourceType worktypes.ResourceType
+	}{
+		{
+			name:         "room",
+			orgAlias:     "integ-resource-org",
+			resourceName: "conf-room-a",
+			resourceType: worktypes.ResourceTypeRoom,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			client := createWorkMailClient(t)
+
+			orgID := wmCreateOrg(t, client, tt.orgAlias)
+
+			resOut, err := client.CreateResource(ctx, &workmailsdk.CreateResourceInput{
+				OrganizationId: aws.String(orgID),
+				Name:           aws.String(tt.resourceName),
+				Type:           tt.resourceType,
+			})
+			require.NoError(t, err, "CreateResource should succeed")
+			resID := aws.ToString(resOut.ResourceId)
+			require.NotEmpty(t, resID)
+
+			descOut, err := client.DescribeResource(ctx, &workmailsdk.DescribeResourceInput{
+				OrganizationId: aws.String(orgID),
+				ResourceId:     aws.String(resID),
+			})
+			require.NoError(t, err, "DescribeResource should succeed")
+			assert.Equal(t, tt.resourceName, aws.ToString(descOut.Name))
+			assert.Equal(t, tt.resourceType, descOut.Type)
+
+			listOut, err := client.ListResources(ctx, &workmailsdk.ListResourcesInput{
+				OrganizationId: aws.String(orgID),
+			})
+			require.NoError(t, err, "ListResources should succeed")
+
+			found := false
+			for _, r := range listOut.Resources {
+				if aws.ToString(r.Id) == resID {
+					found = true
+
+					break
+				}
+			}
+			assert.True(t, found, "resource should appear in list")
+
+			_, err = client.UpdateResource(ctx, &workmailsdk.UpdateResourceInput{
+				OrganizationId: aws.String(orgID),
+				ResourceId:     aws.String(resID),
+				Description:    aws.String("Updated description"),
+			})
+			require.NoError(t, err, "UpdateResource should succeed")
+
+			_, err = client.DeleteResource(ctx, &workmailsdk.DeleteResourceInput{
+				OrganizationId: aws.String(orgID),
+				ResourceId:     aws.String(resID),
+			})
+			require.NoError(t, err, "DeleteResource should succeed")
+		})
+	}
+}
+
+// TestIntegration_WorkMail_MailDomains drives register→get→list→update-default→deregister.
+func TestIntegration_WorkMail_MailDomains(t *testing.T) {
+	t.Parallel()
+	dumpContainerLogsOnFailure(t)
+
+	tests := []struct {
+		name     string
+		orgAlias string
+		domain   string
+	}{
+		{name: "domain_lifecycle", orgAlias: "integ-domain-org", domain: "example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			client := createWorkMailClient(t)
+
+			orgID := wmCreateOrg(t, client, tt.orgAlias)
+
+			_, err := client.RegisterMailDomain(ctx, &workmailsdk.RegisterMailDomainInput{
+				OrganizationId: aws.String(orgID),
+				DomainName:     aws.String(tt.domain),
+			})
+			require.NoError(t, err, "RegisterMailDomain should succeed")
+
+			_, err = client.GetMailDomain(ctx, &workmailsdk.GetMailDomainInput{
+				OrganizationId: aws.String(orgID),
+				DomainName:     aws.String(tt.domain),
+			})
+			require.NoError(t, err, "GetMailDomain should succeed")
+
+			listOut, err := client.ListMailDomains(ctx, &workmailsdk.ListMailDomainsInput{
+				OrganizationId: aws.String(orgID),
+			})
+			require.NoError(t, err, "ListMailDomains should succeed")
+
+			found := false
+			for _, d := range listOut.MailDomains {
+				if aws.ToString(d.DomainName) == tt.domain {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "domain should appear in list")
+
+			_, err = client.DeregisterMailDomain(ctx, &workmailsdk.DeregisterMailDomainInput{
+				OrganizationId: aws.String(orgID),
+				DomainName:     aws.String(tt.domain),
+			})
+			require.NoError(t, err, "DeregisterMailDomain should succeed")
+		})
+	}
+}
+
+// TestIntegration_WorkMail_MailboxPermissions drives put→list→delete on mailbox permissions.
+func TestIntegration_WorkMail_MailboxPermissions(t *testing.T) {
+	t.Parallel()
+	dumpContainerLogsOnFailure(t)
+
+	tests := []struct {
+		name     string
+		orgAlias string
+	}{
+		{name: "perms_lifecycle", orgAlias: "integ-perms-org"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			client := createWorkMailClient(t)
+
+			orgID := wmCreateOrg(t, client, tt.orgAlias)
+
+			ownerOut, err := client.CreateUser(ctx, &workmailsdk.CreateUserInput{
+				OrganizationId: aws.String(orgID),
+				Name:           aws.String("owner"),
+				DisplayName:    aws.String("Owner"),
+				Password:       aws.String("TestPass@1234"),
+			})
+			require.NoError(t, err)
+			ownerID := aws.ToString(ownerOut.UserId)
+
+			granteeOut, err := client.CreateUser(ctx, &workmailsdk.CreateUserInput{
+				OrganizationId: aws.String(orgID),
+				Name:           aws.String("grantee"),
+				DisplayName:    aws.String("Grantee"),
+				Password:       aws.String("TestPass@1234"),
+			})
+			require.NoError(t, err)
+			granteeID := aws.ToString(granteeOut.UserId)
+
+			_, err = client.PutMailboxPermissions(ctx, &workmailsdk.PutMailboxPermissionsInput{
+				OrganizationId:   aws.String(orgID),
+				EntityId:         aws.String(ownerID),
+				GranteeId:        aws.String(granteeID),
+				PermissionValues: []worktypes.PermissionType{worktypes.PermissionTypeFullAccess},
+			})
+			require.NoError(t, err, "PutMailboxPermissions should succeed")
+
+			listOut, err := client.ListMailboxPermissions(ctx, &workmailsdk.ListMailboxPermissionsInput{
+				OrganizationId: aws.String(orgID),
+				EntityId:       aws.String(ownerID),
+			})
+			require.NoError(t, err, "ListMailboxPermissions should succeed")
+			require.Len(t, listOut.Permissions, 1)
+			assert.Equal(t, granteeID, aws.ToString(listOut.Permissions[0].GranteeId))
+
+			_, err = client.DeleteMailboxPermissions(ctx, &workmailsdk.DeleteMailboxPermissionsInput{
+				OrganizationId: aws.String(orgID),
+				EntityId:       aws.String(ownerID),
+				GranteeId:      aws.String(granteeID),
+			})
+			require.NoError(t, err, "DeleteMailboxPermissions should succeed")
 		})
 	}
 }

--- a/test/integration/workmail_test.go
+++ b/test/integration/workmail_test.go
@@ -403,6 +403,7 @@ func TestIntegration_WorkMail_MailDomains(t *testing.T) {
 			for _, d := range listOut.MailDomains {
 				if aws.ToString(d.DomainName) == tt.domain {
 					found = true
+
 					break
 				}
 			}


### PR DESCRIPTION
Batch of validated and staged commits from continuous merge cycle:
- feat(kms): implement GetKeyLastUsage (go-zxusk)
- fix(omics): golangci-lint clean (go-777bf) 
- feat(omics): read-set/reference binary upload (go-777bf)
- fix(workmail): nlreturn integration tests (go-h4zfr)

All commits validated locally. Ready for CI validation and merge.