### PR TITLE
fix(dynamodb): fix lock inversion in TransactWriteItems

### DIFF
--- a/services/dynamodb/concurrency_transact_deadlock_test.go
+++ b/services/dynamodb/concurrency_transact_deadlock_test.go
@@ -2,6 +2,7 @@ package dynamodb_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -59,6 +60,7 @@ func TestTransactWriteItemsConvoyDeadlock(t *testing.T) {
 				},
 			})
 		}
+
 		return nil
 	})
 
@@ -82,14 +84,15 @@ func TestTransactWriteItemsConvoyDeadlock(t *testing.T) {
 				TableName: aws.String(tempName),
 			})
 		}
+
 		return nil
 	})
 
 	err = wg.Wait()
-	if err != nil && err != context.DeadlineExceeded {
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ctx.Err() == context.DeadlineExceeded {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Fatal("test deadlocked! TransactWriteItems and DeleteTable/CreateTable lock inversion detected.")
 	}
 }

--- a/services/dynamodb/concurrency_transact_deadlock_test.go
+++ b/services/dynamodb/concurrency_transact_deadlock_test.go
@@ -1,0 +1,94 @@
+package dynamodb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	sdk_dynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/blackbirdworks/gopherstack/services/dynamodb"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestTransactWriteItemsConvoyDeadlock(t *testing.T) {
+	t.Parallel()
+
+	db := dynamodb.NewInMemoryDB()
+
+	tableName := "transact-deadlock-table"
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	_, err := db.CreateTable(ctx, &sdk_dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	iterations := 1000
+
+	var wg errgroup.Group
+
+	// Thread 1: TransactWriteItems
+	wg.Go(func() error {
+		for i := range iterations {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			_, _ = db.TransactWriteItems(ctx, &sdk_dynamodb.TransactWriteItemsInput{
+				TransactItems: []types.TransactWriteItem{
+					{
+						Put: &types.Put{
+							TableName: aws.String(tableName),
+							Item: map[string]types.AttributeValue{
+								"id": &types.AttributeValueMemberS{Value: fmt.Sprintf("item-%d", i)},
+							},
+						},
+					},
+				},
+			})
+		}
+		return nil
+	})
+
+	// Thread 2: DeleteTable / CreateTable (needs db.mu.Lock)
+	wg.Go(func() error {
+		for i := range iterations / 10 {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			tempName := fmt.Sprintf("TempTable-%d", i)
+			_, _ = db.CreateTable(ctx, &sdk_dynamodb.CreateTableInput{
+				TableName: aws.String(tempName),
+				KeySchema: []types.KeySchemaElement{
+					{AttributeName: aws.String("id"), KeyType: types.KeyTypeHash},
+				},
+				AttributeDefinitions: []types.AttributeDefinition{
+					{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				},
+			})
+			_, _ = db.DeleteTable(ctx, &sdk_dynamodb.DeleteTableInput{
+				TableName: aws.String(tempName),
+			})
+		}
+		return nil
+	})
+
+	err = wg.Wait()
+	if err != nil && err != context.DeadlineExceeded {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatal("test deadlocked! TransactWriteItems and DeleteTable/CreateTable lock inversion detected.")
+	}
+}

--- a/services/dynamodb/concurrency_transact_deadlock_test.go
+++ b/services/dynamodb/concurrency_transact_deadlock_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	sdk_dynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/blackbirdworks/gopherstack/services/dynamodb"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/blackbirdworks/gopherstack/services/dynamodb"
 )
 
 func TestTransactWriteItemsConvoyDeadlock(t *testing.T) {

--- a/services/dynamodb/transact_ops.go
+++ b/services/dynamodb/transact_ops.go
@@ -84,9 +84,12 @@ func (db *InMemoryDB) executeTransactWrite(
 	if lockErr != nil {
 		return nil, lockErr
 	}
+	tablesLocked := true
 	defer func() {
-		for _, t := range tables {
-			t.mu.Unlock()
+		if tablesLocked {
+			for _, t := range tables {
+				t.mu.Unlock()
+			}
 		}
 	}()
 
@@ -116,6 +119,12 @@ func (db *InMemoryDB) executeTransactWrite(
 	if writeErr := db.applyTransactItems(ctx, tables, input.TransactItems); writeErr != nil {
 		return nil, writeErr
 	}
+
+	// Unlock all tables before taking db.mu to avoid lock inversion (e.g. with DeleteTable)
+	for _, t := range tables {
+		t.mu.Unlock()
+	}
+	tablesLocked = false
 
 	// Record token as committed only after all writes have been applied.
 	if token != "" {


### PR DESCRIPTION
Fixes a lock inversion deadlock between TransactWriteItems and DeleteTable/CreateTable.