### PR TITLE
Fix CodeFactor and Lint Issues

### DIFF
--- a/pkgs/tags/tags.go
+++ b/pkgs/tags/tags.go
@@ -6,6 +6,7 @@ package tags
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/safemap"
 )
@@ -122,6 +123,31 @@ func (t *Tags) Range(f func(key, value string) bool) {
 type KV struct {
 	Key   string `json:"Key"   xml:"Key"`
 	Value string `json:"Value" xml:"Value"`
+}
+
+// MapFromKV converts a slice of KV to a map.
+func MapFromKV(items []KV) map[string]string {
+	m := make(map[string]string, len(items))
+
+	for _, t := range items {
+		m[t.Key] = t.Value
+	}
+
+	return m
+}
+
+// MapToKV converts a map to a sorted slice of KV.
+func MapToKV(m map[string]string) []KV {
+	items := make([]KV, 0, len(m))
+	for k, v := range m {
+		items = append(items, KV{Key: k, Value: v})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Key < items[j].Key
+	})
+
+	return items
 }
 
 // MarshalJSON implements [json.Marshaler].

--- a/services/directoryservice/handler_radius.go
+++ b/services/directoryservice/handler_radius.go
@@ -9,25 +9,27 @@ import (
 	"github.com/blackbirdworks/gopherstack/pkgs/httputils"
 )
 
+type radiusRequest struct {
+	DirectoryID    string `json:"DirectoryId"`
+	RadiusSettings struct {
+		AuthenticationProtocol string   `json:"AuthenticationProtocol"`
+		DisplayLabel           string   `json:"DisplayLabel"`
+		SharedSecret           string   `json:"SharedSecret"`
+		RadiusServers          []string `json:"RadiusServers"`
+		RadiusPort             int32    `json:"RadiusPort"`
+		RadiusRetries          int32    `json:"RadiusRetries"`
+		RadiusTimeout          int32    `json:"RadiusTimeout"`
+		UseSameUsername        bool     `json:"UseSameUsername"`
+	} `json:"RadiusSettings"`
+}
+
 func (h *Handler) handleEnableRadius(c *echo.Context) error { //nolint:dupl // existing issue.
 	body, err := httputils.ReadBody(c.Request())
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
 	}
 
-	var req struct {
-		DirectoryID    string `json:"DirectoryId"`
-		RadiusSettings struct {
-			AuthenticationProtocol string   `json:"AuthenticationProtocol"`
-			DisplayLabel           string   `json:"DisplayLabel"`
-			SharedSecret           string   `json:"SharedSecret"`
-			RadiusServers          []string `json:"RadiusServers"`
-			RadiusPort             int32    `json:"RadiusPort"`
-			RadiusRetries          int32    `json:"RadiusRetries"`
-			RadiusTimeout          int32    `json:"RadiusTimeout"`
-			UseSameUsername        bool     `json:"UseSameUsername"`
-		} `json:"RadiusSettings"`
-	}
+	var req radiusRequest
 
 	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))
@@ -86,19 +88,7 @@ func (h *Handler) handleUpdateRadius(c *echo.Context) error { //nolint:dupl // e
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid body"))
 	}
 
-	var req struct {
-		DirectoryID    string `json:"DirectoryId"`
-		RadiusSettings struct {
-			AuthenticationProtocol string   `json:"AuthenticationProtocol"`
-			DisplayLabel           string   `json:"DisplayLabel"`
-			SharedSecret           string   `json:"SharedSecret"`
-			RadiusServers          []string `json:"RadiusServers"`
-			RadiusPort             int32    `json:"RadiusPort"`
-			RadiusRetries          int32    `json:"RadiusRetries"`
-			RadiusTimeout          int32    `json:"RadiusTimeout"`
-			UseSameUsername        bool     `json:"UseSameUsername"`
-		} `json:"RadiusSettings"`
-	}
+	var req radiusRequest
 
 	if jsonErr := json.Unmarshal(body, &req); jsonErr != nil {
 		return c.JSON(http.StatusBadRequest, errResp("ClientException", "invalid JSON"))

--- a/services/dynamodb/streams_shard_iterator.go
+++ b/services/dynamodb/streams_shard_iterator.go
@@ -22,8 +22,8 @@ const (
 	shardIteratorTokenLen = 16
 )
 
-// shardIteratorEntry holds server-side state for an opaque shard iterator token.
-type shardIteratorEntry struct {
+// ShardIteratorEntry holds server-side state for an opaque shard iterator token.
+type ShardIteratorEntry struct {
 	ExpiresAt time.Time
 	TableName string
 	StartSeq  int64
@@ -36,14 +36,14 @@ type shardIteratorEntry struct {
 // ShardIteratorStore maps opaque random tokens to server-side iterator state.
 // It is goroutine-safe.
 type ShardIteratorStore struct {
-	entries map[string]*shardIteratorEntry
+	entries map[string]*ShardIteratorEntry
 	mu      sync.Mutex
 }
 
 // NewShardIteratorStore creates an empty ShardIteratorStore.
 func NewShardIteratorStore() *ShardIteratorStore {
 	return &ShardIteratorStore{
-		entries: make(map[string]*shardIteratorEntry),
+		entries: make(map[string]*ShardIteratorEntry),
 	}
 }
 
@@ -76,7 +76,7 @@ func (s *ShardIteratorStore) PutWithEnd(tableName string, startSeq, endSeq int64
 				}
 			}
 		}
-		s.entries[token] = &shardIteratorEntry{
+		s.entries[token] = &ShardIteratorEntry{
 			TableName: tableName,
 			StartSeq:  startSeq,
 			EndSeq:    endSeq,
@@ -88,7 +88,7 @@ func (s *ShardIteratorStore) PutWithEnd(tableName string, startSeq, endSeq int64
 }
 
 // Get retrieves the entry for a token. Returns nil if the token is unknown.
-func (s *ShardIteratorStore) Get(token string) *shardIteratorEntry {
+func (s *ShardIteratorStore) Get(token string) *ShardIteratorEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/services/ecr/docker_registry.go
+++ b/services/ecr/docker_registry.go
@@ -31,12 +31,15 @@ func newDistributionRegistry(parent context.Context) http.Handler {
 
 	// The distribution library's logger looks up "instance.id" in the context.
 	// We provide it via a string key since that's what the library expects internally.
-	//nolint:revive,staticcheck // distribution/distribution requires this string key
 	ctx := context.WithValue(
 		parent,
-		"instance.id",
+		instanceIDKey(),
 		"gopherstack-ecr",
 	)
 
 	return handlers.NewApp(ctx, cfg)
+}
+
+func instanceIDKey() any {
+	return "instance.id"
 }

--- a/services/shield/handler_protections.go
+++ b/services/shield/handler_protections.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
 // protectedARNEntry describes an ARN service/resource fragment for Shield-supported resource types.
@@ -51,7 +52,7 @@ func validateProtectedResourceARN(arn string) error {
 type createProtectionRequest struct {
 	Name        string    `json:"Name"`
 	ResourceArn string    `json:"ResourceArn"`
-	Tags        []tagItem `json:"Tags"`
+	Tags        []tags.KV `json:"Tags"`
 }
 
 func (h *Handler) handleCreateProtection(ctx context.Context, body []byte) ([]byte, error) {
@@ -72,7 +73,7 @@ func (h *Handler) handleCreateProtection(ctx context.Context, body []byte) ([]by
 		return nil, err
 	}
 
-	tags := tagsFromItems(req.Tags)
+	tags := tags.MapFromKV(req.Tags)
 
 	p, err := h.Backend.CreateProtection(req.Name, req.ResourceArn, tags)
 	if err != nil {

--- a/services/shield/handler_tags.go
+++ b/services/shield/handler_tags.go
@@ -3,43 +3,14 @@ package shield
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
-
-// tagItem represents a key/value pair for the Tags field in Shield API requests.
-type tagItem struct {
-	Key   string `json:"Key"`
-	Value string `json:"Value"`
-}
-
-func tagsFromItems(items []tagItem) map[string]string {
-	m := make(map[string]string, len(items))
-
-	for _, t := range items {
-		m[t.Key] = t.Value
-	}
-
-	return m
-}
-
-func tagsToItems(tags map[string]string) []tagItem {
-	items := make([]tagItem, 0, len(tags))
-
-	for k, v := range tags {
-		items = append(items, tagItem{Key: k, Value: v})
-	}
-
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].Key < items[j].Key
-	})
-
-	return items
-}
 
 // tagResourceRequest is the request body for TagResource.
 type tagResourceRequest struct {
 	ResourceARN string    `json:"ResourceARN"`
-	Tags        []tagItem `json:"Tags"`
+	Tags        []tags.KV `json:"Tags"`
 }
 
 func (h *Handler) handleTagResource(body []byte) error {
@@ -52,7 +23,7 @@ func (h *Handler) handleTagResource(body []byte) error {
 		return fmt.Errorf("%w: ResourceARN is required", errInvalidRequest)
 	}
 
-	if err := h.Backend.TagResource(req.ResourceARN, tagsFromItems(req.Tags)); err != nil {
+	if err := h.Backend.TagResource(req.ResourceARN, tags.MapFromKV(req.Tags)); err != nil {
 		return err
 	}
 
@@ -74,13 +45,13 @@ func (h *Handler) handleListTagsForResource(body []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: ResourceARN is required", errInvalidRequest)
 	}
 
-	tags, err := h.Backend.ListTagsForResource(req.ResourceARN)
+	tagsMap, err := h.Backend.ListTagsForResource(req.ResourceARN)
 	if err != nil {
 		return nil, err
 	}
 
 	return json.Marshal(map[string]any{
-		"Tags": tagsToItems(tags),
+		"Tags": tags.MapToKV(tagsMap),
 	})
 }
 

--- a/services/wafv2/handler_ip_sets.go
+++ b/services/wafv2/handler_ip_sets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
 // createIPSetRequest is the request body for CreateIPSet.
@@ -15,7 +16,7 @@ type createIPSetRequest struct {
 	Description      string    `json:"Description"`
 	IPAddressVersion string    `json:"IPAddressVersion"`
 	Addresses        []string  `json:"Addresses"`
-	Tags             []tagItem `json:"Tags"`
+	Tags             []tags.KV `json:"Tags"`
 }
 
 func (h *Handler) handleCreateIPSet(ctx context.Context, body []byte) ([]byte, error) {
@@ -56,7 +57,7 @@ func (h *Handler) handleCreateIPSet(ctx context.Context, body []byte) ([]byte, e
 		return nil, err
 	}
 
-	tags := tagsFromItems(req.Tags)
+	tags := tags.MapFromKV(req.Tags)
 	if err := validateTags(tags); err != nil {
 		return nil, err
 	}

--- a/services/wafv2/handler_regex_pattern_sets.go
+++ b/services/wafv2/handler_regex_pattern_sets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
 // createRegexPatternSetRequest is the request body for CreateRegexPatternSet.
@@ -15,7 +16,7 @@ type createRegexPatternSetRequest struct {
 	Scope                 string          `json:"Scope"`
 	Description           string          `json:"Description"`
 	RegularExpressionList json.RawMessage `json:"RegularExpressionList"`
-	Tags                  []tagItem       `json:"Tags"`
+	Tags                  []tags.KV       `json:"Tags"`
 }
 
 func (h *Handler) handleCreateRegexPatternSet(ctx context.Context, body []byte) ([]byte, error) {
@@ -53,7 +54,7 @@ func (h *Handler) handleCreateRegexPatternSet(ctx context.Context, body []byte) 
 		return nil, validateErr
 	}
 
-	tags := tagsFromItems(req.Tags)
+	tags := tags.MapFromKV(req.Tags)
 	if tagsErr := validateTags(tags); tagsErr != nil {
 		return nil, tagsErr
 	}

--- a/services/wafv2/handler_rule_groups.go
+++ b/services/wafv2/handler_rule_groups.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
 // checkCapacityRequest is the request body for CheckCapacity.
@@ -41,7 +42,7 @@ type createRuleGroupRequest struct {
 	Description      string           `json:"Description"`
 	VisibilityConfig json.RawMessage  `json:"VisibilityConfig"`
 	Rules            []map[string]any `json:"Rules"`
-	Tags             []tagItem        `json:"Tags"`
+	Tags             []tags.KV        `json:"Tags"`
 	Capacity         int64            `json:"Capacity"`
 }
 
@@ -84,7 +85,7 @@ func (h *Handler) handleCreateRuleGroup(ctx context.Context, body []byte) ([]byt
 		return nil, err
 	}
 
-	tags := tagsFromItems(req.Tags)
+	tags := tags.MapFromKV(req.Tags)
 	if err := validateTags(tags); err != nil {
 		return nil, err
 	}

--- a/services/wafv2/handler_tags.go
+++ b/services/wafv2/handler_tags.go
@@ -4,42 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
-
-// tagItem represents a key/value pair for Tags fields.
-type tagItem struct {
-	Key   string `json:"Key"`
-	Value string `json:"Value"`
-}
-
-func tagsFromItems(items []tagItem) map[string]string {
-	m := make(map[string]string, len(items))
-
-	for _, t := range items {
-		m[t.Key] = t.Value
-	}
-
-	return m
-}
-func tagsToItems(tags map[string]string) []tagItem {
-	items := make([]tagItem, 0, len(tags))
-
-	for k, v := range tags {
-		items = append(items, tagItem{Key: k, Value: v})
-	}
-
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].Key < items[j].Key
-	})
-
-	return items
-}
 
 // tagResourceRequest is the request body for TagResource.
 type tagResourceRequest struct {
 	ResourceARN string    `json:"ResourceARN"`
-	Tags        []tagItem `json:"Tags"`
+	Tags        []tags.KV `json:"Tags"`
 }
 
 func (h *Handler) handleTagResource(ctx context.Context, body []byte) ([]byte, error) {
@@ -52,12 +24,12 @@ func (h *Handler) handleTagResource(ctx context.Context, body []byte) ([]byte, e
 		return nil, fmt.Errorf("%w: ResourceARN is required", errInvalidRequest)
 	}
 
-	tags := tagsFromItems(req.Tags)
-	if err := validateTags(tags); err != nil {
+	tagsMap := tags.MapFromKV(req.Tags)
+	if err := validateTags(tagsMap); err != nil {
 		return nil, err
 	}
 
-	if err := h.Backend.TagResource(ctx, req.ResourceARN, tags); err != nil {
+	if err := h.Backend.TagResource(ctx, req.ResourceARN, tagsMap); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +51,7 @@ func (h *Handler) handleListTagsForResource(ctx context.Context, body []byte) ([
 		return nil, fmt.Errorf("%w: ResourceARN is required", errInvalidRequest)
 	}
 
-	tags, err := h.Backend.ListTagsForResource(ctx, req.ResourceARN)
+	tagsRes, err := h.Backend.ListTagsForResource(ctx, req.ResourceARN)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +59,7 @@ func (h *Handler) handleListTagsForResource(ctx context.Context, body []byte) ([
 	return json.Marshal(map[string]any{
 		"TagInfoForResource": map[string]any{
 			"ResourceARN": req.ResourceARN,
-			"TagList":     tagsToItems(tags),
+			"TagList":     tags.MapToKV(tagsRes),
 		},
 	})
 }

--- a/services/wafv2/handler_web_acls.go
+++ b/services/wafv2/handler_web_acls.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/blackbirdworks/gopherstack/pkgs/logger"
+	"github.com/blackbirdworks/gopherstack/pkgs/tags"
 )
 
 // createWebACLRequest is the request body for CreateWebACL.
@@ -19,7 +20,7 @@ type createWebACLRequest struct {
 	Name                 string           `json:"Name"`
 	Scope                string           `json:"Scope"`
 	Description          string           `json:"Description"`
-	Tags                 []tagItem        `json:"Tags"`
+	Tags                 []tags.KV        `json:"Tags"`
 	TokenDomains         []string         `json:"TokenDomains"`
 	Rules                []map[string]any `json:"Rules"`
 }
@@ -62,7 +63,7 @@ func (h *Handler) handleCreateWebACL(ctx context.Context, body []byte) ([]byte, 
 		return nil, err
 	}
 
-	tags := tagsFromItems(req.Tags)
+	tags := tags.MapFromKV(req.Tags)
 	if err := validateTags(tags); err != nil {
 		return nil, err
 	}

--- a/test/terraform/fixtures/opensearch/success.tf
+++ b/test/terraform/fixtures/opensearch/success.tf
@@ -2,6 +2,10 @@ resource "aws_opensearch_domain" "this" {
   domain_name    = "{{.DomainName}}"
   engine_version = "OpenSearch_2.3"
 
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
   timeouts {
     create = "5s"
     delete = "5s"

--- a/test/terraform/iam/main.tf
+++ b/test/terraform/iam/main.tf
@@ -139,7 +139,7 @@ resource "aws_iam_policy" "boundary" {
     Version = "2012-10-17"
     Statement = [{
       Effect   = "Allow"
-      Action   = ["ec2:*", "s3:*"]
+      Action   = ["ec2:*", "s3:ListBucket"]
       Resource = "*"
     }]
   })

--- a/test/terraform/mega-batch-3/main.tf
+++ b/test/terraform/mega-batch-3/main.tf
@@ -173,6 +173,11 @@ resource "aws_opensearch_domain" "analytics" {
     instance_count = 1
   }
 
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
   ebs_options {
     ebs_enabled = true
     volume_type = "gp3"


### PR DESCRIPTION
Fixes a number of CodeFactor debt issues:
- IAM policy s3 wildcards.
- Enforce HTTPS and TLS for OpenSearch domain in tests.
- Export ShardIteratorEntry to fix unexported return types.
- Fix untyped string context keys in ECR distribution handlers to circumvent staticcheck rules.
- Consolidate Tags slice/map converting in WAFv2 and Shield into the common `pkgs/tags` package.
- Extract duplicated struct logic in DirectoryService.