### PR TITLE
fix(repo): remove accidental JetBrains safe-write file and ignore temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 # JetBrains Safe Write and editor temporary/swap files
 .!*
 *.!*
+*.swp
+*.swo
+*.swn
 .*.swp
 .*.swo
+.*.swn
 *~
-#*#
+\#*#
 /PLAN.md
 /new.sh
 /**/*.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 /.idea
 /Gopherstack.iml
+# JetBrains Safe Write and editor temporary/swap files
+.!*
+*.!*
+.*.swp
+.*.swo
+*~
+#*#
 /PLAN.md
 /new.sh
 /**/*.out

--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ cdk deploy
 - [Migrating from LocalStack](docs/migration.md)
 - [Architecture](docs/architecture/README.md)
 - [Examples](examples/README.md)
+- [Chaos Testing](docs/chaos.md)
 
 ## Development
 

--- a/docs/chaos.md
+++ b/docs/chaos.md
@@ -1,0 +1,97 @@
+# Chaos Testing
+
+Gopherstack includes a built-in Chaos Testing API that allows you to inject faults and simulate network degradation (latency and jitter) against your AWS clients. 
+
+The chaos middleware is **always enabled** and evaluates every incoming AWS SDK request, but it does nothing by default. You can configure faults dynamically at runtime using the Chaos API mounted at `/_gopherstack/chaos`.
+
+## Network Effects
+
+You can simulate network latency and jitter across all requests. This is useful for testing client timeouts and retry behavior.
+
+### `POST /_gopherstack/chaos/effects`
+
+Update the network effects configuration.
+
+**Request Body:**
+```json
+{
+  "latency": 100,
+  "jitter": 50,
+  "latencyRange": {
+    "min": 50,
+    "max": 200
+  }
+}
+```
+
+- `latency`: Base latency added to every request (in milliseconds).
+- `jitter`: Random additional latency between `0` and `jitter` (in milliseconds).
+- `latencyRange`: Random additional latency between `min` and `max` (in milliseconds).
+
+All fields are optional.
+
+### `POST /_gopherstack/chaos/effects/reset`
+
+Resets all network effects back to zero.
+
+## Fault Injection
+
+You can inject specific HTTP errors (like 503 Service Unavailable or 400 ThrottlingException) for particular services, operations, or regions.
+
+### `POST /_gopherstack/chaos/faults`
+
+Replaces the entire fault configuration.
+
+**Request Body:**
+```json
+[
+  {
+    "service": "dynamodb",
+    "operation": "PutItem",
+    "region": "us-east-1",
+    "probability": 0.5,
+    "error": {
+      "code": "ProvisionedThroughputExceededException",
+      "statusCode": 400
+    }
+  },
+  {
+    "service": "s3",
+    "probability": 1.0,
+    "error": {
+      "code": "ServiceUnavailable",
+      "statusCode": 503
+    }
+  }
+]
+```
+
+- **Matching Fields**: `service`, `operation`, `region`. If omitted, the rule matches any request.
+- `probability`: Float between `0.0` and `1.0`. A value of `0` is treated as `1.0` (always fire).
+- `error`: Custom HTTP error. Defaults to 503 `ServiceUnavailable` if not provided.
+
+### Other Fault Endpoints
+
+- `GET /_gopherstack/chaos/faults`: Returns current fault rules.
+- `PATCH /_gopherstack/chaos/faults`: Appends rules to the existing configuration.
+- `DELETE /_gopherstack/chaos/faults`: Removes matching rules.
+- `POST /_gopherstack/chaos/faults/clear`: Clears all fault rules.
+- `DELETE /_gopherstack/chaos/faults/by-index`: Removes a fault rule by index.
+
+## Activity Log
+
+The chaos middleware records fault injection events up to a maximum of 100 recent entries.
+
+- `GET /_gopherstack/chaos/activity`: Returns recent fault injection events in reverse-chronological order.
+
+## State Query
+
+- `GET /_gopherstack/chaos/query`: Returns the combined state of faults, effects, and recent activity.
+
+## AWS Fault Injection Service (FIS)
+
+Gopherstack's Chaos testing integrates natively with the mock AWS Fault Injection Service (FIS). When you run FIS experiments with `aws:fis:inject-api-*` actions, Gopherstack automatically translates them into chaos rules during the experiment and cleans them up afterward.
+
+## Discoverable Targets
+
+- `GET /_gopherstack/chaos/targets`: Returns auto-discovered injectable targets (services, operations, regions) available for fault injection.

--- a/main_test.go
+++ b/main_test.go
@@ -3,14 +3,73 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRepositoryHygieneNoTempFiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		checkReject func(relPath string, isDir bool) bool
+		description string
+	}{
+		{
+			name: "jetbrains safe write temp files",
+			checkReject: func(relPath string, isDir bool) bool {
+				base := filepath.Base(relPath)
+
+				return !isDir && (strings.HasPrefix(base, ".!") || strings.Contains(base, ".!"))
+			},
+			description: "files starting with or containing .! (JetBrains safe-write)",
+		},
+		{
+			name: "editor swap and backup files",
+			checkReject: func(relPath string, isDir bool) bool {
+				base := filepath.Base(relPath)
+
+				return !isDir && (strings.HasSuffix(base, ".swp") || strings.HasSuffix(base, ".swo") ||
+					strings.HasSuffix(base, "~") || (strings.HasPrefix(base, "#") && strings.HasSuffix(base, "#")))
+			},
+			description: "editor swap or backup files (.swp, .swo, ~, #*#)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var violations []string
+
+			err := filepath.WalkDir(".", func(path string, d fs.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if d.IsDir() &&
+					(d.Name() == ".git" || d.Name() == "node_modules" || d.Name() == ".svelte-kit" || d.Name() == ".dolt") {
+					return filepath.SkipDir
+				}
+				if tt.checkReject(path, d.IsDir()) {
+					violations = append(violations, path)
+				}
+
+				return nil
+			})
+
+			require.NoError(t, err)
+			assert.Empty(t, violations, "found disallowed files (%s): %v", tt.description, violations)
+		})
+	}
+}
 
 func TestMultipleServersStartupAndShutdown(t *testing.T) {
 	t.Parallel()

--- a/main_test.go
+++ b/main_test.go
@@ -20,45 +20,70 @@ func TestRepositoryHygieneNoTempFiles(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		checkReject func(relPath string, isDir bool) bool
-		description string
+		name string
+		args struct {
+			checkReject func(relPath string, isDir bool) bool
+		}
+		want struct {
+			description string
+		}
 	}{
 		{
 			name: "jetbrains safe write temp files",
-			checkReject: func(relPath string, isDir bool) bool {
-				base := filepath.Base(relPath)
+			args: struct {
+				checkReject func(relPath string, isDir bool) bool
+			}{
+				checkReject: func(relPath string, isDir bool) bool {
+					base := filepath.Base(relPath)
 
-				return !isDir && (strings.HasPrefix(base, ".!") || strings.Contains(base, ".!"))
+					return !isDir && (strings.HasPrefix(base, ".!") || strings.Contains(base, ".!"))
+				},
 			},
-			description: "files starting with or containing .! (JetBrains safe-write)",
+			want: struct {
+				description string
+			}{
+				description: "files starting with or containing .! (JetBrains safe-write)",
+			},
 		},
 		{
 			name: "editor swap and backup files",
-			checkReject: func(relPath string, isDir bool) bool {
-				base := filepath.Base(relPath)
+			args: struct {
+				checkReject func(relPath string, isDir bool) bool
+			}{
+				checkReject: func(relPath string, isDir bool) bool {
+					base := filepath.Base(relPath)
 
-				return !isDir && (strings.HasSuffix(base, ".swp") || strings.HasSuffix(base, ".swo") ||
-					strings.HasSuffix(base, "~") || (strings.HasPrefix(base, "#") && strings.HasSuffix(base, "#")))
+					return !isDir && (strings.HasSuffix(base, ".swp") || strings.HasSuffix(base, ".swo") ||
+						strings.HasSuffix(base, ".swn") || strings.HasSuffix(base, "~") ||
+						(strings.HasPrefix(base, "#") && strings.HasSuffix(base, "#")))
+				},
 			},
-			description: "editor swap or backup files (.swp, .swo, ~, #*#)",
+			want: struct {
+				description string
+			}{
+				description: "editor swap or backup files (.swp, .swo, .swn, ~, #*#)",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := t.Context()
 			var violations []string
 
 			err := filepath.WalkDir(".", func(path string, d fs.DirEntry, walkErr error) error {
 				if walkErr != nil {
 					return walkErr
 				}
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				if d.IsDir() &&
 					(d.Name() == ".git" || d.Name() == "node_modules" || d.Name() == ".svelte-kit" || d.Name() == ".dolt") {
 					return filepath.SkipDir
 				}
-				if tt.checkReject(path, d.IsDir()) {
+				if tt.args.checkReject(path, d.IsDir()) {
 					violations = append(violations, path)
 				}
 
@@ -66,7 +91,7 @@ func TestRepositoryHygieneNoTempFiles(t *testing.T) {
 			})
 
 			require.NoError(t, err)
-			assert.Empty(t, violations, "found disallowed files (%s): %v", tt.description, violations)
+			assert.Empty(t, violations, "found disallowed files (%s): %v", tt.want.description, violations)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Delete stray tracked file `.!23213!gopherstack` (created by JetBrains Safe Write in commit 9657a614)
- Add `.!*`, `*.!*`, and editor swap/backup files to `.gitignore`
- Add table-driven repository hygiene test in `main_test.go` ensuring temporary files are never tracked

Closes #2437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ignore rules for editor temporary, swap, backup, and safe-write files.

* **Tests**
  * Added automated checks to detect unwanted editor-generated files in the repository.
  * The checks report violations and traversal errors to help maintain a clean project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->