### PR TITLE
fix(dynamodb): fix lock inversion and panic causing deadlocks

### DIFF
--- a/services/dynamodb/concurrency_putitem_deadlock_test.go
+++ b/services/dynamodb/concurrency_putitem_deadlock_test.go
@@ -1,0 +1,95 @@
+package dynamodb_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	sdk_dynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/blackbirdworks/gopherstack/services/dynamodb"
+)
+
+func TestPutItemConvoyDeadlock(t *testing.T) {
+	t.Parallel()
+
+	db := dynamodb.NewInMemoryDB()
+	tableName := "putitem-deadlock-table"
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	_, err := db.CreateTable(ctx, &sdk_dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	iterations := 1000
+	var wg errgroup.Group
+
+	// Thread 1: PutItem
+	wg.Go(func() error {
+		for i := range iterations {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			_, _ = db.PutItem(ctx, &sdk_dynamodb.PutItemInput{
+				TableName: aws.String(tableName),
+				Item: map[string]types.AttributeValue{
+					"id": &types.AttributeValueMemberS{Value: fmt.Sprintf("item-%d", i)},
+				},
+			})
+			t.Logf("PutItem for %s completed", tableName)
+		}
+
+		return nil
+	})
+
+	// Thread 2: DeleteTable / CreateTable (needs db.mu.Lock)
+	wg.Go(func() error {
+		for i := range iterations / 10 {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			tempName := fmt.Sprintf("TempTable-%d", i)
+			_, createErr := db.CreateTable(ctx, &sdk_dynamodb.CreateTableInput{
+				TableName: aws.String(tempName),
+				KeySchema: []types.KeySchemaElement{
+					{AttributeName: aws.String("id"), KeyType: types.KeyTypeHash},
+				},
+				AttributeDefinitions: []types.AttributeDefinition{
+					{AttributeName: aws.String("id"), AttributeType: types.ScalarAttributeTypeS},
+				},
+			})
+			if createErr != nil {
+				t.Logf("CreateTable %s error: %v", tableName, createErr)
+			}
+			_, _ = db.DeleteTable(ctx, &sdk_dynamodb.DeleteTableInput{
+				TableName: aws.String(tempName),
+			})
+		}
+
+		return nil
+	})
+
+	err = wg.Wait()
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("Deadlock detected: context deadline exceeded before all operations finished")
+	}
+}

--- a/services/dynamodb/item_ops_batch.go
+++ b/services/dynamodb/item_ops_batch.go
@@ -612,9 +612,17 @@ func (db *InMemoryDB) applyBatchDeletes(table *Table, indices []int) {
 		// Capture stream record (REMOVE)
 		table.appendStreamRecord(streamEventRemove, deepCopyItem(table.Items[idx]), nil, "", "")
 
-		// Delete by swapping with last and truncating
-		table.Items[idx] = table.Items[len(table.Items)-1]
-		table.Items = table.Items[:len(table.Items)-1]
+		deletedSize := table.itemSizes[idx]
+		lastIdx := len(table.Items) - 1
+
+		if idx != lastIdx {
+			// Delete by swapping with last and truncating
+			table.Items[idx] = table.Items[lastIdx]
+			table.itemSizes[idx] = table.itemSizes[lastIdx]
+		}
+		table.Items = table.Items[:lastIdx]
+		table.itemSizes = table.itemSizes[:lastIdx]
+		table.totalItemSizeBytes -= int64(deletedSize)
 	}
 
 	table.rebuildIndexes()
@@ -692,9 +700,12 @@ func validateBatchWriteRequest(req types.WriteRequest, table *Table) error {
 
 func (db *InMemoryDB) handleBatchPutWithIndex(table *Table, item map[string]any) int {
 	oldItem, matchIndex := db.findMatchForPut(table, item)
+	itemSize, _ := CalculateItemSize(item)
 	if matchIndex != -1 {
 		// Capture stream event (MODIFY) before overwriting in place.
 		table.appendStreamRecord(streamEventModify, oldItem, deepCopyItem(item), "", "")
+		table.totalItemSizeBytes += int64(itemSize) - int64(table.itemSizes[matchIndex])
+		table.itemSizes[matchIndex] = itemSize
 		table.Items[matchIndex] = item
 
 		return matchIndex
@@ -703,6 +714,8 @@ func (db *InMemoryDB) handleBatchPutWithIndex(table *Table, item map[string]any)
 	table.appendStreamRecord(streamEventInsert, nil, deepCopyItem(item), "", "")
 	idx := len(table.Items)
 	table.Items = append(table.Items, item)
+	table.itemSizes = append(table.itemSizes, itemSize)
+	table.totalItemSizeBytes += int64(itemSize)
 
 	return idx
 }

--- a/services/dynamodb/table_ops.go
+++ b/services/dynamodb/table_ops.go
@@ -384,29 +384,23 @@ func (db *InMemoryDB) DeleteTable(
 	region := getRegionFromContext(ctx, db)
 
 	db.mu.Lock("DeleteTable")
-	defer db.mu.Unlock()
-
 	table, tableExists := db.tables.Get(tableKey(region, tableName))
 	if !tableExists {
+		db.mu.Unlock()
+
 		return nil, NewResourceNotFoundException("table not found: " + tableName)
 	}
 
 	// AWS rejects DeleteTable when DeletionProtectionEnabled is true.
 	// The protection must be disabled (via UpdateTable) before the table can be deleted.
 	if table.DeletionProtectionEnabled {
+		db.mu.Unlock()
+
 		return nil, NewValidationException(
 			"Table cannot be deleted while DeletionProtectionEnabled is set to True. " +
 				"Update the table first to disable deletion protection.",
 		)
 	}
-
-	// Cancel any pending activation timer and any in-flight GSI lifecycle timers.
-	// Stop() is called while db.mu is held, which prevents a concurrent CreateTable from
-	// racing with us. If a timer has already fired and the callback is in progress, Stop()
-	// returns false but the callback only writes table.Status or GSI.IndexStatus (both
-	// guarded by table.mu) on an object that is about to move to deletingTables —
-	// this is benign; the janitor will clean it up regardless.
-	stopTableTimers(table)
 
 	db.tables.Delete(tableKey(region, tableName))
 	db.deletingTables.Put(table)
@@ -422,6 +416,16 @@ func (db *InMemoryDB) DeleteTable(
 	if table.StreamARN != "" {
 		db.streamARNIndex.Delete(table.StreamARN)
 	}
+
+	db.mu.Unlock()
+
+	// Cancel any pending activation timer and any in-flight GSI lifecycle timers.
+	// Stop() is called after db.mu is released to prevent holding the global lock
+	// while waiting for table.mu (which would stall all other table operations).
+	// If a timer fires concurrently, it only writes table.Status or GSI.IndexStatus (both
+	// guarded by table.mu) on an object that has already moved to deletingTables —
+	// this is benign; the janitor will clean it up regardless.
+	stopTableTimers(table)
 
 	// Capture state for return
 	gsiDescs := make([]models.GlobalSecondaryIndexDescription, len(table.GlobalSecondaryIndexes))


### PR DESCRIPTION
Fixes a lock inversion in DeleteTable and a panic in BatchWriteItem which both caused deadlocks under high concurrency