### PR TITLE
azurequeue: fix review findings from PR #2447

### DIFF
--- a/services/azurequeue/errors.go
+++ b/services/azurequeue/errors.go
@@ -17,4 +17,11 @@ var (
 	// first dereference if stored as-is. See persistence.go.
 	ErrSnapshotQueueNull   = errors.New("azurequeue: restore snapshot: queue is null")
 	ErrSnapshotMessageNull = errors.New("azurequeue: restore snapshot: message is null")
+
+	// ErrSnapshotQueueNameMismatch is returned by Restore when a snapshot's
+	// "queues" map key differs from that entry's storedQueue.Name. Queue
+	// operations (CreateQueue, DeleteQueue, PutMessage, ...) all key off the
+	// map, while ListQueues reads Name -- a mismatch would let those two
+	// views disagree about a queue's identity. See persistence.go.
+	ErrSnapshotQueueNameMismatch = errors.New("azurequeue: restore snapshot: queue map key does not match Name")
 )

--- a/services/azurequeue/handler_test.go
+++ b/services/azurequeue/handler_test.go
@@ -434,6 +434,11 @@ func TestPutMessage_VisibilityTimeoutOutOfRange(t *testing.T) {
 	}{
 		{name: "negative_rejected", query: "?visibilitytimeout=-1"},
 		{name: "non_numeric_rejected", query: "?visibilitytimeout=abc"},
+		{name: "over_seven_days_rejected", query: "?visibilitytimeout=604801"},
+		// Put Message's visibilitytimeout must be strictly less than its own
+		// messagettl -- equal is rejected, not just greater.
+		{name: "equal_to_ttl_rejected", query: "?visibilitytimeout=60&messagettl=60"},
+		{name: "greater_than_ttl_rejected", query: "?visibilitytimeout=120&messagettl=60"},
 	}
 
 	for _, tt := range tests {
@@ -470,6 +475,97 @@ func TestPutMessage_NeverExpireSentinel(t *testing.T) {
 			body := []byte("<QueueMessage><MessageText>x</MessageText></QueueMessage>")
 			rec := doRequest(t, h, http.MethodPost, "/"+testAccount+"/myqueue/messages?messagettl=-1", body)
 			require.Equal(t, http.StatusCreated, rec.Code, tt.name)
+		})
+	}
+}
+
+// TestPutMessage_MessageTTLZeroRejected is a regression test: real Azure
+// Queue Storage only accepts messagettl=-1 (never expire) or a strictly
+// positive value -- zero would create a message that expires the instant
+// it's created.
+func TestPutMessage_MessageTTLZeroRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "messagettl_zero_rejected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			createQueue(t, h, "myqueue")
+
+			body := []byte("<QueueMessage><MessageText>x</MessageText></QueueMessage>")
+			rec := doRequest(t, h, http.MethodPost, "/"+testAccount+"/myqueue/messages?messagettl=0", body)
+			require.Equal(t, http.StatusBadRequest, rec.Code, tt.name)
+			assert.Contains(t, rec.Body.String(), "OutOfRangeQueryParameterValue", tt.name)
+		})
+	}
+}
+
+// TestGetMessages_VisibilityTimeoutRange is a regression test: unlike Put/
+// Update Message, Get Messages must reject visibilitytimeout=0 (a dequeued
+// message must be hidden for at least one second) as well as values above
+// the seven-day cap.
+func TestGetMessages_VisibilityTimeoutRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "zero_rejected", query: "?visibilitytimeout=0"},
+		{name: "over_seven_days_rejected", query: "?visibilitytimeout=604801"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			createQueue(t, h, "myqueue")
+			putMessage(t, h, "myqueue", "x")
+
+			rec := doRequest(t, h, http.MethodGet, "/"+testAccount+"/myqueue/messages"+tt.query, nil)
+			require.Equal(t, http.StatusBadRequest, rec.Code, tt.name)
+			assert.Contains(t, rec.Body.String(), "OutOfRangeQueryParameterValue", tt.name)
+		})
+	}
+}
+
+// TestUpdateMessage_VisibilityTimeoutRange covers Update Message's
+// visibilitytimeout bounds: zero is permitted (unlike Get Messages), but the
+// seven-day cap still applies.
+func TestUpdateMessage_VisibilityTimeoutRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		visibility string
+		wantStatus int
+	}{
+		{name: "zero_accepted", visibility: "0", wantStatus: http.StatusNoContent},
+		{name: "over_seven_days_rejected", visibility: "604801", wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t)
+			createQueue(t, h, "myqueue")
+			rec := putMessage(t, h, "myqueue", "x")
+			messageID := extractXMLField(t, rec.Body.String(), "MessageId")
+			popReceipt := extractXMLField(t, rec.Body.String(), "PopReceipt")
+
+			rec = doRequest(t, h, http.MethodPut,
+				"/"+testAccount+"/myqueue/messages/"+messageID+"?popreceipt="+popReceipt+
+					"&visibilitytimeout="+tt.visibility, nil)
+			require.Equal(t, tt.wantStatus, rec.Code, tt.name)
 		})
 	}
 }
@@ -563,7 +659,7 @@ func indexOrFail(t *testing.T, s, substr string) int {
 		}
 	}
 
-	t.Fatalf("substring %q not found in %q", substr, s)
+	require.FailNowf(t, "substring not found", "substring %q not found in %q", substr, s)
 
 	return -1
 }

--- a/services/azurequeue/interfaces.go
+++ b/services/azurequeue/interfaces.go
@@ -1,3 +1,8 @@
+// Package azurequeue provides a local, in-memory emulation of Azure Queue
+// Storage's REST+XML wire protocol (queue CRUD plus the full message
+// lifecycle: put/get/peek/delete/update-visibility/clear), Azurite-compatible
+// enough for unmodified azure-sdk-for-go clients to operate against. See
+// AZURE.md and PARITY.md for scope and known gaps.
 package azurequeue
 
 import "time"
@@ -15,6 +20,12 @@ type StorageBackend interface {
 	ListQueues() []QueueInfo
 
 	PutMessage(queue, text string, visibilityTimeout, ttl time.Duration) (MessageInfo, error)
+	// GetMessages and PeekMessages return ErrOutOfRangeQueryParam if
+	// numOfMessages is outside [MinNumOfMessages, MaxNumOfMessages] -- a
+	// defense-in-depth check against direct callers that bypass the
+	// handler's own range validation (see messages.go's parseNumOfMessages),
+	// since an unvalidated negative value would otherwise panic on
+	// allocation.
 	GetMessages(queue string, numOfMessages int, visibilityTimeout time.Duration) ([]MessageInfo, error)
 	PeekMessages(queue string, numOfMessages int) ([]MessageInfo, error)
 	DeleteMessage(queue, messageID, popReceipt string) error

--- a/services/azurequeue/messages.go
+++ b/services/azurequeue/messages.go
@@ -50,17 +50,26 @@ func (h *Handler) handleMessageLevel(c *echo.Context, queue, messageID string) e
 func (h *Handler) putMessage(c *echo.Context, queue string) error {
 	r := c.Request()
 
-	// Put Message defaults visibilitytimeout to 0 (immediately visible), not
-	// Get Messages' DefaultVisibilityTimeout -- a freshly-enqueued message
-	// with no caller-specified delay must be dequeuable right away.
-	visibilityTimeout, ok, errResp := h.parseOptionalSeconds(c, queryVisibilityTimeout, 0)
+	ttl, ok, errResp := h.parseMessageTTL(c)
 	if !ok {
 		return errResp
 	}
 
-	ttl, ok, errResp := h.parseMessageTTL(c)
+	// Put Message defaults visibilitytimeout to 0 (immediately visible), not
+	// Get Messages' DefaultVisibilityTimeout -- a freshly-enqueued message
+	// with no caller-specified delay must be dequeuable right away. Its
+	// upper bound is also checked against ttl: a message can never be
+	// created invisible for as long as, or longer than, its own TTL.
+	visibilityTimeout, ok, errResp := h.parseVisibilityTimeoutSeconds(
+		c, queryVisibilityTimeout, 0, 0, maxVisibilityTimeoutSeconds,
+	)
 	if !ok {
 		return errResp
+	}
+
+	if visibilityTimeout >= ttl {
+		return h.writeError(c, http.StatusBadRequest, "OutOfRangeQueryParameterValue",
+			"The visibilitytimeout must be less than the message's time-to-live.")
 	}
 
 	body, err := httputils.ReadBody(r)
@@ -92,14 +101,19 @@ func (h *Handler) getMessages(c *echo.Context, queue string) error {
 		return errResp
 	}
 
-	visibilityTimeout, ok, errResp := h.parseOptionalSeconds(c, queryVisibilityTimeout, DefaultVisibilityTimeout)
+	// Unlike Put/Update, Get Messages requires a strictly positive
+	// visibilitytimeout (a dequeued message must actually be hidden for at
+	// least one second) -- 0 is rejected, not defaulted.
+	visibilityTimeout, ok, errResp := h.parseVisibilityTimeoutSeconds(
+		c, queryVisibilityTimeout, DefaultVisibilityTimeout, 1, maxVisibilityTimeoutSeconds,
+	)
 	if !ok {
 		return errResp
 	}
 
 	infos, err := h.Backend.GetMessages(queue, numOfMessages, visibilityTimeout)
 	if err != nil {
-		return h.writeQueueNotFoundError(c)
+		return h.writeMessagesListError(c, err)
 	}
 
 	entries := make([]queueMessageXML, 0, len(infos))
@@ -118,7 +132,7 @@ func (h *Handler) peekMessages(c *echo.Context, queue string) error {
 
 	infos, err := h.Backend.PeekMessages(queue, numOfMessages)
 	if err != nil {
-		return h.writeQueueNotFoundError(c)
+		return h.writeMessagesListError(c, err)
 	}
 
 	entries := make([]queueMessageXML, 0, len(infos))
@@ -127,6 +141,21 @@ func (h *Handler) peekMessages(c *echo.Context, queue string) error {
 	}
 
 	return h.writeXML(c, http.StatusOK, queueMessagesList{Messages: entries})
+}
+
+// writeMessagesListError maps a Get/Peek Messages backend error to the
+// corresponding Azure error code/status. ErrOutOfRangeQueryParam is only
+// reachable here as a defense-in-depth backstop (see StorageBackend's
+// GetMessages/PeekMessages doc comments) -- the handler's own
+// parseNumOfMessages already rejects an out-of-range numofmessages before
+// the backend is ever called.
+func (h *Handler) writeMessagesListError(c *echo.Context, err error) error {
+	if errors.Is(err, ErrOutOfRangeQueryParam) {
+		return h.writeError(c, http.StatusBadRequest, "OutOfRangeQueryParameterValue",
+			"A query parameter specified in the request URI is outside the permissible range.")
+	}
+
+	return h.writeQueueNotFoundError(c)
 }
 
 func (h *Handler) clearMessages(c *echo.Context, queue string) error {
@@ -161,7 +190,13 @@ func (h *Handler) updateMessage(c *echo.Context, queue, messageID string) error 
 			"A required query parameter (visibilitytimeout) was not specified.")
 	}
 
-	visibilityTimeout, ok, errResp := h.parseOptionalSeconds(c, queryVisibilityTimeout, DefaultVisibilityTimeout)
+	// Update Message's visibilitytimeout is mandatory (checked above), so the
+	// default value passed here is never actually used; range is 0..604800,
+	// same as Put Message but with no TTL comparison (Update does not change
+	// a message's TTL).
+	visibilityTimeout, ok, errResp := h.parseVisibilityTimeoutSeconds(
+		c, queryVisibilityTimeout, 0, 0, maxVisibilityTimeoutSeconds,
+	)
 	if !ok {
 		return errResp
 	}
@@ -272,8 +307,10 @@ const neverExpireTTL = 100 * 365 * 24 * time.Hour
 // parseMessageTTL parses the messagettl query parameter for Put Message,
 // defaulting to DefaultMessageTTL when absent and special-casing Azure's
 // documented messagettl=-1 "never expire" sentinel (see neverExpireTTL). Any
-// other negative value is rejected as out of range. ok is false if an error
-// response has already been written to c.
+// other negative value, or zero, is rejected as out of range: real Azure
+// Queue Storage only accepts -1 or a strictly positive TTL -- a zero TTL
+// would create a message that expires the instant it's created. ok is false
+// if an error response has already been written to c.
 func (h *Handler) parseMessageTTL(c *echo.Context) (time.Duration, bool, error) {
 	raw := c.QueryParam(queryMessageTTL)
 	if raw == "" {
@@ -289,7 +326,7 @@ func (h *Handler) parseMessageTTL(c *echo.Context) (time.Duration, bool, error) 
 	switch {
 	case n == -1:
 		return neverExpireTTL, true, nil
-	case n < 0:
+	case n <= 0:
 		return 0, false, h.writeError(c, http.StatusBadRequest, "OutOfRangeQueryParameterValue",
 			"A query parameter specified in the request URI is outside the permissible range.")
 	default:
@@ -297,10 +334,20 @@ func (h *Handler) parseMessageTTL(c *echo.Context) (time.Duration, bool, error) 
 	}
 }
 
-// parseOptionalSeconds parses a query parameter as a non-negative integer
-// number of seconds, returning def if the parameter is absent. ok is false
-// if an error response has already been written to c.
-func (h *Handler) parseOptionalSeconds(c *echo.Context, name string, def time.Duration) (time.Duration, bool, error) {
+// maxVisibilityTimeoutSeconds is the largest visibilitytimeout (in seconds)
+// any operation accepts, matching real Azure Queue Storage's documented
+// seven-day cap. It happens to equal DefaultMessageTTL expressed in seconds.
+const maxVisibilityTimeoutSeconds = 7 * 24 * 60 * 60
+
+// parseVisibilityTimeoutSeconds parses the visibilitytimeout query parameter
+// as an integer number of seconds in [minSeconds, maxSeconds], returning def
+// if the parameter is absent. The permitted range differs per operation (see
+// callers): Get Messages requires a strictly positive value, while Put and
+// Update Message permit zero. ok is false if an error response has already
+// been written to c.
+func (h *Handler) parseVisibilityTimeoutSeconds(
+	c *echo.Context, name string, def time.Duration, minSeconds, maxSeconds int,
+) (time.Duration, bool, error) {
 	raw := c.QueryParam(name)
 	if raw == "" {
 		return def, true, nil
@@ -312,7 +359,7 @@ func (h *Handler) parseOptionalSeconds(c *echo.Context, name string, def time.Du
 			"Value for one of the query parameters specified in the request URI is invalid.")
 	}
 
-	if n < 0 {
+	if n < minSeconds || n > maxSeconds {
 		return 0, false, h.writeError(c, http.StatusBadRequest, "OutOfRangeQueryParameterValue",
 			"A query parameter specified in the request URI is outside the permissible range.")
 	}

--- a/services/azurequeue/models.go
+++ b/services/azurequeue/models.go
@@ -66,10 +66,14 @@ func (m *storedMessage) isVisible(now time.Time) bool {
 	return !m.NextVisibleTime.After(now)
 }
 
-// isExpired reports whether m has exceeded its message TTL as of now, swept
-// by Janitor.
+// isExpired reports whether m has reached or exceeded its message TTL as of
+// now, swept by Janitor. The exact expiration instant counts as expired
+// (!now.Before(...), not now.After(...)) so a message can never be read,
+// deleted, or updated at exactly its ExpirationTime -- matching real Azure
+// Queue Storage, which deletes a message once its TTL elapses and does not
+// allow updates after expiration.
 func (m *storedMessage) isExpired(now time.Time) bool {
-	return now.After(m.ExpirationTime)
+	return !now.Before(m.ExpirationTime)
 }
 
 // storedQueue is the backend's internal representation of a queue. Messages

--- a/services/azurequeue/persistence.go
+++ b/services/azurequeue/persistence.go
@@ -79,6 +79,15 @@ func (b *InMemoryBackend) Restore(ctx context.Context, data []byte) error {
 			return fmt.Errorf("%w: %q", ErrSnapshotQueueNull, name)
 		}
 
+		// Queue operations (CreateQueue, DeleteQueue, PutMessage, ...) all
+		// key off the "queues" map, while ListQueues reads storedQueue.Name
+		// -- a snapshot where these disagree would let those two views of
+		// the same queue diverge. Reject it outright rather than silently
+		// preferring one identity over the other.
+		if q.Name != name {
+			return fmt.Errorf("%w: map key %q, Name %q", ErrSnapshotQueueNameMismatch, name, q.Name)
+		}
+
 		for i, msg := range q.Messages {
 			if msg == nil {
 				return fmt.Errorf("%w: index %d in queue %q", ErrSnapshotMessageNull, i, name)

--- a/services/azurequeue/persistence_test.go
+++ b/services/azurequeue/persistence_test.go
@@ -98,6 +98,16 @@ func TestRestore_RejectsNullEntries(t *testing.T) {
 			data:    []byte(`{"version":1,"queues":{"q1":{"Name":"q1","Messages":[null]}}}`),
 			wantErr: azurequeue.ErrSnapshotMessageNull,
 		},
+		{
+			// Regression test: queue operations (CreateQueue, DeleteQueue,
+			// PutMessage, ...) key off the "queues" map, while ListQueues
+			// reads storedQueue.Name -- a snapshot where a map key and its
+			// entry's Name disagree would let those two views of the same
+			// queue diverge. Restore must reject it outright.
+			name:    "queue_name_mismatches_map_key",
+			data:    []byte(`{"version":1,"queues":{"q1":{"Name":"different-name"}}}`),
+			wantErr: azurequeue.ErrSnapshotQueueNameMismatch,
+		},
 	}
 
 	for _, tt := range tests {

--- a/services/azurequeue/store.go
+++ b/services/azurequeue/store.go
@@ -153,6 +153,10 @@ func (b *InMemoryBackend) GetMessages(
 		return nil, ErrQueueNotFound
 	}
 
+	if numOfMessages < MinNumOfMessages || numOfMessages > MaxNumOfMessages {
+		return nil, ErrOutOfRangeQueryParam
+	}
+
 	now := b.now()
 	nextVisible := now.Add(visibilityTimeout)
 
@@ -188,6 +192,10 @@ func (b *InMemoryBackend) PeekMessages(queue string, numOfMessages int) ([]Messa
 		return nil, ErrQueueNotFound
 	}
 
+	if numOfMessages < MinNumOfMessages || numOfMessages > MaxNumOfMessages {
+		return nil, ErrOutOfRangeQueryParam
+	}
+
 	now := b.now()
 
 	out := make([]MessageInfo, 0, numOfMessages)
@@ -219,7 +227,7 @@ func (b *InMemoryBackend) DeleteMessage(queue, messageID, popReceipt string) err
 		return ErrQueueNotFound
 	}
 
-	idx, msg, err := findMessageLocked(q, messageID)
+	idx, msg, err := findMessageLocked(q, messageID, b.now())
 	if err != nil {
 		return err
 	}
@@ -248,7 +256,7 @@ func (b *InMemoryBackend) UpdateMessage(
 		return MessageInfo{}, ErrQueueNotFound
 	}
 
-	_, msg, err := findMessageLocked(q, messageID)
+	_, msg, err := findMessageLocked(q, messageID, b.now())
 	if err != nil {
 		return MessageInfo{}, err
 	}
@@ -292,11 +300,16 @@ func (b *InMemoryBackend) Reset() {
 	b.queues = make(map[string]*storedQueue)
 }
 
-// findMessageLocked resolves a message by ID within q. Callers must hold
-// b.mu (either read or write).
-func findMessageLocked(q *storedQueue, messageID string) (int, *storedMessage, error) {
+// findMessageLocked resolves a message by ID within q, as of now. A message
+// that has reached its expiration instant (see storedMessage.isExpired) is
+// treated as not found even if the Janitor has not yet swept it: real Azure
+// Queue Storage deletes a message once its TTL elapses and rejects
+// Delete/Update against an expired one, so DeleteMessage/UpdateMessage must
+// not be able to observe or mutate it in the gap between expiry and sweep.
+// Callers must hold b.mu (either read or write).
+func findMessageLocked(q *storedQueue, messageID string, now time.Time) (int, *storedMessage, error) {
 	for i, msg := range q.Messages {
-		if msg.ID == messageID {
+		if msg.ID == messageID && !msg.isExpired(now) {
 			return i, msg, nil
 		}
 	}

--- a/services/azurequeue/store.go
+++ b/services/azurequeue/store.go
@@ -256,7 +256,9 @@ func (b *InMemoryBackend) UpdateMessage(
 		return MessageInfo{}, ErrQueueNotFound
 	}
 
-	_, msg, err := findMessageLocked(q, messageID, b.now())
+	now := b.now()
+
+	_, msg, err := findMessageLocked(q, messageID, now)
 	if err != nil {
 		return MessageInfo{}, err
 	}
@@ -265,7 +267,7 @@ func (b *InMemoryBackend) UpdateMessage(
 		return MessageInfo{}, ErrPopReceiptMismatch
 	}
 
-	msg.NextVisibleTime = b.now().Add(visibilityTimeout)
+	msg.NextVisibleTime = now.Add(visibilityTimeout)
 	msg.PopReceipt = b.idFunc()
 
 	if text != nil {

--- a/services/azurequeue/store_test.go
+++ b/services/azurequeue/store_test.go
@@ -329,6 +329,10 @@ func TestInMemoryBackend_UpdateMessage(t *testing.T) {
 		name    string
 	}{
 		{name: "visibility_only", newText: nil},
+		// new(expr) (Go 1.26+) returns a pointer to a copy of expr -- this is
+		// not new(T) called with a value instead of a type; golangci-lint's
+		// modernize check flags the old func(){s:=v;return &s}() idiom in
+		// favor of exactly this form.
 		{name: "replaces_text", newText: new("new text")},
 	}
 
@@ -537,6 +541,143 @@ func TestInMemoryBackend_SetIDFunc(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "id-1", info.ID, tt.name)
 			assert.Equal(t, "id-2", info.PopReceipt, tt.name)
+		})
+	}
+}
+
+// TestInMemoryBackend_DeleteAndUpdateMessage_RejectExpiredMessage is a
+// regression test: findMessageLocked must not return (and let
+// DeleteMessage/UpdateMessage mutate) a message that has reached its
+// expiration instant, even before the Janitor has swept it. Uses the
+// injected clock seam -- no sleeps -- to check both the exact expiry instant
+// and just after it.
+func TestInMemoryBackend_DeleteAndUpdateMessage_RejectExpiredMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		advance time.Duration
+	}{
+		{name: "exactly_at_expiry", advance: time.Second},
+		{name: "just_after_expiry", advance: time.Second + time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			now := base
+
+			b := azurequeue.NewInMemoryBackend()
+			azurequeue.SetNowFunc(b, func() time.Time { return now })
+
+			_, err := b.CreateQueue("q1")
+			require.NoError(t, err)
+
+			info, err := b.PutMessage("q1", "x", 0, time.Second)
+			require.NoError(t, err)
+
+			now = base.Add(tt.advance)
+
+			err = b.DeleteMessage("q1", info.ID, info.PopReceipt)
+			require.ErrorIs(t, err, azurequeue.ErrMessageNotFound, tt.name)
+
+			_, err = b.UpdateMessage("q1", info.ID, info.PopReceipt, time.Minute, nil)
+			assert.ErrorIs(t, err, azurequeue.ErrMessageNotFound, tt.name)
+		})
+	}
+}
+
+// TestInMemoryBackend_DeleteAndUpdateMessage_NotYetExpiredSucceeds pins the
+// boundary from the other side: a message one instant before its expiration
+// is still a normal, mutable message.
+func TestInMemoryBackend_DeleteAndUpdateMessage_NotYetExpiredSucceeds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{name: "just_before_expiry"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			now := base
+
+			b := azurequeue.NewInMemoryBackend()
+			azurequeue.SetNowFunc(b, func() time.Time { return now })
+
+			_, err := b.CreateQueue("q1")
+			require.NoError(t, err)
+
+			info, err := b.PutMessage("q1", "x", 0, time.Second)
+			require.NoError(t, err)
+
+			now = base.Add(999 * time.Millisecond)
+
+			_, err = b.UpdateMessage("q1", info.ID, info.PopReceipt, time.Minute, nil)
+			require.NoError(t, err, tt.name)
+		})
+	}
+}
+
+// TestInMemoryBackend_GetMessages_InvalidNumOfMessages and its Peek sibling
+// are regression tests: a negative numOfMessages previously reached make()
+// unchecked, which panics on a negative capacity; zero and over-max values
+// silently bypassed the documented [MinNumOfMessages, MaxNumOfMessages]
+// bounds. Both must now be rejected with ErrOutOfRangeQueryParam instead.
+func TestInMemoryBackend_GetMessages_InvalidNumOfMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		numOfMessages int
+	}{
+		{name: "negative", numOfMessages: -1},
+		{name: "zero", numOfMessages: 0},
+		{name: "over_max", numOfMessages: azurequeue.MaxNumOfMessages + 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := azurequeue.NewInMemoryBackend()
+			_, err := b.CreateQueue("q1")
+			require.NoError(t, err)
+
+			_, err = b.GetMessages("q1", tt.numOfMessages, time.Second)
+			assert.ErrorIs(t, err, azurequeue.ErrOutOfRangeQueryParam, tt.name)
+		})
+	}
+}
+
+func TestInMemoryBackend_PeekMessages_InvalidNumOfMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		numOfMessages int
+	}{
+		{name: "negative", numOfMessages: -1},
+		{name: "zero", numOfMessages: 0},
+		{name: "over_max", numOfMessages: azurequeue.MaxNumOfMessages + 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := azurequeue.NewInMemoryBackend()
+			_, err := b.CreateQueue("q1")
+			require.NoError(t, err)
+
+			_, err = b.PeekMessages("q1", tt.numOfMessages)
+			assert.ErrorIs(t, err, azurequeue.ErrOutOfRangeQueryParam, tt.name)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

PR #2447 (Azure Queue Storage, M1) merged before its review-fix commit landed — this PR carries those fixes forward against current `main`. Addresses CodeRabbit findings from #2447's review:

- `messagettl=0` is now rejected with `OutOfRangeQueryParameterValue` (previously created a message that expired immediately).
- Per-operation visibility-timeout ranges enforced: Get Messages requires 1-604800s; Put/Update permit 0-604800s; Put additionally rejects a timeout >= the message's TTL.
- Fixed an off-by-one in message expiry (`now == ExpirationTime` was treated as still-live); `findMessageLocked` now takes the current time and treats an expired match as not-found, so Delete/Update can no longer touch an already-expired message ahead of the Janitor sweep.
- `Restore` now rejects a snapshot whose `queues` map key diverges from `storedQueue.Name`, preventing queue-identity drift between map-key-based operations and `Name`-based `ListQueues`.
- `numOfMessages` is validated before allocation in `GetMessages`/`PeekMessages` (previously a negative value panicked in `make()`).
- Added a package doc comment to `services/azurequeue` and swapped a stray `t.Fatalf` for `require.FailNowf` per test convention.

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run ./...` (full repo, exact pinned version) — clean except 2 pre-existing `goimports` findings in `services/dynamodb`, untouched by this change
- [x] `go test -short ./...` — all clean except pre-existing environment-specific failures unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Queue parameter validation, including message TTL, visibility timeout, and message-count limits.
  * Expired messages are now consistently unavailable at their exact expiration time.
  * Snapshot restoration now rejects queues with inconsistent names.
  * Improved error responses for invalid message retrieval parameters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->