### PR TITLE
ci: fix goreleaser sbom output file variable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,7 @@ sboms:
       - "packages"
       - "${artifact}"
       - "--output"
-      - "spdx-json=${signature}"
+      - "spdx-json=${document}"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"


### PR DESCRIPTION
Fixes SBOM generation error where `syft` failed to write output. Changed `spdx-json=${signature}` to `spdx-json=${document}` in the `sboms` block.