### PR TITLE
parity: 154-service audit remediation (mega)

### DIFF
--- a/parity.md
+++ b/parity.md
@@ -608,3 +608,8 @@ Verify bounded growth / delete-path cleanup in: **dynamodbstreams, resourcegroup
 
 ### G. Integration coverage — strength, not a gap
 `test/integration/` has ~230 per-service `<service>_test.go` files; integration coverage is broad. Per-service work should extend existing files, not assume absence.
+
+## Parity audit remediation — single accumulating PR
+
+This tracks the per-service remediation from the 2026-06-19 154-service audit (see sections above).
+Work accumulates on branch `parity-audit-mega`; each service lands as a verified commit.

--- a/services/apigatewayv2/rse.go
+++ b/services/apigatewayv2/rse.go
@@ -1,7 +1,11 @@
 package apigatewayv2
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -17,7 +21,10 @@ import (
 //   - ${request.path}    — Full request path (e.g. "/items/123")
 //   - ${request.header.<name>} — Value of the named request header
 //   - ${request.querystring.<name>} — Value of the named query-string parameter
-//   - ${request.body.<path>} — Replaced with empty string (body parsing not implemented)
+//   - ${request.body.<path>} — Value of the dot-separated JSON path in the
+//     request body (e.g. ${request.body.action} or ${request.body.detail.type});
+//     resolves to empty string when the body is absent, not JSON, or the field
+//     is missing.
 //
 // If expr is empty the literal "$default" route key is returned, which is the
 // catch-all route AWS uses when no other route matches.
@@ -44,12 +51,83 @@ func EvalRouteSelectionExpression(expr string, r *http.Request) string {
 		return r.URL.Query().Get(name)
 	})
 
-	// Substitute ${request.body.<path>} with empty string (not implemented).
-	result = substitutePattern(result, "${request.body.", func(_ string) string {
-		return ""
-	})
+	// Substitute ${request.body.<path>} by extracting the dot-separated field
+	// from the JSON request body. The body is parsed lazily and restored so the
+	// caller can still read it afterwards.
+	if strings.Contains(result, "${request.body.") {
+		body := parseJSONBody(r)
+		result = substitutePattern(result, "${request.body.", func(path string) string {
+			return lookupJSONPath(body, path)
+		})
+	}
 
 	return result
+}
+
+// parseJSONBody reads r.Body, restores it for subsequent readers, and returns
+// the decoded top-level JSON object. It returns nil if the body is absent or
+// is not a JSON object.
+func parseJSONBody(r *http.Request) map[string]any {
+	if r == nil || r.Body == nil {
+		return nil
+	}
+
+	raw, err := io.ReadAll(r.Body)
+	_ = r.Body.Close()
+
+	// Restore the body so callers can read it again.
+	r.Body = io.NopCloser(bytes.NewReader(raw))
+
+	if err != nil || len(raw) == 0 {
+		return nil
+	}
+
+	var obj map[string]any
+	if jsonErr := json.Unmarshal(raw, &obj); jsonErr != nil {
+		return nil
+	}
+
+	return obj
+}
+
+// lookupJSONPath walks a dot-separated path through nested JSON objects and
+// returns the string form of the resolved scalar, or "" when the path does not
+// resolve to a scalar value.
+func lookupJSONPath(obj map[string]any, path string) string {
+	if obj == nil || path == "" {
+		return ""
+	}
+
+	parts := strings.Split(path, ".")
+
+	var cur any = obj
+
+	for _, p := range parts {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+
+		cur, ok = m[p]
+		if !ok {
+			return ""
+		}
+	}
+
+	switch v := cur.(type) {
+	case string:
+		return v
+	case bool:
+		if v {
+			return "true"
+		}
+
+		return "false"
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return ""
+	}
 }
 
 // substitutePattern replaces all occurrences of ${<prefix><name>} in s with

--- a/services/apigatewayv2/rse_test.go
+++ b/services/apigatewayv2/rse_test.go
@@ -1,11 +1,14 @@
 package apigatewayv2_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/blackbirdworks/gopherstack/services/apigatewayv2"
 )
@@ -153,6 +156,76 @@ func TestEvalRouteSelectionExpression(t *testing.T) {
 
 			got := apigatewayv2.EvalRouteSelectionExpression(tt.expr, req)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEvalRouteSelectionExpression_BodyExtraction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		expr string
+		body string
+		want string
+	}{
+		{
+			name: "top_level_string_field",
+			expr: "${request.body.action}",
+			body: `{"action":"subscribe"}`,
+			want: "subscribe",
+		},
+		{
+			name: "nested_field",
+			expr: "${request.body.detail.type}",
+			body: `{"detail":{"type":"ping"}}`,
+			want: "ping",
+		},
+		{
+			name: "number_field_stringified",
+			expr: "${request.body.count}",
+			body: `{"count":42}`,
+			want: "42",
+		},
+		{
+			name: "bool_field_stringified",
+			expr: "${request.body.active}",
+			body: `{"active":true}`,
+			want: "true",
+		},
+		{
+			name: "missing_field_empty",
+			expr: "${request.body.action}",
+			body: `{"other":"x"}`,
+			want: "",
+		},
+		{
+			name: "non_json_body_empty",
+			expr: "${request.body.action}",
+			body: `not json`,
+			want: "",
+		},
+		{
+			name: "combined_with_method",
+			expr: "${request.method}#${request.body.action}",
+			body: `{"action":"sendmessage"}`,
+			want: "POST#sendmessage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
+
+			got := apigatewayv2.EvalRouteSelectionExpression(tt.expr, req)
+			assert.Equal(t, tt.want, got)
+
+			// Body must remain readable after evaluation.
+			rest, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.body, string(rest))
 		})
 	}
 }

--- a/services/awsconfig/backend_real.go
+++ b/services/awsconfig/backend_real.go
@@ -327,9 +327,42 @@ func (b *InMemoryBackend) DescribeComplianceByConfigRule(names []string) []Compl
 	return out
 }
 
-// GetComplianceSummaryByConfigRule returns a stub compliance summary.
+// GetComplianceSummaryByConfigRule returns a compliance summary aggregated from
+// the recorded rule evaluations. AWS returns counts of compliant and
+// non-compliant config rules; here we derive those counts from the stored
+// per-rule compliance types populated via PutEvaluation(s)/PutExternalEvaluation.
+// When no evaluations have been recorded the result is an empty slice.
 func (b *InMemoryBackend) GetComplianceSummaryByConfigRule() []ComplianceSummary {
-	return []ComplianceSummary{}
+	b.mu.RLock("GetComplianceSummaryByConfigRule")
+	defer b.mu.RUnlock()
+
+	if len(b.ruleEvaluations) == 0 {
+		return []ComplianceSummary{}
+	}
+
+	var compliant, nonCompliant int32
+
+	for _, ct := range b.ruleEvaluations {
+		switch ct {
+		case "COMPLIANT":
+			compliant++
+		case "NON_COMPLIANT":
+			nonCompliant++
+		}
+	}
+
+	complianceType := "COMPLIANT"
+	if nonCompliant > 0 {
+		complianceType = "NON_COMPLIANT"
+	}
+
+	return []ComplianceSummary{{
+		ComplianceType: complianceType,
+		ComplianceSummaryByConfigRule: ComplianceSummaryByConfigRule{
+			CompliantResourceCount:    compliant,
+			NonCompliantResourceCount: nonCompliant,
+		},
+	}}
 }
 
 // PutEvaluations stores evaluation results from an AWS Lambda function for a config rule.

--- a/services/awsconfig/backend_real_test.go
+++ b/services/awsconfig/backend_real_test.go
@@ -317,6 +317,83 @@ func TestGetComplianceSummaryByConfigRule(t *testing.T) {
 	if out == nil {
 		t.Fatal("expected non-nil slice")
 	}
+
+	if len(out) != 0 {
+		t.Fatalf("expected empty summary for fresh backend, got %v", out)
+	}
+}
+
+func TestGetComplianceSummaryByConfigRule_Aggregates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		wantType         string
+		evaluations      []awsconfig.EvaluationResult
+		wantCompliant    int32
+		wantNonCompliant int32
+	}{
+		{
+			name: "all compliant",
+			evaluations: []awsconfig.EvaluationResult{
+				{ConfigRuleName: "r1", ComplianceType: "COMPLIANT"},
+				{ConfigRuleName: "r2", ComplianceType: "COMPLIANT"},
+			},
+			wantCompliant:    2,
+			wantNonCompliant: 0,
+			wantType:         "COMPLIANT",
+		},
+		{
+			name: "mixed becomes non-compliant",
+			evaluations: []awsconfig.EvaluationResult{
+				{ConfigRuleName: "r1", ComplianceType: "COMPLIANT"},
+				{ConfigRuleName: "r2", ComplianceType: "NON_COMPLIANT"},
+			},
+			wantCompliant:    1,
+			wantNonCompliant: 1,
+			wantType:         "NON_COMPLIANT",
+		},
+		{
+			name: "not applicable ignored in counts",
+			evaluations: []awsconfig.EvaluationResult{
+				{ConfigRuleName: "r1", ComplianceType: "NOT_APPLICABLE"},
+			},
+			wantCompliant:    0,
+			wantNonCompliant: 0,
+			wantType:         "COMPLIANT",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := awsconfig.NewInMemoryBackend()
+			if err := b.PutEvaluations(tc.evaluations); err != nil {
+				t.Fatalf("PutEvaluations: %v", err)
+			}
+
+			out := b.GetComplianceSummaryByConfigRule()
+			if len(out) != 1 {
+				t.Fatalf("expected one summary, got %v", out)
+			}
+
+			got := out[0]
+			if got.ComplianceType != tc.wantType {
+				t.Errorf("ComplianceType = %q, want %q", got.ComplianceType, tc.wantType)
+			}
+
+			if got.ComplianceSummaryByConfigRule.CompliantResourceCount != tc.wantCompliant {
+				t.Errorf("CompliantResourceCount = %d, want %d",
+					got.ComplianceSummaryByConfigRule.CompliantResourceCount, tc.wantCompliant)
+			}
+
+			if got.ComplianceSummaryByConfigRule.NonCompliantResourceCount != tc.wantNonCompliant {
+				t.Errorf("NonCompliantResourceCount = %d, want %d",
+					got.ComplianceSummaryByConfigRule.NonCompliantResourceCount, tc.wantNonCompliant)
+			}
+		})
+	}
 }
 
 // --- Group 6: Delivery channel status ---

--- a/services/ec2/backend_batch4.go
+++ b/services/ec2/backend_batch4.go
@@ -304,7 +304,7 @@ func (b *InMemoryBackend) CreateClientVpnEndpoint(
 	id := "cvpn-endpoint-" + uuid.New().String()[:8]
 	ep := &ClientVpnEndpoint{
 		ClientVpnEndpointID: id,
-		DNSName:             id + ".prod.clientvpn.us-east-1.amazonaws.com",
+		DNSName:             id + ".prod.clientvpn." + b.Region + ".amazonaws.com",
 		Status:              stateAvailable,
 		Description:         description,
 		ClientCidrBlock:     clientCidrBlock,

--- a/services/ec2/handler_batch4_test.go
+++ b/services/ec2/handler_batch4_test.go
@@ -176,6 +176,35 @@ func TestBatch4_ClientVpnEndpoint(t *testing.T) { //nolint:paralleltest // exist
 	})
 }
 
+// TestBatch4_ClientVpnEndpointDNSNameRegion verifies the Client VPN endpoint
+// DNS name reflects the backend's region rather than a hardcoded us-east-1
+// (parity §C).
+func TestBatch4_ClientVpnEndpointDNSNameRegion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		region string
+	}{
+		{name: "us-west-2", region: "us-west-2"},
+		{name: "eu-central-1", region: "eu-central-1"},
+		{name: "ap-southeast-1", region: "ap-southeast-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := ec2.NewInMemoryBackend("000000000000", tc.region)
+			ep, err := b.CreateClientVpnEndpoint("10.0.0.0/22", "region vpn", nil)
+			require.NoError(t, err)
+			assert.Contains(t, ep.DNSName, ".clientvpn."+tc.region+".amazonaws.com",
+				"DNS name must reflect the request region")
+			assert.NotContains(t, ep.DNSName, "us-east-1")
+		})
+	}
+}
+
 // ---- TransitGatewayPeeringAttachment ----.
 func TestBatch4_TGWPeeringAttachment(t *testing.T) { //nolint:paralleltest // existing issue.
 	b := ec2.NewInMemoryBackend("000000000000", "us-east-1")

--- a/services/sagemakerruntime/backend.go
+++ b/services/sagemakerruntime/backend.go
@@ -13,6 +13,24 @@ const maxInvocationHistory = 1000
 // MaxInvocationHistory is the exported value for testing.
 const MaxInvocationHistory = maxInvocationHistory
 
+// maxSessions bounds the number of stateful endpoint sessions retained in memory.
+// InvokeEndpoint with a NEW session header is a per-request hot path; without a
+// cap the sessions map would grow without bound in a long-running emulator. When
+// the cap is exceeded the oldest session (by CreatedAt) is evicted FIFO-style.
+const maxSessions = 1000
+
+// MaxSessions is the exported value for testing.
+const MaxSessions = maxSessions
+
+// maxAsyncInvocations bounds the number of accepted async inference records
+// retained in memory. RecordAsyncInvocation runs on every InvokeEndpointAsync
+// request; without a cap the map would grow without bound. When the cap is
+// exceeded the oldest record (by CreatedAt) is evicted FIFO-style.
+const maxAsyncInvocations = 1000
+
+// MaxAsyncInvocations is the exported value for testing.
+const MaxAsyncInvocations = maxAsyncInvocations
+
 const sessionDuration = 5 * time.Minute
 
 // Invocation records a single SageMaker Runtime endpoint invocation.
@@ -121,6 +139,7 @@ func (b *InMemoryBackend) StartSession(endpointName string) *Session {
 		ExpiresAt:     now.Add(sessionDuration),
 	}
 	b.sessions[session.ID] = session
+	evictOldest(b.sessions, maxSessions, func(s *Session) time.Time { return s.CreatedAt })
 
 	return cloneSession(session)
 }
@@ -167,6 +186,7 @@ func (b *InMemoryBackend) RecordAsyncInvocation(endpointName, requestedID, input
 		CreatedAt:      time.Now().UTC(),
 	}
 	b.asyncInvocations[inferenceID] = invocation
+	evictOldest(b.asyncInvocations, maxAsyncInvocations, func(a *AsyncInvocation) time.Time { return a.CreatedAt })
 
 	return cloneAsyncInvocation(invocation)
 }
@@ -182,6 +202,34 @@ func (b *InMemoryBackend) ListAsyncInvocations() []*AsyncInvocation {
 	}
 
 	return out
+}
+
+// evictOldest enforces a FIFO size bound on m: while the map exceeds maxSize, it
+// repeatedly removes the entry with the oldest timestamp (as reported by createdAt).
+// This keeps long-running sessions/async-invocation maps from growing without bound.
+func evictOldest[V any](m map[string]V, maxSize int, createdAt func(V) time.Time) {
+	for len(m) > maxSize {
+		var (
+			oldestKey  string
+			oldestTime time.Time
+			found      bool
+		)
+
+		for k, v := range m {
+			t := createdAt(v)
+			if !found || t.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = t
+				found = true
+			}
+		}
+
+		if !found {
+			return
+		}
+
+		delete(m, oldestKey)
+	}
 }
 
 func cloneSession(session *Session) *Session {

--- a/services/sagemakerruntime/leak_test.go
+++ b/services/sagemakerruntime/leak_test.go
@@ -1,0 +1,91 @@
+package sagemakerruntime_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blackbirdworks/gopherstack/services/sagemakerruntime"
+)
+
+// TestInMemoryBackend_BoundedGrowth proves that the per-request session and
+// async-invocation maps stay bounded under sustained insertion (parity §E:
+// unbounded-growth leak). Inserting well past the cap must leave the retained
+// set at exactly the cap, with the oldest entries evicted FIFO-style.
+func TestInMemoryBackend_BoundedGrowth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		// insert performs one record-creating call and returns the live count.
+		insert  func(b *sagemakerruntime.InMemoryBackend, i int) int
+		name    string
+		cap     int
+		inserts int
+	}{
+		{
+			name:    "sessions stay capped",
+			cap:     sagemakerruntime.MaxSessions,
+			inserts: sagemakerruntime.MaxSessions + 500,
+			insert: func(b *sagemakerruntime.InMemoryBackend, i int) int {
+				b.StartSession(fmt.Sprintf("endpoint-%d", i))
+
+				return len(b.ListSessions())
+			},
+		},
+		{
+			name:    "async invocations stay capped",
+			cap:     sagemakerruntime.MaxAsyncInvocations,
+			inserts: sagemakerruntime.MaxAsyncInvocations + 500,
+			insert: func(b *sagemakerruntime.InMemoryBackend, i int) int {
+				// Empty requestedID forces a fresh generated inference ID each call,
+				// guaranteeing a distinct map key per insert.
+				b.RecordAsyncInvocation(fmt.Sprintf("endpoint-%d", i), "", "payload")
+
+				return len(b.ListAsyncInvocations())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := sagemakerruntime.NewInMemoryBackend("000000000000", "us-east-1")
+
+			var count int
+			for i := range tc.inserts {
+				count = tc.insert(b, i)
+				require.LessOrEqual(t, count, tc.cap,
+					"retained set must never exceed the cap during insertion")
+			}
+
+			require.Equal(t, tc.cap, count,
+				"after inserting past the cap the retained set must equal the cap")
+		})
+	}
+}
+
+// TestInMemoryBackend_AsyncInvocationEvictsOldest proves FIFO semantics: the
+// oldest async-invocation record is the one evicted once the cap is exceeded.
+func TestInMemoryBackend_AsyncInvocationEvictsOldest(t *testing.T) {
+	t.Parallel()
+
+	b := sagemakerruntime.NewInMemoryBackend("000000000000", "us-east-1")
+
+	// The first inserted inference ID is the oldest; it must be evicted first.
+	const oldestID = "inference-oldest"
+	b.RecordAsyncInvocation("endpoint-0", oldestID, "payload")
+
+	for i := range sagemakerruntime.MaxAsyncInvocations {
+		b.RecordAsyncInvocation(fmt.Sprintf("endpoint-%d", i+1), "", "payload")
+	}
+
+	got := b.ListAsyncInvocations()
+	require.Len(t, got, sagemakerruntime.MaxAsyncInvocations)
+
+	for _, inv := range got {
+		require.NotEqual(t, oldestID, inv.InferenceID,
+			"oldest async invocation must be evicted once the cap is exceeded")
+	}
+}

--- a/services/sns/accuracy1679_test.go
+++ b/services/sns/accuracy1679_test.go
@@ -1541,6 +1541,60 @@ func TestNotificationEnvelopeFields(t *testing.T) {
 	}
 }
 
+// TestNotificationURLsReflectRegion verifies that the SigningCertURL and
+// UnsubscribeURL embedded in HTTP notifications derive their region from the
+// topic ARN rather than a hardcoded us-east-1 (parity §C).
+func TestNotificationURLsReflectRegion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		region string
+	}{
+		{name: "us-west-2", region: "us-west-2"},
+		{name: "eu-central-1", region: "eu-central-1"},
+		{name: "ap-southeast-1", region: "ap-southeast-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			received := make(chan string, 1)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				received <- string(body)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			b := sns.NewInMemoryBackendWithContext(t.Context(), "000000000000", tc.region)
+			tp, err := b.CreateTopic("region-topic", nil)
+			require.NoError(t, err)
+			require.Contains(t, tp.TopicArn, ":"+tc.region+":",
+				"topic ARN should carry the backend region")
+
+			_, err = b.Subscribe(tp.TopicArn, "http", ts.URL, "")
+			require.NoError(t, err)
+
+			_, err = b.Publish(tp.TopicArn, "region-test", "", "", nil)
+			require.NoError(t, err)
+
+			select {
+			case raw := <-received:
+				env := parseNotificationEnvelope(t, raw)
+				assert.Contains(t, env.SigningCertURL, "sns."+tc.region+".amazonaws.com",
+					"SigningCertURL must reflect the request region")
+				assert.Contains(t, env.UnsubscribeURL, "sns."+tc.region+".amazonaws.com",
+					"UnsubscribeURL must reflect the request region")
+				assert.NotContains(t, env.UnsubscribeURL, "us-east-1")
+			case <-time.After(2 * time.Second):
+				t.Fatal("HTTP delivery did not arrive")
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Subscription DeliveryPolicy attribute (Issue: per-subscription delivery)
 // ---------------------------------------------------------------------------

--- a/services/sns/backend.go
+++ b/services/sns/backend.go
@@ -2362,7 +2362,8 @@ func deliverHTTPWithMeta(parent context.Context, d httpDelivery, client *http.Cl
 			SignatureVersion: "2",
 			Signature:        signature,
 			SigningCertURL:   certURL,
-			UnsubscribeURL:   "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=" + d.subscriptionARN,
+			UnsubscribeURL: "https://sns." + topicRegion +
+				".amazonaws.com/?Action=Unsubscribe&SubscriptionArn=" + d.subscriptionARN,
 		}
 		if d.subject != "" {
 			env.Subject = d.subject


### PR DESCRIPTION
Single accumulating PR for the per-service remediation from the 2026-06-19 audit (parity.md §A-G). All work commits directly to `parity-audit-mega`; each service/sweep lands as a verified commit (build + golangci 0 + tests). Already-merged: high-severity stubs (#2331) + kms/omics/workmail (#2332).

Tracked here: logger discipline (§B), region (§C), remaining §A stubs, leak candidates (§E), per-service emulation depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)